### PR TITLE
fix(ci): tolerate missing storybook-static in forked-PR deploy

### DIFF
--- a/.github/workflows/ci-tests-storybook-forks.yaml
+++ b/.github/workflows/ci-tests-storybook-forks.yaml
@@ -50,12 +50,16 @@ jobs:
 
       - name: Download and Deploy Storybook
         if: steps.pr.outputs.skip != 'true' && github.event.action == 'completed' && github.event.workflow_run.conclusion == 'success'
-        uses: actions/download-artifact@v8
+        # dawidd6 v12 (same as pr-report.yaml): PR branches with a stale workflow
+        # base (pre-#16817) still skip the storybook-static upload for forks, so a
+        # missing artifact must warn instead of failing this exact-main-head check.
+        uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
           name: storybook-static
           path: storybook-static
+          if_no_artifact_found: warn
 
       - name: Handle Storybook Completion — deploy and generate section
         if: steps.pr.outputs.skip != 'true' && github.event.action == 'completed'

--- a/.github/workflows/ci-tests-storybook-forks.yaml
+++ b/.github/workflows/ci-tests-storybook-forks.yaml
@@ -50,9 +50,6 @@ jobs:
 
       - name: Download and Deploy Storybook
         if: steps.pr.outputs.skip != 'true' && github.event.action == 'completed' && github.event.workflow_run.conclusion == 'success'
-        # dawidd6 v12 (same as pr-report.yaml): PR branches with a stale workflow
-        # base (pre-#16817) still skip the storybook-static upload for forks, so a
-        # missing artifact must warn instead of failing this exact-main-head check.
         uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/cicd/storybook-fork-artifact-contract.test.ts
+++ b/scripts/cicd/storybook-fork-artifact-contract.test.ts
@@ -7,7 +7,12 @@ interface WorkflowStep {
   name?: string
   if?: string
   uses?: string
-  with?: { name?: string; if_no_artifact_found?: string }
+  with?: {
+    name?: string
+    github_token?: string
+    run_id?: string
+    if_no_artifact_found?: string
+  }
 }
 
 interface WorkflowJob {
@@ -44,6 +49,8 @@ describe('fork Storybook artifact contract', () => {
     expect(upload.if).toBe('success()')
     expect(download.uses).toMatch(/^dawidd6\/action-download-artifact@/)
     expect(download.with?.name).toBe(upload.with?.name)
+    expect(download.with?.github_token).toBe('${{ secrets.GITHUB_TOKEN }}')
+    expect(download.with?.run_id).toBe('${{ github.event.workflow_run.id }}')
     expect(download.with?.if_no_artifact_found).toBe('warn')
   })
 })

--- a/scripts/cicd/storybook-fork-artifact-contract.test.ts
+++ b/scripts/cicd/storybook-fork-artifact-contract.test.ts
@@ -7,7 +7,7 @@ interface WorkflowStep {
   name?: string
   if?: string
   uses?: string
-  with?: { name?: string }
+  with?: { name?: string; if_no_artifact_found?: string }
 }
 
 interface WorkflowJob {
@@ -42,7 +42,8 @@ describe('fork Storybook artifact contract', () => {
 
     expect(upload.uses).toMatch(/^actions\/upload-artifact@/)
     expect(upload.if).toBe('success()')
-    expect(download.uses).toMatch(/^actions\/download-artifact@/)
+    expect(download.uses).toMatch(/^dawidd6\/action-download-artifact@/)
     expect(download.with?.name).toBe(upload.with?.name)
+    expect(download.with?.if_no_artifact_found).toBe('warn')
   })
 })


### PR DESCRIPTION
Justification: restores green main after bypass merge; CI-only change to the forked-PR storybook deploy helper. Exact main head 88fa8153caab2793c0a9ebfc1867825de58232b7 has a failed check-run (non-gating helper, but tracked by the mandatory current-head red-main assertion and owned as P0 cifix-16776).

## Evidence

- Failing run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33805124655 (job log: `##[error]Unable to download artifact(s): Artifact not found for name: storybook-static`, downloading from forked-PR source run https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33804996893)
- Root cause: producer/consumer contract gap left after #16817 — forked PRs whose base predates #16817 still run the OLD source workflow that skips the `storybook-static` upload for forks (for pull_request events GitHub uses the PR branch's copy of the workflow file), while this consumer on main now runs post-fix code and hard-fails because `actions/download-artifact@v8` has no missing-artifact tolerance input.
- Fix: swap the download step to `dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12` with `if_no_artifact_found: warn` — the exact pattern merged in #16821 for the same failure class in pr-report.yaml. The downstream `pr-storybook-deploy-and-comment.sh` already handles a missing directory gracefully (`[ ! -d "$dir" ] && echo "failed" && return`), so the helper reports the failed deploy instead of going red.
- Local validation: YAML parses (`python3 -c yaml.safe_load`), all `with:` inputs exist in the pinned action's action.yml (github_token, run_id, name, path, if_no_artifact_found).
- Local command + result: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-tests-storybook-forks.yaml'))"` → exit 0.
