### PR TITLE
fix(ci): pin core for release locale updates

### DIFF
--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: i18n-update-core-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
+env:
+  COMFYUI_RELEASE_PIN: 40b9898582d15a753227712e8c863e466e290e0b
+
 jobs:
   update-locales:
     # Branch detection: Only run for manual dispatch or version-bump-* branches from main repo
@@ -43,6 +46,9 @@ jobs:
         uses: ./.github/actions/setup-comfyui-server
         with:
           launch_server: true
+          # Release branches must collect against the backend revision that
+          # pins their frontend series, not the moving default branch.
+          comfyui_ref: ${{ github.event_name == 'pull_request' && github.base_ref != 'main' && env.COMFYUI_RELEASE_PIN || '' }}
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
 


### PR DESCRIPTION
## Summary

Pin release-branch locale generation to the ComfyUI backend revision that carries frontend 1.51.9, preventing moving `master` node definitions from triggering false locale-prune failures.

## Changes

- **What**: Release-branch runs pass backend commit `40b9898582d15a753227712e8c863e466e290e0b` to `setup-comfyui-server`; main and manual runs keep the default branch.

## Review Focus

Confirm the release-only GitHub expression leaves `main` and `workflow_dispatch` behavior unchanged.