### PR TITLE
fix(agent): give the docked panel landmark a real accessible name

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -986,6 +986,14 @@ function onPanelDrop(event: DragEvent): void {
     @dragover="onPanelDragOver"
     @drop="onPanelDrop"
   >
+    <!--
+      `DockedAgentPanel` labels its `role="complementary"` landmark with an
+      unconditional `aria-labelledby="agent-panel-title"`, but only its
+      `AgentPanelLoadError` fallback renders that id. On the success path the
+      reference dangled, so the landmark had no accessible name. Carry the same
+      `agent.title` string here so the name resolves whichever branch renders.
+    -->
+    <h2 id="agent-panel-title" class="sr-only">{{ t('agent.title') }}</h2>
     <input
       ref="fileInput"
       type="file"


### PR DESCRIPTION
## Summary

`playwright-tests (cloud)` is red on `main` at `590e7596e9`; this restores the accessible name the docked agent panel landmark has been missing since #16198, which is what the newly-landed lifecycle spec asserts.

## Changes

- **What**: `AgentPanelRoot` now renders an `sr-only` `<h2 id="agent-panel-title">` carrying `t('agent.title')`. `DockedAgentPanel` sets `aria-labelledby="agent-panel-title"` unconditionally on its `role="complementary"` element, but the only node with that id lives in the `AgentPanelLoadError` fallback, so on the success path the reference dangled and the landmark had no accessible name.

## Review Focus

This is a red-`main` fix-forward, so the provenance matters more than the diff.

The dock used to be the stub shell from [#16071](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16071), which carried the title itself. [#16198](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16198) (`f954e479a3`) swapped the stub for the real `AgentPanelRoot` and the title went with it, leaving the `aria-labelledby` dangling. [#16217](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16217) added `browser_tests/tests/agent/agentPanelLifecycle.spec.ts` on 2026-08-29 and merged on that same six-day-old green receipt at 2026-09-04T00:25:19Z, after the regression had already landed. So the spec is correct and it is `main` that was wrong; the assertion has simply never run against post-#16198 code until now.

Verified locally against a `pnpm build:cloud` dist served on `:6209`, with `PLAYWRIGHT_TEST_URL` pointed at it:

- unmodified `origin/main` @ `590e7596e9`: **1 failed, 5 passed** — `expect(locator('#agent-panel-title')).toHaveCount(1)` received `0`, byte-identical to [run 33822395883](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33822395883)
- with this commit: **6 passed**

The two branches are mutually exclusive (`AgentPanelLoadError` is the async component's `errorComponent`), so this cannot produce two nodes with the same id. `sr-only` and the `agent.title` string are both what the fallback already uses, so a screen reader announces the same name on either path.

Justification: red `main` fix-forward under the program's red-`main` P0 rule; the failing assertion is reproduced and cleared locally before and after, and the change is additive markup with no behavioural surface.

<!-- authored-by:agent pr-shepherd -->
