### PR TITLE
feat(website): add a Workshop section to the homepage

### DIFF
--- a/apps/website/src/components/home/WorkshopSection.test.ts
+++ b/apps/website/src/components/home/WorkshopSection.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkshopBrowseModel } from '../../config/workshop'
+import WorkshopSection from './WorkshopSection.vue'
+
+const models: WorkshopBrowseModel[] = [
+  {
+    id: 'bfl/flux-2-pro',
+    href: '/workshop/models/bfl--flux-2-pro/',
+    name: 'FLUX 2 Pro',
+    provider: 'bfl',
+    output: 'image',
+    description: 'Generates an image.',
+    tags: ['text-to-image']
+  },
+  {
+    id: 'kling/text-to-video',
+    href: '/workshop/models/kling--text-to-video/',
+    name: 'Kling 2.5 Turbo',
+    provider: 'kling',
+    output: 'video',
+    description: 'Generates a video.',
+    tags: []
+  }
+]
+
+function renderSection() {
+  render(WorkshopSection, { props: { models } })
+}
+
+describe('WorkshopSection', () => {
+  it('links each featured model to its own page', () => {
+    renderSection()
+
+    expect(
+      screen.getByRole('link', { name: /FLUX 2 Pro/ }).getAttribute('href')
+    ).toBe('/workshop/models/bfl--flux-2-pro/')
+    expect(
+      screen.getByRole('link', { name: /Kling 2.5 Turbo/ }).getAttribute('href')
+    ).toBe('/workshop/models/kling--text-to-video/')
+  })
+
+  it('offers a way through to the whole catalog', () => {
+    renderSection()
+
+    expect(
+      screen
+        .getByRole('link', { name: 'Browse all models' })
+        .getAttribute('href')
+    ).toBe('/workshop/')
+  })
+
+  it('shows what each model produces alongside who makes it', () => {
+    renderSection()
+
+    const card = screen.getByRole('link', { name: /FLUX 2 Pro/ })
+    expect(card.textContent).toContain('bfl')
+    expect(card.textContent).toContain('image')
+    expect(card.textContent).toContain('Generates an image.')
+  })
+})

--- a/apps/website/src/components/home/WorkshopSection.vue
+++ b/apps/website/src/components/home/WorkshopSection.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { ArrowRight } from '@lucide/vue'
+
+import type { WorkshopBrowseModel } from '../../config/workshop'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
+// Rendered without a client directive: nothing here is interactive, so this
+// section ships as HTML and costs the homepage no JavaScript.
+const { models, locale = 'en' } = defineProps<{
+  models: readonly WorkshopBrowseModel[]
+  locale?: Locale
+}>()
+</script>
+
+<template>
+  <section
+    class="max-w-9xl mx-auto bg-primary-comfy-ink px-4 py-20 lg:px-20 lg:py-24"
+  >
+    <div
+      class="flex flex-col items-start gap-6 lg:flex-row lg:items-end lg:justify-between"
+    >
+      <div>
+        <p
+          class="text-primary-comfy-yellow mb-5 text-sm font-medium tracking-widest uppercase"
+        >
+          {{ t('workshop.hero.eyebrow', locale) }}
+        </p>
+        <h2 class="text-5xl font-light text-primary-comfy-canvas">
+          {{ t('home.workshop.heading', locale) }}
+        </h2>
+        <p class="mt-6 max-w-2xl text-base text-primary-comfy-canvas/70">
+          {{ t('home.workshop.subheading', locale) }}
+        </p>
+      </div>
+
+      <a
+        href="/workshop/"
+        class="hover:border-primary-comfy-yellow hover:text-primary-comfy-yellow inline-flex shrink-0 items-center gap-2 rounded-full border border-primary-comfy-canvas/25 px-6 py-3 text-sm text-primary-comfy-canvas transition-colors"
+      >
+        {{ t('home.workshop.browseAll', locale) }}
+        <ArrowRight aria-hidden="true" class="size-4" />
+      </a>
+    </div>
+
+    <ul
+      class="mt-12 grid list-none grid-cols-1 gap-4 p-0 md:grid-cols-2 xl:grid-cols-3"
+    >
+      <li v-for="model in models" :key="model.id">
+        <a
+          :href="model.href"
+          class="group hover:border-primary-comfy-yellow/60 flex h-full flex-col rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-6 transition hover:-translate-y-0.5 hover:bg-primary-comfy-canvas/8"
+        >
+          <div class="flex items-center justify-between gap-4">
+            <p
+              class="text-primary-comfy-yellow text-xs tracking-wider uppercase"
+            >
+              {{ model.provider }}
+            </p>
+            <span
+              class="rounded-full bg-primary-comfy-canvas/8 px-2.5 py-1 text-xs text-primary-comfy-canvas/60"
+            >
+              {{ model.output }}
+            </span>
+          </div>
+          <h3 class="mt-3 text-xl font-semibold text-primary-comfy-canvas">
+            {{ model.name }}
+          </h3>
+          <p class="mt-3 line-clamp-2 text-sm text-primary-comfy-canvas/65">
+            {{ model.description }}
+          </p>
+          <ArrowRight
+            aria-hidden="true"
+            class="group-hover:text-primary-comfy-yellow mt-auto size-5 shrink-0 self-end text-primary-comfy-canvas/50 transition-transform group-hover:translate-x-1"
+          />
+        </a>
+      </li>
+    </ul>
+  </section>
+</template>

--- a/apps/website/src/components/workshop/WorkshopPlayground.test.ts
+++ b/apps/website/src/components/workshop/WorkshopPlayground.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import type { UserEvent } from '@testing-library/user-event'
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import { nextTick } from 'vue'
@@ -74,41 +75,84 @@ describe('WorkshopPlayground', () => {
     expect(screen.getByText(/"prompt": "Red fox"/)).toBeTruthy()
   })
 
+  const UUID_V4 =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+  const keyOf = (container: Element): string => {
+    const match = /Idempotency-Key: ([^']+)'/.exec(container.textContent)
+    expect(match).not.toBeNull()
+    return match?.[1] ?? ''
+  }
+
+  /**
+   * Only the active tab's panel is in the DOM, and the key lives in the raw
+   * HTTP request. Driven by the keyboard because `TabsRoot` activates on arrow
+   * navigation; a bare click does not move the selection here.
+   */
+  const showHttp = async (user: UserEvent): Promise<void> => {
+    screen.getByRole('tab', { name: 'TypeScript' }).focus()
+    await user.keyboard('{ArrowRight}{ArrowRight}')
+    await nextTick()
+    expect(screen.getByRole('tab', { selected: true }).textContent).toContain(
+      'HTTP'
+    )
+  }
+
+  it('mints a new key when the request is edited, not one per mount', async () => {
+    // The Router permits reuse only for a retry of the unchanged request. A
+    // reader who copies prompt A, edits to prompt B and copies again would
+    // otherwise send two distinct paid requests under one consumed key, which
+    // conflicts or replays the first generation.
+    const user = userEvent.setup()
+    const { container } = render(WorkshopPlayground, { props: { model } })
+
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    await nextTick()
+    await showHttp(user)
+    const afterFirst = keyOf(container)
+    expect(afterFirst).toMatch(UUID_V4)
+
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), ' at dusk')
+    await nextTick()
+    const afterEdit = keyOf(container)
+
+    expect(afterEdit).toMatch(UUID_V4)
+    expect(afterEdit).not.toBe(afterFirst)
+  })
+
+  it('keeps the key while the request is unchanged', async () => {
+    // The other half of the contract: a retry of the same body has to carry the
+    // same key. Reading the snippet in another language is not a new request.
+    const user = userEvent.setup()
+    const { container } = render(WorkshopPlayground, { props: { model } })
+
+    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    await nextTick()
+    await showHttp(user)
+    const before = keyOf(container)
+
+    screen.getByRole('tab', { name: 'HTTP' }).focus()
+    await user.keyboard('{ArrowLeft}{ArrowRight}')
+    await nextTick()
+
+    expect(keyOf(container)).toBe(before)
+  })
+
   it('replaces the placeholder key with a real one, per mount', async () => {
     // The placeholder is what the prerendered island contains. If it survived
     // into the browser, every reader would send the same Idempotency-Key and
     // the Router would treat one reader's run as a repeat of another's.
-    const keyOf = (container: Element): string => {
-      const match = /Idempotency-Key: ([^']+)'/.exec(container.textContent)
-      expect(match).not.toBeNull()
-      return match?.[1] ?? ''
-    }
-
-    // Only the active tab's panel is in the DOM, and the key lives in the raw
-    // HTTP request. Driven by the keyboard because `TabsRoot` activates on
-    // arrow navigation; a bare click does not move the selection here.
     const user = userEvent.setup()
-    const showHttp = async (): Promise<void> => {
-      screen.getByRole('tab', { name: 'TypeScript' }).focus()
-      await user.keyboard('{ArrowRight}{ArrowRight}')
-      await nextTick()
-      expect(screen.getByRole('tab', { selected: true }).textContent).toContain(
-        'HTTP'
-      )
-    }
-
     const first = render(WorkshopPlayground, { props: { model } })
-    await showHttp()
+    await showHttp(user)
     const firstKey = keyOf(first.container)
 
     expect(firstKey).not.toBe('REPLACE-WITH-A-UUID')
-    expect(firstKey).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
-    )
+    expect(firstKey).toMatch(UUID_V4)
 
     first.unmount()
     const second = render(WorkshopPlayground, { props: { model } })
-    await showHttp()
+    await showHttp(user)
 
     expect(keyOf(second.container)).not.toBe(firstKey)
   })

--- a/apps/website/src/components/workshop/WorkshopPlayground.test.ts
+++ b/apps/website/src/components/workshop/WorkshopPlayground.test.ts
@@ -74,6 +74,45 @@ describe('WorkshopPlayground', () => {
     expect(screen.getByText(/"prompt": "Red fox"/)).toBeTruthy()
   })
 
+  it('replaces the placeholder key with a real one, per mount', async () => {
+    // The placeholder is what the prerendered island contains. If it survived
+    // into the browser, every reader would send the same Idempotency-Key and
+    // the Router would treat one reader's run as a repeat of another's.
+    const keyOf = (container: Element): string => {
+      const match = /Idempotency-Key: ([^']+)'/.exec(container.textContent)
+      expect(match).not.toBeNull()
+      return match?.[1] ?? ''
+    }
+
+    // Only the active tab's panel is in the DOM, and the key lives in the raw
+    // HTTP request. Driven by the keyboard because `TabsRoot` activates on
+    // arrow navigation; a bare click does not move the selection here.
+    const user = userEvent.setup()
+    const showHttp = async (): Promise<void> => {
+      screen.getByRole('tab', { name: 'TypeScript' }).focus()
+      await user.keyboard('{ArrowRight}{ArrowRight}')
+      await nextTick()
+      expect(screen.getByRole('tab', { selected: true }).textContent).toContain(
+        'HTTP'
+      )
+    }
+
+    const first = render(WorkshopPlayground, { props: { model } })
+    await showHttp()
+    const firstKey = keyOf(first.container)
+
+    expect(firstKey).not.toBe('REPLACE-WITH-A-UUID')
+    expect(firstKey).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    )
+
+    first.unmount()
+    const second = render(WorkshopPlayground, { props: { model } })
+    await showHttp()
+
+    expect(keyOf(second.container)).not.toBe(firstKey)
+  })
+
   it('copies the selected snippet and confirms the action', async () => {
     const user = userEvent.setup()
     render(WorkshopPlayground, { props: { model } })

--- a/apps/website/src/components/workshop/WorkshopPlayground.vue
+++ b/apps/website/src/components/workshop/WorkshopPlayground.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 
 import { externalLinks } from '../../config/routes'
 import type { WorkshopDetailModel } from '../../config/workshop-detail'
@@ -10,6 +10,7 @@ import { parseWorkshopJsonInput } from '../../config/workshop-json-schema'
 import type { WorkshopSnippetLanguage } from '../../config/workshop-snippets'
 import {
   WORKSHOP_SNIPPET_LANGUAGES,
+  buildWorkshopInput,
   buildWorkshopSnippet,
   workshopIdempotencyKey
 } from '../../config/workshop-snippets'
@@ -39,20 +40,40 @@ const {
 const copiedLanguage = ref<WorkshopSnippetLanguage>()
 
 /**
- * One key per page load, minted in `onMounted` rather than in setup.
+ * The request the snippet currently describes, serialized so it can be compared.
+ * Only the body: the language a reader is reading it in is not part of what
+ * would be sent, so switching tabs must not count as composing a new request.
+ */
+const requestBody = computed(() =>
+  JSON.stringify(buildWorkshopInput(model.fields, values.value))
+)
+
+/**
+ * One key per *composed request*, not per page load.
  *
- * Setup also runs when Astro prerenders this island, so a key made there would
- * be baked into the static HTML and shared by every visitor — they would all
- * send the same `Idempotency-Key`, and the Router would treat one reader's run
- * as a repeat of another's. Minting on the client gives each reader their own.
+ * The Router permits reuse only for a retry of the unchanged request; sending a
+ * changed body under a key that has already been consumed conflicts, or replays
+ * the earlier generation. So an edit has to mint a new one — otherwise a reader
+ * who copies prompt A, edits to prompt B and copies again sends two distinct
+ * paid requests under one key.
  *
- * Until then the snippet shows a placeholder, in the same spirit as the media
- * URLs: visibly not a real value, so a reader who somehow copied it before
- * hydration gets a request the Router rejects rather than one that silently
- * collides with someone else's.
+ * Retries stay safe without any work here: the key is baked into the copied
+ * text as a literal, so re-running that block always sends the key it was
+ * copied with, whatever the form says by then.
+ *
+ * Minted in `onMounted` rather than in setup, and watched without `immediate`,
+ * because setup also runs when Astro prerenders this island — a key made there
+ * would be baked into the static HTML and shared by every visitor, so the
+ * Router would read one reader's run as a repeat of another's. Until hydration
+ * the snippet shows a placeholder, in the same spirit as the media URLs:
+ * visibly not a real value, so a reader who somehow copied it that early gets a
+ * request the Router rejects rather than one that silently collides.
  */
 const idempotencyKey = ref('REPLACE-WITH-A-UUID')
 onMounted(() => {
+  idempotencyKey.value = workshopIdempotencyKey()
+})
+watch(requestBody, () => {
   idempotencyKey.value = workshopIdempotencyKey()
 })
 

--- a/apps/website/src/components/workshop/WorkshopPlayground.vue
+++ b/apps/website/src/components/workshop/WorkshopPlayground.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 import { externalLinks } from '../../config/routes'
 import type { WorkshopDetailModel } from '../../config/workshop-detail'
@@ -10,7 +10,8 @@ import { parseWorkshopJsonInput } from '../../config/workshop-json-schema'
 import type { WorkshopSnippetLanguage } from '../../config/workshop-snippets'
 import {
   WORKSHOP_SNIPPET_LANGUAGES,
-  buildWorkshopSnippet
+  buildWorkshopSnippet,
+  workshopIdempotencyKey
 } from '../../config/workshop-snippets'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
@@ -36,8 +37,33 @@ const {
 } = useClipboard({ copiedDuring: 1500, legacy: true })
 /** Which language was on screen when the copy happened. */
 const copiedLanguage = ref<WorkshopSnippetLanguage>()
+
+/**
+ * One key per page load, minted in `onMounted` rather than in setup.
+ *
+ * Setup also runs when Astro prerenders this island, so a key made there would
+ * be baked into the static HTML and shared by every visitor — they would all
+ * send the same `Idempotency-Key`, and the Router would treat one reader's run
+ * as a repeat of another's. Minting on the client gives each reader their own.
+ *
+ * Until then the snippet shows a placeholder, in the same spirit as the media
+ * URLs: visibly not a real value, so a reader who somehow copied it before
+ * hydration gets a request the Router rejects rather than one that silently
+ * collides with someone else's.
+ */
+const idempotencyKey = ref('REPLACE-WITH-A-UUID')
+onMounted(() => {
+  idempotencyKey.value = workshopIdempotencyKey()
+})
+
 const snippet = computed(() =>
-  buildWorkshopSnippet(language.value, model.id, model.fields, values.value)
+  buildWorkshopSnippet(
+    language.value,
+    model.id,
+    model.fields,
+    values.value,
+    idempotencyKey.value
+  )
 )
 const hasInvalidJson = computed(() =>
   model.fields.some((field) => {
@@ -139,7 +165,7 @@ const languageLabels: Record<WorkshopSnippetLanguage, string> = {
           <pre
             tabindex="0"
             class="focus-visible:ring-primary-comfy-yellow/50 mt-3 max-h-168 overflow-auto rounded-2xl border border-primary-comfy-canvas/10 bg-black p-6 text-sm/relaxed text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none"
-          ><code>{{ option === language ? snippet : buildWorkshopSnippet(option, model.id, model.fields, values) }}</code></pre>
+          ><code>{{ option === language ? snippet : buildWorkshopSnippet(option, model.id, model.fields, values, idempotencyKey) }}</code></pre>
         </TabsContent>
       </TabsRoot>
       <a

--- a/apps/website/src/config/__snapshots__/workshop-snippets.test.ts.snap
+++ b/apps/website/src/config/__snapshots__/workshop-snippets.test.ts.snap
@@ -1,12 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Workshop snippets > builds the http snippet from the current values 1`] = `
-"IDEMPOTENCY_KEY=$(uuidgen)
-
-curl --request POST 'https://api.comfy.org/v2/models/bfl/flux-3' \\
+"curl --request POST 'https://api.comfy.org/v2/models/bfl/flux-3' \\
   --header 'Authorization: Bearer YOUR_API_KEY' \\
   --header 'Content-Type: application/json' \\
-  --header "Idempotency-Key: $IDEMPOTENCY_KEY" \\
+  --header 'Idempotency-Key: 11111111-2222-4333-8444-555555555555' \\
   --data '{
   "prompt": "A red fox",
   "enhance": true

--- a/apps/website/src/config/workshop-featured.test.ts
+++ b/apps/website/src/config/workshop-featured.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'astro/zod'
+import { describe, expect, it } from 'vitest'
+
+import { workshopModelSchema } from '../content/workshop-models.schema'
+import type { WorkshopBrowseModel } from './workshop'
+import {
+  FEATURED_WORKSHOP_MODEL_IDS,
+  featuredWorkshopModels
+} from './workshop-featured'
+
+// The committed catalog is one packed array, a model per line; read it rather
+// than scanning a directory that no longer exists.
+const CATALOG = join(import.meta.dirname, '../content/workshop-models.json')
+
+function catalogIds(): Set<string> {
+  const catalog = z
+    .array(workshopModelSchema)
+    .parse(JSON.parse(readFileSync(CATALOG, 'utf8')))
+  return new Set(catalog.map((entry) => entry.id))
+}
+
+function model(id: string): WorkshopBrowseModel {
+  return {
+    id,
+    href: `/workshop/models/${id.replace('/', '--')}/`,
+    name: id,
+    provider: id.split('/')[0],
+    output: 'image',
+    description: '',
+    tags: []
+  }
+}
+
+describe('featured Workshop models', () => {
+  it('names models the catalog still has', () => {
+    // The catalog is regenerated from whatever Router serves. When a partner
+    // retires a featured model this fails, rather than the homepage quietly
+    // rendering five cards instead of six.
+    const ids = catalogIds()
+    expect(FEATURED_WORKSHOP_MODEL_IDS.filter((id) => !ids.has(id))).toEqual([])
+  })
+
+  it('keeps the editorial order rather than the catalog order', () => {
+    const shuffled = [...FEATURED_WORKSHOP_MODEL_IDS].reverse().map(model)
+
+    expect(featuredWorkshopModels(shuffled).map((entry) => entry.id)).toEqual([
+      ...FEATURED_WORKSHOP_MODEL_IDS
+    ])
+  })
+
+  it('skips a retired model instead of emitting a hole', () => {
+    const withoutFirst = FEATURED_WORKSHOP_MODEL_IDS.slice(1).map(model)
+    const resolved = featuredWorkshopModels(withoutFirst)
+
+    expect(resolved).toHaveLength(FEATURED_WORKSHOP_MODEL_IDS.length - 1)
+    expect(resolved.map((entry) => entry.id)).toEqual(
+      FEATURED_WORKSHOP_MODEL_IDS.slice(1)
+    )
+  })
+})

--- a/apps/website/src/config/workshop-featured.ts
+++ b/apps/website/src/config/workshop-featured.ts
@@ -1,0 +1,36 @@
+import type { WorkshopBrowseModel } from './workshop'
+
+/**
+ * The models the homepage leads with, in display order.
+ *
+ * Hand-picked rather than derived: this is the first thing a visitor sees, so
+ * the choice is editorial (recognisable names across image generation, video,
+ * speech, music, and 3D) and not something a ranking heuristic should be
+ * quietly changing on every catalog regeneration.
+ */
+export const FEATURED_WORKSHOP_MODEL_IDS: readonly string[] = [
+  'bfl/flux-2-pro',
+  'vertexai/gemini-3-pro-image',
+  'kling/text-to-video',
+  'elevenlabs/text-to-speech',
+  'sonilo/text-to-music',
+  'tencent-hunyuan3d/image-to-model-3.1'
+]
+
+/**
+ * Resolves the featured ids against the catalog, preserving the order above.
+ *
+ * An id the catalog no longer has is skipped rather than thrown on: the
+ * catalog is regenerated from whatever Router is currently serving, and a
+ * partner retiring a model should not take the homepage build down with it.
+ * `workshop-featured.test.ts` asserts every id still resolves, so the list
+ * going stale is a failing test rather than a silently shorter homepage.
+ */
+export function featuredWorkshopModels(
+  models: readonly WorkshopBrowseModel[]
+): WorkshopBrowseModel[] {
+  const byId = new Map(models.map((model) => [model.id, model]))
+  return FEATURED_WORKSHOP_MODEL_IDS.map((id) => byId.get(id)).filter(
+    (model): model is WorkshopBrowseModel => model !== undefined
+  )
+}

--- a/apps/website/src/config/workshop-homepage.test.ts
+++ b/apps/website/src/config/workshop-homepage.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { WorkshopModelEntry } from '../content/workshop-models.schema'
+import { FEATURED_WORKSHOP_MODEL_IDS } from './workshop-featured'
+import { resolveHomepageWorkshopModels } from './workshop-homepage'
+
+function entry(id: string): WorkshopModelEntry {
+  return {
+    id,
+    slug: id.replace('/', '--'),
+    displayName: id,
+    provider: id.split('/')[0],
+    modality: 'image',
+    description: '',
+    tags: [],
+    parameters: { type: 'object', properties: {} },
+    roles: []
+  }
+}
+
+describe('resolveHomepageWorkshopModels', () => {
+  it('does not load or expose models when Workshop is disabled', async () => {
+    const loadModels = vi.fn<() => Promise<WorkshopModelEntry[]>>()
+
+    await expect(
+      resolveHomepageWorkshopModels(false, loadModels)
+    ).resolves.toEqual([])
+    expect(loadModels).not.toHaveBeenCalled()
+  })
+
+  it('loads, projects, and selects the featured cards when enabled', async () => {
+    const entries = [...FEATURED_WORKSHOP_MODEL_IDS].reverse().map(entry)
+    const loadModels = vi.fn(async () => entries)
+
+    await expect(
+      resolveHomepageWorkshopModels(true, loadModels)
+    ).resolves.toMatchObject(FEATURED_WORKSHOP_MODEL_IDS.map((id) => ({ id })))
+    expect(loadModels).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/website/src/config/workshop-homepage.ts
+++ b/apps/website/src/config/workshop-homepage.ts
@@ -1,0 +1,19 @@
+import type { WorkshopModelEntry } from '../content/workshop-models.schema'
+import type { WorkshopBrowseModel } from './workshop'
+import { toBrowseModel } from './workshop'
+import { featuredWorkshopModels } from './workshop-featured'
+
+type LoadWorkshopModels = () => Promise<readonly WorkshopModelEntry[]>
+
+/**
+ * Loads the homepage cards only when Workshop exists in this build. Keeping
+ * the load behind the release decision prevents a disabled build from doing
+ * catalog work or accidentally exposing a link to an absent route.
+ */
+export async function resolveHomepageWorkshopModels(
+  enabled: boolean,
+  loadModels: LoadWorkshopModels
+): Promise<WorkshopBrowseModel[]> {
+  if (!enabled) return []
+  return featuredWorkshopModels((await loadModels()).map(toBrowseModel))
+}

--- a/apps/website/src/config/workshop-snippets.test.ts
+++ b/apps/website/src/config/workshop-snippets.test.ts
@@ -2,7 +2,14 @@ import { execFileSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
 import type { WorkshopField } from './workshop-detail'
-import { buildWorkshopInput, buildWorkshopSnippet } from './workshop-snippets'
+import {
+  buildWorkshopInput,
+  buildWorkshopSnippet,
+  workshopIdempotencyKey
+} from './workshop-snippets'
+
+/** A fixed key, so the snippets under test stay byte-for-byte comparable. */
+const TEST_KEY = '11111111-2222-4333-8444-555555555555'
 
 const fields: WorkshopField[] = [
   {
@@ -117,10 +124,13 @@ describe('Workshop snippets', () => {
     'builds the %s snippet from the current values',
     (language) => {
       expect(
-        buildWorkshopSnippet(language, 'bfl/flux-3', fields, {
-          prompt: 'A red fox',
-          enhance: true
-        })
+        buildWorkshopSnippet(
+          language,
+          'bfl/flux-3',
+          fields,
+          { prompt: 'A red fox', enhance: true },
+          TEST_KEY
+        )
       ).toMatchSnapshot()
     }
   )
@@ -174,21 +184,33 @@ describe('Workshop snippets', () => {
     ]
 
     expect(
-      buildWorkshopSnippet('python', 'example/model', complex, {
-        inputs: '[]'
-      })
+      buildWorkshopSnippet(
+        'python',
+        'example/model',
+        complex,
+        { inputs: '[]' },
+        TEST_KEY
+      )
     ).toContain('"inputs": []')
     expect(
-      buildWorkshopSnippet('python', 'example/model', complex, {
-        inputs: '[true, null, 3]'
-      })
+      buildWorkshopSnippet(
+        'python',
+        'example/model',
+        complex,
+        { inputs: '[true, null, 3]' },
+        TEST_KEY
+      )
     ).toContain('[\n        True,\n        None,\n        3\n    ]')
   })
 
   it('preserves an apostrophe in the HTTP request payload', () => {
-    const snippet = buildWorkshopSnippet('http', 'bfl/flux-2-pro', promptOnly, {
-      prompt: "don't stop"
-    })
+    const snippet = buildWorkshopSnippet(
+      'http',
+      'bfl/flux-2-pro',
+      promptOnly,
+      { prompt: "don't stop" },
+      TEST_KEY
+    )
     const args = executeWithStubCurl(snippet)
     const dataIndex = args.indexOf('--data')
 
@@ -200,9 +222,13 @@ describe('Workshop snippets', () => {
     'preserves an untrusted model ID in the %s string literal',
     (language) => {
       const modelId = `bf'l$(printf injected)\`printf injected\`/fl"ux`
-      const snippet = buildWorkshopSnippet(language, modelId, promptOnly, {
-        prompt: 'A red fox'
-      })
+      const snippet = buildWorkshopSnippet(
+        language,
+        modelId,
+        promptOnly,
+        { prompt: 'A red fox' },
+        TEST_KEY
+      )
 
       expect(snippet).toContain(`models.run(${JSON.stringify(modelId)},`)
     }
@@ -210,9 +236,13 @@ describe('Workshop snippets', () => {
 
   it('preserves an untrusted model ID as one HTTP argument', () => {
     const modelId = `bf'l$(printf injected)\`printf injected\`/fl"ux`
-    const snippet = buildWorkshopSnippet('http', modelId, promptOnly, {
-      prompt: 'A red fox'
-    })
+    const snippet = buildWorkshopSnippet(
+      'http',
+      modelId,
+      promptOnly,
+      { prompt: 'A red fox' },
+      TEST_KEY
+    )
 
     expect(executeWithStubCurl(snippet)).toContain(
       `https://api.comfy.org/v2/models/${modelId
@@ -222,12 +252,70 @@ describe('Workshop snippets', () => {
     )
   })
 
+  it('sends the same non-empty Idempotency-Key every time the block is run', () => {
+    // A retry is re-running the copied block, so the key has to survive that.
+    // The first version computed it with `$(uuidgen)`, which is absent from most
+    // Linux images: the command failed and the header went out empty, and this
+    // suite passed anyway because nothing asserted the value.
+    const snippet = buildWorkshopSnippet(
+      'http',
+      'bfl/flux-2-pro',
+      promptOnly,
+      { prompt: 'A red fox' },
+      TEST_KEY
+    )
+
+    const keyFrom = (args: string[]): string | undefined =>
+      args
+        .find((arg) => arg.startsWith('Idempotency-Key:'))
+        ?.slice('Idempotency-Key:'.length)
+        .trim()
+
+    const first = keyFrom(executeWithStubCurl(snippet))
+    const second = keyFrom(executeWithStubCurl(snippet))
+
+    expect(first).toBe(TEST_KEY)
+    expect(second).toBe(first)
+  })
+
+  it('needs no command the shell might not have', () => {
+    // `uuidgen` is not installed on the Linux images CI runs on. Executing with
+    // an empty PATH proves the block depends on no external binary at all.
+    const snippet = buildWorkshopSnippet(
+      'http',
+      'bfl/flux-2-pro',
+      promptOnly,
+      { prompt: 'A red fox' },
+      TEST_KEY
+    )
+    const output = execFileSync(
+      'bash',
+      ['-c', `PATH=; curl() { printf '%s\\0' "$@"; }\n${snippet}`],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+
+    expect(output).toContain(`Idempotency-Key: ${TEST_KEY}`)
+  })
+
+  it('mints a distinct v4 UUID per call', () => {
+    // One per page load, so two readers never collide on the Router's dedupe.
+    const keys = Array.from({ length: 50 }, () => workshopIdempotencyKey())
+
+    for (const key of keys) {
+      expect(key).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      )
+    }
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
   it('encodes reserved characters in model ID path segments', () => {
     const snippet = buildWorkshopSnippet(
       'http',
       'provider/model?variant#one%done',
       promptOnly,
-      { prompt: 'A red fox' }
+      { prompt: 'A red fox' },
+      TEST_KEY
     )
 
     expect(executeWithStubCurl(snippet)).toContain(

--- a/apps/website/src/config/workshop-snippets.ts
+++ b/apps/website/src/config/workshop-snippets.ts
@@ -92,11 +92,46 @@ function modelEndpoint(modelId: string): string {
   return `https://api.comfy.org/v2/models/${encodedId}`
 }
 
+/**
+ * A v4 UUID for the raw request's `Idempotency-Key`.
+ *
+ * Not `crypto.randomUUID()`: that one is restricted to secure contexts, and it
+ * is undefined on exactly the insecure LAN-IP and staging origins the clipboard
+ * fallback in `WorkshopPlayground.vue` exists for. `getRandomValues` carries no
+ * such restriction, so this works everywhere the page does.
+ *
+ * The value is rendered into the snippet as a literal rather than computed by
+ * the shell. An earlier version used `$(uuidgen)`, which is absent on most
+ * Linux images — the command failed and the request went out with an empty key,
+ * which is the one thing the header must never be.
+ */
+export function workshopIdempotencyKey(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20)
+  ].join('-')
+}
+
 export function buildWorkshopSnippet(
   language: WorkshopSnippetLanguage,
   modelId: string,
   fields: readonly WorkshopField[],
-  values: WorkshopFormValues
+  values: WorkshopFormValues,
+  /**
+   * Required rather than defaulted, so no call site can quietly emit a snippet
+   * with no key. Only the raw request uses it; both SDKs mint their own.
+   */
+  idempotencyKey: string
 ): string {
   const input = buildWorkshopInput(fields, values)
   const modelIdLiteral = JSON.stringify(modelId)
@@ -118,19 +153,18 @@ export function buildWorkshopSnippet(
   }
   const continuation = '\\'
   const endpoint = shellSingleQuote(modelEndpoint(modelId))
-  // An idempotency key, assigned once and reused. These are paid calls, and a
-  // disconnect can happen after the model has already run; retrying the same
-  // command without the same key runs and bills it a second time. Both SDKs
-  // mint one, so only the raw request needs this. Held in a variable rather
-  // than inlined so re-running just the curl — the actual retry — sends the
-  // key it sent the first time.
+  // These are paid calls, and a disconnect can happen after the model has
+  // already run, so a retry that does not carry the same key runs and bills it
+  // a second time. The key is baked in as a literal, which is what makes the
+  // copied block stable: re-running it — the whole thing, however the reader
+  // pasted it — sends the key it sent the first time, which is precisely what a
+  // retry needs. A fresh key means a deliberately new call, and comes from
+  // reloading the page.
   return [
-    `IDEMPOTENCY_KEY=$(uuidgen)`,
-    ``,
     `curl --request POST '${endpoint}' ${continuation}`,
     `  --header 'Authorization: Bearer YOUR_API_KEY' ${continuation}`,
     `  --header 'Content-Type: application/json' ${continuation}`,
-    `  --header "Idempotency-Key: $IDEMPOTENCY_KEY" ${continuation}`,
+    `  --header 'Idempotency-Key: ${shellSingleQuote(idempotencyKey)}' ${continuation}`,
     `  --data '${shellSingleQuote(JSON.stringify(input, null, 2))}'`
   ].join('\n')
 }

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1,6 +1,19 @@
 type Locale = 'en' | 'zh-CN' | 'ja'
 
 const translations = {
+  'home.workshop.heading': {
+    en: 'Run any model, from one place',
+    'zh-CN': '在同一个地方运行任何模型'
+  },
+  'home.workshop.subheading': {
+    en: 'Hundreds of models from the labs building them, with their real inputs and the same API you would call from your own application.',
+    'zh-CN':
+      '汇集数百个来自各大实验室的模型，提供真实的输入参数，以及可在你自己的应用中调用的同一套 API。'
+  },
+  'home.workshop.browseAll': {
+    en: 'Browse all models',
+    'zh-CN': '浏览全部模型'
+  },
   'workshop.meta.title': {
     en: 'Comfy Workshop',
     'zh-CN': 'Comfy Workshop'

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import WorkshopSection from "../components/home/WorkshopSection.vue";
 import ProductCardsSection from "../components/home/ProductCardsSection.vue";
 import HeroGraphSection from "../components/hero/HeroGraphSection.vue";
 import SocialProofBarSection from "../components/common/SocialProofBarSection.vue";
@@ -11,6 +12,9 @@ import ProductShowcaseSection from "../components/home/ProductShowcaseSection.vu
 import FeaturedWorkflowsSection from "../components/home/FeaturedWorkflowsSection.vue";
 import CaseStudySpotlightSection from "../components/home/CaseStudySpotlightSection.vue";
 import GetStartedSection from "../components/home/GetStartedSection.vue";
+import { getCollection } from "astro:content";
+import { isWorkshopInBuild } from "../config/workshop-release";
+import { resolveHomepageWorkshopModels } from "../config/workshop-homepage";
 import { t } from "../i18n/translations";
 import {
   comfyUiApplicationNode,
@@ -23,6 +27,15 @@ const { siteUrl } = pageContext(
   Astro.site,
   Astro.url.pathname,
   Astro.currentLocale,
+);
+
+// The same switch that decides whether Workshop is built at all. A release
+// build has no Workshop routes, so the homepage must not link to them; one
+// control rather than two that can drift apart.
+const workshopModels = await resolveHomepageWorkshopModels(
+  isWorkshopInBuild(),
+  async () =>
+    (await getCollection("workshopModels")).map((entry) => entry.data),
 );
 ---
 
@@ -52,6 +65,7 @@ const { siteUrl } = pageContext(
   <MinimaxLicenseHeroSection client:visible />
   <ModelReleaseSection client:visible />
   <FeaturedWorkflowsSection client:load />
+  {workshopModels.length > 0 && <WorkshopSection models={workshopModels} />}
   <ProductShowcaseSection client:load />
   <IndustriesSection client:load />
   <GetStartedSection />


### PR DESCRIPTION
## Summary

Two things, because the second one missed its own PR's merge window.

**1. A Workshop section on the homepage.** Six hand-picked models spanning recognisable image generation, video, speech, music, and 3D capabilities, plus a link to the full catalog.

The section reads the same build-time Workshop decision as the routes. Release builds emit neither the Workshop pages nor the homepage links. Workshop-enabled labeled previews emit the section, catalog, and model routes together.

The featured list is explicit and editorial rather than a ranking, so regenerating the catalog cannot quietly change what the homepage leads with. If a partner retires a featured model, the card is skipped and a test fails so the list is corrected instead of silently shipping fewer cards.

There is no `client:` directive on the section, so it renders to HTML and adds no hydrated island.

**2. The idempotency-key fix that #16844 merged without.** #16844 entered the merge queue at `dbffc1094`, and the queue snapshotted it before this landed on the branch, so `main` currently carries the broken form. Carrying it here rather than opening a third PR for four files.

`IDEMPOTENCY_KEY=$(uuidgen)` is not portable — `uuidgen` is absent from most Linux images, including CI's. The command failed and the request went out with an empty `Idempotency-Key`, which is the one value that header must never have, on calls that are billed. The suite stayed green because it asserted the URL and payload but never the key.

The key is now minted in the page and rendered into the snippet as a literal, so re-running the copied block sends the key it sent the first time — a retry after a disconnect is a retry rather than a second charge.

Three traps designed around:

- **Minted in `onMounted`, not `setup`.** Setup also runs when Astro prerenders the island, so a key made there would be baked into static HTML and shared by every visitor — the Router would read one reader's run as a repeat of another's. Strictly worse than the empty header. Before hydration the snippet shows a visible placeholder, so a value copied early is rejected rather than silently colliding.
- **Not `crypto.randomUUID()`.** It is restricted to secure contexts, so it is undefined on exactly the insecure LAN-IP origins the `legacy: true` clipboard fallback exists for. Built from `getRandomValues`, which has no such restriction.
- **The key is a required parameter**, not defaulted, so no call site can quietly emit a keyless snippet.

Reported by @DrJKL on #16844.

## Verification

- [x] Release build (`WORKSHOP_IN_BUILD=0`): homepage contains zero `workshop` references, zero `/workshop` hrefs, no Workshop pages
- [x] Deployed default (`VERCEL_ENV=preview`, no override): same, and the gate logs 269 pages removed
- [x] Enabled build (`WORKSHOP_IN_BUILD=1`): 269 Workshop pages, 7 homepage links, section renders
- [x] `WorkshopSection` appears in **0 JS chunks in every build** — no client directive, so the homepage pays nothing for it
- [x] One gate on the path: `index.astro` calls `isWorkshopInBuild()` once, and no layout or shared header component references Workshop
- [x] Featured IDs are covered against the packed catalog; a retired model is skipped, with a test that fails when the list goes stale
- [x] Idempotency: the exact block executes twice and delivers the same non-empty key both times; runs with `PATH=` empty, proving no external binary; 50 keys distinct and v4-shaped; the component replaces its placeholder and two mounts differ
- [x] Each of those four guards confirmed to **fail against a mutant that reintroduces the bug**, rather than trusted green
- [x] 0 type errors, lint clean, 1260/1260 unit tests