### PR TITLE
fix(agent): stop retrying terminal CRDT refusals

### DIFF
--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -35,6 +35,8 @@ const STATUS: AgentCrdtStatus = {
   workflowId: 'doc-1',
   updatesApplied: 4,
   lastFrameType: 'doc_update',
+  subscriptionStatus: 'connected',
+  refusalCode: null,
   outcomes: {
     received: 5,
     applied: 4,

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -129,6 +129,13 @@ const REPORT_SOURCE_LABELS: readonly {
 const STATUS_ROWS = [
   ['doc id', () => status.workflowId ?? S.none],
   ['connected', () => (status.connected ? S.yes : S.no)],
+  [
+    'subscription',
+    () =>
+      status.refusalCode
+        ? `${status.subscriptionStatus} (${status.refusalCode})`
+        : status.subscriptionStatus
+  ],
   ['updates applied', () => String(status.updatesApplied)],
   [
     'outcomes (recv/applied/skip/err/gap/reset/drop)',

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -44,6 +44,8 @@ const SNAPSHOT: CrdtDebugSnapshot = {
     workflowId: 'doc-1',
     updatesApplied: 3,
     lastFrameType: 'doc_update',
+    subscriptionStatus: 'connected',
+    refusalCode: null,
     outcomes: {
       received: 3,
       applied: 3,

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -127,7 +127,26 @@ describe('collectCrdtDebugReport', () => {
     expect(report).toContain('Comfy.Setting')
     expect(report).toContain('doc-1')
     expect(report).toContain('doc_update')
+    expect(report).toContain('**Subscription:** connected')
     expect(report).toContain('Document stamps')
+  })
+
+  it('shows the refusal code next to a refused subscription', async () => {
+    const report = await collectCrdtDebugReport({
+      crdt: {
+        ...SNAPSHOT,
+        status: {
+          ...SNAPSHOT.status,
+          connected: false,
+          subscriptionStatus: 'too_large',
+          refusalCode: 'too_large'
+        }
+      },
+      sources: ALL_SOURCES,
+      events: []
+    })
+
+    expect(report).toContain('**Subscription:** too_large (too_large)')
   })
 
   it('leads with an Identifiers block carrying every ID a backend engineer searches by', async () => {

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -382,6 +382,7 @@ function crdtSection(crdt: CrdtDebugSnapshot): string {
   return [
     `- **Enabled:** ${crdt.status.enabled}`,
     `- **Connected:** ${crdt.status.connected}`,
+    `- **Subscription:** ${crdt.status.subscriptionStatus}${crdt.status.refusalCode ? ` (${crdt.status.refusalCode})` : ''}`,
     `- **Doc id:** ${crdt.status.workflowId ?? 'none'}`,
     `- **Updates applied:** ${crdt.status.updatesApplied}`,
     `- **Last frame:** ${crdt.status.lastFrameType ?? 'none'}`,

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -217,6 +217,67 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('stops retrying and reports too_large as a distinct terminal status', () => {
+    vi.useFakeTimers()
+    const { unmount, status } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false, code: 'too_large' })
+    vi.runAllTimers()
+    apiState.target.dispatchEvent(new Event('status'))
+    apiState.target.dispatchEvent(new Event('reconnected'))
+
+    expect(bridge().resubscribe).not.toHaveBeenCalled()
+    expect(bridge().reconcile).not.toHaveBeenCalled()
+    expect(status().subscriptionStatus).toBe('too_large')
+    expect(status().refusalCode).toBe('too_large')
+    unmount()
+  })
+
+  it.for(['unsupported', 'invalid_frame'])(
+    'stops retrying permanent %s refusals',
+    (code) => {
+      vi.useFakeTimers()
+      const { unmount, status } = mountFollower('wf-1')
+
+      dispatchFrame('doc_subscribed', { ok: false, code })
+      vi.runAllTimers()
+
+      expect(bridge().resubscribe).not.toHaveBeenCalled()
+      expect(status().subscriptionStatus).toBe('permanent_failure')
+      expect(status().refusalCode).toBe(code)
+      unmount()
+    }
+  )
+
+  it.for(['too_many', 'overloaded', 'error', 'resubscribe', 'unknown_code'])(
+    'retries transient %s refusals',
+    (code) => {
+      vi.useFakeTimers()
+      const { unmount, status } = mountFollower('wf-1')
+
+      dispatchFrame('doc_subscribed', { ok: false, code })
+      vi.advanceTimersByTime(500)
+
+      expect(bridge().resubscribe).toHaveBeenCalledTimes(1)
+      expect(status().subscriptionStatus).toBe('retrying')
+      expect(status().refusalCode).toBe(code)
+      unmount()
+    }
+  )
+
+  it('keeps not_found transient for the FE-1901 creation race', () => {
+    vi.useFakeTimers()
+    const { unmount, status } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false, code: 'not_found' })
+    vi.advanceTimersByTime(500)
+
+    expect(bridge().resubscribe).toHaveBeenCalledTimes(1)
+    expect(status().subscriptionStatus).toBe('retrying')
+    expect(status().refusalCode).toBe('not_found')
+    unmount()
+  })
+
   it('FE-1901: a confirmed subscribe clears the retry timer', () => {
     vi.useFakeTimers()
     const { unmount, status } = mountFollower('wf-1')

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -191,7 +191,7 @@ describe('useAgentCrdtFollower', () => {
 
   it('FE-1901: retries a refused subscribe with bounded exponential backoff', () => {
     vi.useFakeTimers()
-    const { unmount } = mountFollower('wf-1')
+    const { unmount, status } = mountFollower('wf-1')
 
     dispatchFrame('doc_subscribed', { ok: false })
     expect(bridge().resubscribe).not.toHaveBeenCalled()
@@ -211,9 +211,31 @@ describe('useAgentCrdtFollower', () => {
       vi.advanceTimersByTime(500 * 2 ** attempt)
     }
     expect(bridge().resubscribe).toHaveBeenCalledTimes(6)
-    dispatchFrame('doc_subscribed', { ok: false })
+    expect(status().subscriptionStatus).toBe('retrying')
+    dispatchFrame('doc_subscribed', { ok: false, code: 'overloaded' })
     vi.advanceTimersByTime(60_000)
     expect(bridge().resubscribe).toHaveBeenCalledTimes(6)
+    expect(status().subscriptionStatus).toBe('retry_exhausted')
+    expect(status().refusalCode).toBe('overloaded')
+    unmount()
+  })
+
+  it('a reconnect gives an exhausted follower one more attempt', () => {
+    vi.useFakeTimers()
+    const { unmount, status } = mountFollower('wf-1')
+
+    for (let attempt = 0; attempt < 7; attempt++) {
+      dispatchFrame('doc_subscribed', { ok: false })
+      vi.runAllTimers()
+    }
+    expect(status().subscriptionStatus).toBe('retry_exhausted')
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(bridge().resubscribe).toHaveBeenCalledTimes(7)
+    expect(status().subscriptionStatus).toBe('retrying')
+
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(status().subscriptionStatus).toBe('connected')
     unmount()
   })
 
@@ -275,6 +297,66 @@ describe('useAgentCrdtFollower', () => {
     expect(bridge().resubscribe).toHaveBeenCalledTimes(1)
     expect(status().subscriptionStatus).toBe('retrying')
     expect(status().refusalCode).toBe('not_found')
+    unmount()
+  })
+
+  it('keeps forbidden transient: the server maps it from the same not-found error', () => {
+    vi.useFakeTimers()
+    const { unmount, status } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false, code: 'forbidden' })
+    vi.advanceTimersByTime(500)
+
+    expect(bridge().resubscribe).toHaveBeenCalledTimes(1)
+    expect(status().subscriptionStatus).toBe('retrying')
+    expect(status().refusalCode).toBe('forbidden')
+    unmount()
+  })
+
+  it('records the reconnect a terminal follower ignores', async () => {
+    const { recordDevEvent } = await import('./devPanelLog')
+    const { unmount } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false, code: 'too_large' })
+    apiState.target.dispatchEvent(new Event('reconnected'))
+
+    expect(recordDevEvent).toHaveBeenCalledWith('reconnected', {
+      ignored: 'too_large',
+      refusalCode: 'too_large'
+    })
+    expect(bridge().resubscribe).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('a reconnect without a subscribed workflow stays idle', () => {
+    const { unmount, status } = mountFollower(null)
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+
+    expect(status().subscriptionStatus).toBe('idle')
+    expect(status().refusalCode).toBeNull()
+    unmount()
+  })
+
+  it('a workflow change clears a terminal status and lets the follower recover', async () => {
+    vi.useFakeTimers()
+    const { unmount, workflowId, status } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false, code: 'too_large' })
+    expect(status().subscriptionStatus).toBe('too_large')
+
+    workflowId.value = 'wf-2'
+    await nextTick()
+    expect(status().subscriptionStatus).toBe('idle')
+    expect(status().refusalCode).toBeNull()
+    expect(bridge().subscribe).toHaveBeenLastCalledWith('wf-2')
+
+    apiState.target.dispatchEvent(new Event('status'))
+    expect(bridge().reconcile).toHaveBeenCalledTimes(1)
+
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(status().subscriptionStatus).toBe('connected')
+    expect(status().connected).toBe(true)
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -155,6 +155,13 @@ export interface AgentCrdtOutcomeCounters {
   dropped: number
 }
 
+type AgentCrdtSubscriptionStatus =
+  | 'idle'
+  | 'connected'
+  | 'retrying'
+  | 'too_large'
+  | 'permanent_failure'
+
 export interface AgentCrdtStatus {
   enabled: boolean
   connected: boolean
@@ -167,7 +174,33 @@ export interface AgentCrdtStatus {
    */
   updatesApplied: number
   lastFrameType: string | null
+  subscriptionStatus: AgentCrdtSubscriptionStatus
+  refusalCode: string | null
   outcomes: AgentCrdtOutcomeCounters
+}
+
+type AgentCrdtSubscriptionState =
+  | { status: 'idle' | 'connected'; refusalCode: null }
+  | { status: 'retrying'; refusalCode: string | null }
+  | { status: 'too_large'; refusalCode: 'too_large' }
+  | {
+      status: 'permanent_failure'
+      refusalCode: 'unsupported' | 'invalid_frame'
+    }
+
+function refusedSubscriptionState(code: unknown): AgentCrdtSubscriptionState {
+  if (code === 'too_large') return { status: 'too_large', refusalCode: code }
+  if (code === 'unsupported' || code === 'invalid_frame') {
+    return { status: 'permanent_failure', refusalCode: code }
+  }
+  return {
+    status: 'retrying',
+    refusalCode: typeof code === 'string' ? code : null
+  }
+}
+
+function isTerminalSubscription(state: AgentCrdtSubscriptionState): boolean {
+  return state.status === 'too_large' || state.status === 'permanent_failure'
 }
 
 export const apiTransport: DocFrameTransport = {
@@ -197,6 +230,10 @@ export function useAgentCrdtFollower(
   const updatesApplied = ref(0)
   const lastFrameType = ref<string | null>(null)
   const subscribedWorkflowId = ref<string | null>(null)
+  const subscription = ref<AgentCrdtSubscriptionState>({
+    status: 'idle',
+    refusalCode: null
+  })
   const outcomes = ref<AgentCrdtOutcomeCounters>({
     received: 0,
     applied: 0,
@@ -363,6 +400,7 @@ export function useAgentCrdtFollower(
     recordDevEvent('doc_subscribed', event.detail ?? null)
     if (ok) {
       clearSubscribeRetry()
+      subscription.value = { status: 'connected', refusalCode: null }
       armStaleProbe()
       // FE-1902 (poc-3): only a CONFIRMED binding is worth rebinding to after
       // a remount — persist on ok, not on intent.
@@ -370,7 +408,16 @@ export function useAgentCrdtFollower(
         persistConfirmedDocId(subscribedWorkflowId.value)
     } else {
       clearStaleProbe()
-      scheduleSubscribeRetry()
+      subscription.value = refusedSubscriptionState(event.detail?.code)
+      switch (subscription.value.status) {
+        case 'too_large':
+        case 'permanent_failure':
+          clearSubscribeRetry()
+          break
+        case 'retrying':
+          scheduleSubscribeRetry()
+          break
+      }
       // FE #16637 residual: a refusal is the earliest signal the sender can
       // get that its in-flight batch's doc is gone — don't make it wait out
       // the 10 s result-silence window to notice on its own.
@@ -524,8 +571,10 @@ export function useAgentCrdtFollower(
     )
   }
   const onReconnected: EventListener = () => {
+    if (isTerminalSubscription(subscription.value)) return
     connected.value = false
     clearStaleProbe()
+    subscription.value = { status: 'retrying', refusalCode: null }
     recordDevEvent('reconnected', null)
     bridge.resubscribe()
   }
@@ -543,6 +592,7 @@ export function useAgentCrdtFollower(
    * nothing.
    */
   const onSocketActivity: EventListener = () => {
+    if (isTerminalSubscription(subscription.value)) return
     bridge.reconcile()
   }
 
@@ -577,6 +627,7 @@ export function useAgentCrdtFollower(
       clearSubscribeRetry()
       clearStaleProbe()
       connected.value = false
+      subscription.value = { status: 'idle', refusalCode: null }
       knownDocNodeIds = new Set()
       if (!active) {
         if (next !== null) initialBind = false
@@ -653,6 +704,8 @@ export function useAgentCrdtFollower(
     workflowId: subscribedWorkflowId.value,
     updatesApplied: updatesApplied.value,
     lastFrameType: lastFrameType.value,
+    subscriptionStatus: subscription.value.status,
+    refusalCode: subscription.value.refusalCode,
     outcomes: outcomes.value
   }))
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -159,6 +159,7 @@ type AgentCrdtSubscriptionStatus =
   | 'idle'
   | 'connected'
   | 'retrying'
+  | 'retry_exhausted'
   | 'too_large'
   | 'permanent_failure'
 
@@ -181,7 +182,7 @@ export interface AgentCrdtStatus {
 
 type AgentCrdtSubscriptionState =
   | { status: 'idle' | 'connected'; refusalCode: null }
-  | { status: 'retrying'; refusalCode: string | null }
+  | { status: 'retrying' | 'retry_exhausted'; refusalCode: string | null }
   | { status: 'too_large'; refusalCode: 'too_large' }
   | {
       status: 'permanent_failure'
@@ -193,6 +194,9 @@ function refusedSubscriptionState(code: unknown): AgentCrdtSubscriptionState {
   if (code === 'unsupported' || code === 'invalid_frame') {
     return { status: 'permanent_failure', refusalCode: code }
   }
+  // Everything else stays transient, including `forbidden`: the server maps
+  // it from the same doc-host error as "workflow not found or access denied",
+  // so it shares the FE-1901 creation race with `not_found`.
   return {
     status: 'retrying',
     refusalCode: typeof code === 'string' ? code : null
@@ -372,11 +376,12 @@ export function useAgentCrdtFollower(
     subscribeRetryAttempt = 0
   }
 
-  const scheduleSubscribeRetry = (): void => {
-    if (subscribeRetryTimer !== null) return
-    if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) return
+  /** Arms the next backoff step; false once the attempt budget is spent. */
+  const scheduleSubscribeRetry = (): boolean => {
+    if (subscribeRetryTimer !== null) return true
+    if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) return false
     const target = subscribedWorkflowId.value
-    if (target === null) return
+    if (target === null) return false
     const delay = SUBSCRIBE_RETRY_BASE_MS * 2 ** subscribeRetryAttempt
     subscribeRetryAttempt += 1
     subscribeRetryTimer = setTimeout(() => {
@@ -389,6 +394,7 @@ export function useAgentCrdtFollower(
       })
       bridge.resubscribe()
     }, delay)
+    return true
   }
 
   const onSubscribed: EventListener = (event) => {
@@ -415,7 +421,12 @@ export function useAgentCrdtFollower(
           clearSubscribeRetry()
           break
         case 'retrying':
-          scheduleSubscribeRetry()
+          if (!scheduleSubscribeRetry()) {
+            subscription.value = {
+              status: 'retry_exhausted',
+              refusalCode: subscription.value.refusalCode
+            }
+          }
           break
       }
       // FE #16637 residual: a refusal is the earliest signal the sender can
@@ -571,10 +582,18 @@ export function useAgentCrdtFollower(
     )
   }
   const onReconnected: EventListener = () => {
-    if (isTerminalSubscription(subscription.value)) return
+    if (isTerminalSubscription(subscription.value)) {
+      recordDevEvent('reconnected', {
+        ignored: subscription.value.status,
+        refusalCode: subscription.value.refusalCode
+      })
+      return
+    }
     connected.value = false
     clearStaleProbe()
-    subscription.value = { status: 'retrying', refusalCode: null }
+    if (subscribedWorkflowId.value !== null) {
+      subscription.value = { status: 'retrying', refusalCode: null }
+    }
     recordDevEvent('reconnected', null)
     bridge.resubscribe()
   }


### PR DESCRIPTION
## Summary

Stop the CRDT follower from retrying subscription refusals that cannot recover through backoff.

## Changes

- **What**: Expose a distinct `too_large` terminal status; stop immediately for `unsupported` and `invalid_frame`; retain bounded backoff for transient, unknown, and `not_found` refusals.
- **What**: Prevent socket status and reconnect events from restarting terminal subscriptions.

## Review Focus

Please verify the refusal classification and terminal-state reset on workflow changes.

## Evidence

- `pnpm exec vitest run src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts` — 81 passed.
- `pnpm typecheck` — passed.
- `pnpm exec oxfmt --check <four changed files>` — passed.
- `pnpm exec eslint <four changed files>` — passed.
- Pre-commit lint-staged (oxfmt, oxlint, ESLint, typecheck) — passed.
- Pre-push `knip --cache` — passed.

<!-- authored-by:agent lane-s2-3-1720 -->