### PR TITLE
feat(workshop): add live API snippets to model pages

### DIFF
--- a/apps/website/src/components/workshop/WorkshopPlayground.test.ts
+++ b/apps/website/src/components/workshop/WorkshopPlayground.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { WorkshopDetailModel } from '../../config/workshop-detail'
+import WorkshopPlayground from './WorkshopPlayground.vue'
+
+const model: WorkshopDetailModel = {
+  id: 'bfl/flux-3',
+  slug: 'bfl--flux-3',
+  displayName: 'Flux 3',
+  provider: 'bfl',
+  modality: 'image',
+  description: 'Generates an image.',
+  tags: ['text-to-image'],
+  fields: [
+    {
+      kind: 'text',
+      name: 'prompt',
+      label: 'Prompt',
+      required: true,
+      multiline: true,
+      valueType: 'string'
+    }
+  ]
+}
+
+const jsonModel: WorkshopDetailModel = {
+  ...model,
+  fields: [
+    {
+      kind: 'text',
+      name: 'inputs',
+      label: 'Inputs',
+      required: true,
+      multiline: true,
+      valueType: 'json',
+      jsonSchema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', minLength: 1 },
+            voice_id: { type: 'string', minLength: 1 }
+          },
+          required: ['text', 'voice_id'],
+          additionalProperties: false
+        },
+        minItems: 1,
+        maxItems: 10
+      }
+    }
+  ]
+}
+
+describe('WorkshopPlayground', () => {
+  it('updates every snippet from the current form values', async () => {
+    const user = userEvent.setup()
+    render(WorkshopPlayground, { props: { model } })
+
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    await nextTick()
+    expect(screen.getByText(/"prompt": "Red fox"/)).toBeTruthy()
+
+    const typeScriptTab = screen.getByRole('tab', { name: 'TypeScript' })
+    typeScriptTab.focus()
+    await user.keyboard('{ArrowRight}')
+
+    const pythonTab = screen.getByRole('tab', { name: 'Python' })
+    expect(screen.getByRole('tab', { selected: true })).toBe(pythonTab)
+    expect(screen.getByText(/comfy\.models\.run\("bfl\/flux-3"/)).toBeTruthy()
+    expect(screen.getByText(/"prompt": "Red fox"/)).toBeTruthy()
+  })
+
+  it('copies the selected snippet and confirms the action', async () => {
+    const user = userEvent.setup()
+    render(WorkshopPlayground, { props: { model } })
+
+    // The prompt is required, and copying is blocked until it is filled.
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    await nextTick()
+    await user.click(screen.getByRole('button', { name: 'Copy code' }))
+
+    // Asserted through the confirmation rather than by spying on
+    // `navigator.clipboard.writeText`: this environment cannot grant the
+    // clipboard-write permission, so the shared helper correctly takes its
+    // legacy `execCommand` path and never touches that method. What gets
+    // copied is the same `snippet` expression the panel renders, which the
+    // live-snippet test above already pins.
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy()
+  })
+
+  it('will not copy a snippet whose required fields are still empty', async () => {
+    // On first load most of the catalog is in this state: 253 of 268 models
+    // are missing at least one required value, and 51 would emit `--data {}`.
+    render(WorkshopPlayground, { props: { model } })
+
+    expect(screen.getByRole('button', { name: 'Copy code' })).toHaveProperty(
+      'disabled',
+      true
+    )
+  })
+
+  it('drops the copied confirmation when the language changes', async () => {
+    const user = userEvent.setup()
+    render(WorkshopPlayground, { props: { model } })
+
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    await nextTick()
+    await user.click(screen.getByRole('button', { name: 'Copy code' }))
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy()
+
+    // Otherwise it still reads "Copied" over a snippet never copied.
+    screen.getByRole('tab', { name: 'TypeScript' }).focus()
+    await user.keyboard('{ArrowRight}')
+    await nextTick()
+
+    expect(screen.getByRole('button', { name: 'Copy code' })).toBeTruthy()
+  })
+
+  it('does not copy a snippet containing schema-invalid JSON', async () => {
+    render(WorkshopPlayground, { props: { model: jsonModel } })
+    const input = screen.getByRole('textbox', { name: /Inputs/ })
+    const copy = screen.getByRole('button', { name: 'Copy code' })
+
+    await fireEvent.update(input, '[]')
+    await nextTick()
+    expect(copy).toHaveProperty('disabled', true)
+
+    await fireEvent.update(input, '[{"text":"Hello","voice_id":"Sarah"}]')
+    await nextTick()
+    expect(copy).toHaveProperty('disabled', false)
+  })
+
+  it('keeps the copy confirmation timed from the latest copy', async () => {
+    vi.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(WorkshopPlayground, { props: { model } })
+
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    await nextTick()
+    await user.click(screen.getByRole('button', { name: 'Copy code' }))
+    await vi.advanceTimersByTimeAsync(1000)
+    await user.click(screen.getByRole('button', { name: 'Copied' }))
+    await vi.advanceTimersByTimeAsync(600)
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy()
+
+    await vi.advanceTimersByTimeAsync(900)
+    expect(screen.getByRole('button', { name: 'Copy code' })).toBeTruthy()
+  })
+})

--- a/apps/website/src/components/workshop/WorkshopPlayground.vue
+++ b/apps/website/src/components/workshop/WorkshopPlayground.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
+import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
+import { computed, ref } from 'vue'
+
+import { externalLinks } from '../../config/routes'
+import type { WorkshopDetailModel } from '../../config/workshop-detail'
+import { defaultWorkshopValues } from '../../config/workshop-detail'
+import { parseWorkshopJsonInput } from '../../config/workshop-json-schema'
+import type { WorkshopSnippetLanguage } from '../../config/workshop-snippets'
+import {
+  WORKSHOP_SNIPPET_LANGUAGES,
+  buildWorkshopSnippet
+} from '../../config/workshop-snippets'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import WorkshopForm from './WorkshopForm.vue'
+
+const { model, locale = 'en' } = defineProps<{
+  model: WorkshopDetailModel
+  locale?: Locale
+}>()
+const values = ref(defaultWorkshopValues(model.fields))
+const language = ref<WorkshopSnippetLanguage>('typescript')
+// The shared helper rather than a hand-rolled timer: it carries the
+// `isSupported` guard and legacy fallback that a bare `navigator.clipboard`
+// does not. Without them the button throws in an insecure context — a LAN-IP
+// or staging preview — and Vue swallows the rejection, so it silently does
+// nothing.
+const {
+  copy,
+  copied: copiedRecently,
+  isSupported: canCopy
+} = useClipboard({ copiedDuring: 1500 })
+/** Which language was on screen when the copy happened. */
+const copiedLanguage = ref<WorkshopSnippetLanguage>()
+const snippet = computed(() =>
+  buildWorkshopSnippet(language.value, model.id, model.fields, values.value)
+)
+const hasInvalidJson = computed(() =>
+  model.fields.some((field) => {
+    if (field.kind !== 'text' || field.valueType !== 'json') return false
+    const value = values.value[field.name]
+    return (
+      typeof value === 'string' &&
+      value !== '' &&
+      !parseWorkshopJsonInput(value, field.jsonSchema).success
+    )
+  })
+)
+
+/**
+ * A required field nobody has filled in. On first load that is most of the
+ * catalog — 253 of 268 models are missing at least one, and 51 render a body
+ * of `{}` — so copying then hands over a command that cannot run.
+ */
+const hasEmptyRequired = computed(() =>
+  model.fields.some((field) => {
+    if (!field.required) return false
+    const value = values.value[field.name]
+    return value === undefined || value === ''
+  })
+)
+
+const canCopySnippet = computed(
+  () => canCopy.value && !hasInvalidJson.value && !hasEmptyRequired.value
+)
+
+/**
+ * Confirm only while the panel still shows what was copied. Switching
+ * language replaces the snippet, so a lingering "Copied" would be claiming
+ * something that never happened.
+ *
+ * Derived rather than reset: vueuse owns `copied` and exposes it readonly,
+ * so assigning to it fails silently.
+ */
+const copied = computed(
+  () => copiedRecently.value && copiedLanguage.value === language.value
+)
+
+async function copySnippet() {
+  copiedLanguage.value = language.value
+  await copy(snippet.value)
+}
+
+const languageLabels: Record<WorkshopSnippetLanguage, string> = {
+  typescript: 'TypeScript',
+  python: 'Python',
+  http: 'HTTP'
+}
+</script>
+
+<template>
+  <div class="grid gap-8 lg:grid-cols-2">
+    <WorkshopForm v-model="values" :model="model" :locale="locale" />
+
+    <section>
+      <TabsRoot v-model="language">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <TabsList
+            :aria-label="t('workshop.model.codeLanguage', locale)"
+            class="flex gap-1"
+          >
+            <TabsTrigger
+              v-for="option in WORKSHOP_SNIPPET_LANGUAGES"
+              :key="option"
+              :value="option"
+              class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-primary-comfy-yellow cursor-pointer rounded-full px-4 py-2 text-sm text-primary-comfy-canvas/65 transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-comfy-ink"
+            >
+              {{ languageLabels[option] }}
+            </TabsTrigger>
+          </TabsList>
+          <button
+            type="button"
+            :disabled="!canCopySnippet"
+            class="text-primary-comfy-yellow text-sm hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+            @click="copySnippet"
+          >
+            {{
+              copied
+                ? t('workshop.model.copied', locale)
+                : t('workshop.model.copy', locale)
+            }}
+          </button>
+        </div>
+        <TabsContent
+          v-for="option in WORKSHOP_SNIPPET_LANGUAGES"
+          :key="option"
+          :value="option"
+        >
+          <!--
+            tabindex so a keyboard user can scroll a clipped snippet; an
+            `overflow-auto` region is otherwise unreachable without a mouse.
+            The active tab reuses the `snippet` computed rather than rebuilding
+            it, so what is shown and what is copied cannot drift apart.
+          -->
+          <pre
+            tabindex="0"
+            class="focus-visible:ring-primary-comfy-yellow/50 mt-3 max-h-168 overflow-auto rounded-2xl border border-primary-comfy-canvas/10 bg-black p-6 text-sm/relaxed text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none"
+          ><code>{{ option === language ? snippet : buildWorkshopSnippet(option, model.id, model.fields, values) }}</code></pre>
+        </TabsContent>
+      </TabsRoot>
+      <a
+        :href="externalLinks.apiKeys"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary-comfy-yellow mt-4 inline-flex text-sm font-medium hover:underline"
+      >
+        {{ t('workshop.model.getApiKey', locale) }}
+      </a>
+    </section>
+  </div>
+</template>

--- a/apps/website/src/components/workshop/WorkshopPlayground.vue
+++ b/apps/website/src/components/workshop/WorkshopPlayground.vue
@@ -22,16 +22,18 @@ const { model, locale = 'en' } = defineProps<{
 }>()
 const values = ref(defaultWorkshopValues(model.fields))
 const language = ref<WorkshopSnippetLanguage>('typescript')
-// The shared helper rather than a hand-rolled timer: it carries the
-// `isSupported` guard and legacy fallback that a bare `navigator.clipboard`
-// does not. Without them the button throws in an insecure context — a LAN-IP
-// or staging preview — and Vue swallows the rejection, so it silently does
-// nothing.
+// `legacy: true` on purpose. Without it `isSupported` is just the Clipboard
+// API check, so on an insecure origin — a LAN-IP or staging preview, where
+// `navigator.clipboard` is undefined — the button would be permanently
+// disabled. With it, the helper falls back to `execCommand` and copying
+// still works there. A bare `navigator.clipboard.writeText` would instead
+// throw, and Vue would swallow the rejection, so the button would appear to
+// do nothing at all.
 const {
   copy,
   copied: copiedRecently,
   isSupported: canCopy
-} = useClipboard({ copiedDuring: 1500 })
+} = useClipboard({ copiedDuring: 1500, legacy: true })
 /** Which language was on screen when the copy happened. */
 const copiedLanguage = ref<WorkshopSnippetLanguage>()
 const snippet = computed(() =>

--- a/apps/website/src/config/__snapshots__/workshop-snippets.test.ts.snap
+++ b/apps/website/src/config/__snapshots__/workshop-snippets.test.ts.snap
@@ -1,9 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Workshop snippets > builds the http snippet from the current values 1`] = `
-"curl --request POST 'https://api.comfy.org/v2/models/bfl/flux-3' \\
+"IDEMPOTENCY_KEY=$(uuidgen)
+
+curl --request POST 'https://api.comfy.org/v2/models/bfl/flux-3' \\
   --header 'Authorization: Bearer YOUR_API_KEY' \\
   --header 'Content-Type: application/json' \\
+  --header "Idempotency-Key: $IDEMPOTENCY_KEY" \\
   --data '{
   "prompt": "A red fox",
   "enhance": true

--- a/apps/website/src/config/__snapshots__/workshop-snippets.test.ts.snap
+++ b/apps/website/src/config/__snapshots__/workshop-snippets.test.ts.snap
@@ -1,0 +1,31 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Workshop snippets > builds the http snippet from the current values 1`] = `
+"curl --request POST 'https://api.comfy.org/v2/models/bfl/flux-3' \\
+  --header 'Authorization: Bearer YOUR_API_KEY' \\
+  --header 'Content-Type: application/json' \\
+  --data '{
+  "prompt": "A red fox",
+  "enhance": true
+}'"
+`;
+
+exports[`Workshop snippets > builds the python snippet from the current values 1`] = `
+"from comfy_sdk import Comfy
+
+comfy = Comfy(api_key="YOUR_API_KEY")
+result = comfy.models.run("bfl/flux-3", {
+    "prompt": "A red fox",
+    "enhance": True
+})"
+`;
+
+exports[`Workshop snippets > builds the typescript snippet from the current values 1`] = `
+"import { comfy } from '@comfyorg/sdk'
+
+comfy.config({ credentials: 'YOUR_API_KEY' })
+const { data } = await comfy.models.run("bfl/flux-3", {
+  "prompt": "A red fox",
+  "enhance": true
+})"
+`;

--- a/apps/website/src/config/workshop-snippets.test.ts
+++ b/apps/website/src/config/workshop-snippets.test.ts
@@ -1,0 +1,237 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkshopField } from './workshop-detail'
+import { buildWorkshopInput, buildWorkshopSnippet } from './workshop-snippets'
+
+const fields: WorkshopField[] = [
+  {
+    kind: 'text',
+    name: 'prompt',
+    label: 'Prompt',
+    required: true,
+    multiline: true,
+    valueType: 'string'
+  },
+  {
+    kind: 'toggle',
+    name: 'enhance',
+    label: 'Enhance',
+    required: false,
+    defaultValue: true
+  },
+  {
+    kind: 'media',
+    name: 'media_image',
+    role: 'image',
+    label: 'Image',
+    required: false,
+    multiple: false,
+    accept: 'image'
+  }
+]
+
+const promptOnly = [
+  {
+    kind: 'text' as const,
+    name: 'prompt',
+    label: 'Prompt',
+    required: true,
+    multiline: true,
+    valueType: 'string' as const
+  }
+]
+
+function executeWithStubCurl(command: string): string[] {
+  const output = execFileSync(
+    'bash',
+    ['-c', `curl() { printf '%s\\0' "$@"; }\n${command}`],
+    { encoding: 'utf8' }
+  )
+  return output.split('\0').filter(Boolean)
+}
+
+describe('Workshop snippets', () => {
+  it('builds Router input and groups media roles', () => {
+    expect(
+      buildWorkshopInput(fields, {
+        prompt: 'A red fox',
+        enhance: true,
+        media_image: '<reference.png>'
+      })
+    ).toEqual({
+      prompt: 'A red fox',
+      enhance: true,
+      // A picked file becomes a URL the reader can replace, not `<name>`,
+      // which the API would reject.
+      medias: [
+        {
+          role: 'image',
+          value: 'https://example.com/replace-with-a-url/reference.png'
+        }
+      ]
+    })
+  })
+
+  it('omits unset and empty values without emitting an empty media list', () => {
+    expect(buildWorkshopInput(fields, {})).toEqual({})
+    expect(
+      buildWorkshopInput(fields, {
+        prompt: '',
+        enhance: undefined,
+        media_image: []
+      })
+    ).toEqual({})
+    expect(buildWorkshopInput(fields, { media_image: '' })).toEqual({})
+  })
+
+  it('creates one media entry per selected file', () => {
+    const multipleMedia: WorkshopField = {
+      kind: 'media',
+      name: 'media_image',
+      role: 'image',
+      label: 'Image',
+      required: false,
+      multiple: true,
+      accept: 'image'
+    }
+    expect(
+      buildWorkshopInput([multipleMedia], {
+        media_image: ['<one.png>', '<two.png>']
+      })
+    ).toEqual({
+      medias: [
+        {
+          role: 'image',
+          value: 'https://example.com/replace-with-a-url/one.png'
+        },
+        {
+          role: 'image',
+          value: 'https://example.com/replace-with-a-url/two.png'
+        }
+      ]
+    })
+  })
+
+  it.for(['typescript', 'python', 'http'] as const)(
+    'builds the %s snippet from the current values',
+    (language) => {
+      expect(
+        buildWorkshopSnippet(language, 'bfl/flux-3', fields, {
+          prompt: 'A red fox',
+          enhance: true
+        })
+      ).toMatchSnapshot()
+    }
+  )
+
+  it('parses complex JSON fields into native input values', () => {
+    const complex: WorkshopField[] = [
+      {
+        kind: 'text',
+        name: 'inputs',
+        label: 'Inputs',
+        required: true,
+        multiline: true,
+        valueType: 'json',
+        jsonSchema: { type: 'array' }
+      }
+    ]
+    expect(buildWorkshopInput(complex, { inputs: '[{"text":"Hi"}]' })).toEqual({
+      inputs: [{ text: 'Hi' }]
+    })
+  })
+
+  it('preserves invalid JSON as text instead of dropping the input', () => {
+    const complex: WorkshopField[] = [
+      {
+        kind: 'text',
+        name: 'inputs',
+        label: 'Inputs',
+        required: true,
+        multiline: true,
+        valueType: 'json',
+        jsonSchema: { type: 'array' }
+      }
+    ]
+
+    expect(buildWorkshopInput(complex, { inputs: '[invalid' })).toEqual({
+      inputs: '[invalid'
+    })
+  })
+
+  it('renders empty and populated arrays as Python literals', () => {
+    const complex: WorkshopField[] = [
+      {
+        kind: 'text',
+        name: 'inputs',
+        label: 'Inputs',
+        required: true,
+        multiline: true,
+        valueType: 'json',
+        jsonSchema: { type: 'array' }
+      }
+    ]
+
+    expect(
+      buildWorkshopSnippet('python', 'example/model', complex, {
+        inputs: '[]'
+      })
+    ).toContain('"inputs": []')
+    expect(
+      buildWorkshopSnippet('python', 'example/model', complex, {
+        inputs: '[true, null, 3]'
+      })
+    ).toContain('[\n        True,\n        None,\n        3\n    ]')
+  })
+
+  it('preserves an apostrophe in the HTTP request payload', () => {
+    const snippet = buildWorkshopSnippet('http', 'bfl/flux-2-pro', promptOnly, {
+      prompt: "don't stop"
+    })
+    const args = executeWithStubCurl(snippet)
+    const dataIndex = args.indexOf('--data')
+
+    expect(dataIndex).toBeGreaterThan(-1)
+    expect(JSON.parse(args[dataIndex + 1])).toEqual({ prompt: "don't stop" })
+  })
+
+  it.for(['typescript', 'python'] as const)(
+    'preserves an untrusted model ID in the %s string literal',
+    (language) => {
+      const modelId = `bf'l$(printf injected)\`printf injected\`/fl"ux`
+      const snippet = buildWorkshopSnippet(language, modelId, promptOnly, {
+        prompt: 'A red fox'
+      })
+
+      expect(snippet).toContain(`models.run(${JSON.stringify(modelId)},`)
+    }
+  )
+
+  it('preserves an untrusted model ID as one HTTP argument', () => {
+    const modelId = `bf'l$(printf injected)\`printf injected\`/fl"ux`
+    const snippet = buildWorkshopSnippet('http', modelId, promptOnly, {
+      prompt: 'A red fox'
+    })
+
+    expect(executeWithStubCurl(snippet)).toContain(
+      `https://api.comfy.org/v2/models/${modelId
+        .split('/')
+        .map(encodeURIComponent)
+        .join('/')}`
+    )
+  })
+
+  it('encodes reserved characters in model ID path segments', () => {
+    const snippet = buildWorkshopSnippet(
+      'http',
+      'provider/model?variant#one%done',
+      promptOnly,
+      { prompt: 'A red fox' }
+    )
+
+    expect(executeWithStubCurl(snippet)).toContain(
+      'https://api.comfy.org/v2/models/provider/model%3Fvariant%23one%25done'
+    )
+  })
+})

--- a/apps/website/src/config/workshop-snippets.ts
+++ b/apps/website/src/config/workshop-snippets.ts
@@ -1,0 +1,127 @@
+import type { WorkshopField, WorkshopFormValues } from './workshop-detail'
+export type WorkshopSnippetLanguage = 'typescript' | 'python' | 'http'
+
+export const WORKSHOP_SNIPPET_LANGUAGES: readonly WorkshopSnippetLanguage[] = [
+  'typescript',
+  'python',
+  'http'
+]
+
+/**
+ * The form records a picked file as `<name.png>`, which is not something the
+ * API accepts — `medias[].value` is a URL. Copying that verbatim produces a
+ * command that fails with `invalid_input` and no clue why, on the 197 models
+ * that take media. Swap it for an obvious stand-in the reader will replace.
+ */
+function mediaPlaceholder(upload: string): string {
+  const local = /^<(.+)>$/.exec(upload)
+  if (local === null) return upload
+  return `https://example.com/replace-with-a-url/${local[1]}`
+}
+
+export function buildWorkshopInput(
+  fields: readonly WorkshopField[],
+  values: WorkshopFormValues
+): Record<string, unknown> {
+  const input: Record<string, unknown> = {}
+  const medias: Array<{ role: string; value: string }> = []
+  for (const field of fields) {
+    const value = values[field.name]
+    if (value === undefined || value === '') continue
+    if (field.kind === 'media') {
+      const uploads = Array.isArray(value) ? value : [String(value)]
+      medias.push(
+        ...uploads.map((upload) => ({
+          role: field.role,
+          value: mediaPlaceholder(upload)
+        }))
+      )
+    } else if (field.kind === 'text' && field.valueType === 'json') {
+      try {
+        input[field.name] = JSON.parse(String(value))
+      } catch {
+        input[field.name] = value
+      }
+    } else {
+      input[field.name] = value
+    }
+  }
+  if (medias.length > 0) input.medias = medias
+  return input
+}
+
+function pythonLiteral(value: unknown, depth = 0): string {
+  const pad = '    '.repeat(depth)
+  const childPad = '    '.repeat(depth + 1)
+  if (value === null) return 'None'
+  if (value === true) return 'True'
+  if (value === false) return 'False'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number') return String(value)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    return `[\n${value.map((item) => `${childPad}${pythonLiteral(item, depth + 1)}`).join(',\n')}\n${pad}]`
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value)
+    if (entries.length === 0) return '{}'
+    return `{\n${entries
+      .map(
+        ([key, item]) =>
+          `${childPad}${JSON.stringify(key)}: ${pythonLiteral(item, depth + 1)}`
+      )
+      .join(',\n')}\n${pad}}`
+  }
+  return 'None'
+}
+
+/**
+ * Escapes a value for a POSIX single-quoted argument.
+ *
+ * A single quote cannot appear inside single quotes at all, so the string is
+ * closed, an escaped quote is emitted, and the string is reopened: `'\''`.
+ * Prompts contain apostrophes constantly, and without this the generated
+ * command ends its quote early and no longer parses.
+ */
+function shellSingleQuote(value: string): string {
+  return value.replaceAll("'", `'\\''`)
+}
+
+function modelEndpoint(modelId: string): string {
+  const encodedId = modelId.split('/').map(encodeURIComponent).join('/')
+  return `https://api.comfy.org/v2/models/${encodedId}`
+}
+
+export function buildWorkshopSnippet(
+  language: WorkshopSnippetLanguage,
+  modelId: string,
+  fields: readonly WorkshopField[],
+  values: WorkshopFormValues
+): string {
+  const input = buildWorkshopInput(fields, values)
+  const modelIdLiteral = JSON.stringify(modelId)
+  if (language === 'typescript') {
+    return [
+      "import { comfy } from '@comfyorg/sdk'",
+      '',
+      "comfy.config({ credentials: 'YOUR_API_KEY' })",
+      `const { data } = await comfy.models.run(${modelIdLiteral}, ${JSON.stringify(input, null, 2)})`
+    ].join('\n')
+  }
+  if (language === 'python') {
+    return [
+      'from comfy_sdk import Comfy',
+      '',
+      'comfy = Comfy(api_key="YOUR_API_KEY")',
+      `result = comfy.models.run(${modelIdLiteral}, ${pythonLiteral(input)})`
+    ].join('\n')
+  }
+  const continuation = '\\'
+  const endpoint = shellSingleQuote(modelEndpoint(modelId))
+  return [
+    `curl --request POST '${endpoint}' ${continuation}`,
+    `  --header 'Authorization: Bearer YOUR_API_KEY' ${continuation}`,
+    `  --header 'Content-Type: application/json' ${continuation}`,
+    `  --data '${shellSingleQuote(JSON.stringify(input, null, 2))}'`
+  ].join('\n')
+}

--- a/apps/website/src/config/workshop-snippets.ts
+++ b/apps/website/src/config/workshop-snippets.ts
@@ -118,10 +118,19 @@ export function buildWorkshopSnippet(
   }
   const continuation = '\\'
   const endpoint = shellSingleQuote(modelEndpoint(modelId))
+  // An idempotency key, assigned once and reused. These are paid calls, and a
+  // disconnect can happen after the model has already run; retrying the same
+  // command without the same key runs and bills it a second time. Both SDKs
+  // mint one, so only the raw request needs this. Held in a variable rather
+  // than inlined so re-running just the curl — the actual retry — sends the
+  // key it sent the first time.
   return [
+    `IDEMPOTENCY_KEY=$(uuidgen)`,
+    ``,
     `curl --request POST '${endpoint}' ${continuation}`,
     `  --header 'Authorization: Bearer YOUR_API_KEY' ${continuation}`,
     `  --header 'Content-Type: application/json' ${continuation}`,
+    `  --header "Idempotency-Key: $IDEMPOTENCY_KEY" ${continuation}`,
     `  --data '${shellSingleQuote(JSON.stringify(input, null, 2))}'`
   ].join('\n')
 }

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -73,6 +73,13 @@ const translations = {
     en: 'Run model — sign-in coming next',
     'zh-CN': '运行模型 — 登录功能即将推出'
   },
+  'workshop.model.codeLanguage': { en: 'Code language', 'zh-CN': '代码语言' },
+  'workshop.model.copy': { en: 'Copy code', 'zh-CN': '复制代码' },
+  'workshop.model.copied': { en: 'Copied', 'zh-CN': '已复制' },
+  'workshop.model.getApiKey': {
+    en: 'Get your API key',
+    'zh-CN': '获取 API 密钥'
+  },
   'workshop.model.related': { en: 'Related models', 'zh-CN': '相关模型' },
   'workshop.model.browseAll': {
     en: 'Browse all models',

--- a/apps/website/src/pages/workshop/models/[slug].astro
+++ b/apps/website/src/pages/workshop/models/[slug].astro
@@ -2,7 +2,7 @@
 import type { GetStaticPaths } from 'astro'
 import { getCollection } from 'astro:content'
 
-import WorkshopForm from '../../../components/workshop/WorkshopForm.vue'
+import WorkshopPlayground from '../../../components/workshop/WorkshopPlayground.vue'
 import type { WorkshopDetailModel } from '../../../config/workshop-detail'
 import {
   relatedWorkshopModels,
@@ -70,9 +70,7 @@ const { model, related } = Astro.props
       </ul>
     </div>
 
-    <div class="max-w-2xl">
-      <WorkshopForm model={model} client:load />
-    </div>
+    <WorkshopPlayground model={model} client:load />
 
     <section class="mt-20 border-t border-primary-comfy-canvas/10 pt-10">
       <div class="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary

Adds TypeScript, Python, and raw HTTP examples beside each Workshop model form. The examples update as someone changes the form, so copied code includes the selected model and inputs.

The TypeScript example uses `@comfyorg/sdk` and `comfy.models.run`. The Python example uses `comfy-sdk`. The HTTP example calls the current `/v2` Router endpoint. Media uploads are grouped into the Router `medias` list, including multiple files for roles that accept them.

Payloads and model IDs are escaped for their target language. Regression coverage uses hostile model IDs containing both quote types, `$()`, and backticks; the HTTP snippet is executed against a stub `curl` to prove the endpoint remains one exact argument.

Also links directly to the API key page. The Run button remains disabled until the sign-in and Router execution slice lands.

## Test plan

- [x] Snapshot TypeScript, Python, and HTTP output
- [x] Test form changes update the snippet
- [x] Test JSON fields and single and multiple media roles
- [x] Execute the HTTP snippet and verify apostrophes in payloads
- [x] Preserve untrusted model IDs in all three snippet languages
- [x] Full website unit suite passes
- [x] Astro and Vue typechecks pass
- [x] Release build emits no Workshop routes
- [x] Enabled build creates all 268 model pages
- [x] Knip and repository hooks pass