### PR TITLE
[backport cloud/1.53] fix(billing): keep the scheduled-change title clear of the close button

### DIFF
--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -19,6 +19,7 @@
         >
           {{ confirmTitle }}
         </h2>
+        <div class="size-8 shrink-0" aria-hidden="true" />
       </div>
       <div
         v-if="isReactivating"


### PR DESCRIPTION
Backport of #16756 to `cloud/1.53`.

Cherry-picked clean from `10f2b222f2642d022c0486baa624f46d0f9beb25` — the file's pre-image blob on `cloud/1.53` (`e26b37d9c`) is byte-identical to the one the fix was authored against on `main`, so this is the same one-line diff with no adaptation.

## Why this is needed on this branch

The bug is live on `cloud/1.53`: `SubscriptionTransitionPreviewWorkspace.vue` on this branch still carries the unbalanced header row, so the plan-change confirm title runs underneath the dialog's close (X) button at every viewport below `xl`. Reported by Denys on staging against the downgrade flow ([Slack](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1788429078717289?thread_ts=1787617734.249289)). The X stays clickable, so it is cosmetic — but it lands on the confirm screen of a paid transition.

## Root cause (summary; full analysis in #16756)

Two components own the same row and neither knows it. `SubscriptionRequiredDialogContentUnified.vue` paints the close button out of flow (`absolute top-6 right-4 …`), which reserves **no width**. `SubscriptionTransitionPreviewWorkspace.vue` then builds its header as `[back button, shrink-0] gap-3 [h2, flex-1 text-center]`, and `flex-1` stretches the h2 to the content box's right edge — exactly where the close button sits. The row is asymmetric: 32px of back button + 12px gap consumed on the left, nothing on the right.

```
AS-IS   |[back]  gap  |<----------- h2 flex-1 (text-center) ----------->|
                                                              [X]  <- overlaid, 0 width reserved

TO-BE   |[back]  gap  |<------- h2 flex-1 (text-center) ------>| gap |[spacer]|
                                                                      [X]  <- footprint reserved
```

At `≥1280px` the dialog is `xl:w-[512px]` and the confirm body is `max-w-[400px] mx-auto`, leaving 40px of slack per side, so the overlap disappears — which is why desktop-width development never sees it.

## The change

Reserve the close button's own `size-8` footprint at the end of the confirm header row:

```vue
<div class="size-8 shrink-0" aria-hidden="true" />
```

`size-8` is exactly what `button.variants.ts` gives `size="icon"`, which is what both the back button and the close button are. The title now sits centred between two equal 32px reservations and its box ends 12px (the `gap-3`) short of the button, so no string length in any locale can reach it. The previous behaviour was correct-by-accident for short strings — `confirmChangeTitle` is 40 characters in `tr` and 38 in `fr` against 28 in `en`.

## Verification on this branch

- `SubscriptionTransitionPreviewWorkspace`, `…Reactivation`, `SubscriptionRequiredDialogContentWorkspace` — **57/57 pass** on this branch, matching the count on `main`.
- ESLint clean on the changed file.
- Diff against `cloud/1.53` is exactly the one added line, no other files touched.

## Screenshots

Confirm step at the two widths where the overlap is worst. `textPastCloseEdge` is the title text's right edge minus the close button's left edge — positive means overlap.

| | AS-IS | TO-BE |
|---|---|---|
| **470px** (`+6` → `-16`) | ![as-is 470](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/as-is-470.png) | ![to-be 470](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/to-be-470.png) |
| **390px** (`+4` → `-18`) | ![as-is 390](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/as-is-390.png) | ![to-be 390](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/to-be-390.png) |

<sub>Captures are the ones from #16756, hot-linked from the orphan branch `assets/pr-16756` (PNGs only, no code). The rendered markup on this branch is now identical to `main` for this component, so they apply unchanged. Please keep that branch — deleting it breaks the images in both descriptions.</sub>

## Regression guard

None added, deliberately, and consistent with #16756. The invariant is geometric, and `AGENTS.md` rules out asserting utility classes in unit tests ("Do not write tests that are dependent on non-behavioral features like utility classes or styles") — such a test would restate the diff, not the behaviour. A real guard is a Playwright geometry assertion, but no E2E path reaches the transition-preview confirm step today (`CloudWorkspaceMockHelper` has no preview-endpoint mock), so that path has to be built first. Tracked as a follow-up on the original PR rather than shipping a change-detector into a backport.
