### PR TITLE
feat(workshop): add the model catalog page

### DIFF
--- a/apps/website/src/components/workshop/WorkshopCatalog.test.ts
+++ b/apps/website/src/components/workshop/WorkshopCatalog.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { nextTick } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkshopBrowseModel } from '../../config/workshop'
+import WorkshopCatalog from './WorkshopCatalog.vue'
+
+const models: WorkshopBrowseModel[] = [
+  {
+    id: 'bfl/flux',
+    slug: 'bfl--flux',
+    href: '/workshop/models/bfl--flux/',
+    name: 'Flux',
+    provider: 'bfl',
+    output: 'image',
+    description: 'Generates an image from text.',
+    tags: ['text-to-image']
+  },
+  {
+    id: 'kling/video',
+    slug: 'kling--video',
+    href: '/workshop/models/kling--video/',
+    name: 'Kling Video',
+    provider: 'kling',
+    output: 'video',
+    description: 'Animates an image.',
+    tags: ['image-to-video']
+  }
+]
+
+describe('WorkshopCatalog', () => {
+  it('filters the rendered models by search, output, and provider', async () => {
+    const user = userEvent.setup()
+    render(WorkshopCatalog, {
+      props: { models, detailRoutesAvailable: true }
+    })
+
+    expect(screen.getByRole('link', { name: /Flux/ })).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Kling Video/ })).toBeTruthy()
+
+    await user.type(screen.getByRole('searchbox'), 'animate')
+    await nextTick()
+    expect(screen.queryByRole('link', { name: /Flux/ })).toBeNull()
+    expect(screen.getByRole('link', { name: /Kling Video/ })).toBeTruthy()
+
+    await user.clear(screen.getByRole('searchbox'))
+    await user.click(screen.getByRole('button', { name: /Image 1/ }))
+    await nextTick()
+    expect(screen.getByRole('link', { name: /Flux/ })).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /Kling Video/ })).toBeNull()
+
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Filter by provider' }),
+      'kling'
+    )
+    await nextTick()
+    expect(screen.getByText('No models match these filters.')).toBeTruthy()
+  })
+
+  it('renders the next page on request', async () => {
+    const user = userEvent.setup()
+    const manyModels = Array.from({ length: 49 }, (_, index) => ({
+      ...models[0],
+      id: `bfl/flux-${index + 1}`,
+      slug: `bfl--flux-${index + 1}`,
+      href: `/workshop/models/bfl--flux-${index + 1}/`,
+      name: `Flux ${index + 1}`
+    }))
+    render(WorkshopCatalog, {
+      props: { models: manyModels, detailRoutesAvailable: true }
+    })
+
+    expect(screen.getAllByRole('link')).toHaveLength(48)
+    expect(screen.queryByRole('link', { name: /Flux 49/ })).toBeNull()
+    await user.click(screen.getByRole('button', { name: 'Show more models' }))
+    await nextTick()
+    expect(screen.getAllByRole('link')).toHaveLength(49)
+    expect(screen.getByRole('link', { name: /Flux 49/ })).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /Image 49/ }))
+    await nextTick()
+    expect(screen.getAllByRole('link')).toHaveLength(48)
+  })
+
+  it('uses the singular result label for one model', () => {
+    render(WorkshopCatalog, { props: { models: [models[0]] } })
+
+    expect(screen.getByText('1 model')).toBeTruthy()
+  })
+
+  it('does not link cards until model-detail routes are available', () => {
+    render(WorkshopCatalog, { props: { models } })
+
+    expect(screen.queryAllByRole('link')).toEqual([])
+    expect(screen.getAllByRole('article')).toHaveLength(2)
+  })
+})

--- a/apps/website/src/components/workshop/WorkshopCatalog.test.ts
+++ b/apps/website/src/components/workshop/WorkshopCatalog.test.ts
@@ -10,7 +10,6 @@ import WorkshopCatalog from './WorkshopCatalog.vue'
 const models: WorkshopBrowseModel[] = [
   {
     id: 'bfl/flux',
-    slug: 'bfl--flux',
     href: '/workshop/models/bfl--flux/',
     name: 'Flux',
     provider: 'bfl',
@@ -20,7 +19,6 @@ const models: WorkshopBrowseModel[] = [
   },
   {
     id: 'kling/video',
-    slug: 'kling--video',
     href: '/workshop/models/kling--video/',
     name: 'Kling Video',
     provider: 'kling',
@@ -64,7 +62,6 @@ describe('WorkshopCatalog', () => {
     const manyModels = Array.from({ length: 49 }, (_, index) => ({
       ...models[0],
       id: `bfl/flux-${index + 1}`,
-      slug: `bfl--flux-${index + 1}`,
       href: `/workshop/models/bfl--flux-${index + 1}/`,
       name: `Flux ${index + 1}`
     }))

--- a/apps/website/src/components/workshop/WorkshopCatalog.vue
+++ b/apps/website/src/components/workshop/WorkshopCatalog.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { ChevronRight, Search } from '@lucide/vue'
+import { computed, ref, watch } from 'vue'
+
+import type {
+  WorkshopBrowseModel,
+  WorkshopOutputFilter
+} from '../../config/workshop'
+import {
+  WORKSHOP_OUTPUTS,
+  WORKSHOP_PAGE_SIZE,
+  countWorkshopOutputs,
+  filterWorkshopModels
+} from '../../config/workshop'
+import type { Locale, TranslationKey } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
+const {
+  models,
+  locale = 'en',
+  detailRoutesAvailable = false
+} = defineProps<{
+  models: readonly WorkshopBrowseModel[]
+  locale?: Locale
+  detailRoutesAvailable?: boolean
+}>()
+
+const query = ref('')
+const output = ref<WorkshopOutputFilter>('all')
+const provider = ref('all')
+const visibleLimit = ref(WORKSHOP_PAGE_SIZE)
+
+const counts = computed(() => countWorkshopOutputs(models))
+const providers = computed(() =>
+  [...new Set(models.map((model) => model.provider))].sort()
+)
+const visibleModels = computed(() =>
+  filterWorkshopModels(models, {
+    query: query.value,
+    output: output.value,
+    provider: provider.value
+  })
+)
+const displayedModels = computed(() =>
+  visibleModels.value.slice(0, visibleLimit.value)
+)
+
+watch([query, output, provider], () => {
+  visibleLimit.value = WORKSHOP_PAGE_SIZE
+})
+
+const outputLabelKeys: Record<WorkshopOutputFilter, TranslationKey> = {
+  all: 'workshop.filter.all',
+  image: 'workshop.filter.image',
+  video: 'workshop.filter.video',
+  audio: 'workshop.filter.audio',
+  '3d': 'workshop.filter.3d'
+}
+
+const outputOptions: readonly WorkshopOutputFilter[] = [
+  'all',
+  ...WORKSHOP_OUTPUTS
+]
+</script>
+
+<template>
+  <header class="mb-10">
+    <p
+      class="text-primary-comfy-yellow mb-5 text-sm font-medium tracking-widest uppercase"
+    >
+      {{ t('workshop.hero.eyebrow', locale) }}
+    </p>
+    <h1 class="text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
+      {{ t('workshop.hero.heading', locale) }}
+    </h1>
+    <p class="mt-4 max-w-3xl text-lg text-primary-comfy-canvas/70">
+      {{ t('workshop.hero.subtitle', locale) }}
+    </p>
+  </header>
+
+  <div class="mb-8 flex flex-col gap-4">
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <label class="relative min-w-0 flex-1">
+        <span class="sr-only">{{ t('workshop.search.label', locale) }}</span>
+        <Search
+          aria-hidden="true"
+          class="absolute top-1/2 left-4 size-5 -translate-y-1/2 text-primary-comfy-canvas/50"
+        />
+        <input
+          v-model="query"
+          type="search"
+          :placeholder="t('workshop.search.placeholder', locale)"
+          class="focus:border-primary-comfy-yellow h-12 w-full rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-canvas/5 pr-4 pl-12 text-primary-comfy-canvas outline-none placeholder:text-primary-comfy-canvas/40"
+        />
+      </label>
+      <label>
+        <span class="sr-only">{{ t('workshop.provider.label', locale) }}</span>
+        <select
+          v-model="provider"
+          class="focus:border-primary-comfy-yellow h-12 min-w-48 rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink px-4 text-primary-comfy-canvas outline-none"
+        >
+          <option value="all">
+            {{ t('workshop.provider.all', locale) }}
+          </option>
+          <option v-for="name in providers" :key="name" :value="name">
+            {{ name }}
+          </option>
+        </select>
+      </label>
+    </div>
+
+    <div class="flex gap-2 overflow-x-auto pb-1">
+      <button
+        v-for="option in outputOptions"
+        :key="option"
+        type="button"
+        :aria-pressed="output === option"
+        class="shrink-0 rounded-full border px-4 py-2 text-sm transition-colors"
+        :class="
+          output === option
+            ? 'border-primary-comfy-yellow bg-primary-comfy-yellow text-primary-comfy-ink'
+            : 'border-primary-comfy-canvas/15 text-primary-comfy-canvas/70 hover:border-primary-comfy-canvas/40 hover:text-primary-comfy-canvas'
+        "
+        @click="output = option"
+      >
+        {{ t(outputLabelKeys[option], locale) }}
+        <span class="ml-1 tabular-nums opacity-70">{{ counts[option] }}</span>
+      </button>
+    </div>
+  </div>
+
+  <p class="mb-5 text-sm text-primary-comfy-canvas/60" aria-live="polite">
+    {{
+      t(
+        visibleModels.length === 1 ? 'workshop.result' : 'workshop.results',
+        locale
+      ).replace('{count}', String(visibleModels.length))
+    }}
+  </p>
+
+  <div
+    v-if="visibleModels.length > 0"
+    class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+  >
+    <component
+      :is="detailRoutesAvailable ? 'a' : 'article'"
+      v-for="model in displayedModels"
+      :key="model.id"
+      :href="detailRoutesAvailable ? model.href : undefined"
+      class="flex min-h-56 flex-col rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-6"
+      :class="
+        cn(
+          detailRoutesAvailable &&
+            'group hover:border-primary-comfy-yellow/60 transition hover:-translate-y-0.5 hover:bg-primary-comfy-canvas/8'
+        )
+      "
+    >
+      <p class="text-primary-comfy-yellow text-xs tracking-wider uppercase">
+        {{ model.provider }}
+      </p>
+      <h2 class="mt-2 text-xl font-semibold text-primary-comfy-canvas">
+        {{ model.name }}
+      </h2>
+      <p class="mt-3 line-clamp-3 text-sm text-primary-comfy-canvas/65">
+        {{ model.description }}
+      </p>
+      <div class="mt-auto flex items-end justify-between gap-4 pt-6">
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="tag in model.tags.slice(0, 3)"
+            :key="tag"
+            class="rounded-full bg-primary-comfy-canvas/8 px-2.5 py-1 text-xs text-primary-comfy-canvas/60"
+          >
+            {{ tag }}
+          </span>
+        </div>
+        <ChevronRight
+          v-if="detailRoutesAvailable"
+          aria-hidden="true"
+          class="group-hover:text-primary-comfy-yellow size-5 shrink-0 text-primary-comfy-canvas/50 transition-transform group-hover:translate-x-1"
+        />
+      </div>
+    </component>
+  </div>
+
+  <button
+    v-if="displayedModels.length < visibleModels.length"
+    type="button"
+    class="hover:border-primary-comfy-yellow hover:text-primary-comfy-yellow mx-auto mt-8 block rounded-full border border-primary-comfy-canvas/15 px-6 py-3 text-sm text-primary-comfy-canvas transition-colors"
+    @click="visibleLimit += WORKSHOP_PAGE_SIZE"
+  >
+    {{ t('workshop.showMore', locale) }}
+  </button>
+
+  <div
+    v-if="visibleModels.length === 0"
+    class="rounded-2xl border border-primary-comfy-canvas/10 p-12"
+  >
+    <p class="text-center text-primary-comfy-canvas/60">
+      {{ t('workshop.empty', locale) }}
+    </p>
+  </div>
+</template>

--- a/apps/website/src/config/indexing.ts
+++ b/apps/website/src/config/indexing.ts
@@ -45,7 +45,7 @@ export function isNoindexPathname(pathname: string): boolean {
 export function isExcludedFromSitemap(page: string): boolean {
   const pathname = normalizePathname(new URL(page).pathname)
   return (
-    NOINDEX_PATHNAMES.has(pathname) ||
+    isNoindexPathname(pathname) ||
     MODEL_REDIRECT_PATHNAMES.has(pathname) ||
     (!isWorkshopInBuild() && isWorkshopRoute(pathname))
   )

--- a/apps/website/src/config/llms-txt.test.ts
+++ b/apps/website/src/config/llms-txt.test.ts
@@ -10,6 +10,7 @@ import {
   normalizePath,
   parseLlmsTxtLinks
 } from '../lib/llms-txt'
+import { isNoindexPathname } from './indexing'
 import { getRoutes } from './routes'
 
 const websiteRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -39,8 +40,28 @@ const EXCLUDED_PAGES = new Set([
   '/videos', // "Coming Soon" placeholder
   '/demos', // index is a "Coming Soon" placeholder; the demo pages are listed
   '/platform/serverless-animation', // noindex temporary motion study, not a real page
+  '/workshop', // build-gated; static public/llms.txt cannot vary by build shape
   '/video-sitemap.xml' // machine-readable sitemap output, not a page for agents to read
 ])
+
+const LLMS_TXT_NOINDEX_EXCEPTIONS = new Set([
+  '/privacy-policy',
+  '/terms-of-service'
+])
+
+/**
+ * A page kept out of search indexes has no business in llms.txt either, so
+ * the noindex policy in ./indexing is the second source of exclusions.
+ * Deriving it rather than restating it means a launch that lifts noindex
+ * also starts requiring the page here, instead of leaving a second list to
+ * remember.
+ */
+function isExcludedPage(page: string): boolean {
+  return (
+    EXCLUDED_PAGES.has(page) ||
+    (isNoindexPathname(page) && !LLMS_TXT_NOINDEX_EXCEPTIONS.has(page))
+  )
+}
 
 /**
  * Files the build emits outside src/pages: the sitemap integration writes
@@ -155,7 +176,7 @@ describe('llms.txt', () => {
   it('covers every static page in src/pages', () => {
     const linked = new Set(internalPaths)
     const missing = [...staticPages]
-      .filter((page) => !EXCLUDED_PAGES.has(page) && !linked.has(page))
+      .filter((page) => !isExcludedPage(page) && !linked.has(page))
       .sort()
     expect(missing).toEqual([])
   })
@@ -164,15 +185,12 @@ describe('llms.txt', () => {
     const linked = new Set(internalPaths)
     const missing = Object.values(getRoutes('en'))
       .map(normalizePath)
-      .filter((route) => !EXCLUDED_PAGES.has(route) && !linked.has(route))
+      .filter((route) => !isExcludedPage(route) && !linked.has(route))
     expect(missing).toEqual([])
   })
 
   it('does not list excluded pages by accident', () => {
-    const linked = new Set(internalPaths)
-    const listedButExcluded = [...EXCLUDED_PAGES].filter((page) =>
-      linked.has(page)
-    )
+    const listedButExcluded = internalPaths.filter(isExcludedPage)
     expect(listedButExcluded).toEqual([])
   })
 

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -97,9 +97,13 @@ const LOCALE_INVARIANT_ROUTE_KEYS = new Set<keyof Routes>([
 // platform/serverless-animation: English-only. Its three siblings under
 // /platform/ each have a zh-CN twin and it does not, so without this the
 // emitter advertises a Chinese page that 404s.
+//
+// workshop: the catalog is English-only. It is also build-gated until launch,
+// but enabled previews must not advertise a localized page that does not exist.
 const LOCALE_INVARIANT_EXTRA_PATHS = [
   '/pixal3d-trellis2',
-  '/platform/serverless-animation'
+  '/platform/serverless-animation',
+  '/workshop'
 ]
 
 const LOCALE_INVARIANT_PATHS = new Set<string>([

--- a/apps/website/src/config/workshop.test.ts
+++ b/apps/website/src/config/workshop.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { workshopModelSchema } from '../content/workshop-models.schema'
+import type { WorkshopBrowseModel } from './workshop'
+import {
+  countWorkshopOutputs,
+  filterWorkshopModels,
+  prepareWorkshopBrowseModels,
+  toBrowseModel
+} from './workshop'
+
+// The committed catalog: one packed array, a model per line. Read it the way
+// the content loader does rather than scanning a directory that no longer
+// exists, and validate every entry so the test fails on a bad catalog.
+const CATALOG = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'content',
+  'workshop-models.json'
+)
+
+const rawCatalog: unknown = JSON.parse(readFileSync(CATALOG, 'utf8'))
+
+if (!Array.isArray(rawCatalog)) {
+  throw new TypeError('Workshop catalog must be an array')
+}
+
+const collection = rawCatalog.map((entry) => workshopModelSchema.parse(entry))
+
+const models: WorkshopBrowseModel[] = [
+  {
+    id: 'bfl/flux',
+    slug: 'bfl--flux',
+    href: '/workshop/models/bfl--flux/',
+    name: 'Flux',
+    provider: 'bfl',
+    output: 'image',
+    description: 'Generates an image from text.',
+    tags: ['text-to-image']
+  },
+  {
+    id: 'kling/video',
+    slug: 'kling--video',
+    href: '/workshop/models/kling--video/',
+    name: 'Kling Video',
+    provider: 'kling',
+    output: 'video',
+    description: 'Animates an image.',
+    tags: ['image-to-video']
+  }
+]
+
+describe('Workshop catalog', () => {
+  it('contains every model in the committed Router snapshot', () => {
+    expect(collection).toHaveLength(268)
+    expect(new Set(collection.map((model) => model.id)).size).toBe(268)
+  })
+
+  it('projects a card without the model input schema', () => {
+    // The browse island receives these over the wire, and `parameters` is the
+    // bulk of an entry, so a projection that leaked it would quietly multiply
+    // the page weight.
+    const card = toBrowseModel(collection[0])
+
+    expect(card.id).toBe(collection[0].id)
+    expect(card.href).toBe(`/workshop/models/${collection[0].slug}/`)
+    expect(Object.keys(card)).not.toContain('parameters')
+  })
+
+  it.for([
+    { modality: 'music' as const, output: 'audio' as const },
+    { modality: 'svg' as const, output: 'image' as const }
+  ])(
+    'maps the $modality modality to the $output output',
+    ({ modality, output }) => {
+      const entry = collection.find(
+        (candidate) => candidate.modality === modality
+      )
+
+      expect(entry).toBeDefined()
+      if (!entry) throw new Error(`Missing ${modality} model`)
+      expect(toBrowseModel(entry).output).toBe(output)
+    }
+  )
+
+  it('projects and sorts catalog entries for the page', () => {
+    const entries = [collection[1], collection[0]]
+
+    expect(
+      prepareWorkshopBrowseModels(entries).map((model) => model.id)
+    ).toEqual(
+      entries
+        .map((entry) => entry.id)
+        .sort((left, right) => left.localeCompare(right))
+    )
+  })
+
+  it('searches names, providers, descriptions, and tags', () => {
+    expect(filterWorkshopModels(models, { query: 'Flux' })).toEqual([models[0]])
+    expect(filterWorkshopModels(models, { query: 'animate' })).toEqual([
+      models[1]
+    ])
+    expect(filterWorkshopModels(models, { query: 'BFL' })).toEqual([models[0]])
+    expect(filterWorkshopModels(models, { query: 'text to image' })).toEqual([
+      models[0]
+    ])
+  })
+
+  it('combines output and provider filters', () => {
+    expect(
+      filterWorkshopModels(models, { output: 'video', provider: 'kling' })
+    ).toEqual([models[1]])
+    expect(
+      filterWorkshopModels(models, { output: 'image', provider: 'kling' })
+    ).toEqual([])
+  })
+
+  it('counts the output groups', () => {
+    expect(countWorkshopOutputs(models)).toEqual({
+      all: 2,
+      image: 1,
+      video: 1,
+      audio: 0,
+      '3d': 0
+    })
+  })
+})

--- a/apps/website/src/config/workshop.test.ts
+++ b/apps/website/src/config/workshop.test.ts
@@ -33,7 +33,6 @@ const collection = rawCatalog.map((entry) => workshopModelSchema.parse(entry))
 const models: WorkshopBrowseModel[] = [
   {
     id: 'bfl/flux',
-    slug: 'bfl--flux',
     href: '/workshop/models/bfl--flux/',
     name: 'Flux',
     provider: 'bfl',
@@ -43,7 +42,6 @@ const models: WorkshopBrowseModel[] = [
   },
   {
     id: 'kling/video',
-    slug: 'kling--video',
     href: '/workshop/models/kling--video/',
     name: 'Kling Video',
     provider: 'kling',

--- a/apps/website/src/config/workshop.ts
+++ b/apps/website/src/config/workshop.ts
@@ -8,7 +8,6 @@ export type WorkshopOutputFilter = WorkshopOutput | 'all'
 
 export interface WorkshopBrowseModel {
   readonly id: string
-  readonly slug: string
   readonly href: string
   readonly name: string
   readonly provider: string
@@ -31,7 +30,6 @@ function outputFor(modality: WorkshopModelEntry['modality']): WorkshopOutput {
 export function toBrowseModel(entry: WorkshopModelEntry): WorkshopBrowseModel {
   return {
     id: entry.id,
-    slug: entry.slug,
     href: `/workshop/models/${entry.slug}/`,
     name: entry.displayName,
     provider: entry.provider,

--- a/apps/website/src/config/workshop.ts
+++ b/apps/website/src/config/workshop.ts
@@ -1,0 +1,98 @@
+import type { WorkshopModelEntry } from '../content/workshop-models.schema'
+
+export const WORKSHOP_OUTPUTS = ['image', 'video', 'audio', '3d'] as const
+export const WORKSHOP_PAGE_SIZE = 48
+
+type WorkshopOutput = (typeof WORKSHOP_OUTPUTS)[number]
+export type WorkshopOutputFilter = WorkshopOutput | 'all'
+
+export interface WorkshopBrowseModel {
+  readonly id: string
+  readonly slug: string
+  readonly href: string
+  readonly name: string
+  readonly provider: string
+  readonly output: WorkshopOutput
+  readonly description: string
+  readonly tags: readonly string[]
+}
+
+function outputFor(modality: WorkshopModelEntry['modality']): WorkshopOutput {
+  if (modality === 'music') return 'audio'
+  if (modality === 'svg') return 'image'
+  return modality
+}
+
+/**
+ * The card-sized view of a model. Deliberately a projection rather than the
+ * whole entry: `parameters` is the largest field on a model and the browse
+ * page has no use for it, so it never reaches the browser.
+ */
+export function toBrowseModel(entry: WorkshopModelEntry): WorkshopBrowseModel {
+  return {
+    id: entry.id,
+    slug: entry.slug,
+    href: `/workshop/models/${entry.slug}/`,
+    name: entry.displayName,
+    provider: entry.provider,
+    output: outputFor(entry.modality),
+    description: entry.description,
+    tags: entry.tags
+  }
+}
+
+/**
+ * Projects and orders the Router snapshot for the catalog page at build time.
+ */
+export function prepareWorkshopBrowseModels(
+  entries: readonly WorkshopModelEntry[]
+): WorkshopBrowseModel[] {
+  return entries
+    .map(toBrowseModel)
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export interface WorkshopFilter {
+  readonly query?: string
+  readonly output?: WorkshopOutputFilter
+  readonly provider?: string
+}
+
+function searchTerms(value: string): string {
+  return value
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+export function filterWorkshopModels(
+  models: readonly WorkshopBrowseModel[],
+  { query = '', output = 'all', provider = 'all' }: WorkshopFilter
+): WorkshopBrowseModel[] {
+  const needle = searchTerms(query)
+  return models.filter(
+    (model) =>
+      (output === 'all' || model.output === output) &&
+      (provider === 'all' || model.provider === provider) &&
+      (needle === '' ||
+        searchTerms(
+          [model.name, model.provider, model.description, ...model.tags].join(
+            ' '
+          )
+        ).includes(needle))
+  )
+}
+
+export function countWorkshopOutputs(
+  models: readonly WorkshopBrowseModel[]
+): Record<WorkshopOutputFilter, number> {
+  const counts: Record<WorkshopOutputFilter, number> = {
+    all: models.length,
+    image: 0,
+    video: 0,
+    audio: 0,
+    '3d': 0
+  }
+  for (const model of models) counts[model.output] += 1
+  return counts
+}

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1,6 +1,64 @@
 type Locale = 'en' | 'zh-CN' | 'ja'
 
 const translations = {
+  'workshop.meta.title': {
+    en: 'Comfy Workshop',
+    'zh-CN': 'Comfy Workshop'
+  },
+  'workshop.meta.description': {
+    en: 'Browse and run AI models with Comfy.',
+    'zh-CN': '使用 Comfy 浏览并运行 AI 模型。'
+  },
+  'workshop.hero.eyebrow': {
+    en: 'Comfy Workshop',
+    'zh-CN': 'Comfy Workshop'
+  },
+  'workshop.hero.heading': {
+    en: 'Build with the best AI models',
+    'zh-CN': '使用顶尖 AI 模型进行创作'
+  },
+  'workshop.hero.subtitle': {
+    en: 'Compare models, try their inputs, and use the same API from your own application.',
+    'zh-CN': '比较模型、尝试输入，并在你自己的应用中使用相同的 API。'
+  },
+  'workshop.search.label': {
+    en: 'Search models',
+    'zh-CN': '搜索模型'
+  },
+  'workshop.search.placeholder': {
+    en: 'Search models, providers, and capabilities',
+    'zh-CN': '搜索模型、提供商和功能'
+  },
+  'workshop.provider.label': {
+    en: 'Filter by provider',
+    'zh-CN': '按提供商筛选'
+  },
+  'workshop.provider.all': {
+    en: 'All providers',
+    'zh-CN': '所有提供商'
+  },
+  'workshop.filter.all': { en: 'All', 'zh-CN': '全部' },
+  'workshop.filter.image': { en: 'Image', 'zh-CN': '图像' },
+  'workshop.filter.video': { en: 'Video', 'zh-CN': '视频' },
+  'workshop.filter.audio': { en: 'Audio', 'zh-CN': '音频' },
+  'workshop.filter.3d': { en: '3D', 'zh-CN': '3D' },
+  'workshop.result': {
+    en: '{count} model',
+    'zh-CN': '{count} 个模型'
+  },
+  'workshop.results': {
+    en: '{count} models',
+    'zh-CN': '{count} 个模型'
+  },
+  'workshop.empty': {
+    en: 'No models match these filters.',
+    'zh-CN': '没有符合这些筛选条件的模型。'
+  },
+  'workshop.showMore': {
+    en: 'Show more models',
+    'zh-CN': '显示更多模型'
+  },
+
   // Tags (global, reusable across sections)
   'tags.partnerNodes': {
     en: 'Partner Nodes',

--- a/apps/website/src/pages/workshop/index.astro
+++ b/apps/website/src/pages/workshop/index.astro
@@ -1,0 +1,24 @@
+---
+import { getCollection } from 'astro:content'
+
+import WorkshopCatalog from '../../components/workshop/WorkshopCatalog.vue'
+import { prepareWorkshopBrowseModels } from '../../config/workshop'
+import { t } from '../../i18n/translations'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+
+// Projected at build time so the island receives card-sized records. The
+// models' input schemas are the bulk of each entry and the browse page has
+// no use for them, so they never reach the browser.
+const models = prepareWorkshopBrowseModels(
+  (await getCollection('workshopModels')).map((entry) => entry.data)
+)
+---
+
+<BaseLayout
+  title={t('workshop.meta.title')}
+  description={t('workshop.meta.description')}
+>
+  <main class="mx-auto max-w-10xl px-6 py-16 lg:px-8 lg:py-24">
+    <WorkshopCatalog models={models} client:load />
+  </main>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds the first Workshop page at `/workshop`. It lists the 268 Router models from the committed catalog and lets people search them or filter by provider and output type.

The page renders the first 48 model links into the HTML, then loads more on request. Search and filters continue to use the complete catalog. Model parameter schemas are not sent to this page.

Workshop remains absent from release builds. In Workshop-enabled labeled previews, the catalog is indexable and appears in the sitemap as an English-only, locale-invariant route. Static `llms.txt` continues to omit it until launch because that file cannot vary by build shape. Model links are implemented in the next slice.

## Test plan

- [x] Search, provider, and output filters tested together
- [x] Show more pagination tested
- [x] Catalog has 268 unique model IDs and links
- [x] Astro typecheck passes
- [x] Website production build passes
- [x] Release build emits no Workshop route or `llms.txt` link
- [x] Enabled build includes `/workshop/` in the sitemap with valid hreflang targets
- [x] Built page contains 48 initial model links and no parameter schemas
- [x] Knip and repository pre-push checks pass