### PR TITLE
test: finish #16546 review follow-up

### DIFF
--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
@@ -323,7 +323,9 @@ describe('normalizeSubgraphDefinitions', () => {
     const duplicate = makeSubgraph('legacy-id')
     duplicate.name = 'duplicate'
     const parent = makeSubgraph('parent', ['legacy-id'])
-    const rootNode = makeSubgraph('root', ['legacy-id']).nodes![0]
+    const rootNode = makeSubgraph('root', ['legacy-id']).nodes?.[0]
+    expect(rootNode).toBeDefined()
+    if (!rootNode) return
 
     const result = normalizeSubgraphDefinitions(
       [first, duplicate, parent],
@@ -341,8 +343,9 @@ describe('normalizeSubgraphDefinitions', () => {
     expect(result.subgraphs).toHaveLength(2)
     expect(result.subgraphs[0].name).toBe('first')
     expect(isUuidShapedSubgraphId(normalizedLegacyId)).toBe(true)
-    expect(result.subgraphs[1].nodes![0].type).toBe(normalizedLegacyId)
-    expect(result.rootNodes![0].type).toBe(normalizedLegacyId)
+    expect(result.subgraphs[1].nodes).toHaveLength(1)
+    expect(result.subgraphs[1].nodes?.[0]?.type).toBe(normalizedLegacyId)
+    expect(result.rootNodes?.[0]?.type).toBe(normalizedLegacyId)
   })
 
   it('keeps the first same-owner link across regular and floating links', () => {
@@ -364,8 +367,8 @@ describe('normalizeSubgraphDefinitions', () => {
 
     expect(result.links).toHaveLength(1)
     expect(result.floatingLinks).toHaveLength(0)
-    expect(result.links![0].id).toBe(toLinkId(1))
-    expect(result.inputs![0].linkIds).toEqual([toLinkId(1)])
+    expect(result.links?.[0]?.id).toBe(toLinkId(1))
+    expect(result.inputs?.[0]?.linkIds).toEqual([toLinkId(1)])
     expect(subgraph.floatingLinks).toHaveLength(1)
   })
 })

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
@@ -76,7 +76,8 @@ describe('normalizeSubgraphDefinitionIds', () => {
 
     expect(result.subgraphs).toHaveLength(2)
     expect(isUuidShapedSubgraphId(normalizedId)).toBe(true)
-    expect(result.subgraphs[1].nodes![0].type).toBe(normalizedId)
+    expect(result.subgraphs[1].nodes).toHaveLength(1)
+    expect(result.subgraphs[1].nodes?.[0]?.type).toBe(normalizedId)
   })
 
   it('recursively normalizes a subgraph-within-subgraph definition and hoists it to the flat result', () => {


### PR DESCRIPTION
## Summary

Finishes the test-quality follow-up from [#16546](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546): the merged head already removed the non-behavioral cursor test and typed the recursive fixture; this PR removes the final non-null assertion.

<details><summary>Full context for agent readers</summary>

## Changes

- **What**: Proves the normalized parent has one node before reading it through optional access.

## Review Focus

The three review requests from #16546 are accounted for:

1. [Non-behavioral cursor test](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546#discussion_r3922851267):
   > This test codifies the known stale-position bug without causing an ancestor move or any observable event. The unused second rectangle value cannot affect the component, so the test passes regardless of whether ancestor movement is handled. That makes it a change-detector test for the current implementation, which our test rules reject. Please remove it or replace it with a behavioral test that drives the real movement signal and asserts the expected cursor position.

   Addressed on the merged head: the change-detector test was removed while the scroll-driven behavioral test remains.

2. [Recursive fixture typing](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546#discussion_r3922851273):
   > The new tests use repeated assertions to manufacture a recursive fixture shape, including `as unknown as` later in this case and several non-null assertions. `docs/testing/vitest-patterns.md` and the TypeScript guidance reject these type escapes in edited tests. Please make the fixture builder return the recursive test type and narrow `find()` results through assertions or a helper so these cases prove the shape without bypassing the compiler.

   Addressed on the merged head: `makeSubgraph` returns the recursive fixture type and `findSubgraph` narrows lookup results.

3. [Remaining non-null assertion](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16546#discussion_r3926917622):
   > One non-null assertion remains in this newly added normalization test, so the type-safety finding is not fully resolved. Please prove the node exists as the later cases do, then access it without `!`.

   Addressed here by asserting the node-list length before optional access, exactly as suggested.

## Evidence

- `pnpm test:unit src/components/maskeditor/BrushCursor.test.ts src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts --run` — 36/36 passed.
- `pnpm lint` — passed with existing repository warnings only (0 errors).
- `pnpm typecheck` — passed.
- Commit hook — scoped format, type-aware oxlint, ESLint, and typecheck passed.

</details>

<!-- authored-by:agent lane-act-fe-16546-followup-1802 -->
