### PR TITLE
fix: retain errors that outrun prompt responses

### DIFF
--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -895,6 +895,64 @@ describe('ComfyApp', () => {
       expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
     })
 
+    it('surfaces an execution error received before the prompt response', async () => {
+      const graphId = '11111111-1111-4111-8111-111111111111'
+      const graph = new LGraph()
+      const workflow = markLoaded(
+        new ComfyWorkflow({
+          path: 'workflows/fast-failure.json',
+          modified: 0,
+          size: 0
+        })
+      )
+      workflow.changeTracker.activeState = {
+        ...createWorkflowGraphData(),
+        id: graphId
+      }
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.setActiveGraph(graphId, workflow.path)
+      const executionStore = useExecutionStore()
+      const addEventListener = vi.spyOn(api, 'addEventListener')
+      executionStore.bindExecutionEvents()
+      const executionErrorHandler = addEventListener.mock.calls.find(
+        ([event]) => event === 'execution_error'
+      )?.[1] as EventListener | undefined
+      vi.spyOn(api, 'queuePrompt').mockImplementation(async () => {
+        executionErrorHandler?.(
+          new CustomEvent('execution_error', {
+            detail: {
+              prompt_id: 'job-1',
+              node_id: '1',
+              node_type: 'DevToolsErrorRaiseNode',
+              exception_message: 'Error node was called!',
+              exception_type: 'Exception',
+              traceback: []
+            }
+          })
+        )
+        return { prompt_id: 'job-1', error: '' }
+      })
+
+      try {
+        await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+        expect(executionErrorHandler).toBeTypeOf('function')
+        expect(executionErrorStore.lastExecutionError?.prompt_id).toBe('job-1')
+        expect(executionErrorStore.isErrorOverlayOpen).toBe(true)
+      } finally {
+        executionStore.unbindExecutionEvents()
+      }
+    })
+
     it('stores workflow telemetry metadata for every accepted batch submission', async () => {
       prepareEmptyPromptQueue()
       const registry = new TelemetryRegistry()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -844,6 +844,14 @@ export class ComfyApp {
     }
   }
 
+  private surfaceExecutionError(detail: ExecutionErrorWsMessage) {
+    if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
+      useExecutionErrorStore().showErrorOverlay()
+    } else {
+      useDialogService().showExecutionErrorDialog(detail)
+    }
+  }
+
   /**
    * Handles updates from the API socket
    */
@@ -893,11 +901,7 @@ export class ComfyApp {
           nodeType: detail.node_type
         })
       } else if (isActiveWorkflowError) {
-        if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
-          useExecutionErrorStore().showErrorOverlay()
-        } else {
-          useDialogService().showExecutionErrorDialog(detail)
-        }
+        this.surfaceExecutionError(detail)
       }
       this.canvas.draw(true, true)
     })
@@ -1859,7 +1863,7 @@ export class ComfyApp {
             queueResultOverride = null
             try {
               if (res.prompt_id) {
-                executionStore.storeJob({
+                const deferredRunError = executionStore.storeJob({
                   id: res.prompt_id,
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
@@ -1870,6 +1874,9 @@ export class ComfyApp {
                   workflowContext,
                   workflowExecutionIntent
                 })
+                if (deferredRunError) {
+                  this.surfaceExecutionError(deferredRunError)
+                }
               }
             } catch (error) {
               console.warn('Failed to store queued job metadata', {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1009,7 +1009,7 @@ describe('useExecutionStore - background workflow error routing', () => {
   const workflowB = makeWorkflow('/workflows/b.json', graphBId)
 
   function callStoreJob(jobId: string, workflow: Workflow) {
-    store.storeJob({
+    return store.storeJob({
       nodes: ['1'],
       id: jobId,
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
@@ -1099,6 +1099,18 @@ describe('useExecutionStore - background workflow error routing', () => {
     callStoreJob('job-a', workflowA)
     fireExecutionError('job-a')
 
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-a')
+    expect(errorStore.totalErrorCount).toBe(1)
+  })
+
+  it('replays a visible workflow error that arrives before its job metadata', () => {
+    fireExecutionError('job-a')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+
+    const deferredError = callStoreJob('job-a', workflowA)
+
+    expect(deferredError).toMatchObject({ prompt_id: 'job-a' })
     expect(errorStore.lastExecutionError?.prompt_id).toBe('job-a')
     expect(errorStore.totalErrorCount).toBe(1)
   })

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1115,6 +1115,41 @@ describe('useExecutionStore - background workflow error routing', () => {
     expect(errorStore.totalErrorCount).toBe(1)
   })
 
+  it('keeps a deferred background error off the visible workflow', () => {
+    fireExecutionError('job-b')
+
+    const deferredError = callStoreJob('job-b', workflowB)
+
+    expect(deferredError).toBeUndefined()
+    expect(errorStore.lastExecutionError).toBeNull()
+
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
+  })
+
+  it('replays deferred validation errors after attribution', () => {
+    fireExecutionError('job-a', {
+      exception_message: cloudValidationMessage,
+      exception_type: 'ValidationError'
+    })
+
+    callStoreJob('job-a', workflowA)
+
+    expect(Object.keys(errorStore.lastNodeErrors ?? {})).toEqual(['1'])
+  })
+
+  it('replays deferred service errors after attribution', () => {
+    fireExecutionError('job-a', {
+      node_id: '',
+      exception_message: 'Job has stagnated',
+      exception_type: 'StagnationError'
+    })
+
+    callStoreJob('job-a', workflowA)
+
+    expect(errorStore.lastPromptError?.message).toContain('Job has stagnated')
+  })
+
   it('routes background validation node errors to their own workflow', () => {
     callStoreJob('job-b', workflowB)
     fireExecutionError('job-b', {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -26,8 +26,10 @@ import type {
   ExecutionStartWsMessage,
   ExecutionSuccessWsMessage,
   JobId,
+  NodeError,
   NodeProgressState,
   NotificationWsMessage,
+  PromptError,
   ProgressStateWsMessage,
   ProgressTextWsMessage,
   ProgressWsMessage
@@ -120,6 +122,22 @@ interface WorkflowStatusUpdate {
   showStatus?: boolean
 }
 
+type DeferredRunError =
+  | {
+      kind: 'execution'
+      detail: ExecutionErrorWsMessage
+    }
+  | {
+      kind: 'node'
+      detail: ExecutionErrorWsMessage
+      nodeErrors: Record<string, NodeError>
+    }
+  | {
+      kind: 'prompt'
+      detail: ExecutionErrorWsMessage
+      promptError: PromptError
+    }
+
 export const WORKFLOW_STATUS_I18N_KEYS: Record<
   WorkflowExecutionStatus,
   string
@@ -167,6 +185,7 @@ export const useExecutionStore = defineStore('execution', () => {
   // Buffers statuses arriving before storeJob attaches the workflow.
   // FIFO-capped to bound growth if a matching storeJob never fires.
   const pendingWorkflowStatusByJobId = new Map<string, WorkflowStatusUpdate>()
+  const deferredRunErrorsByJobId = new Map<string, DeferredRunError>()
 
   function bufferPendingWorkflowStatus(
     jobId: string,
@@ -187,6 +206,52 @@ export const useExecutionStore = defineStore('execution', () => {
       if (oldest === undefined) break
       pendingWorkflowStatusByJobId.delete(oldest)
     }
+  }
+
+  function bufferDeferredRunError(jobId: string, error: DeferredRunError) {
+    deferredRunErrorsByJobId.delete(jobId)
+    deferredRunErrorsByJobId.set(jobId, error)
+    while (deferredRunErrorsByJobId.size > MAX_PROGRESS_JOBS) {
+      const oldest = deferredRunErrorsByJobId.keys().next().value
+      if (oldest === undefined) break
+      deferredRunErrorsByJobId.delete(oldest)
+    }
+  }
+
+  function recordRunError(error: DeferredRunError, key: string) {
+    if (error.kind === 'execution') {
+      executionErrorStore.recordExecutionError(error.detail, key)
+    } else if (error.kind === 'node') {
+      executionErrorStore.recordNodeErrors(error.nodeErrors, key)
+    } else {
+      executionErrorStore.recordPromptError(error.promptError, key)
+    }
+  }
+
+  function recordOrDeferRunError(
+    jobId: string,
+    error: DeferredRunError,
+    key: string | null
+  ) {
+    if (key === null) {
+      bufferDeferredRunError(jobId, error)
+      return
+    }
+    recordRunError(error, key)
+  }
+
+  function flushDeferredRunError(
+    jobId: string
+  ): ExecutionErrorWsMessage | undefined {
+    const error = deferredRunErrorsByJobId.get(jobId)
+    if (!error) return
+
+    deferredRunErrorsByJobId.delete(jobId)
+    const key = runErrorKeyForJob(jobId)
+    if (key === null) return
+
+    recordRunError(error, key)
+    if (key === executionErrorStore.captureRunErrorKey()) return error.detail
   }
 
   function mutateStatus(
@@ -448,6 +513,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
     if (workflowStatus.value.size > 0) workflowStatus.value = new Map()
     pendingWorkflowStatusByJobId.clear()
+    deferredRunErrorsByJobId.clear()
     jobIdToWorkflow.clear()
 
     cancelPendingProgressUpdates()
@@ -736,7 +802,11 @@ export const useExecutionStore = defineStore('execution', () => {
       endTime,
       failureReason: 'execution_failed'
     })
-    executionErrorStore.recordExecutionError(e.detail, runErrorKey)
+    recordOrDeferRunError(
+      e.detail.prompt_id,
+      { kind: 'execution', detail: e.detail },
+      runErrorKey
+    )
     clearInitializationByJobId(e.detail.prompt_id)
     resetExecutionState(e.detail.prompt_id)
   }
@@ -759,7 +829,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleServiceLevelError(
     detail: ExecutionErrorWsMessage,
-    runErrorKey: string | null | undefined
+    runErrorKey: string | null
   ): boolean {
     const nodeId = detail.node_id
     if (nodeId !== null && nodeId !== undefined && String(nodeId) !== '')
@@ -767,13 +837,18 @@ export const useExecutionStore = defineStore('execution', () => {
 
     clearInitializationByJobId(detail.prompt_id)
     resetExecutionState(detail.prompt_id)
-    executionErrorStore.recordPromptError(
+    recordOrDeferRunError(
+      detail.prompt_id,
       {
-        type: detail.exception_type ?? 'error',
-        message: detail.exception_type
-          ? `${detail.exception_type}: ${detail.exception_message}`
-          : (detail.exception_message ?? ''),
-        details: detail.traceback?.join('\n') ?? ''
+        kind: 'prompt',
+        detail,
+        promptError: {
+          type: detail.exception_type ?? 'error',
+          message: detail.exception_type
+            ? `${detail.exception_type}: ${detail.exception_message}`
+            : (detail.exception_message ?? ''),
+          details: detail.traceback?.join('\n') ?? ''
+        }
       },
       runErrorKey
     )
@@ -782,7 +857,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleCloudValidationError(
     detail: ExecutionErrorWsMessage,
-    runErrorKey: string | null | undefined
+    runErrorKey: string | null
   ): boolean {
     const result = classifyCloudValidationError(detail.exception_message)
     if (!result) return false
@@ -791,9 +866,17 @@ export const useExecutionStore = defineStore('execution', () => {
     resetExecutionState(detail.prompt_id)
 
     if (result.kind === 'nodeErrors') {
-      executionErrorStore.recordNodeErrors(result.nodeErrors, runErrorKey)
+      recordOrDeferRunError(
+        detail.prompt_id,
+        { kind: 'node', detail, nodeErrors: result.nodeErrors },
+        runErrorKey
+      )
     } else {
-      executionErrorStore.recordPromptError(result.promptError, runErrorKey)
+      recordOrDeferRunError(
+        detail.prompt_id,
+        { kind: 'prompt', detail, promptError: result.promptError },
+        runErrorKey
+      )
     }
     return true
   }
@@ -953,7 +1036,9 @@ export const useExecutionStore = defineStore('execution', () => {
     if (workflow?.path) {
       ensureSessionWorkflowPath(id, workflow.path, workflow.instanceId)
     }
+    const deferredRunError = flushDeferredRunError(String(id))
     flushPendingWorkflowStatus(String(id), workflow)
+    return deferredRunError
   }
 
   function flushPendingWorkflowStatus(


### PR DESCRIPTION
## Summary

Preserve execution errors that arrive before the prompt response attaches the job to its workflow, then surface them only if that workflow is active.

## Changes

- **What**: Buffer one terminal runtime, validation, or service error per unattributed job; replay it after `storeJob` establishes workflow ownership.
- **What**: Keep background-workflow errors in their own scoped bucket without opening an overlay over the active workflow.
- **Dependencies**: None.

## Review Focus

The current-main custom-node self-check failed because the backend emitted `execution_error` before POST `/prompt` returned. The event was correctly considered unattributable at arrival time but was permanently discarded. The buffer is FIFO-bounded by the existing job-progress limit and cleared with other execution-session state.

Red evidence: custom-node run 33802197983, cloud 1/5.

Local verification: 365 affected tests passed (1 skipped); typecheck, ESLint, oxlint, formatting, and Knip passed.