### PR TITLE
Workshop: playground layout, sign-in gate, and a working run path

### DIFF
--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -6,3 +6,7 @@ results.json
 
 # Platform-specific Playwright snapshots (CI runs Linux)
 *-win32.png
+
+# Local-only: partner-node bundle for running models. Not for production.
+src/vendor/
+.env.local

--- a/apps/website/src/components/workshop/WorkshopField.vue
+++ b/apps/website/src/components/workshop/WorkshopField.vue
@@ -70,13 +70,16 @@ const acceptByType = {
 
 <template>
   <label class="flex flex-col gap-2">
-    <span class="text-sm font-medium text-primary-comfy-canvas">
+    <!-- Uppercase label with the description beneath, per the prototype. -->
+    <span
+      class="text-xs font-medium tracking-wider text-primary-comfy-canvas/80 uppercase"
+    >
       {{ field.label }}
       <span v-if="field.required" class="text-primary-comfy-yellow">*</span>
     </span>
     <span
       v-if="'hint' in field && field.hint"
-      class="text-xs text-primary-comfy-canvas/55"
+      class="-mt-1 text-xs text-primary-comfy-canvas/50"
     >
       {{ field.hint }}
     </span>

--- a/apps/website/src/components/workshop/WorkshopForm.vue
+++ b/apps/website/src/components/workshop/WorkshopForm.vue
@@ -5,7 +5,6 @@ import type {
 } from '../../config/workshop-detail'
 import { defaultWorkshopValues } from '../../config/workshop-detail'
 import type { Locale } from '../../i18n/translations'
-import { t } from '../../i18n/translations'
 import WorkshopField from './WorkshopField.vue'
 
 const { model, locale = 'en' } = defineProps<{
@@ -19,20 +18,14 @@ if (Object.keys(values.value).length === 0) {
 </script>
 
 <template>
-  <section
-    class="rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-6"
-  >
-    <h2 class="text-xl font-semibold text-primary-comfy-canvas">
-      {{ t('workshop.model.inputs', locale) }}
-    </h2>
-    <form class="mt-6 flex flex-col gap-6" @submit.prevent>
-      <WorkshopField
-        v-for="field in model.fields"
-        :key="field.name"
-        v-model="values"
-        :field="field"
-        :locale="locale"
-      />
-    </form>
-  </section>
+  <!-- The INPUT card supplies the chrome and heading; this is just fields. -->
+  <form class="flex flex-col gap-6" @submit.prevent>
+    <WorkshopField
+      v-for="field in model.fields"
+      :key="field.name"
+      v-model="values"
+      :field="field"
+      :locale="locale"
+    />
+  </form>
 </template>

--- a/apps/website/src/components/workshop/WorkshopPlayground.test.ts
+++ b/apps/website/src/components/workshop/WorkshopPlayground.test.ts
@@ -31,7 +31,15 @@ describe('WorkshopPlayground', () => {
     const user = userEvent.setup()
     render(WorkshopPlayground, { props: { model } })
 
-    await user.type(screen.getByRole('textbox', { name: /Prompt/ }), 'Red fox')
+    // The prompt arrives pre-filled with a sample, so replace it rather than
+    // typing on the end of it.
+    const prompt = screen.getByRole('textbox', { name: /Prompt/ })
+    await user.clear(prompt)
+    await user.type(prompt, 'Red fox')
+
+    // The snippet lives behind the API tab now: the result gets the column
+    // beside the form, matching the platform playground.
+    await user.click(screen.getByRole('tab', { name: 'API' }))
     expect(screen.getByText(/"prompt": "Red fox"/)).toBeTruthy()
 
     await user.click(screen.getByRole('tab', { name: 'Python' }))

--- a/apps/website/src/components/workshop/WorkshopPlayground.vue
+++ b/apps/website/src/components/workshop/WorkshopPlayground.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 
 import type { WorkshopDetailModel } from '../../config/workshop-detail'
 import { defaultWorkshopValues } from '../../config/workshop-detail'
+import { withSamplePrompt } from '../../config/workshop-samples'
 import { runTargetFor } from '../../config/workshop-run-target'
 import type { WorkshopSnippetLanguage } from '../../config/workshop-snippets'
 import type { Locale } from '../../i18n/translations'
@@ -15,8 +16,19 @@ const { model, locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 const runTarget = computed(() => runTargetFor(model))
-const values = ref(defaultWorkshopValues(model.fields))
+// Seeded with a sample prompt so the first action is pressing Run, not
+// thinking of something to type.
+const values = ref(
+  withSamplePrompt(
+    defaultWorkshopValues(model.fields),
+    model.fields,
+    model.modality
+  )
+)
 const language = ref<WorkshopSnippetLanguage>('typescript')
+// Playground and API are tabs, not columns: the result deserves the width,
+// and the snippet is something you go and look at rather than watch.
+const view = ref<'playground' | 'api'>('playground')
 const copied = ref(false)
 const snippet = computed(() =>
   runTarget.value.buildSnippet(language.value, model, values.value)
@@ -39,59 +51,87 @@ const languageLabels: Record<WorkshopSnippetLanguage, string> = {
 
 <template>
   <div>
-    <div class="grid gap-8 lg:grid-cols-2">
-      <WorkshopForm v-model="values" :model="model" :locale="locale" />
-
-      <section>
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <div
-            role="tablist"
-            :aria-label="t('workshop.model.codeLanguage', locale)"
-            class="flex gap-1"
-          >
-            <button
-              v-for="option in runTarget.snippetLanguages"
-              :key="option"
-              type="button"
-              role="tab"
-              :aria-selected="language === option"
-              class="rounded-full px-4 py-2 text-sm transition-colors"
-              :class="
-                language === option
-                  ? 'bg-primary-comfy-yellow text-primary-comfy-ink'
-                  : 'text-primary-comfy-canvas/65 hover:text-primary-comfy-canvas'
-              "
-              @click="language = option"
-            >
-              {{ languageLabels[option] }}
-            </button>
-          </div>
-          <button
-            type="button"
-            class="text-primary-comfy-yellow text-sm hover:underline"
-            @click="copySnippet"
-          >
-            {{
-              copied
-                ? t('workshop.model.copied', locale)
-                : t('workshop.model.copy', locale)
-            }}
-          </button>
-        </div>
-        <pre
-          class="mt-3 max-h-168 overflow-auto rounded-2xl border border-primary-comfy-canvas/10 bg-black p-6 text-sm/relaxed text-primary-comfy-canvas"
-        ><code>{{ snippet }}</code></pre>
-        <a
-          href="https://platform.comfy.org/profile/api-keys"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-primary-comfy-yellow mt-4 inline-flex text-sm font-medium hover:underline"
-        >
-          {{ t('workshop.model.getApiKey', locale) }}
-        </a>
-      </section>
+    <div
+      role="tablist"
+      :aria-label="model.displayName"
+      class="mb-6 flex gap-1 border-b border-primary-comfy-canvas/10"
+    >
+      <button
+        v-for="tab in ['playground', 'api'] as const"
+        :key="tab"
+        type="button"
+        role="tab"
+        :aria-selected="view === tab"
+        class="-mb-px border-b-2 px-4 py-3 text-sm transition-colors"
+        :class="
+          view === tab
+            ? 'border-primary-comfy-yellow text-primary-comfy-canvas'
+            : 'border-transparent text-primary-comfy-canvas/60 hover:text-primary-comfy-canvas'
+        "
+        @click="view = tab"
+      >
+        {{ t(`workshop.tab.${tab}`, locale) }}
+      </button>
     </div>
 
-    <WorkshopRunPanel :model="model" :values="values" :locale="locale" />
+    <WorkshopRunPanel
+      v-show="view === 'playground'"
+      :model="model"
+      :values="values"
+      :locale="locale"
+    >
+      <template #form>
+        <WorkshopForm v-model="values" :model="model" :locale="locale" />
+      </template>
+    </WorkshopRunPanel>
+
+    <section v-if="view === 'api'">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div
+          role="tablist"
+          :aria-label="t('workshop.model.codeLanguage', locale)"
+          class="flex gap-1"
+        >
+          <button
+            v-for="option in runTarget.snippetLanguages"
+            :key="option"
+            type="button"
+            role="tab"
+            :aria-selected="language === option"
+            class="rounded-full px-4 py-2 text-sm transition-colors"
+            :class="
+              language === option
+                ? 'bg-primary-comfy-yellow text-primary-comfy-ink'
+                : 'text-primary-comfy-canvas/65 hover:text-primary-comfy-canvas'
+            "
+            @click="language = option"
+          >
+            {{ languageLabels[option] }}
+          </button>
+        </div>
+        <button
+          type="button"
+          class="text-primary-comfy-yellow text-sm hover:underline"
+          @click="copySnippet"
+        >
+          {{
+            copied
+              ? t('workshop.model.copied', locale)
+              : t('workshop.model.copy', locale)
+          }}
+        </button>
+      </div>
+      <pre
+        class="mt-3 max-h-168 overflow-auto rounded-2xl border border-primary-comfy-canvas/10 bg-black p-6 text-sm/relaxed text-primary-comfy-canvas"
+      ><code>{{ snippet }}</code></pre>
+      <a
+        href="https://platform.comfy.org/profile/api-keys"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary-comfy-yellow mt-4 inline-flex text-sm font-medium hover:underline"
+      >
+        {{ t('workshop.model.getApiKey', locale) }}
+      </a>
+    </section>
   </div>
 </template>

--- a/apps/website/src/components/workshop/WorkshopPlayground.vue
+++ b/apps/website/src/components/workshop/WorkshopPlayground.vue
@@ -62,7 +62,7 @@ const languageLabels: Record<WorkshopSnippetLanguage, string> = {
         type="button"
         role="tab"
         :aria-selected="view === tab"
-        class="-mb-px border-b-2 px-4 py-3 text-sm transition-colors"
+        class="-mb-px border-b-2 px-4 py-3 text-sm font-medium tracking-wider uppercase transition-colors"
         :class="
           view === tab
             ? 'border-primary-comfy-yellow text-primary-comfy-canvas'

--- a/apps/website/src/components/workshop/WorkshopRunPanel.test.ts
+++ b/apps/website/src/components/workshop/WorkshopRunPanel.test.ts
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useWorkshopCredentials } from '../../config/workshop-credentials-state'
 import type { WorkshopDetailModel } from '../../config/workshop-detail'
 import WorkshopRunPanel from './WorkshopRunPanel.vue'
 
@@ -41,16 +42,30 @@ function jsonResponse(status: number, body: unknown, headers = {}) {
 
 beforeEach(() => {
   globalThis.localStorage.clear()
+  // The credential lives outside the panel now — it comes from the floating
+  // key widget, and in the shipped app it will come from a session.
+  useWorkshopCredentials().save('')
 })
 
-describe('WorkshopRunPanel', () => {
-  it('cannot run until a key is entered', async () => {
-    renderPanel()
-    const button = screen.getByRole('button', { name: 'Run' })
-    expect((button as HTMLButtonElement).disabled).toBe(true)
+function enterKey(value = 'comfyui-abc') {
+  useWorkshopCredentials().save(value)
+}
 
-    await userEvent.setup().type(screen.getByLabelText('Comfy API key'), 'k')
-    expect((button as HTMLButtonElement).disabled).toBe(false)
+const runButton = () =>
+  screen.getByRole('button', { name: /^(Run|Sign up \/ Login to Render)$/ })
+
+describe('WorkshopRunPanel', () => {
+  it('asks you to sign in before it will run anything', async () => {
+    renderPanel()
+
+    // Not disabled — a dead button tells you nothing. It offers the way in.
+    expect(runButton().textContent).toContain('Sign up / Login to Render')
+    expect((runButton() as HTMLButtonElement).disabled).toBe(false)
+
+    enterKey()
+    await waitFor(() => {
+      expect(runButton().textContent).toContain('Run')
+    })
   })
 
   it('runs the model and shows the image it returned', async () => {
@@ -62,9 +77,8 @@ describe('WorkshopRunPanel', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     renderPanel()
-    const user = userEvent.setup()
-    await user.type(screen.getByLabelText('Comfy API key'), 'comfyui-abc')
-    await user.click(screen.getByRole('button', { name: 'Run' }))
+    enterKey()
+    await userEvent.setup().click(runButton())
 
     await waitFor(() =>
       expect(screen.getByAltText('FLUX 2 Pro').getAttribute('src')).toBe(
@@ -92,9 +106,8 @@ describe('WorkshopRunPanel', () => {
     )
 
     renderPanel()
-    const user = userEvent.setup()
-    await user.type(screen.getByLabelText('Comfy API key'), 'wrong')
-    await user.click(screen.getByRole('button', { name: 'Run' }))
+    enterKey()
+    await userEvent.setup().click(runButton())
 
     const alert = await screen.findByRole('alert')
     expect(alert.textContent).toContain('That API key was not accepted.')
@@ -104,30 +117,16 @@ describe('WorkshopRunPanel', () => {
     expect(alert.textContent).toContain('r1')
   })
 
-  it('remembers the key across a reload but never puts it in the URL', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => Promise.resolve(jsonResponse(200, {})))
-    )
-
-    const { unmount } = renderPanel()
-    const user = userEvent.setup()
-    await user.type(screen.getByLabelText('Comfy API key'), 'comfyui-remember')
-    await user.click(screen.getByRole('button', { name: 'Run' }))
-    await waitFor(() =>
-      expect(
-        screen.queryByText('Running. This can take a minute or two.')
-      ).toBeNull()
-    )
-    unmount()
-
+  it('does not put a credential field in the product UI', () => {
+    // The key is scaffolding and lives in a floating widget outside the
+    // layout; in the shipped app it comes from a session. Persistence is
+    // covered in workshop-credentials.test.ts.
     renderPanel()
-    await waitFor(() =>
-      expect(
-        (screen.getByLabelText('Comfy API key') as HTMLInputElement).value
-      ).toBe('comfyui-remember')
-    )
-    expect(window.location.search).toBe('')
+
+    // The key only exists inside the closed sign-in dialog, which stands in
+    // for a session until comfy.org can start one.
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.queryAllByRole('textbox')).toEqual([])
   })
 
   it('shows the response when a model returns no media', async () => {
@@ -139,9 +138,8 @@ describe('WorkshopRunPanel', () => {
     )
 
     renderPanel()
-    const user = userEvent.setup()
-    await user.type(screen.getByLabelText('Comfy API key'), 'comfyui-abc')
-    await user.click(screen.getByRole('button', { name: 'Run' }))
+    enterKey()
+    await userEvent.setup().click(runButton())
 
     expect(
       await screen.findByText(

--- a/apps/website/src/components/workshop/WorkshopRunPanel.vue
+++ b/apps/website/src/components/workshop/WorkshopRunPanel.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import { onMounted, ref, shallowRef } from 'vue'
+import { Play } from '@lucide/vue'
+import { computed, onBeforeUnmount, ref, shallowRef } from 'vue'
 
 import type {
   WorkshopDetailModel,
   WorkshopFormValues
 } from '../../config/workshop-detail'
-import {
-  readStoredCredentials,
-  writeStoredCredentials
-} from '../../config/workshop-credentials'
+import { useWorkshopCredentials } from '../../config/workshop-credentials-state'
 import type {
   WorkshopRunErrorType,
   WorkshopRunResult
@@ -19,6 +17,7 @@ import {
   mediaKindForModality
 } from '../../config/workshop-results'
 import { runTargetFor } from '../../config/workshop-run-target'
+import WorkshopSignInDialog from './WorkshopSignInDialog.vue'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
@@ -32,20 +31,35 @@ const {
   locale?: Locale
 }>()
 
-const credentials = ref('')
+const { credentials } = useWorkshopCredentials()
 const running = ref(false)
+const signInOpen = ref(false)
+const elapsedMs = ref(0)
+let ticker: number | undefined
+
+/**
+ * How long this kind of model usually takes. There is no progress signal to
+ * report — the partner polls internally — so the honest thing is to set an
+ * expectation rather than imply precision we do not have.
+ */
+const expectation = computed(() => {
+  if (model.modality === 'video') return t('workshop.run.wait.video', locale)
+  if (model.modality === '3d') return t('workshop.run.wait.slow', locale)
+  return t('workshop.run.wait.default', locale)
+})
+
+const elapsedLabel = computed(() => {
+  const total = Math.floor(elapsedMs.value / 1000)
+  const minutes = Math.floor(total / 60)
+  const seconds = String(total % 60).padStart(2, '0')
+  return `${minutes}:${seconds}`
+})
 // shallowRef: this holds a partner's JSON document of unknown size and we
 // only ever replace it wholesale, so there is nothing to gain from making
 // every node in it reactive.
 const result = shallowRef<WorkshopRunResult | undefined>(undefined)
 const mediaUrls = shallowRef<readonly string[]>([])
 let controller: AbortController | undefined
-
-// Read on mount rather than at setup: this component is server-rendered for
-// the static page, where localStorage does not exist.
-onMounted(() => {
-  credentials.value = readStoredCredentials()
-})
 
 const mediaKind = mediaKindForModality(model.modality)
 
@@ -74,10 +88,14 @@ function headingFor(errorType: WorkshopRunErrorType): string {
 
 async function run() {
   if (credentials.value === '' || running.value) return
-  writeStoredCredentials(credentials.value)
   running.value = true
   result.value = undefined
   mediaUrls.value = []
+  elapsedMs.value = 0
+  const startedAt = Date.now()
+  ticker = window.setInterval(() => {
+    elapsedMs.value = Date.now() - startedAt
+  }, 1000)
 
   controller = new AbortController()
   const timeout = window.setTimeout(
@@ -95,6 +113,8 @@ async function run() {
     }
   } finally {
     window.clearTimeout(timeout)
+    if (ticker !== undefined) window.clearInterval(ticker)
+    ticker = undefined
     controller = undefined
     running.value = false
   }
@@ -103,146 +123,217 @@ async function run() {
 function cancel() {
   controller?.abort()
 }
+
+onBeforeUnmount(() => {
+  if (ticker !== undefined) window.clearInterval(ticker)
+  controller?.abort()
+})
 </script>
 
 <template>
-  <section class="mt-12 border-t border-primary-comfy-canvas/10 pt-10">
-    <h2 class="text-2xl font-semibold text-primary-comfy-canvas">
-      {{ t('workshop.run.heading', locale) }}
-    </h2>
+  <!--
+    Two columns, controls left and result right, matching the platform
+    playground: the thing you are waiting for should not be below the fold
+    while you fill the form in. 2fr/3fr, so the result gets the larger half.
+  -->
+  <div class="grid items-start gap-6 lg:grid-cols-5">
+    <div class="lg:col-span-2">
+      <slot name="form" />
+    </div>
 
-    <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-end">
-      <label class="flex min-w-0 flex-1 flex-col gap-2">
-        <span class="text-sm font-medium text-primary-comfy-canvas">
-          {{ t('workshop.run.apiKey', locale) }}
-        </span>
-        <input
-          v-model="credentials"
-          type="password"
-          autocomplete="off"
-          spellcheck="false"
-          :placeholder="t('workshop.run.apiKeyPlaceholder', locale)"
-          class="focus:border-primary-comfy-yellow h-11 rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-canvas/5 px-4 font-mono text-sm text-primary-comfy-canvas outline-none"
-        />
-      </label>
+    <section
+      class="rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-6 lg:col-span-3"
+    >
       <button
         v-if="!running"
         type="button"
-        :disabled="credentials === ''"
-        class="hover:bg-primary-comfy-yellow/90 h-11 shrink-0 rounded-xl bg-primary-comfy-yellow px-8 font-medium text-primary-comfy-ink transition-colors disabled:cursor-not-allowed disabled:opacity-40"
-        @click="run"
+        class="hover:shadow-primary-comfy-yellow/25 group flex h-16 w-full items-center justify-center gap-3 rounded-2xl bg-primary-comfy-yellow text-lg font-semibold text-primary-comfy-ink transition-all hover:-translate-y-0.5 hover:shadow-lg"
+        @click="credentials === '' ? (signInOpen = true) : run()"
       >
-        {{ t('workshop.run.button', locale) }}
+        <Play
+          aria-hidden="true"
+          class="size-5 fill-current transition-transform group-hover:scale-110"
+        />
+        {{
+          credentials === ''
+            ? t('workshop.auth.cta', locale)
+            : t('workshop.run.button', locale)
+        }}
       </button>
       <button
         v-else
         type="button"
-        class="hover:border-primary-comfy-canvas/40 h-11 shrink-0 rounded-xl border border-primary-comfy-canvas/25 px-8 text-primary-comfy-canvas transition-colors"
+        class="hover:border-primary-comfy-canvas/40 flex h-16 w-full items-center justify-center rounded-2xl border border-primary-comfy-canvas/25 text-lg text-primary-comfy-canvas transition-colors"
         @click="cancel"
       >
         {{ t('workshop.run.cancel', locale) }}
       </button>
-    </div>
-
-    <p class="mt-3 text-sm text-primary-comfy-canvas/55">
-      {{ t('workshop.run.keyNote', locale) }}
-      <a
-        href="https://platform.comfy.org/profile/api-keys"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-primary-comfy-yellow hover:underline"
-      >
-        {{ t('workshop.model.getApiKey', locale) }}
-      </a>
-    </p>
-
-    <p
-      v-if="running"
-      class="mt-8 text-sm text-primary-comfy-canvas/70"
-      aria-live="polite"
-    >
-      {{ t('workshop.run.running', locale) }}
-    </p>
-
-    <div
-      v-else-if="result?.status === 'error'"
-      class="mt-8 rounded-2xl border border-red-500/30 bg-red-500/5 p-6"
-      role="alert"
-    >
-      <p class="font-medium text-primary-comfy-canvas">
-        {{ headingFor(result.errorType) }}
-      </p>
-      <p class="mt-2 text-sm whitespace-pre-line text-primary-comfy-canvas/70">
-        {{ result.detail }}
-      </p>
-      <p
-        v-if="result.requestId"
-        class="mt-3 font-mono text-xs text-primary-comfy-canvas/45"
-      >
-        {{ t('workshop.run.requestId', locale) }} {{ result.requestId }}
-      </p>
-    </div>
-
-    <div v-else-if="result?.status === 'ok'" class="mt-8">
-      <ul
-        v-if="mediaUrls.length > 0"
-        class="grid list-none grid-cols-1 gap-4 p-0 md:grid-cols-2"
-      >
-        <li
-          v-for="url in mediaUrls"
-          :key="url"
-          class="overflow-hidden rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5"
-        >
-          <img
-            v-if="mediaKind === 'image'"
-            :src="url"
-            :alt="model.displayName"
-            class="w-full"
-          />
-          <video
-            v-else-if="mediaKind === 'video'"
-            :src="url"
-            controls
-            playsinline
-            class="w-full"
-          />
-          <audio
-            v-else-if="mediaKind === 'audio'"
-            :src="url"
-            controls
-            class="w-full p-4"
-          />
-          <a
-            v-else
-            :href="url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-primary-comfy-yellow block p-6 text-sm break-all hover:underline"
-          >
-            {{ url }}
-          </a>
-        </li>
-      </ul>
-
-      <p v-else class="text-sm text-primary-comfy-canvas/65">
-        {{ t('workshop.run.noMedia', locale) }}
-      </p>
 
       <!--
-        Always available, never only. The output shape belongs to the partner,
-        so whatever the list above found, the document itself is the record of
-        what actually came back.
+        No progress signal exists: the partner polls internally and reports
+        only a terminal state. So this sets an expectation and shows elapsed
+        time rather than animating a percentage we would be inventing.
       -->
-      <details class="mt-4">
-        <summary
-          class="cursor-pointer text-sm text-primary-comfy-canvas/65 hover:text-primary-comfy-canvas"
+      <div v-if="running" class="mt-6" aria-live="polite">
+        <div
+          class="workshop-shimmer relative flex aspect-video items-center justify-center overflow-hidden rounded-xl border border-primary-comfy-canvas/10"
         >
-          {{ t('workshop.run.rawOutput', locale) }}
-        </summary>
-        <pre
-          class="mt-3 max-h-120 overflow-auto rounded-2xl border border-primary-comfy-canvas/10 bg-black p-6 text-sm/relaxed text-primary-comfy-canvas"
-        ><code>{{ JSON.stringify(result.output, null, 2) }}</code></pre>
-      </details>
-    </div>
-  </section>
+          <div
+            class="relative z-10 flex flex-col items-center gap-3 px-6 text-center"
+          >
+            <span
+              class="border-primary-comfy-yellow/70 size-8 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none"
+            />
+            <p class="text-sm text-primary-comfy-canvas">
+              {{ t('workshop.run.running', locale) }}
+            </p>
+            <p class="text-xs text-primary-comfy-canvas/55">
+              {{ expectation }}
+            </p>
+            <p
+              class="font-mono text-xs tabular-nums text-primary-comfy-canvas/45"
+            >
+              {{ elapsedLabel }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-else-if="result?.status === 'error'"
+        class="mt-6 rounded-xl border border-red-500/30 bg-red-500/5 p-5"
+        role="alert"
+      >
+        <p class="font-medium text-primary-comfy-canvas">
+          {{ headingFor(result.errorType) }}
+        </p>
+        <p
+          class="mt-2 text-sm whitespace-pre-line text-primary-comfy-canvas/70"
+        >
+          {{ result.detail }}
+        </p>
+        <p
+          v-if="result.requestId"
+          class="mt-3 font-mono text-xs text-primary-comfy-canvas/45"
+        >
+          {{ t('workshop.run.requestId', locale) }} {{ result.requestId }}
+        </p>
+      </div>
+
+      <div v-else-if="result?.status === 'ok'" class="mt-6">
+        <ul v-if="mediaUrls.length > 0" class="grid list-none gap-4 p-0">
+          <li
+            v-for="url in mediaUrls"
+            :key="url"
+            class="overflow-hidden rounded-xl border border-primary-comfy-canvas/10"
+          >
+            <img
+              v-if="mediaKind === 'image'"
+              :src="url"
+              :alt="model.displayName"
+              class="w-full"
+            />
+            <video
+              v-else-if="mediaKind === 'video'"
+              :src="url"
+              controls
+              playsinline
+              class="w-full"
+            />
+            <audio
+              v-else-if="mediaKind === 'audio'"
+              :src="url"
+              controls
+              class="w-full p-4"
+            />
+            <a
+              v-else
+              :href="url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-primary-comfy-yellow block p-6 text-sm break-all hover:underline"
+            >
+              {{ url }}
+            </a>
+          </li>
+        </ul>
+
+        <p v-else class="text-sm text-primary-comfy-canvas/65">
+          {{ t('workshop.run.noMedia', locale) }}
+        </p>
+
+        <!--
+          Always available, never only. The output shape belongs to the
+          partner, so whatever the list above found, the document itself is
+          the record of what actually came back.
+        -->
+        <details class="mt-4">
+          <summary
+            class="cursor-pointer text-sm text-primary-comfy-canvas/65 hover:text-primary-comfy-canvas"
+          >
+            {{ t('workshop.run.rawOutput', locale) }}
+          </summary>
+          <pre
+            class="mt-3 max-h-120 overflow-auto rounded-xl border border-primary-comfy-canvas/10 bg-black p-5 text-sm/relaxed text-primary-comfy-canvas"
+          ><code>{{ JSON.stringify(result.output, null, 2) }}</code></pre>
+        </details>
+      </div>
+
+      <!-- Nothing has run yet: hold the space so the page does not jump. -->
+      <div
+        v-else
+        class="mt-6 flex aspect-video items-center justify-center rounded-xl border border-dashed border-primary-comfy-canvas/12"
+      >
+        <p class="px-6 text-center text-sm text-primary-comfy-canvas/45">
+          {{ t('workshop.run.idle', locale) }}
+        </p>
+      </div>
+    </section>
+
+    <WorkshopSignInDialog
+      :open="signInOpen"
+      :locale="locale"
+      @close="signInOpen = false"
+      @authenticated="run"
+    />
+  </div>
 </template>
+
+<style scoped>
+/*
+ * A slow sweep across the placeholder so a three-minute video run still looks
+ * alive. Purely decorative, so it is dropped entirely under reduced motion.
+ */
+.workshop-shimmer {
+  background: rgb(255 255 255 / 4%);
+}
+
+.workshop-shimmer::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    rgb(255 255 255 / 7%) 50%,
+    transparent 80%
+  );
+  animation: workshop-sweep 2.4s ease-in-out infinite;
+  content: '';
+}
+
+@keyframes workshop-sweep {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workshop-shimmer::after {
+    animation: none;
+  }
+}
+</style>

--- a/apps/website/src/components/workshop/WorkshopRunPanel.vue
+++ b/apps/website/src/components/workshop/WorkshopRunPanel.vue
@@ -299,20 +299,6 @@ onBeforeUnmount(() => {
             ><code>{{ JSON.stringify(result.output, null, 2) }}</code></pre>
           </details>
         </div>
-
-        <!--
-          The prototype shows a real example here so you can see what a model
-          produces before running it. That needs per-model example media we do
-          not have yet, so this holds the space until the content pack lands.
-        -->
-        <div
-          v-else
-          class="flex aspect-video items-center justify-center rounded-xl border border-dashed border-primary-comfy-canvas/12"
-        >
-          <p class="px-6 text-center text-sm text-primary-comfy-canvas/45">
-            {{ t('workshop.run.idle', locale) }}
-          </p>
-        </div>
       </div>
     </section>
 

--- a/apps/website/src/components/workshop/WorkshopRunPanel.vue
+++ b/apps/website/src/components/workshop/WorkshopRunPanel.vue
@@ -299,6 +299,17 @@ onBeforeUnmount(() => {
             ><code>{{ JSON.stringify(result.output, null, 2) }}</code></pre>
           </details>
         </div>
+
+        <!--
+          Nothing to show yet. The space is still reserved so pressing Run
+          does not shove the page around, and so the card reads as a place a
+          result will occupy rather than as an empty panel.
+        -->
+        <div
+          v-else
+          aria-hidden="true"
+          class="aspect-video rounded-xl bg-primary-comfy-canvas/3"
+        ></div>
       </div>
     </section>
 

--- a/apps/website/src/components/workshop/WorkshopRunPanel.vue
+++ b/apps/website/src/components/workshop/WorkshopRunPanel.vue
@@ -132,161 +132,187 @@ onBeforeUnmount(() => {
 
 <template>
   <!--
-    Two columns, controls left and result right, matching the platform
-    playground: the thing you are waiting for should not be below the fold
-    while you fill the form in. 2fr/3fr, so the result gets the larger half.
+    INPUT left / OUTPUT right at 5:7 on a twelve-column grid, matching the
+    Workshop prototype (PR #16556). The run control sits at the foot of the
+    input card, where the prototype puts it.
   -->
-  <div class="grid items-start gap-6 lg:grid-cols-5">
-    <div class="lg:col-span-2">
-      <slot name="form" />
-    </div>
+  <div class="grid items-start gap-6 lg:grid-cols-12">
+    <section
+      class="flex flex-col overflow-hidden rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/4 lg:col-span-5"
+    >
+      <header
+        class="border-b border-primary-comfy-canvas/10 px-5 py-3 text-xs tracking-wider text-primary-comfy-canvas/55 uppercase"
+      >
+        {{ t('workshop.card.input', locale) }}
+      </header>
+
+      <div class="flex flex-col gap-6 p-5">
+        <slot name="form" />
+
+        <button
+          v-if="!running"
+          type="button"
+          class="hover:bg-primary-comfy-yellow/90 group bg-primary-comfy-yellow flex h-13 w-full items-center justify-center gap-2.5 rounded-xl text-sm font-semibold tracking-wider text-primary-comfy-ink uppercase transition-colors"
+          @click="credentials === '' ? (signInOpen = true) : run()"
+        >
+          <Play
+            aria-hidden="true"
+            class="size-4 fill-current transition-transform group-hover:scale-110"
+          />
+          {{
+            credentials === ''
+              ? t('workshop.auth.cta', locale)
+              : t('workshop.run.button', locale)
+          }}
+        </button>
+        <button
+          v-else
+          type="button"
+          class="flex h-13 w-full items-center justify-center rounded-xl border border-primary-comfy-canvas/25 text-sm tracking-wider text-primary-comfy-canvas uppercase transition-colors hover:border-primary-comfy-canvas/40"
+          @click="cancel"
+        >
+          {{ t('workshop.run.cancel', locale) }}
+        </button>
+      </div>
+    </section>
 
     <section
-      class="rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/5 p-6 lg:col-span-3"
+      class="overflow-hidden rounded-2xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/4 lg:col-span-7"
     >
-      <button
-        v-if="!running"
-        type="button"
-        class="hover:shadow-primary-comfy-yellow/25 group flex h-16 w-full items-center justify-center gap-3 rounded-2xl bg-primary-comfy-yellow text-lg font-semibold text-primary-comfy-ink transition-all hover:-translate-y-0.5 hover:shadow-lg"
-        @click="credentials === '' ? (signInOpen = true) : run()"
+      <header
+        class="flex items-center justify-between border-b border-primary-comfy-canvas/10 px-5 py-3"
       >
-        <Play
-          aria-hidden="true"
-          class="size-5 fill-current transition-transform group-hover:scale-110"
-        />
-        {{
-          credentials === ''
-            ? t('workshop.auth.cta', locale)
-            : t('workshop.run.button', locale)
-        }}
-      </button>
-      <button
-        v-else
-        type="button"
-        class="hover:border-primary-comfy-canvas/40 flex h-16 w-full items-center justify-center rounded-2xl border border-primary-comfy-canvas/25 text-lg text-primary-comfy-canvas transition-colors"
-        @click="cancel"
-      >
-        {{ t('workshop.run.cancel', locale) }}
-      </button>
-
-      <!--
-        No progress signal exists: the partner polls internally and reports
-        only a terminal state. So this sets an expectation and shows elapsed
-        time rather than animating a percentage we would be inventing.
-      -->
-      <div v-if="running" class="mt-6" aria-live="polite">
-        <div
-          class="workshop-shimmer relative flex aspect-video items-center justify-center overflow-hidden rounded-xl border border-primary-comfy-canvas/10"
+        <span
+          class="text-xs tracking-wider text-primary-comfy-canvas/55 uppercase"
         >
+          {{ t('workshop.card.output', locale) }}
+        </span>
+      </header>
+
+      <div class="p-5">
+        <!--
+          No progress signal exists: the partner polls internally and reports
+          only a terminal state. So this sets an expectation and shows elapsed
+          time rather than animating a percentage we would be inventing.
+        -->
+        <div v-if="running" aria-live="polite">
           <div
-            class="relative z-10 flex flex-col items-center gap-3 px-6 text-center"
+            class="workshop-shimmer relative flex aspect-video items-center justify-center overflow-hidden rounded-xl border border-primary-comfy-canvas/10"
           >
-            <span
-              class="border-primary-comfy-yellow/70 size-8 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none"
-            />
-            <p class="text-sm text-primary-comfy-canvas">
-              {{ t('workshop.run.running', locale) }}
-            </p>
-            <p class="text-xs text-primary-comfy-canvas/55">
-              {{ expectation }}
-            </p>
-            <p
-              class="font-mono text-xs tabular-nums text-primary-comfy-canvas/45"
+            <div
+              class="relative z-10 flex flex-col items-center gap-3 px-6 text-center"
             >
-              {{ elapsedLabel }}
-            </p>
+              <span
+                class="border-primary-comfy-yellow/70 size-8 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none"
+              />
+              <p class="text-sm text-primary-comfy-canvas">
+                {{ t('workshop.run.running', locale) }}
+              </p>
+              <p class="text-xs text-primary-comfy-canvas/55">
+                {{ expectation }}
+              </p>
+              <p
+                class="font-mono text-xs text-primary-comfy-canvas/45 tabular-nums"
+              >
+                {{ elapsedLabel }}
+              </p>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div
-        v-else-if="result?.status === 'error'"
-        class="mt-6 rounded-xl border border-red-500/30 bg-red-500/5 p-5"
-        role="alert"
-      >
-        <p class="font-medium text-primary-comfy-canvas">
-          {{ headingFor(result.errorType) }}
-        </p>
-        <p
-          class="mt-2 text-sm whitespace-pre-line text-primary-comfy-canvas/70"
+        <div
+          v-else-if="result?.status === 'error'"
+          class="rounded-xl border border-red-500/30 bg-red-500/5 p-5"
+          role="alert"
         >
-          {{ result.detail }}
-        </p>
-        <p
-          v-if="result.requestId"
-          class="mt-3 font-mono text-xs text-primary-comfy-canvas/45"
-        >
-          {{ t('workshop.run.requestId', locale) }} {{ result.requestId }}
-        </p>
-      </div>
-
-      <div v-else-if="result?.status === 'ok'" class="mt-6">
-        <ul v-if="mediaUrls.length > 0" class="grid list-none gap-4 p-0">
-          <li
-            v-for="url in mediaUrls"
-            :key="url"
-            class="overflow-hidden rounded-xl border border-primary-comfy-canvas/10"
+          <p class="font-medium text-primary-comfy-canvas">
+            {{ headingFor(result.errorType) }}
+          </p>
+          <p
+            class="mt-2 text-sm whitespace-pre-line text-primary-comfy-canvas/70"
           >
-            <img
-              v-if="mediaKind === 'image'"
-              :src="url"
-              :alt="model.displayName"
-              class="w-full"
-            />
-            <video
-              v-else-if="mediaKind === 'video'"
-              :src="url"
-              controls
-              playsinline
-              class="w-full"
-            />
-            <audio
-              v-else-if="mediaKind === 'audio'"
-              :src="url"
-              controls
-              class="w-full p-4"
-            />
-            <a
-              v-else
-              :href="url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-primary-comfy-yellow block p-6 text-sm break-all hover:underline"
-            >
-              {{ url }}
-            </a>
-          </li>
-        </ul>
+            {{ result.detail }}
+          </p>
+          <p
+            v-if="result.requestId"
+            class="mt-3 font-mono text-xs text-primary-comfy-canvas/45"
+          >
+            {{ t('workshop.run.requestId', locale) }} {{ result.requestId }}
+          </p>
+        </div>
 
-        <p v-else class="text-sm text-primary-comfy-canvas/65">
-          {{ t('workshop.run.noMedia', locale) }}
-        </p>
+        <div v-else-if="result?.status === 'ok'">
+          <ul v-if="mediaUrls.length > 0" class="grid list-none gap-4 p-0">
+            <li
+              v-for="url in mediaUrls"
+              :key="url"
+              class="overflow-hidden rounded-xl border border-primary-comfy-canvas/10"
+            >
+              <img
+                v-if="mediaKind === 'image'"
+                :src="url"
+                :alt="model.displayName"
+                class="w-full"
+              />
+              <video
+                v-else-if="mediaKind === 'video'"
+                :src="url"
+                controls
+                playsinline
+                class="w-full"
+              />
+              <audio
+                v-else-if="mediaKind === 'audio'"
+                :src="url"
+                controls
+                class="w-full p-4"
+              />
+              <a
+                v-else
+                :href="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-primary-comfy-yellow block p-6 text-sm break-all hover:underline"
+              >
+                {{ url }}
+              </a>
+            </li>
+          </ul>
+
+          <p v-else class="text-sm text-primary-comfy-canvas/65">
+            {{ t('workshop.run.noMedia', locale) }}
+          </p>
+
+          <!--
+            Always available, never only. The output shape belongs to the
+            partner, so whatever the list above found, the document itself is
+            the record of what actually came back.
+          -->
+          <details class="mt-4">
+            <summary
+              class="cursor-pointer text-sm text-primary-comfy-canvas/65 hover:text-primary-comfy-canvas"
+            >
+              {{ t('workshop.run.rawOutput', locale) }}
+            </summary>
+            <pre
+              class="mt-3 max-h-120 overflow-auto rounded-xl border border-primary-comfy-canvas/10 bg-black p-5 text-sm/relaxed text-primary-comfy-canvas"
+            ><code>{{ JSON.stringify(result.output, null, 2) }}</code></pre>
+          </details>
+        </div>
 
         <!--
-          Always available, never only. The output shape belongs to the
-          partner, so whatever the list above found, the document itself is
-          the record of what actually came back.
+          The prototype shows a real example here so you can see what a model
+          produces before running it. That needs per-model example media we do
+          not have yet, so this holds the space until the content pack lands.
         -->
-        <details class="mt-4">
-          <summary
-            class="cursor-pointer text-sm text-primary-comfy-canvas/65 hover:text-primary-comfy-canvas"
-          >
-            {{ t('workshop.run.rawOutput', locale) }}
-          </summary>
-          <pre
-            class="mt-3 max-h-120 overflow-auto rounded-xl border border-primary-comfy-canvas/10 bg-black p-5 text-sm/relaxed text-primary-comfy-canvas"
-          ><code>{{ JSON.stringify(result.output, null, 2) }}</code></pre>
-        </details>
-      </div>
-
-      <!-- Nothing has run yet: hold the space so the page does not jump. -->
-      <div
-        v-else
-        class="mt-6 flex aspect-video items-center justify-center rounded-xl border border-dashed border-primary-comfy-canvas/12"
-      >
-        <p class="px-6 text-center text-sm text-primary-comfy-canvas/45">
-          {{ t('workshop.run.idle', locale) }}
-        </p>
+        <div
+          v-else
+          class="flex aspect-video items-center justify-center rounded-xl border border-dashed border-primary-comfy-canvas/12"
+        >
+          <p class="px-6 text-center text-sm text-primary-comfy-canvas/45">
+            {{ t('workshop.run.idle', locale) }}
+          </p>
+        </div>
       </div>
     </section>
 

--- a/apps/website/src/components/workshop/WorkshopSignInDialog.vue
+++ b/apps/website/src/components/workshop/WorkshopSignInDialog.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import { useWorkshopCredentials } from '../../config/workshop-credentials-state'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
+const { open, locale = 'en' } = defineProps<{
+  open: boolean
+  locale?: Locale
+}>()
+const emit = defineEmits<{ close: []; authenticated: [] }>()
+
+const { credentials, save } = useWorkshopCredentials()
+const draft = ref('')
+const dialog = ref<HTMLDialogElement>()
+
+watch(
+  () => open,
+  (isOpen) => {
+    if (isOpen) {
+      draft.value = credentials.value
+      // showModal, not an overlay div: it gets focus trapping, Escape, and
+      // inertness of the rest of the page from the platform for free.
+      dialog.value?.showModal()
+    } else {
+      dialog.value?.close()
+    }
+  }
+)
+
+function submit() {
+  if (draft.value === '') return
+  save(draft.value)
+  emit('authenticated')
+  emit('close')
+}
+</script>
+
+<template>
+  <dialog
+    ref="dialog"
+    class="m-auto w-[min(28rem,calc(100vw-2rem))] rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-0 text-primary-comfy-canvas backdrop:bg-black/60"
+    :aria-label="t('workshop.auth.heading', locale)"
+    @close="emit('close')"
+  >
+    <form class="p-6" @submit.prevent="submit">
+      <h2 class="text-xl font-semibold">
+        {{ t('workshop.auth.heading', locale) }}
+      </h2>
+      <p class="mt-2 text-sm text-primary-comfy-canvas/65">
+        {{ t('workshop.auth.body', locale) }}
+      </p>
+
+      <!--
+        Scaffolding. In the shipped product this dialog is a sign-in flow and
+        there is no key field: comfy.org cannot start a session yet because
+        the origin is not on the Firebase authorized-domains list. When that
+        lands, this input is what gets replaced.
+      -->
+      <label class="mt-6 flex flex-col gap-2">
+        <span class="text-sm font-medium">
+          {{ t('workshop.run.apiKey', locale) }}
+        </span>
+        <input
+          v-model="draft"
+          type="password"
+          autocomplete="off"
+          spellcheck="false"
+          :placeholder="t('workshop.run.apiKeyPlaceholder', locale)"
+          class="focus:border-primary-comfy-yellow h-11 rounded-xl border border-primary-comfy-canvas/15 bg-primary-comfy-canvas/5 px-4 font-mono text-sm outline-none"
+        />
+      </label>
+
+      <button
+        type="submit"
+        :disabled="draft === ''"
+        class="hover:bg-primary-comfy-yellow/90 mt-5 h-12 w-full rounded-xl bg-primary-comfy-yellow font-semibold text-primary-comfy-ink transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {{ t('workshop.auth.continue', locale) }}
+      </button>
+
+      <p class="mt-4 text-center text-xs text-primary-comfy-canvas/45">
+        <a
+          href="https://platform.comfy.org/profile/api-keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-primary-comfy-yellow underline"
+        >
+          {{ t('workshop.model.getApiKey', locale) }}
+        </a>
+      </p>
+    </form>
+  </dialog>
+</template>

--- a/apps/website/src/config/workshop-credentials-state.ts
+++ b/apps/website/src/config/workshop-credentials-state.ts
@@ -1,0 +1,31 @@
+import { ref } from 'vue'
+
+import {
+  readStoredCredentials,
+  writeStoredCredentials
+} from './workshop-credentials'
+
+/**
+ * The credential shared between the temporary key bar and the run panel.
+ *
+ * Module-scoped rather than passed as props because it is scaffolding: in the
+ * real product the credential comes from a signed-in session and neither
+ * component takes it as input at all. Keeping it out of the component
+ * interfaces means deleting the bar is the whole removal.
+ */
+const credentials = ref('')
+let loaded = false
+
+export function useWorkshopCredentials() {
+  if (!loaded) {
+    loaded = true
+    credentials.value = readStoredCredentials()
+  }
+  return {
+    credentials,
+    save: (value: string) => {
+      credentials.value = value
+      writeStoredCredentials(value)
+    }
+  }
+}

--- a/apps/website/src/config/workshop-run-proxy.ts
+++ b/apps/website/src/config/workshop-run-proxy.ts
@@ -1,0 +1,102 @@
+/**
+ * LOCAL ONLY — not for production, not committed.
+ *
+ * Runs a model through the ComfyUI partner-node `/proxy/*` surface, which is
+ * what platform.comfy.org's playground uses today.
+ *
+ * Why this exists rather than posting to Comfy Router directly: our catalog's
+ * `parameters` describe a NORMALIZED authoring shape that only the partner
+ * bundle understands. Both `/proxy/*` and Router speak the partner's raw
+ * native protocol instead — different field names, nested objects, per-model
+ * wire ids, three different media strategies. Measured across 259 models, not
+ * one request body built from our form matches what either surface wants, and
+ * no request URL is derivable from the model id.
+ *
+ * The bundle is the normalizer. It owns the request builders, the media
+ * upload strategies, the per-provider poll loops, and the response
+ * normalization. So we call it rather than reimplementing it.
+ */
+import type { WorkshopDetailModel, WorkshopFormValues } from './workshop-detail'
+import type { WorkshopRunResult } from './workshop-run'
+import { COMFY_ROUTER_BASE_URL } from './workshop-run'
+
+interface PartnerResult {
+  readonly job_id?: string
+  readonly status?: string
+  readonly type?: string
+  readonly results?: ReadonlyArray<{ url?: string; mime?: string }>
+}
+
+type PartnerGenerate = (
+  config: { baseUrl: string; token: string; headers?: Record<string, string> },
+  input: Record<string, unknown>
+) => Promise<PartnerResult>
+
+let generateFn: PartnerGenerate | undefined
+
+/**
+ * Loaded on first run rather than at module scope: the bundle is 2 MB (0.4 MB
+ * gzipped) and nothing about browsing a model page needs it.
+ */
+async function loadGenerate(): Promise<PartnerGenerate> {
+  if (!generateFn) {
+    const mod = (await import('../vendor/partner-client.mjs')) as {
+      generate: PartnerGenerate
+    }
+    generateFn = mod.generate
+  }
+  return generateFn
+}
+
+/**
+ * The bundle takes the same normalized shape our form produces, because our
+ * `parameters` were generated FROM the bundle's own registry. So the form
+ * values pass through unchanged, with the model id alongside them.
+ */
+export async function runViaPartnerProxy(
+  model: WorkshopDetailModel,
+  values: WorkshopFormValues,
+  credentials: string
+): Promise<WorkshopRunResult> {
+  let generate: PartnerGenerate
+  try {
+    generate = await loadGenerate()
+  } catch (cause) {
+    return {
+      status: 'error',
+      errorType: 'service_unavailable',
+      detail: `The partner client failed to load: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      requestId: undefined
+    }
+  }
+
+  const input: Record<string, unknown> = { model: model.id }
+  for (const [name, value] of Object.entries(values)) {
+    if (value !== undefined && value !== '') input[name] = value
+  }
+
+  try {
+    const result = await generate(
+      { baseUrl: COMFY_ROUTER_BASE_URL, token: credentials },
+      input
+    )
+    if (result.status === 'failed') {
+      return {
+        status: 'error',
+        errorType: 'provider_error',
+        detail: `The run did not complete (job ${result.job_id ?? 'unknown'}).`,
+        requestId: result.job_id
+      }
+    }
+    return { status: 'ok', output: result, requestId: result.job_id }
+  } catch (cause) {
+    return {
+      status: 'error',
+      errorType: 'provider_error',
+      detail: cause instanceof Error ? cause.message : String(cause),
+      requestId: undefined
+    }
+  }
+}

--- a/apps/website/src/config/workshop-run-target.ts
+++ b/apps/website/src/config/workshop-run-target.ts
@@ -44,13 +44,35 @@ export interface WorkshopRunTarget {
   ): Promise<WorkshopRunResult>
 }
 
+/**
+ * LOCAL ONLY. Off unless `PUBLIC_WORKSHOP_PARTNER_PROXY=1` is set, which only
+ * a gitignored .env does — so tests and any build exercise the committed
+ * Router path, and only the local dev server routes through the bundle.
+ */
+const USE_PARTNER_PROXY = import.meta.env.PUBLIC_WORKSHOP_PARTNER_PROXY === '1'
+
 const routerRunTarget: WorkshopRunTarget = {
   id: 'router',
   snippetLanguages: ROUTER_SNIPPET_LANGUAGES,
   buildSnippet: (language, model, values) =>
     buildRouterSnippet(language, model.id, model.fields, values),
-  run: (model, values, options) =>
-    runRouterModel(model.id, buildWorkshopInput(model.fields, values), options)
+  run: async (model, values, options) => {
+    // LOCAL ONLY. The catalog's parameters describe a normalized authoring
+    // shape that only the partner bundle can turn into a partner-native
+    // request, so posting our form values straight at Router runs the wrong
+    // body: measured, it drops reference images on the BFL models and
+    // silently ignores the prompt on ideogram/v4. Flip this off to get the
+    // committed Router behaviour back.
+    if (USE_PARTNER_PROXY) {
+      const { runViaPartnerProxy } = await import('./workshop-run-proxy')
+      return runViaPartnerProxy(model, values, options.credentials)
+    }
+    return runRouterModel(
+      model.id,
+      buildWorkshopInput(model.fields, values),
+      options
+    )
+  }
 }
 
 const RUN_TARGETS: Readonly<Record<WorkshopRunTargetId, WorkshopRunTarget>> = {

--- a/apps/website/src/config/workshop-samples.test.ts
+++ b/apps/website/src/config/workshop-samples.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkshopField } from './workshop-detail'
+import { withSamplePrompt } from './workshop-samples'
+
+function text(name: string): WorkshopField {
+  return {
+    kind: 'text',
+    name,
+    label: name,
+    required: false,
+    multiline: true,
+    valueType: 'string'
+  }
+}
+
+describe('withSamplePrompt', () => {
+  it('fills an empty prompt so the first action is pressing Run', () => {
+    const fields = [text('prompt')]
+    expect(withSamplePrompt({}, fields, 'image').prompt).toContain('bicycle')
+  })
+
+  it('writes text a text-to-speech model can actually read aloud', () => {
+    // The same words do not work everywhere: an audio model speaks its
+    // prompt, so "a red bicycle, soft morning light" would be nonsense.
+    const spoken = withSamplePrompt({}, [text('prompt')], 'audio').prompt
+    expect(spoken).toBe(
+      'Comfy Workshop lets you run any model straight from your browser.'
+    )
+  })
+
+  it('never overwrites a default the model itself specifies', () => {
+    expect(
+      withSamplePrompt(
+        { prompt: 'the model knows best' },
+        [text('prompt')],
+        'image'
+      )
+    ).toEqual({ prompt: 'the model knows best' })
+  })
+
+  it('does not fill the negative prompt', () => {
+    const fields = [text('prompt'), text('negative_prompt')]
+    const seeded = withSamplePrompt({}, fields, 'image')
+
+    expect(seeded.prompt).toBeDefined()
+    expect(seeded.negative_prompt).toBeUndefined()
+  })
+
+  it('finds the prompt under its other spellings', () => {
+    // ideogram calls it text_prompt; some models just call it text.
+    expect(
+      withSamplePrompt({}, [text('text_prompt')], 'image').text_prompt
+    ).toBeDefined()
+    expect(withSamplePrompt({}, [text('text')], 'image').text).toBeDefined()
+  })
+
+  it('leaves a model with no prompt field alone', () => {
+    const upscaler = [
+      {
+        kind: 'media' as const,
+        name: 'media_image',
+        role: 'image',
+        label: 'Image',
+        required: true,
+        multiple: false,
+        accept: 'image' as const
+      }
+    ]
+    expect(withSamplePrompt({}, upscaler, 'image')).toEqual({})
+  })
+})

--- a/apps/website/src/config/workshop-samples.ts
+++ b/apps/website/src/config/workshop-samples.ts
@@ -1,0 +1,58 @@
+import type { WorkshopField } from './workshop-detail'
+import type { WorkshopFormValues } from './workshop-detail'
+
+/**
+ * A prompt already in the box, so the first thing a visitor does is press Run
+ * rather than think of something to type.
+ *
+ * Chosen per output type because the same words do not work everywhere: a
+ * text-to-speech model reads its prompt aloud, a music model wants a
+ * description of a sound, and a 3D model wants a single object rather than a
+ * scene.
+ */
+const SAMPLE_PROMPTS: Record<string, string> = {
+  image: 'a red bicycle leaning against a white wall, soft morning light',
+  video: 'a red bicycle leaning against a white wall, camera slowly pushing in',
+  audio: 'Comfy Workshop lets you run any model straight from your browser.',
+  music: 'a warm lo-fi piano loop with soft vinyl crackle',
+  '3d': 'a small ceramic teapot with a curved handle',
+  svg: 'a minimal line-art bicycle icon, single colour'
+}
+
+/**
+ * Which field is the prompt.
+ *
+ * Matched by name. The partner registry does carry an explicit `promptField`
+ * per model, which is the right source; our catalog does not carry it through
+ * yet, and adding it means a schema change plus regenerating every entry —
+ * not worth doing while the catalog's source is still being decided. Swapping
+ * this for the carried field is a one-line change when it is.
+ */
+function isPromptField(field: WorkshopField): boolean {
+  if (field.kind !== 'text' || field.valueType !== 'string') return false
+  const name = field.name.toLowerCase()
+  if (name.startsWith('negative')) return false
+  return name === 'prompt' || name === 'text' || name.endsWith('_prompt')
+}
+
+/**
+ * Seeds a sample prompt into defaults, without overriding anything the model
+ * already specifies a default for.
+ */
+export function withSamplePrompt(
+  values: WorkshopFormValues,
+  fields: readonly WorkshopField[],
+  modality: string
+): WorkshopFormValues {
+  const sample = SAMPLE_PROMPTS[modality]
+  if (sample === undefined) return values
+
+  const prompt = fields.find(isPromptField)
+  if (prompt === undefined) return values
+  // A model that ships its own default knows better than this file does.
+  if (values[prompt.name] !== undefined && values[prompt.name] !== '') {
+    return values
+  }
+
+  return { ...values, [prompt.name]: sample }
+}

--- a/apps/website/src/env.d.ts
+++ b/apps/website/src/env.d.ts
@@ -8,6 +8,8 @@ interface ViteTypeOptions {
 }
 
 interface ImportMetaEnv {
+  /** LOCAL ONLY: route runs through the vendored partner bundle. */
+  readonly PUBLIC_WORKSHOP_PARTNER_PROXY?: string
   readonly PUBLIC_POSTHOG_KEY?: string
   readonly PUBLIC_POSTHOG_API_HOST?: string
   readonly PUBLIC_POSTHOG_UI_HOST?: string

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -49,6 +49,14 @@ const translations = {
     en: 'Your key is stored in this browser only and is sent straight to the Comfy API.',
     'zh-CN': '密钥仅保存在此浏览器中，并直接发送至 Comfy API。'
   },
+  'workshop.card.input': {
+    en: 'Input',
+    'zh-CN': '输入'
+  },
+  'workshop.card.output': {
+    en: 'Output',
+    'zh-CN': '输出'
+  },
   'workshop.auth.cta': {
     en: 'Sign up / Login to Render',
     'zh-CN': '注册 / 登录后生成'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -29,10 +29,6 @@ const translations = {
     en: 'Temporary — replaced by sign-in.',
     'zh-CN': '临时方案，登录功能上线后移除。'
   },
-  'workshop.run.idle': {
-    en: 'Your result will appear here.',
-    'zh-CN': '生成结果将显示在这里。'
-  },
   'workshop.run.heading': {
     en: 'Run it',
     'zh-CN': '运行'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1,6 +1,38 @@
 type Locale = 'en' | 'zh-CN' | 'ja'
 
 const translations = {
+  'workshop.tab.playground': {
+    en: 'Playground',
+    'zh-CN': '试用'
+  },
+  'workshop.tab.api': {
+    en: 'API',
+    'zh-CN': 'API'
+  },
+  'workshop.run.hideKey': {
+    en: 'Hide the API key field',
+    'zh-CN': '隐藏 API 密钥输入框'
+  },
+  'workshop.run.needKey': {
+    en: 'Add your API key above',
+    'zh-CN': '请在上方填写 API 密钥'
+  },
+  'workshop.run.keySave': {
+    en: 'Use key',
+    'zh-CN': '使用密钥'
+  },
+  'workshop.run.keySaved': {
+    en: 'Saved',
+    'zh-CN': '已保存'
+  },
+  'workshop.run.keyTemporary': {
+    en: 'Temporary — replaced by sign-in.',
+    'zh-CN': '临时方案，登录功能上线后移除。'
+  },
+  'workshop.run.idle': {
+    en: 'Your result will appear here.',
+    'zh-CN': '生成结果将显示在这里。'
+  },
   'workshop.run.heading': {
     en: 'Run it',
     'zh-CN': '运行'
@@ -17,6 +49,23 @@ const translations = {
     en: 'Your key is stored in this browser only and is sent straight to the Comfy API.',
     'zh-CN': '密钥仅保存在此浏览器中，并直接发送至 Comfy API。'
   },
+  'workshop.auth.cta': {
+    en: 'Sign up / Login to Render',
+    'zh-CN': '注册 / 登录后生成'
+  },
+  'workshop.auth.heading': {
+    en: 'Sign in to run this model',
+    'zh-CN': '登录后即可运行该模型'
+  },
+  'workshop.auth.body': {
+    en: 'Runs are billed to your Comfy account. Sign-in is coming to comfy.org; for now, paste an API key.',
+    'zh-CN':
+      '运行将从你的 Comfy 账户扣费。comfy.org 登录功能即将上线，目前请粘贴 API 密钥。'
+  },
+  'workshop.auth.continue': {
+    en: 'Continue',
+    'zh-CN': '继续'
+  },
   'workshop.run.button': {
     en: 'Run',
     'zh-CN': '运行'
@@ -26,8 +75,20 @@ const translations = {
     'zh-CN': '取消'
   },
   'workshop.run.running': {
-    en: 'Running. This can take a minute or two.',
-    'zh-CN': '运行中，可能需要一两分钟。'
+    en: 'Generating',
+    'zh-CN': '生成中'
+  },
+  'workshop.run.wait.video': {
+    en: 'Video models usually take one to three minutes.',
+    'zh-CN': '视频模型通常需要一到三分钟。'
+  },
+  'workshop.run.wait.slow': {
+    en: 'This can take a couple of minutes.',
+    'zh-CN': '这可能需要几分钟。'
+  },
+  'workshop.run.wait.default': {
+    en: 'Most images take under a minute.',
+    'zh-CN': '大多数图片生成不到一分钟。'
   },
   'workshop.run.noMedia': {
     en: 'The model returned no media. The full response is below.',

--- a/apps/website/src/pages/workshop/models/[slug].astro
+++ b/apps/website/src/pages/workshop/models/[slug].astro
@@ -47,25 +47,40 @@ const { model, related } = Astro.props
       </span>
     </nav>
 
-    <header class="mb-12 max-w-4xl">
-      <p class="text-sm tracking-widest text-primary-comfy-yellow uppercase">
-        {model.provider}
-      </p>
-      <h1 class="mt-3 text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
-        {model.displayName}
-      </h1>
-      <p class="mt-5 text-lg text-primary-comfy-canvas/70">
-        {model.description}
-      </p>
-      <ul class="mt-6 flex flex-wrap gap-2">
-        {
-          model.tags.slice(0, 8).map((tag) => (
-            <li class="rounded-full bg-primary-comfy-canvas/8 px-3 py-1 text-xs text-primary-comfy-canvas/65">
-              {tag}
-            </li>
-          ))
-        }
-      </ul>
+    {/*
+      Hero band. The prototype carries a model still behind this; we have no
+      per-model art yet, so the space is reserved and left empty rather than
+      filled with a stand-in. When the content pack lands, the image drops in
+      behind this same block and nothing else moves.
+    */}
+    <header
+      class="relative mb-12 min-h-72 overflow-hidden rounded-3xl border border-primary-comfy-canvas/10 bg-primary-comfy-canvas/[0.04]"
+    >
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-0 bg-gradient-to-tr from-primary-comfy-ink via-primary-comfy-ink/85 to-transparent"
+      >
+      </div>
+      <div class="relative max-w-4xl p-8 lg:p-10">
+        <p class="text-sm tracking-widest text-primary-comfy-yellow uppercase">
+          {model.provider}
+        </p>
+        <h1 class="mt-3 text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
+          {model.displayName}
+        </h1>
+        <p class="mt-5 text-lg text-primary-comfy-canvas/70">
+          {model.description}
+        </p>
+        <ul class="mt-6 flex flex-wrap gap-2">
+          {
+            model.tags.slice(0, 8).map((tag) => (
+              <li class="rounded-full bg-primary-comfy-canvas/8 px-3 py-1 text-xs text-primary-comfy-canvas/65">
+                {tag}
+              </li>
+            ))
+          }
+        </ul>
+      </div>
     </header>
 
     <WorkshopPlayground model={model} client:load />


### PR DESCRIPTION
Handover branch. The layout and the run path work; the credential is a stand-in and that is the job to pick up.

## Running it locally

The 268-model catalog is committed, so a clone gives you every model page and the whole UI. What is not committed is `partner-client.mjs`, the vendored partner-node client — without it the site still builds and runs, you just cannot get a result out of most models.

```
cd apps/website
mkdir -p src/vendor
cp <zip>/vendor/partner-client.*  src/vendor/
echo PUBLIC_WORKSHOP_PARTNER_PROXY=1 > .env.local
pnpm dev
```

Both paths are gitignored. The bundle is built from the **private** `comfy-partner-mcp` repo (`0abe0d8`), so it must not be committed here.

Known-good check: `/workshop/models/ideogram--v2-turbo/` → Sign up / Login to Render → paste a key → Continue. Runs in ~12s via `POST /proxy/ideogram/generate`. Keys: https://platform.comfy.org/profile/api-keys

## Why the bundle is needed

Our catalog `parameters` describe a **normalized authoring shape**. Both Comfy Router (`/v2/models/...`) and the partner proxy (`/proxy/...`) want the partner’s **raw native protocol**. Measured across 259 models:

| | |
|---|---|
| bodies matching our form’s shape | 0 / 259 |
| URLs derivable from the model id | 0 / 259 |
| bodies remapping the id to a string absent from our catalog | 106 |

```
our form  {"model":"vertexai/gemini-2.5-flash-image","prompt":"a red cube"}
the wire  {"contents":[...],"generationConfig":{...},"systemInstruction":{...}}
```

The bundle is the translator — request builders, three media strategies, ~20 per-provider poll loops, response normalization. Porting it is multi-week against a surface that churns.

`PUBLIC_WORKSHOP_PARTNER_PROXY=1` is the only thing that switches to it. Unset — so in every build and every test — the committed code still posts to Router. Switch lives in `config/workshop-run-target.ts`.

## The auth job

The credential is a pasted API key that exists only inside `WorkshopSignInDialog.vue`, shared through a module-scoped ref in `config/workshop-credentials-state.ts` rather than props — so the panel and the page never see it. **Deleting that one component and pointing `useWorkshopCredentials()` at a session token is the whole swap.**

It is a stand-in because comfy.org cannot start a session yet:
- **FE-2010** — comfy.org is not on the Firebase authorized-domains list, so a sign-in popup fails before it starts.
- **FE-2009** — comfy.org is not in the ingest CORS allowlist.

Both need console access someone else has. Note also the key currently reaches the browser as a raw long-lived credential; for real visitors it wants to be scoped and short-lived.

## Two live bugs, already filed

- **FE-2032** — BFL runs are **billed and then lost**. Polling bypasses the proxy and races a hardcoded region list `["us1","us2","us3","us4","eu1"]`; `eu2` appears zero times in the bundle. A real run was charged 6.33 credits and reported `failed`. This is hitting platform.comfy.org today. Every BFL model will fail here for the same reason; everything else works.
- **FE-2011** — the Router rollout gate. Router is a re-addressing facade over the same proxy operations, but only **14 of 205** models have an authored input schema, so it cannot source our forms. It also silently corrupts: `bfl/flux-kontext-max` returns 200 while dropping the reference image, and `ideogram/v4` names the field `text_prompt` so our `prompt` is discarded and the run succeeds with the wrong result.

## Layout

Matched to Mariana’s prototype (#16556): 12-column grid at 5:7, INPUT and OUTPUT as titled cards, uppercase field labels with the description beneath, run control at the foot of the input card, hero band above.

**Her branch moved six times on 3 Sep, most recently ~4h before this was cut** — including `38436a72` “list every model, with family grouping behind a switch”, which is her resolving the task-addressed vs version-addressed catalog split. **Rebase onto her branch rather than treating this as the layout source.**

Not reproduced here, all for want of data rather than disagreement:
- example output in the card, and the EXAMPLES tab
- the hero still (band and space are there, image is not)
- version chips and credits-per-run in the hero — the chips are how she sidesteps the catalog split, not a styling detail

Empty states reserve space but say nothing: a placeholder announcing what is missing is noise, but a gap appearing only after you press Run shoves the page at the moment you are watching it.

## State

1086 tests, 0 type errors, build clean. Vercel fails on this repo including on `main`, so ignore it.