### PR TITLE
fix(ci): keep unified report within comment limit

### DIFF
--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -43,6 +43,7 @@ interface PerfReport {
 const CURRENT_PATH = 'test-results/perf-metrics.json'
 const BASELINE_PATH = 'temp/perf-baseline/perf-metrics.json'
 const HISTORY_DIR = 'temp/perf-history'
+const compact = process.argv.includes('--compact')
 
 type MetricKey =
   | 'styleRecalcs'
@@ -168,7 +169,7 @@ function computeCV(stats: MetricStats): number {
 function formatValue(value: number, unit: string): string {
   if (unit === 'ms') return `${value.toFixed(0)}ms`
   if (unit === 'bytes') return formatBytes(value)
-  return `${value.toFixed(0)}`
+  return value.toFixed(0)
 }
 
 function formatDelta(pct: number | null): string {
@@ -257,7 +258,8 @@ function renderHeadlineSummary(
 function renderFullReport(
   prGroups: Map<string, PerfMeasurement[]>,
   baseline: PerfReport,
-  historical: PerfReport[]
+  historical: PerfReport[],
+  compact: boolean
 ): string[] {
   const lines: string[] = []
   const baselineGroups = groupByName(baseline.measurements)
@@ -327,6 +329,8 @@ function renderFullReport(
     lines.push('✅ No regressions detected.', '')
   }
 
+  if (compact) return lines
+
   lines.push(
     `<details><summary>All metrics</summary>`,
     '',
@@ -389,12 +393,16 @@ function renderFullReport(
 function renderColdStartReport(
   prGroups: Map<string, PerfMeasurement[]>,
   baseline: PerfReport,
-  historicalCount: number
+  historicalCount: number,
+  compact: boolean
 ): string[] {
   const lines: string[] = []
   const baselineGroups = groupByName(baseline.measurements)
   lines.push(
-    `> ℹ️ Collecting baseline variance data (${historicalCount}/15 runs). Significance will appear after 2 main branch runs.`,
+    `> ℹ️ Collecting baseline variance data (${historicalCount}/15 runs). Significance will appear after 2 main branch runs.`
+  )
+  if (compact) return lines
+  lines.push(
     '',
     '<details><summary>All metrics (cold start)</summary>',
     '',
@@ -440,11 +448,13 @@ function renderColdStartReport(
 }
 
 function renderNoBaselineReport(
-  prGroups: Map<string, PerfMeasurement[]>
+  prGroups: Map<string, PerfMeasurement[]>,
+  compact: boolean
 ): string[] {
   const lines: string[] = []
+  lines.push('> ℹ️ No baseline found — significance unavailable.')
+  if (compact) return lines
   lines.push(
-    '> ℹ️ No baseline found — significance unavailable.',
     '',
     '<details><summary>Absolute values</summary>',
     '',
@@ -484,24 +494,32 @@ function main() {
   lines.push(...renderHeadlineSummary(prGroups))
 
   if (baseline && historical.length >= 2) {
-    lines.push(...renderFullReport(prGroups, baseline, historical))
+    lines.push(...renderFullReport(prGroups, baseline, historical, compact))
   } else if (baseline) {
-    lines.push(...renderColdStartReport(prGroups, baseline, historical.length))
+    lines.push(
+      ...renderColdStartReport(prGroups, baseline, historical.length, compact)
+    )
   } else {
-    lines.push(...renderNoBaselineReport(prGroups))
+    lines.push(...renderNoBaselineReport(prGroups, compact))
   }
 
-  const rawData = {
-    ...current,
-    measurements: current.measurements.map(
-      ({ allFrameDurationsMs: _, ...rest }) => rest
-    )
+  if (compact) {
+    lines.push('', '_Full measurements: `perf-metrics` CI artifact._')
   }
-  lines.push('\n<details><summary>Raw data</summary>\n')
-  lines.push('```json')
-  lines.push(JSON.stringify(rawData, null, 2))
-  lines.push('```')
-  lines.push('\n</details>')
+
+  if (!compact) {
+    const rawData = {
+      ...current,
+      measurements: current.measurements.map(
+        ({ allFrameDurationsMs: _, ...rest }) => rest
+      )
+    }
+    lines.push('\n<details><summary>Raw data</summary>\n')
+    lines.push('```json')
+    lines.push(JSON.stringify(rawData, null, 2))
+    lines.push('```')
+    lines.push('\n</details>')
+  }
 
   process.stdout.write(lines.join('\n') + '\n')
 }

--- a/scripts/report-compactness.test.ts
+++ b/scripts/report-compactness.test.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoRoot = process.cwd()
+const sizeReportScript = join(repoRoot, 'scripts/size-report.js')
+const perfReportScript = join(repoRoot, 'scripts/perf-report.ts')
+const tsx = join(repoRoot, 'node_modules/.bin/tsx')
+const tempDirectories: string[] = []
+
+function createTempDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'report-compactness-'))
+  tempDirectories.push(directory)
+  return directory
+}
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(value))
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true })
+  }
+})
+
+describe('compact CI reports', () => {
+  it('keeps bundle summaries while moving file details to the artifact', () => {
+    const directory = createTempDirectory()
+    const bundle = {
+      file: 'assets/example.js',
+      category: 'Other',
+      size: 120,
+      gzip: 100,
+      brotli: 80
+    }
+    writeJson(join(directory, 'temp/size/example.json'), bundle)
+    writeJson(join(directory, 'temp/size-prev/example.json'), {
+      ...bundle,
+      size: 100,
+      gzip: 90,
+      brotli: 70
+    })
+
+    const full = execFileSync(process.execPath, [sizeReportScript], {
+      cwd: directory,
+      encoding: 'utf-8'
+    })
+    const compact = execFileSync(
+      process.execPath,
+      [sizeReportScript, '--compact'],
+      { cwd: directory, encoding: 'utf-8' }
+    )
+
+    expect(full).toContain('assets/example.js')
+    expect(compact).toContain('## 📦 Bundle:')
+    expect(compact).toContain('`size-data` CI artifact')
+    expect(compact).not.toContain('assets/example.js')
+  })
+
+  it('keeps performance headlines while moving raw measurements to the artifact', () => {
+    const directory = createTempDirectory()
+    writeJson(join(directory, 'test-results/perf-metrics.json'), {
+      timestamp: '2026-09-03T00:00:00.000Z',
+      gitSha: 'test-sha',
+      branch: 'test-branch',
+      measurements: [
+        {
+          name: 'canvas-idle',
+          durationMs: 1000,
+          styleRecalcs: 1,
+          styleRecalcDurationMs: 1,
+          layouts: 1,
+          layoutDurationMs: 1,
+          taskDurationMs: 1,
+          heapDeltaBytes: 1,
+          heapUsedBytes: 1,
+          domNodes: 1,
+          jsHeapTotalBytes: 1,
+          scriptDurationMs: 1,
+          eventListeners: 1,
+          totalBlockingTimeMs: 1,
+          frameDurationMs: 16,
+          p95FrameDurationMs: 17
+        }
+      ]
+    })
+
+    const full = execFileSync(tsx, [perfReportScript], {
+      cwd: directory,
+      encoding: 'utf-8'
+    })
+    const compact = execFileSync(tsx, [perfReportScript, '--compact'], {
+      cwd: directory,
+      encoding: 'utf-8'
+    })
+
+    expect(full).toContain('<summary>Raw data</summary>')
+    expect(compact).toContain('## ⚡ Performance Report')
+    expect(compact).toContain('`perf-metrics` CI artifact')
+    expect(compact).not.toContain('<summary>Raw data</summary>')
+  })
+})

--- a/scripts/size-report.js
+++ b/scripts/size-report.js
@@ -66,8 +66,9 @@ import { getCategoryMetadata } from './bundle-categories.js'
 
 const currDir = path.resolve('temp/size')
 const prevDir = path.resolve('temp/size-prev')
+const compact = process.argv.includes('--compact')
 
-run()
+void run()
 
 /**
  * Main entry for generating the size report
@@ -80,7 +81,7 @@ async function run() {
   }
 
   const report = await buildBundleReport()
-  const output = renderReport(report)
+  const output = renderReport(report, compact)
   process.stdout.write(output)
 }
 
@@ -172,13 +173,14 @@ async function buildBundleReport() {
 /**
  * Render the complete report in markdown
  * @param {BundleReport} report
+ * @param {boolean} compact
  * @returns {string}
  */
-function renderReport(report) {
+function renderReport(report, compact) {
   const parts = [renderCompactHeader(report)]
 
   if (report.categories.length > 0) {
-    parts.push('\n' + renderCategoryDetails(report))
+    parts.push('\n' + renderCategoryDetails(report, compact))
   }
 
   return (
@@ -319,9 +321,10 @@ function renderCategoryGlance(report) {
 /**
  * Render per-category detail tables wrapped in collapsible sections
  * @param {BundleReport} report
+ * @param {boolean} compact
  * @returns {string}
  */
-function renderCategoryDetails(report) {
+function renderCategoryDetails(report, compact) {
   const lines = ['<details>', '<summary>Details</summary>', '']
 
   lines.push(renderSummary(report))
@@ -333,12 +336,13 @@ function renderCategoryDetails(report) {
     lines.push('')
   }
 
-  for (const category of report.categories) {
-    lines.push(renderCategoryBlock(category, report.hasBaseline))
-    lines.push('')
-  }
-
-  if (report.categories.length > 0) {
+  if (compact) {
+    lines.push('_Full bundle details: `size-data` CI artifact._', '')
+  } else {
+    for (const category of report.categories) {
+      lines.push(renderCategoryBlock(category, report.hasBaseline))
+      lines.push('')
+    }
     lines.pop()
   }
 

--- a/scripts/unified-report.ts
+++ b/scripts/unified-report.ts
@@ -19,9 +19,11 @@ const hasSizeData = existsSync('temp/size')
 
 if (sizeStatus === 'ready' && hasSizeData) {
   try {
-    const sizeReport = execFileSync('node', ['scripts/size-report.js'], {
-      encoding: 'utf-8'
-    }).trimEnd()
+    const sizeReport = execFileSync(
+      'node',
+      ['scripts/size-report.js', '--compact'],
+      { encoding: 'utf-8' }
+    ).trimEnd()
     lines.push(sizeReport)
   } catch {
     lines.push('## 📦 Bundle Size')
@@ -46,7 +48,7 @@ if (perfStatus === 'ready' && existsSync('test-results/perf-metrics.json')) {
   try {
     const perfReport = execFileSync(
       'pnpm',
-      ['exec', 'tsx', 'scripts/perf-report.ts'],
+      ['exec', 'tsx', 'scripts/perf-report.ts', '--compact'],
       { encoding: 'utf-8' }
     ).trimEnd()
     lines.push(perfReport)


### PR DESCRIPTION
## Closed unmerged

The suspected second failure did not occur. After #16763 merged, the live unified-report workflow successfully updated [PR #16812's report comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16812#issuecomment-5530252229) to 126,235 bytes with bundle, performance, and coverage sections intact.

Compacting the report would remove useful detail without fixing an observed limit, so this follow-up is intentionally closed.

## Verification retained

- Reconstructed report from the original failed-run artifacts: 142,971 bytes.
- Live post-#16763 report comment: 126,235 bytes, updated successfully.
- Proposed compact mode was locally verified but is not needed and will not land.

<!-- authored-by:agent operator-8b -->