### PR TITLE
fix(ci): upload Storybook artifacts for fork PRs

### DIFF
--- a/.github/workflows/ci-tests-storybook.yaml
+++ b/.github/workflows/ci-tests-storybook.yaml
@@ -81,7 +81,7 @@ jobs:
           echo "url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
 
       - name: Upload Storybook build
-        if: success() && github.event.pull_request.head.repo.fork == false
+        if: success()
         uses: actions/upload-artifact@v6
         with:
           name: storybook-static

--- a/scripts/cicd/storybook-fork-artifact-contract.test.ts
+++ b/scripts/cicd/storybook-fork-artifact-contract.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  if?: string
+  uses?: string
+  with?: { name?: string }
+}
+
+interface WorkflowJob {
+  if?: string
+  steps?: WorkflowStep[]
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>
+}
+
+const readWorkflow = (path: string) =>
+  parse(readFileSync(path, 'utf8')) as Workflow
+
+const findStep = (workflow: Workflow, name: string) => {
+  const step = Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .find((step) => step.name === name)
+
+  expect(step, `Missing workflow step: ${name}`).toBeDefined()
+  return step!
+}
+
+describe('fork Storybook artifact contract', () => {
+  it('uploads the artifact consumed by the trusted fork deployment workflow', () => {
+    const producer = readWorkflow('.github/workflows/ci-tests-storybook.yaml')
+    const consumer = readWorkflow(
+      '.github/workflows/ci-tests-storybook-forks.yaml'
+    )
+    const upload = findStep(producer, 'Upload Storybook build')
+    const download = findStep(consumer, 'Download and Deploy Storybook')
+
+    expect(upload.uses).toMatch(/^actions\/upload-artifact@/)
+    expect(upload.if).toBe('success()')
+    expect(download.uses).toMatch(/^actions\/download-artifact@/)
+    expect(download.with?.name).toBe(upload.with?.name)
+  })
+})


### PR DESCRIPTION
Justification: Emergency fix for red `main`; the trusted fork deployment workflow cannot download an artifact that the source workflow deliberately skips.

## Summary

Upload successful Storybook builds from fork PRs so the trusted `workflow_run` deployment can download and deploy them.

## Changes

- Remove the contradictory non-fork condition from the `storybook-static` upload step.
- Add a permanent producer/consumer workflow contract regression.

## Review Focus

The fork PR workflow remains read-only and secretless. The trusted workflow continues to own deployment credentials and PR comments.

## Verification

- `pnpm test:unit scripts/cicd/storybook-fork-artifact-contract.test.ts` — 1 passed; failed before the workflow fix.
- `pnpm typecheck:scripts` — passed.
- `pnpm typecheck` — passed.
- `pnpm exec eslint scripts/cicd/storybook-fork-artifact-contract.test.ts` — passed.
- `pnpm exec oxfmt --check .github/workflows/ci-tests-storybook.yaml scripts/cicd/storybook-fork-artifact-contract.test.ts` — passed.
- Commit hooks and pre-push Knip — passed.
- Reproduced in [run 33790566574](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33790566574); source [run 33790416069](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33790416069) succeeded with zero artifacts because its upload step was skipped.

<!-- authored-by:agent operator-4 -->