### PR TITLE
fix(agent): expose #agent-panel-title after successful panel open

### DIFF
--- a/src/workbench/extensions/agent/components/agent/PanelHeader.test.ts
+++ b/src/workbench/extensions/agent/components/agent/PanelHeader.test.ts
@@ -28,6 +28,14 @@ function mount(isMaximized = false) {
 }
 
 describe('PanelHeader', () => {
+  it('exposes the heading id the dock landmark labels', () => {
+    mount()
+
+    expect(
+      screen.getByRole('heading', { name: 'Comfy Agent' })
+    ).toHaveAttribute('id', 'agent-panel-title')
+  })
+
   it('passes the full tooltip config to the button directive', () => {
     mount()
 

--- a/src/workbench/extensions/agent/components/agent/PanelHeader.vue
+++ b/src/workbench/extensions/agent/components/agent/PanelHeader.vue
@@ -32,7 +32,10 @@ const sizeToggleLabel = computed(() =>
   <header
     class="border-agent-border flex h-12 shrink-0 items-center gap-2 border-b px-4"
   >
-    <h1 class="text-agent-fg my-0 text-sm font-normal whitespace-nowrap">
+    <h1
+      id="agent-panel-title"
+      class="text-agent-fg my-0 text-sm font-normal whitespace-nowrap"
+    >
       {{ t('agent.title') }}
     </h1>
     <span


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud Playwright fails because keyboard open already shows the dock, but `#agent-panel-title` is never in the success-path DOM. The complementary landmark still points at that id.

## Evidence

**Failing run:** https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33822896207  
**SHA:** `9a24b373`  
**Job:** `playwright-tests (cloud)` — browsers=failure; sharded=success  
**Spec:** `browser_tests/tests/agent/agentPanelLifecycle.spec.ts:68` — `supports keyboard activation and returns one complementary landmark`

What happens today (the failing spec is the proof):

1. Focus the Ask Comfy Agent button and press Enter.
2. `#docked-agent-panel` becomes visible (`toBeVisible` passed).
3. The landmark has `role="complementary"` and `aria-labelledby="agent-panel-title"` (both passed).
4. `expect(page.locator('#agent-panel-title')).toHaveCount(1)` times out at 5000ms — received 0 on the first attempt and all 3 retries.

This is not a keyboard-activation failure and not a flake. Click-open in the same file also mounts the success tree; only this test asks for the title id.

`#11452` (`getSlotKey`) is discarded as cause. That commit only touches `src/renderer/core/layout/slots/slotIdentifier.ts` and an eslint suppression. It does not load, label, or render the agent panel. The next merge after the lifecycle spec (`#16217`) just happened to be `#11452`.

Also not `#16754` (error-overlay / in-flight execution errors). Does not reopen `#16537` or `#16567`. Does not touch `#16559` (knip).

## Root cause

`DockedAgentPanel.vue:6` always sets `aria-labelledby="agent-panel-title"`. That id is only rendered on the chunk-load **error** fallback (`DockedAgentPanel.vue:48`). The success path (`AgentPanelRoot` → `AgentPanel` → `PanelHeader`) had a visible `<h1>` with `t('agent.title')` and no id.

`#16198` removed the Suspense fallback that used to render `#agent-panel-title` while loading. The success heading never received the id, so after a successful open the labelledby target is missing.

## Change

- **What:** `PanelHeader.vue:36` — add `id="agent-panel-title"` to the existing success-path `<h1>`.
- Unit proof: `PanelHeader.test.ts` asserts the heading named "Comfy Agent" carries that id.
- No e2e spec changes. No other product behavior.

## Verify (human, minutes)

```
pnpm exec playwright test browser_tests/tests/agent/agentPanelLifecycle.spec.ts --grep "supports keyboard activation"
```

Expected: after keyboard activation, `#agent-panel-title` is present (count 1); that test green. No other product behavior change.

## Review Focus

The dock landmark and the visible heading must share one id on the success path. The error fallback already owns the same id and is mutually exclusive with `PanelHeader`.

## Screenshots (if applicable)

N/A — a11y id wiring; no visual change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd50d3ca-5bca-4e30-a350-e95776a9b7a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd50d3ca-5bca-4e30-a350-e95776a9b7a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

