### PR TITLE
test(agent): align R-73 suite title

### DIFF
--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -174,7 +174,7 @@ function dispatchOpsResult(detail: unknown): void {
   bridge().dispatchEvent(new CustomEvent('doc_ops_result', { detail }))
 }
 
-describe('R-73 cross-workflow pending operation characterization', () => {
+describe('R-73 cross-workflow pending operations', () => {
   beforeEach(() => {
     bridgeState.current = null
     bridgeState.transport.up = true


### PR DESCRIPTION
## Summary

Rename the R-73 suite so its title covers both characterization and regression-guard cases, following the deferred review nit from #16655.

## Changes

- **What**: Removes the obsolete `characterization` qualifier from the enclosing describe title.

## Review Focus

Confirm the neutral suite title accurately describes all three cases.

## Evidence

- `pnpm exec vitest run src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts` — 3 tests passed.
- `pnpm exec oxlint --type-aware src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts` — 0 warnings and 0 errors.
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts` — clean.
- `pnpm typecheck` — clean via the pre-commit hook.
- `pnpm knip --cache` — clean via the pre-push hook.
- `git diff --check` — clean.

Source review: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16655#discussion_r3922421639

<!-- authored-by:agent lane-act-fe-16655-followup-9189cf20-0114 -->