### PR TITLE
fix(ci): main red after #16819 — PR: Unified Report perf-metrics download

### DIFF
--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -99,6 +99,7 @@ jobs:
           name: perf-metrics
           run_id: ${{ steps.find-perf.outputs.run-id }}
           path: test-results/
+          if_no_artifact_found: warn
 
       - name: Download perf baseline
         if: steps.pr-meta.outputs.skip != 'true' && steps.find-perf.outputs.status == 'ready'


### PR DESCRIPTION
Justification: restores green main after bypass merge of #16819; CI-only change.

## Evidence

- Failing run on exact main head `fe89f7d0`: `PR: Unified Report` run [33794070328](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33794070328) (2026-09-03T19:02:26Z), step `Download perf metrics (current)`: `##[error]no artifacts found`.
- Upstream run [33794021109](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33794021109) (`CI: Performance Report`, PR #16819 head `72952823`) concluded `success` without uploading the `perf-metrics` artifact — its upload step is `if-no-files-found: warn`.
- The `Download perf metrics (current)` step omitted `if_no_artifact_found`, so the dawidd6/action-download-artifact default `fail` applied. The sibling `Download size data` / `Download coverage data` steps already pass `warn`, and `scripts/unified-report.ts` explicitly handles a missing `test-results/perf-metrics.json` (renders an unavailable-metrics section, lines 61-62). So `warn` is the intended contract; only the artifact-download step was missing it.
- Fix: add `if_no_artifact_found: warn` — one line, no behavior change when the artifact exists.
- Local validation: `python3 -c "yaml.safe_load(...)`` — YAML parses; diff is one added line.

Tracked as P0 row `cifix-16770` in the fleet program todo.