### PR TITLE
[test-harness followup] Harden harness CLI flag handling

### DIFF
--- a/browser_tests/fixtures/data/agent/README.md
+++ b/browser_tests/fixtures/data/agent/README.md
@@ -25,6 +25,33 @@ instructions, then run the recorder command below with one `--prompt` per
 turn. Replay the new case with the command in `browser_tests/README.md` under
 "Replay coverage for agent bug fixes" plus `-g <case id>`.
 
+## Playbook: record a case
+
+Prerequisites: the cloud checkout beside this repo with its own local stack up
+(`cloud up` there: Postgres on 54331, Redis on 6379), a ComfyUI backend on
+8188, `ANTHROPIC_API_KEY`, `COMFY_BIN` pointing at a comfy-cli that works
+without a home directory, and the launcher from the integration environment
+PR checked out alongside this one.
+
+1. Bring the recording stack up (Temporal engine so a turn can be cancelled):
+
+```bash
+AGENT_MODEL=claude-opus-5 COMFY_BIN=~/.local/bin/comfy pnpm exec tsx scripts/dev-agent-integration.ts --record --engine temporal --catalog browser_tests/fixtures/data/agent/conversations/agent-rec-set-widget-existing.json --cloud-repo ../cloud --agent-port 8087 --doc-host-port 8096 --temporal-port 7234
+```
+
+2. Paste the recorder command it prints, filling `AGENT_MODEL`, the case id,
+   the seed fixture and one `--prompt` per turn (`--cancel-turn` and
+   `--cancel-after-ms` for a cancelled turn).
+
+3. Replay the new case:
+
+```bash
+PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:6310 DISTRIBUTION=cloud pnpm exec playwright test browser_tests/tests/agent/agentConversationReplay.spec.ts --project=cloud -g agent-rec-<slug>
+```
+
+Sidecars (raw frames, rows, capture, receipt) land in `conversations/recordings/`;
+commit only the fixture.
+
 ## Recording a conversation
 
 One command records a whole thread against a running agent, applies the gates

--- a/browser_tests/fixtures/data/agent/README.md
+++ b/browser_tests/fixtures/data/agent/README.md
@@ -30,14 +30,13 @@ turn. Replay the new case with the command in `browser_tests/README.md` under
 Prerequisites: the cloud checkout beside this repo with its own local stack up
 (`cloud up` there: Postgres on 54331, Redis on 6379), a ComfyUI backend on
 8188, `ANTHROPIC_API_KEY`, `COMFY_BIN` pointing at a comfy-cli that works
-without a home directory, and the launcher from the integration environment
-PR checked out alongside this one.
+without a home directory.
 
 1. Bring the recording stack up (Temporal engine so a turn can be cancelled):
 
-```bash
-AGENT_MODEL=claude-opus-5 COMFY_BIN=~/.local/bin/comfy pnpm exec tsx scripts/dev-agent-integration.ts --record --engine temporal --catalog browser_tests/fixtures/data/agent/conversations/agent-rec-set-widget-existing.json --cloud-repo ../cloud --agent-port 8087 --doc-host-port 8096 --temporal-port 7234
-```
+   ```bash
+   AGENT_MODEL=claude-opus-5 COMFY_BIN=~/.local/bin/comfy pnpm exec tsx scripts/dev-agent-integration.ts --record --engine temporal --catalog browser_tests/fixtures/data/agent/conversations/agent-rec-set-widget-existing.json --cloud-repo ../cloud --agent-port 8087 --doc-host-port 8096 --temporal-port 7234
+   ```
 
 2. Paste the recorder command it prints, filling `AGENT_MODEL`, the case id,
    the seed fixture and one `--prompt` per turn (`--cancel-turn` and
@@ -45,11 +44,14 @@ AGENT_MODEL=claude-opus-5 COMFY_BIN=~/.local/bin/comfy pnpm exec tsx scripts/dev
 
 3. Replay the new case:
 
-```bash
-PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:6310 DISTRIBUTION=cloud pnpm exec playwright test browser_tests/tests/agent/agentConversationReplay.spec.ts --project=cloud -g agent-rec-<slug>
-```
+   Start the cloud-distribution frontend, then replay on its port:
 
-Sidecars (raw frames, rows, capture, receipt) land in `conversations/recordings/`;
+   ```bash
+   DISTRIBUTION=cloud DEV_SERVER_COMFYUI_URL=http://127.0.0.1:8188 pnpm dev
+   PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 DISTRIBUTION=cloud pnpm exec playwright test browser_tests/tests/agent/agentConversationReplay.spec.ts --project=cloud -g agent-rec-SLUG
+   ```
+
+Sidecars (raw frames, rows, receipt) land in `conversations/recordings/`;
 commit only the fixture.
 
 ## Recording a conversation

--- a/browser_tests/fixtures/data/agent/README.md
+++ b/browser_tests/fixtures/data/agent/README.md
@@ -44,10 +44,15 @@ without a home directory.
 
 3. Replay the new case:
 
-   Start the cloud-distribution frontend, then replay on its port:
+   Start the cloud-distribution frontend in one terminal:
 
    ```bash
    DISTRIBUTION=cloud DEV_SERVER_COMFYUI_URL=http://127.0.0.1:8188 pnpm dev
+   ```
+
+   Replay on its port from a second terminal:
+
+   ```bash
    PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 DISTRIBUTION=cloud pnpm exec playwright test browser_tests/tests/agent/agentConversationReplay.spec.ts --project=cloud -g agent-rec-SLUG
    ```
 

--- a/scripts/dev-agent-options.test.ts
+++ b/scripts/dev-agent-options.test.ts
@@ -112,9 +112,29 @@ describe('parseOptions', () => {
       message: 'must leave room for the Temporal UI port'
     },
     { args: ['--cloud-repo'], message: '--cloud-repo requires a value' },
+    {
+      args: ['--cloud-repo', '--record'],
+      message: '--cloud-repo requires a value'
+    },
+    {
+      args: ['--frontend-port', '6208', '--frontend-port', '6209'],
+      message: 'Repeated option: --frontend-port'
+    },
+    { args: ['--', 'operand'], message: 'Unexpected argument: operand' },
     { args: ['--unknown'], message: 'Unknown option: --unknown' }
   ])('rejects an invalid launcher contract: $message', ({ args, message }) => {
     expect(() => parseOptions(args)).toThrow(message)
+  })
+
+  it('accepts an option terminator with no operands', () => {
+    expect(parseOptions(['--']).help).toBe(false)
+  })
+
+  it('returns help without validating or consuming later options', () => {
+    expect(parseOptions(['--help', '--record'])).toMatchObject({
+      help: true,
+      record: false
+    })
   })
 })
 

--- a/scripts/dev-agent-options.ts
+++ b/scripts/dev-agent-options.ts
@@ -45,7 +45,8 @@ Options:
 
 function optionValue(args: string[], index: number, option: string): string {
   const value = args.at(index + 1)
-  if (value === undefined) throw new Error(`${option} requires a value`)
+  if (value === undefined || value.startsWith('--'))
+    throw new Error(`${option} requires a value`)
   return value
 }
 
@@ -104,8 +105,21 @@ export function parseOptions(args: string[]): Options {
     temporalPort: 7234,
     temporalUiPort: 0
   }
+  const seen = new Set<string>()
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
+    if (arg === '--') {
+      const positional = args.slice(index + 1)
+      if (positional.length > 0)
+        throw new Error(`Unexpected argument: ${positional[0]}`)
+      break
+    }
+    if (arg === '--help') {
+      options.help = true
+      return options
+    }
+    if (seen.has(arg)) throw new Error(`Repeated option: ${arg}`)
+    seen.add(arg)
     switch (arg) {
       case '--agent-port':
         options.agentPort = port(optionValue(args, index, arg), arg)
@@ -149,9 +163,6 @@ export function parseOptions(args: string[]): Options {
       case '--frontend-port':
         options.frontendPort = port(optionValue(args, index, arg), arg)
         index++
-        break
-      case '--help':
-        options.help = true
         break
       default:
         throw new Error(`Unknown option: ${arg}`)


### PR DESCRIPTION
Hardens harness CLI flags and preserves the recorder playbook.

<details><summary>Full context for agent readers</summary>

## Phase C reviewer findings

- Flag handling: missing values cannot consume the next flag, repeated flags fail, `--` is handled explicitly, trailing operands and unknown flags fail.
- Help side effects: `--help` returns before record-mode validation or execution.

Tracking sibling: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17503.

## Verification

- `pnpm exec vitest run scripts/dev-agent-options.test.ts` — 20 passed.
- `pnpm typecheck` — passed.
- `pnpm eslint scripts/dev-agent-options.ts scripts/dev-agent-options.test.ts` — passed.
- Commit hooks: format, oxlint, ESLint, typecheck — passed.
- Push hook: knip — passed.

</details>
