### PR TITLE
fix(agent): pin workflow adoption to tab instances

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1361,7 +1361,7 @@ describe('AgentPanelRoot canvas draft on send', () => {
       ],
       links: []
     })
-    hostStores.workflow.activeWorkflow = {
+    const activeWorkflow = {
       path: 'workflows/video_minimax_h3_i2v.json',
       directory: 'workflows',
       filename: 'video_minimax_h3_i2v',
@@ -1369,6 +1369,8 @@ describe('AgentPanelRoot canvas draft on send', () => {
       isModified: false,
       activeState
     }
+    hostStores.workflow.tabs.set(activeWorkflow.path, activeWorkflow)
+    hostStores.workflow.activeWorkflow = activeWorkflow
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
@@ -3073,6 +3075,56 @@ describe('AgentPanelRoot workflow binding', () => {
         String(frame).includes('doc_subscribe')
       )
     ).toBe(false)
+  })
+
+  it('does not reattribute a send when its originating tab closes during preparation', async () => {
+    const origin = makeTab('wf-origin')
+    origin.activeState = fromPartial<ComfyWorkflowJSON>({ id: 'origin-draft' })
+    const replacement = addTab('workflows/replacement.json', {
+      activeState: fromPartial<ComfyWorkflowJSON>({ id: 'replacement-draft' })
+    })
+    useAgentWorkflowTabBindingStore().bind('wf-replacement', replacement.path)
+    const bodies: Record<string, unknown>[] = []
+    let workflowRequests = 0
+    let releasePreparation: () => void = () => undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('/messages') && init?.method === 'POST') {
+          bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+          return json(202, ack('wf-fresh', 'm-1'))
+        }
+        if (url.includes('/messages')) return json(200, [])
+        if (url.includes('/agent/threads'))
+          return json(200, { threads: [], pagination: { page: 1 } })
+        if (url.includes('/workflows')) {
+          workflowRequests++
+          if (workflowRequests > 1)
+            await new Promise<void>((resolve) => {
+              releasePreparation = resolve
+            })
+          return json(200, {
+            data: [],
+            pagination: { offset: 0, limit: 100, total: 0, has_more: false }
+          })
+        }
+        return new Response('{}', { status: 200 })
+      })
+    )
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    await vi.waitFor(() => expect(workflowRequests).toBe(1))
+    await userEvent.type(screen.getByRole('textbox'), 'build a graph')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await vi.waitFor(() => expect(workflowRequests).toBe(2))
+    hostStores.workflow.tabs.delete(origin.path)
+    hostStores.workflow.activeWorkflow = replacement
+    releasePreparation()
+
+    await vi.waitFor(() => expect(bodies).toHaveLength(1))
+    expect(bodies[0]).not.toHaveProperty('workflow_id')
+    expect(bodies[0]).not.toHaveProperty('current_tab')
+    expect(bodies[0]).not.toHaveProperty('draft')
   })
 
   it('sends only the remaining chip after one is dismissed', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -117,6 +117,7 @@ vi.mock(
 )
 
 type FakeTab = {
+  instanceId: string
   path: string
   directory: string
   filename: string
@@ -131,6 +132,7 @@ const hostStores = vi.hoisted(() => ({
     activeWorkflow: FakeTab | null
     openWorkflows: FakeTab[]
     tabs: Map<string, FakeTab>
+    closedInstances: Set<string>
     getWorkflowByPath: (path: string) => FakeTab | null
     nodeToNodeLocatorId: (node: {
       graph?: { id?: string }
@@ -148,19 +150,24 @@ const hostStores = vi.hoisted(() => ({
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   const { reactive } = await import('vue')
   const tabs = new Map<string, FakeTab>()
+  const closedInstances = new Set<string>()
   const store = reactive({
     activeWorkflow: null as FakeTab | null,
     get openWorkflows() {
-      return Array.from(tabs.values())
+      return Array.from(tabs.values()).filter(
+        ({ instanceId }) => !closedInstances.has(instanceId)
+      )
     },
     tabs,
+    closedInstances,
     getWorkflowByPath: (path: string) => tabs.get(path) ?? null,
     nodeToNodeLocatorId: (node: {
       graph?: { id?: string }
       id: string | number
     }) => (node.graph?.id ? `${node.graph.id}:${node.id}` : String(node.id)),
     closeWorkflow: vi.fn(async (tab: FakeTab) => {
-      tabs.delete(tab.path)
+      closedInstances.add(tab.instanceId)
+      if (tab.isTemporary) tabs.delete(tab.path)
     }),
     createTemporary: (path?: string, data?: ComfyWorkflowJSON) => {
       const requested = (path ?? 'Unsaved Workflow.json').replace(/\.json$/, '')
@@ -169,6 +176,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
       while (tabs.has(`workflows/${stem}.json`))
         stem = `${requested} (${counter++})`
       const tab: FakeTab = {
+        instanceId: crypto.randomUUID(),
         path: `workflows/${stem}.json`,
         directory: 'workflows',
         filename: stem,
@@ -304,6 +312,7 @@ beforeEach(() => {
     (_name: string, defaultValue?: unknown) => defaultValue
   )
   hostStores.workflow.tabs.clear()
+  hostStores.workflow.closedInstances.clear()
   hostStores.workflow.activeWorkflow = null
   hostStores.canvas.selectedItems = []
   hostStores.canvas.currentGraph = null
@@ -346,6 +355,7 @@ async function renderAndSend(text: string): Promise<void> {
 function addTab(path: string, overrides: Partial<FakeTab> = {}): FakeTab {
   const slash = path.lastIndexOf('/')
   const tab: FakeTab = {
+    instanceId: crypto.randomUUID(),
     path,
     directory: path.slice(0, slash),
     filename: path.slice(slash + 1).replace(/\.json$/, ''),
@@ -718,6 +728,7 @@ describe('AgentPanelRoot attach flow', () => {
   it('hides the assets entry in builder mode', async () => {
     stubUploadFetch()
     hostStores.workflow.activeWorkflow = {
+      instanceId: crypto.randomUUID(),
       path: 'workflows/current.json',
       directory: 'workflows',
       filename: 'current',
@@ -1362,6 +1373,7 @@ describe('AgentPanelRoot canvas draft on send', () => {
       links: []
     })
     const activeWorkflow = {
+      instanceId: crypto.randomUUID(),
       path: 'workflows/video_minimax_h3_i2v.json',
       directory: 'workflows',
       filename: 'video_minimax_h3_i2v',
@@ -1932,6 +1944,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
   function makeTab(id?: string): FakeTab {
     const tab: FakeTab = {
+      instanceId: crypto.randomUUID(),
       path: 'workflows/current.json',
       directory: 'workflows',
       filename: 'current',
@@ -1948,7 +1961,8 @@ describe('AgentPanelRoot workflow binding', () => {
 
   function mockMessagesEndpoint(
     ackWorkflowId: string,
-    cloudWorkflows: { id: string; name: string }[] = []
+    cloudWorkflows: { id: string; name: string }[] = [],
+    beforeAck?: () => void
   ): unknown[] {
     const bodies: unknown[] = []
     vi.stubGlobal(
@@ -1956,6 +1970,7 @@ describe('AgentPanelRoot workflow binding', () => {
       vi.fn(async (url: string, init?: RequestInit) => {
         if (url.includes('/messages') && init?.method === 'POST') {
           bodies.push(JSON.parse(String(init.body)))
+          beforeAck?.()
           return json(202, ack(ackWorkflowId, `m-${bodies.length}`))
         }
         if (url.includes('/messages')) return json(200, [])
@@ -3039,6 +3054,72 @@ describe('AgentPanelRoot workflow binding', () => {
     ])
   })
 
+  it('does not adopt a workflow into a saved tab with no resolved cloud id', async () => {
+    const tab = makeTab()
+    mockMessagesEndpoint('wf-fresh')
+
+    await renderAndSend('build a graph')
+
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(tab.path)
+    ).toBeUndefined()
+  })
+
+  it('follows the same temporary tab instance when its path changes before the ack', async () => {
+    const tab = makeTab()
+    tab.isTemporary = true
+    const originalPath = tab.path
+    const savedPath = 'workflows/saved.json'
+    mockMessagesEndpoint('wf-fresh', [], () => {
+      hostStores.workflow.tabs.delete(originalPath)
+      tab.path = savedPath
+      tab.isTemporary = false
+      hostStores.workflow.tabs.set(savedPath, tab)
+    })
+
+    await renderAndSend('build a graph')
+
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')).toBe(
+      savedPath
+    )
+  })
+
+  it('does not adopt into a replacement tab that reuses the origin path', async () => {
+    const origin = makeTab()
+    origin.isTemporary = true
+    const path = origin.path
+    let replacement: FakeTab | undefined
+    mockMessagesEndpoint('wf-fresh', [], () => {
+      hostStores.workflow.tabs.delete(path)
+      replacement = addTab(path, { isTemporary: true })
+      hostStores.workflow.activeWorkflow = replacement
+    })
+
+    await renderAndSend('build a graph')
+
+    expect(replacement).toBeDefined()
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(path)
+    ).toBeUndefined()
+  })
+
+  it('does not overwrite a binding acquired while the message is in flight', async () => {
+    const tab = makeTab()
+    tab.isTemporary = true
+    mockMessagesEndpoint('wf-fresh', [], () => {
+      useAgentWorkflowTabBindingStore().bind('wf-other', tab.path)
+    })
+
+    await renderAndSend('build a graph')
+
+    expect(useAgentWorkflowTabBindingStore().workflowIdFor(tab.path)).toBe(
+      'wf-other'
+    )
+    expect(
+      useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')
+    ).toBeUndefined()
+  })
+
   it('does not subscribe a minted workflow after its tab is backgrounded', async () => {
     const origin = makeTab()
     origin.isTemporary = true
@@ -3118,7 +3199,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await userEvent.type(screen.getByRole('textbox'), 'build a graph')
     await userEvent.click(screen.getByRole('button', { name: 'Send' }))
     await vi.waitFor(() => expect(workflowRequests).toBe(2))
-    hostStores.workflow.tabs.delete(origin.path)
+    hostStores.workflow.closedInstances.add(origin.instanceId)
     hostStores.workflow.activeWorkflow = replacement
     releasePreparation()
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -2864,6 +2864,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await sendFromComposer('second message')
 
     expect(bodies[1]).not.toHaveProperty('workflow_id')
+    expect(bodies[1]).not.toHaveProperty('draft')
     expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-42')).toBe(
       origin.path
     )
@@ -3125,6 +3126,18 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[0]).not.toHaveProperty('workflow_id')
     expect(bodies[0]).not.toHaveProperty('current_tab')
     expect(bodies[0]).not.toHaveProperty('draft')
+    await screen.findByRole('button', { name: 'Stop' })
+    expect(
+      useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')
+    ).toBeUndefined()
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(replacement.path)
+    ).toBe('wf-replacement')
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
   })
 
   it('sends only the remaining chip after one is dismissed', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -121,6 +121,7 @@ type FakeTab = {
   path: string
   directory: string
   filename: string
+  suffix?: string
   isTemporary: boolean
   isModified: boolean
   activeState: ComfyWorkflowJSON | null
@@ -2754,6 +2755,38 @@ describe('AgentPanelRoot workflow binding', () => {
       ],
       current_tab: 'wf-cloud-current'
     })
+  })
+
+  it('sends a saved app workflow instead of the existing thread workflow', async () => {
+    const activeState = fromPartial<ComfyWorkflowJSON>({
+      nodes: Array.from({ length: 19 }, (_, index) => ({
+        id: index + 1,
+        type: index === 0 ? 'LoadImage' : `ImageEditNode${index}`
+      })),
+      links: []
+    })
+    const appTab = addTab('workflows/all-in-one-image-edit-models.app.json', {
+      filename: 'all-in-one-image-edit-models',
+      suffix: 'app.json',
+      activeState
+    })
+    hostStores.workflow.activeWorkflow = appTab
+    useAgentConversationStore().setThreadId('th-two-node-workflow')
+    const bodies = mockMessagesEndpoint('wf-all-in-one', [
+      { id: 'wf-all-in-one', name: 'all-in-one-image-edit-models.app' }
+    ])
+
+    await renderAndSend('replace the image in the Load Image node')
+
+    expect(bodies[0]).toMatchObject({
+      workflow_id: 'wf-all-in-one',
+      current_tab: 'wf-all-in-one',
+      draft: { content: activeState }
+    })
+    expect(
+      (bodies[0] as { draft: { content: { nodes: unknown[] } } }).draft.content
+        .nodes
+    ).toHaveLength(19)
   })
 
   it('does not resolve temporary tabs through the cloud workflow index', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -32,6 +32,7 @@ const getServerFeature = vi.hoisted(() =>
   vi.fn((_name: string, defaultValue?: unknown) => defaultValue)
 )
 const focusNodeInstance = vi.hoisted(() => vi.fn())
+const socketSend = vi.hoisted(() => vi.fn())
 
 vi.mock('@/composables/canvas/useFocusNode', () => ({
   useFocusNode: () => ({ focusNodeInstance })
@@ -61,7 +62,7 @@ vi.mock('@/scripts/api', () => ({
     fetchApi: (route: string, options?: RequestInit) =>
       fetch(route.startsWith('/api') ? route : `/api${route}`, options),
     getServerFeature,
-    socket: { readyState: 1, send: vi.fn() },
+    socket: { readyState: 1, send: socketSend },
     addEventListener: ws.add,
     removeEventListener: ws.remove,
     addCustomEventListener: ws.add,
@@ -314,6 +315,7 @@ beforeEach(() => {
   workflowService.saveWorkflowAs.mockClear()
   workflowService.openWorkflow.mockClear()
   focusNodeInstance.mockReset()
+  socketSend.mockReset()
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
@@ -2959,6 +2961,68 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[0]).not.toHaveProperty('open_tabs')
     expect(bodies[0]).not.toHaveProperty('current_tab')
     expect(app.loadGraphData).not.toHaveBeenCalled()
+  })
+
+  it('binds a minted workflow to its unsaved tab and subscribes once', async () => {
+    const tab = makeTab()
+    tab.isTemporary = true
+    mockMessagesEndpoint('wf-fresh')
+
+    await renderAndSend('build a graph')
+
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')).toBe(
+      tab.path
+    )
+    const subscribes = socketSend.mock.calls
+      .map(
+        ([frame]) =>
+          JSON.parse(String(frame)) as { type: string; data: unknown }
+      )
+      .filter(({ type }) => type === 'doc_subscribe')
+    expect(subscribes).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ workflow_id: 'wf-fresh' })
+      })
+    ])
+  })
+
+  it('does not subscribe a minted workflow after its tab is backgrounded', async () => {
+    const origin = makeTab()
+    origin.isTemporary = true
+    const background = addTab('workflows/background.json')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('/messages') && init?.method === 'POST') {
+          hostStores.workflow.activeWorkflow = background
+          return json(202, ack('wf-fresh', 'm-1'))
+        }
+        if (url.includes('/agent/threads'))
+          return json(200, { threads: [], pagination: { page: 1 } })
+        if (url.includes('/workflows'))
+          return json(200, {
+            data: [],
+            pagination: {
+              offset: 0,
+              limit: 100,
+              total: 0,
+              has_more: false
+            }
+          })
+        return new Response('{}', { status: 200 })
+      })
+    )
+
+    await renderAndSend('build a graph')
+
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')).toBe(
+      origin.path
+    )
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
   })
 
   it('sends only the remaining chip after one is dismissed', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -2846,6 +2846,56 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[1]).not.toHaveProperty('current_tab')
   })
 
+  it('keeps an existing thread workflow on its own tab when sending from an unsaved tab', async () => {
+    const origin = makeTab('wf-42')
+    const bodies = mockMessagesEndpoint('wf-42')
+
+    await renderAndSend('first message')
+    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
+    await screen.findByRole('button', { name: 'Send' })
+
+    const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
+    hostStores.workflow.activeWorkflow = scratch
+    await nextTick()
+    socketSend.mockClear()
+
+    await sendFromComposer('second message')
+
+    expect(bodies[1]).not.toHaveProperty('workflow_id')
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-42')).toBe(
+      origin.path
+    )
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(scratch.path)
+    ).toBeUndefined()
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
+  })
+
+  it('does not bind an unsaved tab to a workflow that already has an open tab', async () => {
+    addTab('workflows/current.json')
+    const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
+    hostStores.workflow.activeWorkflow = scratch
+    mockMessagesEndpoint('wf-42', [{ id: 'wf-42', name: 'current' }])
+
+    await renderAndSend('first message')
+
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(scratch.path)
+    ).toBeUndefined()
+    expect(
+      useAgentWorkflowTabBindingStore().tabPathFor('wf-42')
+    ).toBeUndefined()
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
+  })
+
   it('stages a mention pick once and reports the tag gesture', async () => {
     makeTab('wf-42')
     mockMessagesEndpoint('wf-42')

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -279,16 +279,21 @@ async function refreshCloudWorkflowIds(): Promise<void> {
   }
 }
 
-function openSavedTabsNamed(filename: string): ComfyWorkflow[] {
+function cloudWorkflowName(tab: ComfyWorkflow): string {
+  return tab.suffix === 'app.json' ? `${tab.filename}.app` : tab.filename
+}
+
+function openSavedTabsNamed(name: string): ComfyWorkflow[] {
   return workflowStore.openWorkflows.filter(
-    (tab) => !tab.isTemporary && tab.filename === filename
+    (tab) => !tab.isTemporary && cloudWorkflowName(tab) === name
   )
 }
 
 function cloudIdFor(tab: ComfyWorkflow): string | undefined {
+  const name = cloudWorkflowName(tab)
   const saved =
-    !tab.isTemporary && openSavedTabsNamed(tab.filename).length === 1
-      ? cloudIdsByName.get(tab.filename)
+    !tab.isTemporary && openSavedTabsNamed(name).length === 1
+      ? cloudIdsByName.get(name)
       : undefined
   return saved ?? bindingStore.workflowIdFor(tab.path)
 }

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -486,7 +486,14 @@ const isCrdtDevPanelEnabled = resolveDebugPanelEnabled(
 function resumedTurnTabPath(): string | null {
   if (workflowDetached.value) return null
   const bound = boundWorkflowId.value
-  if (bound === null) return activeWorkflowTurnContext()?.tabPath ?? null
+  if (bound === null) {
+    // An id-less context means the turn has no workflow at all: attributing
+    // it to whatever tab happens to be active lights the editing spinner on
+    // that tab and markModifieds it on completion. Only a context carrying a
+    // real workflow id may be attributed.
+    const context = activeWorkflowTurnContext()
+    return context?.id !== undefined ? context.tabPath : null
+  }
   const boundPath = bindingStore.tabPathFor(bound)
   if (boundPath !== undefined) return boundPath
   const context = activeWorkflowTurnContext()

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -75,7 +75,10 @@ import type {
 } from './schemas/agentApiSchema'
 import type { ChatSession } from './stores/agent/agentChatHistoryStore'
 import type { ConversationEntry } from './stores/agent/agentConversationStore'
-import type { WorkflowTurnContext } from './composables/agent/useAgentSession'
+import type {
+  TurnOrigin,
+  WorkflowTurnContext
+} from './composables/agent/useAgentSession'
 import { useAgentSession } from './composables/agent/useAgentSession'
 import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTabBindingStore'
 import { createAgentRestClient } from './services/agent/agentRestClient'
@@ -292,14 +295,23 @@ function cloudIdFor(tab: ComfyWorkflow): string | undefined {
 
 const workflowDetached = ref(false)
 
+// Resolves the tab a turn is attributed to. `null` (the send had no origin
+// tab) resolves to nothing rather than falling back to the active tab, so
+// re-attaching during prepare() cannot pull a later tab into this turn.
+function originWorkflow(origin?: TurnOrigin): ComfyWorkflow | undefined {
+  if (origin === null) return undefined
+  return (
+    (origin === undefined
+      ? workflowStore.activeWorkflow
+      : workflowStore.getWorkflowByPath(origin.tabPath)) ?? undefined
+  )
+}
+
 function activeWorkflowTurnContext(
-  originTabPath?: string
+  origin?: TurnOrigin
 ): WorkflowTurnContext | undefined {
   if (workflowDetached.value) return undefined
-  const active =
-    originTabPath === undefined
-      ? workflowStore.activeWorkflow
-      : workflowStore.getWorkflowByPath(originTabPath)
+  const active = originWorkflow(origin)
   if (!active) return undefined
   const id = cloudIdFor(active)
   return id === undefined
@@ -307,14 +319,9 @@ function activeWorkflowTurnContext(
     : { id, tabPath: active.path }
 }
 
-function activeWorkflowDraft(
-  originTabPath?: string
-): DraftSnapshot | undefined {
+function activeWorkflowDraft(origin?: TurnOrigin): DraftSnapshot | undefined {
   if (workflowDetached.value) return undefined
-  const active =
-    originTabPath === undefined
-      ? workflowStore.activeWorkflow
-      : workflowStore.getWorkflowByPath(originTabPath)
+  const active = originWorkflow(origin)
   if (!active) return undefined
   // captureCanvasState() folds the LIVE canvas into whichever workflow it is
   // called on, so it is only correct while that workflow is still the active
@@ -358,9 +365,7 @@ function onClearWorkflow(): void {
   workflowDetached.value = true
 }
 
-function openTabsSnapshot(
-  originTabPath?: string
-): OpenTabsSnapshot | undefined {
+function openTabsSnapshot(origin?: TurnOrigin): OpenTabsSnapshot | undefined {
   const openTabs = workflowStore.openWorkflows.flatMap((tab) => {
     const workflowId = cloudIdFor(tab)
     return workflowId === undefined
@@ -368,10 +373,9 @@ function openTabsSnapshot(
       : [{ workflow_id: workflowId, name: tab.filename }]
   })
   if (openTabs.length === 0) return undefined
-  const active =
-    originTabPath === undefined
-      ? workflowStore.activeWorkflow
-      : workflowStore.getWorkflowByPath(originTabPath)
+  // A turn with no origin tab still reports the open tabs (they are context,
+  // not attribution) but must not name a current_tab.
+  const active = originWorkflow(origin)
   return {
     open_tabs: openTabs,
     current_tab:

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -308,11 +308,22 @@ function activeWorkflowTurnContext(
     : { id, tabPath: active.path }
 }
 
-function activeWorkflowDraft(): DraftSnapshot | undefined {
+function activeWorkflowDraft(
+  originTabPath?: string
+): DraftSnapshot | undefined {
   if (workflowDetached.value) return undefined
-  const active = workflowStore.activeWorkflow
+  const active =
+    originTabPath === undefined
+      ? workflowStore.activeWorkflow
+      : (workflowStore.getWorkflowByPath(originTabPath) ??
+        workflowStore.activeWorkflow)
   if (!active) return undefined
-  active.changeTracker?.captureCanvasState()
+  // captureCanvasState() folds the LIVE canvas into whichever workflow it is
+  // called on, so it is only correct while that workflow is still the active
+  // tab. If the user switched away mid-turn, the originating tab's own
+  // serialized activeState is the snapshot that belongs with this send.
+  if (active.path === workflowStore.activeWorkflow?.path)
+    active.changeTracker?.captureCanvasState()
   const content = active.activeState
   if (!content) return undefined
   return { content }

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -292,9 +292,15 @@ function cloudIdFor(tab: ComfyWorkflow): string | undefined {
 
 const workflowDetached = ref(false)
 
-function activeWorkflowTurnContext(): WorkflowTurnContext | undefined {
+function activeWorkflowTurnContext(
+  originTabPath?: string
+): WorkflowTurnContext | undefined {
   if (workflowDetached.value) return undefined
-  const active = workflowStore.activeWorkflow
+  const active =
+    originTabPath === undefined
+      ? workflowStore.activeWorkflow
+      : (workflowStore.getWorkflowByPath(originTabPath) ??
+        workflowStore.activeWorkflow)
   if (!active) return undefined
   const id = cloudIdFor(active)
   return id === undefined
@@ -343,7 +349,9 @@ function onClearWorkflow(): void {
   workflowDetached.value = true
 }
 
-function openTabsSnapshot(): OpenTabsSnapshot | undefined {
+function openTabsSnapshot(
+  originTabPath?: string
+): OpenTabsSnapshot | undefined {
   const openTabs = workflowStore.openWorkflows.flatMap((tab) => {
     const workflowId = cloudIdFor(tab)
     return workflowId === undefined
@@ -351,7 +359,11 @@ function openTabsSnapshot(): OpenTabsSnapshot | undefined {
       : [{ workflow_id: workflowId, name: tab.filename }]
   })
   if (openTabs.length === 0) return undefined
-  const active = workflowStore.activeWorkflow
+  const active =
+    originTabPath === undefined
+      ? workflowStore.activeWorkflow
+      : (workflowStore.getWorkflowByPath(originTabPath) ??
+        workflowStore.activeWorkflow)
   return {
     open_tabs: openTabs,
     current_tab:

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -299,8 +299,7 @@ function activeWorkflowTurnContext(
   const active =
     originTabPath === undefined
       ? workflowStore.activeWorkflow
-      : (workflowStore.getWorkflowByPath(originTabPath) ??
-        workflowStore.activeWorkflow)
+      : workflowStore.getWorkflowByPath(originTabPath)
   if (!active) return undefined
   const id = cloudIdFor(active)
   return id === undefined
@@ -315,8 +314,7 @@ function activeWorkflowDraft(
   const active =
     originTabPath === undefined
       ? workflowStore.activeWorkflow
-      : (workflowStore.getWorkflowByPath(originTabPath) ??
-        workflowStore.activeWorkflow)
+      : workflowStore.getWorkflowByPath(originTabPath)
   if (!active) return undefined
   // captureCanvasState() folds the LIVE canvas into whichever workflow it is
   // called on, so it is only correct while that workflow is still the active
@@ -373,8 +371,7 @@ function openTabsSnapshot(
   const active =
     originTabPath === undefined
       ? workflowStore.activeWorkflow
-      : (workflowStore.getWorkflowByPath(originTabPath) ??
-        workflowStore.activeWorkflow)
+      : workflowStore.getWorkflowByPath(originTabPath)
   return {
     open_tabs: openTabs,
     current_tab:

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -300,11 +300,13 @@ const workflowDetached = ref(false)
 // re-attaching during prepare() cannot pull a later tab into this turn.
 function originWorkflow(origin?: TurnOrigin): ComfyWorkflow | undefined {
   if (origin === null) return undefined
-  return (
-    (origin === undefined
-      ? workflowStore.activeWorkflow
-      : workflowStore.getWorkflowByPath(origin.tabPath)) ?? undefined
-  )
+  return origin === undefined
+    ? (workflowStore.activeWorkflow ?? undefined)
+    : origin.instanceId === undefined
+      ? (workflowStore.getWorkflowByPath(origin.tabPath) ?? undefined)
+      : workflowStore.openWorkflows.find(
+          ({ instanceId }) => instanceId === origin.instanceId
+        )
 }
 
 function activeWorkflowTurnContext(
@@ -314,9 +316,12 @@ function activeWorkflowTurnContext(
   const active = originWorkflow(origin)
   if (!active) return undefined
   const id = cloudIdFor(active)
-  return id === undefined
-    ? { tabPath: active.path }
-    : { id, tabPath: active.path }
+  const context = {
+    tabPath: active.path,
+    instanceId: active.instanceId,
+    isTemporary: active.isTemporary
+  }
+  return id === undefined ? context : { ...context, id }
 }
 
 function activeWorkflowDraft(origin?: TurnOrigin): DraftSnapshot | undefined {
@@ -388,16 +393,24 @@ function onWorkflowAdopted(
   sent: WorkflowTurnContext | undefined
 ): void {
   if (sent === undefined) return
-  // An unbound tab adopts a workflow only when it was minted for this turn:
-  // an id that already resolves to an open tab belongs to that tab.
-  const adoptable =
-    sent.id === undefined
-      ? boundTabFor(workflowId) === null
-      : sent.id === workflowId
-  if (adoptable) {
-    bindingStore.bind(workflowId, sent.tabPath)
-    tabActivity.setEditing(sent.tabPath)
+  if (sent.instanceId === undefined) return
+  const tab = workflowStore.openWorkflows.find(
+    ({ instanceId }) => instanceId === sent.instanceId
+  )
+  if (!tab) return
+  if (sent.id !== undefined) {
+    if (sent.id === workflowId && cloudIdFor(tab) === workflowId)
+      tabActivity.setEditing(tab.path)
+    return
   }
+  if (
+    !sent.isTemporary ||
+    cloudIdFor(tab) !== undefined ||
+    boundTabFor(workflowId) !== null
+  )
+    return
+  bindingStore.bind(workflowId, tab.path)
+  tabActivity.setEditing(tab.path)
 }
 
 const {

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -296,8 +296,10 @@ function activeWorkflowTurnContext(): WorkflowTurnContext | undefined {
   if (workflowDetached.value) return undefined
   const active = workflowStore.activeWorkflow
   if (!active) return undefined
-  const bound = cloudIdFor(active)
-  return bound === undefined ? undefined : { id: bound, tabPath: active.path }
+  const id = cloudIdFor(active)
+  return id === undefined
+    ? { tabPath: active.path }
+    : { id, tabPath: active.path }
 }
 
 function activeWorkflowDraft(): DraftSnapshot | undefined {
@@ -361,7 +363,7 @@ function onWorkflowAdopted(
   workflowId: string,
   sent: WorkflowTurnContext | undefined
 ): void {
-  if (sent !== undefined && sent.id === workflowId) {
+  if (sent !== undefined && (sent.id === undefined || sent.id === workflowId)) {
     bindingStore.bind(workflowId, sent.tabPath)
     tabActivity.setEditing(sent.tabPath)
   }

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -363,7 +363,14 @@ function onWorkflowAdopted(
   workflowId: string,
   sent: WorkflowTurnContext | undefined
 ): void {
-  if (sent !== undefined && (sent.id === undefined || sent.id === workflowId)) {
+  if (sent === undefined) return
+  // An unbound tab adopts a workflow only when it was minted for this turn:
+  // an id that already resolves to an open tab belongs to that tab.
+  const adoptable =
+    sent.id === undefined
+      ? boundTabFor(workflowId) === null
+      : sent.id === workflowId
+  if (adoptable) {
     bindingStore.bind(workflowId, sent.tabPath)
     tabActivity.setEditing(sent.tabPath)
   }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -817,6 +817,47 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(adopted).toHaveBeenCalledWith('wf-b', undefined)
   })
 
+  it('(h6) a bind landing in the prepare()/POST window makes an echoed id read as an echo', async () => {
+    // Regression for the r3929083595 race: priorWorkflowId was snapshotted
+    // before prepare(), so a bindWorkflow() landing in that window (a late
+    // agent_active_tab frame, loadThread, an overlapping send) left the guard
+    // comparing the echoed id against a stale pre-turn binding and
+    // re-binding the origin tab to a workflow the mid-turn event had already
+    // bound elsewhere.
+    const postMessage = vi.fn<AgentRestClient['postMessage']>(
+      () =>
+        new Promise<AgentTurnAccepted>((resolve) =>
+          resolve({
+            thread_id: 'th-1',
+            message_id: 'msg-1',
+            workflow_id: 'wf-x'
+          })
+        )
+    )
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    const adopted = vi.fn()
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        current: () => undefined,
+        adopted
+      }
+    })
+    session.start()
+
+    const sendPromise = session.sendMessage('hello')
+    // The mid-turn bind establishes the thread's existing workflow while the
+    // POST is in flight; the ack then echoes exactly that id.
+    session.bindWorkflow('wf-x')
+    await sendPromise
+
+    // An echo of the current binding is not a mint: no re-adoption.
+    expect(adopted).not.toHaveBeenCalled()
+    expect(session.boundWorkflowId.value).toBe('wf-x')
+  })
+
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {
     const rest = fakeRest()
     const { source } = fakeEvents()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -678,6 +678,7 @@ describe('useAgentSession (v1 composition root)', () => {
       tabPath: 'tab-a'
     })
     expect(vi.mocked(postMessage).mock.calls[0][1]).toMatchObject({
+      workflowId: 'wf-a',
       tabs: { current_tab: 'wf-a' }
     })
   })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -21,7 +21,7 @@ import type {
 import { useAgentConversationStore } from '../../stores/agent/agentConversationStore'
 
 import type { SelectedNode } from './useCanvasSelection'
-import type { AgentEventSource } from './useAgentSession'
+import type { AgentEventSource, TurnOrigin } from './useAgentSession'
 import { useAgentSession } from './useAgentSession'
 
 function fakeRest(overrides: Partial<AgentRestClient> = {}): AgentRestClient {
@@ -73,6 +73,15 @@ function fakeEvents() {
     status: (live: boolean) => statusListener?.(live)
   }
 }
+
+// Mirrors AgentPanelRoot's originWorkflow(): an explicit `null` origin means
+// the send had no origin tab and must resolve to nothing, while an omitted
+// origin falls back to whatever tab is active right now.
+const pathFor = (
+  origin: TurnOrigin | undefined,
+  activePath: string | undefined
+): string | undefined =>
+  origin === null ? undefined : (origin?.tabPath ?? activePath)
 
 const wire = (raw: unknown): unknown => zAgentWsEvent.parse(raw)
 const thinking = (id: string, delta: string) =>
@@ -647,20 +656,22 @@ describe('useAgentSession (v1 composition root)', () => {
       rest,
       events: source,
       workflow: {
-        // Mirrors the real deps: honor an explicit originTabPath (resolved
+        // Mirrors the real deps: honor an explicit origin (resolved
         // post-prepare) and fall back to whatever tab is active right now
         // when called with no argument (the pre-await identity capture).
-        current: (originTabPath) => {
-          const path = originTabPath ?? activePath
-          return { id: idForPath(path), tabPath: path }
+        current: (origin) => {
+          const path = pathFor(origin, activePath)
+          return path === undefined
+            ? undefined
+            : { id: idForPath(path), tabPath: path }
         },
         adopted,
         prepare,
-        tabs: (originTabPath) => {
-          const path = originTabPath ?? activePath
+        tabs: (origin) => {
+          const path = pathFor(origin, activePath)
           return {
-            open_tabs: [{ workflow_id: idForPath(path), name: path }],
-            current_tab: idForPath(path)
+            open_tabs: [{ workflow_id: 'wf-a', name: 'tab-a' }],
+            current_tab: path === undefined ? undefined : idForPath(path)
           }
         }
       }
@@ -704,18 +715,22 @@ describe('useAgentSession (v1 composition root)', () => {
       rest,
       events: source,
       workflow: {
-        current: (originTabPath) => {
-          const path = originTabPath ?? activePath
-          return { id: idForPath(path), tabPath: path }
+        current: (origin) => {
+          const path = pathFor(origin, activePath)
+          return path === undefined
+            ? undefined
+            : { id: idForPath(path), tabPath: path }
         },
         adopted: vi.fn(),
         prepare,
         // The draft is read on the same post-await leg as current()/tabs(), so
         // it has to honor the same pinned identity or the turn ships one tab's
         // canvas under another tab's workflow id.
-        draft: (originTabPath) => {
-          const path = originTabPath ?? activePath
-          return { content: { nodes: [{ id: 1, type: path }], links: [] } }
+        draft: (origin) => {
+          const path = pathFor(origin, activePath)
+          return path === undefined
+            ? undefined
+            : { content: { nodes: [{ id: 1, type: path }], links: [] } }
         }
       }
     })
@@ -730,6 +745,76 @@ describe('useAgentSession (v1 composition root)', () => {
       workflowId: 'wf-a',
       draft: { content: { nodes: [{ id: 1, type: 'tab-a' }], links: [] } }
     })
+  })
+
+  it('(h9) a send that starts with no origin tab is not reattributed to a tab attached during prepare()', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-b'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    const adopted = vi.fn()
+    let releasePrepare: () => void = () => undefined
+    const prepare = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePrepare = resolve
+        })
+    )
+    // The panel is detached when the user hits send, so there is no origin
+    // tab: activeWorkflowTurnContext() returns undefined for every lookup
+    // while `detached` holds, exactly like the real deps.
+    let detached = true
+    let activePath: string | undefined = undefined
+    const resolve = (origin: TurnOrigin | undefined) =>
+      detached ? undefined : pathFor(origin, activePath)
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        current: (origin) => {
+          const path = resolve(origin)
+          return path === undefined ? undefined : { id: 'wf-b', tabPath: path }
+        },
+        adopted,
+        prepare,
+        tabs: (origin) => {
+          const path = resolve(origin)
+          return {
+            open_tabs: [{ workflow_id: 'wf-b', name: 'tab-b' }],
+            current_tab: path === undefined ? undefined : 'wf-b'
+          }
+        },
+        draft: (origin) => {
+          const path = resolve(origin)
+          return path === undefined
+            ? undefined
+            : { content: { nodes: [{ id: 1, type: path }], links: [] } }
+        }
+      }
+    })
+    session.start()
+
+    const sendPromise = session.sendMessage('hello')
+    // The user re-attaches (onSelectTab clears workflowDetached) and selects
+    // tab-b while prepare() is still in flight.
+    detached = false
+    activePath = 'tab-b'
+    releasePrepare()
+    await sendPromise
+
+    const sent = vi.mocked(postMessage).mock.calls[0][1]
+    expect(sent).not.toHaveProperty('workflowId')
+    expect(sent).not.toHaveProperty('draft')
+    expect(sent.tabs?.current_tab).toBeUndefined()
+    // open_tabs is context, not attribution, so it still travels.
+    expect(sent.tabs?.open_tabs).toEqual([
+      { workflow_id: 'wf-b', name: 'tab-b' }
+    ])
+    // The ack echoes wf-b; with no origin tab there is nothing to bind it to.
+    expect(adopted).toHaveBeenCalledWith('wf-b', undefined)
   })
 
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -625,6 +625,63 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(vi.mocked(postMessage).mock.calls[0][1]).not.toHaveProperty('draft')
   })
 
+  it('(h7) a tab switch while prepare() is pending does not reattribute the send to the new tab', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-1'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    const adopted = vi.fn()
+    let releasePrepare: () => void = () => undefined
+    const prepare = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePrepare = resolve
+        })
+    )
+    let activePath = 'tab-a'
+    const idForPath = (path: string) => (path === 'tab-a' ? 'wf-a' : 'wf-b')
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        // Mirrors the real deps: honor an explicit originTabPath (resolved
+        // post-prepare) and fall back to whatever tab is active right now
+        // when called with no argument (the pre-await identity capture).
+        current: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return { id: idForPath(path), tabPath: path }
+        },
+        adopted,
+        prepare,
+        tabs: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return {
+            open_tabs: [{ workflow_id: idForPath(path), name: path }],
+            current_tab: idForPath(path)
+          }
+        }
+      }
+    })
+    session.start()
+
+    const sendPromise = session.sendMessage('hello')
+    // Simulate the user switching tabs while prepare() is still in flight.
+    activePath = 'tab-b'
+    releasePrepare()
+    await sendPromise
+
+    expect(adopted).toHaveBeenCalledWith('wf-1', {
+      id: 'wf-a',
+      tabPath: 'tab-a'
+    })
+    expect(vi.mocked(postMessage).mock.calls[0][1]).toMatchObject({
+      tabs: { current_tab: 'wf-a' }
+    })
+  })
+
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {
     const rest = fakeRest()
     const { source } = fakeEvents()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -682,6 +682,55 @@ describe('useAgentSession (v1 composition root)', () => {
     })
   })
 
+  it('(h8) the draft snapshot follows the originating tab, not the tab switched to during prepare()', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-1'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    let releasePrepare: () => void = () => undefined
+    const prepare = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePrepare = resolve
+        })
+    )
+    let activePath = 'tab-a'
+    const idForPath = (path: string) => (path === 'tab-a' ? 'wf-a' : 'wf-b')
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        current: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return { id: idForPath(path), tabPath: path }
+        },
+        adopted: vi.fn(),
+        prepare,
+        // The draft is read on the same post-await leg as current()/tabs(), so
+        // it has to honor the same pinned identity or the turn ships one tab's
+        // canvas under another tab's workflow id.
+        draft: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return { content: { nodes: [{ id: 1, type: path }], links: [] } }
+        }
+      }
+    })
+    session.start()
+
+    const sendPromise = session.sendMessage('what is on my canvas')
+    activePath = 'tab-b'
+    releasePrepare()
+    await sendPromise
+
+    expect(vi.mocked(postMessage).mock.calls[0][1]).toMatchObject({
+      workflowId: 'wf-a',
+      draft: { content: { nodes: [{ id: 1, type: 'tab-a' }], links: [] } }
+    })
+  })
+
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {
     const rest = fakeRest()
     const { source } = fakeEvents()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -46,10 +46,14 @@ export interface AgentSessionDeps {
   rest: AgentRestClient
   events: AgentEventSource
   workflow?: {
-    current(): WorkflowTurnContext | undefined
+    // originTabPath, when given, pins resolution to the tab that initiated
+    // the send instead of whatever tab is active when this is called - it
+    // is read after prepare() so cloud ids it resolves are fresh, but must
+    // still describe the pre-await originating tab, not a later switch.
+    current(originTabPath?: string): WorkflowTurnContext | undefined
     adopted(workflowId: string, sent: WorkflowTurnContext | undefined): void
     prepare?(): Promise<void>
-    tabs?(): OpenTabsSnapshot | undefined
+    tabs?(originTabPath?: string): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
     draft?(): DraftSnapshot | undefined
   }
@@ -193,13 +197,23 @@ export function useAgentSession(deps: AgentSessionDeps) {
     promptEditState.value = { phase: 'idle' }
     sending.value = true
     stopRequestedWhileSending = false
+    // Capture the originating tab identity before the first await: prepare()
+    // can take up to PREPARE_TIMEOUT_MS, and a tab switch while it is
+    // pending must not reattribute this send to the newly active tab. The id
+    // lookups themselves stay post-await (prepare() is what warms them), but
+    // pinned to this originating path rather than whatever is active later.
+    const originTabPath = workflow?.current()?.tabPath
+    // The ack does not say whether the server minted a workflow or echoed
+    // the thread's existing one; an unbound tab may only adopt an id the
+    // session was not already bound to before this turn.
+    const priorWorkflowId = boundWorkflowId.value
     if (workflow?.prepare)
       await Promise.race([
         workflow.prepare().catch(() => undefined),
         new Promise<void>((resolve) => setTimeout(resolve, PREPARE_TIMEOUT_MS))
       ])
-    const wfContext = workflow?.current()
-    const tabs = workflow?.tabs?.()
+    const wfContext = workflow?.current(originTabPath)
+    const tabs = workflow?.tabs?.(originTabPath)
     async function postTurn(threadId: string) {
       const draft = workflow?.draft?.()
       const shouldSendDraft =
@@ -221,10 +235,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : input
       )
     }
-    // The ack does not say whether the server minted a workflow or echoed
-    // the thread's existing one; an unbound tab may only adopt an id the
-    // session was not already bound to before this turn.
-    const priorWorkflowId = boundWorkflowId.value
     try {
       const ack = await postTurn(conversationStore.threadId ?? 'new')
       conversationStore.setThreadId(ack.thread_id)

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -33,7 +33,7 @@ interface SentTag {
 }
 
 export interface WorkflowTurnContext {
-  id: string
+  id?: string
   tabPath: string
 }
 
@@ -216,7 +216,9 @@ export function useAgentSession(deps: AgentSessionDeps) {
       }
       return rest.postMessage(
         threadId,
-        wfContext ? { ...input, workflowId: wfContext.id } : input
+        wfContext?.id !== undefined
+          ? { ...input, workflowId: wfContext.id }
+          : input
       )
     }
     try {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -221,13 +221,19 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : input
       )
     }
+    // The ack does not say whether the server minted a workflow or echoed
+    // the thread's existing one; an unbound tab may only adopt an id the
+    // session was not already bound to before this turn.
+    const priorWorkflowId = boundWorkflowId.value
     try {
       const ack = await postTurn(conversationStore.threadId ?? 'new')
       conversationStore.setThreadId(ack.thread_id)
       localStorage.setItem(THREAD_STORAGE_KEY, ack.thread_id)
       if (ack.workflow_id !== undefined) {
         bindWorkflow(ack.workflow_id)
-        workflow?.adopted(ack.workflow_id, wfContext)
+        const echoedToUnboundTab =
+          wfContext?.id === undefined && ack.workflow_id === priorWorkflowId
+        if (!echoedToUnboundTab) workflow?.adopted(ack.workflow_id, wfContext)
       }
       const turnId = ack.message_id as TurnId
       conversationStore.recordUser(

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -55,7 +55,7 @@ export interface AgentSessionDeps {
     prepare?(): Promise<void>
     tabs?(originTabPath?: string): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
-    draft?(): DraftSnapshot | undefined
+    draft?(originTabPath?: string): DraftSnapshot | undefined
   }
 }
 
@@ -215,9 +215,15 @@ export function useAgentSession(deps: AgentSessionDeps) {
     const wfContext = workflow?.current(originTabPath)
     const tabs = workflow?.tabs?.(originTabPath)
     async function postTurn(threadId: string) {
-      const draft = workflow?.draft?.()
+      const draft = workflow?.draft?.(originTabPath)
+      // An unsaved tab now yields a context carrying only its tabPath, so a
+      // merely-defined wfContext no longer implies the tab has a workflow the
+      // thread could own. An existing thread takes a draft only from a tab
+      // with a real workflow id; otherwise an unbound scratch tab would leak
+      // its canvas into someone else's thread.
       const shouldSendDraft =
-        draft !== undefined && (threadId === 'new' || wfContext !== undefined)
+        draft !== undefined &&
+        (threadId === 'new' || wfContext?.id !== undefined)
       const input = {
         content: text,
         tabs,

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -233,10 +233,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
             tabPath: originContext.tabPath,
             instanceId: originContext.instanceId
           }
-    // The ack does not say whether the server minted a workflow or echoed
-    // the thread's existing one; an unbound tab may only adopt an id the
-    // session was not already bound to before this turn.
-    const priorWorkflowId = boundWorkflowId.value
     if (workflow?.prepare)
       await Promise.race([
         workflow.prepare().catch(() => undefined),
@@ -276,9 +272,18 @@ export function useAgentSession(deps: AgentSessionDeps) {
       conversationStore.setThreadId(ack.thread_id)
       localStorage.setItem(THREAD_STORAGE_KEY, ack.thread_id)
       if (ack.workflow_id !== undefined) {
+        // The ack does not say whether the server minted a workflow or echoed
+        // the thread's existing one; an unbound tab may only adopt an id the
+        // session is not already bound to. Compare against the binding as of
+        // the ack, not a pre-prepare() snapshot: a bindWorkflow() landing in
+        // the prepare()/POST window (a late agent_active_tab frame, an
+        // overlapping send, loadThread) must make an echoed id read as an
+        // echo, not as freshly minted. A minted id is never equal to the
+        // current binding, so genuine adoption still fires.
+        const boundAtAck = boundWorkflowId.value
         bindWorkflow(ack.workflow_id)
         const echoedToUnboundTab =
-          wfContext?.id === undefined && ack.workflow_id === priorWorkflowId
+          wfContext?.id === undefined && ack.workflow_id === boundAtAck
         if (!echoedToUnboundTab) workflow?.adopted(ack.workflow_id, wfContext)
       }
       const turnId = ack.message_id as TurnId

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -37,6 +37,22 @@ export interface WorkflowTurnContext {
   tabPath: string
 }
 
+/**
+ * Which tab a turn belongs to, resolved once before prepare() and then handed
+ * to every post-await lookup. The three states are deliberately distinct:
+ *
+ * - omitted: resolve whatever tab is active right now. Only correct outside a
+ *   send, where there is nothing to pin to.
+ * - `null`: the send had no origin tab at all (panel detached, or no workflow
+ *   open when it started).
+ * - `{ tabPath }`: pin resolution to that tab.
+ *
+ * Collapsing `null` into the omitted case is what lets a detached send pick up
+ * whichever tab the user selects during prepare(), i.e. exactly the late
+ * binding this pin exists to remove.
+ */
+export type TurnOrigin = { tabPath: string } | null
+
 type PromptEditState =
   | { phase: 'idle' }
   | { phase: 'stopping'; turnId: TurnId }
@@ -46,16 +62,17 @@ export interface AgentSessionDeps {
   rest: AgentRestClient
   events: AgentEventSource
   workflow?: {
-    // originTabPath, when given, pins resolution to the tab that initiated
-    // the send instead of whatever tab is active when this is called - it
-    // is read after prepare() so cloud ids it resolves are fresh, but must
-    // still describe the pre-await originating tab, not a later switch.
-    current(originTabPath?: string): WorkflowTurnContext | undefined
+    // origin, when given, pins resolution to the tab that initiated the send
+    // instead of whatever tab is active when this is called - it is read
+    // after prepare() so cloud ids it resolves are fresh, but must still
+    // describe the pre-await originating tab, not a later switch. See
+    // TurnOrigin for why "no origin tab" is a value rather than an omission.
+    current(origin?: TurnOrigin): WorkflowTurnContext | undefined
     adopted(workflowId: string, sent: WorkflowTurnContext | undefined): void
     prepare?(): Promise<void>
-    tabs?(originTabPath?: string): OpenTabsSnapshot | undefined
+    tabs?(origin?: TurnOrigin): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
-    draft?(originTabPath?: string): DraftSnapshot | undefined
+    draft?(origin?: TurnOrigin): DraftSnapshot | undefined
   }
 }
 
@@ -202,7 +219,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
     // pending must not reattribute this send to the newly active tab. The id
     // lookups themselves stay post-await (prepare() is what warms them), but
     // pinned to this originating path rather than whatever is active later.
-    const originTabPath = workflow?.current()?.tabPath
+    // A send that starts with no origin tab must stay that way: `null` is not
+    // "resolve the active tab", or re-attaching during prepare() reattributes
+    // the turn to the tab selected afterwards.
+    const originContext = workflow?.current()
+    const origin: TurnOrigin =
+      originContext === undefined ? null : { tabPath: originContext.tabPath }
     // The ack does not say whether the server minted a workflow or echoed
     // the thread's existing one; an unbound tab may only adopt an id the
     // session was not already bound to before this turn.
@@ -212,10 +234,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
         workflow.prepare().catch(() => undefined),
         new Promise<void>((resolve) => setTimeout(resolve, PREPARE_TIMEOUT_MS))
       ])
-    const wfContext = workflow?.current(originTabPath)
-    const tabs = workflow?.tabs?.(originTabPath)
+    const wfContext = workflow?.current(origin)
+    const tabs = workflow?.tabs?.(origin)
     async function postTurn(threadId: string) {
-      const draft = workflow?.draft?.(originTabPath)
+      const draft = workflow?.draft?.(origin)
       // An unsaved tab now yields a context carrying only its tabPath, so a
       // merely-defined wfContext no longer implies the tab has a workflow the
       // thread could own. An existing thread takes a draft only from a tab

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -35,6 +35,8 @@ interface SentTag {
 export interface WorkflowTurnContext {
   id?: string
   tabPath: string
+  instanceId?: string
+  isTemporary?: boolean
 }
 
 /**
@@ -45,13 +47,14 @@ export interface WorkflowTurnContext {
  *   send, where there is nothing to pin to.
  * - `null`: the send had no origin tab at all (panel detached, or no workflow
  *   open when it started).
- * - `{ tabPath }`: pin resolution to that tab.
+ * - `{ tabPath, instanceId? }`: pin resolution to that tab, using its stable
+ *   instance identity when the workflow host provides one.
  *
  * Collapsing `null` into the omitted case is what lets a detached send pick up
  * whichever tab the user selects during prepare(), i.e. exactly the late
  * binding this pin exists to remove.
  */
-export type TurnOrigin = { tabPath: string } | null
+export type TurnOrigin = { tabPath: string; instanceId?: string } | null
 
 type PromptEditState =
   | { phase: 'idle' }
@@ -224,7 +227,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
     // the turn to the tab selected afterwards.
     const originContext = workflow?.current()
     const origin: TurnOrigin =
-      originContext === undefined ? null : { tabPath: originContext.tabPath }
+      originContext === undefined
+        ? null
+        : {
+            tabPath: originContext.tabPath,
+            instanceId: originContext.instanceId
+          }
     // The ack does not say whether the server minted a workflow or echoed
     // the thread's existing one; an unbound tab may only adopt an id the
     // session was not already bound to before this turn.


### PR DESCRIPTION
Pins send/adoption identity to `ComfyWorkflow.instanceId`; closed, replaced, renamed, rebound, and unresolved saved tabs cannot inherit an ack binding.

This is now the behavioral consolidation endpoint for #16840: it includes stable instance identity plus #16840's later spinner-attribution and saved `.app.json` fixes. No prerequisite landing order remains.

<details><summary>Full context for agent readers</summary>

This PR now covers the complete frontend tab-attribution/adoption hardening:

- Resolve a turn's origin from the still-open workflow instance, not `workflowLookup` or a reusable path.
- Revalidate the instance and its current binding at ack time.
- Adopt only into a tab that was temporary and unbound when sent and remains unbound when acked.
- Keep existing bindings stable rather than blindly rewriting them at ack.
- Rearm the editing spinner only when the acknowledged turn resolves to a real workflow.
- Resolve saved app workflows by their cloud `.app.json` name.

The branch originally diverged from #16840 before its final two fixes. Commits `ddafe69e2` and `9a07daf35` restore those fixes without giving up stable `instanceId` adoption, making this head the behavioral superset rather than a follow-up that must land second.

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/AgentPanelRoot.test.ts src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts` — 183 passed.
- `pnpm typecheck` — passed.
- Scoped ESLint and `oxfmt --check` — passed.
- Local integration with #16901's workflow-aware result settlement — 211 focused tests and typecheck passed.

</details>

<!-- authored-by:agent lane-shep-26-2356 -->

<!-- authored-by:agent lane-prhyg-22-0103 -->
