### PR TITLE
feat(workshop): derive input fields for every model

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -33,6 +33,7 @@
     "@lucide/vue": "catalog:",
     "@vercel/analytics": "catalog:",
     "@vueuse/core": "catalog:",
+    "ajv": "catalog:",
     "class-variance-authority": "catalog:",
     "cva": "catalog:",
     "gsap": "catalog:",

--- a/apps/website/src/config/workshop-fields.test.ts
+++ b/apps/website/src/config/workshop-fields.test.ts
@@ -1,0 +1,391 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { z } from 'astro/zod'
+import { describe, expect, it } from 'vitest'
+
+import { workshopModelSchema } from '../content/workshop-models.schema'
+import { deriveWorkshopFields } from './workshop-fields'
+import { parseWorkshopJsonInput } from './workshop-json-schema'
+
+// The committed catalog: one packed array, a model per line. Read it the way
+// the content loader does rather than scanning a directory that no longer
+// exists, and validate every entry so the test fails on a bad catalog.
+const CATALOG = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'content',
+  'workshop-models.json'
+)
+
+const collection = z
+  .array(workshopModelSchema)
+  .parse(JSON.parse(readFileSync(CATALOG, 'utf8')))
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+describe('deriveWorkshopFields', () => {
+  it('does not invent defaults for optional booleans', () => {
+    const fields = deriveWorkshopFields(
+      { properties: { enabled: { type: 'boolean' } } },
+      []
+    )
+    expect(fields[0]).toMatchObject({ kind: 'toggle', required: false })
+    expect(fields[0]).not.toHaveProperty('defaultValue')
+  })
+
+  it('preserves the catalog true-only regeneration constraint without a false default', () => {
+    const model = collection.find(
+      (model) => model.id === 'minimax/hailuo-03-regeneration'
+    )
+    expect(model).toBeDefined()
+    if (!model) throw new Error('Missing regeneration model')
+    const field = deriveWorkshopFields(model.parameters, model.roles).find(
+      (field) => field.name === 'source_is_unmodified_h3_768p'
+    )
+    expect(field).toMatchObject({
+      kind: 'select',
+      options: [true],
+      required: true
+    })
+    expect(field).not.toHaveProperty('defaultValue')
+  })
+
+  it('maps Router properties and media roles to form controls', () => {
+    expect(
+      deriveWorkshopFields(
+        {
+          type: 'object',
+          properties: {
+            model: { type: 'string' },
+            medias: { type: 'array' },
+            dispatch_mode: { type: 'string', enum: ['sync', 'async'] },
+            prompt: { type: 'string', maxLength: 2000 },
+            count: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 4,
+              default: 2
+            },
+            quality: {
+              type: 'string',
+              enum: ['standard', 'high'],
+              default: 'high'
+            },
+            enhance: { type: 'boolean', default: true }
+          },
+          required: ['prompt']
+        },
+        [
+          {
+            role: 'reference_image',
+            required: true,
+            cardinality: 'single',
+            minItems: 1,
+            maxItems: 1
+          }
+        ]
+      )
+    ).toEqual([
+      {
+        kind: 'text',
+        name: 'prompt',
+        label: 'Prompt',
+        required: true,
+        multiline: true,
+        valueType: 'string',
+        maxLength: 2000
+      },
+      {
+        kind: 'number',
+        name: 'count',
+        label: 'Count',
+        required: false,
+        integer: true,
+        min: 1,
+        max: 4,
+        step: 1,
+        defaultValue: 2
+      },
+      {
+        kind: 'select',
+        name: 'quality',
+        label: 'Quality',
+        required: false,
+        options: ['standard', 'high'],
+        defaultValue: 'high'
+      },
+      {
+        kind: 'toggle',
+        name: 'enhance',
+        label: 'Enhance',
+        required: false,
+        defaultValue: true
+      },
+      {
+        kind: 'media',
+        name: 'media_reference_image',
+        role: 'reference_image',
+        label: 'Reference Image',
+        required: true,
+        multiple: false,
+        maxItems: 1,
+        accept: 'image'
+      }
+    ])
+  })
+
+  it('represents every required input in the committed catalog', () => {
+    expect(collection.length).toBeGreaterThan(0)
+    for (const model of collection) {
+      const fields = deriveWorkshopFields(model.parameters, model.roles)
+      const fieldNames = new Set(fields.map((field) => field.name))
+      // JSON Schema says `required` is an array of strings, but the schema
+      // types it as arbitrary JSON, so narrow rather than assume.
+      const required = Array.isArray(model.parameters.required)
+        ? model.parameters.required.filter(
+            (name): name is string => typeof name === 'string'
+          )
+        : []
+      for (const name of required) {
+        if (['model', 'medias', 'dispatch_mode'].includes(name)) continue
+        expect(fieldNames, `${model.id} is missing ${name}`).toContain(name)
+      }
+      expect(fields, `${model.id} has no form fields`).not.toHaveLength(0)
+      expect(
+        new Set(fields.map((field) => field.name)).size,
+        `${model.id} has duplicate form field names`
+      ).toBe(fields.length)
+    }
+  })
+
+  it('maps every media role shape to the correct upload control', () => {
+    expect(
+      deriveWorkshopFields({ properties: {} }, [
+        {
+          role: 'source_video',
+          required: true,
+          cardinality: 'single',
+          minItems: 1,
+          maxItems: 1
+        },
+        {
+          role: 'reference_audio',
+          required: false,
+          cardinality: 'many',
+          minItems: 0
+        },
+        {
+          role: 'document',
+          required: false,
+          cardinality: 'single',
+          minItems: 0,
+          maxItems: 1
+        },
+        {
+          role: 'mask',
+          required: false,
+          cardinality: 'single',
+          minItems: 0,
+          maxItems: 1
+        }
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        kind: 'media',
+        role: 'source_video',
+        accept: 'video',
+        multiple: false
+      }),
+      expect.objectContaining({
+        kind: 'media',
+        role: 'reference_audio',
+        accept: 'audio',
+        multiple: true
+      }),
+      expect.objectContaining({
+        kind: 'media',
+        role: 'document',
+        accept: 'file',
+        multiple: false
+      }),
+      expect.objectContaining({
+        kind: 'media',
+        role: 'mask',
+        accept: 'image',
+        multiple: false
+      })
+    ])
+  })
+
+  it('preserves a bounded multi-file role from the catalog', () => {
+    const model = collection.find(
+      (model) => model.id === 'bfl/flux-3-image-to-video'
+    )
+    expect(model).toBeDefined()
+    if (!model) throw new Error('Missing FLUX 3 image-to-video model')
+
+    const field = deriveWorkshopFields(model.parameters, model.roles).find(
+      (field) => field.kind === 'media' && field.role === 'image'
+    )
+    expect(field).toMatchObject({
+      kind: 'media',
+      multiple: true,
+      maxItems: 10
+    })
+  })
+
+  it('preserves text-length constraints from the catalog', () => {
+    const model = collection.find(
+      (model) => model.id === 'kling/lip-sync-text-to-video'
+    )
+    expect(model).toBeDefined()
+    if (!model) throw new Error('Missing Kling lip-sync model')
+
+    const field = deriveWorkshopFields(model.parameters, model.roles).find(
+      (field) => field.name === 'prompt'
+    )
+    expect(field).toMatchObject({
+      kind: 'text',
+      minLength: 1,
+      maxLength: 120
+    })
+  })
+
+  it('keeps complex required inputs usable as JSON text', () => {
+    expect(
+      deriveWorkshopFields(
+        {
+          properties: {
+            inputs: { type: 'array', default: [{ text: 'Hello' }] }
+          },
+          required: ['inputs']
+        },
+        []
+      )
+    ).toEqual([
+      {
+        kind: 'text',
+        name: 'inputs',
+        label: 'Inputs',
+        required: true,
+        multiline: true,
+        valueType: 'json',
+        jsonSchema: {
+          type: 'array',
+          default: [{ text: 'Hello' }]
+        },
+        defaultValue: '[\n  {\n    "text": "Hello"\n  }\n]'
+      }
+    ])
+  })
+
+  it('retains and enforces the complete catalog schema for JSON inputs', () => {
+    const model = collection.find(
+      (model) => model.id === 'elevenlabs/text-to-dialogue'
+    )
+    expect(model).toBeDefined()
+    if (!model) throw new Error('Missing ElevenLabs dialogue model')
+
+    const field = deriveWorkshopFields(model.parameters, model.roles).find(
+      (field) => field.name === 'inputs'
+    )
+    expect(field).toMatchObject({
+      kind: 'text',
+      valueType: 'json',
+      jsonSchema: {
+        type: 'array',
+        minItems: 1,
+        maxItems: 10
+      }
+    })
+    if (field?.kind !== 'text' || !field.jsonSchema) {
+      throw new Error('Missing JSON schema for dialogue inputs')
+    }
+
+    expect(parseWorkshopJsonInput('[]', field.jsonSchema).success).toBe(false)
+    expect(parseWorkshopJsonInput('[{text:', field.jsonSchema).success).toBe(
+      false
+    )
+    expect(
+      parseWorkshopJsonInput('[{"text":"Hello"}]', field.jsonSchema).success
+    ).toBe(false)
+    expect(
+      parseWorkshopJsonInput(
+        '[{"text":"Hello","voice_id":"Sarah"}]',
+        field.jsonSchema
+      )
+    ).toEqual({
+      success: true,
+      value: [{ text: 'Hello', voice_id: 'Sarah' }]
+    })
+  })
+})
+
+describe('open-ended and free-precision inputs', () => {
+  it('keeps a curated-or-custom field open instead of closing it', () => {
+    // ElevenLabs and Fish Audio `voice`, and HeyGen `avatar_id`, list stock
+    // options but also accept an id you cloned yourself. A closed select
+    // makes your own voice unreachable.
+    const [field] = deriveWorkshopFields(
+      {
+        properties: {
+          voice: {
+            anyOf: [{ enum: ['rachel', 'adam'] }, { type: 'string' }],
+            description: 'A stock voice, or your own voice id.'
+          }
+        }
+      },
+      []
+    )
+
+    expect(field).toMatchObject({
+      kind: 'text',
+      hint: 'A stock voice, or your own voice id.',
+      suggestions: ['rachel', 'adam']
+    })
+  })
+
+  it('still closes a field that only offers listed values', () => {
+    const [field] = deriveWorkshopFields(
+      { properties: { size: { enum: ['1024x1024', '512x512'] } } },
+      []
+    )
+
+    expect(field.kind).toBe('select')
+  })
+
+  it('does not invent a precision limit the schema never set', () => {
+    const [free] = deriveWorkshopFields(
+      { properties: { guidance: { type: 'number', minimum: 0, maximum: 10 } } },
+      []
+    )
+    const [declared] = deriveWorkshopFields(
+      { properties: { strength: { type: 'number', multipleOf: 0.05 } } },
+      []
+    )
+    const [whole] = deriveWorkshopFields(
+      { properties: { seed: { type: 'integer' } } },
+      []
+    )
+
+    expect(free.kind === 'number' && free.step).toBe('any')
+    expect(declared.kind === 'number' && declared.step).toBe(0.05)
+    expect(whole.kind === 'number' && whole.step).toBe(1)
+  })
+
+  it('leaves no catalog field with an invented 0.01 step', () => {
+    const invented = collection.flatMap((model) =>
+      deriveWorkshopFields(model.parameters, model.roles).filter((field) => {
+        if (field.kind !== 'number' || field.step !== 0.01) return false
+        const properties = model.parameters.properties
+        const schema = isRecord(properties) ? properties[field.name] : undefined
+        return !isRecord(schema) || schema.multipleOf !== 0.01
+      })
+    )
+
+    expect(invented).toEqual([])
+  })
+})

--- a/apps/website/src/config/workshop-fields.ts
+++ b/apps/website/src/config/workshop-fields.ts
@@ -1,0 +1,283 @@
+import type { WorkshopModelEntry } from '../content/workshop-models.schema'
+
+type MediaRole = WorkshopModelEntry['roles'][number]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+type FieldOption = string | number | boolean
+
+interface WorkshopTextFieldBase {
+  readonly kind: 'text'
+  readonly name: string
+  readonly label: string
+  readonly hint?: string
+  readonly required: boolean
+  readonly multiline: boolean
+  readonly minLength?: number
+  readonly maxLength?: number
+  readonly defaultValue?: string
+  /** Values the schema names without restricting the field to them. */
+  readonly suggestions?: readonly FieldOption[]
+}
+
+export type WorkshopCatalogField =
+  | (WorkshopTextFieldBase & {
+      readonly valueType: 'string'
+      readonly jsonSchema?: never
+    })
+  | (WorkshopTextFieldBase & {
+      readonly valueType: 'json'
+      /** Authoritative Router schema used to validate the parsed value. */
+      readonly jsonSchema: Readonly<Record<string, unknown>>
+    })
+  | {
+      readonly kind: 'select'
+      readonly name: string
+      readonly label: string
+      readonly hint?: string
+      readonly required: boolean
+      readonly options: readonly FieldOption[]
+      readonly defaultValue?: FieldOption
+    }
+  | {
+      readonly kind: 'number'
+      readonly name: string
+      readonly label: string
+      readonly hint?: string
+      readonly required: boolean
+      readonly integer: boolean
+      readonly min?: number
+      readonly max?: number
+      readonly step: number | 'any'
+      readonly defaultValue?: number
+    }
+  | {
+      readonly kind: 'toggle'
+      readonly name: string
+      readonly label: string
+      readonly hint?: string
+      readonly required: boolean
+      readonly defaultValue?: boolean
+    }
+  | {
+      readonly kind: 'media'
+      readonly name: string
+      readonly role: string
+      readonly label: string
+      readonly required: boolean
+      readonly multiple: boolean
+      readonly maxItems?: number
+      readonly accept: 'image' | 'video' | 'audio' | 'file'
+    }
+
+function labelFor(name: string): string {
+  return name
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function hintFor(schema: Record<string, unknown>): { readonly hint?: string } {
+  return typeof schema.description === 'string'
+    ? { hint: schema.description }
+    : {}
+}
+
+function primitiveOptions(schema: Record<string, unknown>): FieldOption[] {
+  if (Array.isArray(schema.enum)) {
+    return schema.enum.filter(
+      (value): value is FieldOption =>
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+    )
+  }
+  if (!Array.isArray(schema.anyOf)) return []
+  return schema.anyOf.flatMap((variant) =>
+    isRecord(variant) ? primitiveOptions(variant) : []
+  )
+}
+
+/**
+ * Finds the string variant when a schema lists some values but also accepts
+ * any string: `anyOf: [{enum: [...]}, {type: 'string'}]`.
+ *
+ * ElevenLabs and Fish Audio `voice`, and HeyGen `avatar_id`, are all this
+ * shape - pick a stock one, or paste the id of one you cloned yourself.
+ * Rendering it as a closed select makes your own voice unreachable, so the
+ * listed values become suggestions on a text field instead.
+ */
+function openStringVariant(
+  schema: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!Array.isArray(schema.anyOf)) return undefined
+  return schema.anyOf.find(
+    (variant): variant is Record<string, unknown> =>
+      isRecord(variant) &&
+      variant.enum === undefined &&
+      variant.type === 'string'
+  )
+}
+
+function textLengthLimits(schema: Record<string, unknown>): {
+  readonly minLength?: number
+  readonly maxLength?: number
+} {
+  return {
+    ...(typeof schema.minLength === 'number'
+      ? { minLength: schema.minLength }
+      : {}),
+    ...(typeof schema.maxLength === 'number'
+      ? { maxLength: schema.maxLength }
+      : {})
+  }
+}
+
+function fieldFor(
+  name: string,
+  schema: Record<string, unknown>,
+  required: boolean
+): WorkshopCatalogField {
+  const common = {
+    name,
+    label: labelFor(name),
+    ...hintFor(schema),
+    required
+  }
+  const options = primitiveOptions(schema)
+  const openString = openStringVariant(schema)
+  if (options.length > 0 && openString) {
+    const textSchema = { ...schema, ...openString }
+    return {
+      kind: 'text',
+      ...common,
+      multiline: false,
+      valueType: 'string',
+      ...textLengthLimits(textSchema),
+      suggestions: options,
+      ...(typeof schema.default === 'string'
+        ? { defaultValue: schema.default }
+        : {})
+    }
+  }
+  if (options.length > 0) {
+    const defaultValue =
+      typeof schema.default === 'string' ||
+      typeof schema.default === 'number' ||
+      typeof schema.default === 'boolean'
+        ? schema.default
+        : undefined
+    return {
+      kind: 'select',
+      ...common,
+      options,
+      ...(defaultValue === undefined ? {} : { defaultValue })
+    }
+  }
+  if (schema.type === 'number' || schema.type === 'integer') {
+    return {
+      kind: 'number',
+      ...common,
+      integer: schema.type === 'integer',
+      ...(typeof schema.minimum === 'number' ? { min: schema.minimum } : {}),
+      ...(typeof schema.maximum === 'number' ? { max: schema.maximum } : {}),
+      // Only the schema may narrow precision. A float that does not declare
+      // multipleOf accepts any value, and a hard-coded 0.01 silently made
+      // 73 fields reject inputs the provider allows.
+      step:
+        typeof schema.multipleOf === 'number'
+          ? schema.multipleOf
+          : schema.type === 'integer'
+            ? 1
+            : 'any',
+      ...(typeof schema.default === 'number'
+        ? { defaultValue: schema.default }
+        : {})
+    }
+  }
+  if (schema.type === 'boolean') {
+    return {
+      kind: 'toggle',
+      ...common,
+      ...(typeof schema.default === 'boolean'
+        ? { defaultValue: schema.default }
+        : {})
+    }
+  }
+  if (schema.type === 'string') {
+    return {
+      kind: 'text',
+      ...common,
+      multiline:
+        name === 'prompt' ||
+        (typeof schema.maxLength === 'number' && schema.maxLength > 200),
+      valueType: 'string',
+      ...textLengthLimits(schema),
+      ...(typeof schema.default === 'string'
+        ? { defaultValue: schema.default }
+        : {})
+    }
+  }
+  return {
+    kind: 'text',
+    ...common,
+    multiline: true,
+    valueType: 'json',
+    jsonSchema: schema,
+    ...(schema.default === undefined
+      ? {}
+      : { defaultValue: JSON.stringify(schema.default, null, 2) })
+  }
+}
+
+function acceptFor(role: string): 'image' | 'video' | 'audio' | 'file' {
+  if (role.includes('image') || role === 'mask') return 'image'
+  if (role.includes('video')) return 'video'
+  if (role.includes('audio')) return 'audio'
+  return 'file'
+}
+
+export function deriveWorkshopFields(
+  parameters: WorkshopModelEntry['parameters'],
+  roles: readonly MediaRole[]
+): WorkshopCatalogField[] {
+  const properties = isRecord(parameters.properties)
+    ? parameters.properties
+    : {}
+  const required = new Set(
+    isStringArray(parameters.required) ? parameters.required : []
+  )
+  const fields = Object.entries(properties).flatMap(([name, schema]) => {
+    if (
+      name === 'model' ||
+      name === 'medias' ||
+      name === 'dispatch_mode' ||
+      !isRecord(schema)
+    ) {
+      return []
+    }
+    return [fieldFor(name, schema, required.has(name))]
+  })
+  return [
+    ...fields,
+    ...roles.map(
+      (role): WorkshopCatalogField => ({
+        kind: 'media',
+        name: `media_${role.role}`,
+        role: role.role,
+        label: labelFor(role.role),
+        required: role.required,
+        multiple: role.cardinality === 'many',
+        ...(role.maxItems === undefined ? {} : { maxItems: role.maxItems }),
+        accept: acceptFor(role.role)
+      })
+    )
+  ]
+}

--- a/apps/website/src/config/workshop-json-schema.ts
+++ b/apps/website/src/config/workshop-json-schema.ts
@@ -1,0 +1,38 @@
+import Ajv from 'ajv'
+import type { ValidateFunction } from 'ajv'
+
+export type WorkshopJsonParseResult =
+  | { readonly success: true; readonly value: unknown }
+  | { readonly success: false }
+
+const ajv = new Ajv({ allErrors: true, strict: false })
+const validators = new WeakMap<
+  Readonly<Record<string, unknown>>,
+  ValidateFunction
+>()
+
+function validatorFor(
+  schema: Readonly<Record<string, unknown>>
+): ValidateFunction {
+  const existing = validators.get(schema)
+  if (existing) return existing
+
+  const validator = ajv.compile(schema)
+  validators.set(schema, validator)
+  return validator
+}
+
+/** Parse a JSON form value and validate it against the Router's full schema. */
+export function parseWorkshopJsonInput(
+  rawValue: string,
+  schema: Readonly<Record<string, unknown>>
+): WorkshopJsonParseResult {
+  try {
+    const value: unknown = JSON.parse(rawValue)
+    return validatorFor(schema)(value)
+      ? { success: true, value }
+      : { success: false }
+  } catch {
+    return { success: false }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ catalogs:
     ag-psd:
       specifier: ^31.0.2
       version: 31.0.2
+    ajv:
+      specifier: ^8.20.0
+      version: 8.20.0
     algoliasearch:
       specifier: ^5.21.0
       version: 5.56.0
@@ -941,6 +944,9 @@ importers:
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.4.0(vue@3.5.42(typescript@6.0.3))
+      ajv:
+        specifier: 'catalog:'
+        version: 8.20.0
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,6 +67,7 @@ catalog:
   '@vueuse/core': ^14.4.0
   '@vueuse/integrations': ^14.4.0
   '@webgpu/types': ^0.1.66
+  ajv: ^8.20.0
   ag-psd: ^31.0.2
   algoliasearch: ^5.21.0
   astro: ^7.2.1


### PR DESCRIPTION
## Summary

Derives the form fields for every Workshop model from the canonical `parameters` and `roles` stored in the packed catalog. Derived fields are not persisted beside their source schema; they are created at the model-detail consumption boundary.

The derivation produces text, select, number, toggle, and media controls. It removes the model ID and Router transport settings from the visible form. Complex objects and lists remain editable as JSON text, so models with required complex inputs remain representable.

Open string unions retain their curated values as suggestions instead of becoming closed selects. Numeric precision follows `multipleOf`, integers use step 1, and unrestricted numbers use `step="any"`. Boolean defaults and true-only constraints are preserved exactly from the source schema.

## Test plan

- [x] Test each derived field type
- [x] Test media roles and file types
- [x] Test complex inputs represented as JSON text
- [x] Test open string unions remain editable
- [x] Test numeric steps do not narrow the source schema
- [x] Test optional booleans do not acquire defaults
- [x] Test required true-only booleans preserve their constraint
- [x] Check every required input across the packed catalog
- [x] Check every model has form fields
- [x] Website unit tests, typecheck, build, E2E, lint, and patch coverage pass