### PR TITLE
feat(comfy-multi-player): expose canonical op inspection

### DIFF
--- a/packages/comfy-multi-player/.agents/checks/api-contract.md
+++ b/packages/comfy-multi-player/.agents/checks/api-contract.md
@@ -4,7 +4,7 @@ Catch breaking changes to this package's public surface. Applies to `src/index.t
 
 ## What to check
 
-1. **Public exports** — `src/index.ts` re-exports the op layer, KA-11 read gate, ADR-004 follower reads, #71's payload-bound constants and `opBoundsRefusal` from `src/limits.ts`, the snapshot surface from `src/read.ts`, and everything from `types` and `stamps`. A removed or renamed export without a compatibility alias is breaking. New exports are fine only when deliberately classified.
+1. **Public exports** — `src/index.ts` re-exports the op layer (including ADR-022's pure `inspectOps` storage preflight), KA-11 read gate, ADR-004 follower reads, #71's payload-bound constants and `opBoundsRefusal` from `src/limits.ts`, the snapshot surface from `src/read.ts`, and everything from `types` and `stamps`. A removed or renamed export without a compatibility alias is breaking. New exports are fine only when deliberately classified.
    Most of `src/doc.ts` stays private because its accessors and mutators bypass the op layer (KA-1, KA-2, KA-4, FC-5). Re-adding `export * from "./doc.js"`, or adding a `./doc` subpath, or exposing any further `doc.ts` runtime export from the entrypoint, is a blocking finding, not a compatibility fix. The named exceptions are `nodesMap`, `linksMap`, and `OPAQUE_WIDGETS_KEY` (ADR-004's frontend-follower reads) plus `encodingLosses` (KA-1's read-only value diagnostic, which takes no document); `test/public-api.regression.test.ts` guards that exact list, and widening it is a diff rather than a silent consequence of adding an export.
    Prefer snapshot reads for new consumers: values returned by `src/read.ts` must not expose a live `Y.AbstractType`, at any depth. `test/readonly-surface.test.ts` proves its current functions return deep-copied, deep-frozen plain data, and that they refuse a document carrying content under an unreadable schema on the same predicate `project()` uses (KA-11). Not the same DISPOSITION, and do not report it as such: for a document carrying NOTHING the snapshot surface returns its empty value where `project()` refuses — Amendment A12 records that divergence against A5's consumer-impact note. Two things are blocking findings here: a gate on this surface that asks "does the document carry content" by enumerating the §1 root NAMES (blind to a v2 that renamed them, which is the canonical bump trigger), and a new entrypoint export not classified by that test.
 
@@ -31,7 +31,7 @@ Staleness anchors for rule 1 (the public export surface this profile restates).
 verbatim in the cited file; if an export is removed or renamed, this profile fails
 CI so the prose above cannot silently describe a contract that no longer exists.
 -->
-<!-- claim: export { applyOps } from "./applier.js" :: src/index.ts -->
+<!-- claim: export { applyOps, inspectOps } from "./applier.js" :: src/index.ts -->
 <!-- claim: export { project } from "./project.js" :: src/index.ts -->
 <!-- claim: export * from "./clock.js" :: src/index.ts -->
 <!-- claim: export { mint } from "./mint.js" :: src/index.ts -->

--- a/packages/comfy-multi-player/docs/decisions/ADR-022-canonical-op-inspection.md
+++ b/packages/comfy-multi-player/docs/decisions/ADR-022-canonical-op-inspection.md
@@ -1,0 +1,83 @@
+# ADR-022: pure canonical operation inspection
+
+- **Status:** Accepted
+- **Date:** 2026-09-03
+- **Invariants:** KA-2, KA-3, KA-4; FC-2, FC-3
+
+## Context
+
+ADR-029 moves durable applied-operation identity out of an indefinitely growing Yjs `__applied`
+map. Storage needs each stamped operation's exact canonical bytes, SHA-256 digest, creator actor,
+and creator Lamport counter before it can classify a retry. Reimplementing any of those facts in
+Go would create a second canonicalizer and allow browser, Node, and storage semantics to drift.
+
+`applyOps` already validates the wire envelope, canonicalizes the whole semantic operation, and
+hashes those canonical bytes. It cannot be used for preflight because it also requires and mutates
+a document.
+
+## Decision
+
+Expose `inspectOps(ops)` from the package entrypoint. It is synchronous, dependency-free, and pure:
+it reads only its arguments and returns one result per input in input order:
+
+```text
+{ index, op_id, canonical_op, canonical_digest,
+  creator_actor, creator_lamport }
+```
+
+`canonical_op` is the UTF-8 encoding of the exact canonical string used by `applyOps`.
+`canonical_digest` is its raw 32-byte SHA-256. Creator identity comes from the required op stamp
+`[counter, actor]`, never server arrival order or call metadata.
+
+Inspection runs the same envelope validation, operation bounds, canonicalizer, SHA-256
+implementation, and batch-size limit as `applyOps`. It does not perform document- or
+catalog-dependent semantic checks. Two identical occurrences of one `op_id` remain in the ordered
+result. If one batch reuses an `op_id` with different canonical bytes, inspection throws the
+existing typed `OpRejectedError` with code `op_id_reuse` before a host can call storage.
+
+The Node doc host may base64-encode these byte arrays for JSON transport. Go may decode, compare,
+and persist them, but must not canonicalize, hash, extract stamps, or infer semantic order.
+
+```diagram
+stamped ops
+    │
+    ▼
+┌────────────────────────────────┐
+│ inspectOps                     │
+│ validate → canonicalize → hash │
+└───────────────┬────────────────┘
+                │ ordered immutable facts
+                ▼
+┌────────────────────────────────┐
+│ host transport / storage       │
+│ no semantic implementation     │
+└────────────────────────────────┘
+```
+
+## Consequences
+
+- CMP remains the sole canonicalizer and semantic applier (KA-3, FC-3).
+- Duplicate and changed-payload reuse classification remains byte-identical to the apply boundary
+  (KA-4).
+- Creator-owned Lamport order remains embedded in and extracted from the operation (KA-2).
+- Cloud indexes and arrival order remain durability coordinates, never semantic order (FC-2).
+- A storage preflight cannot certify document- or catalog-dependent applicability; `applyOps`
+  retains that authority.
+
+## Alternatives considered
+
+- **Canonicalize and hash in Go:** rejected because it creates a second implementation and
+  violates FC-3.
+- **Apply against a throwaway Y.Doc:** rejected because inspection would acquire irrelevant
+  document/catalog preconditions and duplicate the host's apply work.
+- **Return JSON strings or hex digests:** rejected because storage owns exact bytes and a raw
+  32-byte digest; transport encoding belongs to the host boundary.
+
+## Glossary
+
+- **Canonical operation bytes:** deterministic UTF-8 bytes of the complete semantic-op envelope.
+- **CMP:** `@comfyorg/comfy-multi-player`, the shared browser-and-Node package.
+- **Creator Lamport counter:** the non-negative counter in an operation's authoritative stamp.
+- **FC:** foreclose invariant, a design direction the program must not enter.
+- **KA:** keep-alive invariant, behavior the program must preserve.
+- **Storage preflight:** pure operation inspection before any durable lookup or write.

--- a/packages/comfy-multi-player/src/applier.ts
+++ b/packages/comfy-multi-player/src/applier.ts
@@ -122,6 +122,7 @@ import {
   type GrowConnectOp,
   type GrowSpec,
   type InteriorSetWidgetOp,
+  type CanonicalOpInspection,
   type Op,
   type SetWidgetOp,
   type StampKey,
@@ -349,6 +350,60 @@ export function canonicalOp(op: Op): string {
  */
 export function opDigest(op: Op): string {
   return sha256Hex(canonicalOp(op));
+}
+
+/**
+ * Validate and inspect stamped operations without reading or mutating a doc.
+ *
+ * This is the storage preflight boundary from ADR-022. Canonical bytes and
+ * their digest are produced together through the same canonicalizer and
+ * SHA-256 implementation as {@link applyOps}. Input order is preserved.
+ * Identical repeated ids remain inspectable; reuse with different canonical
+ * bytes is rejected before a storage caller can perform a lookup.
+ */
+export function inspectOps(ops: Op[]): CanonicalOpInspection[] {
+  if (ops.length > MAX_OPS_PER_BATCH) {
+    throw new OpRejectedError(
+      "malformed_op",
+      `batch of ${ops.length} ops exceeds the ${MAX_OPS_PER_BATCH}-op limit`,
+    );
+  }
+
+  const canonicalById = new Map<string, string>();
+  return ops.map((op, index) => {
+    validateEnvelope(op);
+    if (op.stamp === undefined) {
+      throw new OpRejectedError(
+        "malformed_op",
+        `${op.op}: stamp is required for canonical inspection`,
+      );
+    }
+
+    const canonical = canonicalOp(op);
+    const prior = canonicalById.get(op.op_id);
+    if (prior !== undefined && prior !== canonical) {
+      throw new OpRejectedError(
+        "op_id_reuse",
+        `op_id '${op.op_id}' is reused with a different payload at index ${index}`,
+      );
+    }
+    canonicalById.set(op.op_id, canonical);
+
+    const digestHex = sha256Hex(canonical);
+    const canonicalDigest = new Uint8Array(digestHex.length / 2);
+    for (let offset = 0; offset < digestHex.length; offset += 2) {
+      canonicalDigest[offset / 2] = Number.parseInt(digestHex.slice(offset, offset + 2), 16);
+    }
+
+    return {
+      index,
+      op_id: op.op_id,
+      canonical_op: new TextEncoder().encode(canonical),
+      canonical_digest: canonicalDigest,
+      creator_actor: op.stamp[1],
+      creator_lamport: op.stamp[0],
+    };
+  });
 }
 
 /**

--- a/packages/comfy-multi-player/src/index.ts
+++ b/packages/comfy-multi-player/src/index.ts
@@ -18,6 +18,8 @@
  *    snapshot every replica forks from — schema §9);
  *  - `applyOps(doc, ops, catalog?)` — idempotent, LWW-gated, abort-remainder
  *    op application (schema §2–§4);
+ *  - `inspectOps(ops)` — pure validation and canonical bytes/digest/stamp
+ *    extraction for storage preflight (ADR-022);
  *  - `project(doc, catalog)` — canonical workflow JSON projection (schema §7),
  *    fail-closed on a schema this package cannot read (KA-11);
  *  - `migrate(doc, fromVersion)` — layout versioning, fail-closed (schema §10);
@@ -68,7 +70,7 @@ export {
   nodesMap,
   type EncodingLoss,
 } from "./doc.js";
-export { applyOps } from "./applier.js";
+export { applyOps, inspectOps } from "./applier.js";
 export { project } from "./project.js";
 export { mint } from "./mint.js";
 export { migrate } from "./migrate.js";

--- a/packages/comfy-multi-player/src/types.ts
+++ b/packages/comfy-multi-player/src/types.ts
@@ -602,6 +602,20 @@ export interface ApplyResult {
   ops_seen: number;
 }
 
+/** Pure, ordered storage facts for one validated stamped semantic op. */
+export interface CanonicalOpInspection {
+  /** Original index in the inspected batch. */
+  index: number;
+  op_id: string;
+  /** Exact UTF-8 bytes of the canonical semantic-op envelope. */
+  canonical_op: Uint8Array;
+  /** Raw 32-byte SHA-256 of {@link canonical_op}. */
+  canonical_digest: Uint8Array;
+  /** Creator identity from the op's authoritative stamp, not host arrival metadata. */
+  creator_actor: string;
+  creator_lamport: number;
+}
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------

--- a/packages/comfy-multi-player/test/inspect-ops.test.ts
+++ b/packages/comfy-multi-player/test/inspect-ops.test.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  inspectOps,
+  OpRejectedError,
+  type SetWidgetOp,
+} from "../src/index.js";
+
+const opId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function setWidget(value: number, id = opId, counter = 7, stampActor = "human:creator"): SetWidgetOp {
+  return {
+    value,
+    widget: "steps",
+    node_id: 42,
+    stamp: [counter, stampActor],
+    base_version: 2,
+    actor: "host:arrival-metadata",
+    op_id: id,
+    op: "set_widget",
+  };
+}
+
+describe("inspectOps", () => {
+  it("returns exact canonical bytes, raw SHA-256, creator stamp, and input indexes in order", () => {
+    const first = setWidget(25);
+    const second = setWidget(30, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 9, "agent:creator");
+
+    const inspected = inspectOps([first, second]);
+
+    expect(inspected.map(({ index, op_id }) => ({ index, op_id }))).toEqual([
+      { index: 0, op_id: first.op_id },
+      { index: 1, op_id: second.op_id },
+    ]);
+    expect(inspected[0]).toMatchObject({
+      creator_actor: "human:creator",
+      creator_lamport: 7,
+    });
+    expect(inspected[1]).toMatchObject({
+      creator_actor: "agent:creator",
+      creator_lamport: 9,
+    });
+
+    for (const item of inspected) {
+      expect(item.canonical_op).toBeInstanceOf(Uint8Array);
+      expect(item.canonical_digest).toBeInstanceOf(Uint8Array);
+      expect(item.canonical_digest).toHaveLength(32);
+      expect(Buffer.from(item.canonical_digest)).toEqual(
+        createHash("sha256").update(item.canonical_op).digest(),
+      );
+    }
+
+    expect(new TextDecoder().decode(inspected[0]!.canonical_op)).toBe(
+      JSON.stringify({
+        actor: first.actor,
+        base_version: first.base_version,
+        node_id: first.node_id,
+        op: first.op,
+        op_id: first.op_id,
+        stamp: first.stamp,
+        value: first.value,
+        widget: first.widget,
+      }),
+    );
+  });
+
+  it("preserves identical duplicates but rejects changed bytes with typed op_id_reuse", () => {
+    const op = setWidget(25);
+    expect(inspectOps([op, { ...op }])).toHaveLength(2);
+
+    try {
+      inspectOps([op, setWidget(30)]);
+      expect.fail("changed op_id reuse must be rejected");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpRejectedError);
+      expect(error).toMatchObject({ code: "op_id_reuse" });
+    }
+  });
+
+  it("requires the creator stamp and preserves the applier's malformed-op type", () => {
+    const unstamped = { ...setWidget(25), stamp: undefined } as unknown as SetWidgetOp;
+    try {
+      inspectOps([unstamped]);
+      expect.fail("unstamped ops must be rejected");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpRejectedError);
+      expect(error).toMatchObject({ code: "malformed_op" });
+    }
+  });
+});

--- a/packages/comfy-multi-player/test/public-api.regression.test.ts
+++ b/packages/comfy-multi-player/test/public-api.regression.test.ts
@@ -50,6 +50,7 @@ describe("public API", () => {
       expect.objectContaining({
         mint: expect.any(Function),
         applyOps: expect.any(Function),
+        inspectOps: expect.any(Function),
         project: expect.any(Function),
         migrate: expect.any(Function),
         compareStampKeys: expect.any(Function),

--- a/packages/comfy-multi-player/test/readonly-surface.test.ts
+++ b/packages/comfy-multi-player/test/readonly-surface.test.ts
@@ -716,6 +716,7 @@ describe("read-only surface — classification", () => {
    */
   const OP_LAYER_AND_TYPES: readonly string[] = [
     "applyOps",
+    "inspectOps",
     "project",
     "mint",
     "migrate",


### PR DESCRIPTION
Pure CMP storage preflight.

- Exact canonical bytes and raw SHA-256.
- Creator stamp and input order preserved.
- Changed within-batch ID reuse stays typed.

<details><summary>Full context for agent readers</summary>

This stacked PR adds ADR-022 and exports `inspectOps(ops)` from the canonical frontend workspace package introduced by #16644. It shares `applyOps`' envelope validator, operation bounds, canonicalizer, SHA-256 implementation, and batch limit; it does not read or mutate a Y.Doc. The output carries exact UTF-8 canonical bytes, raw 32-byte digest, creator actor/Lamport from the op stamp, and original batch indexes. Exact duplicate IDs remain ordered results; changed canonical bytes throw CMP's existing `OpRejectedError` with `op_id_reuse`.

This preserves KA-2/KA-3/KA-4 and FC-2/FC-3: cloud may transport or persist these facts but gains no Go canonicalizer or second applier.

Stack dependency: #16644 must merge first. The immutable package release and cloud exact-version pin must follow the source merge; they are intentionally not fabricated in this PR.

## Evidence

- `pnpm run build` — passed.
- `pnpm run check:purity` — passed; runtime dependency roots exactly `{yjs}` and bare-Node import clean.
- `pnpm run check:imports` — passed, 17 modules / 47 dependencies / 0 violations.
- `pnpm run check:pins` — passed offline, 174 tracked files / 19 citation sites / 6 pins.
- `pnpm run check:profile-claims` — passed, 60 presence + 10 absence claims.
- `pnpm run check:coderabbit` — passed, generated instructions match.
- `pnpm run verify:corpus` — passed, 8 files.
- `pnpm run lint` — passed with repository baseline warnings only, 0 errors.
- `pnpm run typecheck` — passed.
- `pnpm exec vitest run test/inspect-ops.test.ts test/public-api.regression.test.ts test/readonly-surface.test.ts test/purity.test.ts test/stateless.test.ts` — 47/47 passed after the commit-hook formatter.
- Full `pnpm test` first pass — 873 passed; three expected pre-build/export-classification failures exposed by running before `build` and before classifying the new public export. Both causes were fixed and the affected 47 tests were rerun green; the 10-minute exhaustive permutation suite itself passed.
- `git diff --check` — clean.

</details>

<!-- authored-by:agent lane-adr029-3-2215 -->