### PR TITLE
docs(agent): repair follower ADR review links

### DIFF
--- a/.agents/checks/follower-boundary.md
+++ b/.agents/checks/follower-boundary.md
@@ -7,8 +7,8 @@ tools: [Read, Grep, glob]
 
 Check changes under `src/workbench/extensions/agent/**` (and anything importing
 `@comfyorg/comfy-multi-player` or the agent CRDT seam) against the follower invariants in
-[FOLLOWER](../../docs/adr/FOLLOWER-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md) and the CRDT
-layout split in [LAYOUT](../../docs/adr/LAYOUT-crdt-layout-intent-and-local-measurement.md).
+[FOLLOWER](../../docs/adr/CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md) and the CRDT
+layout split in [LAYOUT](../../docs/adr/CRDT-LAYOUT-0003-crdt-layout-intent-and-local-measurement.md).
 
 These are load-bearing: a low-context change that violates one can silently foreclose the
 future P2P / offline / multi-writer / multi-agent story, or ship a follower that renders in

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -117,7 +117,7 @@ reviews:
     - path: 'src/workbench/extensions/agent/**'
       instructions: |
         Treat `.agents/checks/follower-boundary.md` and
-        `docs/adr/FOLLOWER-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md` as
+        `docs/adr/CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md` as
         required review context. Flag: the follower writing the shared doc,
         client-sent raw Yjs `update_b64`, layout/presence fields in the shared
         semantic doc, an optimistic overlay merged back as a Yjs update,


### PR DESCRIPTION
- Fixes both stale ADR-0016 review links.
- Points automated review at the existing ADR-0025 source of truth.

Coordination: [#17028](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17028) makes the identical edit to both files here (blobs `b9cb0f9375b8` and `2d114b25464d` are byte-identical at `238ce97d39d5` and `cd3c4c8db265`) and adds a CI guard so the class cannot recur. A `git merge-file` replay off merge base `4a31fa33f6e9` exits 0 with zero conflict markers, so the two land in either order without conflict; whichever lands second contributes no net change for these two files. If #17028 merges first this PR becomes a zero-change PR and should be closed rather than rebased.

<details><summary>Full context for agent readers</summary>

The follower-boundary agent profile and CodeRabbit path instruction still referenced the deleted ADR-0016 path. This updates the link and all profile prose/examples to ADR 0025 without changing the enforced invariants.

## Evidence

- `python3` YAML/frontmatter parse: pass.
- ADR-0025 target exists: pass.
- Stale follower ADR-0016 references in both guard files: zero.
- `git diff --check`: pass.
- Commit hooks: pass.

</details>

<!-- authored-by:agent lane-codify-invariants-per-repo-0130 -->