### PR TITLE
feat(workshop): add a model page and input form for every model

### DIFF
--- a/apps/website/src/components/workshop/WorkshopField.test.ts
+++ b/apps/website/src/components/workshop/WorkshopField.test.ts
@@ -1,0 +1,437 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  WorkshopField as Field,
+  WorkshopFormValues
+} from '../../config/workshop-detail'
+import WorkshopField from './WorkshopField.vue'
+
+function renderField(field: Field) {
+  const updated = vi.fn()
+  const values = ref<WorkshopFormValues>({})
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(WorkshopField, {
+          field,
+          modelValue: values.value,
+          'onUpdate:modelValue': (next: WorkshopFormValues) => {
+            values.value = next
+            updated(next)
+          }
+        })
+    }
+  })
+  render(Host)
+  return updated
+}
+
+describe('WorkshopField', () => {
+  it('renders multiline text fields with their declared length limits', () => {
+    renderField({
+      kind: 'text',
+      name: 'prompt',
+      label: 'Prompt',
+      required: true,
+      multiline: true,
+      valueType: 'string',
+      minLength: 1,
+      maxLength: 120
+    })
+    const input = screen.getByRole('textbox', { name: /Prompt/ })
+    expect(input.tagName).toBe('TEXTAREA')
+    expect(input.getAttribute('minlength')).toBe('1')
+    expect(input.getAttribute('maxlength')).toBe('120')
+  })
+
+  it('validates parsed JSON against the retained Router schema', async () => {
+    renderField({
+      kind: 'text',
+      name: 'inputs',
+      label: 'Inputs',
+      required: true,
+      multiline: true,
+      valueType: 'json',
+      jsonSchema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', minLength: 1 },
+            voice_id: { type: 'string', minLength: 1 }
+          },
+          required: ['text', 'voice_id'],
+          additionalProperties: false
+        },
+        minItems: 1,
+        maxItems: 10
+      }
+    })
+    const input = screen.getByRole('textbox', {
+      name: /Inputs/
+    }) as HTMLTextAreaElement
+
+    await fireEvent.update(input, '[]')
+    await nextTick()
+    expect(input.validationMessage).toBe(
+      "Enter JSON that matches this model input's schema."
+    )
+
+    await fireEvent.update(input, '[{"text":"Hello","voice_id":"Sarah"}]')
+    await nextTick()
+    expect(input.validationMessage).toBe('')
+  })
+
+  it('renders and updates select fields', async () => {
+    const updated = renderField({
+      kind: 'select',
+      name: 'quality',
+      label: 'Quality',
+      required: false,
+      options: ['standard', 'high']
+    })
+    const select = screen.getByRole('combobox', { name: 'Quality' })
+    await userEvent.setup().selectOptions(select, 'standard')
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ quality: 'standard' })
+  })
+
+  it('preselects a declared default without rendering a placeholder', async () => {
+    const updated = renderField({
+      kind: 'select',
+      name: 'quality',
+      label: 'Quality',
+      required: false,
+      options: ['standard', 'high'],
+      defaultValue: 'high'
+    })
+    const select = screen.getByRole('combobox', {
+      name: 'Quality'
+    }) as HTMLSelectElement
+
+    expect(select.value).toBe('high')
+    expect(screen.getAllByRole('option', { hidden: true })).toHaveLength(2)
+    await userEvent.setup().selectOptions(select, 'standard')
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ quality: 'standard' })
+  })
+
+  it('renders bounded number fields', () => {
+    renderField({
+      kind: 'number',
+      name: 'count',
+      label: 'Count',
+      required: false,
+      integer: true,
+      min: 1,
+      max: 4,
+      step: 1
+    })
+    const input = screen.getByRole('spinbutton', { name: 'Count' })
+    expect(input.getAttribute('min')).toBe('1')
+    expect(input.getAttribute('max')).toBe('4')
+  })
+
+  it('renders toggle fields', () => {
+    renderField({
+      kind: 'toggle',
+      name: 'enhance',
+      label: 'Enhance',
+      required: false,
+      defaultValue: false
+    })
+    expect(screen.getByRole('switch', { name: 'Enhance' })).toBeTruthy()
+  })
+
+  it('associates field hints with their controls', () => {
+    renderField({
+      kind: 'text',
+      name: 'prompt',
+      label: 'Prompt',
+      hint: 'Describe the image.',
+      required: true,
+      multiline: true,
+      valueType: 'string'
+    })
+
+    const hint = screen.getByText('Describe the image.')
+    expect(
+      screen
+        .getByRole('textbox', { name: 'Prompt *' })
+        .getAttribute('aria-describedby')
+    ).toBe(hint.id)
+  })
+
+  it.for([
+    ['image', 'image/*'],
+    ['video', 'video/*'],
+    ['audio', 'audio/*'],
+    ['file', null]
+  ] as const)('maps %s media fields to accept=%s', ([accept, expected]) => {
+    renderField({
+      kind: 'media',
+      name: `media_${accept}`,
+      role: accept,
+      label: 'Media',
+      required: true,
+      multiple: false,
+      accept
+    })
+    expect(screen.getByLabelText(/Media/).getAttribute('accept')).toBe(expected)
+  })
+
+  it('offers suggested values as completions, not as a closed list', async () => {
+    // The schema names these values without restricting the field to them, so
+    // the input has to stay typable: a caller's own cloned voice id is valid
+    // and is not in the list.
+    const updated = renderField({
+      kind: 'text',
+      name: 'voice',
+      label: 'Voice',
+      required: false,
+      multiline: false,
+      valueType: 'string',
+      suggestions: ['Rachel', 'Adam']
+    })
+
+    // `list` makes the input a combobox to assistive tech rather than a plain
+    // textbox, which is the right announcement for "type one or pick one".
+    const input = screen.getByRole('combobox', { name: 'Voice' })
+    expect(input.tagName).toBe('INPUT')
+    expect(input.getAttribute('list')).toBe('voice-suggestions')
+    expect(
+      screen
+        .getAllByRole('option', { hidden: true })
+        .map((option) => option.getAttribute('value'))
+    ).toEqual(['Rachel', 'Adam'])
+
+    await userEvent.setup().type(input, 'my-own-voice-id')
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ voice: 'my-own-voice-id' })
+  })
+
+  it('leaves a plain text field without a suggestion list', () => {
+    renderField({
+      kind: 'text',
+      name: 'prompt',
+      label: 'Prompt',
+      required: false,
+      multiline: false,
+      valueType: 'string'
+    })
+
+    const input = screen.getByRole('textbox', { name: 'Prompt' })
+    expect(input.tagName).toBe('INPUT')
+    expect(input.getAttribute('type')).toBe('text')
+    expect(input.hasAttribute('list')).toBe(false)
+    expect(screen.queryAllByRole('option', { hidden: true })).toEqual([])
+  })
+
+  it('passes an unconstrained step through instead of inventing precision', () => {
+    renderField({
+      kind: 'number',
+      name: 'guidance',
+      label: 'Guidance',
+      required: false,
+      integer: false,
+      step: 'any'
+    })
+
+    expect(
+      screen.getByRole('spinbutton', { name: 'Guidance' }).getAttribute('step')
+    ).toBe('any')
+  })
+
+  it('clears a number field rather than reporting NaN', async () => {
+    const updated = renderField({
+      kind: 'number',
+      name: 'steps',
+      label: 'Steps',
+      required: false,
+      integer: true,
+      step: 1
+    })
+
+    const input = screen.getByRole('spinbutton', { name: 'Steps' })
+    await userEvent.setup().type(input, '4{backspace}')
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ steps: undefined })
+  })
+
+  it('returns to no selection when the placeholder is chosen', async () => {
+    const updated = renderField({
+      kind: 'select',
+      name: 'quality',
+      label: 'Quality',
+      required: false,
+      options: ['standard', 'high']
+    })
+
+    const select = screen.getByRole('combobox', { name: 'Quality' })
+    const user = userEvent.setup()
+    await user.selectOptions(select, 'high')
+    await nextTick()
+    await user.selectOptions(select, '')
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ quality: undefined })
+  })
+
+  it('records an uploaded file as a single value or a list, per the field', async () => {
+    // The value stands in for an upload the run path resolves later; what
+    // matters here is that a single-file field never yields an array and a
+    // multiple one always does, because the request body shape depends on it.
+    const single = renderField({
+      kind: 'media',
+      name: 'media_image',
+      role: 'image',
+      label: 'Image',
+      required: false,
+      multiple: false,
+      accept: 'image'
+    })
+    const user = userEvent.setup()
+    await user.upload(
+      screen.getByLabelText(/Image/),
+      new File(['x'], 'cat.png', { type: 'image/png' })
+    )
+    await nextTick()
+    expect(single).toHaveBeenLastCalledWith({ media_image: '<cat.png>' })
+  })
+
+  it('keeps every file when the field takes more than one', async () => {
+    const updated = renderField({
+      kind: 'media',
+      name: 'media_frames',
+      role: 'frames',
+      label: 'Frames',
+      required: false,
+      multiple: true,
+      accept: 'image'
+    })
+    await userEvent
+      .setup()
+      .upload(screen.getByLabelText(/Frames/), [
+        new File(['a'], 'a.png', { type: 'image/png' }),
+        new File(['b'], 'b.png', { type: 'image/png' })
+      ])
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({
+      media_frames: ['<a.png>', '<b.png>']
+    })
+  })
+
+  it('rejects more files than the role permits', async () => {
+    const updated = renderField({
+      kind: 'media',
+      name: 'media_frames',
+      role: 'frames',
+      label: 'Frames',
+      required: false,
+      multiple: true,
+      maxItems: 2,
+      accept: 'image'
+    })
+    const input = screen.getByLabelText(/Frames/) as HTMLInputElement
+    await userEvent
+      .setup()
+      .upload(input, [
+        new File(['a'], 'a.png', { type: 'image/png' }),
+        new File(['b'], 'b.png', { type: 'image/png' }),
+        new File(['c'], 'c.png', { type: 'image/png' })
+      ])
+    await nextTick()
+
+    expect(input.validationMessage).toBe('Select no more than 2 files.')
+    expect(updated).toHaveBeenLastCalledWith({ media_frames: undefined })
+  })
+
+  it('toggles on and back off', async () => {
+    const updated = renderField({
+      kind: 'toggle',
+      name: 'enhance',
+      label: 'Enhance',
+      required: false,
+      defaultValue: false
+    })
+    const toggle = screen.getByRole('switch', { name: 'Enhance' })
+    const user = userEvent.setup()
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    await user.click(toggle)
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ enhance: true })
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+    await user.click(toggle)
+    await nextTick()
+    expect(updated).toHaveBeenLastCalledWith({ enhance: false })
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('shows a visible error when too many files are picked', async () => {
+    // setCustomValidity alone was invisible: the only submit control is
+    // disabled, so the browser never surfaced it and the selection vanished
+    // with no explanation.
+    const updated = renderField({
+      kind: 'media',
+      name: 'media_frames',
+      role: 'frames',
+      label: 'Frames',
+      required: false,
+      multiple: true,
+      maxItems: 1,
+      accept: 'image'
+    })
+
+    const input = screen.getByLabelText(/Frames/) as HTMLInputElement
+    await userEvent
+      .setup()
+      .upload(input, [
+        new File(['a'], 'a.png', { type: 'image/png' }),
+        new File(['b'], 'b.png', { type: 'image/png' })
+      ])
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('1')
+    // The picker must not keep listing files the form has thrown away.
+    expect(input.value).toBe('')
+    expect(updated).toHaveBeenLastCalledWith({ media_frames: undefined })
+    // And the failure is announced, not just painted.
+    expect(input.getAttribute('aria-describedby')).toContain(alert.id)
+  })
+
+  it('shows a visible error for JSON the model would reject', async () => {
+    renderField({
+      kind: 'text',
+      name: 'inputs',
+      label: 'Inputs',
+      required: true,
+      multiline: true,
+      valueType: 'json',
+      jsonSchema: { type: 'array', minItems: 1 }
+    })
+
+    // userEvent reads [ and ] as key descriptors; [[ and ]] are the literals.
+    await userEvent.setup().type(screen.getByLabelText(/Inputs/), '[[]]')
+
+    expect((await screen.findByRole('alert')).textContent).toBeTruthy()
+  })
+
+  it('keeps a numeric option a number, not the string the DOM gives back', async () => {
+    // The index lookup exists only for this. 16 selects in the catalog have
+    // numeric options, and a regression to target.value would ship "50".
+    const updated = renderField({
+      kind: 'select',
+      name: 'fps',
+      label: 'Fps',
+      required: false,
+      options: [25, 50]
+    })
+
+    await userEvent.setup().selectOptions(screen.getByLabelText(/Fps/), '50')
+
+    expect(updated).toHaveBeenLastCalledWith({ fps: 50 })
+  })
+})

--- a/apps/website/src/components/workshop/WorkshopField.vue
+++ b/apps/website/src/components/workshop/WorkshopField.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { computed, ref } from 'vue'
+
+import type {
+  WorkshopField,
+  WorkshopFormValue,
+  WorkshopFormValues
+} from '../../config/workshop-detail'
+import { parseWorkshopJsonInput } from '../../config/workshop-json-schema'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
+const { field, locale = 'en' } = defineProps<{
+  field: WorkshopField
+  locale?: Locale
+}>()
+const values = defineModel<WorkshopFormValues>({ required: true })
+/**
+ * A validation message the visitor can actually see.
+ *
+ * `setCustomValidity` alone was invisible here: the only submit control is
+ * disabled, so the browser never surfaces it and the field failed silently.
+ */
+const error = ref('')
+const controlId = `workshop-field-${field.name}`
+const errorId = `${controlId}-error`
+const labelId = `${controlId}-label`
+const hintId = `${controlId}-hint`
+const hint = computed(() => ('hint' in field ? field.hint : undefined))
+
+/** Both the hint and any error, so a screen reader is told about the failure. */
+const describedBy = computed(() => {
+  const ids = [
+    hint.value ? hintId : undefined,
+    error.value ? errorId : undefined
+  ].filter((id) => id !== undefined)
+  return ids.length > 0 ? ids.join(' ') : undefined
+})
+
+function set(value: WorkshopFormValue) {
+  values.value = { ...values.value, [field.name]: value }
+}
+
+function textValue(): string {
+  const value = values.value[field.name]
+  return typeof value === 'string' ? value : ''
+}
+
+function numberValue(): number | undefined {
+  const value = values.value[field.name]
+  return typeof value === 'number' ? value : undefined
+}
+
+function booleanValue(): boolean {
+  return values.value[field.name] === true
+}
+
+function onText(event: Event) {
+  const input = event.target as HTMLInputElement | HTMLTextAreaElement
+  const value = input.value
+  const invalid =
+    field.kind === 'text' &&
+    field.valueType === 'json' &&
+    value !== '' &&
+    !parseWorkshopJsonInput(value, field.jsonSchema).success
+
+  error.value = invalid ? t('workshop.model.invalidJson', locale) : ''
+  input.setCustomValidity(error.value)
+  set(value)
+}
+
+function onNumber(event: Event) {
+  const value = (event.target as HTMLInputElement).valueAsNumber
+  set(Number.isNaN(value) ? undefined : value)
+}
+
+function onSelect(event: Event) {
+  if (field.kind !== 'select') return
+  const placeholderOffset = field.defaultValue === undefined ? 1 : 0
+  const index =
+    (event.target as HTMLSelectElement).selectedIndex - placeholderOffset
+  set(index < 0 ? undefined : field.options[index])
+}
+
+function onMedia(event: Event) {
+  if (field.kind !== 'media') return
+  const input = event.target as HTMLInputElement
+  const files = [...(input.files ?? [])]
+  if (field.maxItems !== undefined && files.length > field.maxItems) {
+    error.value = t('workshop.model.maxFiles', locale).replace(
+      '{count}',
+      String(field.maxItems)
+    )
+    input.setCustomValidity(error.value)
+    // Clear the picker too. Leaving it listing files the form has discarded
+    // is what made this look like nothing happened, and keeping a previously
+    // valid selection would contradict what the control shows.
+    input.value = ''
+    set(undefined)
+    return
+  }
+  error.value = ''
+  input.setCustomValidity('')
+  const uploads = files.map((file) => `<${file.name}>`)
+  set(uploads.length === 0 ? undefined : field.multiple ? uploads : uploads[0])
+}
+
+const acceptByType = {
+  image: 'image/*',
+  video: 'video/*',
+  audio: 'audio/*',
+  file: undefined
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <label
+      v-if="field.kind !== 'toggle'"
+      :for="controlId"
+      class="text-sm font-medium text-primary-comfy-canvas"
+    >
+      {{ field.label }}
+      <span v-if="field.required" class="text-primary-comfy-yellow">*</span>
+    </label>
+    <span
+      v-else
+      :id="labelId"
+      class="text-sm font-medium text-primary-comfy-canvas"
+    >
+      {{ field.label }}
+      <span v-if="field.required" class="text-primary-comfy-yellow">*</span>
+    </span>
+    <span v-if="hint" :id="hintId" class="text-xs text-primary-comfy-canvas/55">
+      {{ hint }}
+    </span>
+
+    <textarea
+      v-if="field.kind === 'text' && field.multiline"
+      :id="controlId"
+      :value="textValue()"
+      :required="field.required"
+      :minlength="field.minLength"
+      :maxlength="field.maxLength"
+      :aria-describedby="describedBy"
+      rows="5"
+      class="focus:border-primary-comfy-yellow min-h-32 resize-y rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-canvas/5 px-4 py-3 font-mono text-sm text-primary-comfy-canvas outline-none"
+      @input="onText"
+    />
+    <input
+      v-else-if="field.kind === 'text'"
+      :id="controlId"
+      type="text"
+      :value="textValue()"
+      :required="field.required"
+      :minlength="field.minLength"
+      :maxlength="field.maxLength"
+      :list="field.suggestions ? `${field.name}-suggestions` : undefined"
+      :aria-describedby="describedBy"
+      class="focus:border-primary-comfy-yellow h-11 rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-canvas/5 px-4 text-sm text-primary-comfy-canvas outline-none"
+      @input="onText"
+    />
+    <select
+      v-else-if="field.kind === 'select'"
+      :id="controlId"
+      :value="values[field.name] ?? field.defaultValue"
+      :required="field.required"
+      :aria-describedby="describedBy"
+      class="focus:border-primary-comfy-yellow h-11 rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink px-4 text-sm text-primary-comfy-canvas outline-none"
+      @change="onSelect"
+    >
+      <option v-if="field.defaultValue === undefined" value="">
+        {{ t('workshop.model.select', locale) }}
+      </option>
+      <!--
+        `selected` rather than relying on the select's `:value`. A `value`
+        attribute on a server-rendered <select> is inert — the browser picks
+        the first option instead — so 71 model pages showed an option that
+        contradicted the form state until hydration corrected it.
+      -->
+      <option
+        v-for="option in field.options"
+        :key="String(option)"
+        :value="option"
+        :selected="option === (values[field.name] ?? field.defaultValue)"
+      >
+        {{ option }}
+      </option>
+    </select>
+    <input
+      v-else-if="field.kind === 'number'"
+      :id="controlId"
+      type="number"
+      :value="numberValue()"
+      :required="field.required"
+      :min="field.min"
+      :max="field.max"
+      :step="field.step"
+      :aria-describedby="describedBy"
+      class="focus:border-primary-comfy-yellow h-11 rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-canvas/5 px-4 text-sm text-primary-comfy-canvas outline-none"
+      @input="onNumber"
+    />
+    <button
+      v-else-if="field.kind === 'toggle'"
+      type="button"
+      role="switch"
+      :aria-checked="booleanValue()"
+      :aria-labelledby="labelId"
+      :aria-describedby="describedBy"
+      :class="
+        cn(
+          'relative h-7 w-12 rounded-full transition-colors',
+          booleanValue()
+            ? 'bg-primary-comfy-yellow'
+            : 'bg-primary-comfy-canvas/20'
+        )
+      "
+      @click="set(!booleanValue())"
+    >
+      <span
+        :class="
+          cn(
+            'absolute top-1 left-1 size-5 rounded-full bg-primary-comfy-ink transition-transform',
+            booleanValue() && 'translate-x-5'
+          )
+        "
+      />
+    </button>
+    <input
+      v-else-if="field.kind === 'media'"
+      :id="controlId"
+      type="file"
+      :required="field.required"
+      :multiple="field.multiple"
+      :accept="acceptByType[field.accept]"
+      :aria-describedby="describedBy"
+      class="file:bg-primary-comfy-yellow rounded-xl border border-dashed border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 p-4 text-sm text-primary-comfy-canvas file:mr-4 file:rounded-full file:border-0 file:px-4 file:py-2 file:text-primary-comfy-ink"
+      @change="onMedia"
+    />
+    <!--
+      Values the schema names without restricting the field to them, e.g. the
+      stock voices on a text-to-speech model. Offered as completions rather
+      than a closed dropdown so a caller's own value stays typable.
+    -->
+    <datalist
+      v-if="field.kind === 'text' && field.suggestions"
+      :id="`${field.name}-suggestions`"
+    >
+      <option
+        v-for="option in field.suggestions"
+        :key="String(option)"
+        :value="option"
+      />
+    </datalist>
+
+    <p v-if="error" :id="errorId" role="alert" class="text-sm text-red-400">
+      {{ error }}
+    </p>
+  </div>
+</template>

--- a/apps/website/src/components/workshop/WorkshopForm.test.ts
+++ b/apps/website/src/components/workshop/WorkshopForm.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { nextTick } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import type {
+  WorkshopDetailModel,
+  WorkshopFormValues
+} from '../../config/workshop-detail'
+import WorkshopForm from './WorkshopForm.vue'
+
+const model = {
+  id: 'bfl/flux-3',
+  slug: 'bfl-flux-3',
+  displayName: 'Flux 3',
+  provider: 'Black Forest Labs',
+  modality: 'image',
+  description: 'Text to image.',
+  tags: ['image'],
+  fields: [
+    {
+      kind: 'text',
+      name: 'prompt',
+      label: 'Prompt',
+      required: true,
+      multiline: true,
+      valueType: 'string'
+    },
+    {
+      kind: 'select',
+      name: 'aspect_ratio',
+      label: 'Aspect ratio',
+      required: false,
+      options: ['1:1', '16:9'],
+      defaultValue: '1:1'
+    }
+  ]
+} satisfies WorkshopDetailModel
+
+/**
+ * Asserting on what the component emits, rather than on an injected update
+ * handler, is what a caller actually observes — and it keeps the fixture and
+ * the props in their real types with no casts.
+ */
+function renderForm() {
+  return render(WorkshopForm, { props: { model } })
+}
+
+function lastEmittedValues(
+  utils: ReturnType<typeof renderForm>
+): WorkshopFormValues | undefined {
+  const emitted = utils.emitted('update:modelValue') as
+    | [WorkshopFormValues][]
+    | undefined
+  return emitted?.at(-1)?.[0]
+}
+
+function utilsSelectValue(): string {
+  return (screen.getByLabelText(/aspect ratio/i) as HTMLSelectElement).value
+}
+
+describe('WorkshopForm', () => {
+  it('renders one control per field in the model', () => {
+    renderForm()
+
+    expect(screen.getByLabelText(/prompt/i)).toBeTruthy()
+    expect(screen.getByLabelText(/aspect ratio/i)).toBeTruthy()
+  })
+
+  it('seeds the schema defaults and reports them', async () => {
+    // The page renders this before the visitor has touched anything, so the
+    // form has to become the model's defaults rather than stay empty and send
+    // a request with no aspect ratio.
+    const utils = renderForm()
+
+    await waitFor(() =>
+      expect(lastEmittedValues(utils)).toMatchObject({ aspect_ratio: '1:1' })
+    )
+    expect(utilsSelectValue()).toBe('1:1')
+  })
+
+  it('keeps an edit instead of re-seeding over it', async () => {
+    const utils = renderForm()
+    await userEvent.setup().type(screen.getByLabelText(/prompt/i), 'a cat')
+    await nextTick()
+
+    // The seed must not come back and overwrite what was typed.
+    expect(lastEmittedValues(utils)).toMatchObject({
+      prompt: 'a cat',
+      aspect_ratio: '1:1'
+    })
+  })
+
+  it('shows the run control as not yet available', () => {
+    renderForm()
+
+    const submit = screen.getByRole('button', {
+      name: 'Run model — sign-in coming next'
+    })
+    expect(submit.hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/apps/website/src/components/workshop/WorkshopForm.vue
+++ b/apps/website/src/components/workshop/WorkshopForm.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type {
+  WorkshopDetailModel,
+  WorkshopFormValues
+} from '../../config/workshop-detail'
+import { defaultWorkshopValues } from '../../config/workshop-detail'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import WorkshopField from './WorkshopField.vue'
+
+const { model, locale = 'en' } = defineProps<{
+  model: WorkshopDetailModel
+  locale?: Locale
+}>()
+// Defaulted, because the page renders this island with `model` alone —
+// Astro's Vue shim types a component from `defineProps`, so `modelValue`
+// cannot be passed from `.astro` at all. The form therefore seeds itself
+// from the schema and reports the result by emitting.
+const values = defineModel<WorkshopFormValues>({ default: () => ({}) })
+if (Object.keys(values.value).length === 0) {
+  values.value = defaultWorkshopValues(model.fields)
+}
+</script>
+
+<template>
+  <section
+    class="rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-6"
+  >
+    <h2 class="text-xl font-semibold text-primary-comfy-canvas">
+      {{ t('workshop.model.inputs', locale) }}
+    </h2>
+    <form class="mt-6 flex flex-col gap-6" @submit.prevent>
+      <WorkshopField
+        v-for="field in model.fields"
+        :key="field.name"
+        v-model="values"
+        :field="field"
+        :locale="locale"
+      />
+      <button
+        type="submit"
+        disabled
+        class="bg-primary-comfy-yellow mt-2 rounded-full px-5 py-3 font-medium text-primary-comfy-ink opacity-50"
+      >
+        {{ t('workshop.model.runNext', locale) }}
+      </button>
+    </form>
+  </section>
+</template>

--- a/apps/website/src/config/workshop-detail.test.ts
+++ b/apps/website/src/config/workshop-detail.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkshopModelEntry } from '../content/workshop-models.schema'
+import type { WorkshopDetailModel } from './workshop-detail'
+import {
+  defaultWorkshopValues,
+  relatedWorkshopModels,
+  toDetailModel
+} from './workshop-detail'
+
+const entry: WorkshopModelEntry = {
+  id: 'provider/model-v1',
+  slug: 'provider--model-v1',
+  displayName: 'Model V1',
+  provider: 'provider',
+  modality: 'image',
+  description: 'Generates an image.',
+  tags: ['text-to-image'],
+  parameters: {
+    type: 'object',
+    required: ['prompt'],
+    properties: { prompt: { type: 'string' } }
+  },
+  roles: []
+}
+
+function model(
+  slug: string,
+  provider: string,
+  modality: string
+): WorkshopDetailModel {
+  return { ...toDetailModel(entry), slug, provider, modality }
+}
+
+describe('toDetailModel', () => {
+  it('derives fields rather than reading a stored copy', () => {
+    // The catalog carries the provider's schema; the form shape is decided
+    // here, so a policy change does not require regenerating 268 files.
+    expect(toDetailModel(entry).fields).toEqual([
+      {
+        kind: 'text',
+        name: 'prompt',
+        label: 'Prompt',
+        required: true,
+        multiline: true,
+        valueType: 'string'
+      }
+    ])
+  })
+
+  it('carries the identity the run call needs', () => {
+    expect(toDetailModel(entry)).toMatchObject({
+      id: 'provider/model-v1',
+      slug: 'provider--model-v1',
+      displayName: 'Model V1'
+    })
+  })
+})
+
+describe('defaultWorkshopValues', () => {
+  it('returns no values when there are no fields', () => {
+    expect(defaultWorkshopValues([])).toEqual({})
+  })
+
+  it('seeds a value for every field, defined or not', () => {
+    expect(
+      defaultWorkshopValues([
+        {
+          kind: 'toggle',
+          name: 'enhance',
+          label: 'Enhance',
+          required: false,
+          defaultValue: true
+        },
+        {
+          kind: 'text',
+          name: 'prompt',
+          label: 'Prompt',
+          required: true,
+          multiline: true,
+          valueType: 'string'
+        }
+      ])
+      // `prompt` is present and undefined rather than absent, so the form binds
+      // every input on first render instead of switching from uncontrolled.
+    ).toEqual({ enhance: true, prompt: undefined })
+  })
+})
+
+describe('relatedWorkshopModels', () => {
+  const subject = model('subject', 'alpha', 'image')
+  const pool = [
+    subject,
+    model('same-both', 'alpha', 'image'),
+    model('same-provider', 'alpha', 'video'),
+    model('same-modality', 'beta', 'image'),
+    model('unrelated', 'beta', 'audio')
+  ]
+
+  it('ranks same provider above same modality, and excludes itself', () => {
+    expect(
+      relatedWorkshopModels(subject, pool).map((entry) => entry.slug)
+    ).toEqual(['same-both', 'same-provider', 'same-modality', 'unrelated'])
+  })
+
+  it('never returns more than the limit', () => {
+    expect(relatedWorkshopModels(subject, pool, 2)).toHaveLength(2)
+  })
+
+  it('returns every remaining candidate when the pool is smaller than the limit', () => {
+    expect(relatedWorkshopModels(subject, [subject, pool[1]], 4)).toEqual([
+      pool[1]
+    ])
+  })
+})

--- a/apps/website/src/config/workshop-detail.ts
+++ b/apps/website/src/config/workshop-detail.ts
@@ -1,0 +1,79 @@
+import type { WorkshopModelEntry } from '../content/workshop-models.schema'
+import type { WorkshopCatalogField } from './workshop-fields'
+import { deriveWorkshopFields } from './workshop-fields'
+
+/**
+ * The form field union lives with the code that derives it. Re-exported under
+ * the page-facing name so a component imports one module, not two.
+ */
+export type WorkshopField = WorkshopCatalogField
+
+export interface WorkshopDetailModel {
+  readonly id: string
+  readonly slug: string
+  readonly displayName: string
+  readonly provider: string
+  readonly modality: string
+  readonly description: string
+  readonly tags: readonly string[]
+  readonly fields: readonly WorkshopField[]
+}
+
+export type WorkshopFormValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | undefined
+export type WorkshopFormValues = Readonly<Record<string, WorkshopFormValue>>
+
+/**
+ * The page's view of a model. `fields` is derived here rather than stored,
+ * so the catalog holds only what the Router client gives us and the form
+ * policy stays in code.
+ */
+export function toDetailModel(entry: WorkshopModelEntry): WorkshopDetailModel {
+  return {
+    id: entry.id,
+    slug: entry.slug,
+    displayName: entry.displayName,
+    provider: entry.provider,
+    modality: entry.modality,
+    description: entry.description,
+    tags: entry.tags,
+    fields: deriveWorkshopFields(entry.parameters, entry.roles)
+  }
+}
+
+export function defaultWorkshopValues(
+  fields: readonly WorkshopField[]
+): WorkshopFormValues {
+  return Object.fromEntries(
+    fields.map((field) => [
+      field.name,
+      'defaultValue' in field ? field.defaultValue : undefined
+    ])
+  )
+}
+
+export function relatedWorkshopModels(
+  model: WorkshopDetailModel,
+  pool: readonly WorkshopDetailModel[],
+  limit = 4
+): WorkshopDetailModel[] {
+  return pool
+    .filter((candidate) => candidate.slug !== model.slug)
+    .sort((left, right) => {
+      const leftScore =
+        Number(left.provider === model.provider) * 2 +
+        Number(left.modality === model.modality)
+      const rightScore =
+        Number(right.provider === model.provider) * 2 +
+        Number(right.modality === model.modality)
+      return (
+        rightScore - leftScore ||
+        left.displayName.localeCompare(right.displayName)
+      )
+    })
+    .slice(0, limit)
+}

--- a/apps/website/src/config/workshop-fields.test.ts
+++ b/apps/website/src/config/workshop-fields.test.ts
@@ -388,4 +388,40 @@ describe('open-ended and free-precision inputs', () => {
 
     expect(invented).toEqual([])
   })
+
+  it('offers an image picker for angle-named media roles', () => {
+    // view_left / view_right / view_back name the camera angle, not the
+    // medium. Matched by substring alone they fall through to a generic file
+    // picker, and kling/dual-character-effect has only those two roles, so it
+    // would offer no image picker at all.
+    const fields = deriveWorkshopFields({ type: 'object', properties: {} }, [
+      { role: 'view_left', required: true, cardinality: 'single', minItems: 1 },
+      { role: 'view_right', required: true, cardinality: 'single', minItems: 1 }
+    ])
+
+    expect(
+      fields.map((field) => field.kind === 'media' && field.accept)
+    ).toEqual(['image', 'image'])
+  })
+
+  it('gives unbounded free text a textarea, not a one-line input', () => {
+    // Testing only `maxLength > 200` sends every unbounded string to a
+    // single-line box. Unbounded is the common case in this catalog: no
+    // negative_prompt anywhere declares a maxLength.
+    const [unbounded, short, long] = deriveWorkshopFields(
+      {
+        type: 'object',
+        properties: {
+          negative_prompt: { type: 'string' },
+          title: { type: 'string', maxLength: 60 },
+          story: { type: 'string', maxLength: 4000 }
+        }
+      },
+      []
+    )
+
+    expect(unbounded.kind === 'text' && unbounded.multiline).toBe(true)
+    expect(short.kind === 'text' && short.multiline).toBe(false)
+    expect(long.kind === 'text' && long.multiline).toBe(true)
+  })
 })

--- a/apps/website/src/config/workshop-fields.ts
+++ b/apps/website/src/config/workshop-fields.ts
@@ -215,9 +215,12 @@ function fieldFor(
     return {
       kind: 'text',
       ...common,
+      // A bound above 200 means long prose. So does no bound at all, which
+      // is the common case: every `negative_prompt` in the catalog is an
+      // unbounded string, and testing `maxLength > 200` alone put 135 of 332
+      // free-text fields into a single-line box.
       multiline:
-        name === 'prompt' ||
-        (typeof schema.maxLength === 'number' && schema.maxLength > 200),
+        typeof schema.maxLength === 'number' ? schema.maxLength > 200 : true,
       valueType: 'string',
       ...textLengthLimits(schema),
       ...(typeof schema.default === 'string'
@@ -237,7 +240,16 @@ function fieldFor(
   }
 }
 
+/**
+ * Which file types a media input should accept.
+ *
+ * `view_*` roles are named for the camera angle rather than the medium, so a
+ * substring match alone drops them to a generic file picker. Four models
+ * carry them, and `kling/dual-character-effect` has nothing but `view_left`
+ * and `view_right`, so it would offer no image picker at all.
+ */
 function acceptFor(role: string): 'image' | 'video' | 'audio' | 'file' {
+  if (role.startsWith('view_')) return 'image'
   if (role.includes('image') || role === 'mask') return 'image'
   if (role.includes('video')) return 'video'
   if (role.includes('audio')) return 'audio'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -58,6 +58,26 @@ const translations = {
     en: 'Show more models',
     'zh-CN': '显示更多模型'
   },
+  'workshop.model.breadcrumb': { en: 'Workshop', 'zh-CN': 'Workshop' },
+  'workshop.model.inputs': { en: 'Model inputs', 'zh-CN': '模型输入' },
+  'workshop.model.select': { en: 'Select an option', 'zh-CN': '选择一个选项' },
+  'workshop.model.maxFiles': {
+    en: 'Select no more than {count} files.',
+    'zh-CN': '最多选择 {count} 个文件。'
+  },
+  'workshop.model.invalidJson': {
+    en: "Enter JSON that matches this model input's schema.",
+    'zh-CN': '请输入符合此模型输入架构的 JSON。'
+  },
+  'workshop.model.runNext': {
+    en: 'Run model — sign-in coming next',
+    'zh-CN': '运行模型 — 登录功能即将推出'
+  },
+  'workshop.model.related': { en: 'Related models', 'zh-CN': '相关模型' },
+  'workshop.model.browseAll': {
+    en: 'Browse all models',
+    'zh-CN': '浏览所有模型'
+  },
 
   // Tags (global, reusable across sections)
   'tags.partnerNodes': {

--- a/apps/website/src/pages/workshop/index.astro
+++ b/apps/website/src/pages/workshop/index.astro
@@ -19,6 +19,6 @@ const models = prepareWorkshopBrowseModels(
   description={t('workshop.meta.description')}
 >
   <main class="mx-auto max-w-10xl px-6 py-16 lg:px-8 lg:py-24">
-    <WorkshopCatalog models={models} client:load />
+    <WorkshopCatalog models={models} detailRoutesAvailable client:load />
   </main>
 </BaseLayout>

--- a/apps/website/src/pages/workshop/models/[slug].astro
+++ b/apps/website/src/pages/workshop/models/[slug].astro
@@ -1,0 +1,105 @@
+---
+import type { GetStaticPaths } from 'astro'
+import { getCollection } from 'astro:content'
+
+import WorkshopForm from '../../../components/workshop/WorkshopForm.vue'
+import type { WorkshopDetailModel } from '../../../config/workshop-detail'
+import {
+  relatedWorkshopModels,
+  toDetailModel
+} from '../../../config/workshop-detail'
+import { t } from '../../../i18n/translations'
+import BaseLayout from '../../../layouts/BaseLayout.astro'
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const models = (await getCollection('workshopModels')).map((entry) =>
+    toDetailModel(entry.data)
+  )
+  return models.map((model) => ({
+    params: { slug: model.slug },
+    props: { model, related: relatedWorkshopModels(model, models) }
+  }))
+}
+
+interface Props {
+  model: WorkshopDetailModel
+  related: readonly WorkshopDetailModel[]
+}
+
+const { model, related } = Astro.props
+---
+
+<BaseLayout
+  title={`${model.displayName} · Workshop - Comfy`}
+  description={model.description}
+>
+  <main class="mx-auto max-w-10xl px-6 py-12 lg:px-8 lg:py-16">
+    <nav aria-label="Breadcrumb" class="mb-8 text-sm text-primary-comfy-canvas/55">
+      <a href="/workshop/" class="hover:text-primary-comfy-yellow">
+        {t('workshop.model.breadcrumb')}
+      </a>
+      <span aria-hidden="true" class="mx-2">/</span>
+      <span aria-current="page" class="text-primary-comfy-canvas">
+        {model.displayName}
+      </span>
+    </nav>
+
+    {/*
+      A div, not a header. `markdown-twin.ts` drops HEADER along with the
+      site chrome, so wrapping the hero in one leaves every model's llms.txt
+      entry with a title and nothing else. The h1 still carries the heading.
+    */}
+    <div class="mb-12 max-w-4xl">
+      <p class="text-sm tracking-widest text-primary-comfy-yellow uppercase">
+        {model.provider}
+      </p>
+      <h1 class="mt-3 text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
+        {model.displayName}
+      </h1>
+      <p class="mt-5 text-lg text-primary-comfy-canvas/70">
+        {model.description}
+      </p>
+      <ul class="mt-6 flex flex-wrap gap-2">
+        {
+          model.tags.slice(0, 8).map((tag) => (
+            <li class="rounded-full bg-primary-comfy-canvas/8 px-3 py-1 text-xs text-primary-comfy-canvas/65">
+              {tag}
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+
+    <div class="max-w-2xl">
+      <WorkshopForm model={model} client:load />
+    </div>
+
+    <section class="mt-20 border-t border-primary-comfy-canvas/10 pt-10">
+      <div class="flex items-center justify-between gap-4">
+        <h2 class="text-2xl font-semibold text-primary-comfy-canvas">
+          {t('workshop.model.related')}
+        </h2>
+        <a href="/workshop/" class="text-sm text-primary-comfy-yellow hover:underline">
+          {t('workshop.model.browseAll')}
+        </a>
+      </div>
+      <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {
+          related.map((candidate) => (
+            <a
+              href={`/workshop/models/${candidate.slug}/`}
+              class="rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-5 transition-colors hover:border-primary-comfy-yellow/60"
+            >
+              <p class="text-xs tracking-wider text-primary-comfy-yellow uppercase">
+                {candidate.provider}
+              </p>
+              <h3 class="mt-2 font-medium text-primary-comfy-canvas">
+                {candidate.displayName}
+              </h3>
+            </a>
+          ))
+        }
+      </div>
+    </section>
+  </main>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds a prerendered page for each of the 268 Workshop models when Workshop is enabled. Every page shows the model name, provider, description, tags, generated input form, and four related models.

The form renders the five derived control kinds: text, select, number, toggle, and media upload. Generated defaults, required fields, numeric limits, accepted file types, and multiple-file roles are carried into the controls.

Workshop remains absent from release builds. In Workshop-enabled labeled previews, the English-only catalog and model routes are indexable and represented consistently in the sitemap and hreflang metadata.

## Test plan

- [x] Test all five field controls
- [x] Test field defaults and related-model selection
- [x] Astro and Vue typechecks pass
- [x] Enabled build creates all 268 model routes
- [x] Release build emits no Workshop routes
- [x] Unknown model routes return 404
- [x] Enabled sitemap and hreflang targets are valid
- [x] Knip and repository hooks pass