### PR TITLE
ci: add informational CRDT skew alarm against comfy-multi-player main

### DIFF
--- a/.github/scripts/crdt-skew-override.mjs
+++ b/.github/scripts/crdt-skew-override.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Point this workspace at a specific comfy-multi-player commit instead of the pinned
+ * release, for the `CI: CRDT Skew Alarm` workflow. Run from the repo root.
+ *
+ * The override MUST live in pnpm-workspace.yaml. pnpm 11 no longer reads the `pnpm`
+ * field of package.json: it warns "keys were ignored" and resolves the pin anyway, so a
+ * package.json override produces a green run that never tested upstream at all.
+ *
+ * The matching `allowBuilds` entry is not optional either. allowBuilds is keyed by the
+ * resolved reference, and without an entry pnpm skips comfy-multi-player's `prepare`
+ * script; `dist/` is then absent and every import fails in a way that reads as a skew
+ * signal rather than a harness fault.
+ *
+ * Usage: node .github/scripts/crdt-skew-override.mjs --spec <tarball-url>
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const PACKAGE = '@comfyorg/comfy-multi-player'
+const WORKSPACE_FILE = 'pnpm-workspace.yaml'
+
+function parseArgs(argv) {
+  const args = { spec: null, file: WORKSPACE_FILE }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--spec') args.spec = argv[++i]
+    else if (argv[i] === '--file') args.file = argv[++i]
+  }
+  return args
+}
+
+function fail(message) {
+  process.stderr.write(`::error::${message}\n`)
+  process.exit(1)
+}
+
+const { spec, file } = parseArgs(process.argv.slice(2))
+if (!spec) fail('crdt-skew-override: --spec <tarball-url> is required')
+
+const lines = readFileSync(file, 'utf8').split('\n')
+
+/** Insert `entry` as the first member of the top-level `block:` mapping. */
+function inject(block, entry) {
+  const at = lines.findIndex((line) => line.trimEnd() === `${block}:`)
+  if (at === -1) {
+    fail(
+      `${file} has no top-level '${block}:' block; the skew alarm's override mechanism needs updating`
+    )
+  }
+  lines.splice(at + 1, 0, entry)
+}
+
+inject('overrides', `  '${PACKAGE}': '${spec}'`)
+inject('allowBuilds', `  '${PACKAGE}@${spec}': true`)
+
+writeFileSync(file, lines.join('\n'))
+process.stdout.write(`${file}: ${PACKAGE} -> ${spec}\n`)

--- a/.github/scripts/crdt-skew-report.mjs
+++ b/.github/scripts/crdt-skew-report.mjs
@@ -70,10 +70,26 @@ function readVitestReport(reportPath) {
   }
 }
 
+/**
+ * `no-skew-signal` is only allowed once the suite provably ran to completion and every
+ * test passed. A zero `numFailedTests` is not sufficient on its own: vitest also reports
+ * zero failures for a suite that was cancelled, that collected no tests at all, or that
+ * skipped tests, and each of those would otherwise publish a cheerful all-clear about an
+ * upstream revision nothing actually exercised.
+ *
+ * If the follower suite ever gains an intentional `test.skip` / `test.todo`, this gate
+ * starts returning `inconclusive-incomplete-suite` on every run. That is deliberate:
+ * account for the expected `pending` count here rather than dropping the
+ * `passed === total` requirement.
+ */
 function verdictFor(tests, testsOutcome) {
   if (!tests.parsed) return 'inconclusive-no-report'
   if (tests.failed > 0) return 'skew-signal'
-  if (testsOutcome === 'failure') return 'inconclusive-runner-failed'
+  if (testsOutcome !== 'success') return 'inconclusive-runner-failed'
+  if (!Number.isInteger(tests.total) || tests.total <= 0) {
+    return 'inconclusive-incomplete-suite'
+  }
+  if (tests.passed !== tests.total) return 'inconclusive-incomplete-suite'
   return 'no-skew-signal'
 }
 

--- a/.github/scripts/crdt-skew-report.mjs
+++ b/.github/scripts/crdt-skew-report.mjs
@@ -43,18 +43,29 @@ function readVitestReport(reportPath) {
     }
   }
   const failing = []
+  const failedFiles = []
   for (const file of report.testResults ?? []) {
+    let fileHadFailedAssertion = false
     for (const assertion of file.assertionResults ?? []) {
       if (assertion.status !== 'failed') continue
+      fileHadFailedAssertion = true
       failing.push({
         name: assertion.fullName || assertion.title || '(unnamed test)',
         file: file.name ?? null,
-        message:
-          (assertion.failureMessages ?? [])
-            .join('\n')
-            .split('\n')
-            .slice(0, 6)
-            .join('\n') || null
+        message: firstLines(assertion.failureMessages ?? [])
+      })
+    }
+    // A file that failed to collect (import error, top-level throw) never runs a
+    // test, so vitest leaves `numFailedTests` at 0 and only marks the file itself
+    // as failed. That is the shape an upstream that removed a module or export
+    // produces, so it has to count as skew rather than as a runner problem.
+    if (file.status === 'failed' && !fileHadFailedAssertion) {
+      const name = file.name ?? '(unnamed file)'
+      failedFiles.push(name)
+      failing.push({
+        name: `${name} (failed to collect)`,
+        file: file.name ?? null,
+        message: firstLines([file.message ?? ''])
       })
     }
   }
@@ -66,8 +77,13 @@ function readVitestReport(reportPath) {
     pending: report.numPendingTests ?? null,
     suites_total: report.numTotalTestSuites ?? null,
     suites_failed: report.numFailedTestSuites ?? null,
+    files_failed_to_collect: failedFiles,
     failing_tests: failing
   }
+}
+
+function firstLines(messages) {
+  return messages.join('\n').split('\n').slice(0, 6).join('\n') || null
 }
 
 /**
@@ -84,7 +100,9 @@ function readVitestReport(reportPath) {
  */
 function verdictFor(tests, testsOutcome) {
   if (!tests.parsed) return 'inconclusive-no-report'
-  if (tests.failed > 0) return 'skew-signal'
+  if (tests.failed > 0 || tests.files_failed_to_collect.length > 0) {
+    return 'skew-signal'
+  }
   if (testsOutcome !== 'success') return 'inconclusive-runner-failed'
   if (!Number.isInteger(tests.total) || tests.total <= 0) {
     return 'inconclusive-incomplete-suite'
@@ -116,7 +134,7 @@ if (out) writeFileSync(out, json)
 process.stdout.write(json)
 
 const counts = tests.parsed
-  ? `${tests.passed}/${tests.total} passed, ${tests.failed} failed, ${tests.pending} skipped`
+  ? `${tests.passed}/${tests.total} passed, ${tests.failed} failed, ${tests.pending} skipped, ${tests.files_failed_to_collect.length} files failed to collect`
   : `no counts available (${tests.error})`
 
 const summary = [
@@ -155,6 +173,7 @@ if (process.env.GITHUB_OUTPUT) {
       `total=${tests.total ?? ''}`,
       `passed=${tests.passed ?? ''}`,
       `failed=${tests.failed ?? ''}`,
+      `files_failed_to_collect=${tests.files_failed_to_collect?.length ?? ''}`,
       ''
     ].join('\n')
   )

--- a/.github/scripts/crdt-skew-report.mjs
+++ b/.github/scripts/crdt-skew-report.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Turn the vitest JSON report from the `CI: CRDT Skew Alarm` workflow into pass/fail
+ * counts, a job summary, and a machine-readable artifact.
+ *
+ * The verdict is deliberately conservative: anything short of "the suite ran to
+ * completion against upstream and passed" is reported as inconclusive rather than as an
+ * all-clear, because a false all-clear is the one outcome this alarm exists to prevent.
+ *
+ * Usage:
+ *   node .github/scripts/crdt-skew-report.mjs --report <vitest.json> --out <report.json>
+ *
+ * Environment (supplied by the workflow):
+ *   CMP_PACKAGE, CMP_SHA, CMP_SPEC, PINNED_VERSION, TESTS_OUTCOME
+ */
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync
+} from 'node:fs'
+
+function parseArgs(argv) {
+  const args = { report: null, out: null }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--report') args.report = argv[++i]
+    else if (argv[i] === '--out') args.out = argv[++i]
+  }
+  return args
+}
+
+function readVitestReport(reportPath) {
+  if (!reportPath || !existsSync(reportPath)) {
+    return { parsed: false, error: `no vitest report at ${reportPath}` }
+  }
+  let report
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'))
+  } catch (error) {
+    return {
+      parsed: false,
+      error: `vitest report parse failed: ${error.message}`
+    }
+  }
+  const failing = []
+  for (const file of report.testResults ?? []) {
+    for (const assertion of file.assertionResults ?? []) {
+      if (assertion.status !== 'failed') continue
+      failing.push({
+        name: assertion.fullName || assertion.title || '(unnamed test)',
+        file: file.name ?? null,
+        message:
+          (assertion.failureMessages ?? [])
+            .join('\n')
+            .split('\n')
+            .slice(0, 6)
+            .join('\n') || null
+      })
+    }
+  }
+  return {
+    parsed: true,
+    total: report.numTotalTests ?? null,
+    passed: report.numPassedTests ?? null,
+    failed: report.numFailedTests ?? null,
+    pending: report.numPendingTests ?? null,
+    suites_total: report.numTotalTestSuites ?? null,
+    suites_failed: report.numFailedTestSuites ?? null,
+    failing_tests: failing
+  }
+}
+
+function verdictFor(tests, testsOutcome) {
+  if (!tests.parsed) return 'inconclusive-no-report'
+  if (tests.failed > 0) return 'skew-signal'
+  if (testsOutcome === 'failure') return 'inconclusive-runner-failed'
+  return 'no-skew-signal'
+}
+
+const { report: reportPath, out } = parseArgs(process.argv.slice(2))
+const tests = readVitestReport(reportPath)
+const verdict = verdictFor(tests, process.env.TESTS_OUTCOME)
+
+const result = {
+  schema: 'crdt-skew-alarm/1',
+  generated_at: new Date().toISOString(),
+  informational_only: true,
+  premise: 'pin-vs-remote',
+  package: process.env.CMP_PACKAGE ?? null,
+  pinned_version: process.env.PINNED_VERSION ?? null,
+  upstream_sha: process.env.CMP_SHA ?? null,
+  upstream_spec: process.env.CMP_SPEC ?? null,
+  tests_outcome: process.env.TESTS_OUTCOME ?? null,
+  tests,
+  verdict
+}
+
+const json = `${JSON.stringify(result, null, 2)}\n`
+if (out) writeFileSync(out, json)
+process.stdout.write(json)
+
+const counts = tests.parsed
+  ? `${tests.passed}/${tests.total} passed, ${tests.failed} failed, ${tests.pending} skipped`
+  : `no counts available (${tests.error})`
+
+const summary = [
+  '## CRDT skew alarm',
+  '',
+  `Verdict: **${verdict}**`,
+  '',
+  `- Pinned: \`${result.package}@${result.pinned_version}\``,
+  `- Upstream \`main\`: \`${result.upstream_sha}\``,
+  `- Follower suite: ${counts}`,
+  '',
+  'This job is informational. It runs on a schedule and on manual dispatch only, so it',
+  'never gates a pull request or the merge queue.',
+  ''
+]
+
+if (tests.failing_tests?.length) {
+  summary.push('### Failing tests', '')
+  for (const failure of tests.failing_tests.slice(0, 25)) {
+    summary.push(`- \`${failure.name}\``)
+  }
+  if (tests.failing_tests.length > 25) {
+    summary.push(`- ...and ${tests.failing_tests.length - 25} more`)
+  }
+  summary.push('')
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary.join('\n')}\n`)
+}
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    [
+      `verdict=${verdict}`,
+      `total=${tests.total ?? ''}`,
+      `passed=${tests.passed ?? ''}`,
+      `failed=${tests.failed ?? ''}`,
+      ''
+    ].join('\n')
+  )
+}

--- a/.github/workflows/ci-crdt-skew-alarm.yaml
+++ b/.github/workflows/ci-crdt-skew-alarm.yaml
@@ -123,8 +123,13 @@ jobs:
         continue-on-error: true
         run: pnpm test:unit --reporter=json --outputFile="$RUNNER_TEMP/vitest.json" "$CRDT_TEST_DIR"
 
+      # `!cancelled()` rather than the implicit `success()`: when upstream resolution,
+      # install, or the override verification fails there is no vitest report, and the
+      # inconclusive verdict for that is exactly what the alarm should record. Under the
+      # implicit check this step is skipped and the run produces no artifact at all.
       - name: Publish pass/fail counts
         id: verdict
+        if: ${{ !cancelled() }}
         env:
           CMP_SHA: ${{ steps.upstream.outputs.sha }}
           CMP_SPEC: ${{ steps.upstream.outputs.spec }}
@@ -147,7 +152,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Ring the alarm
-        if: steps.verdict.outputs.verdict != 'no-skew-signal'
+        if: ${{ !cancelled() && steps.verdict.outputs.verdict != 'no-skew-signal' }}
         env:
           VERDICT: ${{ steps.verdict.outputs.verdict }}
           FAILED: ${{ steps.verdict.outputs.failed }}

--- a/.github/workflows/ci-crdt-skew-alarm.yaml
+++ b/.github/workflows/ci-crdt-skew-alarm.yaml
@@ -1,0 +1,156 @@
+# Description: Informational alarm for skew between the pinned
+# @comfyorg/comfy-multi-player release and that package's `main` branch.
+#
+# It reinstalls this repo against the tip of comfy-multi-player `main` and re-runs the
+# agent CRDT follower suite, so a breaking upstream change surfaces on a schedule rather
+# than at the next pin bump.
+#
+# NON-BLOCKING BY CONSTRUCTION: there is no `pull_request`, `push` or `merge_group`
+# trigger, so this workflow can never gate a pull request or the merge queue. A red run
+# is the alarm ringing, not a broken main.
+#
+# PREMISE (today): pin-vs-remote. The root package.json depends on a published
+# @comfyorg/comfy-multi-player version and this job overrides that resolution with a
+# tarball of upstream `main`. Once #16644 moves comfy-multi-player into the pnpm
+# workspace the premise becomes workspace-package-vs-release-tag, and the override step
+# should be replaced by a workspace-vs-tag comparison.
+name: 'CI: CRDT Skew Alarm'
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  CMP_PACKAGE: '@comfyorg/comfy-multi-player'
+  CMP_REMOTE: https://github.com/Comfy-Org/comfy-multi-player.git
+  CRDT_TEST_DIR: src/workbench/extensions/agent/crdt/
+
+jobs:
+  skew-alarm:
+    name: follower suite against comfy-multi-player main
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve upstream comfy-multi-player main
+        id: upstream
+        run: |
+          set -euo pipefail
+          sha="$(git ls-remote "$CMP_REMOTE" refs/heads/main | cut -f1)"
+          if [ -z "$sha" ]; then
+            echo "::error::could not resolve $CMP_REMOTE refs/heads/main"
+            exit 1
+          fi
+          {
+            echo "sha=$sha"
+            echo "spec=https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/$sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      # No pnpm store cache: this job installs and builds an unreviewed upstream
+      # revision, and setup-node's post step would write it into a lockfile-keyed cache
+      # that the publish workflows restore.
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Read the pinned version
+        id: pin
+        run: |
+          set -euo pipefail
+          version="$(node -p "
+            const pkg = require('./package.json');
+            pkg.dependencies?.[process.env.CMP_PACKAGE]
+              ?? pkg.devDependencies?.[process.env.CMP_PACKAGE]
+              ?? ''
+          ")"
+          if [ -z "$version" ]; then
+            echo "::error::$CMP_PACKAGE is not a direct dependency of package.json; the alarm's pin-vs-remote premise no longer holds (see the header comment about #16644)"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Override the pin with upstream main
+        run: |
+          node .github/scripts/crdt-skew-override.mjs --spec "${{ steps.upstream.outputs.spec }}"
+          git --no-pager diff -- pnpm-workspace.yaml
+
+      # pipefail matters here: without it `tee` would swallow a failed install and the
+      # verify step below would be the first thing to notice.
+      - name: Install against upstream main
+        run: |
+          set -euo pipefail
+          pnpm install --no-frozen-lockfile 2>&1 | tee "$RUNNER_TEMP/install.log"
+
+      # A pass only counts as "no skew" once the resolved tree provably references the
+      # upstream SHA. Without this gate the suite can quietly re-confirm the pin and
+      # report a cheerful all-clear that tested nothing.
+      - name: Verify the override took effect
+        env:
+          CMP_SHA: ${{ steps.upstream.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if grep -qi 'keys were ignored' "$RUNNER_TEMP/install.log"; then
+            echo "::error::pnpm ignored the override keys; the installed tree is still the pin"
+            exit 1
+          fi
+          if ! grep -q "$CMP_SHA" pnpm-lock.yaml; then
+            echo "::error::pnpm-lock.yaml does not resolve $CMP_PACKAGE at $CMP_SHA; any test result would be about the pin, not the skew"
+            exit 1
+          fi
+          if [ ! -d "node_modules/$CMP_PACKAGE/dist" ]; then
+            echo "::error::node_modules/$CMP_PACKAGE/dist is missing; the prepare build did not run"
+            exit 1
+          fi
+          echo "override verified: pnpm-lock.yaml resolves $CMP_PACKAGE at $CMP_SHA"
+
+      - name: Run the agent CRDT follower suite
+        id: tests
+        continue-on-error: true
+        run: pnpm test:unit --reporter=json --outputFile="$RUNNER_TEMP/vitest.json" "$CRDT_TEST_DIR"
+
+      - name: Publish pass/fail counts
+        id: verdict
+        env:
+          CMP_SHA: ${{ steps.upstream.outputs.sha }}
+          CMP_SPEC: ${{ steps.upstream.outputs.spec }}
+          PINNED_VERSION: ${{ steps.pin.outputs.version }}
+          TESTS_OUTCOME: ${{ steps.tests.outcome }}
+        run: |
+          node .github/scripts/crdt-skew-report.mjs \
+            --report "$RUNNER_TEMP/vitest.json" \
+            --out "$RUNNER_TEMP/crdt-skew-alarm.json"
+
+      - name: Upload the skew report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: crdt-skew-alarm
+          path: |
+            ${{ runner.temp }}/crdt-skew-alarm.json
+            ${{ runner.temp }}/vitest.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Ring the alarm
+        if: steps.verdict.outputs.verdict != 'no-skew-signal'
+        env:
+          VERDICT: ${{ steps.verdict.outputs.verdict }}
+          FAILED: ${{ steps.verdict.outputs.failed }}
+        run: |
+          echo "::error::$VERDICT ($FAILED failing) - $CMP_PACKAGE pinned at ${{ steps.pin.outputs.version }} vs main ${{ steps.upstream.outputs.sha }}"
+          exit 1

--- a/.github/workflows/ci-crdt-skew-alarm.yaml
+++ b/.github/workflows/ci-crdt-skew-alarm.yaml
@@ -156,6 +156,9 @@ jobs:
         env:
           VERDICT: ${{ steps.verdict.outputs.verdict }}
           FAILED: ${{ steps.verdict.outputs.failed }}
+          FILES_FAILED_TO_COLLECT: ${{ steps.verdict.outputs.files_failed_to_collect }}
+          PINNED_VERSION: ${{ steps.pin.outputs.version }}
+          CMP_SHA: ${{ steps.upstream.outputs.sha }}
         run: |
-          echo "::error::$VERDICT ($FAILED failing) - $CMP_PACKAGE pinned at ${{ steps.pin.outputs.version }} vs main ${{ steps.upstream.outputs.sha }}"
+          echo "::error::$VERDICT ($FAILED failing, $FILES_FAILED_TO_COLLECT files failed to collect) - $CMP_PACKAGE pinned at $PINNED_VERSION vs main $CMP_SHA"
           exit 1


### PR DESCRIPTION
## Summary

Re-homes the informational comfy-multi-player skew alarm into this repo, so follower drift between the pinned `@comfyorg/comfy-multi-player` release and that package's `main` is watched again.

## Changes

- **What**: adds `.github/workflows/ci-crdt-skew-alarm.yaml` plus two helper scripts. The job reinstalls this repo against the tip of comfy-multi-player `main` and re-runs `src/workbench/extensions/agent/crdt/`, publishing pass/fail counts to the job summary and a JSON artifact.
- **Breaking**: none. Schedule and `workflow_dispatch` only, so it has no `pull_request`, `push` or `merge_group` trigger and cannot gate a PR or the merge queue.
- **Dependencies**: none.

## Background

The alarm previously lived in comfy-multi-player as `.github/workflows/frontend-skew-alarm.yml`. It was removed when that repo's standalone CI went read-only, and no skew job has existed on either side since, so an upstream break is currently only discovered at the next pin bump.

## Review Focus

Two failure modes the previous implementation had, and how this one is guarded:

- The override is written to `pnpm-workspace.yaml`, not `package.json`. pnpm 11 no longer reads the `pnpm` field of `package.json` (it warns `keys were ignored`) and resolves the pin instead, which produces a green run that never tested upstream at all.
- The resolved `pnpm-lock.yaml` is asserted to reference the upstream SHA, and `node_modules/@comfyorg/comfy-multi-player/dist` to exist, before any pass/fail is reported. A suite that quietly re-confirmed the pin would otherwise read as an all-clear. Anything short of "ran to completion against upstream and passed" is reported as `inconclusive-*`, not `no-skew-signal`.
- The `allowBuilds` entry is injected alongside the override because `allowBuilds` is keyed by the resolved reference. Without it pnpm skips comfy-multi-player's `prepare` script, `dist/` is missing, and every import error reads as a skew signal rather than a harness fault.
- No pnpm store cache, per the `node_cache` note on `.github/actions/setup-frontend`: this job installs and builds an unreviewed upstream revision.

Premise today is pin-vs-remote, since the root `package.json` still depends on a published version. After [#16644](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16644) moves comfy-multi-player into the pnpm workspace, the premise becomes workspace-package-vs-release-tag and the override step should be replaced by a workspace-vs-tag comparison. The header comment and the `Read the pinned version` step both say so, and that step fails loudly rather than silently changing meaning if the dependency stops being direct.

## Verification

Run locally against this branch:

- `yamllint --config-file .yamllint .github/workflows/ci-crdt-skew-alarm.yaml` clean
- `actionlint .github/workflows/ci-crdt-skew-alarm.yaml` clean (exit 0, includes shellcheck of the `run:` blocks)
- `oxfmt --check .github/scripts/` clean
- `node --check` on both scripts
- `crdt-skew-override.mjs` applied to a copy of the real `pnpm-workspace.yaml`: both entries land as the first member of their block, the result parses as YAML, and `overrides['@comfyorg/comfy-multi-player']` reads back as the tarball spec. Against a file with no `overrides:` block it exits 1 with an actionable `::error::`.
- `crdt-skew-report.mjs` exercised over four fixture states: 328/328 -> `no-skew-signal`; 325/328 with 3 failures -> `skew-signal`; missing report -> `inconclusive-no-report`; green report with a failed runner -> `inconclusive-runner-failed`.

The end-to-end dispatched run can only happen after merge, since `workflow_dispatch` needs the workflow present on the default branch.
