### PR TITLE
test: remove remaining non-null assertions from subgraph normalization tests

### DIFF
--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
@@ -322,7 +322,9 @@ describe('normalizeSubgraphDefinitions', () => {
     const duplicate = makeSubgraph('legacy-id')
     duplicate.name = 'duplicate'
     const parent = makeSubgraph('parent', ['legacy-id'])
-    const rootNode = makeSubgraph('root', ['legacy-id']).nodes![0]
+    const rootNode = makeSubgraph('root', ['legacy-id']).nodes?.[0]
+    expect(rootNode).toBeDefined()
+    if (!rootNode) return
 
     const result = normalizeSubgraphDefinitions(
       [first, duplicate, parent],
@@ -340,8 +342,9 @@ describe('normalizeSubgraphDefinitions', () => {
     expect(result.subgraphs).toHaveLength(2)
     expect(result.subgraphs[0].name).toBe('first')
     expect(isUuidShapedSubgraphId(normalizedLegacyId)).toBe(true)
-    expect(result.subgraphs[1].nodes![0].type).toBe(normalizedLegacyId)
-    expect(result.rootNodes![0].type).toBe(normalizedLegacyId)
+    expect(result.subgraphs[1].nodes).toHaveLength(1)
+    expect(result.subgraphs[1].nodes?.[0]?.type).toBe(normalizedLegacyId)
+    expect(result.rootNodes?.[0]?.type).toBe(normalizedLegacyId)
   })
 
   it('keeps the first same-owner link across regular and floating links', () => {
@@ -363,8 +366,8 @@ describe('normalizeSubgraphDefinitions', () => {
 
     expect(result.links).toHaveLength(1)
     expect(result.floatingLinks).toHaveLength(0)
-    expect(result.links![0].id).toBe(toLinkId(1))
-    expect(result.inputs![0].linkIds).toEqual([toLinkId(1)])
+    expect(result.links?.[0]?.id).toBe(toLinkId(1))
+    expect(result.inputs?.[0]?.linkIds).toEqual([toLinkId(1)])
     expect(subgraph.floatingLinks).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Test-only follow-up to #16546 (merged as `606fb5eedf`): resolves the remaining type-safety feedback from the DrJKL review threads. No behaviour change.

## Review threads addressed

1. [Thread 1 — change-detector test in `BrushCursor.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546#discussion_r3922851267) — DrJKL: "This test codifies the known stale-position bug without causing an ancestor move or any observable event... Please remove it or replace it with a behavioral test that drives the real movement signal and asserts the expected cursor position." Already resolved on the merged PR: the change-detector case was removed in [`e0ea806e8`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/e0ea806e8); the behavioural window-scroll test remains in the file at main. No further change needed; verified at this PR's base.

2. [Thread 2 — recursive fixture type escapes in `subgraphDeduplication.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546#discussion_r3922851273) — DrJKL: "The new tests use repeated assertions to manufacture a recursive fixture shape, including `as unknown as` later in this case and several non-null assertions... make the fixture builder return the recursive test type and narrow `find()` results through assertions or a helper so these cases prove the shape without bypassing the compiler." Already resolved on the merged PR in [`7e540e16a`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/7e540e16a) — no `as unknown as` remains in the file at main. The residual non-null assertions are addressed by this PR.

3. [Thread 3 — remaining non-null assertion in the normalization test](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546#discussion_r3926917622) — DrJKL: "One non-null assertion remains in this newly added normalization test, so the type-safety finding is not fully resolved. Please prove the node exists as the later cases do, then access it without `!`." **Fixed by this PR**: node existence is proven with the file's established `expect(...).toBeDefined()` + guard pattern, node-list length is asserted before optional access (`result.subgraphs[1].nodes?.[0]?.type`), and the remaining `!` uses in the normalization tests (`rootNodes`, `links`, `inputs`) are narrowed the same way.

## Evidence

- `pnpm exec vitest run src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts` — 22/22 passed
- `pnpm typecheck` (`vue-tsc --noEmit`) — clean
- `pnpm lint` (stylelint + oxlint + eslint) — 0 errors (188 pre-existing repo-wide deprecation warnings, unchanged)
- husky pre-commit (lint-staged) and pre-push (knip) hooks green; no hook bypass used
- Head: `3045e26672e62143c26eaf1fa368ced1e039ebd9`, based on `main` at `606fb5eedf`

<!-- authored-by:agent -->
