### PR TITLE
docs(agent): align production debug gate contract

### DIFF
--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -7,14 +7,14 @@
  * sticky — `?crdtDebug=1` turns it on for the origin until `?crdtDebug=0`
  * turns it off — so a tester can be handed a link rather than a build.
  *
- * The query-param path is deliberately blocked on the production hostname
+ * The instrument is deliberately disabled on the production hostname
  * (review: dante01yoon on #16365, 2026-09-01). A link is something a tester
  * forwards, and a forwarded `?crdtDebug=1` landing on `cloud.comfy.org` would
  * flip the instrument on for whoever opens it there, with no re-review step —
  * unlike staging/testcloud/dev, where the audience is already internal. A
- * saved `Comfy.Agent.CrdtDebug.enabled=true` from a non-prod origin does NOT
- * carry over: localStorage is scoped per-origin already, so this only needs
- * to stop the query param from minting a *new* prod opt-in.
+ * stale saved `Comfy.Agent.CrdtDebug.enabled=true` is also ignored there, so
+ * neither query parameters nor persisted choices can retain debug events in
+ * production.
  *
  * Verbosity is a separate axis on purpose. Turning the panel on should not
  * also flood the console: `?crdtDebug=trace` opts into the per-frame chatter,


### PR DESCRIPTION
## Summary

- document that the CRDT debug instrument is fully disabled on the production hostname
- clarify that both query-parameter and stale persisted opt-ins are rejected

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/16765#discussion_r3927213805.

## Test plan

- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/crdtDebugGate.ts`
- `pnpm exec eslint src/workbench/extensions/agent/crdt/crdtDebugGate.ts`
- pre-commit hooks: Oxfmt, type-aware Oxlint, ESLint, full typecheck
- pre-push Knip
