### PR TITLE
feat(crdt): support subgraph-interior connect ops

### DIFF
--- a/packages/comfy-multi-player/src/applier.ts
+++ b/packages/comfy-multi-player/src/applier.ts
@@ -1127,6 +1127,15 @@ function requireOutputSlot(src: Y.Map<unknown>, op: ConnectOp): Y.Array<unknown>
 function requireOpOnlyValid(op: ConnectOp): void {
   requireOutputSlotDomain(op);
 
+  if (op.path !== undefined) {
+    if (!Array.isArray(op.path) || op.path.length === 0) {
+      throw new OpRejectedError("malformed_op", "connect: path must be a non-empty array when present");
+    }
+    if (op.grow != null) {
+      throw new OpRejectedError("malformed_op", "connect: interior autogrow is not supported");
+    }
+  }
+
   if (op.node_incarnation !== undefined && (typeof op.node_incarnation !== "string" || op.node_incarnation.length === 0)) {
     throw new OpRejectedError("malformed_op", "connect: node_incarnation must be a non-empty string");
   }
@@ -1174,10 +1183,124 @@ function requireOpOnlyValid(op: ConnectOp): void {
   }
 }
 
+interface InteriorConnectScope {
+  nodes: Y.Map<Y.Map<unknown>>;
+  links: Y.Map<unknown>;
+  definition: Y.Map<unknown>;
+}
+
+/** Resolve the definition addressed by an interior connect's instance path. */
+function resolveInteriorConnectScope(
+  doc: Y.Doc,
+  op: ConnectOp,
+  catalog?: WidgetCatalog,
+): InteriorConnectScope | null {
+  if (!op.path || op.path.length === 0) return null;
+  const host = resolveInteriorNode(doc, op.path.map(String), catalog);
+  if (host === null) return null;
+  const hostType = String(host.get("type") ?? "");
+  const definition = resolveDefinition(doc, hostType);
+  if (!definition) {
+    throw new OpRejectedError(
+      "not_a_subgraph",
+      `node ${String(host.get("id"))} is not a subgraph; cannot connect inside it`,
+    );
+  }
+  const definitionId = String(definition.get("id") ?? hostType);
+  const instances = countDefinitionInstances(doc, definitionId, catalog);
+  if (instances > 1) {
+    throw new OpRejectedError(
+      "shared_definition_unforked",
+      `definition ${definitionId} is instantiated ${instances} times; interior writes to shared definitions are rejected until forking is specced (schema §5.3)`,
+    );
+  }
+  const nodes = definition.get("nodes");
+  const links = definition.get("links");
+  if (!(nodes instanceof Y.Map) || !(links instanceof Y.Map)) {
+    throw new OpRejectedError("malformed_op", `subgraph definition ${definitionId} has malformed graph storage`);
+  }
+  return { nodes: nodes as Y.Map<Y.Map<unknown>>, links, definition };
+}
+
+function applyInteriorConnect(
+  doc: Y.Doc,
+  op: ConnectOp,
+  scope: InteriorConnectScope,
+): SuccessfulOutcome {
+  const linkRefusal = arrayItemRefusal(op.link_id) ?? mapValueRefusal(op.link_id);
+  if (linkRefusal !== null) {
+    throw new OpRejectedError("malformed_op", `connect: link_id: ${linkRefusal}`);
+  }
+
+  const src = scope.nodes.get(String(op.from_node));
+  const dst = scope.nodes.get(String(op.to_node));
+  if (!dst) return "no-op";
+  const sourceOutputs = src ? requireOutputSlot(src, op) : null;
+  const toIdx = op.to_slot as number;
+  const inputs = dst.get("inputs");
+  if (!(inputs instanceof Y.Array) || toIdx >= inputs.length) {
+    throw new OpRejectedError(
+      "input_slot_missing",
+      `connect: input slot ${String(toIdx)} not found on node ${String(op.to_node)}`,
+    );
+  }
+  const input = inputs.get(toIdx);
+  if (!(input instanceof Y.Map)) {
+    throw new OpRejectedError("input_slot_missing", `connect: input slot ${toIdx} is not a slot record`);
+  }
+
+  if (!claimLinkIdentity(doc, op, scope)) return "lww-dropped";
+  const stamps = stampsMap(doc);
+  const targetKey = stampTargetKey(op);
+  const prior = stamps.get(targetKey) as StampKey | undefined;
+  const key = stampKey(op);
+  if (prior != null && compareStampKeys(key, prior) <= 0) return "lww-dropped";
+  mset(stamps, targetKey, key);
+
+  const previous = input.get("link");
+  if (previous != null && previous !== op.link_id) removeLinkInScope(scope, previous);
+  if (!src || !sourceOutputs) return "no-op";
+
+  const linkKey = String(op.link_id);
+  if (!scope.links.has(linkKey)) {
+    mset(scope.links, linkKey, {
+      id: op.link_id,
+      origin_id: op.from_node,
+      origin_slot: op.from_slot,
+      target_id: op.to_node,
+      target_slot: toIdx,
+      type: op.link_type,
+    });
+  }
+  const linkOrder = scope.definition.get("link_order");
+  const orderedIds = Array.isArray(linkOrder) ? [...linkOrder] : [];
+  if (!orderedIds.some((id) => String(id) === linkKey)) {
+    orderedIds.push(linkKey);
+    mset(scope.definition, "link_order", orderedIds);
+  }
+  mset(input, "link", op.link_id);
+  const output = sourceOutputs.get(op.from_slot) as Y.Map<unknown>;
+  let outputLinks = output.get("links");
+  if (!(outputLinks instanceof Y.Array)) {
+    outputLinks = new Y.Array<unknown>();
+    mset(output, "links", outputLinks);
+  }
+  if (!(outputLinks as Y.Array<unknown>).toArray().includes(op.link_id)) {
+    apush(outputLinks as Y.Array<unknown>, op.link_id);
+  }
+  return "applied";
+}
+
 function applyConnect(doc: Y.Doc, op: ConnectOp, catalog?: WidgetCatalog): SuccessfulOutcome {
   // OP-ONLY validation first, before ANY document read decides the outcome
   // (KA-4, Amendment A6).
   requireOpOnlyValid(op);
+
+  if (op.path && op.path.length > 0) {
+    const scope = resolveInteriorConnectScope(doc, op, catalog);
+    if (scope === null) return "no-op";
+    return applyInteriorConnect(doc, op, scope);
+  }
 
   const nodes = nodesMap(doc);
   const dst = nodes.get(String(op.to_node));
@@ -1319,17 +1442,25 @@ function applyConnect(doc: Y.Doc, op: ConnectOp, catalog?: WidgetCatalog): Succe
 }
 
 /** Claim the normalized complete-tuple link register (schema Amendment A18). */
-function claimLinkIdentity(doc: Y.Doc, op: ConnectOp): boolean {
+function claimLinkIdentity(doc: Y.Doc, op: ConnectOp, scope?: InteriorConnectScope): boolean {
   const stamps = stampsMap(doc);
   const normalizedId = String(op.link_id);
-  const targetKey = JSON.stringify(["link", normalizedId]);
+  const targetKey = JSON.stringify([
+    "link",
+    ...(scope && op.path ? [op.path.map(String)] : []),
+    normalizedId,
+  ]);
   const prior = stamps.get(targetKey) as StampKey | undefined;
   const key = stampKey(op);
   if (prior != null && compareStampKeys(key, prior) <= 0) return false;
 
-  const links = linksMap(doc);
+  const links = scope?.links ?? linksMap(doc);
   if (links.has(normalizedId)) mdel(links, normalizedId);
-  scrubLinkRefs(doc, (candidate) => candidate != null && String(candidate) === normalizedId);
+  if (scope) {
+    scrubNodeLinkRefs(scope.nodes, (candidate) => candidate != null && String(candidate) === normalizedId);
+  } else {
+    scrubLinkRefs(doc, (candidate) => candidate != null && String(candidate) === normalizedId);
+  }
   mset(stamps, targetKey, key);
   return true;
 }
@@ -1663,9 +1794,26 @@ function removeLink(doc: Y.Doc, linkId: unknown): void {
   scrubLinkRefs(doc, (candidate) => candidate != null && String(candidate) === key);
 }
 
+function removeLinkInScope(scope: InteriorConnectScope, linkId: unknown): void {
+  const key = String(linkId);
+  if (scope.links.has(key)) mdel(scope.links, key);
+  scrubNodeLinkRefs(scope.nodes, (candidate) => candidate != null && String(candidate) === key);
+  const linkOrder = scope.definition.get("link_order");
+  if (Array.isArray(linkOrder)) {
+    mset(scope.definition, "link_order", linkOrder.filter((id) => String(id) !== key));
+  }
+}
+
 /** Scrub input/output references selected by one shared link-id predicate. */
 function scrubLinkRefs(doc: Y.Doc, shouldRemove: (linkId: unknown) => boolean): void {
-  nodesMap(doc).forEach((node) => {
+  scrubNodeLinkRefs(nodesMap(doc), shouldRemove);
+}
+
+function scrubNodeLinkRefs(
+  nodes: Y.Map<Y.Map<unknown>>,
+  shouldRemove: (linkId: unknown) => boolean,
+): void {
+  nodes.forEach((node) => {
     const ins = node.get("inputs");
     if (ins instanceof Y.Array) {
       ins.forEach((slot: unknown) => {

--- a/packages/comfy-multi-player/src/stamps.ts
+++ b/packages/comfy-multi-player/src/stamps.ts
@@ -109,6 +109,9 @@ export function writeTarget(op: WireOp): unknown[] {
         }
         return ["input", String(op.to_node), "grow", String(op.grow.name).split(".", 1)[0]];
       }
+      if (op.path && op.path.length > 0) {
+        return ["input", op.path.map(String), String(op.to_node), op.to_slot];
+      }
       return ["input", String(op.to_node), op.to_slot];
     case "disconnect":
       return ["input", String(op.to_node), op.to_slot];

--- a/packages/comfy-multi-player/src/types.ts
+++ b/packages/comfy-multi-player/src/types.ts
@@ -212,6 +212,8 @@ export interface PromotedHostWrite {
 /** Fields every `connect` carries, whichever way its destination slot is addressed. */
 interface ConnectOpBase extends OpBase {
   op: "connect";
+  /** Non-empty subgraph-instance path for an interior connect. */
+  path?: [NodeId, ...NodeId[]];
   /** Link identity, minted at op-mint time (int in comfy-cli). */
   link_id: NodeId;
   from_node: NodeId;

--- a/packages/comfy-multi-player/test/interior-connect.regression.test.ts
+++ b/packages/comfy-multi-player/test/interior-connect.regression.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyOps,
+  mint,
+  project,
+  type ConnectOp,
+  type WidgetCatalog,
+  type WorkflowJSON,
+} from "../src/index.js";
+
+const catalog: WidgetCatalog = {
+  types: {
+    Source: { widget_order: [] },
+    Sink: { widget_order: [] },
+  },
+};
+
+const workflow = {
+  nodes: [{ id: 100, type: "definition-1", inputs: [], outputs: [] }],
+  links: [],
+  definitions: {
+    subgraphs: [
+      {
+        id: "definition-1",
+        nodes: [
+          {
+            id: 1,
+            type: "Source",
+            inputs: [],
+            outputs: [{ name: "text", type: "STRING", links: null }],
+          },
+          {
+            id: 2,
+            type: "Sink",
+            inputs: [{ name: "text", type: "STRING", link: null }],
+            outputs: [],
+          },
+        ],
+        links: [],
+      },
+    ],
+  },
+} as unknown as WorkflowJSON;
+
+describe("interior connect regression", () => {
+  it("applies and projects a concrete link inside one subgraph definition", () => {
+    const doc = mint(workflow, catalog);
+    const connect = {
+      op: "connect",
+      op_id: "interiorconnect0000000000000001",
+      actor: "human:a",
+      base_version: 1,
+      stamp: [1, "human:a"],
+      path: ["100"],
+      link_id: 41,
+      from_node: 1,
+      from_slot: 0,
+      to_node: 2,
+      to_slot: 0,
+      link_type: "STRING",
+    } as unknown as ConnectOp;
+
+    expect(applyOps(doc, [connect], catalog).outcomes).toEqual([
+      { op_id: connect.op_id, outcome: "applied" },
+    ]);
+
+    const definitions = project(doc, catalog).definitions as {
+      subgraphs: Array<{
+        nodes: Array<{
+          id: number;
+          inputs?: Array<{ link: number | null }>;
+          outputs?: Array<{ links: number[] | null }>;
+        }>;
+        links: unknown[];
+      }>;
+    };
+    const definition = definitions.subgraphs[0]!;
+
+    expect(definition.links).toEqual([
+      {
+        id: 41,
+        origin_id: 1,
+        origin_slot: 0,
+        target_id: 2,
+        target_slot: 0,
+        type: "STRING",
+      },
+    ]);
+    expect(definition.nodes.find(({ id }) => id === 1)?.outputs?.[0]?.links).toEqual([41]);
+    expect(definition.nodes.find(({ id }) => id === 2)?.inputs?.[0]?.link).toBe(41);
+  });
+});

--- a/src/workbench/extensions/agent/crdt/linkMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.test.ts
@@ -41,6 +41,7 @@ describe('attachLinkMintPort', () => {
   let port: LinkMintPort
   let enabled: boolean
   let bound: boolean
+  let interiorPaths: Map<string, string[]>
   let session: MintSession
   let placedListeners: Set<
     (scope: LinkScopeView, topology: LinkTopologyView) => void
@@ -61,6 +62,7 @@ describe('attachLinkMintPort', () => {
     minted = []
     enabled = true
     bound = true
+    interiorPaths = new Map()
     session = createMintSession()
     placedListeners = new Set()
     deletedListeners = new Set()
@@ -78,6 +80,8 @@ describe('attachLinkMintPort', () => {
       session,
       isEnabled: () => enabled,
       isDocBound: () => bound,
+      resolveInteriorPath: (owningGraphId) =>
+        interiorPaths.get(owningGraphId) ?? null,
       enqueue: (operations) => minted.push(...operations)
     })
   })
@@ -120,7 +124,25 @@ describe('attachLinkMintPort', () => {
     expect(minted).toEqual([])
   })
 
-  it('surfaces a subgraph-interior placement observably instead of minting', () => {
+  it('mints a connect with the resolved path for a subgraph-interior placement', () => {
+    interiorPaths.set('subgraph-uuid', ['57'])
+    place(SUBGRAPH_SCOPE, topology(41))
+
+    expect(minted).toEqual([
+      {
+        op: 'connect',
+        path: ['57'],
+        link_id: 41,
+        from_node: 1,
+        from_slot: 0,
+        to_node: 2,
+        to_slot: 3,
+        link_type: 'IMAGE'
+      }
+    ])
+  })
+
+  it('surfaces an unresolvable subgraph-interior placement observably', () => {
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)

--- a/src/workbench/extensions/agent/crdt/linkMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.ts
@@ -63,6 +63,8 @@ export interface LinkMintPortDeps {
   isEnabled(): boolean
   /** A semantic doc is bound for the active workflow. */
   isDocBound(): boolean
+  /** Subgraph-node id chain from the root to the graph owning the link. */
+  resolveInteriorPath(owningGraphId: string): string[] | null
   /** Receives minted semantic operations (the sender's inbox). */
   enqueue(operations: GraphOperation[]): void
 }
@@ -106,7 +108,10 @@ export function attachLinkMintPort(deps: LinkMintPortDeps): LinkMintPort {
 
   function onPlaced(scope: LinkScopeView, topology: LinkTopologyView): void {
     if (!gateOpen()) return
-    if (!isRootScope(scope)) {
+    const path = isRootScope(scope)
+      ? undefined
+      : deps.resolveInteriorPath(scope.owningGraphId)
+    if (path !== undefined && (path === null || path.length === 0)) {
       surfaceUnrepresentable('subgraph-interior connect', topology.id)
       return
     }
@@ -118,7 +123,8 @@ export function attachLinkMintPort(deps: LinkMintPortDeps): LinkMintPort {
         from_slot: topology.originSlot,
         to_node: topology.targetNodeId,
         to_slot: topology.targetSlot,
-        link_type: String(topology.type)
+        link_type: String(topology.type),
+        ...(path === undefined ? {} : { path: [path[0], ...path.slice(1)] })
       }
     ])
   }

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -125,6 +125,12 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
   const deletedListeners = new Set<DeletedListener>()
   const setListeners = new Set<SetListener>()
 
+  function resolveInteriorPath(owningGraphId: string): string[] | null {
+    const graph = deps.getGraph()
+    if (!graph) return null
+    return findSubgraphNodePathById(graph as unknown as LGraph, owningGraphId)
+  }
+
   const linkPort = attachLinkMintPort({
     events: {
       onPlaced(listener) {
@@ -139,6 +145,7 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     session,
     isEnabled: deps.isEnabled,
     isDocBound: deps.isDocBound,
+    resolveInteriorPath,
     enqueue: deps.enqueue
   })
 
@@ -176,11 +183,7 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
       if (!graph) return null
       return String(graph.rootGraph?.id ?? graph.id)
     },
-    resolveInteriorPath(owningGraphId) {
-      const graph = deps.getGraph()
-      if (!graph) return null
-      return findSubgraphNodePathById(graph as unknown as LGraph, owningGraphId)
-    },
+    resolveInteriorPath,
     enqueue: deps.enqueue
   })
 


### PR DESCRIPTION
## Dependency

This PR is based on and targets the open CMP workspace PR #16644 (`christian-byrne/ecw-106-comfy-multi-player-workspace`) because the shared package source and frontend follower contract it changes have not landed on `main` yet. Retarget to `main` after #16644 lands.

## Summary

- route concrete `connect` operations with an instance `path` into the addressed subgraph definition
- preserve definition link objects/order and scope input/link LWW identities by the full interior path
- mint resolved interior paths from the frontend link port instead of dropping subgraph link placements

## Review focus

Preserve KA-1, KA-2, KA-3, KA-4, FC-3, and FC-7 while scoping link identity and input-register stamps by the resolved interior path.

## Test plan

- `pnpm exec vitest run test/interior-connect.regression.test.ts`
- `pnpm --dir packages/comfy-multi-player run typecheck`
- `pnpm --dir packages/comfy-multi-player run lint`
- `pnpm --dir packages/comfy-multi-player exec vitest run --reporter=dot` (72 files, 870 tests)
- `pnpm exec vitest run src/workbench/extensions/agent/crdt/linkMintPort.test.ts src/workbench/extensions/agent/crdt/mintPortWiring.test.ts` (25 tests)
- `pnpm typecheck`