### PR TITLE
feat(billing): a receipt screen when payment lands but the workspace lags

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2777,7 +2777,12 @@
     "cancelPayment": "Cancel payment",
     "cancelUnavailable": "This payment is already processing and can't be canceled.",
     "cancelUnreachable": "Couldn't reach the server. Your payment has not been canceled — try again.",
-    "paymentCanceledNotice": "Payment canceled. Nothing was charged."
+    "paymentCanceledNotice": "Payment canceled. Nothing was charged.",
+    "reconciliationScreenTitle": "Payment received",
+    "reconciliationScreenDetail": "Your payment went through, but we couldn't finish updating your workspace. It usually catches up on its own — you won't be charged again.",
+    "reconciliationSupportLabel": "If it doesn't resolve, give support this ID",
+    "gotIt": "Got it",
+    "contactSupport": "Contact support"
   },
   "subscription": {
     "plansForWorkspace": "Plans for {workspace}",

--- a/src/platform/workspace/components/SubscriptionReconciliationWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionReconciliationWorkspace.test.ts
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import SubscriptionReconciliationWorkspace from './SubscriptionReconciliationWorkspace.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+describe('SubscriptionReconciliationWorkspace', () => {
+  it('hands over the support id and offers only acknowledgement and support', async () => {
+    const { emitted } = render(SubscriptionReconciliationWorkspace, {
+      props: { operationId: 'op-recon-1' },
+      global: { plugins: [i18n] }
+    })
+
+    expect(screen.getByText('Payment received')).toBeInTheDocument()
+    expect(screen.getByText(/won't be charged again/)).toBeInTheDocument()
+    expect(
+      screen.getByText("If it doesn't resolve, give support this ID")
+    ).toBeInTheDocument()
+    expect(screen.getByText('op-recon-1')).toHaveClass('font-mono')
+
+    // Terminal: no retry, no payment collection, no way back into the flow.
+    expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull()
+    expect(
+      screen.queryByRole('button', { name: 'Update payment method' })
+    ).toBeNull()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Contact support' })
+    )
+    expect(emitted().contactSupport).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Got it' }))
+    expect(emitted().close).toBeTruthy()
+  })
+
+  it('omits the support box when no operation id is known', () => {
+    render(SubscriptionReconciliationWorkspace, {
+      global: { plugins: [i18n] }
+    })
+
+    expect(
+      screen.queryByText("If it doesn't resolve, give support this ID")
+    ).toBeNull()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionReconciliationWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionReconciliationWorkspace.vue
@@ -1,0 +1,68 @@
+<template>
+  <div
+    class="mx-auto flex h-full max-w-[400px] flex-col items-stretch justify-between text-sm motion-safe:animate-in motion-safe:duration-300 motion-safe:fade-in motion-safe:slide-in-from-bottom-2"
+  >
+    <div class="flex flex-col items-center gap-4 pt-8">
+      <i
+        class="icon-[lucide--clock] size-12 shrink-0 text-warning-background"
+      />
+      <h2
+        class="m-0 text-center text-xl font-semibold text-base-foreground lg:text-2xl"
+      >
+        {{ $t('billingOperation.reconciliationScreenTitle') }}
+      </h2>
+      <p class="m-0 text-center text-sm text-muted-foreground">
+        {{ $t('billingOperation.reconciliationScreenDetail') }}
+      </p>
+
+      <!-- Shown only when an operation id is known: an empty box reads as a
+           second failure rather than a support handle. -->
+      <div
+        v-if="operationId"
+        class="mt-4 flex w-full flex-col gap-1 rounded-xl bg-secondary-background p-4"
+      >
+        <span class="text-sm text-muted-foreground">
+          {{ $t('billingOperation.reconciliationSupportLabel') }}
+        </span>
+        <span class="font-mono text-sm text-base-foreground">{{
+          operationId
+        }}</span>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2 pt-8 pb-4">
+      <Button
+        variant="inverted"
+        size="lg"
+        class="w-full rounded-lg"
+        @click="$emit('close')"
+      >
+        {{ $t('billingOperation.gotIt') }}
+      </Button>
+      <Button
+        variant="muted-textonly"
+        size="lg"
+        class="w-full rounded-lg"
+        @click="$emit('contactSupport')"
+      >
+        {{ $t('billingOperation.contactSupport') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+const { operationId = null } = defineProps<{
+  /** The billing operation id support needs to locate the charge. */
+  operationId?: string | null
+}>()
+
+defineEmits<{
+  /** This step is terminal for the dialog — closing is the expected exit. */
+  close: []
+  /** Open the support destination with the operation id at hand. */
+  contactSupport: []
+}>()
+</script>

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -16,14 +16,16 @@
           isEmbeddedConfirmStep ||
           isVerifyingStep ||
           isDeclinedStep ||
-          isProcessingErrorStep) &&
+          isProcessingErrorStep ||
+          isReconciliationStep) &&
           'h-[min(740px,85vh)] overflow-hidden rounded-2xl bg-base-background xl:h-[min(740px,90vh)] xl:w-[512px]',
         (isEmbeddedPaymentStep ||
           isEmbeddedSuccessStep ||
           isEmbeddedConfirmStep ||
           isVerifyingStep ||
           isDeclinedStep ||
-          isProcessingErrorStep) &&
+          isProcessingErrorStep ||
+          isReconciliationStep) &&
           'motion-safe:xl:transition-[width] motion-safe:xl:duration-300 motion-safe:xl:ease-in-out',
         // The w-fit shell hugs min-content on phones; give the embedded
         // steps a real width floor below xl.
@@ -32,7 +34,8 @@
           isEmbeddedConfirmStep ||
           isVerifyingStep ||
           isDeclinedStep ||
-          isProcessingErrorStep) &&
+          isProcessingErrorStep ||
+          isReconciliationStep) &&
           'max-xl:w-[min(430px,92vw)]',
         isEmbeddedPaymentStep && 'max-xl:h-[min(740px,85vh)]'
       )
@@ -74,7 +77,8 @@
         !isEmbeddedConfirmStep &&
         !isVerifyingStep &&
         !isDeclinedStep &&
-        !isProcessingErrorStep
+        !isProcessingErrorStep &&
+        !isReconciliationStep
       "
       class="flex flex-col items-center gap-3"
     >
@@ -254,6 +258,13 @@
       @try-again="handleDeclinedBack"
     />
 
+    <SubscriptionReconciliationWorkspace
+      v-if="checkoutStep === 'reconciliation'"
+      :operation-id="reconciliationOperationId"
+      @close="handleReconciliationClose"
+      @contact-support="handleContactSupport"
+    />
+
     <!-- Success Step - "You're all set" -->
     <SubscriptionSuccessWorkspace
       v-if="checkoutStep === 'success' && (selectedTierKey || isTeamCheckout)"
@@ -273,6 +284,8 @@ import { useEventListener } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { buildSupportUrl } from '@/platform/support/config'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
@@ -282,6 +295,7 @@ import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 import SubscriptionDeclinedWorkspace from './SubscriptionDeclinedWorkspace.vue'
 import SubscriptionProcessingErrorWorkspace from './SubscriptionProcessingErrorWorkspace.vue'
+import SubscriptionReconciliationWorkspace from './SubscriptionReconciliationWorkspace.vue'
 import SubscriptionVerifyingWorkspace from './SubscriptionVerifyingWorkspace.vue'
 import UnifiedPricingTable from './UnifiedPricingTable.vue'
 
@@ -347,6 +361,7 @@ const {
   handleSubscribeTeamClick,
   handleBackToPricing,
   handleSuccessClose,
+  handleReconciliationClose,
   handleAddCreditCard,
   handleConfirmTransition,
   handleTeamSubscribe,
@@ -411,6 +426,20 @@ const isDeclinedStep = computed(() => checkoutStep.value === 'declined')
 const isProcessingErrorStep = computed(
   () => checkoutStep.value === 'processing_error'
 )
+const isReconciliationStep = computed(
+  () => checkoutStep.value === 'reconciliation'
+)
+
+// Same destination as the Comfy.ContactSupport command: the Zendesk request
+// form, pre-filled so support can match the ticket to the account.
+function handleContactSupport() {
+  const { userEmail, resolvedUserInfo } = useCurrentUser()
+  const supportUrl = buildSupportUrl({
+    userEmail: userEmail.value,
+    userId: resolvedUserInfo.value?.id
+  })
+  window.open(supportUrl, '_blank', 'noopener,noreferrer')
+}
 
 // The decline CTA returns to confirm and opens method collection, which is
 // dialog state rather than checkout state.

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -2673,6 +2673,13 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.checkoutStep.value).toBe('declined')
     })
 
+    it('reaches the reconciliation step when the charge lands but the workspace lags', async () => {
+      const checkout = await reentryOn('reconciliation_needed')
+
+      expect(checkout.checkoutStep.value).toBe('reconciliation')
+      expect(checkout.reconciliationOperationId.value).toBe('op-reentry')
+    })
+
     it('backs out of an in-flow decline to the preserved preview', async () => {
       const checkout = await setupWithApprovedPreview()
 
@@ -2697,6 +2704,65 @@ describe('useSubscriptionCheckout', () => {
       await reentryOn('succeeded')
 
       expect(emit).toHaveBeenCalledWith('close', true)
+    })
+  })
+
+  describe('an in-flow charge that lands while the workspace lags', () => {
+    async function subscribeIntoReconciliation(rendersRecoverySteps: boolean) {
+      const checkout = await setup(
+        undefined,
+        'personal',
+        true,
+        rendersRecoverySteps
+      )
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'new_subscription',
+        requires_reactivation_confirmation: false
+      } as PreviewSubscribeResponse
+      checkout.quoteIsCurrent.value = true
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      checkout.checkoutStep.value = 'preview'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-recon-flow'
+      })
+      const operation: MockSubscriptionActionOperation = {
+        opId: 'op-recon-flow',
+        status: 'reconciliation_needed',
+        workspaceId: 'workspace-1'
+      }
+      mockStartOperation.mockResolvedValueOnce(operation)
+      mockGetOperation.mockImplementation((opId: string) =>
+        opId === operation.opId ? operation : undefined
+      )
+
+      await checkout.handleAddCreditCard()
+      return checkout
+    }
+
+    it('routes to the terminal reconciliation step with the operation id', async () => {
+      const checkout = await subscribeIntoReconciliation(true)
+
+      expect(checkout.checkoutStep.value).toBe('reconciliation')
+      expect(checkout.reconciliationOperationId.value).toBe('op-recon-flow')
+    })
+
+    it('closes without claiming a subscription on acknowledgement', async () => {
+      const checkout = await subscribeIntoReconciliation(true)
+
+      checkout.handleReconciliationClose()
+
+      expect(emit).toHaveBeenCalledWith('close', false)
+    })
+
+    it('keeps a host without recovery steps on its confirm step', async () => {
+      const checkout = await subscribeIntoReconciliation(false)
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      // The footer reconciliation block still carries the outcome there.
+      expect(checkout.reconciliationOperationId.value).toBe('op-recon-flow')
     })
   })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -46,6 +46,7 @@ type CheckoutStep =
   | 'success'
   | 'declined'
   | 'processing_error'
+  | 'reconciliation'
 export type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 
 export type SubscriptionCheckoutSelection =
@@ -935,6 +936,13 @@ export function useSubscriptionCheckout(
     emit('close', true)
   }
 
+  // The payment landed but the subscription isn't confirmed active, so this
+  // close never claims `subscribed` — the caller must not treat the workspace
+  // as upgraded until reconciliation catches up.
+  function handleReconciliationClose() {
+    emit('close', false)
+  }
+
   // While a host that renders the outcome steps holds an operation, its
   // outcome renders there — the store's success/failure toasts stay quiet.
   // Closing the dialog releases the operation back to toast delivery. Hosts
@@ -1411,6 +1419,14 @@ export function useSubscriptionCheckout(
       checkoutStep.value = 'success'
     } else if (operation.status === 'failed' && rendersRecoverySteps) {
       showFailureOutcome(operation)
+    } else if (
+      operation.status === 'reconciliation_needed' &&
+      rendersRecoverySteps
+    ) {
+      // The charge landed but the workspace update didn't. Terminal for the
+      // dialog: nothing here can be retried or canceled, so the step is a
+      // receipt with the operation id and closing is the expected exit.
+      checkoutStep.value = 'reconciliation'
     }
   }
 
@@ -1495,6 +1511,10 @@ export function useSubscriptionCheckout(
       if (status === 'failed') {
         const operation = activeCheckoutOperation.value
         if (operation) showFailureOutcome(operation)
+        return
+      }
+      if (status === 'reconciliation_needed') {
+        checkoutStep.value = 'reconciliation'
         return
       }
       if (status === undefined) {
@@ -1731,6 +1751,7 @@ export function useSubscriptionCheckout(
     handleSubscribeTeamClick,
     handleBackToPricing,
     handleSuccessClose,
+    handleReconciliationClose,
     handleAddCreditCard: handleSubscription,
     handleConfirmTransition: handleSubscription,
     handleTeamSubscribe: handleTeamSubscription,


### PR DESCRIPTION
When a payment goes through but the workspace doesn't update (`reconciliation_needed`), users now get a clear receipt screen instead of a technical note pinned under the confirm button: it says the payment was received, that they won't be charged again, and hands them the operation ID to give support if the workspace doesn't catch up on its own. "Got it" closes the dialog; "Contact support" opens the existing Zendesk request form (`buildSupportUrl` from `src/platform/support/config.ts`, same destination as the `Comfy.ContactSupport` command), pre-filled with account details.

Implementation notes:

- New `SubscriptionReconciliationWorkspace.vue` (outcome 5d), modeled on the 5c processing-error step: lucide clock in the shared warning treatment, boxed support label + monospace operation id (box omitted when no id is known, mirroring 5b's reason box).
- Routing uses the same two hooks the declined/processing outcomes use in `useSubscriptionCheckout.ts`: the terminal-operation resolution after subscribe, and the verifying-step watcher for a live `pending → reconciliation_needed` transition. Both are gated on `rendersRecoverySteps`, so only the unified dialog host opts in.
- The step is terminal for the dialog: no retry, no update-payment affordance, no spinner. `handleReconciliationClose` emits `close(false)` — the payment landed but the subscription isn't confirmed active, so the close never claims `subscribed`.
- Legacy hosts and the existing footer reconciliation block are untouched; re-entry with an already-reconciling operation also keeps today's behavior (pricing entry + footer block), since the dialog-owning claim only applies to pending charges.
- New `billingOperation.*` locale keys: `reconciliationScreenTitle`, `reconciliationScreenDetail`, `reconciliationSupportLabel`, `gotIt`, `contactSupport` (the only existing "Got it" key is scoped to `agent.*`).
- Tests: colocated component test; composable tests for in-flow routing, re-entry routing, close semantics, and the unchanged legacy host.

Linear: FE-1992

Stacked on #16571 (`comfydesigner/checkout-failure-dialog`); retarget to `main` when that merges.