### PR TITLE
docs(design-system): record the SemVer policy and the #14790 brand-layer verdict

### DIFF
--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -47,3 +47,22 @@ utilities. Size them with `size-*`, not font-size classes.
 
 Run the **Version Bump Design System** workflow to open a version PR, then merge
 it with the `Release` label. Publishing to npm happens automatically on merge.
+
+### SemVer policy
+
+This package follows SemVer for everything it exports: the CSS entry points
+(`style.css`, `base.css`, and every `./css/*` path in the [exports
+table](#exports)) and the icon SVGs are the public surface, and removing or
+repurposing tokens, `@font-face` declarations, or an entire file from that
+surface is a **major** bump — even when no in-repo consumer breaks, because
+published consumers pin this package by version.
+
+Precedent (recorded 2026-09-03): #14790 ("move the brand layer into the
+package") took brand tokens out of `_palette.css` and stopped `base.css`
+loading Inter. That PR was merged into a feature-branch stack with an
+in-tree version of `1.1.0`, and the review raised whether it should have been
+`2.0.0`. The verdict: the change **is breaking** — the PR's own body says so,
+and nothing was ever published to npm at `1.1.0` (the published versions are
+`1.0.0` and `1.0.1`), so there is no shipped `1.1.x` to defend. The next
+release that carries the brand-layer move must therefore be **`2.0.0`**, not
+`1.1.0`; do not let the in-tree `1.1.0` from that stack reach npm.


### PR DESCRIPTION
Docs-only follow-up answering the unanswered SemVer question on #14790 (benceruleanlu's approving review [pullrequestreview-4899465199](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14790#pullrequestreview-4899465199): "if we're following SemVer, we made breaking changes... maybe we want to bump it to 2.0 instead of 1.1?").

**Verdict: the brand-layer move was breaking, and the next release carrying it must be `2.0.0`, not `1.1.0`.** Key facts:

- The PR body itself declares the change **breaking**: `_palette.css` no longer carries brand tokens; `base.css` no longer loads Inter.
- At merge (2026-08-29, mergeCommit `ac4dd382`) the in-tree version was `1.1.0` — but that was on the non-default branch stack (`glary/design-system-brand-yellow-f2ff59`), and **`1.1.0` was never published**: npm for `@comfyorg/design-system` has only `1.0.0` and `1.0.1` (latest `1.0.1`). There is no shipped `1.1.x` to defend.
- On `main` today the version is `1.0.1`. When the stack lands and the Version Bump Design System workflow runs, the bump must be major (`2.0.0`), per SemVer for a 1.x package.

This PR records both the policy (exports are the public SemVer surface; removing tokens/`@font-face`/files from them = major) and the verdict in the README's `Releasing` section, so the answer lives where the package documents versioning. No code changes, no version change in this PR — the actual `2.0.0` bump belongs to the release workflow once the stack merges.

## Evidence

- `gh api repos/Comfy-Org/ComfyUI_frontend/contents/packages/design-system/package.json?ref=ac4dd38` → `"version": "1.1.0"`; `ref=main` → `"version": "1.0.1"`.
- `curl -s https://registry.npmjs.org/@comfyorg/design-system` → `dist-tags.latest: 1.0.1`, versions `1.0.0, 1.0.1`, last published 2026-08-21.
- `gh api repos/Comfy-Org/ComfyUI_frontend/compare/ac4dd38...main` → `diverged`, merge behind main: the stack (incl. #14790) is not on `main`.
- Commit is markdown-only: `git show --stat` → 1 file changed, `packages/design-system/README.md`.

<!-- authored-by:agent lane-srx-35-1653 -->
