### PR TITLE
[backport cloud/1.53] fix: retain execution errors received before prompt responses

### DIFF
--- a/browser_tests/fixtures/helpers/ExecutionHelper.ts
+++ b/browser_tests/fixtures/helpers/ExecutionHelper.ts
@@ -14,6 +14,7 @@ const PROMPT_ROUTE_PATTERN = /\/api\/prompt$/
 type RunOptions = {
   nodeErrors?: Record<string, NodeError>
   onPromptRequest?: (requestBody: unknown) => void | Promise<void>
+  beforePromptResponse?: (jobId: string) => void | Promise<void>
 }
 
 /**
@@ -77,7 +78,7 @@ export class ExecutionHelper {
    */
   async run(options: RunOptions = {}): Promise<string> {
     const jobId = `test-job-${++this.jobCounter}`
-    const { nodeErrors = {}, onPromptRequest } = options
+    const { nodeErrors = {}, onPromptRequest, beforePromptResponse } = options
 
     let fulfilled!: () => void
     const prompted = new Promise<void>((r) => {
@@ -88,6 +89,7 @@ export class ExecutionHelper {
       PROMPT_ROUTE_PATTERN,
       async (route) => {
         await onPromptRequest?.(route.request().postDataJSON())
+        await beforePromptResponse?.(jobId)
         await route.fulfill({
           status: 200,
           contentType: 'application/json',

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -1,9 +1,15 @@
+import { mergeTests } from '@playwright/test'
+
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const webSocketTest = mergeTests(test, webSocketFixture)
 
 test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -53,3 +59,44 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
     await expect(runtimePanel).toContainText('Error log')
   })
 })
+
+webSocketTest.describe(
+  'Errors tab - early execution errors',
+  { tag: '@ui' },
+  () => {
+    webSocketTest(
+      'Should surface an execution error received before the prompt response',
+      async ({ comfyPage, getWebSocket }) => {
+        await comfyPage.settings.setSetting(
+          'Comfy.RightSidePanel.ShowErrorsTab',
+          true
+        )
+        await comfyPage.workflow.loadWorkflow('nodes/execution_error')
+        const execution = new ExecutionHelper(comfyPage, await getWebSocket())
+        const errorReceived = comfyPage.page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              window.app!.api.addEventListener(
+                'execution_error',
+                () => resolve(),
+                {
+                  once: true
+                }
+              )
+            })
+        )
+
+        await execution.run({
+          beforePromptResponse: async (jobId) => {
+            execution.executionError(jobId, '17', 'Early execution failure')
+            await errorReceived
+          }
+        })
+
+        await expect(
+          comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
+        ).toBeVisible()
+      }
+    )
+  }
+)

--- a/browser_tests/tests/topbar/workflowTabStatus.spec.ts
+++ b/browser_tests/tests/topbar/workflowTabStatus.spec.ts
@@ -81,12 +81,7 @@ test.describe('Workflow tab status indicator', () => {
 
     exec.executionError(jobId, KSAMPLER_NODE, 'boom')
 
-    // The error opens a modal dialog that aria-hides the rest of the app
-    // (focus trap), taking the tab out of the accessibility tree. Dismiss it
-    // so the badge is reachable by role.
     const errorDialog = comfyPage.page.getByTestId(TestIds.dialogs.errorDialog)
-    await expect(errorDialog).toBeVisible()
-    await comfyPage.page.keyboard.press('Escape')
     await expect(errorDialog).toBeHidden()
 
     await expect(

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -385,11 +385,9 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
 
       const ws = await getWebSocket()
       const exec = new ExecutionHelper(comfyPage, ws)
-      exec.executionError(
-        'mocked-prompt',
-        INNER_EXECUTION_ID,
-        'boom inside the subgraph'
-      )
+      const jobId = await exec.run()
+      await comfyPage.nextFrame()
+      exec.executionError(jobId, INNER_EXECUTION_ID, 'boom inside the subgraph')
 
       await expect(innerWrapper).toHaveClass(ERROR_CLASS)
     })

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1712,6 +1712,26 @@ describe('useWorkflowService', () => {
     })
   })
 
+  describe('duplicateWorkflow', () => {
+    it('opens a distinct temporary workflow when duplicating repeatedly', async () => {
+      const workflowStore = useWorkflowStore()
+      const source = createModeTestWorkflow({
+        path: 'workflows/source.json'
+      })
+      source.changeTracker.activeState = makeWorkflowData()
+      workflowStore.createNewTemporary('source (Copy).json', makeWorkflowData())
+
+      await useWorkflowService().duplicateWorkflow(source)
+
+      expect(app.loadGraphData).toHaveBeenCalledWith(
+        expect.objectContaining({ id: expect.any(String) }),
+        true,
+        true,
+        expect.objectContaining({ path: 'workflows/source (Copy) (2).json' })
+      )
+    })
+  })
+
   describe('afterLoadNewGraph', () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>
     let existingWorkflow: LoadedComfyWorkflow

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -44,10 +44,28 @@ import {
   generateUUID
 } from '@/utils/formatUtil'
 import type { AppMode } from '@/utils/appMode'
+import type { UUID } from '@/utils/uuid'
+import { ensureNonZeroUuid } from '@/utils/uuid'
 
 function linearModeToAppMode(linearMode: unknown): AppMode | null {
   if (typeof linearMode !== 'boolean') return null
   return linearMode ? 'app' : 'graph'
+}
+
+/**
+ * Returns the root graph id to scope run errors by, minting one when the graph
+ * carries the zero id. `loadApiJson` and `importA1111` populate the root graph
+ * without `configure()`, so every such import would otherwise share the zero
+ * id's bucket and lose it once a reload generated a real id. The id is written
+ * back into `workflowData` so the state this load persists reloads under the
+ * same key.
+ */
+function adoptRootGraphId(workflowData: ComfyWorkflowJSON): UUID | null {
+  if (!app.isGraphReady) return null
+
+  const rootGraph = app.rootGraph
+  workflowData.id = ensureNonZeroUuid(rootGraph)
+  return workflowData.id
 }
 
 // TRANSITIONAL (decision log D14): deletable when ECS scopes workflow
@@ -642,6 +660,11 @@ export const useWorkflowService = () => {
     const workflowStore = useWorkspaceStore().workflow
     const { isAppMode } = useAppMode()
     const wasAppMode = isAppMode.value
+    const rootGraphId = adoptRootGraphId(workflowData)
+
+    function activateRunErrors(workflow: ComfyWorkflow) {
+      useExecutionErrorStore().setActiveGraph(rootGraphId, workflow.path)
+    }
 
     // Determine the initial app mode for fresh loads from serialized state.
     // null means linearMode was never explicitly set (not builder-saved).
@@ -672,11 +695,12 @@ export const useWorkflowService = () => {
         const isSameActiveWorkflowLoad =
           !!existingWorkflow &&
           workflowStore.isActive(existingWorkflow) &&
-          areWorkflowIdsEquivalent(
-            existingId,
-            workflowData.id,
-            existingWorkflow.legacyId
-          )
+          (existingWorkflow.isTemporary ||
+            areWorkflowIdsEquivalent(
+              existingId,
+              workflowData.id,
+              existingWorkflow.legacyId
+            ))
 
         if (
           existingWorkflow &&
@@ -685,6 +709,7 @@ export const useWorkflowService = () => {
         ) {
           const loadedWorkflow =
             await workflowStore.openWorkflow(existingWorkflow)
+          activateRunErrors(loadedWorkflow)
           if (loadedWorkflow.initialMode === undefined) {
             // Prefer the file's linearMode over the draft's since the file
             // is the authoritative saved state.
@@ -715,11 +740,13 @@ export const useWorkflowService = () => {
         tempWorkflow.shareId = shareId
       }
       trackIfEnteringApp(tempWorkflow)
-      await workflowStore.openWorkflow(tempWorkflow)
+      const loadedWorkflow = await workflowStore.openWorkflow(tempWorkflow)
+      activateRunErrors(loadedWorkflow)
       return
     }
 
     const loadedWorkflow = await workflowStore.openWorkflow(value)
+    activateRunErrors(loadedWorkflow)
     if (shareId) {
       loadedWorkflow.shareId = shareId
     }
@@ -776,9 +803,13 @@ export const useWorkflowService = () => {
     const suffix = workflow.isPersisted ? ' (Copy)' : ''
     // Remove the suffix `(2)` or similar
     const filename = workflow.filename.replace(/\s*\(\d+\)$/, '') + suffix
+    const duplicate = workflowStore.createNewTemporary(
+      appendJsonExt(filename),
+      state
+    )
 
     await queueWorkflowLoad(() =>
-      app.loadGraphData(state, true, true, filename)
+      app.loadGraphData(state, true, true, duplicate)
     )
   }
 

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -4,6 +4,7 @@ import type { CurveData } from '@/components/curve/types'
 import { t } from '@/i18n'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type { SerialisableGraph } from '@/lib/litegraph/src/types/serialisation'
 import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
@@ -53,6 +54,7 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { extractFilesFromDragEvent } from '@/utils/eventUtils'
+import { zeroUuid } from '@/utils/uuid'
 import type { importA1111 } from './pnginfo'
 
 type WorkflowService = ReturnType<typeof useWorkflowService>
@@ -97,13 +99,17 @@ const {
     setOutputFromLegacy: vi.fn(),
     removeOutputFromLegacy: vi.fn(),
     resetAllOutputsAndPreviews: vi.fn(),
+    snapshotOutputs: vi.fn(),
+    restoreOutputs: vi.fn(),
     stashPreviewsForWorkflow: vi.fn(),
     restorePreviewsForWorkflow: vi.fn(),
     discardPreviewsForWorkflow: vi.fn()
   },
   mockSubgraphNavigationStore: {
     saveCurrentViewport: vi.fn(),
-    updateHash: vi.fn()
+    updateHash: vi.fn(),
+    exportState: vi.fn(() => []),
+    restoreState: vi.fn()
   },
   mockTeamWorkspaceStore: {
     activeWorkspaceId: 'workspace-a' as string | null,
@@ -114,7 +120,10 @@ const {
     activeWorkflow: null as ComfyWorkflow | null,
     createNewTemporary: vi.fn(),
     openWorkflow: vi.fn(),
-    getWorkflowByPath: vi.fn(() => null)
+    getWorkflowByPath: vi.fn<(path: string) => ComfyWorkflow | null>(
+      () => null
+    ),
+    isActive: vi.fn<(workflow: ComfyWorkflow) => boolean>(() => false)
   },
   mockRefreshMissingModelPipeline: vi.fn(),
   mockImportA1111: vi.fn<typeof importA1111>(),
@@ -979,6 +988,43 @@ describe('ComfyApp', () => {
       }
     })
 
+    it('records a rejected submission on the workflow that queued it', async () => {
+      prepareEmptyPromptQueue()
+      const executionErrorStore = useExecutionErrorStore()
+      const queuedRunErrorKey = executionErrorStore.captureRunErrorKey()
+      const recordPromptError = vi.spyOn(
+        executionErrorStore,
+        'recordPromptError'
+      )
+      let rejectQueue: (error: PromptExecutionError) => void = () => {}
+      vi.spyOn(api, 'queuePrompt').mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            rejectQueue = reject
+          })
+      )
+
+      const submission = app.queuePrompt(0)
+      await vi.waitFor(() => expect(api.queuePrompt).toHaveBeenCalledOnce())
+      executionErrorStore.setActiveGraph('22222222-2222-4222-8222-222222222222')
+      rejectQueue(
+        new PromptExecutionError({
+          error: {
+            type: 'prompt_no_outputs',
+            message: 'Prompt has no outputs',
+            details: ''
+          }
+        })
+      )
+
+      await expect(submission).resolves.toBe(true)
+      expect(recordPromptError).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'prompt_no_outputs' }),
+        queuedRunErrorKey
+      )
+      expect(executionErrorStore.lastPromptError).toBeNull()
+    })
+
     it('tracks prompt construction failures at the submission stage', async () => {
       prepareEmptyPromptQueue()
       const trackExecutionOutcome = vi.fn()
@@ -1759,6 +1805,234 @@ describe('ComfyApp', () => {
 
       expect(missingNodesStore.missingNodesError).toBeNull()
       expect(executionErrorStore.lastExecutionError).toBeNull()
+    })
+
+    it('records run errors after clearing the current workflow', () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const executionErrorStore = useExecutionErrorStore()
+
+      app.clean()
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'after-clear',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
+
+      expect(executionErrorStore.lastExecutionError?.prompt_id).toBe(
+        'after-clear'
+      )
+    })
+  })
+
+  describe('workflow tab switching', () => {
+    const workflowAId = '11111111-1111-4111-8111-111111111111'
+    const workflowBId = '22222222-2222-4222-8222-222222222222'
+
+    const failedKSamplerErrors: Record<string, NodeError> = {
+      '1': {
+        errors: [
+          {
+            type: 'value_bigger_than_max',
+            message: 'Value 200 bigger than max of 100',
+            details: 'steps',
+            extra_info: { input_name: 'steps' }
+          }
+        ],
+        dependent_outputs: [],
+        class_type: 'KSampler'
+      }
+    }
+
+    function workflowGraphData(id: string): ComfyWorkflowJSON {
+      return { ...createWorkflowGraphData(), id }
+    }
+
+    function serialisedGraph(id: string): SerialisableGraph {
+      return {
+        id,
+        revision: 0,
+        version: 1,
+        state: {
+          lastGroupId: 0,
+          lastNodeId: 0,
+          lastLinkId: 0,
+          lastRerouteId: 0
+        },
+        nodes: [],
+        links: []
+      }
+    }
+
+    async function switchToWorkflow(
+      workflowService: WorkflowService,
+      graph: LGraph,
+      workflow: ComfyWorkflow,
+      workflowId: string
+    ) {
+      workflowService.beforeLoadNewGraph()
+      app.clean()
+      graph.configure(serialisedGraph(workflowId))
+      await workflowService.afterLoadNewGraph(
+        workflow,
+        workflowGraphData(workflowId)
+      )
+    }
+
+    it('does not open the visible workflow overlay for a background run error', () => {
+      const workflowA = markLoaded(
+        new ComfyWorkflow({ path: 'workflows/a.json', modified: 0, size: 0 })
+      )
+      const workflowB = markLoaded(
+        new ComfyWorkflow({ path: 'workflows/b.json', modified: 0, size: 0 })
+      )
+      workflowA.changeTracker.activeState = workflowGraphData(workflowAId)
+      workflowB.changeTracker.activeState = workflowGraphData(workflowBId)
+
+      useExecutionStore().storeJob({
+        nodes: ['1'],
+        id: 'job-b',
+        promptOutput: {},
+        workflow: workflowB
+      })
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.setActiveGraph(workflowAId, workflowA.path)
+
+      const addEventListener = vi.spyOn(api, 'addEventListener')
+      Reflect.apply(Reflect.get(app, 'addApiUpdateHandlers'), app, [])
+      const executionErrorHandler = addEventListener.mock.calls.find(
+        ([event]) => event === 'execution_error'
+      )?.[1] as EventListener | undefined
+
+      executionErrorHandler?.(
+        new CustomEvent('execution_error', {
+          detail: {
+            prompt_id: 'job-b',
+            node_id: '1',
+            node_type: 'TestNode',
+            exception_message: 'boom',
+            exception_type: 'RuntimeError',
+            traceback: []
+          }
+        })
+      )
+
+      expect(executionErrorHandler).toBeTypeOf('function')
+      expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
+    })
+
+    it('restores the failed run state when returning to a workflow tab', async () => {
+      const workflowService = await useRealWorkflowService()
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+
+      const workflowA = markLoaded(
+        new ComfyWorkflow({ path: 'workflows/a.json', modified: 0, size: 0 })
+      )
+      const workflowB = markLoaded(
+        new ComfyWorkflow({ path: 'workflows/b.json', modified: 0, size: 0 })
+      )
+      await switchToWorkflow(workflowService, graph, workflowA, workflowAId)
+
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.recordNodeErrors(failedKSamplerErrors)
+      expect(executionErrorStore.totalErrorCount).toBe(1)
+
+      await switchToWorkflow(workflowService, graph, workflowB, workflowBId)
+
+      expect(executionErrorStore.lastNodeErrors).toBeNull()
+      expect(executionErrorStore.totalErrorCount).toBe(0)
+
+      await switchToWorkflow(workflowService, graph, workflowA, workflowAId)
+
+      expect(executionErrorStore.lastNodeErrors).toEqual(failedKSamplerErrors)
+      expect(executionErrorStore.totalErrorCount).toBe(1)
+    })
+
+    it('gives each imported workflow its own restorable run errors', async () => {
+      const workflowService = await useRealWorkflowService()
+      const workflowStore = useWorkflowStore()
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      singletonApp.canvas = mockCanvas
+      Reflect.set(mockCanvas, 'ds', { scale: 1, offset: [0, 0] })
+      mockWorkspaceWorkflow.createNewTemporary.mockImplementation(
+        workflowStore.createNewTemporary
+      )
+      mockWorkspaceWorkflow.getWorkflowByPath.mockImplementation(
+        workflowStore.getWorkflowByPath
+      )
+      mockWorkspaceWorkflow.isActive.mockImplementation(workflowStore.isActive)
+      mockWorkspaceWorkflow.openWorkflow.mockImplementation(
+        async (workflow) => {
+          const loadedWorkflow = await workflowStore.openWorkflow(workflow)
+          mockWorkspaceWorkflow.activeWorkflow = loadedWorkflow
+          return loadedWorkflow
+        }
+      )
+
+      await app.loadApiJson({}, 'api-a')
+      const importedA = mockWorkspaceWorkflow.activeWorkflow
+      const importedAId = importedA?.activeState?.id
+      if (!importedA || !importedAId) {
+        throw new Error('Expected the first imported workflow to have an id')
+      }
+      expect(importedAId).not.toBe(zeroUuid)
+      expect(importedAId).toBe(graph.id)
+
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.recordNodeErrors(failedKSamplerErrors)
+
+      await app.loadApiJson({}, 'api-b')
+      const importedBId = mockWorkspaceWorkflow.activeWorkflow?.activeState?.id
+      expect(importedBId).not.toBe(zeroUuid)
+      expect(importedBId).not.toBe(importedAId)
+      expect(executionErrorStore.lastNodeErrors).toBeNull()
+
+      await switchToWorkflow(workflowService, graph, importedA, importedAId)
+
+      expect(executionErrorStore.lastNodeErrors).toEqual(failedKSamplerErrors)
+    })
+
+    it('reuses the active workflow when importing the same file again', async () => {
+      await useRealWorkflowService()
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const importedWorkflow = markLoaded(
+        new ComfyWorkflow({
+          path: 'workflows/repeat.json',
+          modified: 0,
+          size: -1
+        })
+      )
+      mockWorkspaceWorkflow.createNewTemporary.mockImplementation(
+        (_path, workflowData) => {
+          if (workflowData) {
+            importedWorkflow.changeTracker.activeState = workflowData
+          }
+          return importedWorkflow
+        }
+      )
+      mockWorkspaceWorkflow.getWorkflowByPath.mockImplementation(
+        () => mockWorkspaceWorkflow.activeWorkflow
+      )
+      mockWorkspaceWorkflow.isActive.mockImplementation(
+        (workflow) => mockWorkspaceWorkflow.activeWorkflow === workflow
+      )
+
+      await app.loadApiJson({}, 'repeat')
+      const activeWorkflow = mockWorkspaceWorkflow.activeWorkflow
+      await app.loadApiJson({}, 'repeat')
+
+      expect(mockWorkspaceWorkflow.activeWorkflow).toBe(activeWorkflow)
     })
   })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -125,6 +125,7 @@ import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 
 import { getWorkflowMode } from '@/utils/appMode'
 import { anyItemOverlapsRect } from '@/utils/mathUtil'
+import { ensureNonZeroUuid } from '@/utils/uuid'
 import {
   collectAllNodes,
   forEachNode,
@@ -876,6 +877,8 @@ export class ComfyApp {
     })
 
     api.addEventListener('execution_error', ({ detail }) => {
+      const isActiveWorkflowError =
+        useExecutionStore().isJobErrorForActiveWorkflow(detail.prompt_id)
       const precondition = resolveAccountPrecondition({
         exceptionType: detail.exception_type ?? '',
         exceptionMessage: detail.exception_message ?? ''
@@ -884,10 +887,12 @@ export class ComfyApp {
         useAccountPreconditionDialog().open(precondition, {
           nodeType: detail.node_type
         })
-      } else if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
-        useExecutionErrorStore().showErrorOverlay()
-      } else {
-        useDialogService().showExecutionErrorDialog(detail)
+      } else if (isActiveWorkflowError) {
+        if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
+          useExecutionErrorStore().showErrorOverlay()
+        } else {
+          useDialogService().showExecutionErrorDialog(detail)
+        }
       }
       this.canvas.draw(true, true)
     })
@@ -1767,6 +1772,7 @@ export class ComfyApp {
           // user switches tabs while the request is in flight.
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
+          const queuedRunErrorKey = executionErrorStore.captureRunErrorKey()
           const startTime = performance.now()
           const p = await this.graphToPrompt(this.rootGraph).catch(
             (error: unknown) => {
@@ -1825,7 +1831,10 @@ export class ComfyApp {
                 ...(workflowContext && { workflowContext })
               })
             }
-            executionErrorStore.recordNodeErrors(res.node_errors ?? null)
+            executionErrorStore.recordNodeErrors(
+              res.node_errors ?? null,
+              queuedRunErrorKey
+            )
             queueResultOverride = null
             try {
               if (res.prompt_id) {
@@ -1936,15 +1945,21 @@ export class ComfyApp {
               // Keep the legacy result before empty node errors are normalized.
               const nodeErrors = error.response.node_errors
               queueResultOverride = !nodeErrors
-              executionErrorStore.recordNodeErrors(nodeErrors ?? null)
+              executionErrorStore.recordNodeErrors(
+                nodeErrors ?? null,
+                queuedRunErrorKey
+              )
 
               // Store prompt-level error separately only when no node-specific errors exist,
               // because node errors already carry the full context. Prompt-level errors
               // (e.g. prompt_no_outputs, no_prompt) lack node IDs and need their own path.
-              if (!executionErrorStore.hasNodeError) {
+              if (!nodeErrors || Object.keys(nodeErrors).length === 0) {
                 const promptError = normalizePromptError(error.response.error)
                 if (promptError) {
-                  executionErrorStore.recordPromptError(promptError)
+                  executionErrorStore.recordPromptError(
+                    promptError,
+                    queuedRunErrorKey
+                  )
                 }
               }
 
@@ -2562,7 +2577,7 @@ export class ComfyApp {
     const nodeOutputStore = useNodeOutputStore()
     nodeOutputStore.resetAllOutputsAndPreviews()
     const executionErrorStore = useExecutionErrorStore()
-    executionErrorStore.clearRunErrors()
+    executionErrorStore.setActiveGraph(null)
     useMissingNodesErrorStore().setMissingNodeTypes([])
 
     useDomWidgetStore().clear()
@@ -2571,7 +2586,10 @@ export class ComfyApp {
     // (`LGraph`) `clear` breaks the subgraph structure.
     if (this.rootGraph && !this.canvas.subgraph) {
       this.rootGraph.clear()
+      ensureNonZeroUuid(this.rootGraph)
     }
+
+    executionErrorStore.setActiveGraph(this.rootGraph?.id ?? null)
   }
 
   clientPosToCanvasPos(pos: Vector2): Vector2 {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -877,8 +877,6 @@ export class ComfyApp {
     })
 
     api.addEventListener('execution_error', ({ detail }) => {
-      const isActiveWorkflowError =
-        useExecutionStore().isJobErrorForActiveWorkflow(detail.prompt_id)
       const precondition = resolveAccountPrecondition({
         exceptionType: detail.exception_type ?? '',
         exceptionMessage: detail.exception_message ?? ''
@@ -887,12 +885,6 @@ export class ComfyApp {
         useAccountPreconditionDialog().open(precondition, {
           nodeType: detail.node_type
         })
-      } else if (isActiveWorkflowError) {
-        if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
-          useExecutionErrorStore().showErrorOverlay()
-        } else {
-          useDialogService().showExecutionErrorDialog(detail)
-        }
       }
       this.canvas.draw(true, true)
     })

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -1,4 +1,5 @@
 import { fromAny } from '@total-typescript/shoehorn'
+import { createTestingPinia } from '@pinia/testing'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -900,5 +901,146 @@ describe('added-node error scan coordination', () => {
 
     finishOtherGraph()
     expect(store.hasPendingAddedNodeErrorScan(graphB, executionId)).toBe(false)
+  })
+})
+
+describe('setActiveGraph', () => {
+  const graphAId = '11111111-1111-4111-8111-111111111111'
+  const graphBId = '22222222-2222-4222-8222-222222222222'
+
+  const nodeErrors = {
+    '1': nodeError(
+      [validationError('value_bigger_than_max', 'steps', {}, 'Too big', '')],
+      'KSampler'
+    )
+  }
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('keeps each graph run errors separate and restores them on return', () => {
+    const store = useExecutionErrorStore()
+    const executionError = {
+      prompt_id: 'graph-a-run',
+      timestamp: 0,
+      node_id: '1',
+      node_type: 'KSampler',
+      executed: [],
+      exception_message: 'fail',
+      exception_type: 'RuntimeError',
+      traceback: []
+    }
+    const promptError = {
+      type: 'execution',
+      message: 'prompt failed',
+      details: ''
+    }
+
+    store.setActiveGraph(graphAId)
+    store.recordNodeErrors(nodeErrors)
+    store.recordExecutionError(executionError)
+    store.recordPromptError(promptError)
+
+    store.setActiveGraph(graphBId)
+    expect(store.lastNodeErrors).toBeNull()
+    expect(store.lastExecutionError).toBeNull()
+    expect(store.lastPromptError).toBeNull()
+    expect(store.totalErrorCount).toBe(0)
+
+    store.setActiveGraph(graphAId)
+    expect(store.lastNodeErrors).toEqual(nodeErrors)
+    expect(store.lastExecutionError).toEqual(executionError)
+    expect(store.lastPromptError).toEqual(promptError)
+    expect(store.totalErrorCount).toBe(3)
+  })
+
+  it('keeps workflows with the same graph id separate', () => {
+    const store = useExecutionErrorStore()
+
+    store.setActiveGraph(graphAId, 'workflows/a.json')
+    store.recordNodeErrors(nodeErrors)
+
+    store.setActiveGraph(graphAId, 'workflows/b.json')
+    expect(store.lastNodeErrors).toBeNull()
+
+    store.setActiveGraph(graphAId, 'workflows/a.json')
+    expect(store.lastNodeErrors).toEqual(nodeErrors)
+  })
+
+  it('hides run errors while detached from a graph', () => {
+    const store = useExecutionErrorStore()
+
+    store.setActiveGraph(graphAId)
+    store.recordNodeErrors(nodeErrors)
+
+    store.setActiveGraph(null)
+    expect(store.lastNodeErrors).toBeNull()
+    expect(store.hasAnyError).toBe(false)
+
+    store.setActiveGraph(graphAId)
+    expect(store.lastNodeErrors).toEqual(nodeErrors)
+  })
+
+  it('drops run errors on new runs without touching other graphs', () => {
+    const store = useExecutionErrorStore()
+
+    store.setActiveGraph(graphAId)
+    store.recordNodeErrors(nodeErrors)
+
+    store.setActiveGraph(graphBId)
+    store.clearRunErrors()
+
+    store.setActiveGraph(graphAId)
+    expect(store.lastNodeErrors).toEqual(nodeErrors)
+
+    store.clearRunErrors()
+    expect(store.lastNodeErrors).toBeNull()
+  })
+
+  it('prunes a bucket when its last error is cleared', () => {
+    const store = useExecutionErrorStore()
+    const promptError = {
+      type: 'execution',
+      message: 'prompt failed',
+      details: ''
+    }
+
+    store.setActiveGraph(graphAId)
+    store.recordPromptError(promptError)
+    expect(store.lastPromptError).toEqual(promptError)
+
+    store.clearPromptError()
+    store.setActiveGraph(graphBId)
+    store.setActiveGraph(graphAId)
+
+    expect(store.lastPromptError).toBeNull()
+    expect(store.hasAnyError).toBe(false)
+  })
+
+  it('closes the error overlay when the active graph changes', () => {
+    const store = useExecutionErrorStore()
+
+    store.setActiveGraph(graphAId)
+    store.recordNodeErrors(nodeErrors)
+    store.showErrorOverlay()
+
+    store.setActiveGraph(null)
+    expect(store.isErrorOverlayOpen).toBe(false)
+
+    store.setActiveGraph(graphAId)
+    expect(store.isErrorOverlayOpen).toBe(false)
+  })
+
+  it('ignores errors recorded while no graph is active', () => {
+    const store = useExecutionErrorStore()
+
+    store.setActiveGraph(null)
+    store.recordNodeErrors(nodeErrors)
+
+    expect(store.lastNodeErrors).toBeNull()
+
+    store.setActiveGraph(graphAId)
+    expect(store.lastNodeErrors).toBeNull()
   })
 })

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -31,6 +31,8 @@ import {
   getExecutionIdByNode,
   getNodeByExecutionId
 } from '@/utils/graphTraversalUtil'
+import type { UUID } from '@/utils/uuid'
+import { zeroUuid } from '@/utils/uuid'
 import {
   SIMPLE_ERROR_TYPES,
   errorsForSlot,
@@ -47,6 +49,12 @@ interface SlotNodeErrorClearTarget {
   useRecordedBounds?: boolean
 }
 
+interface RunErrorState {
+  nodeErrors: Record<string, NodeError> | null
+  executionError: ExecutionErrorWsMessage | null
+  promptError: PromptError | null
+}
+
 /** Execution error state: node errors, runtime errors, prompt errors, and missing assets. */
 export const useExecutionErrorStore = defineStore('executionError', () => {
   const workflowStore = useWorkflowStore()
@@ -55,11 +63,69 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   const missingNodesStore = useMissingNodesErrorStore()
   const missingMediaStore = useMissingMediaStore()
 
-  const lastNodeErrors = ref<Record<string, NodeError> | null>(null)
-  const lastExecutionError = ref<ExecutionErrorWsMessage | null>(null)
-  const lastPromptError = ref<PromptError | null>(null)
-
+  /**
+   * Run errors belong to the workflow that produced them, so they are parked
+   * under its path and root graph id and follow that graph back into view
+   * rather than being discarded when another workflow is loaded.
+   */
+  const runErrorsByWorkflow = ref(new Map<string, RunErrorState>())
+  const activeRunErrorKey = ref<string | null>(`:${zeroUuid}`)
   const isErrorOverlayOpen = ref(false)
+
+  const activeRunErrors = computed<RunErrorState | undefined>(() =>
+    activeRunErrorKey.value === null
+      ? undefined
+      : runErrorsByWorkflow.value.get(activeRunErrorKey.value)
+  )
+
+  const lastNodeErrors = computed(
+    () => activeRunErrors.value?.nodeErrors ?? null
+  )
+  const lastExecutionError = computed(
+    () => activeRunErrors.value?.executionError ?? null
+  )
+  const lastPromptError = computed(
+    () => activeRunErrors.value?.promptError ?? null
+  )
+
+  function updateRunErrors(patch: Partial<RunErrorState>, key: string | null) {
+    if (key === null) return
+
+    const next: RunErrorState = {
+      nodeErrors: null,
+      executionError: null,
+      promptError: null,
+      ...runErrorsByWorkflow.value.get(key),
+      ...patch
+    }
+
+    if (Object.values(next).every((value) => value === null)) {
+      runErrorsByWorkflow.value.delete(key)
+    } else {
+      runErrorsByWorkflow.value.set(key, next)
+    }
+  }
+
+  function runErrorKey(graphId: UUID, workflowPath?: string) {
+    return `${workflowPath ?? workflowStore.activeWorkflow?.path ?? ''}:${graphId}`
+  }
+
+  function captureRunErrorKey() {
+    return activeRunErrorKey.value
+  }
+
+  /**
+   * Point the store at the run errors of `graphId`. `null` detaches it, so a
+   * discarded graph shows nothing until the next one is loaded. The overlay is
+   * dismissed on every move so it only ever reopens for the graph in front.
+   */
+  function setActiveGraph(graphId: UUID | null, workflowPath?: string) {
+    const key = graphId === null ? null : runErrorKey(graphId, workflowPath)
+    if (key === activeRunErrorKey.value) return
+    activeRunErrorKey.value = key
+    isErrorOverlayOpen.value = false
+  }
+
   const pendingAddedNodeScans = new WeakMap<
     LGraph,
     Map<NodeExecutionId, number>
@@ -96,18 +162,39 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     return (pendingAddedNodeScans.get(rootGraph)?.get(executionId) ?? 0) > 0
   }
 
-  /** Replaces the full record; empty or null means the run produced no errors. */
-  function recordNodeErrors(nodeErrors: Record<string, NodeError> | null) {
-    lastNodeErrors.value =
-      nodeErrors && Object.keys(nodeErrors).length > 0 ? nodeErrors : null
+  /**
+   * Replaces the full record; empty or null means the run produced no errors.
+   *
+   * `key` files the errors against the workflow that produced them, which is
+   * not necessarily the one on screen. Build it with `runErrorKey`. It defaults
+   * to the visible workflow for callers that record synchronously while
+   * submitting it.
+   */
+  function recordNodeErrors(
+    nodeErrors: Record<string, NodeError> | null,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors(
+      {
+        nodeErrors:
+          nodeErrors && Object.keys(nodeErrors).length > 0 ? nodeErrors : null
+      },
+      key
+    )
   }
 
-  function recordExecutionError(detail: ExecutionErrorWsMessage) {
-    lastExecutionError.value = detail
+  function recordExecutionError(
+    detail: ExecutionErrorWsMessage,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors({ executionError: detail }, key)
   }
 
-  function recordPromptError(promptError: PromptError) {
-    lastPromptError.value = promptError
+  function recordPromptError(
+    promptError: PromptError,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors({ promptError }, key)
   }
 
   function showErrorOverlay() {
@@ -122,23 +209,24 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
    *  loaded graph rather than the run, so only replacing or discarding the
    *  graph invalidates it. */
   function clearRunErrors() {
-    lastExecutionError.value = null
-    lastPromptError.value = null
-    lastNodeErrors.value = null
+    if (activeRunErrorKey.value !== null) {
+      runErrorsByWorkflow.value.delete(activeRunErrorKey.value)
+    }
     isErrorOverlayOpen.value = false
   }
 
-  function clearExecutionStartErrors() {
-    lastExecutionError.value = null
-    lastPromptError.value = null
-    if (!lastNodeErrors.value) {
+  function clearExecutionStartErrors(
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors({ executionError: null, promptError: null }, key)
+    if (key === activeRunErrorKey.value && !lastNodeErrors.value) {
       isErrorOverlayOpen.value = false
     }
   }
 
   /** Clear only prompt-level errors. Called during resetExecutionState. */
-  function clearPromptError() {
-    lastPromptError.value = null
+  function clearPromptError(key: string | null = activeRunErrorKey.value) {
+    updateRunErrors({ promptError: null }, key)
   }
 
   function clearSimpleNodeErrorsFromRecord(
@@ -288,7 +376,10 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     }
 
     if (updated === lastNodeErrors.value) return
-    lastNodeErrors.value = Object.keys(updated).length > 0 ? updated : null
+    updateRunErrors(
+      { nodeErrors: Object.keys(updated).length > 0 ? updated : null },
+      activeRunErrorKey.value
+    )
   }
 
   /**
@@ -573,14 +664,19 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
 
   return {
     // Read-only state
-    lastNodeErrors: computed(() => lastNodeErrors.value),
-    lastExecutionError: computed(() => lastExecutionError.value),
-    lastPromptError: computed(() => lastPromptError.value),
+    lastNodeErrors,
+    lastExecutionError,
+    lastPromptError,
 
     // Recording
     recordNodeErrors,
     recordExecutionError,
     recordPromptError,
+
+    // Workflow scoping
+    captureRunErrorKey,
+    runErrorKey,
+    setActiveGraph,
 
     // Clearing
     clearRunErrors,

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -16,6 +16,7 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
+import { useDialogService } from '@/services/dialogService'
 import type {
   ExecutionErrorWsMessage,
   NodeError,
@@ -188,6 +189,19 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     key: string | null = activeRunErrorKey.value
   ) {
     updateRunErrors({ executionError: detail }, key)
+  }
+
+  function showExecutionError(
+    detail: ExecutionErrorWsMessage,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    if (key === null || key !== activeRunErrorKey.value) return
+
+    if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
+      showErrorOverlay()
+    } else {
+      useDialogService().showExecutionErrorDialog(detail)
+    }
   }
 
   function recordPromptError(
@@ -685,6 +699,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
 
     // Overlay UI
     isErrorOverlayOpen,
+    showExecutionError,
     showErrorOverlay,
     dismissErrorOverlay,
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -987,6 +987,197 @@ describe('useExecutionStore - workflowStatus', () => {
   })
 })
 
+describe('useExecutionStore - background workflow error routing', () => {
+  const graphAId = '11111111-1111-4111-8111-111111111111'
+  const graphBId = '22222222-2222-4222-8222-222222222222'
+
+  let store: ReturnType<typeof useExecutionStore>
+  let errorStore: ReturnType<typeof useExecutionErrorStore>
+
+  type Workflow = Parameters<typeof store.storeJob>[0]['workflow']
+  const makeWorkflow = (path: string, graphId: string): Workflow =>
+    ({
+      path,
+      filename: path.split('/').pop(),
+      activeState: { id: graphId },
+      initialState: { id: graphId }
+    }) as Workflow
+
+  const workflowA = makeWorkflow('/workflows/a.json', graphAId)
+  const workflowB = makeWorkflow('/workflows/b.json', graphBId)
+
+  function callStoreJob(jobId: string, workflow: Workflow) {
+    store.storeJob({
+      nodes: ['1'],
+      id: jobId,
+      promptOutput: { '1': createPromptNode('Node', 'TestNode') },
+      startTime: 42,
+      submissionAcceptedAt: 62,
+      workflow
+    })
+  }
+
+  function fireExecutionError(
+    jobId: string,
+    detail: Record<string, unknown> = {}
+  ) {
+    const handler = apiEventHandlers.get('execution_error')
+    if (!handler) throw new Error('execution_error handler not bound')
+    handler(
+      new CustomEvent('execution_error', {
+        detail: {
+          prompt_id: jobId,
+          node_id: '1',
+          node_type: 'TestNode',
+          exception_message: 'boom',
+          exception_type: 'RuntimeError',
+          traceback: [],
+          ...detail
+        }
+      })
+    )
+  }
+
+  function fireExecutionStart(jobId: string) {
+    const handler = apiEventHandlers.get('execution_start')
+    if (!handler) throw new Error('execution_start handler not bound')
+    handler(
+      new CustomEvent('execution_start', { detail: { prompt_id: jobId } })
+    )
+  }
+
+  const cloudValidationMessage = JSON.stringify({
+    error: { type: 'prompt_outputs_failed_validation', message: 'invalid' },
+    node_errors: {
+      '1': {
+        errors: [
+          {
+            type: 'value_bigger_than_max',
+            message: 'Value 200 bigger than max of 100',
+            details: 'steps',
+            extra_info: { input_name: 'steps' }
+          }
+        ],
+        dependent_outputs: [],
+        class_type: 'KSampler'
+      }
+    }
+  })
+
+  beforeEach(() => {
+    apiEventHandlers.clear()
+    mockOpenWorkflows.value = [workflowA, workflowB]
+    store = useExecutionStore()
+    errorStore = useExecutionErrorStore()
+    store.bindExecutionEvents()
+    // Workflow A is the one on screen; workflow B runs in the background.
+    errorStore.setActiveGraph(graphAId, workflowA.path)
+  })
+
+  it('keeps a background run failure off the visible workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+    expect(errorStore.totalErrorCount).toBe(0)
+  })
+
+  it('surfaces the background failure after switching to its workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b')
+
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
+    expect(errorStore.totalErrorCount).toBe(1)
+  })
+
+  it('still records a failure produced by the visible workflow', () => {
+    callStoreJob('job-a', workflowA)
+    fireExecutionError('job-a')
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-a')
+    expect(errorStore.totalErrorCount).toBe(1)
+  })
+
+  it('routes background validation node errors to their own workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b', {
+      exception_message: cloudValidationMessage,
+      exception_type: 'ValidationError'
+    })
+
+    expect(errorStore.lastNodeErrors).toBeNull()
+
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    expect(Object.keys(errorStore.lastNodeErrors ?? {})).toEqual(['1'])
+  })
+
+  it('routes a background service-level error to its own workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b', {
+      node_id: '',
+      exception_message: 'Job has stagnated',
+      exception_type: 'StagnationError'
+    })
+
+    expect(errorStore.lastPromptError).toBeNull()
+
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    expect(errorStore.lastPromptError?.message).toContain('Job has stagnated')
+  })
+
+  it('falls back to the queue-derived workflow id for jobs from a previous page load', () => {
+    // No storeJob: the job predates this session, so only the polled
+    // queue/history mapping identifies its workflow.
+    store.registerJobWorkflowIdMapping('job-b', graphBId)
+    fireExecutionError('job-b')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
+  })
+
+  it('clears execution-start errors only for the producing workflow', () => {
+    errorStore.recordPromptError({
+      type: 'visible-error',
+      message: 'visible workflow failed',
+      details: ''
+    })
+    callStoreJob('job-b', workflowB)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    errorStore.recordPromptError({
+      type: 'background-error',
+      message: 'background workflow failed',
+      details: ''
+    })
+    errorStore.setActiveGraph(graphAId, workflowA.path)
+
+    fireExecutionStart('job-b')
+
+    expect(errorStore.lastPromptError?.type).toBe('visible-error')
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    expect(errorStore.lastPromptError).toBeNull()
+  })
+
+  it('does not route a known ambiguous job to the visible workflow', () => {
+    const duplicateWorkflow = makeWorkflow('/workflows/c.json', graphBId)
+    mockOpenWorkflows.value = [workflowA, workflowB, duplicateWorkflow]
+    store.registerJobWorkflowIdMapping('job-ambiguous', graphBId)
+
+    fireExecutionError('job-ambiguous')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+  })
+
+  it('does not route an unattributable failure to the visible workflow', () => {
+    fireExecutionError('job-unknown')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+  })
+})
+
 describe('useExecutionStore - clearActiveJobIfStale', () => {
   let store: ReturnType<typeof useExecutionStore>
 
@@ -1898,6 +2089,22 @@ describe('useExecutionStore - WebSocket event handlers', () => {
     handler(new CustomEvent(event, { detail }))
   }
 
+  function storeVisibleJob(jobId: string) {
+    const workflow = createQueuedWorkflow()
+    mockActiveWorkflow.value = workflow
+    mockOpenWorkflows.value = [workflow]
+    useExecutionErrorStore().setActiveGraph(
+      workflow.activeState!.id!,
+      workflow.path
+    )
+    store.storeJob({
+      nodes: [],
+      id: jobId,
+      promptOutput: {},
+      workflow
+    })
+  }
+
   beforeEach(() => {
     apiEventHandlers.clear()
     store = useExecutionStore()
@@ -1917,6 +2124,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
     it('clears transient errors while preserving validation errors', () => {
       const errorStore = useExecutionErrorStore()
+      storeVisibleJob('job-1')
       const nodeErrors = {
         '1': {
           class_type: 'Test',
@@ -2220,6 +2428,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
   describe('execution_error', () => {
     it('routes a service-level error (no node_id) to the prompt error store', () => {
       const errorStore = useExecutionErrorStore()
+      storeVisibleJob('job-1')
 
       fire('execution_error', {
         prompt_id: 'job-1',
@@ -2238,6 +2447,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
     it('routes a runtime error (with node_id) to lastExecutionError', () => {
       const errorStore = useExecutionErrorStore()
+      storeVisibleJob('job-1')
 
       fire('execution_error', {
         prompt_id: 'job-1',
@@ -2310,6 +2520,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
     it('still routes an ordinary node runtime error to the error panel', () => {
       const errorStore = useExecutionErrorStore()
+      storeVisibleJob('job-1')
 
       fire('execution_error', {
         prompt_id: 'job-1',

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -128,6 +128,12 @@ vi.mock('@/scripts/api', () => ({
     removeEventListener: vi.fn((event: string) => {
       apiEventHandlers.delete(event)
     }),
+    dispatchCustomEvent: vi.fn((event: string, detail?: unknown) => {
+      const handler = apiEventHandlers.get(event)
+      if (!handler) return false
+      handler(new CustomEvent(event, { detail }))
+      return true
+    }),
     clientId: 'test-client',
     apiURL: vi.fn((path: string) => `/api${path}`)
   }
@@ -603,6 +609,7 @@ describe('useExecutionStore - workflowStatus', () => {
   }
 
   function callStoreJob(jobId: string, workflow: Workflow) {
+    store.registerJobWorkflowIdMapping(jobId, workflow.path)
     store.storeJob({
       nodes: ['1'],
       id: jobId,
@@ -1139,6 +1146,50 @@ describe('useExecutionStore - background workflow error routing', () => {
     expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
   })
 
+  it('resets the active job and flushes its buffered failure after mapping', () => {
+    fireExecutionStart('job-b')
+    fireExecutionError('job-b')
+
+    expect(store.isIdle).toBe(true)
+
+    store.registerJobWorkflowIdMapping('job-b', graphBId)
+
+    expect(errorStore.lastExecutionError).toBeNull()
+
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
+  })
+
+  it('does not replay a buffered failure after execution succeeds', () => {
+    fireExecutionError('job-b')
+    api.dispatchCustomEvent('execution_success', {
+      prompt_id: 'job-b',
+      timestamp: 0
+    })
+
+    store.registerJobWorkflowIdMapping('job-b', graphBId)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+
+    expect(errorStore.lastExecutionError).toBeNull()
+  })
+
+  it('does not replay a buffered failure after execution is interrupted', () => {
+    fireExecutionError('job-b')
+    api.dispatchCustomEvent('execution_interrupted', {
+      prompt_id: 'job-b',
+      timestamp: 0,
+      node_id: '1',
+      node_type: 'TestNode',
+      executed: []
+    })
+
+    store.registerJobWorkflowIdMapping('job-b', graphBId)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+
+    expect(errorStore.lastExecutionError).toBeNull()
+    expect(errorStore.totalErrorCount).toBe(0)
+  })
+
   it('clears execution-start errors only for the producing workflow', () => {
     errorStore.recordPromptError({
       type: 'visible-error',
@@ -1161,7 +1212,7 @@ describe('useExecutionStore - background workflow error routing', () => {
     expect(errorStore.lastPromptError).toBeNull()
   })
 
-  it('does not route a known ambiguous job to the visible workflow', () => {
+  it('buffers a mapped job with an ambiguous path until storeJob', () => {
     const duplicateWorkflow = makeWorkflow('/workflows/c.json', graphBId)
     mockOpenWorkflows.value = [workflowA, workflowB, duplicateWorkflow]
     store.registerJobWorkflowIdMapping('job-ambiguous', graphBId)
@@ -1169,6 +1220,11 @@ describe('useExecutionStore - background workflow error routing', () => {
     fireExecutionError('job-ambiguous')
 
     expect(errorStore.lastExecutionError).toBeNull()
+
+    callStoreJob('job-ambiguous', workflowB)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-ambiguous')
   })
 
   it('does not route an unattributable failure to the visible workflow', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -454,7 +454,6 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleExecutionStart(e: CustomEvent<ExecutionStartWsMessage>) {
     executionIdToLocatorCache.clear()
-    executionErrorStore.clearExecutionStartErrors()
     activeJobId.value = e.detail.prompt_id
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
     clearInitializationByJobId(activeJobId.value)
@@ -465,6 +464,9 @@ export const useExecutionStore = defineStore('execution', () => {
       const path = queuedJobs.value[activeJobId.value]?.workflow?.path
       if (path) ensureSessionWorkflowPath(activeJobId.value, path)
     }
+    executionErrorStore.clearExecutionStartErrors(
+      runErrorKeyForJob(activeJobId.value)
+    )
     queuedJobs.value[activeJobId.value].executionStartedAt ??= performance.now()
     setWorkflowStatus(activeJobId.value, {
       status: 'running',
@@ -636,8 +638,62 @@ export const useExecutionStore = defineStore('execution', () => {
     }
   }
 
+  /**
+   * Queue and history polling supply a workflow id but no path, so the open
+   * workflow carrying that root graph provides it. Two open workflows can share
+   * a root graph id — an imported copy of one already on screen — and those runs
+   * belong to different error buckets, so an ambiguous match resolves to
+   * nothing rather than the wrong workflow.
+   */
+  function openWorkflowPathForGraph(graphId: WorkflowId): string | undefined {
+    const matches = workflowStore.openWorkflows.filter(
+      (w) => (w.activeState?.id ?? w.initialState?.id) === graphId
+    )
+    return matches.length === 1 ? matches[0].path : undefined
+  }
+
+  /**
+   * Run-error key of the workflow that produced `jobId`, for filing its errors
+   * against that workflow rather than whichever one is currently on screen.
+   *
+   * `jobIdToWorkflow` only covers jobs queued by this browser session and is
+   * purged the moment a run ends, so `jobIdToWorkflowId` — also populated from
+   * queue and history polling — backs it up for jobs from a previous page load.
+   *
+   * `null` means the job cannot be attributed to one known workflow, so
+   * recording is suppressed rather than assigning it to whichever workflow is
+   * currently visible.
+   */
+  function runErrorKeyForJob(jobId: string): string | null {
+    const workflow = jobIdToWorkflow.get(jobId)
+    const graphId =
+      workflow?.activeState?.id ??
+      workflow?.initialState?.id ??
+      jobIdToWorkflowId.value.get(jobId)
+    if (graphId === undefined) return null
+
+    const path =
+      workflow?.path ??
+      jobIdToSessionWorkflowPath.value.get(jobId) ??
+      openWorkflowPathForGraph(graphId)
+    if (path === undefined) return null
+
+    return executionErrorStore.runErrorKey(graphId, path)
+  }
+
+  function isJobErrorForActiveWorkflow(jobId: string): boolean {
+    const runErrorKey = runErrorKeyForJob(jobId)
+    return (
+      runErrorKey !== null &&
+      runErrorKey === executionErrorStore.captureRunErrorKey()
+    )
+  }
+
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
     const endTime = performance.now()
+    // Resolved up front: resetExecutionState() drops the job's workflow entry
+    // before the handlers below record anything.
+    const runErrorKey = runErrorKeyForJob(e.detail.prompt_id)
     setWorkflowStatus(e.detail.prompt_id, {
       status: 'failed',
       endTime,
@@ -654,7 +710,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (isCloud) {
       // Cloud wraps validation errors (400) in exception_message as embedded JSON.
       // Pre-flight validation isn't a runtime failure — no badge.
-      if (handleCloudValidationError(e.detail)) {
+      if (handleCloudValidationError(e.detail, runErrorKey)) {
         return
       }
     }
@@ -664,7 +720,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (handleAccountPreconditionError(e.detail)) return
 
     // Service-level errors (e.g. "Job has stagnated") have no associated node.
-    if (handleServiceLevelError(e.detail)) {
+    if (handleServiceLevelError(e.detail, runErrorKey)) {
       return
     }
 
@@ -673,7 +729,7 @@ export const useExecutionStore = defineStore('execution', () => {
       endTime,
       failureReason: 'execution_failed'
     })
-    executionErrorStore.recordExecutionError(e.detail)
+    executionErrorStore.recordExecutionError(e.detail, runErrorKey)
     clearInitializationByJobId(e.detail.prompt_id)
     resetExecutionState(e.detail.prompt_id)
   }
@@ -694,25 +750,32 @@ export const useExecutionStore = defineStore('execution', () => {
     return true
   }
 
-  function handleServiceLevelError(detail: ExecutionErrorWsMessage): boolean {
+  function handleServiceLevelError(
+    detail: ExecutionErrorWsMessage,
+    runErrorKey: string | null | undefined
+  ): boolean {
     const nodeId = detail.node_id
     if (nodeId !== null && nodeId !== undefined && String(nodeId) !== '')
       return false
 
     clearInitializationByJobId(detail.prompt_id)
     resetExecutionState(detail.prompt_id)
-    executionErrorStore.recordPromptError({
-      type: detail.exception_type ?? 'error',
-      message: detail.exception_type
-        ? `${detail.exception_type}: ${detail.exception_message}`
-        : (detail.exception_message ?? ''),
-      details: detail.traceback?.join('\n') ?? ''
-    })
+    executionErrorStore.recordPromptError(
+      {
+        type: detail.exception_type ?? 'error',
+        message: detail.exception_type
+          ? `${detail.exception_type}: ${detail.exception_message}`
+          : (detail.exception_message ?? ''),
+        details: detail.traceback?.join('\n') ?? ''
+      },
+      runErrorKey
+    )
     return true
   }
 
   function handleCloudValidationError(
-    detail: ExecutionErrorWsMessage
+    detail: ExecutionErrorWsMessage,
+    runErrorKey: string | null | undefined
   ): boolean {
     const result = classifyCloudValidationError(detail.exception_message)
     if (!result) return false
@@ -721,9 +784,9 @@ export const useExecutionStore = defineStore('execution', () => {
     resetExecutionState(detail.prompt_id)
 
     if (result.kind === 'nodeErrors') {
-      executionErrorStore.recordNodeErrors(result.nodeErrors)
+      executionErrorStore.recordNodeErrors(result.nodeErrors, runErrorKey)
     } else {
-      executionErrorStore.recordPromptError(result.promptError)
+      executionErrorStore.recordPromptError(result.promptError, runErrorKey)
     }
     return true
   }
@@ -796,6 +859,7 @@ export const useExecutionStore = defineStore('execution', () => {
     executionIdToLocatorCache.clear()
     nodeProgressStates.value = {}
     const jobId = jobIdParam ?? activeJobId.value ?? null
+    const runErrorKey = jobId ? runErrorKeyForJob(jobId) : undefined
     if (jobId) {
       const map = { ...nodeProgressStatesByJob.value }
       delete map[jobId]
@@ -806,7 +870,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (jobId) delete queuedJobs.value[jobId]
     activeJobId.value = null
     _executingNodeProgress.value = null
-    executionErrorStore.clearPromptError()
+    executionErrorStore.clearPromptError(runErrorKey)
   }
 
   function getNodeIdIfExecuting(nodeId: string | number) {
@@ -989,6 +1053,7 @@ export const useExecutionStore = defineStore('execution', () => {
     unbindExecutionEvents,
     storeJob,
     registerJobWorkflowIdMapping,
+    isJobErrorForActiveWorkflow,
     uniqueExecutingNodeIdStrings,
     // Raw executing progress data for backward compatibility in ComfyApp.
     _executingNodeProgress,

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -120,6 +120,11 @@ interface WorkflowStatusUpdate {
   showStatus?: boolean
 }
 
+interface PendingExecutionError {
+  detail: ExecutionErrorWsMessage
+  endTime: number
+}
+
 export const WORKFLOW_STATUS_I18N_KEYS: Record<
   WorkflowExecutionStatus,
   string
@@ -166,6 +171,7 @@ export const useExecutionStore = defineStore('execution', () => {
   // Buffers statuses arriving before storeJob attaches the workflow.
   // FIFO-capped to bound growth if a matching storeJob never fires.
   const pendingWorkflowStatusByJobId = new Map<string, WorkflowStatusUpdate>()
+  const pendingExecutionErrorsByJobId = new Map<string, PendingExecutionError>()
 
   function bufferPendingWorkflowStatus(
     jobId: string,
@@ -185,6 +191,17 @@ export const useExecutionStore = defineStore('execution', () => {
       const oldest = pendingWorkflowStatusByJobId.keys().next().value
       if (oldest === undefined) break
       pendingWorkflowStatusByJobId.delete(oldest)
+    }
+  }
+
+  function bufferPendingExecutionError(error: PendingExecutionError) {
+    const jobId = error.detail.prompt_id
+    pendingExecutionErrorsByJobId.delete(jobId)
+    pendingExecutionErrorsByJobId.set(jobId, error)
+    while (pendingExecutionErrorsByJobId.size > MAX_PROGRESS_JOBS) {
+      const oldest = pendingExecutionErrorsByJobId.keys().next().value
+      if (oldest === undefined) break
+      pendingExecutionErrorsByJobId.delete(oldest)
     }
   }
 
@@ -447,6 +464,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
     if (workflowStatus.value.size > 0) workflowStatus.value = new Map()
     pendingWorkflowStatusByJobId.clear()
+    pendingExecutionErrorsByJobId.clear()
     jobIdToWorkflow.clear()
 
     cancelPendingProgressUpdates()
@@ -485,6 +503,7 @@ export const useExecutionStore = defineStore('execution', () => {
     e: CustomEvent<ExecutionInterruptedWsMessage>
   ) {
     const jobId = e.detail.prompt_id
+    pendingExecutionErrorsByJobId.delete(jobId)
     setWorkflowStatus(jobId, {
       status: 'failed',
       endTime: performance.now(),
@@ -504,6 +523,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
     const jobId = e.detail.prompt_id
+    pendingExecutionErrorsByJobId.delete(jobId)
     setWorkflowStatus(jobId, {
       status: 'completed',
       endTime: performance.now()
@@ -681,57 +701,66 @@ export const useExecutionStore = defineStore('execution', () => {
     return executionErrorStore.runErrorKey(graphId, path)
   }
 
-  function isJobErrorForActiveWorkflow(jobId: string): boolean {
-    const runErrorKey = runErrorKeyForJob(jobId)
-    return (
-      runErrorKey !== null &&
-      runErrorKey === executionErrorStore.captureRunErrorKey()
-    )
-  }
-
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
     const endTime = performance.now()
     // Resolved up front: resetExecutionState() drops the job's workflow entry
     // before the handlers below record anything.
     const runErrorKey = runErrorKeyForJob(e.detail.prompt_id)
-    setWorkflowStatus(e.detail.prompt_id, {
+    if (runErrorKey === null) {
+      bufferPendingExecutionError({ detail: e.detail, endTime })
+      resetExecutionState(e.detail.prompt_id)
+      return
+    }
+
+    processExecutionError(e.detail, runErrorKey, endTime)
+  }
+
+  function processExecutionError(
+    detail: ExecutionErrorWsMessage,
+    runErrorKey: string,
+    endTime: number
+  ) {
+    setWorkflowStatus(detail.prompt_id, {
       status: 'failed',
       endTime,
       failureReason: 'execution_failed',
       showStatus: false
     })
     useTelemetry()?.trackExecutionError({
-      jobId: e.detail.prompt_id,
-      nodeId: String(e.detail.node_id),
-      nodeType: e.detail.node_type,
-      error: e.detail.exception_message
+      jobId: detail.prompt_id,
+      nodeId: String(detail.node_id),
+      nodeType: detail.node_type,
+      error: detail.exception_message
     })
 
     if (isCloud) {
       // Cloud wraps validation errors (400) in exception_message as embedded JSON.
       // Pre-flight validation isn't a runtime failure — no badge.
-      if (handleCloudValidationError(e.detail, runErrorKey)) {
+      if (handleCloudValidationError(detail, runErrorKey)) {
+        executionErrorStore.showExecutionError(detail, runErrorKey)
         return
       }
     }
 
     // Account preconditions (sign-in, subscription, credits) open their own
     // modal and must stay out of the error panel and error count.
-    if (handleAccountPreconditionError(e.detail)) return
+    if (handleAccountPreconditionError(detail)) return
 
     // Service-level errors (e.g. "Job has stagnated") have no associated node.
-    if (handleServiceLevelError(e.detail, runErrorKey)) {
+    if (handleServiceLevelError(detail, runErrorKey)) {
+      executionErrorStore.showExecutionError(detail, runErrorKey)
       return
     }
 
-    setWorkflowStatus(e.detail.prompt_id, {
+    setWorkflowStatus(detail.prompt_id, {
       status: 'failed',
       endTime,
       failureReason: 'execution_failed'
     })
-    executionErrorStore.recordExecutionError(e.detail, runErrorKey)
-    clearInitializationByJobId(e.detail.prompt_id)
-    resetExecutionState(e.detail.prompt_id)
+    executionErrorStore.recordExecutionError(detail, runErrorKey)
+    executionErrorStore.showExecutionError(detail, runErrorKey)
+    clearInitializationByJobId(detail.prompt_id)
+    resetExecutionState(detail.prompt_id)
   }
 
   function handleAccountPreconditionError(
@@ -946,6 +975,18 @@ export const useExecutionStore = defineStore('execution', () => {
       ensureSessionWorkflowPath(id, workflow.path)
     }
     flushPendingWorkflowStatus(String(id), workflow)
+    flushPendingExecutionError(String(id))
+  }
+
+  function flushPendingExecutionError(jobId: string) {
+    const pending = pendingExecutionErrorsByJobId.get(jobId)
+    if (!pending) return
+
+    const runErrorKey = runErrorKeyForJob(jobId)
+    if (runErrorKey === null) return
+
+    pendingExecutionErrorsByJobId.delete(jobId)
+    processExecutionError(pending.detail, runErrorKey, pending.endTime)
   }
 
   function flushPendingWorkflowStatus(
@@ -989,6 +1030,7 @@ export const useExecutionStore = defineStore('execution', () => {
   function registerJobWorkflowIdMapping(jobId: JobId, workflowId: WorkflowId) {
     if (!jobId || !workflowId) return
     jobIdToWorkflowId.value.set(jobId, workflowId)
+    flushPendingExecutionError(jobId)
   }
 
   /**
@@ -1053,7 +1095,6 @@ export const useExecutionStore = defineStore('execution', () => {
     unbindExecutionEvents,
     storeJob,
     registerJobWorkflowIdMapping,
-    isJobErrorForActiveWorkflow,
     uniqueExecutingNodeIdStrings,
     // Raw executing progress data for backward compatibility in ComfyApp.
     _executingNodeProgress,

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -32,3 +32,9 @@ export function createUuidv4(): UUID {
     (Number(a) ^ ((Math.random() * 16) >> (Number(a) * 0.25))).toString(16)
   )
 }
+
+/** Ensures an entity has a stable, non-zero UUID and returns it. */
+export function ensureNonZeroUuid(entity: { id: UUID }): UUID {
+  if (entity.id === zeroUuid) entity.id = createUuidv4()
+  return entity.id
+}


### PR DESCRIPTION
## Summary

Backports #16807 to `cloud/1.53`, including prerequisite #15361 for workflow-scoped execution errors.

## Changes

- **What**: Preserve and route execution errors that arrive before prompt responses establish workflow attribution.
- **Dependencies**: Backports #15361 in the preceding commit.

## Review Focus

The #15361 conflict resolution retains `cloud/1.53`'s current `storeJob()` contract, which derives workflow mode internally.
