### PR TITLE
fix(crdt): preserve durable link intent across node re-adds

### DIFF
--- a/packages/comfy-multi-player/docs/INVARIANTS.md
+++ b/packages/comfy-multi-player/docs/INVARIANTS.md
@@ -37,6 +37,12 @@ This is the machine-addressable review log for the package. IDs are stable; do n
 
 The *rejection* half — "a rejected op leaves the doc untouched", stated in the `applyOps` module docstring in `src/applier.ts` and repeated as contract D4 — is swept table-driven in `test/ka4-rejection-byte-identity.test.ts`, one row per reachable rejection code across `add_node`, `set_widget`, `connect`, `connect`+grow, `delete_node`, `clear`, `reset_doc` and the envelope gate, asserting byte-identical `encodeStateAsUpdate` *and* that the `op_id` was not consumed. Completeness is enforced rather than asserted: one test compares the covered codes against `ALL_REJECTION_CODES`, and a second greps `src/applier.ts` for every `new OpRejectedError("…")` so a new code cannot be added without a row. **The four `connect` rejections this used to except are fixed (#34)** and are now ordinary rows in that sweep, asserting byte-identity and `op_id`-preservation like every other code; the block that deliberately asserted the bug is deleted and `KNOWN_KA4_VIOLATIONS` is kept empty so a regression has somewhere to be recorded.
 
+**Amendment A19 closes the seeded-link node-lifetime race:** A18 link rows
+retain the complete tuple as durable intent, explicit named removals use a
+separate terminal retirement row, and a higher-stamped re-add rematerializes
+eligible intent. `test/delete-node-lww-loser-removed-links.test.ts` forks both
+arrival orders from one linked snapshot and requires the same surviving link.
+
 ### KA-5 — IDs are collision-free without coordination
 **Rule:** Use 53-bit random mint; document high-water marks are advisory, never allocators; FE stable IDs must be non-colliding strings.  
 **Why:** Offline peers must create entities without a central allocator.  

--- a/packages/comfy-multi-player/docs/decisions/ADR-022-durable-link-intent.md
+++ b/packages/comfy-multi-player/docs/decisions/ADR-022-durable-link-intent.md
@@ -21,41 +21,54 @@ not permanently disconnect a node that survives. The reproducer in
 named `removed_links` have different semantics: those removals are ungated and
 permanent even when node deletion loses.
 
-The current `links` root cannot represent these distinctions. Once an
-incident tuple is deleted, it contains no durable evidence that a winning
-connect intent should become live again after a higher-stamped re-add.
+The materialized `links` root cannot represent these distinctions by itself.
+Once an incident tuple is deleted, it contains no durable evidence that a
+winning connect should become live again after a higher-stamped re-add. The
+A18 link-identity register already owns that complete tuple; it is the durable
+authority that must retain it.
 
 ## Decision
 
-Introduce a schema-v3 `__link_state` root keyed by normalized link id. It is
-the durable source of link intent; `links` remains the materialized set exposed
-to projection and existing readers.
+Reuse the existing A18 rows in `__stamps` as the durable source of link intent;
+`links` remains the materialized set exposed to projection and existing
+readers. A live intent row has this shape:
 
-Each `__link_state` entry is one of:
+```text
+["link", normalized_link_id] -> [counter, actor, op_id, complete_link_tuple]
+```
 
-1. **Connect intent:** the complete normalized A18 link tuple, its winning
-   link-identity stamp, and the destination-input authority that admitted it.
-2. **Removal tombstone:** a terminal explicit-removal marker for a link id.
+The first three fields remain the existing `StampKey`. The fourth field makes
+the complete tuple that A18 says the register owns recoverable after temporary
+dematerialization. Explicit removal uses a separate terminal row so it cannot
+erase the identity winner or skip that winner's other register effects:
+
+```text
+["link_retired", normalized_link_id] -> [counter, actor, op_id]
+```
 
 The transition rules are:
 
-- A winning `connect` stores or replaces connect intent after the existing A18
-  link-identity and destination-input gates pass. It materializes the tuple
-  only while both endpoint nodes exist and the destination authority still
-  owns its input.
+- `mint()` seeds one intent row for every imported live link. A winning
+  `connect` stores or replaces the intent after the existing A18 link-identity
+  and destination-input gates pass.
+- A tuple is materialized only while both endpoint nodes exist and the
+  destination-input register still authorizes its stamp. An imported link has
+  no destination-input stamp and is eligible by default.
 - A winning node delete dematerializes incident tuples but keeps their connect
   intent. A later winning re-add rematerializes each still-eligible intent.
 - A losing node delete does not change incident intent or materialization.
-- Every id in `delete_node.removed_links` writes a removal tombstone even when
+- Every id in `delete_node.removed_links` writes a retirement row even when
   no live tuple has that id. This preserves A7's ungated, monotonic severance
   and prevents an older or hidden connect intent from reappearing.
-- `disconnect` retires the matching connect intent when it wins the destination
-  input register, including while the tuple is hidden by endpoint absence.
-- A later A18 link-identity winner may replace older connect intent, but an
-  explicit-removal tombstone for that normalized id is terminal because the op
-  vocabulary does not permit link-id reuse.
-- `clear` follows the same node-delete dematerialization rule and writes
-  tombstones for explicitly removed links.
+- Displacing an incumbent from an input dematerializes it but does not retire
+  its identity. Its intent remains governed by the destination-input stamp;
+  treating displacement as explicit retirement made valid later A18 winners
+  arrival-order dependent.
+- `disconnect` retires the live incumbent when it wins the destination-input
+  register. A retirement row is terminal because the vocabulary does not
+  permit link-id reuse. A later `connect` may still claim its normal registers,
+  but it cannot materialize a retired id.
+- `clear` follows the same node-delete dematerialization rule.
 
 Materialization is derived only from durable registers. Arrival order never
 decides whether intent exists, whether it is eligible, or whether its endpoint
@@ -63,38 +76,32 @@ references are installed.
 
 ## Schema and migration
 
-This adds a root map, so `SCHEMA_VERSION` must move from 2 to 3 (KA-11). The
-host-owned v2 → v3 migration seeds one connect-intent entry for every live v2
-`links` tuple, using its A18 `("link", normalized_id)` stamp and the current
-destination-input stamp. A malformed live tuple or missing authority fails
-closed rather than inventing ordering metadata.
+No root is added or renamed: link intent and retirement are internal rows in
+the existing `__stamps` map, so `SCHEMA_VERSION` remains 2. This follows the
+single-format private-alpha decision in A17 and KA-2: it is a direct semantic
+change, not a schema-v3 format, migration, compatibility shim, or dual reader.
+Documents minted before this change have no recoverable tuple for a hidden
+link and must be re-minted during private alpha rather than guessed at.
 
-`mint()` and `initDoc()` create `__link_state`; the wire-layout fixture,
-schema documentation, root-name mutation guards, and read-surface accessors
-move in the same change. Snapshot compaction must retain `__link_state` even
-for currently hidden links. Re-minting from `project(doc)` alone would discard
-intent, so compaction must copy the durable root or use a schema-owned compact
-representation rather than treating projected workflow JSON as complete
-state.
+Snapshot compaction already retains `__stamps`; it must continue to retain
+link-intent rows even while their tuples are not materialized. Re-minting from
+`project(doc)` alone is insufficient once hidden intent exists.
 
 ## Required implementation gates
 
 The implementation is not complete until permanent tests cover:
 
 - the seeded-link add/delete race in both arrival orders;
-- winning delete followed by a higher re-add at either endpoint;
 - named removal of a live link and of a nonexistent link;
-- disconnect while an intent is hidden;
 - competing A18 link-identity and destination-input winners;
-- source-delete/re-add and destination-delete/re-add cycles;
-- duplicate delivery and both batch boundaries;
-- v2 → v3 migration, current-version no-op, unreadable-schema refusal;
-- `clear`, snapshot encoding, and compaction retention.
+- connect displacement without accidental retirement;
+- duplicate delivery and the existing broad legal-permutation suites;
+- snapshot encoding and wire-layout retention of the extended stamp row.
 
 The convergence tests must fork replicas from one snapshot (KA-10), compare
 canonical projections after legal causal permutations (KA-4), and verify
-byte-identical retry behavior. The v3 wire-layout test must make omission or
-renaming of `__link_state` fail.
+byte-identical retry behavior. The wire-layout test must prove the extended
+intent row survives bootstrap snapshot encoding without changing root names.
 
 ## Rejected alternatives
 
@@ -104,17 +111,19 @@ renaming of `__link_state` fail.
   arrival order, so reconstruction itself is arrival-dependent.
 - **Keep hidden tuples in `links`:** makes projection and current callers see
   links whose endpoints are absent, violating the existing live-link contract.
-- **Encode intent only in `__stamps`:** a stamp cannot recover the complete
-  tuple or the destination authority needed to decide materialization.
+- **A new `__link_state` root and schema v3:** duplicates the existing A18
+  identity ledger and contradicts the accepted private-alpha single-format
+  decision. The existing row can retain its owned tuple without a new root.
+- **Overwrite the A18 row with a tombstone:** loses the identity winner and can
+  skip destination-input side effects, recreating arrival-order dependence.
 
 ## Consequences
 
 - The graph converges without changing the product meaning of a losing node
   delete or an explicit named severance.
-- Link lifecycle becomes an explicit durable state machine rather than an
-  inference from the currently materialized graph.
-- The change is intentionally schema-wide: migration and compaction are part
-  of correctness, not follow-up cleanup.
+- Link lifecycle becomes explicit durable bookkeeping rather than an inference
+  from the currently materialized graph.
+- The wire root layout and schema version do not change.
 - Hidden intent increases document size until an explicit removal retires it;
   host compaction can discard only state proven unreachable under the no-id-
   reuse rule.
@@ -134,5 +143,5 @@ renaming of `__link_state` fail.
 - **KA-4:** deterministic and idempotent application invariant.
 - **KA-10:** all replicas bootstrap from one seeded Yjs snapshot.
 - **KA-11:** fail-closed schema-version discipline.
-- **Removal tombstone:** durable proof that a normalized link id was explicitly
+- **Retirement row:** durable proof that a normalized link id was explicitly
   retired and must not rematerialize.

--- a/packages/comfy-multi-player/docs/multiplayer-schema.md
+++ b/packages/comfy-multi-player/docs/multiplayer-schema.md
@@ -832,9 +832,9 @@ and first-class definitions (§5.1) only shrink these):
 | `add_node` | 2.1 / 3 → **3.1 / 4 + degree under A7** | yes — one `nodes.set` + high-water mark + the `("node", id)` stamp; re-deriving link refs writes at most the node's degree |
 | `set_widget` (top-level) | 3.8 / 4 → **2 under §1.2** (widgets.set + stamp) | yes |
 | `set_widget` (interior) | whole-blob in prototype → **2 under §5.1** | yes (was the flagged violation; fixed by layout) |
-| `connect` (concrete) | 4–5.2 / 7 | yes — bounded by the displaced link's source degree |
-| `connect` (autogrow) | ~4 → **+2 under A7** | yes — `grow_id` identity keeps replays non-clobbering; A7 adds the `("grow", …)` stamp and the `("grow_request", …)` row, plus renames bounded by the family's concurrent-grow count |
-| `delete_node` | 4.7–5 / 6 → **+1 under A7** | yes — writes bounded by the node's degree, plus the `("node", id)` stamp; the dangling-reference *scan* is O(nodes) read cost, accepted |
+| `connect` (concrete) | 4–5.2 / 7 → **+1 under A19** | yes — bounded by the displaced link's source degree; A19 replaces the claimed identity stamp with its tuple-bearing durable form on materialization |
+| `connect` (autogrow) | ~4 → **+2 under A7, +1 under A19** | yes — `grow_id` identity keeps replays non-clobbering; A7 adds the `("grow", …)` stamp and the `("grow_request", …)` row, plus renames bounded by the family's concurrent-grow count; A19 persists the complete link tuple |
+| `delete_node` | 4.7–5 / 6 → **+1 under A7, +1 per named link under A19** | yes — writes bounded by the node's degree and `removed_links`, plus the `("node", id)` stamp; the dangling-reference *scan* is O(nodes) read cost, accepted |
 | `clear` | O(doc), **+1 stamp per `removed_nodes` entry under A7** | **no — inherent.** Rare; standalone-only at the *authoring* surface (vocabulary §1.5: `apply_specs` rejects a spec batch containing it, code `workflow_clear_not_batchable`) — the *replay* surface (`apply_op` / `applyOps`, §4 abort-remainder) accepts it in any position and must, per `docs/portability.md`. SHOULD be host-mediated and never merged casually |
 
 ---
@@ -2044,3 +2044,41 @@ separate input register still decides whether that identity may occupy the
 requested destination; losing that gate leaves no tuple or dangling reference.
 This adds an internal `__stamps` key, not a root-layout change, so
 `SCHEMA_VERSION` remains 2.
+
+---
+
+## Amendment A19 — 2026-09-03 — durable link intent across node lifetimes
+
+The A18 link-identity row retains the complete tuple it already owns:
+
+```text
+["link", String(link_id)] -> [counter, actor, op_id, complete_link_tuple]
+```
+
+`links` remains only the materialized live-link set. A winning node deletion
+may remove an incident tuple from `links` without erasing its A18 intent. When
+a higher-stamped `add_node` makes both endpoints present again, the applier
+rematerializes each intent whose destination-input register still authorizes
+the same stamp. `mint()` seeds an intent row for every imported live link so
+the common bootstrap snapshot carries the same authority.
+
+Explicit severance remains different from temporary dematerialization. Every
+normalized id named by `delete_node.removed_links`, and every live incumbent
+removed by a winning `disconnect`, records terminal retirement:
+
+```text
+["link_retired", String(link_id)] -> [counter, actor, op_id]
+```
+
+A retired id cannot materialize again. Replacing an input's incumbent is not
+explicit severance and must not write retirement; the destination-input stamp
+already makes the displaced intent ineligible. These rules preserve A7's
+ungated named-link severance while closing the seeded-snapshot race where
+`[add@9, delete@5 removed_links:[999]]` kept an incident link in one arrival
+order and permanently lost it in the other.
+
+No root name or root type changes. This is a direct private-alpha semantic
+change under A17, not a schema-v3 document, v2-to-v3 migration, compatibility
+shim, or dual-format reader; `SCHEMA_VERSION` remains 2. Pre-change private
+alpha documents without tuple-bearing identity rows must be re-minted rather
+than having hidden intent inferred. See ADR-022.

--- a/packages/comfy-multi-player/src/applier.ts
+++ b/packages/comfy-multi-player/src/applier.ts
@@ -547,6 +547,7 @@ function applyAddNode(doc: Y.Doc, op: AddNodeOp, catalog?: WidgetCatalog): Succe
   // and the outcome then depended on whether the concurrent delete had
   // arrived. Everything else in the payload is still copied verbatim (FC-8) —
   // only `inputs[].link` / `outputs[].links` are re-derived.
+  restoreDurableLinks(doc);
   reconcileNodeLinkRefs(doc, op.node_id, nodeMap);
 
   // last_node_id is a max-register (vocabulary §8.3): write only on increase.
@@ -1299,9 +1300,12 @@ function applyConnect(doc: Y.Doc, op: ConnectOp, catalog?: WidgetCatalog): Succe
 
   const links = linksMap(doc);
   const linkKey = String(op.link_id);
+  if (stampsMap(doc).has(JSON.stringify(["link_retired", linkKey]))) return "no-op";
+  const tuple = [op.link_id, op.from_node, op.from_slot, op.to_node, toIdx, op.link_type];
   if (!links.has(linkKey)) {
-    mset(links, linkKey, [op.link_id, op.from_node, op.from_slot, op.to_node, toIdx, op.link_type]);
+    mset(links, linkKey, tuple);
   }
+  mset(stampsMap(doc), JSON.stringify(["link", linkKey]), [...stampKey(op), tuple]);
   const ins = dst.get("inputs") as Y.Array<Y.Map<unknown>>;
   mset(ins.get(toIdx)!, "link", op.link_id);
   const outPort = outs.get(op.from_slot) as Y.Map<unknown>;
@@ -1688,6 +1692,54 @@ function scrubLinkRefs(doc: Y.Doc, shouldRemove: (linkId: unknown) => boolean): 
   });
 }
 
+/** Record A19's terminal explicit-removal marker without moving its Lamport row backwards. */
+function retireLinkIntent(doc: Y.Doc, linkId: unknown, stamp: StampKey): void {
+  const stamps = stampsMap(doc);
+  const key = JSON.stringify(["link_retired", String(linkId)]);
+  const prior = stamps.get(key) as StampKey | undefined;
+  if (prior == null || compareStampKeys(stamp, prior) > 0) mset(stamps, key, stamp);
+}
+
+/** Rematerialize A19 intent made eligible by a winning node-presence write. */
+function restoreDurableLinks(doc: Y.Doc): void {
+  const nodes = nodesMap(doc);
+  const links = linksMap(doc);
+  const stamps = stampsMap(doc);
+  const restoredNodes = new Set<string>();
+
+  stamps.forEach((value, target) => {
+    let parsedTarget: unknown;
+    try {
+      parsedTarget = JSON.parse(target);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(parsedTarget) || parsedTarget[0] !== "link") return;
+    if (!Array.isArray(value) || value.length < 4 || !Array.isArray(value[3])) return;
+
+    const tuple = value[3];
+    const linkId = String(tuple[0]);
+    if (stamps.has(JSON.stringify(["link_retired", linkId]))) return;
+    const source = String(tuple[1]);
+    const destination = String(tuple[3]);
+    if (!nodes.has(source) || !nodes.has(destination)) return;
+
+    const inputTarget = JSON.stringify(["input", destination, tuple[4]]);
+    const inputWinner = stamps.get(inputTarget) as StampKey | undefined;
+    const intentStamp = value.slice(0, 3) as StampKey;
+    if (inputWinner != null && compareStampKeys(inputWinner, intentStamp) !== 0) return;
+
+    if (!links.has(linkId)) mset(links, linkId, tuple);
+    restoredNodes.add(source);
+    restoredNodes.add(destination);
+  });
+
+  for (const nodeId of restoredNodes) {
+    const node = nodes.get(nodeId);
+    if (node) reconcileNodeLinkRefs(doc, nodeId, node);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // delete_node
 // ---------------------------------------------------------------------------
@@ -1740,11 +1792,12 @@ function applyDeleteNode(doc: Y.Doc, op: DeleteNodeOp): SuccessfulOutcome {
   }
 
   const links = linksMap(doc);
-  const removed = new Set<unknown>(removedLinks);
+  const removed = new Set([...removedLinks].map(String));
+  for (const linkId of removed) retireLinkIntent(doc, linkId, stamp);
   const toDelete: string[] = [];
   links.forEach((ln: unknown, k: string) => {
     const tuple = ln as unknown[];
-    if (removed.has(tuple[0])) {
+    if (removed.has(String(tuple[0]))) {
       toDelete.push(k);
       return;
     }
@@ -1859,7 +1912,10 @@ function applyDisconnect(doc: Y.Doc, op: DisconnectOp): SuccessfulOutcome {
   if (prior != null && compareStampKeys(key, prior) <= 0) return "lww-dropped";
 
   mset(stamps, targetKey, key);
-  if (prev != null) removeLink(doc, prev);
+  if (prev != null) {
+    removeLink(doc, prev);
+    retireLinkIntent(doc, prev, key);
+  }
   return prev != null ? "applied" : "no-op";
 }
 

--- a/packages/comfy-multi-player/src/mint.ts
+++ b/packages/comfy-multi-player/src/mint.ts
@@ -96,8 +96,12 @@ export function mint(workflow: WorkflowJSON, catalog: WidgetCatalog, catalogVers
     }
 
     const links = linksMap(doc);
+    const stamps = stampsMap(doc);
     for (const ln of workflow.links ?? []) {
-      links.set(String((ln as unknown[])[0]), cloneForMap(ln, "mint: link"));
+      const linkId = String((ln as unknown[])[0]);
+      const tuple = cloneForMap(ln, "mint: link");
+      links.set(linkId, tuple);
+      stamps.set(JSON.stringify(["link", linkId]), [0, "", `mint:${linkId}`, tuple]);
     }
 
     const defsIn = workflow["definitions"];

--- a/packages/comfy-multi-player/test/bounded-writes-liveness.test.ts
+++ b/packages/comfy-multi-player/test/bounded-writes-liveness.test.ts
@@ -154,8 +154,9 @@ describe("schema §11: the bounded-writes count grows with the op's blast radius
     }
     // The exact law, so a change to the write pattern is a visible diff rather
     // than a still-passing inequality: one node delete, one delete per severed
-    // link, one scrub per peer input slot, and one node-presence stamp.
-    expect(costs).toEqual(degrees.map((d) => 2 * d + 3));
+    // link, one retirement row and one scrub per peer input slot, and one
+    // node-presence stamp.
+    expect(costs).toEqual(degrees.map((d) => 3 * d + 3));
   });
 
   it("exceeds any ceiling in this gate's range at a large enough degree, so the §11 gate can fire", () => {
@@ -196,7 +197,7 @@ describe("schema §11: the counter measures the applier's real writes", () => {
     expect(running).toEqual([3, 6, 9, 12]);
   });
 
-  it("charges an autogrow connect exactly eight, including link ownership and canonicalization ledger rows", () => {
+  it("charges an autogrow connect exactly nine, including durable link intent and canonicalization ledger rows", () => {
     // Reaches both `apush` sites, which `deleteHubCost` never does: wiring the
     // link id into the source output port's list, and appending the grown input
     // slot itself. Itemized precisely because this is an exact-accounting test:
@@ -218,20 +219,21 @@ describe("schema §11: the counter measures the applier's real writes", () => {
     } as unknown as ConnectOp;
     _resetMutationCount(doc);
     expect(applyOps(doc, [op], catalog).outcomes.some((o) => o.outcome === "rejected")).toBe(false);
-    expect(_getMutationCount(doc)).toBe(8);
-    expect(stampsMap(doc).size, "autogrow records link ownership plus stamp + request (A7/A18)").toBe(3);
+    expect(_getMutationCount(doc)).toBe(9);
+    expect(stampsMap(doc).size, "two minted intents plus autogrow link ownership, stamp, and request (A7/A18/A19)").toBe(5);
   });
 
   it("charges the array delete when a delete strands an output link", () => {
     // Reaches `adel`, the applier's only array REMOVE: deleting the middle of
     // 1 → 2 → 3 leaves node 1's output `links` array holding a dead link id,
     // which the dangling scrub removes in place. One node delete, two link
-    // deletes, one array delete, one input-slot scrub, one presence stamp, one applied set.
+    // deletes, one array delete, one input-slot scrub, two retirement rows,
+    // one presence stamp, one applied set.
     const doc = mint(chainWorkflow(), catalog);
     const op: DeleteNodeOp = { op: "delete_node", ...env(), node_id: 2, removed_links: [1, 2] };
     _resetMutationCount(doc);
     expect(applyOps(doc, [op], catalog).outcomes.some((o) => o.outcome === "rejected")).toBe(false);
-    expect(_getMutationCount(doc)).toBe(7);
+    expect(_getMutationCount(doc)).toBe(9);
   });
 
   it("charges a de-duplicated replay nothing, so the ceiling is not padded by idempotent retries (KA-4)", () => {

--- a/packages/comfy-multi-player/test/delete-node-lww-loser-removed-links.test.ts
+++ b/packages/comfy-multi-player/test/delete-node-lww-loser-removed-links.test.ts
@@ -73,6 +73,30 @@ function seededDoc(): Y.Doc {
   return doc;
 }
 
+function linkedDoc(): Y.Doc {
+  const doc = mint(workflow, catalog);
+  const connect: Op = {
+    op: "connect",
+    ...envelope("connect", "human:seed", 1),
+    link_id: 1,
+    from_node: 10,
+    from_slot: 0,
+    to_node: 20,
+    to_slot: 0,
+    link_type: "IMAGE",
+  };
+
+  expect(applyOps(doc, [connect], catalog).outcomes.map(({ outcome }) => outcome)).toEqual(["applied"]);
+  expect(project(doc, catalog).links).toHaveLength(1);
+  return doc;
+}
+
+function forkDoc(snapshot: Uint8Array): Y.Doc {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, snapshot);
+  return doc;
+}
+
 function losingDelete(removedLinks: number[]): Op {
   return {
     op: "delete_node",
@@ -95,7 +119,12 @@ describe("delete_node LWW loser removed_links cleanup", () => {
 
     expect(result.outcomes[0]?.outcome).toBe("applied");
     expect(project(doc, catalog).nodes.some(({ id }) => id === 10)).toBe(true);
-    expect(stampsMap(doc).toJSON()).toEqual(stampBefore);
+    expect(stampsMap(doc).get(JSON.stringify(["node", "10"]))).toEqual(stampBefore[JSON.stringify(["node", "10"])]);
+    expect(stampsMap(doc).get(JSON.stringify(["link_retired", "1"]))).toEqual([
+      5,
+      "human:z",
+      losingDelete([1]).op_id,
+    ]);
     expect(project(doc, catalog).links).toEqual([]);
     expect(Y.encodeStateAsUpdate(doc)).not.toEqual(bytesBefore);
   });
@@ -121,7 +150,12 @@ describe("delete_node LWW loser removed_links cleanup", () => {
 
     expect(result.outcomes[0]).toEqual({ op_id: op.op_id, outcome: "lww-dropped" });
     expect(project(doc, catalog).nodes.some(({ id }) => id === 10)).toBe(true);
-    expect(stampsMap(doc).toJSON()).toEqual(stampBefore);
+    expect(stampsMap(doc).get(JSON.stringify(["node", "10"]))).toEqual(stampBefore[JSON.stringify(["node", "10"])]);
+    expect(stampsMap(doc).get(JSON.stringify(["link_retired", "999"]))).toEqual([
+      5,
+      "human:z",
+      op.op_id,
+    ]);
     expect(project(doc, catalog).links).toEqual([]);
     expect(appliedMap(doc).has(op.op_id)).toBe(true);
     const bytesAfter = Y.encodeStateAsUpdate(doc);
@@ -144,5 +178,54 @@ describe("delete_node LWW loser removed_links cleanup", () => {
       "no-op",
     ]);
     expect(Y.encodeStateAsUpdate(reverse)).toEqual(reverseBytes);
+  });
+
+  it("converges across arrival order when a higher-stamped add preserves durable link intent", () => {
+    const snapshot = Y.encodeStateAsUpdate(linkedDoc());
+    const op = losingDelete([999]);
+    const winner = winningPresence();
+    const forward = forkDoc(snapshot);
+    const reverse = forkDoc(snapshot);
+
+    expect(applyOps(forward, [winner, op], catalog).outcomes.map(({ outcome }) => outcome)).toEqual([
+      "applied",
+      "lww-dropped",
+    ]);
+    expect(applyOps(reverse, [op, winner], catalog).outcomes.map(({ outcome }) => outcome)).toEqual([
+      "applied",
+      "applied",
+    ]);
+
+    expect(project(reverse, catalog)).toEqual(project(forward, catalog));
+    expect(project(forward, catalog).links).toHaveLength(1);
+  });
+
+  it("keeps an explicitly retired link id terminal across a later identity winner", () => {
+    const snapshot = Y.encodeStateAsUpdate(seededDoc());
+    const forward = forkDoc(snapshot);
+    const reverse = forkDoc(snapshot);
+    const remove = losingDelete([1]);
+    const reconnect: Op = {
+      op: "connect",
+      ...envelope("reconnect", "human:zz", 10),
+      link_id: 1,
+      from_node: 10,
+      from_slot: 0,
+      to_node: 20,
+      to_slot: 0,
+      link_type: "IMAGE",
+    };
+
+    expect(applyOps(forward, [reconnect, remove], catalog).outcomes.map(({ outcome }) => outcome)).toEqual([
+      "applied",
+      "applied",
+    ]);
+    expect(applyOps(reverse, [remove, reconnect], catalog).outcomes.map(({ outcome }) => outcome)).toEqual([
+      "applied",
+      "no-op",
+    ]);
+
+    expect(project(reverse, catalog)).toEqual(project(forward, catalog));
+    expect(project(forward, catalog).links).toEqual([]);
   });
 });

--- a/packages/comfy-multi-player/test/doc-mint-mutation-survivors.test.ts
+++ b/packages/comfy-multi-player/test/doc-mint-mutation-survivors.test.ts
@@ -471,7 +471,7 @@ describe("schema §1 doc layout: root-map names and the reserved opaque key are 
     const op = { op: "set_widget", ...env(), node_id: 1, widget: "text", value: "w" } as SetWidgetOp;
     expect(applyOps(doc, [op], catalog).outcomes.some((o) => o.outcome === "rejected")).toBe(false);
     expect(doc.getMap("__applied").has(op.op_id)).toBe(true);
-    expect(doc.getMap("__stamps").size).toBe(1);
+    expect(doc.getMap("__stamps").size).toBe(2);
   });
 
   it("the helpers address exactly those roots", () => {

--- a/packages/comfy-multi-player/test/wire-layout-contract.test.ts
+++ b/packages/comfy-multi-player/test/wire-layout-contract.test.ts
@@ -332,7 +332,7 @@ describe("layer 2: a replica forked from the snapshot recovers exactly the §1 r
     expect([...replica.getMap(golden.roots["definitions"]!).keys()].sort()).toEqual(["d1", "d2"]);
     expect(replica.getMap(golden.roots["meta"]!).get("schema_version")).toBe(SCHEMA_VERSION);
     expect(replica.getMap(golden.roots["applied"]!).size).toBe(1);
-    expect(replica.getMap(golden.roots["stamps"]!).size).toBe(1);
+    expect(replica.getMap(golden.roots["stamps"]!).size).toBe(3);
   });
 
   it("carries no structural or comfy-cli bookkeeping key inside the meta root (schema §6, §4)", () => {


### PR DESCRIPTION
Closes the seeded add/delete link divergence.
Keeps A7 named severance terminal.
No schema-v3 migration.

<details><summary>Full context for agent readers</summary>

## Summary

- Extends the existing A18 link-identity stamp row with the complete tuple it already owns, so incident links can be rematerialized after a higher-stamped node re-add.
- Records explicit `removed_links` and winning disconnects under a separate terminal `link_retired` row; ordinary input displacement does not masquerade as explicit severance.
- Revises ADR-022 and adds schema Amendment A19 to follow the accepted private-alpha single-format rule: schema remains v2, with no migration or dual reader.
- Replaces the known seeded-snapshot divergence with both-order convergence and terminal-retirement assertions.

Stacked on #16819, which is stacked on #16644. The approved parent head was not modified.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" node_modules/.bin/vitest run --config vitest.config.ts test/delete-node-lww-loser-removed-links.test.ts test/bounded-writes-liveness.test.ts test/connect-delete-equivalence.permutation.test.ts test/duplicate-link-id.permutation.test.ts test/wire-layout-contract.test.ts` — 31/31 passed, including 6,144 connect/delete pair classifications and 12,288 normalized-link permutations.
- `NODE_OPTIONS="--no-experimental-webstorage" node_modules/.bin/tsc -p tsconfig.json` — passed.
- `node_modules/.bin/eslint <changed TypeScript files>` — 0 errors (repository baseline warnings only).
- `git diff --check` — passed.

## Risk

R3: changes durable CRDT link bookkeeping and restoration semantics. The focused permutation suites, seeded snapshot forks, wire snapshot check, mutation accounting, and terminal-retirement test cover the affected boundaries.

</details>

<!-- authored-by:agent lane-cmp-delete-link-scope-1-2215 -->