### PR TITLE
fix(agent): stop retrying fatal doc errors

### DIFF
--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -26,6 +26,7 @@ export type DevEventKind =
   | 'doc_subscribed'
   | 'doc_update'
   | 'doc_ops_result'
+  | 'doc_error'
   | 'human_ops_settled'
   | 'doc_reset'
   | 'schema_error'

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -195,6 +195,26 @@ describe('doc frame client', () => {
     })
     expect(
       parseServerDocFrame({
+        type: 'doc_error',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          code: 'fatal_doc',
+          message: 'document frame handling failed',
+          request_type: 'doc_subscribe'
+        }
+      })
+    ).toEqual({
+      type: 'doc_error',
+      data: {
+        workflowId: 'wf-1',
+        code: 'fatal_doc',
+        message: 'document frame handling failed',
+        requestType: 'doc_subscribe'
+      }
+    })
+    expect(
+      parseServerDocFrame({
         type: 'doc_reset',
         data: { v: 1, workflow_id: 'wf-1', seq: 43, actor: 'agent:th-1:turn-2' }
       })
@@ -222,5 +242,53 @@ describe('doc frame client', () => {
         expiresAt: 123
       }
     })
+  })
+
+  it('keeps a fatal workflow terminal without replacing its Y.Doc', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    const bridge = new LayoutFollowerBridge(client)
+    const errors: unknown[] = []
+    bridge.addEventListener('doc_error', (event) => {
+      if (event instanceof CustomEvent) errors.push(event.detail)
+    })
+    bridge.subscribe('wf-1')
+    const doc = bridge.follower.doc
+    doc.getMap('nodes').set('one', { x: 10 })
+
+    transport.receive('doc_error', {
+      v: 1,
+      workflow_id: 'wf-1',
+      code: 'fatal_doc',
+      message: 'document frame handling failed',
+      request_type: 'doc_subscribe'
+    })
+    bridge.resubscribe()
+    bridge.reconcile()
+
+    expect(errors).toEqual([
+      {
+        workflowId: 'wf-1',
+        code: 'fatal_doc',
+        message: 'document frame handling failed',
+        requestType: 'doc_subscribe'
+      }
+    ])
+    expect(transport.sent).toHaveLength(1)
+    expect(bridge.follower.doc).toBe(doc)
+    expect(doc.getMap('nodes').toJSON()).toEqual({ one: { x: 10 } })
+  })
+
+  it('keeps ordinary reconnect resubscription transient', () => {
+    const transport = new TestTransport()
+    const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
+    bridge.subscribe('wf-1')
+
+    bridge.resubscribe()
+
+    expect(transport.sent.map((frame) => JSON.parse(frame).type)).toEqual([
+      'doc_subscribe',
+      'doc_subscribe'
+    ])
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -26,6 +26,13 @@ export interface DocSubscribed {
   message?: string
 }
 
+export interface DocError {
+  workflowId: string
+  code: 'fatal_doc'
+  message: string
+  requestType: string
+}
+
 interface DocOpsResult {
   workflowId: string
   ok: boolean
@@ -64,6 +71,7 @@ export type ServerDocFrame =
   | { type: 'doc_update'; data: DocUpdate }
   | { type: 'doc_subscribed'; data: DocSubscribed }
   | { type: 'doc_ops_result'; data: DocOpsResult }
+  | { type: 'doc_error'; data: DocError }
   | { type: 'doc_reset'; data: DocReset }
   | { type: 'awareness'; data: DocAwareness }
 
@@ -100,6 +108,7 @@ interface WireData {
   failed?: unknown
   state?: unknown
   expires_at?: unknown
+  request_type?: unknown
 }
 
 function decodeBase64(value: string): Uint8Array {
@@ -225,6 +234,23 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
     }
   }
 
+  if (
+    frame.type === 'doc_error' &&
+    data.code === 'fatal_doc' &&
+    typeof data.message === 'string' &&
+    typeof data.request_type === 'string'
+  ) {
+    return {
+      type: frame.type,
+      data: {
+        workflowId: data.workflow_id,
+        code: data.code,
+        message: data.message,
+        requestType: data.request_type
+      }
+    }
+  }
+
   if (frame.type === 'doc_reset' && typeof data.seq === 'number') {
     return {
       type: frame.type,
@@ -269,6 +295,7 @@ export class DocFrameClient extends EventTarget {
       'doc_update',
       'doc_subscribed',
       'doc_ops_result',
+      'doc_error',
       'doc_reset',
       'awareness'
     ]) {

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -274,7 +274,7 @@ describe('FE-TEARDOWN-1 — teardown completes with a dead socket', () => {
     const { transport, client, bridge, projected } = wire()
     transport.open = true
     bridge.subscribe(WORKFLOW_ID)
-    expect(transport.listenerCount).toBe(5)
+    expect(transport.listenerCount).toBe(6)
 
     // Backend restarts, then the user closes the agent panel.
     transport.open = false

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -1,4 +1,5 @@
 import type {
+  DocError,
   DocFrameClient,
   DocOp,
   DocReset,
@@ -100,6 +101,7 @@ export class LayoutFollowerBridge extends EventTarget {
    * harmless). It never moves {@link lastSeq} backwards.
    */
   private catchUpPending = false
+  private terminalWorkflowId: string | null = null
 
   constructor(private readonly client: DocFrameClient) {
     super()
@@ -107,6 +109,7 @@ export class LayoutFollowerBridge extends EventTarget {
     client.addEventListener('doc_reset', this.onDocReset)
     client.addEventListener('doc_subscribed', this.onDocSubscribed)
     client.addEventListener('doc_ops_result', this.forwardFrame)
+    client.addEventListener('doc_error', this.onDocError)
   }
 
   /** The semantic doc this bridge currently follows. */
@@ -139,6 +142,7 @@ export class LayoutFollowerBridge extends EventTarget {
   get hasPendingSubscribe(): boolean {
     return (
       this.desiredWorkflowId !== null &&
+      this.terminalWorkflowId !== this.desiredWorkflowId &&
       this.sentWorkflowId !== this.desiredWorkflowId
     )
   }
@@ -155,6 +159,7 @@ export class LayoutFollowerBridge extends EventTarget {
    */
   subscribe(workflowId: string): void {
     const lineage = this.lineageWorkflowId
+    if (workflowId !== this.desiredWorkflowId) this.terminalWorkflowId = null
     this.lineageWorkflowId = workflowId
     this.desiredWorkflowId = workflowId
     if (lineage !== null && lineage !== workflowId) {
@@ -184,7 +189,12 @@ export class LayoutFollowerBridge extends EventTarget {
       this.sentWorkflowId = null
       trySend(() => this.client.unsubscribe(sent))
     }
-    if (desired === null || this.sentWorkflowId === desired) return
+    if (
+      desired === null ||
+      this.terminalWorkflowId === desired ||
+      this.sentWorkflowId === desired
+    )
+      return
     if (
       trySend(() => this.client.subscribe(desired, this.follower.stateVector()))
     ) {
@@ -196,6 +206,11 @@ export class LayoutFollowerBridge extends EventTarget {
   }
 
   resubscribe(): void {
+    if (
+      this.desiredWorkflowId !== null &&
+      this.terminalWorkflowId === this.desiredWorkflowId
+    )
+      return
     this.sentWorkflowId = null
     this.reconcile()
   }
@@ -225,6 +240,7 @@ export class LayoutFollowerBridge extends EventTarget {
       this.client.removeEventListener('doc_reset', this.onDocReset)
       this.client.removeEventListener('doc_subscribed', this.onDocSubscribed)
       this.client.removeEventListener('doc_ops_result', this.forwardFrame)
+      this.client.removeEventListener('doc_error', this.onDocError)
       this.desiredWorkflowId = null
       this.sentWorkflowId = null
       this.followerDoc.destroy()
@@ -351,6 +367,15 @@ export class LayoutFollowerBridge extends EventTarget {
       this.catchUpPending = this.ackSeq !== null
     } else this.sentWorkflowId = null
     this.dispatchEvent(new CustomEvent(event.type, { detail: event.detail }))
+  }
+
+  private readonly onDocError: EventListener = (event) => {
+    if (!(event instanceof CustomEvent)) return
+    const error = event.detail as DocError
+    if (error.workflowId !== this.sentWorkflowId) return
+    this.terminalWorkflowId = error.workflowId
+    this.sentWorkflowId = null
+    this.dispatchEvent(new CustomEvent(event.type, { detail: error }))
   }
 
   private readonly forwardFrame: EventListener = (event) => {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -255,6 +255,23 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('stops retrying after a fatal doc error for the active workflow', () => {
+    vi.useFakeTimers()
+    const { unmount, status } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false, code: 'overloaded' })
+    dispatchFrame('doc_error', { workflowId: 'wf-1', code: 'fatal_doc' })
+    vi.runAllTimers()
+    apiState.target.dispatchEvent(new Event('status'))
+    apiState.target.dispatchEvent(new Event('reconnected'))
+
+    expect(bridge().resubscribe).not.toHaveBeenCalled()
+    expect(bridge().reconcile).not.toHaveBeenCalled()
+    expect(status().subscriptionStatus).toBe('fatal_doc')
+    expect(status().refusalCode).toBe('fatal_doc')
+    unmount()
+  })
+
   it.for(['unsupported', 'invalid_frame'])(
     'stops retrying permanent %s refusals',
     (code) => {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -161,6 +161,7 @@ type AgentCrdtSubscriptionStatus =
   | 'retrying'
   | 'retry_exhausted'
   | 'too_large'
+  | 'fatal_doc'
   | 'permanent_failure'
 
 export interface AgentCrdtStatus {
@@ -184,6 +185,7 @@ type AgentCrdtSubscriptionState =
   | { status: 'idle' | 'connected'; refusalCode: null }
   | { status: 'retrying' | 'retry_exhausted'; refusalCode: string | null }
   | { status: 'too_large'; refusalCode: 'too_large' }
+  | { status: 'fatal_doc'; refusalCode: 'fatal_doc' }
   | {
       status: 'permanent_failure'
       refusalCode: 'unsupported' | 'invalid_frame'
@@ -204,7 +206,11 @@ function refusedSubscriptionState(code: unknown): AgentCrdtSubscriptionState {
 }
 
 function isTerminalSubscription(state: AgentCrdtSubscriptionState): boolean {
-  return state.status === 'too_large' || state.status === 'permanent_failure'
+  return (
+    state.status === 'too_large' ||
+    state.status === 'fatal_doc' ||
+    state.status === 'permanent_failure'
+  )
 }
 
 export const apiTransport: DocFrameTransport = {
@@ -560,6 +566,22 @@ export function useAgentCrdtFollower(
       event instanceof CustomEvent ? (event.detail ?? null) : null
     )
   }
+  const onDocError: EventListener = (event) => {
+    if (!(event instanceof CustomEvent)) return
+    const detail = event.detail as { workflowId?: unknown; code?: unknown }
+    if (
+      detail.workflowId !== subscribedWorkflowId.value ||
+      detail.code !== 'fatal_doc'
+    )
+      return
+    connected.value = false
+    lastFrameType.value = event.type
+    clearSubscribeRetry()
+    clearStaleProbe()
+    subscription.value = { status: 'fatal_doc', refusalCode: 'fatal_doc' }
+    sender.abortIfUnbound()
+    recordDevEvent('doc_error', event.detail)
+  }
   // s5-metrics-1: the bridge withholds a frame and forces a resubscribe when
   // it detects a seq jump (FEB-2) — that frame never becomes a `doc_update`
   // event, so `gap` can only be counted from the bridge's own `doc_gap`
@@ -621,6 +643,7 @@ export function useAgentCrdtFollower(
   bridge.addEventListener('doc_reset', onDocReset)
   bridge.addEventListener('follower_replaced', onFollowerReplaced)
   bridge.addEventListener('schema_error', onSchemaError)
+  bridge.addEventListener('doc_error', onDocError)
   bridge.addEventListener('doc_gap', onGap)
   bridge.addEventListener('doc_stale', onStale)
   api.addEventListener('reconnected', onReconnected)
@@ -707,6 +730,7 @@ export function useAgentCrdtFollower(
       bridge.removeEventListener('doc_reset', onDocReset)
       bridge.removeEventListener('follower_replaced', onFollowerReplaced)
       bridge.removeEventListener('schema_error', onSchemaError)
+      bridge.removeEventListener('doc_error', onDocError)
       bridge.removeEventListener('doc_gap', onGap)
       bridge.removeEventListener('doc_stale', onStale)
       sender.detach()


### PR DESCRIPTION
Consumes cloud `doc_error` frames as terminal per workflow.
Preserves the current Y.Doc and existing transient reconnect behavior.
Stacks on #16806 without weakening `too_large` handling.

<details><summary>Full context for agent readers</summary>

## Summary

- Parse the cloud #8222 `doc_error` / `fatal_doc` frame and dispatch a typed client event.
- Mark only the affected workflow terminal in the follower bridge and status seam, preventing timer, socket-activity, and reconnect resubscription while retaining the current Y.Doc.
- Clear that terminal latch only when the workflow target changes; ordinary reconnects remain transient.

This PR is based on #16806 so its refusal-code discrimination remains the single implementation for `too_large`, `unsupported`, and `invalid_frame`.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm test:unit src/workbench/extensions/agent/crdt/docFrameClient.test.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — 61 passed.
- `pnpm exec eslint <six changed files>` — passed.
- `pnpm exec oxfmt --check <six changed files>` — passed.
- `pnpm typecheck` — passed.
- Pre-commit lint-staged (oxfmt, oxlint, ESLint, typecheck) — passed.
- Pre-push `knip --cache` — passed.

Cloud dependency #8222 is merged.

</details>

<!-- authored-by:agent lane-docerr-1-2102 -->
