### PR TITLE
feat(workflow): report publish tag fallback

### DIFF
--- a/src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.test.ts
@@ -5,12 +5,19 @@ import { nextTick } from 'vue'
 
 import { COMFY_HUB_TAG_OPTIONS } from '@/platform/workflow/sharing/constants/comfyHubTags'
 
-const mockFetchTagLabels = vi.hoisted(() => vi.fn())
+const { mockFetchTagLabels, mockReportError } = vi.hoisted(() => ({
+  mockFetchTagLabels: vi.fn(),
+  mockReportError: vi.fn()
+}))
 
 vi.mock('@/platform/workflow/sharing/services/comfyHubService', () => ({
   useComfyHubService: () => ({
     fetchTagLabels: mockFetchTagLabels
   })
+}))
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
 }))
 
 import ComfyHubDescribeStep from './ComfyHubDescribeStep.vue'
@@ -123,7 +130,8 @@ describe('ComfyHubDescribeStep', () => {
   })
 
   it('falls back to hardcoded tags when API fails', async () => {
-    mockFetchTagLabels.mockRejectedValue(new Error('network error'))
+    const error = new Error('network error')
+    mockFetchTagLabels.mockRejectedValue(error)
     const { container } = renderStep()
     await flushPromises()
 
@@ -136,6 +144,18 @@ describe('ComfyHubDescribeStep', () => {
 
     expect(suggestionValues).toHaveLength(10)
     expect(suggestionValues[0]).toBe(COMFY_HUB_TAG_OPTIONS[0])
+    expect(mockReportError).toHaveBeenCalledWith(error, {
+      errorType: 'workflow_publish_tags_fallback',
+      tags: {
+        failure_kind: 'degraded',
+        feature_area: 'workflow',
+        operation: 'load',
+        outcome: 'recovered',
+        assert_mode: 'soft'
+      },
+      context: { fallback_tag_count: COMFY_HUB_TAG_OPTIONS.length },
+      level: 'warning'
+    })
   })
 
   it('adds a suggested tag when clicked', async () => {

--- a/src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.vue
@@ -93,6 +93,7 @@ import TagsInputItem from '@/components/ui/tags-input/TagsInputItem.vue'
 import TagsInputItemDelete from '@/components/ui/tags-input/TagsInputItemDelete.vue'
 import TagsInputItemText from '@/components/ui/tags-input/TagsInputItemText.vue'
 import Textarea from '@/components/ui/textarea/Textarea.vue'
+import { reportError } from '@/platform/telemetry/reportError'
 import { COMFY_HUB_TAG_OPTIONS } from '@/platform/workflow/sharing/constants/comfyHubTags'
 import { useComfyHubService } from '@/platform/workflow/sharing/services/comfyHubService'
 import { computed, onMounted, ref } from 'vue'
@@ -120,8 +121,19 @@ const { fetchTagLabels } = useComfyHubService()
 onMounted(async () => {
   try {
     tagOptions.value = await fetchTagLabels()
-  } catch {
-    // Fall back to hardcoded tags
+  } catch (error) {
+    reportError(error, {
+      errorType: 'workflow_publish_tags_fallback',
+      tags: {
+        failure_kind: 'degraded',
+        feature_area: 'workflow',
+        operation: 'load',
+        outcome: 'recovered',
+        assert_mode: 'soft'
+      },
+      context: { fallback_tag_count: COMFY_HUB_TAG_OPTIONS.length },
+      level: 'warning'
+    })
   }
 })
 


### PR DESCRIPTION
- Publish-tag fallback now reaches telemetry.
- Hardcoded suggestions and user flow stay unchanged.
- Focused tests and local gates are green.

<details><summary>Full context for agent readers</summary>

When live ComfyHub tag labels fail to load, `ComfyHubDescribeStep.vue` now reports `workflow_publish_tags_fallback` through `reportError()` at warning level before retaining the existing hardcoded suggestions. The event feeds the `failure_kind: degraded` / `feature_area: workflow` alert family and includes only the safe fallback-tag count.

The focused component test verifies both the rendered fallback and the exact tags/context. This depends on the telemetry taxonomy in [#16784](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16784). Open [#14173](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14173) also touches the component, but only changes the title translation keys near the top of the template; this instrumentation changes the mounted fetch catch and test.

## Evidence

- `NODE_OPTIONS=--no-experimental-webstorage pnpm test:unit src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.test.ts` — 6 passed
- `pnpm exec oxfmt --check <two changed files>` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with existing warnings only
- pre-push `pnpm knip --cache` — passed
- `git show --check HEAD` — passed

</details>

<!-- authored-by:agent lane-tele-6-1653 -->