### PR TITLE
[backport core/1.53] fix: preserve PrimitiveNode widget value on workflow load

### DIFF
--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -6,9 +6,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
-  INodeOutputSlot
+  INodeOutputSlot,
+  ISerialisedNode
 } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { assetService } from '@/platform/assets/services/assetService'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
@@ -85,26 +87,253 @@ function widgetSlot(
 describe('PrimitiveNode', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.namedValuesRestore = false
   })
 
-  it('resets itself when the store reports a link the graph cannot resolve', () => {
+  function intFixture() {
     const graph = new LGraph()
-    const node = new PrimitiveNode('Primitive')
-    graph.add(node)
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    return { graph, primitive, target }
+  }
+
+  function restoreIntPrimitive(
+    primitive: PrimitiveNode,
+    target: LGraphNode,
+    values: ISerialisedNode['widgets_values'],
+    named?: ISerialisedNode['widgets_values_named']
+  ) {
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({
+        widgets_values: values,
+        widgets_values_named: named,
+        outputs: [{ type: 'INT' }]
+      })
+    )
+    appState.configuringGraph = false
+    primitive.onAfterGraphConfigured()
+  }
+
+  it('keeps its serialized value when the target widget has a stale value', () => {
+    const { primitive, target } = intFixture()
+
+    restoreIntPrimitive(primitive, target, [222])
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+
+    primitive.widgets![0].value = 333
+    primitive.applyToGraph()
+    primitive.disconnectOutput(0)
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(333)
+  })
+
+  it.each([
+    { label: 'null', value: null },
+    { label: 'undefined', value: undefined }
+  ])('restores an explicit $label value', ({ value }) => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('value', 'STRING')
+    target.inputs[0].widget = {
+      name: 'value',
+      [GET_CONFIG]: () => ['STRING', {}]
+    }
+    target.addWidget('text', 'value', 'stale', () => {})
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: [value], outputs: [{ type: 'STRING' }] })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets).toHaveLength(1)
+    expect(primitive.widgets?.[0].value).toBe(value)
+  })
+
+  it('restores named main and control values when enabled', () => {
+    LiteGraph.namedValuesRestore = true
+    const { primitive, target } = intFixture()
+
+    restoreIntPrimitive(primitive, target, [222, 'randomize'], {
+      value: 333,
+      control_after_generate: 'fixed'
+    })
+
+    expect(primitive.widgets?.[0].value).toBe(333)
+    expect(primitive.widgets?.[1].value).toBe('fixed')
+  })
+
+  it('does not apply a serialized value left over from an unresolved output type', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Loader')
+    target.comfyClass = 'CheckpointLoaderSimple'
+    graph.add(target)
+    target.addInput('ckpt_name', 'COMBO')
+    target.inputs[0].widget = {
+      name: 'ckpt_name',
+      [GET_CONFIG]: () => [['a.safetensors', 'b.safetensors'], {}]
+    }
+    target.addWidget('combo', 'ckpt_name', 'a.safetensors', () => {}, {
+      values: ['a.safetensors', 'b.safetensors']
+    })
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: '*' }] })
+    )
+
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe('a.safetensors')
+  })
+
+  it('keeps its serialized value for an asset browser widget', () => {
+    vi.spyOn(assetService, 'shouldUseAssetBrowser').mockReturnValue(true)
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    target.comfyClass = 'CheckpointLoaderSimple'
+    graph.add(target)
+    target.addInput('ckpt_name', 'COMBO')
+    target.inputs[0].widget = {
+      name: 'ckpt_name',
+      [GET_CONFIG]: () => [['target.safetensors', 'serialized.safetensors'], {}]
+    }
+    target.addWidget('combo', 'ckpt_name', 'target.safetensors', () => {}, {
+      values: ['target.safetensors', 'serialized.safetensors']
+    })
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({
+        widgets_values: ['serialized.safetensors'],
+        outputs: [{ type: 'COMBO' }]
+      })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0]).toMatchObject({
+      type: 'asset',
+      value: 'serialized.safetensors'
+    })
+  })
+
+  it('restores its serialized value after a reroute resolves its widget config', () => {
+    const graph = new LGraph()
+    const reroute = new LGraphNode('Reroute')
+    graph.add(reroute)
+    reroute.addInput('', '*')
+    reroute.inputs[0].widget = { name: 'value' }
+    reroute.addOutput('', '*')
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, reroute, 0)
+    reroute.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+    expect(primitive.widgets).toBeUndefined()
+    reroute.inputs[0].widget![GET_CONFIG] =
+      target.inputs[0].widget?.[GET_CONFIG]
+    primitive.recreateWidget()
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
+  it('drops restoration when the store reports an unresolvable link', () => {
+    const { graph, primitive, target } = intFixture()
     useLinkStore().registerLink(graphScopeOf(graph), {
       id: toLinkId(999),
       graphId: graphScopeOf(graph).owningGraphId,
-      originNodeId: node.id,
+      originNodeId: primitive.id,
       originSlot: 0,
       targetNodeId: toNodeId(42),
       targetSlot: 0,
       type: '*'
     })
-    const onLastDisconnect = vi.spyOn(node, 'onLastDisconnect')
+    const onLastDisconnect = vi.spyOn(primitive, 'onLastDisconnect')
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
 
-    node.onAfterGraphConfigured()
+    primitive.onAfterGraphConfigured()
 
     expect(onLastDisconnect).toHaveBeenCalled()
+    expect(primitive.widgets?.length).toBeFalsy()
+    primitive.connect(0, target, 0)
+    expect(primitive.widgets?.[0].value).toBe(111)
+  })
+
+  it('keeps an unconsumed serialized value until its widget is first built', () => {
+    const { primitive, target } = intFixture()
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+
+    primitive.onAfterGraphConfigured()
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
+  it('clears its serialized value when its output is disconnected', () => {
+    const { primitive, target } = intFixture()
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+
+    primitive.onLastDisconnect()
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(111)
+  })
+
+  it('does not retain restoration configured before graph insertion', () => {
+    const { graph, target } = intFixture()
+    const primitive = new PrimitiveNode('Primitive')
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    graph.add(primitive)
+
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(111)
   })
 })
 

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -1,10 +1,12 @@
 import { intersection } from 'es-toolkit/compat'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { createWidgetRestorationState } from '@/lib/litegraph/src/LGraphNode'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
   INodeOutputSlot,
+  ISerialisedNode,
   ISlotType,
   LLink
 } from '@/lib/litegraph/src/litegraph'
@@ -22,7 +24,6 @@ import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetValue } from '@/types/simplifiedWidget'
-import { zeroUuid } from '@/utils/uuid'
 import {
   ComfyWidgets,
   addValueControlWidgets,
@@ -124,6 +125,18 @@ export class PrimitiveNode extends LGraphNode {
     return values
   }
 
+  override configure(serialisedNode: ISerialisedNode) {
+    const type = serialisedNode.outputs?.[0]?.type
+    super.configure(serialisedNode)
+    if (!this.graph || this.widgets?.length || typeof type !== 'string') return
+
+    useWidgetValueStore().setNodeWidgetRestoration(
+      this.graph.rootGraph.id,
+      this.id,
+      createWidgetRestorationState(serialisedNode)
+    )
+  }
+
   override onAfterGraphConfigured() {
     if (
       this.graph &&
@@ -135,6 +148,14 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
+  }
+
+  private _clearWidgetRestoration() {
+    if (this.graph)
+      useWidgetValueStore().clearNodeWidgetRestoration(
+        this.graph.rootGraph.id,
+        this.id
+      )
   }
 
   override onConnectionsChange(
@@ -223,6 +244,8 @@ export class PrimitiveNode extends LGraphNode {
     if (!config) return
 
     const { type } = getWidgetType(config)
+    if (recreating || this.outputs[0].type !== type)
+      this._clearWidgetRestoration()
     // Update our output to restrict to the widget type
     this.outputs[0].type = type
     this.outputs[0].name = type
@@ -251,78 +274,68 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-
-    if (
-      type === 'COMBO' &&
-      assetService.shouldUseAssetBrowser(node.comfyClass, widgetName)
-    ) {
-      widget = this._createAssetWidget(node, widgetName, inputData)
-      const theirWidget = node.widgets?.find((w) => w.name === widgetName)
-      if (theirWidget) widget.value = theirWidget.value
-      this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
-      return
-    }
-
-    if (isValidWidgetType(type)) {
-      widget = (ComfyWidgets[type](this, 'value', inputData, app) || {}).widget
-    } else {
-      // @ts-expect-error InputSpec is not typed correctly
-      widget = this.addWidget(type, 'value', null, () => {}, {})
-    }
-
-    if (node?.widgets && widget) {
-      const theirWidget = node.widgets.find((w) => w.name === widgetName)
-      if (theirWidget) {
-        widget.value = theirWidget.value
-      }
-    }
-
-    if (
-      !inputData?.[1]?.control_after_generate &&
-      (widget.type === 'number' || widget.type === 'combo')
-    ) {
-      const graphId = this.graph?.rootGraph.id ?? zeroUuid
-      let control_value =
-        useWidgetValueStore().getPositionalRestoredWidgetValue(
-          graphId,
+    const restoredValue = this.graph
+      ? useWidgetValueStore().getRestoredWidgetValue(
+          this.graph.rootGraph.id,
           this.id,
-          1
+          'value',
+          0
         )
-      if (!control_value) {
-        control_value = 'fixed'
-      }
-      addValueControlWidgets(
-        this,
-        widget,
-        control_value as string,
-        undefined,
-        inputData
-      )
-      if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
+      : undefined
 
-      const filter = useWidgetValueStore().getPositionalRestoredWidgetValue(
-        graphId,
-        this.id,
-        2
-      )
-      if (filter && this.widgets && this.widgets.length === 3) {
-        this.widgets[2].value = filter
+    try {
+      if (
+        type === 'COMBO' &&
+        assetService.shouldUseAssetBrowser(node.comfyClass, widgetName)
+      ) {
+        widget = this._createAssetWidget(node, widgetName, inputData)
+        const theirWidget = node.widgets?.find((w) => w.name === widgetName)
+        if (theirWidget) widget.value = theirWidget.value
+        if (restoredValue) widget.value = restoredValue.value
+        this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
+        return
       }
+
+      if (isValidWidgetType(type)) {
+        widget = (ComfyWidgets[type](this, 'value', inputData, app) || {})
+          .widget
+      } else {
+        // @ts-expect-error InputSpec is not typed correctly
+        widget = this.addWidget(type, 'value', null, () => {}, {})
+      }
+
+      if (node?.widgets && widget) {
+        const theirWidget = node.widgets.find((w) => w.name === widgetName)
+        if (theirWidget) {
+          widget.value = theirWidget.value
+        }
+      }
+      if (restoredValue) widget.value = restoredValue.value
+
+      if (
+        !inputData?.[1]?.control_after_generate &&
+        (widget.type === 'number' || widget.type === 'combo')
+      ) {
+        addValueControlWidgets(this, widget, 'fixed', undefined, inputData)
+        if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
+      }
+
+      // Restore any saved control values
+      const controlValues = this.controlValues
+      if (
+        this.widgets &&
+        this.lastType === this.widgets[0]?.type &&
+        controlValues?.length === this.widgets.length - 1
+      ) {
+        for (let i = 0; i < controlValues.length; i++) {
+          this.widgets[i + 1].value = controlValues[i]
+        }
+      }
+
+      this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
+    } finally {
+      this._clearWidgetRestoration()
     }
-
-    // Restore any saved control values
-    const controlValues = this.controlValues
-    if (
-      this.widgets &&
-      this.lastType === this.widgets[0]?.type &&
-      controlValues?.length === this.widgets.length - 1
-    ) {
-      for (let i = 0; i < controlValues.length; i++) {
-        this.widgets[i + 1].value = controlValues[i]
-      }
-    }
-
-    this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
   }
 
   private _createAssetWidget(
@@ -368,7 +381,7 @@ export class PrimitiveNode extends LGraphNode {
   recreateWidget() {
     const values = this.widgets?.map((w) => w.value)
     this._removeWidgets()
-    this._onFirstConnection(true)
+    this._onFirstConnection(!!values?.length)
     if (values?.length && this.widgets) {
       for (let i = 0; i < this.widgets.length; i++)
         this.widgets[i].value = values[i]
@@ -448,6 +461,7 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   onLastDisconnect() {
+    this._clearWidgetRestoration()
     // We can't remove + re-add the output here as if you drag a link over the same link
     // it removes, then re-adds, causing it to break
     this.outputs[0].type = '*'

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -180,6 +180,28 @@ function serialiseWidgetValues(widgets: IBaseWidget[]) {
   return { widgets_values: positional, widgets_values_named: named }
 }
 
+export function createWidgetRestorationState(
+  info: Pick<ISerialisedNode, 'widgets_values' | 'widgets_values_named'>,
+  fallbackNames?: readonly string[]
+) {
+  const positional = Array.from(info.widgets_values ?? [])
+  const named =
+    info.widgets_values_named ??
+    (info.widgets_values && fallbackNames
+      ? Object.fromEntries(
+          positional.flatMap((value, index) =>
+            fallbackNames[index] ? [[fallbackNames[index], value]] : []
+          )
+        )
+      : undefined)
+
+  return {
+    positional,
+    named: named ? { ...named } : undefined,
+    restoreNamed: Boolean(named && LiteGraph.namedValuesRestore)
+  }
+}
+
 interface ConnectByTypeOptions {
   /** @deprecated Events */
   createEventInCase?: boolean
@@ -1124,25 +1146,18 @@ export class LGraphNode
     // SubgraphNode callback.
     this._internalConfigureAfterSlots?.()
 
-    const positionalValues = Array.from(info.widgets_values ?? [])
-    const getNamedValues = () => {
-      if (info.widgets_values_named) return info.widgets_values_named
-
-      const map = this.constructor.nodeData?.fallbackWidgetsValuesNames
-      if (!info.widgets_values || !map) return
-
-      return Object.fromEntries(
-        positionalValues.flatMap((v, i) => (map[i] ? [[map[i], v]] : []))
-      )
-    }
-    const namedValues = getNamedValues()
+    const restoration = createWidgetRestorationState(
+      info,
+      this.constructor.nodeData?.fallbackWidgetsValuesNames
+    )
+    const namedValues = restoration.named
     const graphId = this.graph?.rootGraph.id ?? zeroUuid
     try {
-      useWidgetValueStore().setNodeWidgetRestoration(graphId, this.id, {
-        positional: positionalValues,
-        named: namedValues ? { ...namedValues } : undefined,
-        restoreNamed: Boolean(namedValues && LiteGraph.namedValuesRestore)
-      })
+      useWidgetValueStore().setNodeWidgetRestoration(
+        graphId,
+        this.id,
+        restoration
+      )
 
       if (this.widgets) {
         for (const w of this.widgets) {

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -24,6 +24,31 @@ interface WidgetRestorationState {
   restoreNamed: boolean
 }
 
+function setNodeScoped<T>(
+  graphMap: Map<UUID, Map<NodeId, T>>,
+  graphId: UUID,
+  nodeId: NodeId,
+  value: T
+): void {
+  let nodeMap = graphMap.get(graphId)
+  if (!nodeMap) {
+    nodeMap = new Map()
+    graphMap.set(graphId, nodeMap)
+  }
+  nodeMap.set(nodeId, value)
+}
+
+function clearNodeScoped<T>(
+  graphMap: Map<UUID, Map<NodeId, T>>,
+  graphId: UUID,
+  nodeId: NodeId
+): void {
+  const nodeMap = graphMap.get(graphId)
+  if (!nodeMap) return
+  nodeMap.delete(nodeId)
+  if (nodeMap.size === 0) graphMap.delete(graphId)
+}
+
 export function stripGraphPrefix(scopedId: SerializedNodeId): NodeId | null {
   return parseNodeId(String(scopedId).replace(/^(.*:)+/, ''))
 }
@@ -44,12 +69,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     nodeId: NodeId,
     restoration: WidgetRestorationState
   ): void {
-    let graphRestorations = graphWidgetRestorations.get(graphId)
-    if (!graphRestorations) {
-      graphRestorations = new Map()
-      graphWidgetRestorations.set(graphId, graphRestorations)
-    }
-    graphRestorations.set(nodeId, restoration)
+    setNodeScoped(graphWidgetRestorations, graphId, nodeId, restoration)
   }
 
   function getRestoredWidgetValue(
@@ -71,20 +91,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   }
 
   function clearNodeWidgetRestoration(graphId: UUID, nodeId: NodeId): void {
-    const restorations = graphWidgetRestorations.get(graphId)
-    if (!restorations) return
-    restorations.delete(nodeId)
-    if (restorations.size === 0) graphWidgetRestorations.delete(graphId)
-  }
-
-  function getPositionalRestoredWidgetValue(
-    graphId: UUID,
-    nodeId: NodeId,
-    positionalIndex: number
-  ): WidgetValue | undefined {
-    return graphWidgetRestorations.get(graphId)?.get(nodeId)?.positional[
-      positionalIndex
-    ]
+    clearNodeScoped(graphWidgetRestorations, graphId, nodeId)
   }
 
   function getGraphWidgetStates(graphId: UUID): Map<WidgetId, WidgetState> {
@@ -439,7 +446,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     setNodeWidgetRestoration,
     clearNodeWidgetRestoration,
     getRestoredWidgetValue,
-    getPositionalRestoredWidgetValue,
     getWidget,
     getWidgetRenderState,
     setValue,


### PR DESCRIPTION
Manual backport of #16459 to `core/1.53` — the automatic backport failed on cherry-pick conflicts.

- Same fix: PrimitiveNode keeps its widget value on workflow load.
- Conflicts were context-only (main-only widget-store code not in 1.53); resolved by applying only this PR's hunks.
- Deliberately keeps 1.53's existing name-restore gating — does not carry in the opt-in semantics from #16538, which is not backported.

<details><summary>Full context for agent readers</summary>

Source merge commit: 88fa8153caab2793c0a9ebfc1867825de58232b7 (squash of #16459).

Conflict resolution:
- `src/lib/litegraph/src/LGraphNode.ts`: added the exported `createWidgetRestorationState` helper and replaced the inline restoration block in `configure()` with a call to it. On main the helper computes `restoreNamed: Boolean(named && (LiteGraph.namedValuesRestore || fallbackNames))`; the `|| fallbackNames` half comes from #16538 (merged after the 1.53 cut, no backport label). This backport uses `restoreNamed: Boolean(named && LiteGraph.namedValuesRestore)`, which is exactly what 1.53 already does, so non-Primitive node behavior on the release branch is unchanged.
- `src/stores/widgetValueStore.ts`: added the `setNodeScoped`/`clearNodeScoped` helpers, switched the restoration map to them, removed the now-unused `getPositionalRestoredWidgetValue`. Did not bring in main-only `onValueChange`/`WidgetValueChange` code.
- `src/extensions/core/widgetInputs.ts` and its test applied cleanly.

Verification on the branch: `pnpm vitest run src/extensions/core/widgetInputs.test.ts src/stores/ src/lib/litegraph/src/LGraphNode.test.ts` → 55 files, 1232 passed, 1 skipped; `pnpm typecheck` clean; `pnpm oxlint` 0/0 and `pnpm oxfmt --check` clean on the four touched files.

<!-- authored-by:agent w3-w24 -->
</details>
