### PR TITLE
fix: secure remaining UUID fallbacks

### DIFF
--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -555,6 +555,14 @@ describe('formatUtil', () => {
       expect(getRandomValues).toHaveBeenCalledOnce()
     })
 
+    it('clears the version and variant high bits', () => {
+      vi.stubGlobal('crypto', {
+        getRandomValues: (bytes: Uint8Array) => bytes.fill(0xff)
+      })
+
+      expect(generateUUID()).toBe('ffffffff-ffff-4fff-bfff-ffffffffffff')
+    })
+
     it('throws when Web Crypto is unavailable', () => {
       vi.stubGlobal('crypto', undefined)
 

--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   appendWorkflowJsonExt,
@@ -540,6 +540,27 @@ describe('formatUtil', () => {
       ['non-hex character', 'gcea40bb-b0cf-4b40-a758-8935cfe8d52f']
     ])('rejects a %s', ([, value]) => {
       expect(isValidUuid(value)).toBe(false)
+    })
+  })
+
+  describe('generateUUID', () => {
+    it('uses getRandomValues when randomUUID is unavailable', () => {
+      const getRandomValues = vi.fn((bytes: Uint8Array) => {
+        bytes.set(Array.from({ length: 16 }, (_, index) => index))
+        return bytes
+      })
+      vi.stubGlobal('crypto', { getRandomValues })
+
+      expect(generateUUID()).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f')
+      expect(getRandomValues).toHaveBeenCalledOnce()
+    })
+
+    it('throws when Web Crypto is unavailable', () => {
+      vi.stubGlobal('crypto', undefined)
+
+      expect(() => generateUUID()).toThrow(
+        'Web Crypto is required to generate a UUID'
+      )
     })
   })
 

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -411,24 +411,25 @@ export const isValidUuid = (value: unknown): value is string =>
   typeof value === 'string' && UUID_PATTERN.test(value)
 
 /**
- * Generates a RFC4122 compliant UUID v4 using the native crypto API when available
+ * Generates an RFC4122 compliant UUID v4 using the Web Crypto API.
  * @returns A properly formatted UUID string
+ * @throws When the Web Crypto API is unavailable
  */
 export const generateUUID = (): string => {
-  // Use native crypto.randomUUID() if available (modern browsers)
-  if (
-    typeof crypto !== 'undefined' &&
-    typeof crypto.randomUUID === 'function'
-  ) {
-    return crypto.randomUUID()
+  const webCrypto = globalThis.crypto
+  if (typeof webCrypto?.randomUUID === 'function') {
+    return webCrypto.randomUUID()
   }
 
-  // Fallback implementation for older browsers
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0
-    const v = c === 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
+  if (typeof webCrypto?.getRandomValues !== 'function') {
+    throw new Error('Web Crypto is required to generate a UUID')
+  }
+
+  const bytes = webCrypto.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'))
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`
 }
 
 const isCivitaiHost = (hostname: string): boolean =>

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   clearPendingSubscriptionCheckoutAttempt,
@@ -54,5 +54,22 @@ describe('subscriptionCheckoutTracker', () => {
 
     expect(metadata).not.toBeNull()
     expect(metadata).not.toHaveProperty('payment_intent_source')
+  })
+
+  it('uses secure random values for attempt IDs on insecure origins', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(0)
+        return bytes
+      }
+    })
+
+    const attempt = recordPendingSubscriptionCheckoutAttempt({
+      tier: 'pro',
+      cycle: 'monthly',
+      checkout_type: 'new'
+    })
+
+    expect(attempt.attempt_id).toBe('00000000-0000-4000-8000-000000000000')
   })
 })

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -87,10 +87,6 @@ const dispatchPendingCheckoutChangeEvent = () => {
   window.dispatchEvent(new Event(PENDING_SUBSCRIPTION_CHECKOUT_EVENT))
 }
 
-const createAttemptId = (): string => {
-  return generateUUID()
-}
-
 type CheckoutStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
 
 const getStorage = (): CheckoutStorage | null => {
@@ -284,7 +280,7 @@ export const createPendingSubscriptionCheckoutAttempt = (
   input: PendingSubscriptionCheckoutAttemptInput
 ): PendingSubscriptionCheckoutAttempt => {
   return {
-    attempt_id: createAttemptId(),
+    attempt_id: generateUUID(),
     started_at_ms: Date.now(),
     tier: input.tier,
     cycle: input.cycle,

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -1,4 +1,5 @@
 import type { SubscriptionDuration } from '@comfyorg/ingest-types'
+import { generateUUID } from '@comfyorg/shared-frontend-utils/formatUtil'
 import {
   getTierPrice,
   toTierKey
@@ -87,11 +88,7 @@ const dispatchPendingCheckoutChangeEvent = () => {
 }
 
 const createAttemptId = (): string => {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
-    return crypto.randomUUID()
-  }
-
-  return `attempt-${Date.now()}`
+  return generateUUID()
 }
 
 type CheckoutStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>

--- a/src/renderer/extensions/layerEditor/psdExport.test.ts
+++ b/src/renderer/extensions/layerEditor/psdExport.test.ts
@@ -371,13 +371,15 @@ describe('helpers', () => {
     expect(makeGuid()).toMatch(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/)
   })
 
-  it('falls back to a manual guid when randomUUID is unavailable', () => {
-    vi.stubGlobal('crypto', {})
-    try {
-      expect(makeGuid()).toMatch(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/)
-    } finally {
-      vi.unstubAllGlobals()
-    }
+  it('uses secure random values when randomUUID is unavailable', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(0)
+        return bytes
+      }
+    })
+
+    expect(makeGuid()).toBe('00000000-0000-4000-8000-000000000000')
   })
 
   it('computes placed bounds for plain and rotated transforms', () => {

--- a/src/renderer/extensions/layerEditor/psdExport.ts
+++ b/src/renderer/extensions/layerEditor/psdExport.ts
@@ -1,4 +1,5 @@
 import type { Layer, LayerMaskData, LinkedFile, Psd } from 'ag-psd'
+import { generateUUID } from '@comfyorg/shared-frontend-utils/formatUtil'
 
 import type { Compositor } from './engine/compositor'
 import type { ContentEntry, ContentStore } from './engine/content'
@@ -32,14 +33,7 @@ export interface PsdExportDeps {
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v))
 
 export function makeGuid(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
-    return crypto.randomUUID()
-  let out = ''
-  for (let i = 0; i < 36; i++) {
-    if (i === 8 || i === 13 || i === 18 || i === 23) out += '-'
-    else out += Math.floor(Math.random() * 16).toString(16)
-  }
-  return out
+  return generateUUID()
 }
 
 export function transformCorners(t: Transform): number[] {


### PR DESCRIPTION
## Summary

Removes the remaining insecure-origin UUID fallbacks identified in #16777.

## Changes

- **What**: `generateUUID()` now falls back from `crypto.randomUUID()` to `crypto.getRandomValues()` and fails closed without Web Crypto. PSD GUIDs and subscription checkout attempt IDs now use that shared implementation.
- **Tests**: Covers deterministic `getRandomValues()` output, unavailable-Web-Crypto failure, PSD GUID fallback, and checkout attempt IDs.

## Review Focus

Confirm fail-closed behavior is appropriate when both Web Crypto UUID APIs are unavailable.

## Evidence

- `pnpm test:unit packages/shared-frontend-utils/src/formatUtil.test.ts src/renderer/extensions/layerEditor/psdExport.test.ts src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.test.ts` — 128 passed
- `pnpm typecheck` — passed
- targeted ESLint and type-aware oxlint — passed
- `pnpm --filter @comfyorg/shared-frontend-utils typecheck` — existing unrelated `piiUtil.test.ts` `$set`/`$set_once` errors; full repository typecheck passed

Source: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16777#discussion_r3925373178

<!-- authored-by:agent lane-uuid-1-1658 -->
