### PR TITLE
refactor: localize deferred primitive widget restoration

### DIFF
--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -6,14 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
-  INodeOutputSlot
+  INodeOutputSlot,
+  ISerialisedNode
 } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { assetService } from '@/platform/assets/services/assetService'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -90,7 +90,7 @@ describe('PrimitiveNode', () => {
     LiteGraph.namedValuesRestore = false
   })
 
-  it('keeps its serialized value when the target widget has a stale value', () => {
+  function intFixture() {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -103,14 +103,32 @@ describe('PrimitiveNode', () => {
 
     const primitive = new PrimitiveNode('Primitive')
     graph.add(primitive)
+    return { graph, primitive, target }
+  }
+
+  function restoreIntPrimitive(
+    primitive: PrimitiveNode,
+    target: LGraphNode,
+    values: ISerialisedNode['widgets_values'],
+    named?: ISerialisedNode['widgets_values_named']
+  ) {
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
     primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+      fromPartial({
+        widgets_values: values,
+        widgets_values_named: named,
+        outputs: [{ type: 'INT' }]
+      })
     )
     appState.configuringGraph = false
-
     primitive.onAfterGraphConfigured()
+  }
+
+  it('keeps its serialized value when the target widget has a stale value', () => {
+    const { primitive, target } = intFixture()
+
+    restoreIntPrimitive(primitive, target, [222])
 
     expect(primitive.widgets?.[0].value).toBe(222)
 
@@ -122,7 +140,10 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(333)
   })
 
-  it('restores a serialized null value over the target widget value', () => {
+  it.each([
+    { label: 'null', value: null },
+    { label: 'undefined', value: undefined }
+  ])('restores an explicit $label value', ({ value }) => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -132,79 +153,29 @@ describe('PrimitiveNode', () => {
       [GET_CONFIG]: () => ['STRING', {}]
     }
     target.addWidget('text', 'value', 'stale', () => {})
-
     const primitive = new PrimitiveNode('Primitive')
     graph.add(primitive)
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
     primitive.configure(
-      fromPartial({ widgets_values: [null], outputs: [{ type: 'STRING' }] })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[0].value).toBeNull()
-  })
-
-  it('restores a serialized explicit undefined value over the target widget value', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('value', 'STRING')
-    target.inputs[0].widget = {
-      name: 'value',
-      [GET_CONFIG]: () => ['STRING', {}]
-    }
-    target.addWidget('text', 'value', 'stale', () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [undefined],
-        outputs: [{ type: 'STRING' }]
-      })
+      fromPartial({ widgets_values: [value], outputs: [{ type: 'STRING' }] })
     )
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
 
     expect(primitive.widgets).toHaveLength(1)
-    expect(primitive.widgets?.[0].value).toBeUndefined()
+    expect(primitive.widgets?.[0].value).toBe(value)
   })
 
-  it('prefers named serialized values when named restoration is enabled', () => {
+  it('restores named main and control values when enabled', () => {
     LiteGraph.namedValuesRestore = true
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
+    const { primitive, target } = intFixture()
 
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [222, 'randomize'],
-        widgets_values_named: {
-          value: 333,
-          control_after_generate: 'fixed'
-        },
-        outputs: [{ type: 'INT' }]
-      })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
+    restoreIntPrimitive(primitive, target, [222, 'randomize'], {
+      value: 333,
+      control_after_generate: 'fixed'
+    })
 
     expect(primitive.widgets?.[0].value).toBe(333)
     expect(primitive.widgets?.[1].value).toBe('fixed')
@@ -270,31 +241,6 @@ describe('PrimitiveNode', () => {
     })
   })
 
-  it('restores its serialized value when the widget is built by a recreate', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
-    )
-    appState.configuringGraph = false
-
-    primitive.recreateWidget()
-
-    expect(primitive.widgets?.[0].value).toBe(222)
-  })
-
   it('restores its serialized value after a reroute resolves its widget config', () => {
     const graph = new LGraph()
     const reroute = new LGraphNode('Reroute')
@@ -321,14 +267,7 @@ describe('PrimitiveNode', () => {
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
-    expect(
-      useWidgetValueStore().getRestoredWidgetValue(
-        graph.rootGraph.id,
-        primitive.id,
-        'value',
-        0
-      )
-    ).toEqual({ value: 222 })
+    expect(primitive.widgets).toBeUndefined()
     reroute.inputs[0].widget![GET_CONFIG] =
       target.inputs[0].widget?.[GET_CONFIG]
     primitive.recreateWidget()
@@ -336,39 +275,8 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(222)
   })
 
-  it('resets itself when the store reports a link the graph cannot resolve', () => {
-    const graph = new LGraph()
-    const node = new PrimitiveNode('Primitive')
-    graph.add(node)
-    useLinkStore().registerLink(graphScopeOf(graph), {
-      id: toLinkId(999),
-      graphId: graphScopeOf(graph).owningGraphId,
-      originNodeId: node.id,
-      originSlot: 0,
-      targetNodeId: toNodeId(42),
-      targetSlot: 0,
-      type: '*'
-    })
-    const onLastDisconnect = vi.spyOn(node, 'onLastDisconnect')
-
-    node.onAfterGraphConfigured()
-
-    expect(onLastDisconnect).toHaveBeenCalled()
-  })
-
-  it('drops its serialized value when the widget cannot be built during load', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
+  it('drops restoration when the store reports an unresolvable link', () => {
+    const { graph, primitive, target } = intFixture()
     useLinkStore().registerLink(graphScopeOf(graph), {
       id: toLinkId(999),
       graphId: graphScopeOf(graph).owningGraphId,
@@ -378,37 +286,54 @@ describe('PrimitiveNode', () => {
       targetSlot: 0,
       type: '*'
     })
+    const onLastDisconnect = vi.spyOn(primitive, 'onLastDisconnect')
     primitive.configure(
       fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
     )
 
     primitive.onAfterGraphConfigured()
 
+    expect(onLastDisconnect).toHaveBeenCalled()
     expect(primitive.widgets?.length).toBeFalsy()
-
     primitive.connect(0, target, 0)
-
     expect(primitive.widgets?.[0].value).toBe(111)
   })
 
+  it('keeps an unconsumed serialized value until its widget is first built', () => {
+    const { primitive, target } = intFixture()
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+
+    primitive.onAfterGraphConfigured()
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
   it('clears its serialized value when its output is disconnected', () => {
-    const graph = new LGraph()
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
+    const { primitive, target } = intFixture()
     primitive.configure(
       fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
     )
 
     primitive.onLastDisconnect()
+    primitive.connect(0, target, 0)
 
-    expect(
-      useWidgetValueStore().getRestoredWidgetValue(
-        graph.rootGraph.id,
-        primitive.id,
-        'value',
-        0
-      )
-    ).toBeUndefined()
+    expect(primitive.widgets?.[0].value).toBe(111)
+  })
+
+  it('does not retain restoration configured before graph insertion', () => {
+    const { graph, target } = intFixture()
+    const primitive = new PrimitiveNode('Primitive')
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    graph.add(primitive)
+
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(111)
   })
 })
 

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -1,6 +1,7 @@
 import { intersection } from 'es-toolkit/compat'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { createWidgetRestorationState } from '@/lib/litegraph/src/LGraphNode'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
@@ -23,7 +24,6 @@ import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetValue } from '@/types/simplifiedWidget'
-import { zeroUuid } from '@/utils/uuid'
 import {
   ComfyWidgets,
   addValueControlWidgets,
@@ -40,7 +40,6 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
-  private configuredWidgetType?: string
   static override category: string
   constructor(title: string) {
     super(title)
@@ -126,14 +125,16 @@ export class PrimitiveNode extends LGraphNode {
     return values
   }
 
-  override onConfigure(serialisedNode: ISerialisedNode) {
-    super.onConfigure?.(serialisedNode)
+  override configure(serialisedNode: ISerialisedNode) {
     const type = serialisedNode.outputs?.[0]?.type
-    this.configuredWidgetType = typeof type === 'string' ? type : undefined
-  }
+    super.configure(serialisedNode)
+    if (!this.graph || this.widgets?.length || typeof type !== 'string') return
 
-  protected override deferWidgetRestorationAfterConfigure(): boolean {
-    return Boolean(this.graph && this.configuredWidgetType)
+    useWidgetValueStore().setNodeWidgetRestoration(
+      this.graph.rootGraph.id,
+      this.id,
+      createWidgetRestorationState(serialisedNode)
+    )
   }
 
   override onAfterGraphConfigured() {
@@ -149,16 +150,12 @@ export class PrimitiveNode extends LGraphNode {
     }
   }
 
-  private _restorationGraphId() {
-    return this.graph?.rootGraph.id ?? zeroUuid
-  }
-
-  private _clearConfiguredWidgetValues() {
-    useWidgetValueStore().clearNodeWidgetRestoration(
-      this._restorationGraphId(),
-      this.id
-    )
-    this.configuredWidgetType = undefined
+  private _clearWidgetRestoration() {
+    if (this.graph)
+      useWidgetValueStore().clearNodeWidgetRestoration(
+        this.graph.rootGraph.id,
+        this.id
+      )
   }
 
   override onConnectionsChange(
@@ -247,6 +244,8 @@ export class PrimitiveNode extends LGraphNode {
     if (!config) return
 
     const { type } = getWidgetType(config)
+    if (recreating || this.outputs[0].type !== type)
+      this._clearWidgetRestoration()
     // Update our output to restrict to the widget type
     this.outputs[0].type = type
     this.outputs[0].name = type
@@ -275,19 +274,14 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-    const configuredType = recreating ? undefined : this.configuredWidgetType
-    if (configuredType && configuredType !== type) {
-      this._clearConfiguredWidgetValues()
-    }
-    const configuredWidgetValue =
-      configuredType === type
-        ? useWidgetValueStore().getRestoredWidgetValue(
-            this._restorationGraphId(),
-            this.id,
-            'value',
-            0
-          )
-        : undefined
+    const restoredValue = this.graph
+      ? useWidgetValueStore().getRestoredWidgetValue(
+          this.graph.rootGraph.id,
+          this.id,
+          'value',
+          0
+        )
+      : undefined
 
     try {
       if (
@@ -297,7 +291,7 @@ export class PrimitiveNode extends LGraphNode {
         widget = this._createAssetWidget(node, widgetName, inputData)
         const theirWidget = node.widgets?.find((w) => w.name === widgetName)
         if (theirWidget) widget.value = theirWidget.value
-        if (configuredWidgetValue) widget.value = configuredWidgetValue.value
+        if (restoredValue) widget.value = restoredValue.value
         this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
         return
       }
@@ -316,7 +310,7 @@ export class PrimitiveNode extends LGraphNode {
           widget.value = theirWidget.value
         }
       }
-      if (configuredWidgetValue) widget.value = configuredWidgetValue.value
+      if (restoredValue) widget.value = restoredValue.value
 
       if (
         !inputData?.[1]?.control_after_generate &&
@@ -340,7 +334,7 @@ export class PrimitiveNode extends LGraphNode {
 
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
     } finally {
-      if (configuredType) this._clearConfiguredWidgetValues()
+      this._clearWidgetRestoration()
     }
   }
 
@@ -467,7 +461,7 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   onLastDisconnect() {
-    this._clearConfiguredWidgetValues()
+    this._clearWidgetRestoration()
     // We can't remove + re-add the output here as if you drag a link over the same link
     // it removes, then re-adds, causing it to break
     this.outputs[0].type = '*'

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -183,6 +183,30 @@ function serialiseWidgetValues(widgets: IBaseWidget[]) {
   return { widgets_values: positional, widgets_values_named: named }
 }
 
+export function createWidgetRestorationState(
+  info: Pick<ISerialisedNode, 'widgets_values' | 'widgets_values_named'>,
+  fallbackNames?: readonly string[]
+) {
+  const positional = Array.from(info.widgets_values ?? [])
+  const named =
+    info.widgets_values_named ??
+    (info.widgets_values && fallbackNames
+      ? Object.fromEntries(
+          positional.flatMap((value, index) =>
+            fallbackNames[index] ? [[fallbackNames[index], value]] : []
+          )
+        )
+      : undefined)
+
+  return {
+    positional,
+    named: named ? { ...named } : undefined,
+    restoreNamed: Boolean(
+      named && (LiteGraph.namedValuesRestore || fallbackNames)
+    )
+  }
+}
+
 interface ConnectByTypeOptions {
   /** @deprecated Events */
   createEventInCase?: boolean
@@ -1127,28 +1151,18 @@ export class LGraphNode
     // SubgraphNode callback.
     this._internalConfigureAfterSlots?.()
 
-    const positionalValues = Array.from(info.widgets_values ?? [])
-    const getNamedValues = () => {
-      if (info.widgets_values_named) return info.widgets_values_named
-
-      const map = this.constructor.nodeData?.fallbackWidgetsValuesNames
-      if (!info.widgets_values || !map) return
-
-      return Object.fromEntries(
-        positionalValues.flatMap((v, i) => (map[i] ? [[map[i], v]] : []))
-      )
-    }
-    const namedValues = getNamedValues()
-    const graphId = this.graph?.rootGraph.id ?? zeroUuid
-    const shouldRestoreNamed =
-      LiteGraph.namedValuesRestore ||
+    const restoration = createWidgetRestorationState(
+      info,
       this.constructor.nodeData?.fallbackWidgetsValuesNames
+    )
+    const namedValues = restoration.named
+    const graphId = this.graph?.rootGraph.id ?? zeroUuid
     try {
-      useWidgetValueStore().setNodeWidgetRestoration(graphId, this.id, {
-        positional: positionalValues,
-        named: namedValues ? { ...namedValues } : undefined,
-        restoreNamed: Boolean(namedValues && shouldRestoreNamed)
-      })
+      useWidgetValueStore().setNodeWidgetRestoration(
+        graphId,
+        this.id,
+        restoration
+      )
 
       if (this.widgets) {
         for (const w of this.widgets) {
@@ -1202,14 +1216,8 @@ export class LGraphNode
         )
       }
     } finally {
-      if (!this.deferWidgetRestorationAfterConfigure()) {
-        useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
-      }
+      useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
     }
-  }
-
-  protected deferWidgetRestorationAfterConfigure(): boolean {
-    return false
   }
 
   /**


### PR DESCRIPTION
## Summary

Simplifies the restoration added by #16459 by keeping deferred lifetime handling inside `PrimitiveNode` instead of extending `LGraphNode` with a Primitive-driven hook and parallel instance state.

## Changes

- **What**: Extracts the existing serialized-to-generic restoration conversion, then reuses that state when a graph-attached Primitive has not materialized its link-derived widget yet.
- **What**: Removes `configuredWidgetType`, the zero-UUID fallback, and `deferWidgetRestorationAfterConfigure()`; the configured output slot remains the type source of truth.
- **What**: Clears pending restoration after materialization, type mismatch, disconnect, or removal, and consolidates the tests around observable behavior.

## Review Focus

This is stacked on #16459. The key question is whether `PrimitiveNode.configure()` is the narrowest acceptable owner for extending restoration through delayed link resolution.

I did not add an ECS System: there is no general reconciliation scheduler to phase this through yet. A System becomes a better fit when connectivity-to-widget materialization is modeled for all deferred entities, rather than as a Primitive-only scheduler.