### PR TITLE
fix(agent-crdt): preserve restored same-document subscription

### DIFF
--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.integration.test.ts
@@ -1,0 +1,149 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import { render } from '@testing-library/vue'
+
+import type { GraphMutations } from '@/core/graph/graphMutations'
+
+const apiState = vi.hoisted(() => {
+  const docFrames = new EventTarget()
+  const socketEvents = new EventTarget()
+  const send = vi.fn()
+
+  return {
+    docFrames,
+    socketEvents,
+    send,
+    api: {
+      socket: { readyState: 1, send },
+      addCustomEventListener: (type: string, listener: EventListener) =>
+        docFrames.addEventListener(type, listener),
+      removeCustomEventListener: (type: string, listener: EventListener) =>
+        docFrames.removeEventListener(type, listener),
+      addEventListener: (type: string, listener: EventListener) =>
+        socketEvents.addEventListener(type, listener),
+      removeEventListener: (type: string, listener: EventListener) =>
+        socketEvents.removeEventListener(type, listener)
+    }
+  }
+})
+
+vi.mock('@/scripts/api', () => ({ api: apiState.api }))
+vi.mock('@/scripts/app', () => ({ app: { graph: null, canvas: null } }))
+
+import { STALE_AFTER_MS, useAgentCrdtFollower } from './useAgentCrdtFollower'
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+
+const graphMutations = fromPartial<GraphMutations>({
+  clearSemanticGraph: vi.fn(() => true)
+})
+
+interface SentFrame {
+  type: string
+  data: { workflow_id: string }
+}
+
+function framesSent(): SentFrame[] {
+  return apiState.send.mock.calls.map(
+    ([frame]) => JSON.parse(frame) as SentFrame
+  )
+}
+
+function dispatchServerFrame(
+  type: string,
+  data: Record<string, unknown>
+): void {
+  apiState.docFrames.dispatchEvent(
+    new CustomEvent(type, { detail: { v: 1, ...data } })
+  )
+}
+
+function mountFollower(initialWorkflowId: string | null): {
+  unmount: () => void
+  workflowId: Ref<string | null>
+  status: () => AgentCrdtStatus
+} {
+  const workflowId = ref(initialWorkflowId)
+  let readStatus!: () => AgentCrdtStatus
+  const host = defineComponent({
+    setup() {
+      const { status } = useAgentCrdtFollower(workflowId, graphMutations)
+      readStatus = () => status.value as AgentCrdtStatus
+      return () => null
+    }
+  })
+  const { unmount } = render(host)
+  return { unmount, workflowId, status: readStatus }
+}
+
+describe('useAgentCrdtFollower production subscription composition', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    apiState.send.mockClear()
+  })
+
+  it('preserves a restored same-document subscription through acknowledgement', async () => {
+    vi.useFakeTimers()
+    const initial = mountFollower('doc-a')
+    dispatchServerFrame('doc_subscribed', {
+      workflow_id: 'doc-a',
+      ok: true,
+      seq: 1
+    })
+    initial.unmount()
+    apiState.send.mockClear()
+
+    const restored = mountFollower(null)
+    expect(framesSent()).toEqual([
+      expect.objectContaining({
+        type: 'doc_subscribe',
+        data: expect.objectContaining({ workflow_id: 'doc-a' })
+      })
+    ])
+    dispatchServerFrame('doc_subscribed', {
+      workflow_id: 'doc-a',
+      ok: true,
+      seq: 1
+    })
+    apiState.send.mockClear()
+
+    restored.workflowId.value = 'doc-a'
+    await nextTick()
+
+    expect(restored.status().connected).toBe(true)
+    expect(framesSent()).toEqual([])
+
+    vi.advanceTimersByTime(STALE_AFTER_MS)
+    expect(framesSent()).toEqual([
+      expect.objectContaining({
+        type: 'doc_subscribe',
+        data: expect.objectContaining({ workflow_id: 'doc-a' })
+      })
+    ])
+    expect(framesSent()).not.toContainEqual(
+      expect.objectContaining({ type: 'doc_ops' })
+    )
+    apiState.send.mockClear()
+
+    restored.workflowId.value = 'doc-b'
+    await nextTick()
+
+    expect(restored.status()).toMatchObject({
+      connected: false,
+      workflowId: 'doc-b'
+    })
+    expect(framesSent()).toEqual([
+      expect.objectContaining({
+        type: 'doc_unsubscribe',
+        data: expect.objectContaining({ workflow_id: 'doc-a' })
+      }),
+      expect.objectContaining({
+        type: 'doc_subscribe',
+        data: expect.objectContaining({ workflow_id: 'doc-b' })
+      })
+    ])
+    restored.unmount()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -877,6 +877,25 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('FE-1969: a same-document activation edge still resets and re-subscribes', async () => {
+    const { unmount, isTargetActive, status } = mountFollower('wf-a')
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(status().connected).toBe(true)
+    expect(bridge().subscribe).toHaveBeenCalledTimes(1)
+
+    isTargetActive.value = false
+    await nextTick()
+    expect(status()).toMatchObject({ connected: false, workflowId: null })
+    expect(bridge().unsubscribe).toHaveBeenCalledTimes(1)
+
+    isTargetActive.value = true
+    await nextTick()
+    expect(status()).toMatchObject({ connected: false, workflowId: 'wf-a' })
+    expect(bridge().subscribe).toHaveBeenCalledTimes(2)
+    expect(bridge().subscribe).toHaveBeenLastCalledWith('wf-a')
+    unmount()
+  })
+
   it('sends minted human operations through the doc client', () => {
     const workflowId = ref<string | null>('wf-1')
     let enqueue!: ReturnType<

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -627,11 +627,20 @@ export function useAgentCrdtFollower(
       [next, active],
       previous: [string | null | undefined, boolean | undefined] | undefined
     ) => {
+      // An acknowledgement of the doc we already follow (FE-1969: a persisted
+      // rebind lands first, then the reactive layer names the same id) is not
+      // a retarget. `bridge.subscribe(same)` is a `reconcile()` no-op because
+      // `sentWorkflowId === desired`, so running the reset below would zero
+      // `connected` and cancel the stale probe and any pending retry with no
+      // frame on its way to restore them. Safe to skip the rest: the inactive
+      // branch nulls `subscribedWorkflowId`, so an activation edge can never
+      // match here, and `initialBind` is already false on every path that
+      // leaves `subscribedWorkflowId` set.
+      if (active && next !== null && next === subscribedWorkflowId.value) return
       // Only the inactive->active edge, and never the `immediate` first run
       // (`previous` is undefined there), so a plain mount or retarget keeps its
       // existing "reconcile on frame or on graph readiness" behaviour.
       const justActivated = active && previous?.[1] === false
-      if (active && next !== null && next === subscribedWorkflowId.value) return
       clearSubscribeRetry()
       clearStaleProbe()
       connected.value = false

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -631,6 +631,7 @@ export function useAgentCrdtFollower(
       // (`previous` is undefined there), so a plain mount or retarget keeps its
       // existing "reconcile on frame or on graph readiness" behaviour.
       const justActivated = active && previous?.[1] === false
+      if (active && next !== null && next === subscribedWorkflowId.value) return
       clearSubscribeRetry()
       clearStaleProbe()
       connected.value = false


### PR DESCRIPTION
## Summary

Preserves connected and stale-recovery state when a restored follower's first reactive acknowledgement names its already-subscribed document.

## Changes

- Treat the active same-document transition as an idempotent acknowledgement before subscription teardown.
- Add a production-composition regression using the real `DocFrameClient` and `LayoutFollowerBridge`, covering restored `null` → same-document acknowledgement, stale-probe rearming, zero duplicate frames, and a true document retarget.

## Review Focus

The early return applies only while active and only when the acknowledged document already equals follower intent; inactive transitions and true retargets retain the existing reset path.

Follow-up to #16708. Extends [FE-1969](https://linear.app/comfyorg/issue/FE-1969/crdt-follower-cannot-restore-persisted-binding-through-agentpanelroot).

## Evidence

- Regression failed on the base implementation with `connected` false after same-document acknowledgement.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test:unit src/workbench/extensions/agent/crdt/useAgentCrdtFollower.integration.test.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts src/workbench/extensions/agent/crdt/followerSubscription.test.ts` — 109 passed at `045e209c93`. (An earlier revision of this section said 80; the same command reported 85 at `be3646c63b` and 109 after merging `main`.)
- `NODE_OPTIONS=--no-experimental-webstorage pnpm typecheck` — passed.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm lint --fix` — 0 errors; baseline warnings only.
- `pnpm knip` — passed.
- Targeted oxfmt and ESLint checks — passed.

<!-- authored-by:agent lane-qax-32 -->

## End-to-end coverage: why this fix has no `browser_tests/` case

The `End-To-End Regression Coverage For Fixes` check asks for a Playwright regression or a concrete
explanation. This is the explanation.

The defect is an ordering problem between two reactive writers inside
`startAgentCrdtFollower`: a persisted rebind sets `subscribedWorkflowId`, and the
`[workflowId, isTargetActive]` watch then fires naming that same id. Without the guard the watch
treats the acknowledgement as a retarget and zeroes `connected`, clears the stale probe and drops
any pending retry, with no frame inbound to restore them. Its observable symptom is a follower that
looks bound but silently stops applying frames.

Reproducing that in the browser needs a live doc subscription that survives a reload, and the
existing agent harness cannot express it today:

- `agentConversationTest` (`browser_tests/fixtures/agentConversationFixture.ts`) drives real
  turns over the CRDT path, but has no reload step, so the persisted-rebind path this fix guards
  is never entered.
- `agentChatRefreshPersistence.spec.ts` does reload, but runs under
  `test.use({ connectWebSocketToServer: false })`, so no document is ever subscribed and the
  follower watch under test never runs.

Rather than assert the symptom through a proxy, the regression added here
(`useAgentCrdtFollower.integration.test.ts`) composes the real `DocFrameClient` and
`LayoutFollowerBridge` instead of mocks, and drives the actual restored-`null` to same-document
acknowledgement sequence. It is red on `main`'s implementation and green with the guard: deleting
only the guard line from the merged file fails
`preserves a restored same-document subscription through acknowledgement`.

The missing capability is harness work in its own right - a reload path in the conversation
fixture that keeps the socket and doc subscription alive - and is worth doing so this class of
restore bug becomes browser-observable. It is out of scope for this fix and should not gate it.
