### PR TITLE
test: fully type right panel workflow fixtures

### DIFF
--- a/src/components/rightSidePanel/RightSidePanel.test.ts
+++ b/src/components/rightSidePanel/RightSidePanel.test.ts
@@ -13,7 +13,6 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
-import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
@@ -206,7 +205,7 @@ describe('RightSidePanel global parameters tab', () => {
     mockApp.rootGraph = null
   })
 
-  function renderWithNoSelection(
+  async function renderWithNoSelection(
     activeWorkflowPath: string | null,
     pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
   ) {
@@ -225,7 +224,7 @@ describe('RightSidePanel global parameters tab', () => {
 
     const workflowStore = useWorkflowStore()
     workflowStore.activeWorkflow = activeWorkflowPath
-      ? ({ path: activeWorkflowPath } as LoadedComfyWorkflow)
+      ? await workflowStore.createTemporary(activeWorkflowPath).load()
       : null
 
     const rendered = render(RightSidePanel, {
@@ -245,16 +244,15 @@ describe('RightSidePanel global parameters tab', () => {
   }
 
   it('remounts TabGlobalParameters when the active workflow changes', async () => {
-    const { onTabGlobalParametersSetup } =
-      renderWithNoSelection('workflows/a.json')
+    const { onTabGlobalParametersSetup } = await renderWithNoSelection('a.json')
 
     const first = screen.getByTestId('tab-global-parameters')
     expect(onTabGlobalParametersSetup).toHaveBeenCalledTimes(1)
 
     const workflowStore = useWorkflowStore()
-    workflowStore.activeWorkflow = {
-      path: 'workflows/b.json'
-    } as LoadedComfyWorkflow
+    workflowStore.activeWorkflow = await workflowStore
+      .createTemporary('b.json')
+      .load()
     await nextTick()
 
     expect(onTabGlobalParametersSetup).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
## Summary

Replaces partial `LoadedComfyWorkflow` assertions with real loaded temporary workflows so TypeScript validates the right-panel test fixtures.

Follow-up to the [changes-requested review envelope](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16730#pullrequestreview-5098304245). This PR carries its unresolved [`LoadedComfyWorkflow` fixture thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16730#discussion_r3921508494) by replacing the asserted partial values with fully typed loaded workflows.

## Changes

- **What**: Build both active-workflow fixtures through `createTemporary(...).load()` and remove the `LoadedComfyWorkflow` assertions.

## Review Focus

Confirm the production workflow factory remains appropriate for this component test and the remount behavior is unchanged.