### PR TITLE
test(litegraph): run group round trips for every fixture

### DIFF
--- a/src/lib/litegraph/src/LGraph.roundTrip.test.ts
+++ b/src/lib/litegraph/src/LGraph.roundTrip.test.ts
@@ -259,12 +259,12 @@ describe('LGraph round trip preserves the input', () => {
 
         expect(twice).toEqual(once)
       })
+
+      test('keeps every group, by identity and bounds', () => {
+        const grouped = withGroups(graph)
+
+        expectPreserved(groupKeys(grouped), groupKeys(roundTrip(grouped)))
+      })
     })
   }
-
-  test('keeps every group, by identity and bounds', () => {
-    const grouped = withGroups(fixtures[0].graph)
-
-    expectPreserved(groupKeys(grouped), groupKeys(roundTrip(grouped)))
-  })
 })


### PR DESCRIPTION
## Summary

Runs group round-trip coverage against all three workflow fixtures instead of only the first.

## Changes

- **What**: Move the existing group-preservation test into each fixture's suite.

## Review Focus

Confirm each fixture now exercises group identity and bounds preservation without changing the existing oracle.

Source: [FE #16595](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16595) and the [unaddressed review finding](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16595#issuecomment-5510928434). Originating reviewer: CodeJuggernaut.

Verification: 19 passed, 5 fixture-specific skips; typecheck, Oxfmt, ESLint, Oxlint, Knip, and commit hooks passed.
