### PR TITLE
fix: harden dev agent harness lifecycle

### DIFF
--- a/docs/testing/agent-integration-development.md
+++ b/docs/testing/agent-integration-development.md
@@ -112,7 +112,9 @@ traffic continues to reach ComfyUI.
 HTTP and the socket are stubs because a replay must be deterministic and
 model-free, so the agent's side is data; the in-process doc host runs the same
 library the real host runs. The smoke is the only path that proves the real
-HTTP, socket, agent and doc host together. Every frame carries its offset from
+HTTP, socket and agent together; it runs on the standalone harness, which
+unsets `DOC_HOST_ENDPOINT` and turns CRDT mode off, so the external doc host
+is not on that path. Every frame carries its offset from
 the turn's first frame; replay sends back to back by default and
 `AGENT_REPLAY_TIMING=recorded` waits out the recorded gaps.
 

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -16,17 +16,31 @@ import {
   waitForStartup
 } from './dev-agent-supervisor'
 
+function multiPlayerDependencySpec(manifest: unknown): string {
+  const dependencies =
+    typeof manifest === 'object' && manifest !== null
+      ? (manifest as { dependencies?: unknown }).dependencies
+      : undefined
+  const spec =
+    typeof dependencies === 'object' && dependencies !== null
+      ? (dependencies as Record<string, unknown>)[
+          '@comfyorg/comfy-multi-player'
+        ]
+      : undefined
+  return typeof spec === 'string' ? spec : ''
+}
+
 async function assertWorkspacePackage(): Promise<void> {
-  const manifest = JSON.parse(
+  const manifest: unknown = JSON.parse(
     await readFile(resolve(PROJECT_ROOT, 'package.json'), 'utf8')
-  ) as { dependencies?: Record<string, string> }
-  const dependency = manifest.dependencies?.['@comfyorg/comfy-multi-player']
-  if (dependency?.startsWith('link:')) {
+  )
+  const dependency = multiPlayerDependencySpec(manifest)
+  if (dependency.startsWith('link:')) {
     throw new Error(
       '@comfyorg/comfy-multi-player must not be pnpm linked; use the in-workspace package'
     )
   }
-  if (!dependency?.startsWith('workspace:')) {
+  if (!dependency.startsWith('workspace:')) {
     console.warn(
       '[dev-agent-integration] @comfyorg/comfy-multi-player is the published package; edits to it will not hot-reload until it is an in-workspace dependency'
     )

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -16,31 +16,17 @@ import {
   waitForStartup
 } from './dev-agent-supervisor'
 
-function multiPlayerDependencySpec(manifest: unknown): string {
-  const dependencies =
-    typeof manifest === 'object' && manifest !== null
-      ? (manifest as { dependencies?: unknown }).dependencies
-      : undefined
-  const spec =
-    typeof dependencies === 'object' && dependencies !== null
-      ? (dependencies as Record<string, unknown>)[
-          '@comfyorg/comfy-multi-player'
-        ]
-      : undefined
-  return typeof spec === 'string' ? spec : ''
-}
-
 async function assertWorkspacePackage(): Promise<void> {
-  const manifest: unknown = JSON.parse(
+  const manifest = JSON.parse(
     await readFile(resolve(PROJECT_ROOT, 'package.json'), 'utf8')
-  )
-  const dependency = multiPlayerDependencySpec(manifest)
-  if (dependency.startsWith('link:')) {
+  ) as { dependencies?: Record<string, string> }
+  const dependency = manifest.dependencies?.['@comfyorg/comfy-multi-player']
+  if (dependency?.startsWith('link:')) {
     throw new Error(
       '@comfyorg/comfy-multi-player must not be pnpm linked; use the in-workspace package'
     )
   }
-  if (!dependency.startsWith('workspace:')) {
+  if (!dependency?.startsWith('workspace:')) {
     console.warn(
       '[dev-agent-integration] @comfyorg/comfy-multi-player is the published package; edits to it will not hot-reload until it is an in-workspace dependency'
     )

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -41,8 +41,8 @@ async function assertWorkspacePackage(): Promise<void> {
     )
   }
   if (!dependency.startsWith('workspace:')) {
-    console.warn(
-      '[dev-agent-integration] @comfyorg/comfy-multi-player is the published package; edits to it will not hot-reload until it is an in-workspace dependency'
+    throw new Error(
+      '@comfyorg/comfy-multi-player must use a workspace: dependency'
     )
   }
 }

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -41,8 +41,8 @@ async function assertWorkspacePackage(): Promise<void> {
     )
   }
   if (!dependency.startsWith('workspace:')) {
-    throw new Error(
-      '@comfyorg/comfy-multi-player must use a workspace: dependency'
+    console.warn(
+      '[dev-agent-integration] @comfyorg/comfy-multi-player is the published package; edits to it will not hot-reload until it is an in-workspace dependency'
     )
   }
 }

--- a/scripts/dev-agent-record-mode.ts
+++ b/scripts/dev-agent-record-mode.ts
@@ -23,7 +23,6 @@ const PG_PORT = 54331
 const REDIS_PORT = 6379
 const CLOUD_QUICKSTART =
   'start the cloud stack first: `cloud up` from the cloud checkout, or scripts/start-all.sh'
-// Fixed so a rerun seeds nothing and the printed recorder command never moves.
 const TEMPORAL_INSTALL =
   'brew install temporal, or: https://docs.temporal.io/cli#install'
 // Fixed so a rerun seeds nothing and the printed recorder command never moves.

--- a/scripts/dev-agent-record-mode.ts
+++ b/scripts/dev-agent-record-mode.ts
@@ -94,7 +94,7 @@ async function containerFor(
     .map((line) => line.split(' '))
     .filter(
       ([, imageName, ...ports]) =>
-        imageName.includes(image) &&
+        imageName.replace(/@.+$/, '').replace(/:[^/]+$/, '') === image &&
         ports.join(' ').includes(`:${portNumber}->`)
     )
     .map(([name]) => name)

--- a/scripts/dev-agent-record-mode.ts
+++ b/scripts/dev-agent-record-mode.ts
@@ -26,6 +26,7 @@ const CLOUD_QUICKSTART =
 // Fixed so a rerun seeds nothing and the printed recorder command never moves.
 const TEMPORAL_INSTALL =
   'brew install temporal, or: https://docs.temporal.io/cli#install'
+// Fixed so a rerun seeds nothing and the printed recorder command never moves.
 const RECORD_USER_ID = 'rec-local-user'
 const RECORD_WORKSPACE_ID = 'w-1f2e3d4c-5b6a-4798-8899-aabbccddeeff'
 

--- a/scripts/dev-agent-supervisor.test.ts
+++ b/scripts/dev-agent-supervisor.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { assertFree, supervise, waitForStartup } from './dev-agent-supervisor'
 
-vi.mock('node:fs/promises', () => ({ rm: vi.fn() }))
+vi.mock(import('node:fs/promises'), () => ({ rm: vi.fn() }))
 
 class FakeChild extends EventEmitter {
   exitCode: number | null = null
@@ -127,6 +127,52 @@ describe('waitForStartup', () => {
 })
 
 describe('supervise teardown', () => {
+  it('escalates a repeated termination signal immediately', async () => {
+    vi.useFakeTimers()
+    let alive = true
+    const signals: NodeJS.Signals[] = []
+    vi.spyOn(process, 'kill').mockImplementation((_pid, signal) => {
+      if (signal === 0 && !alive) {
+        throw Object.assign(new Error('missing'), { code: 'ESRCH' })
+      }
+      if (signal === 'SIGTERM' || signal === 'SIGKILL') signals.push(signal)
+      if (signal === 'SIGKILL') alive = false
+      return true
+    })
+    const child = new FakeChild()
+    const supervisor = supervise('/tmp/agent-data')
+    supervisor.watch(child as unknown as ChildProcess)
+
+    process.emit('SIGINT', 'SIGINT')
+    const stopped = supervisor.stop(130)
+    process.emit('SIGTERM', 'SIGTERM')
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL'])
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(stopped).resolves.toBe(130)
+  })
+
+  it('shares the first result and cleanup across concurrent stop calls', async () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('missing'), { code: 'ESRCH' })
+    })
+    let finishCleanup: () => void = () => {}
+    const cleanup = new Promise<void>((resolve) => (finishCleanup = resolve))
+    vi.mocked(rm).mockReturnValue(cleanup)
+    const supervisor = supervise('/tmp/agent-data')
+
+    const first = supervisor.stop(130)
+    const second = supervisor.stop(0)
+    let secondResolved = false
+    void second.then(() => (secondResolved = true))
+    await Promise.resolve()
+
+    expect(secondResolved).toBe(false)
+    finishCleanup()
+    await expect(Promise.all([first, second])).resolves.toEqual([130, 130])
+    expect(rm).toHaveBeenCalledOnce()
+  })
+
   it('kills an orphaned process group before deleting its data', async () => {
     vi.useFakeTimers()
     let alive = true

--- a/scripts/dev-agent-supervisor.ts
+++ b/scripts/dev-agent-supervisor.ts
@@ -138,10 +138,9 @@ export function waitForStartup(
   ])
 }
 
-// One lifecycle for a spawned group: the first exit reason wins and teardown runs once.
 export function supervise(dataDir: string) {
   const children: ChildProcess[] = []
-  let stopping = false
+  let stopPromise: Promise<void> | null = null
   let requestedExitCode: number | null = null
   let resolveExitRequest: (code: number) => void = () => {}
   const exitRequested = new Promise<number>((resolveExit) => {
@@ -155,19 +154,19 @@ export function supervise(dataDir: string) {
   const onSighup = () => requestExit(129)
   const onSigint = () => requestExit(130)
   const onSigterm = () => requestExit(143)
-  // Repeated signals during teardown must not kill the launcher over its detached children.
   process.on('SIGHUP', onSighup)
   process.on('SIGINT', onSigint)
   process.on('SIGTERM', onSigterm)
   return {
     exitRequested,
     requested: () => requestedExitCode !== null,
-    // Signalled newest first, so a dependent stops before what it was talking to.
     stop: async (exitCode: number): Promise<number> => {
-      if (stopping) return exitCode
-      stopping = true
-      const newestFirst = [...children].reverse()
-      try {
+      if (stopPromise !== null) {
+        await stopPromise
+        return exitCode
+      }
+      stopPromise = (async () => {
+        const newestFirst = [...children].reverse()
         for (const child of newestFirst) stopGroup(child, 'SIGTERM')
         await Promise.all(
           newestFirst.map((child) => waitForGroupExit(child, 2000))
@@ -185,11 +184,12 @@ export function supervise(dataDir: string) {
           )
         }
         await rm(dataDir, { force: true, recursive: true })
-      } finally {
+      })().finally(() => {
         process.removeListener('SIGHUP', onSighup)
         process.removeListener('SIGINT', onSigint)
         process.removeListener('SIGTERM', onSigterm)
-      }
+      })
+      await stopPromise
       return exitCode
     },
     watch: (child: ChildProcess) => {

--- a/scripts/dev-agent-supervisor.ts
+++ b/scripts/dev-agent-supervisor.ts
@@ -140,14 +140,19 @@ export function waitForStartup(
 
 export function supervise(dataDir: string) {
   const children: ChildProcess[] = []
-  let stopPromise: Promise<void> | null = null
+  let stopPromise: Promise<number> | null = null
   let requestedExitCode: number | null = null
   let resolveExitRequest: (code: number) => void = () => {}
   const exitRequested = new Promise<number>((resolveExit) => {
     resolveExitRequest = resolveExit
   })
   const requestExit = (code: number) => {
-    if (requestedExitCode !== null) return
+    if (requestedExitCode !== null) {
+      if (stopPromise !== null) {
+        for (const child of [...children].reverse()) stopGroup(child, 'SIGKILL')
+      }
+      return
+    }
     requestedExitCode = code
     resolveExitRequest(code)
   }
@@ -161,10 +166,7 @@ export function supervise(dataDir: string) {
     exitRequested,
     requested: () => requestedExitCode !== null,
     stop: async (exitCode: number): Promise<number> => {
-      if (stopPromise !== null) {
-        await stopPromise
-        return exitCode
-      }
+      if (stopPromise !== null) return await stopPromise
       stopPromise = (async () => {
         const newestFirst = [...children].reverse()
         for (const child of newestFirst) stopGroup(child, 'SIGTERM')
@@ -184,13 +186,13 @@ export function supervise(dataDir: string) {
           )
         }
         await rm(dataDir, { force: true, recursive: true })
+        return exitCode
       })().finally(() => {
         process.removeListener('SIGHUP', onSighup)
         process.removeListener('SIGINT', onSigint)
         process.removeListener('SIGTERM', onSigterm)
       })
-      await stopPromise
-      return exitCode
+      return await stopPromise
     },
     watch: (child: ChildProcess) => {
       children.push(child)

--- a/scripts/vite-config-dev-agent.test.ts
+++ b/scripts/vite-config-dev-agent.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+
+async function importConfig(devAgentUrl: string) {
+  return await execFileAsync(
+    process.execPath,
+    ['--import', 'tsx', '--eval', "import('./vite.config.mts')"],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DEV_AGENT_SESSION_TOKEN: 'test-session-token',
+        DEV_AGENT_URL: devAgentUrl,
+        VITE_AGENT_STANDALONE: undefined
+      }
+    }
+  )
+}
+
+describe('dev agent proxy transport', () => {
+  it.for([
+    'https://agent.example.com',
+    'http://localhost:8095',
+    'http://127.0.0.1:8095',
+    'http://[::1]:8095'
+  ])('accepts a protected target at %s', async (devAgentUrl) => {
+    await expect(importConfig(devAgentUrl)).resolves.toBeDefined()
+  })
+
+  it('rejects forwarding credentials to remote cleartext targets', async () => {
+    await expect(
+      importConfig('http://agent.example.com')
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        'DEV_AGENT_URL must use https unless it targets loopback'
+      )
+    })
+  })
+})

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -217,6 +217,18 @@ if (process.env.VITE_AGENT_STANDALONE === 'true' && !DEV_AGENT_URL) {
   )
 }
 
+// The proxy attaches DEV_AGENT_SESSION_TOKEN as a bearer token, so cleartext
+// is only acceptable when the target never leaves the machine.
+if (DEV_AGENT_URL) {
+  const { protocol, hostname } = new URL(DEV_AGENT_URL)
+  const loopback = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(hostname)
+  if (protocol !== 'https:' && !(protocol === 'http:' && loopback)) {
+    throw new Error(
+      `DEV_AGENT_URL must use https unless it targets loopback; got ${DEV_AGENT_URL}`
+    )
+  }
+}
+
 const cloudProxyConfig =
   DISTRIBUTION === 'cloud' ? { secure: false, changeOrigin: true } : {}
 


### PR DESCRIPTION
- Reuses #16877; no duplicate carrier.
- Fixes all nine non-Origin harness findings from #16781.
- Focused checks are green; hosted checks are refreshing.

<details><summary>Full context for agent readers</summary>

## Summary

Harden the local Agent harness while keeping child ownership structural under the supervisor.

## Changes

- fail closed when Vite or a long-running child exits before readiness, and reject an already-occupied agent port
- handle SIGHUP and repeated termination signals, escalating repeat signals to process-group SIGKILL while awaiting the shared cleanup promise
- sanitize record-mode ambient state, bind to loopback, validate Temporal port collisions, and preserve quoted `--pg-exec` arguments
- require the unmocked smoke to observe completion-only feedback controls rather than a merely hidden Stop button
- notify status-only event listeners when the standalone source disconnects
- retain `supervisor.spawn()` as the only launcher child-creation path

## Source finding map

- readiness: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007687 — fixed
- repeat signals and SIGHUP: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007689 — fixed
- record environment: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007691 — fixed
- process identity/readiness: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007696 — fixed by an agent-port ownership preflight
- completion oracle: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007702 — fixed
- Temporal ports: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007706 — fixed
- `--pg-exec`: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007712 — fixed
- unsolicited child exit: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007717 — fixed
- disconnect status: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16781#discussion_r3930007724 — fixed

## Evidence

- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run scripts/dev-agent-supervisor.test.ts scripts/dev-agent-options.test.ts src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts` — 23/23 passed
- `pnpm typecheck` — passed
- `pnpm typecheck:browser` — passed in commit hook
- changed-file Oxfmt, type-aware Oxlint, and ESLint — passed
- `pnpm exec playwright test browser_tests/tests/agent/agentHarnessSmoke.spec.ts --project=agent-harness --list` — one dedicated unmocked smoke collected
- `pnpm knip` — passed in push hook
- commit and push hooks — passed under Node 25

</details>

<!-- authored-by:agent lane-ecw-222-0144 -->