### PR TITLE
feat(i18n): translation pipeline for website content collections

### DIFF
--- a/.github/workflows/i18n-update-website-content.yaml
+++ b/.github/workflows/i18n-update-website-content.yaml
@@ -2,30 +2,39 @@
 # under apps/website/src/content/, using OpenAI, gated by the pipeline's own
 # AI review pass (see apps/website/scripts/i18n-content/review.ts). Manual
 # dispatch only for now — same rationale as i18n-update-website.yaml.
+#
+# Dispatch with `gh workflow run i18n-update-website-content.yaml --ref
+# <branch>`: no custom branch input. github.ref_name is the ref GitHub itself
+# resolved the dispatch against — unlike a free-text input, it can't be
+# spoofed to a fork PR merge ref or an arbitrary string, so it's safe to both
+# check out and use as the push target.
 name: 'i18n: Update Website Content'
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to translate and push results onto'
-        required: true
-        type: string
+  workflow_dispatch: {}
 
 concurrency:
-  group: i18n-update-website-content-${{ github.event.inputs.branch }}
+  group: i18n-update-website-content-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   update-website-content-translations:
-    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
+    # i18n/-prefixed is this pipeline's own branch convention: narrows which
+    # refs this job will ever check out or push to, on top of github.ref_name
+    # already being a real branch GitHub resolved the dispatch against.
+    if: github.repository == 'Comfy-Org/ComfyUI_frontend' && startsWith(github.ref_name, 'i18n/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          token: ${{ secrets.PR_GH_TOKEN }}
-          ref: ${{ github.event.inputs.branch }}
+          # Untrusted code from this ref runs in the next two steps with
+          # OPENAI_API_KEY in its environment; a persisted PR_GH_TOKEN in
+          # .git/config would be readable by that same code. Push with an
+          # explicit credential in its own step instead.
+          persist-credentials: false
 
       - name: Setup ComfyUI Frontend
         uses: ./.github/actions/setup-frontend
@@ -40,7 +49,7 @@ jobs:
 
       - name: Commit and push generated translations
         env:
-          TARGET_BRANCH: ${{ github.event.inputs.branch }}
+          PR_GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
         run: |
           git add apps/website/src/content/
           if git diff --cached --quiet; then
@@ -49,4 +58,4 @@ jobs:
           fi
           git -c user.name=github-actions -c user.email=github-actions@github.com \
             commit -m 'Update website content translations'
-          git push origin "HEAD:refs/heads/$TARGET_BRANCH"
+          git push "https://x-access-token:${PR_GH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/${{ github.ref_name }}"

--- a/.github/workflows/i18n-update-website-content.yaml
+++ b/.github/workflows/i18n-update-website-content.yaml
@@ -58,4 +58,4 @@ jobs:
           fi
           git -c user.name=github-actions -c user.email=github-actions@github.com \
             commit -m 'Update website content translations'
-          git push "https://x-access-token:${PR_GH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/${{ github.ref_name }}"
+          git push "https://x-access-token:${PR_GH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/$GITHUB_REF_NAME"

--- a/.github/workflows/i18n-update-website-content.yaml
+++ b/.github/workflows/i18n-update-website-content.yaml
@@ -1,0 +1,52 @@
+# Description: Generates missing/stale customer-story and FAQ translations
+# under apps/website/src/content/, using OpenAI, gated by the pipeline's own
+# AI review pass (see apps/website/scripts/i18n-content/review.ts). Manual
+# dispatch only for now — same rationale as i18n-update-website.yaml.
+name: 'i18n: Update Website Content'
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to translate and push results onto'
+        required: true
+        type: string
+
+concurrency:
+  group: i18n-update-website-content-${{ github.event.inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  update-website-content-translations:
+    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.PR_GH_TOKEN }}
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup ComfyUI Frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Update website content translations
+        run: pnpm --filter website i18n-content:translate
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Format
+        run: pnpm format
+
+      - name: Commit and push generated translations
+        env:
+          TARGET_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          git add apps/website/src/content/
+          if git diff --cached --quiet; then
+            echo "No new translations generated."
+            exit 0
+          fi
+          git -c user.name=github-actions -c user.email=github-actions@github.com \
+            commit -m 'Update website content translations'
+          git push origin "HEAD:refs/heads/$TARGET_BRANCH"

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -20,7 +20,9 @@
     "generate:models": "tsx ./scripts/generate-models.ts",
     "validate:jsonld": "tsx ./scripts/validate-jsonld.ts",
     "check:hreflang": "tsx ./scripts/check-hreflang.ts",
-    "validate:llms-txt-links": "tsx ./scripts/validate-llms-txt-links.ts"
+    "validate:llms-txt-links": "tsx ./scripts/validate-llms-txt-links.ts",
+    "i18n-content:check": "tsx ./scripts/i18n-content/update-content-translations.ts --check",
+    "i18n-content:translate": "tsx ./scripts/i18n-content/update-content-translations.ts"
   },
   "dependencies": {
     "@astrojs/sitemap": "catalog:",
@@ -57,12 +59,14 @@
     "@vitejs/plugin-vue": "catalog:",
     "astro": "catalog:",
     "happy-dom": "catalog:",
+    "openai": "catalog:",
     "tailwindcss": "catalog:",
     "tsx": "catalog:",
     "tw-animate-css": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
     "vue-component-type-helpers": "catalog:",
-    "vue-tsc": "catalog:"
+    "vue-tsc": "catalog:",
+    "yaml": "catalog:"
   }
 }

--- a/apps/website/scripts/i18n-content/config.ts
+++ b/apps/website/scripts/i18n-content/config.ts
@@ -1,0 +1,41 @@
+import type { OpenAI } from 'openai'
+
+export interface OutputLocale {
+  code: string
+  name: string
+  guidance?: string
+}
+
+export interface TranslationPipelineConfig {
+  model: string
+  reasoningEffort: NonNullable<OpenAI.ChatCompletionReasoningEffort>
+  maxItemsPerRequest: number
+  maxSourceCharsPerRequest: number
+  maxTruncationSplitDepth: number
+  requestConcurrency: number
+  maxTranslationRounds: number
+  glossary: string
+  outputLocales: OutputLocale[]
+}
+
+const glossary = `Keep these names untranslated: ComfyUI, Comfy, Comfy Cloud, Comfy Desktop, Comfy API, LoRA, ControlNet, VAE, CLIP, flux, HiDream.
+This is a customer story or FAQ answer for a professional creative-AI tool: match the source's tone and confidence, but never introduce a claim, statistic, or superlative that is not already in the English source.`
+
+const japaneseGuidance = `Use natural, professional Japanese as written by a native copywriter, not a literal word-for-word rendering of the English sentence structure.
+Keep widely-recognized technical and product terms in English (Latin script): API, GPU, node, workflow, LoRA, ControlNet, VAE, CLIP.
+Never overclaim: if the English source is measured or hedged, the Japanese must be too.`
+
+export const translationPipelineConfig: TranslationPipelineConfig = {
+  model: 'gpt-5.6-terra',
+  reasoningEffort: 'high',
+  maxItemsPerRequest: 20,
+  maxSourceCharsPerRequest: 8000,
+  maxTruncationSplitDepth: 3,
+  requestConcurrency: 2,
+  maxTranslationRounds: 3,
+  glossary,
+  outputLocales: [
+    { code: 'zh-CN', name: 'Simplified Chinese' },
+    { code: 'ja', name: 'Japanese', guidance: japaneseGuidance }
+  ]
+}

--- a/apps/website/scripts/i18n-content/document.test.ts
+++ b/apps/website/scripts/i18n-content/document.test.ts
@@ -207,11 +207,29 @@ describe('splitBody + joinBody', () => {
       '<AuthorBio people={[{ name: "Jane", bio: `Jane is an artist.` }]} />\n'
     const segments = splitBody(body)
 
+    const translatable = segments.filter((s) => s.translatable)
+    expect(translatable).toHaveLength(1)
+    expect(translatable[0].text).toBe('Jane is an artist.')
+    expect(joinBody(segments)).toBe(body)
+  })
+
+  it('keeps prose translatable before and after a self-closing component with no bio: field', () => {
+    const body = 'Intro text.\n\n<Figure src="x.png" alt="a" />\n\nOutro text.'
+    const segments = splitBody(body)
+
     expect(segments).toContainEqual({
       translatable: true,
-      text: 'Jane is an artist.'
+      text: 'Intro text.\n\n'
     })
-    expect(segments.map((s) => s.text).join('')).toBe(body)
+    expect(segments).toContainEqual({
+      translatable: false,
+      text: '<Figure src="x.png" alt="a" />'
+    })
+    expect(segments).toContainEqual({
+      translatable: true,
+      text: '\n\nOutro text.'
+    })
+    expect(joinBody(segments)).toBe(body)
   })
 
   it('finds the true matching close of a component nested inside itself', () => {

--- a/apps/website/scripts/i18n-content/document.test.ts
+++ b/apps/website/scripts/i18n-content/document.test.ts
@@ -202,6 +202,18 @@ describe('splitBody + joinBody', () => {
     expect(joinBody(segments)).toBe(body)
   })
 
+  it('extracts a bio: field from a body that is only a standalone self-closing <AuthorBio />', () => {
+    const body =
+      '<AuthorBio people={[{ name: "Jane", bio: `Jane is an artist.` }]} />\n'
+    const segments = splitBody(body)
+
+    expect(segments).toContainEqual({
+      translatable: true,
+      text: 'Jane is an artist.'
+    })
+    expect(segments.map((s) => s.text).join('')).toBe(body)
+  })
+
   it('finds the true matching close of a component nested inside itself', () => {
     const body = '<Section><Section>inner</Section> outer-after</Section>'
     const segments = splitBody(body)

--- a/apps/website/scripts/i18n-content/document.test.ts
+++ b/apps/website/scripts/i18n-content/document.test.ts
@@ -201,6 +201,27 @@ describe('splitBody + joinBody', () => {
     })
     expect(joinBody(segments)).toBe(body)
   })
+
+  it('finds the true matching close of a component nested inside itself', () => {
+    const body = '<Section><Section>inner</Section> outer-after</Section>'
+    const segments = splitBody(body)
+
+    expect(segments).toEqual([{ translatable: true, text: body }])
+    expect(joinBody(segments)).toBe(body)
+  })
+
+  it('does not mistake a quoted > for a component boundary', () => {
+    const body =
+      '<Section title="A > B">first</Section>\n<Section>second</Section>'
+    const segments = splitBody(body)
+
+    expect(segments).toEqual([
+      { translatable: true, text: '<Section title="A > B">first</Section>' },
+      { translatable: false, text: '\n' },
+      { translatable: true, text: '<Section>second</Section>' }
+    ])
+    expect(joinBody(segments)).toBe(body)
+  })
 })
 
 describe('findMdxSyntaxErrors', () => {

--- a/apps/website/scripts/i18n-content/document.test.ts
+++ b/apps/website/scripts/i18n-content/document.test.ts
@@ -1,0 +1,185 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  applyCustomersTranslations,
+  applyFaqTranslations,
+  customersTranslatableFields,
+  discoverDocuments,
+  faqTranslatableFields,
+  parseDocument,
+  readDocument,
+  serializeDocument
+} from './document'
+import type { CustomersFrontmatter, FaqFrontmatter } from './document'
+
+const customerFixture = `---
+title: "Built for AI"
+category: "SHOWCASE"
+description: "A description."
+cover: "https://media.comfy.org/cover.png"
+order: 4
+sections:
+  - id: topic-1
+    label: "THE PROGRAM"
+  - id: topic-2
+    label: "TEACHING WITH AI"
+---
+
+<Section id="topic-1">
+
+### A question?
+
+Some prose with a [link](https://docs.comfy.org/tutorials).
+
+</Section>
+`
+
+const faqFixture = `---
+question: "What are Partner Nodes, and do they cost extra?"
+order: 14
+---
+
+Partner Nodes let you run proprietary models. [Read more](https://docs.comfy.org/tutorials/partner-nodes/overview).
+`
+
+describe('parseDocument', () => {
+  it('splits a customer story into frontmatter and body', () => {
+    const { frontmatter, body } =
+      parseDocument<CustomersFrontmatter>(customerFixture)
+    expect(frontmatter.title).toBe('Built for AI')
+    expect(frontmatter.sections).toEqual([
+      { id: 'topic-1', label: 'THE PROGRAM' },
+      { id: 'topic-2', label: 'TEACHING WITH AI' }
+    ])
+    expect(body).toContain('<Section id="topic-1">')
+    expect(body).toContain('[link](https://docs.comfy.org/tutorials)')
+  })
+
+  it('splits an FAQ entry into frontmatter and body', () => {
+    const { frontmatter, body } = parseDocument<FaqFrontmatter>(faqFixture)
+    expect(frontmatter.question).toBe(
+      'What are Partner Nodes, and do they cost extra?'
+    )
+    expect(frontmatter.order).toBe(14)
+    expect(body).toContain('Partner Nodes let you run proprietary models.')
+  })
+})
+
+describe('customersTranslatableFields + applyCustomersTranslations', () => {
+  it('extracts title, category, description, and every section label', () => {
+    const { frontmatter } = parseDocument<CustomersFrontmatter>(customerFixture)
+    expect(customersTranslatableFields(frontmatter)).toEqual([
+      { path: 'title', value: 'Built for AI' },
+      { path: 'category', value: 'SHOWCASE' },
+      { path: 'description', value: 'A description.' },
+      { path: 'sections.0.label', value: 'THE PROGRAM' },
+      { path: 'sections.1.label', value: 'TEACHING WITH AI' }
+    ])
+  })
+
+  it('applies translations without touching cover, order, or section ids', () => {
+    const { frontmatter } = parseDocument<CustomersFrontmatter>(customerFixture)
+    const translated = applyCustomersTranslations(
+      frontmatter,
+      new Map([
+        ['title', 'AIのために作られた'],
+        ['sections.0.label', 'プログラム']
+      ])
+    )
+    expect(translated.title).toBe('AIのために作られた')
+    expect(translated.category).toBe('SHOWCASE')
+    expect(translated.cover).toBe('https://media.comfy.org/cover.png')
+    expect(translated.order).toBe(4)
+    expect(translated.sections).toEqual([
+      { id: 'topic-1', label: 'プログラム' },
+      { id: 'topic-2', label: 'TEACHING WITH AI' }
+    ])
+  })
+})
+
+describe('faqTranslatableFields + applyFaqTranslations', () => {
+  it('extracts only the question', () => {
+    const { frontmatter } = parseDocument<FaqFrontmatter>(faqFixture)
+    expect(faqTranslatableFields(frontmatter)).toEqual([
+      {
+        path: 'question',
+        value: 'What are Partner Nodes, and do they cost extra?'
+      }
+    ])
+  })
+
+  it('applies the translated question without touching order', () => {
+    const { frontmatter } = parseDocument<FaqFrontmatter>(faqFixture)
+    const translated = applyFaqTranslations(
+      frontmatter,
+      new Map([['question', 'パートナーノードとは？']])
+    )
+    expect(translated.question).toBe('パートナーノードとは？')
+    expect(translated.order).toBe(14)
+  })
+})
+
+describe('serializeDocument', () => {
+  it('round-trips frontmatter and body through parseDocument', () => {
+    const { frontmatter, body } = parseDocument<FaqFrontmatter>(faqFixture)
+    const serialized = serializeDocument(frontmatter, body)
+    const reparsed = parseDocument<FaqFrontmatter>(serialized)
+    expect(reparsed.frontmatter).toEqual(frontmatter)
+    expect(reparsed.body.trim()).toBe(body.trim())
+  })
+})
+
+describe('discoverDocuments', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'i18n-content-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('finds customer stories and categorized FAQ entries by their English source', () => {
+    mkdirSync(join(dir, 'customers', 'en'), { recursive: true })
+    writeFileSync(
+      join(dir, 'customers', 'en', 'kathy-smith.mdx'),
+      customerFixture
+    )
+    mkdirSync(join(dir, 'faq', 'pricing', 'en'), { recursive: true })
+    writeFileSync(
+      join(dir, 'faq', 'pricing', 'en', 'partner-nodes.mdx'),
+      faqFixture
+    )
+
+    const refs = discoverDocuments(dir)
+
+    expect(refs.map((ref) => ref.id)).toEqual([
+      'customers/kathy-smith',
+      'faq/pricing/partner-nodes'
+    ])
+    expect(refs[0].localePath('ja')).toBe(
+      join(dir, 'customers', 'ja', 'kathy-smith.mdx')
+    )
+    expect(refs[1].localePath('ja')).toBe(
+      join(dir, 'faq', 'pricing', 'ja', 'partner-nodes.mdx')
+    )
+  })
+
+  it('parses a discovered document according to its kind', () => {
+    mkdirSync(join(dir, 'customers', 'en'), { recursive: true })
+    const path = join(dir, 'customers', 'en', 'kathy-smith.mdx')
+    writeFileSync(path, customerFixture)
+
+    const [ref] = discoverDocuments(dir)
+    const { frontmatter } = readDocument(ref, path) as {
+      frontmatter: CustomersFrontmatter
+    }
+
+    expect(frontmatter.title).toBe('Built for AI')
+  })
+})

--- a/apps/website/scripts/i18n-content/document.test.ts
+++ b/apps/website/scripts/i18n-content/document.test.ts
@@ -177,6 +177,30 @@ describe('splitBody + joinBody', () => {
     expect(segments).toEqual([{ translatable: true, text: body }])
     expect(joinBody(segments)).toBe(body)
   })
+
+  it('translates an <AuthorBio> children block outside any <Section>', () => {
+    const body =
+      '<Section id="a">one</Section>\n\n<AuthorBio>Jane is an artist.</AuthorBio>\n'
+    const segments = splitBody(body)
+
+    expect(segments).toContainEqual({
+      translatable: true,
+      text: '<AuthorBio>Jane is an artist.</AuthorBio>'
+    })
+    expect(joinBody(segments)).toBe(body)
+  })
+
+  it('translates a bio: field inside a self-closing <AuthorBio /> without disturbing its structure', () => {
+    const body =
+      '<Section id="a">one</Section>\n\n<AuthorBio people={[{ name: "Jane", bio: `Jane is an artist.` }]} />\n'
+    const segments = splitBody(body)
+
+    expect(segments).toContainEqual({
+      translatable: true,
+      text: 'Jane is an artist.'
+    })
+    expect(joinBody(segments)).toBe(body)
+  })
 })
 
 describe('findMdxSyntaxErrors', () => {
@@ -213,6 +237,12 @@ describe('findMdxSyntaxErrors', () => {
     expect(findMdxSyntaxErrors('text with a stray }brace')).toEqual([
       'unbalanced braces: unexpected }'
     ])
+  })
+
+  it('does not mistake a > inside a quoted attribute for the tag close', () => {
+    expect(
+      findMdxSyntaxErrors('<Section title="A > B">text</Section>')
+    ).toEqual([])
   })
 })
 

--- a/apps/website/scripts/i18n-content/document.test.ts
+++ b/apps/website/scripts/i18n-content/document.test.ts
@@ -10,9 +10,12 @@ import {
   customersTranslatableFields,
   discoverDocuments,
   faqTranslatableFields,
+  findMdxSyntaxErrors,
+  joinBody,
   parseDocument,
   readDocument,
-  serializeDocument
+  serializeDocument,
+  splitBody
 } from './document'
 import type { CustomersFrontmatter, FaqFrontmatter } from './document'
 
@@ -129,7 +132,87 @@ describe('serializeDocument', () => {
     const serialized = serializeDocument(frontmatter, body)
     const reparsed = parseDocument<FaqFrontmatter>(serialized)
     expect(reparsed.frontmatter).toEqual(frontmatter)
-    expect(reparsed.body.trim()).toBe(body.trim())
+    expect(reparsed.body).toBe(body)
+  })
+
+  it('preserves a body that opens with an indented code block', () => {
+    const fixture = `---
+question: "How do I run this?"
+order: 1
+---
+
+    def example():
+        return 1
+`
+    const { frontmatter, body } = parseDocument<FaqFrontmatter>(fixture)
+    const reparsed = parseDocument<FaqFrontmatter>(
+      serializeDocument(frontmatter, body)
+    )
+    expect(reparsed.body).toBe(body)
+    expect(reparsed.body).toContain('    def example():')
+  })
+})
+
+describe('splitBody + joinBody', () => {
+  it('splits multiple <Section> blocks out as separate translatable segments', () => {
+    const body =
+      '\n<Section id="a">one</Section>\n\n<Section id="b">two</Section>\n'
+    const segments = splitBody(body)
+
+    expect(segments).toEqual([
+      { translatable: false, text: '\n' },
+      { translatable: true, text: '<Section id="a">one</Section>' },
+      { translatable: false, text: '\n\n' },
+      { translatable: true, text: '<Section id="b">two</Section>' },
+      { translatable: false, text: '\n' }
+    ])
+    expect(joinBody(segments)).toBe(body)
+  })
+
+  it('treats a body with no <Section> tags as one translatable segment', () => {
+    const body = '\nPartner Nodes let you run proprietary models.\n'
+
+    const segments = splitBody(body)
+
+    expect(segments).toEqual([{ translatable: true, text: body }])
+    expect(joinBody(segments)).toBe(body)
+  })
+})
+
+describe('findMdxSyntaxErrors', () => {
+  it('is silent on well-formed nested components', () => {
+    expect(
+      findMdxSyntaxErrors(
+        '<Section id="a"><Quote>text</Quote><Figure src="x.png" /></Section>'
+      )
+    ).toEqual([])
+  })
+
+  it('flags a tag that is never closed', () => {
+    expect(findMdxSyntaxErrors('<Section id="a">text')).toEqual([
+      '<Section> is never closed'
+    ])
+  })
+
+  it('flags a mismatched closing tag', () => {
+    expect(findMdxSyntaxErrors('<Section id="a">text</Quote>')).toEqual([
+      '</Quote> does not match the open <Section>'
+    ])
+  })
+
+  it('flags an unbalanced opening brace', () => {
+    expect(findMdxSyntaxErrors('<Figure people={[{ name: "a" }]} />')).toEqual(
+      []
+    )
+    expect(findMdxSyntaxErrors('text with a stray {brace')).toEqual([
+      'unbalanced braces: 1 unclosed {'
+    ])
+  })
+
+  it('flags an unbalanced closing brace', () => {
+    expect(findMdxSyntaxErrors('text with a stray }brace')).toEqual([
+      'unbalanced braces: unexpected }'
+    ])
   })
 })
 
@@ -168,6 +251,19 @@ describe('discoverDocuments', () => {
     expect(refs[1].localePath('ja')).toBe(
       join(dir, 'faq', 'pricing', 'ja', 'partner-nodes.mdx')
     )
+  })
+
+  it('ignores a directory that happens to be named like an .mdx file', () => {
+    mkdirSync(join(dir, 'customers', 'en'), { recursive: true })
+    writeFileSync(
+      join(dir, 'customers', 'en', 'kathy-smith.mdx'),
+      customerFixture
+    )
+    mkdirSync(join(dir, 'customers', 'en', 'draft.mdx'), { recursive: true })
+
+    const refs = discoverDocuments(dir)
+
+    expect(refs.map((ref) => ref.id)).toEqual(['customers/kathy-smith'])
   })
 
   it('parses a discovered document according to its kind', () => {

--- a/apps/website/scripts/i18n-content/document.ts
+++ b/apps/website/scripts/i18n-content/document.ts
@@ -75,6 +75,9 @@ function findTopLevelBlocks(body: string): { start: number; end: number }[] {
 // ..., bio: `text` }]} /> is self-closing, so it never yields a block.
 const bioFieldPattern = /\bbio:\s*`([^`]*)`/g
 
+// Only ever called on a self-closing tag's own text (its full `<Tag .../>`
+// span), never on surrounding prose: a tag with no bio: field is pure
+// markup, so "no match" correctly means "none of this is translatable."
 function splitBioFields(text: string): BodySegment[] {
   const segments: BodySegment[] = []
   let cursor = 0
@@ -99,6 +102,33 @@ function splitBioFields(text: string): BodySegment[] {
   return segments.length > 0 ? segments : [{ translatable: false, text }]
 }
 
+function splitProse(text: string): BodySegment[] {
+  return [{ translatable: text.trim().length > 0, text }]
+}
+
+// The text around (or entirely without) a top-level block: ordinary prose,
+// whitespace, and self-closing components. A self-closing tag's own span
+// goes through splitBioFields (markup, minus any translatable bio: field);
+// everything else is prose, translatable unless it's pure whitespace.
+function splitGap(text: string): BodySegment[] {
+  const segments: BodySegment[] = []
+  let cursor = 0
+  for (const match of text.matchAll(mdxTagPattern)) {
+    if (!match[3].trimEnd().endsWith('/')) continue
+    const index = match.index ?? 0
+    const tagEnd = index + match[0].length
+    if (index > cursor) {
+      segments.push(...splitProse(text.slice(cursor, index)))
+    }
+    segments.push(...splitBioFields(text.slice(index, tagEnd)))
+    cursor = tagEnd
+  }
+  if (cursor < text.length) {
+    segments.push(...splitProse(text.slice(cursor)))
+  }
+  return segments
+}
+
 // A customer story's body can run well past a single translation request's
 // character budget (longest today: ~15KB), but each <Section> or <AuthorBio>
 // within it is small (longest today: ~4.8KB). Splitting on that existing
@@ -108,22 +138,13 @@ function splitBioFields(text: string): BodySegment[] {
 // one segment.
 export function splitBody(body: string): BodySegment[] {
   const blocks = findTopLevelBlocks(body)
-  if (blocks.length === 0) {
-    // A body with no open/close block (e.g. one standalone self-closing
-    // <AuthorBio .../>) still needs its bio: fields extracted; plain prose
-    // with no tags at all has nothing for splitBioFields to find and should
-    // stay translatable in full rather than fall back to its "no match"
-    // default of non-translatable.
-    return [...body.matchAll(mdxTagPattern)].length > 0
-      ? splitBioFields(body)
-      : [{ translatable: true, text: body }]
-  }
+  if (blocks.length === 0) return splitGap(body)
 
   const segments: BodySegment[] = []
   let cursor = 0
   for (const block of blocks) {
     if (block.start > cursor) {
-      segments.push(...splitBioFields(body.slice(cursor, block.start)))
+      segments.push(...splitGap(body.slice(cursor, block.start)))
     }
     segments.push({
       translatable: true,
@@ -132,7 +153,7 @@ export function splitBody(body: string): BodySegment[] {
     cursor = block.end
   }
   if (cursor < body.length) {
-    segments.push(...splitBioFields(body.slice(cursor)))
+    segments.push(...splitGap(body.slice(cursor)))
   }
   return segments
 }

--- a/apps/website/scripts/i18n-content/document.ts
+++ b/apps/website/scripts/i18n-content/document.ts
@@ -108,7 +108,16 @@ function splitBioFields(text: string): BodySegment[] {
 // one segment.
 export function splitBody(body: string): BodySegment[] {
   const blocks = findTopLevelBlocks(body)
-  if (blocks.length === 0) return [{ translatable: true, text: body }]
+  if (blocks.length === 0) {
+    // A body with no open/close block (e.g. one standalone self-closing
+    // <AuthorBio .../>) still needs its bio: fields extracted; plain prose
+    // with no tags at all has nothing for splitBioFields to find and should
+    // stay translatable in full rather than fall back to its "no match"
+    // default of non-translatable.
+    return [...body.matchAll(mdxTagPattern)].length > 0
+      ? splitBioFields(body)
+      : [{ translatable: true, text: body }]
+  }
 
   const segments: BodySegment[] = []
   let cursor = 0

--- a/apps/website/scripts/i18n-content/document.ts
+++ b/apps/website/scripts/i18n-content/document.ts
@@ -42,16 +42,46 @@ export interface BodySegment {
   text: string
 }
 
-const sectionPattern = /<Section\b[^<>]*>[\s\S]*?<\/Section>/g
+const blockPattern = /<([A-Za-z][A-Za-z0-9._-]*)\b[^<>]*>[\s\S]*?<\/\1>/g
+
+// bio fields are the one place prose lives inside a component's JSX
+// attribute expression rather than as tag children: <AuthorBio people={[{
+// ..., bio: `text` }]} /> is self-closing, so it never matches blockPattern.
+const bioFieldPattern = /\bbio:\s*`([^`]*)`/g
+
+function splitBioFields(text: string): BodySegment[] {
+  const segments: BodySegment[] = []
+  let cursor = 0
+  for (const match of text.matchAll(bioFieldPattern)) {
+    const index = match.index ?? 0
+    const innerStart = index + match[0].length - match[1].length - 1
+    const innerEnd = innerStart + match[1].length
+    if (innerStart > cursor) {
+      segments.push({
+        translatable: false,
+        text: text.slice(cursor, innerStart)
+      })
+    }
+    if (match[1].length > 0) {
+      segments.push({ translatable: true, text: match[1] })
+    }
+    cursor = innerEnd
+  }
+  if (cursor < text.length) {
+    segments.push({ translatable: false, text: text.slice(cursor) })
+  }
+  return segments.length > 0 ? segments : [{ translatable: false, text }]
+}
 
 // A customer story's body can run well past a single translation request's
-// character budget (longest today: ~15KB), but each <Section> within it is
-// small (longest today: ~4.8KB). Splitting on that existing structural
-// boundary keeps every translation request comfortably sized without
-// inventing an arbitrary character-based cut that could land mid-sentence or
-// mid-component. A body with no <Section> tags (FAQ answers) is one segment.
+// character budget (longest today: ~15KB), but each <Section> or <AuthorBio>
+// within it is small (longest today: ~4.8KB). Splitting on that existing
+// structural boundary keeps every translation request comfortably sized
+// without inventing an arbitrary character-based cut that could land
+// mid-sentence or mid-component. A body with no such tags (FAQ answers) is
+// one segment.
 export function splitBody(body: string): BodySegment[] {
-  const matches = [...body.matchAll(sectionPattern)]
+  const matches = [...body.matchAll(blockPattern)]
   if (matches.length === 0) return [{ translatable: true, text: body }]
 
   const segments: BodySegment[] = []
@@ -59,13 +89,13 @@ export function splitBody(body: string): BodySegment[] {
   for (const match of matches) {
     const index = match.index ?? 0
     if (index > cursor) {
-      segments.push({ translatable: false, text: body.slice(cursor, index) })
+      segments.push(...splitBioFields(body.slice(cursor, index)))
     }
     segments.push({ translatable: true, text: match[0] })
     cursor = index + match[0].length
   }
   if (cursor < body.length) {
-    segments.push({ translatable: false, text: body.slice(cursor) })
+    segments.push(...splitBioFields(body.slice(cursor)))
   }
   return segments
 }
@@ -74,14 +104,17 @@ export function joinBody(segments: readonly BodySegment[]): string {
   return segments.map((segment) => segment.text).join('')
 }
 
-const mdxTagPattern = /<(\/?)([a-zA-Z][a-zA-Z0-9._-]*)([^<>]*)>/g
+const mdxTagPattern =
+  /<(\/?)([a-zA-Z][a-zA-Z0-9._-]*)((?:"[^"]*"|'[^']*'|[^<>])*)>/g
 
 // Astro compiles a generated .mdx file as JSX at build time, and nothing in
 // this pipeline otherwise runs that compiler before a translation is
 // committed. This is a syntax heuristic, not a substitute for it: it catches
 // the two failure shapes an LLM actually produces (a dropped/mismatched
 // closing tag, an unbalanced `{`/`}` from stray JSX-looking text) without
-// taking on a full MDX/JSX parser as a dependency.
+// taking on a full MDX/JSX parser as a dependency. The attrs group treats
+// quoted strings as opaque so a `>` inside an attribute value (e.g.
+// title="A > B") isn't mistaken for the tag's own close.
 export function findMdxSyntaxErrors(body: string): string[] {
   const stack: string[] = []
   const errors: string[] = []

--- a/apps/website/scripts/i18n-content/document.ts
+++ b/apps/website/scripts/i18n-content/document.ts
@@ -1,0 +1,167 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { parse, stringify } from 'yaml'
+
+export interface CustomersFrontmatter {
+  title: string
+  category: string
+  description: string
+  cover: string
+  readMore?: string
+  order: number
+  sections: { id: string; label: string }[]
+}
+
+export interface FaqFrontmatter {
+  question: string
+  order: number
+}
+
+type DocumentKind = 'customers' | 'faq'
+
+export interface DocumentRef {
+  id: string
+  kind: DocumentKind
+  enPath: string
+  localePath: (locale: string) => string
+}
+
+export interface TranslatableField {
+  path: string
+  value: string
+}
+
+export interface ParsedDocument<Frontmatter> {
+  frontmatter: Frontmatter
+  body: string
+}
+
+const frontmatterFence = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/
+
+export function parseDocument<Frontmatter>(
+  raw: string
+): ParsedDocument<Frontmatter> {
+  const match = frontmatterFence.exec(raw)
+  if (!match) throw new Error('document is missing a frontmatter fence')
+  return { frontmatter: parse(match[1]) as Frontmatter, body: match[2] }
+}
+
+export function serializeDocument(frontmatter: unknown, body: string): string {
+  return `---\n${stringify(frontmatter).trimEnd()}\n---\n\n${body.trimStart()}`
+}
+
+export function customersTranslatableFields(
+  frontmatter: CustomersFrontmatter
+): TranslatableField[] {
+  return [
+    { path: 'title', value: frontmatter.title },
+    { path: 'category', value: frontmatter.category },
+    { path: 'description', value: frontmatter.description },
+    ...frontmatter.sections.map((section, index) => ({
+      path: `sections.${index}.label`,
+      value: section.label
+    }))
+  ]
+}
+
+export function applyCustomersTranslations(
+  frontmatter: CustomersFrontmatter,
+  translations: ReadonlyMap<string, string>
+): CustomersFrontmatter {
+  return {
+    ...frontmatter,
+    title: translations.get('title') ?? frontmatter.title,
+    category: translations.get('category') ?? frontmatter.category,
+    description: translations.get('description') ?? frontmatter.description,
+    sections: frontmatter.sections.map((section, index) => ({
+      ...section,
+      label: translations.get(`sections.${index}.label`) ?? section.label
+    }))
+  }
+}
+
+export function faqTranslatableFields(
+  frontmatter: FaqFrontmatter
+): TranslatableField[] {
+  return [{ path: 'question', value: frontmatter.question }]
+}
+
+export function applyFaqTranslations(
+  frontmatter: FaqFrontmatter,
+  translations: ReadonlyMap<string, string>
+): FaqFrontmatter {
+  return {
+    ...frontmatter,
+    question: translations.get('question') ?? frontmatter.question
+  }
+}
+
+export function discoverDocuments(contentDir: string): DocumentRef[] {
+  const customersDir = join(contentDir, 'customers', 'en')
+  const customers: DocumentRef[] = existsSync(customersDir)
+    ? readdirSync(customersDir)
+        .filter((filename) => filename.endsWith('.mdx'))
+        .map((filename) => {
+          const slug = filename.slice(0, -'.mdx'.length)
+          return {
+            id: `customers/${slug}`,
+            kind: 'customers' as const,
+            enPath: join(customersDir, filename),
+            localePath: (locale: string) =>
+              join(contentDir, 'customers', locale, filename)
+          }
+        })
+    : []
+
+  const faqRoot = join(contentDir, 'faq')
+  const categories = existsSync(faqRoot)
+    ? readdirSync(faqRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+    : []
+  const faq: DocumentRef[] = categories.flatMap((category) => {
+    const enDir = join(faqRoot, category, 'en')
+    if (!existsSync(enDir)) return []
+    return readdirSync(enDir)
+      .filter((filename) => filename.endsWith('.mdx'))
+      .map((filename) => ({
+        id: `faq/${category}/${filename.slice(0, -'.mdx'.length)}`,
+        kind: 'faq' as const,
+        enPath: join(faqRoot, category, 'en', filename),
+        localePath: (locale: string) =>
+          join(faqRoot, category, locale, filename)
+      }))
+  })
+
+  return [...customers, ...faq].sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export function readDocument(ref: DocumentRef, path: string) {
+  const raw = readFileSync(path, 'utf8')
+  return ref.kind === 'customers'
+    ? parseDocument<CustomersFrontmatter>(raw)
+    : parseDocument<FaqFrontmatter>(raw)
+}
+
+export function translatableFields(
+  ref: DocumentRef,
+  frontmatter: CustomersFrontmatter | FaqFrontmatter
+): TranslatableField[] {
+  return ref.kind === 'customers'
+    ? customersTranslatableFields(frontmatter as CustomersFrontmatter)
+    : faqTranslatableFields(frontmatter as FaqFrontmatter)
+}
+
+export function applyFrontmatterTranslations(
+  ref: DocumentRef,
+  frontmatter: CustomersFrontmatter | FaqFrontmatter,
+  translations: ReadonlyMap<string, string>
+): CustomersFrontmatter | FaqFrontmatter {
+  return ref.kind === 'customers'
+    ? applyCustomersTranslations(
+        frontmatter as CustomersFrontmatter,
+        translations
+      )
+    : applyFaqTranslations(frontmatter as FaqFrontmatter, translations)
+}

--- a/apps/website/scripts/i18n-content/document.ts
+++ b/apps/website/scripts/i18n-content/document.ts
@@ -42,11 +42,37 @@ export interface BodySegment {
   text: string
 }
 
-const blockPattern = /<([A-Za-z][A-Za-z0-9._-]*)\b[^<>]*>[\s\S]*?<\/\1>/g
+const mdxTagPattern =
+  /<(\/?)([a-zA-Z][a-zA-Z0-9._-]*)((?:"[^"]*"|'[^']*'|[^<>])*)>/g
+
+// A lazy `<Tag>...</Tag>` regex stops at the first same-name close it finds,
+// which is the wrong one once a component nests inside itself (e.g. a
+// <Section> containing another <Section>). Walking mdxTagPattern with a
+// stack finds each top-level block's true matching close regardless of
+// nesting, reusing the same quote-aware tag scan findMdxSyntaxErrors uses.
+function findTopLevelBlocks(body: string): { start: number; end: number }[] {
+  const blocks: { start: number; end: number }[] = []
+  const stack: { name: string; start: number }[] = []
+  for (const match of body.matchAll(mdxTagPattern)) {
+    const [full, closing, name, attrs] = match
+    if (attrs.trimEnd().endsWith('/')) continue
+    const index = match.index ?? 0
+    if (!closing) {
+      stack.push({ name, start: index })
+      continue
+    }
+    const open = stack.pop()
+    if (!open || open.name !== name) continue
+    if (stack.length === 0) {
+      blocks.push({ start: open.start, end: index + full.length })
+    }
+  }
+  return blocks
+}
 
 // bio fields are the one place prose lives inside a component's JSX
 // attribute expression rather than as tag children: <AuthorBio people={[{
-// ..., bio: `text` }]} /> is self-closing, so it never matches blockPattern.
+// ..., bio: `text` }]} /> is self-closing, so it never yields a block.
 const bioFieldPattern = /\bbio:\s*`([^`]*)`/g
 
 function splitBioFields(text: string): BodySegment[] {
@@ -81,18 +107,20 @@ function splitBioFields(text: string): BodySegment[] {
 // mid-sentence or mid-component. A body with no such tags (FAQ answers) is
 // one segment.
 export function splitBody(body: string): BodySegment[] {
-  const matches = [...body.matchAll(blockPattern)]
-  if (matches.length === 0) return [{ translatable: true, text: body }]
+  const blocks = findTopLevelBlocks(body)
+  if (blocks.length === 0) return [{ translatable: true, text: body }]
 
   const segments: BodySegment[] = []
   let cursor = 0
-  for (const match of matches) {
-    const index = match.index ?? 0
-    if (index > cursor) {
-      segments.push(...splitBioFields(body.slice(cursor, index)))
+  for (const block of blocks) {
+    if (block.start > cursor) {
+      segments.push(...splitBioFields(body.slice(cursor, block.start)))
     }
-    segments.push({ translatable: true, text: match[0] })
-    cursor = index + match[0].length
+    segments.push({
+      translatable: true,
+      text: body.slice(block.start, block.end)
+    })
+    cursor = block.end
   }
   if (cursor < body.length) {
     segments.push(...splitBioFields(body.slice(cursor)))
@@ -103,9 +131,6 @@ export function splitBody(body: string): BodySegment[] {
 export function joinBody(segments: readonly BodySegment[]): string {
   return segments.map((segment) => segment.text).join('')
 }
-
-const mdxTagPattern =
-  /<(\/?)([a-zA-Z][a-zA-Z0-9._-]*)((?:"[^"]*"|'[^']*'|[^<>])*)>/g
 
 // Astro compiles a generated .mdx file as JSX at build time, and nothing in
 // this pipeline otherwise runs that compiler before a translation is

--- a/apps/website/scripts/i18n-content/document.ts
+++ b/apps/website/scripts/i18n-content/document.ts
@@ -37,6 +37,85 @@ export interface ParsedDocument<Frontmatter> {
   body: string
 }
 
+export interface BodySegment {
+  translatable: boolean
+  text: string
+}
+
+const sectionPattern = /<Section\b[^<>]*>[\s\S]*?<\/Section>/g
+
+// A customer story's body can run well past a single translation request's
+// character budget (longest today: ~15KB), but each <Section> within it is
+// small (longest today: ~4.8KB). Splitting on that existing structural
+// boundary keeps every translation request comfortably sized without
+// inventing an arbitrary character-based cut that could land mid-sentence or
+// mid-component. A body with no <Section> tags (FAQ answers) is one segment.
+export function splitBody(body: string): BodySegment[] {
+  const matches = [...body.matchAll(sectionPattern)]
+  if (matches.length === 0) return [{ translatable: true, text: body }]
+
+  const segments: BodySegment[] = []
+  let cursor = 0
+  for (const match of matches) {
+    const index = match.index ?? 0
+    if (index > cursor) {
+      segments.push({ translatable: false, text: body.slice(cursor, index) })
+    }
+    segments.push({ translatable: true, text: match[0] })
+    cursor = index + match[0].length
+  }
+  if (cursor < body.length) {
+    segments.push({ translatable: false, text: body.slice(cursor) })
+  }
+  return segments
+}
+
+export function joinBody(segments: readonly BodySegment[]): string {
+  return segments.map((segment) => segment.text).join('')
+}
+
+const mdxTagPattern = /<(\/?)([a-zA-Z][a-zA-Z0-9._-]*)([^<>]*)>/g
+
+// Astro compiles a generated .mdx file as JSX at build time, and nothing in
+// this pipeline otherwise runs that compiler before a translation is
+// committed. This is a syntax heuristic, not a substitute for it: it catches
+// the two failure shapes an LLM actually produces (a dropped/mismatched
+// closing tag, an unbalanced `{`/`}` from stray JSX-looking text) without
+// taking on a full MDX/JSX parser as a dependency.
+export function findMdxSyntaxErrors(body: string): string[] {
+  const stack: string[] = []
+  const errors: string[] = []
+  for (const [, closing, name, attrs] of body.matchAll(mdxTagPattern)) {
+    if (attrs.trimEnd().endsWith('/')) continue
+    if (!closing) {
+      stack.push(name)
+      continue
+    }
+    const open = stack.pop()
+    if (open !== name) {
+      errors.push(
+        open
+          ? `</${name}> does not match the open <${open}>`
+          : `</${name}> has no matching open tag`
+      )
+    }
+  }
+  for (const unclosed of stack) errors.push(`<${unclosed}> is never closed`)
+
+  let braceDepth = 0
+  for (const char of body) {
+    if (char === '{') braceDepth++
+    else if (char === '}') braceDepth--
+    if (braceDepth < 0) {
+      errors.push('unbalanced braces: unexpected }')
+      break
+    }
+  }
+  if (braceDepth > 0) errors.push(`unbalanced braces: ${braceDepth} unclosed {`)
+
+  return errors
+}
+
 const frontmatterFence = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/
 
 export function parseDocument<Frontmatter>(
@@ -48,7 +127,10 @@ export function parseDocument<Frontmatter>(
 }
 
 export function serializeDocument(frontmatter: unknown, body: string): string {
-  return `---\n${stringify(frontmatter).trimEnd()}\n---\n\n${body.trimStart()}`
+  // body is reproduced exactly as parseDocument captured it (including its
+  // leading blank line) — trimming it would turn a body that starts with an
+  // indented Markdown code block into plain prose.
+  return `---\n${stringify(frontmatter).trimEnd()}\n---\n${body}`
 }
 
 export function customersTranslatableFields(
@@ -97,22 +179,27 @@ export function applyFaqTranslations(
   }
 }
 
+function mdxFilenames(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.mdx'))
+    .map((entry) => entry.name)
+}
+
 export function discoverDocuments(contentDir: string): DocumentRef[] {
   const customersDir = join(contentDir, 'customers', 'en')
-  const customers: DocumentRef[] = existsSync(customersDir)
-    ? readdirSync(customersDir)
-        .filter((filename) => filename.endsWith('.mdx'))
-        .map((filename) => {
-          const slug = filename.slice(0, -'.mdx'.length)
-          return {
-            id: `customers/${slug}`,
-            kind: 'customers' as const,
-            enPath: join(customersDir, filename),
-            localePath: (locale: string) =>
-              join(contentDir, 'customers', locale, filename)
-          }
-        })
-    : []
+  const customers: DocumentRef[] = mdxFilenames(customersDir).map(
+    (filename) => {
+      const slug = filename.slice(0, -'.mdx'.length)
+      return {
+        id: `customers/${slug}`,
+        kind: 'customers' as const,
+        enPath: join(customersDir, filename),
+        localePath: (locale: string) =>
+          join(contentDir, 'customers', locale, filename)
+      }
+    }
+  )
 
   const faqRoot = join(contentDir, 'faq')
   const categories = existsSync(faqRoot)
@@ -120,19 +207,14 @@ export function discoverDocuments(contentDir: string): DocumentRef[] {
         .filter((entry) => entry.isDirectory())
         .map((entry) => entry.name)
     : []
-  const faq: DocumentRef[] = categories.flatMap((category) => {
-    const enDir = join(faqRoot, category, 'en')
-    if (!existsSync(enDir)) return []
-    return readdirSync(enDir)
-      .filter((filename) => filename.endsWith('.mdx'))
-      .map((filename) => ({
-        id: `faq/${category}/${filename.slice(0, -'.mdx'.length)}`,
-        kind: 'faq' as const,
-        enPath: join(faqRoot, category, 'en', filename),
-        localePath: (locale: string) =>
-          join(faqRoot, category, locale, filename)
-      }))
-  })
+  const faq: DocumentRef[] = categories.flatMap((category) =>
+    mdxFilenames(join(faqRoot, category, 'en')).map((filename) => ({
+      id: `faq/${category}/${filename.slice(0, -'.mdx'.length)}`,
+      kind: 'faq' as const,
+      enPath: join(faqRoot, category, 'en', filename),
+      localePath: (locale: string) => join(faqRoot, category, locale, filename)
+    }))
+  )
 
   return [...customers, ...faq].sort((a, b) => a.id.localeCompare(b.id))
 }

--- a/apps/website/scripts/i18n-content/manifest.test.ts
+++ b/apps/website/scripts/i18n-content/manifest.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { hashSource, loadManifest, saveManifest } from './manifest'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'i18n-manifest-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('loadManifest', () => {
+  it('returns an empty manifest when the file does not exist', () => {
+    expect(loadManifest(join(dir, 'missing.json'))).toEqual({
+      version: 1,
+      entries: {}
+    })
+  })
+
+  it('rejects a file with the wrong shape', () => {
+    const path = join(dir, 'manifest.json')
+    writeFileSync(path, JSON.stringify({ version: 2 }))
+    expect(() => loadManifest(path)).toThrow()
+  })
+
+  it('rejects an array in place of entries', () => {
+    const path = join(dir, 'manifest.json')
+    writeFileSync(path, JSON.stringify({ version: 1, entries: [] }))
+    expect(() => loadManifest(path)).toThrow()
+  })
+
+  it('rejects an array in place of a locale map', () => {
+    const path = join(dir, 'manifest.json')
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        entries: { 'ui.copy': [hashSource('Copy')] }
+      })
+    )
+    expect(() => loadManifest(path)).toThrow()
+  })
+})
+
+describe('saveManifest + loadManifest', () => {
+  it('round-trips entries and sorts keys', () => {
+    const path = join(dir, 'manifest.json')
+    saveManifest(path, {
+      version: 1,
+      entries: {
+        'ui.readMore': { ja: hashSource('Read more') },
+        'ui.copy': { ja: hashSource('Copy'), 'zh-CN': hashSource('Copy') }
+      }
+    })
+    expect(loadManifest(path)).toEqual({
+      version: 1,
+      entries: {
+        'ui.copy': { ja: hashSource('Copy'), 'zh-CN': hashSource('Copy') },
+        'ui.readMore': { ja: hashSource('Read more') }
+      }
+    })
+  })
+})
+
+describe('hashSource', () => {
+  it('is deterministic and sensitive to content changes', () => {
+    expect(hashSource('Copy')).toBe(hashSource('Copy'))
+    expect(hashSource('Copy')).not.toBe(hashSource('copy'))
+  })
+})

--- a/apps/website/scripts/i18n-content/manifest.test.ts
+++ b/apps/website/scripts/i18n-content/manifest.test.ts
@@ -47,6 +47,18 @@ describe('loadManifest', () => {
     )
     expect(() => loadManifest(path)).toThrow()
   })
+
+  it('rejects a locale hash that is not 64 lowercase hex characters', () => {
+    const path = join(dir, 'manifest.json')
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        entries: { 'ui.copy': { ja: 'not-a-hash' } }
+      })
+    )
+    expect(() => loadManifest(path)).toThrow()
+  })
 })
 
 describe('saveManifest + loadManifest', () => {

--- a/apps/website/scripts/i18n-content/manifest.ts
+++ b/apps/website/scripts/i18n-content/manifest.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+export interface TranslationManifest {
+  version: 1
+  entries: Record<string, Record<string, string>>
+}
+
+function isManifest(value: unknown): value is TranslationManifest {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as { version?: unknown }).version === 1 &&
+    typeof (value as { entries?: unknown }).entries === 'object' &&
+    (value as { entries?: unknown }).entries !== null &&
+    Object.values((value as TranslationManifest).entries).every(
+      (locales) =>
+        typeof locales === 'object' &&
+        locales !== null &&
+        Object.values(locales).every(
+          (hash) => typeof hash === 'string' && /^[0-9a-f]{64}$/.test(hash)
+        )
+    )
+  )
+}
+
+export function loadManifest(path: string): TranslationManifest {
+  if (!existsSync(path)) return { version: 1, entries: {} }
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+  if (!isManifest(parsed)) throw new Error(`${path} is not a valid manifest`)
+  return parsed
+}
+
+export function saveManifest(
+  path: string,
+  manifest: TranslationManifest
+): void {
+  const entries = Object.fromEntries(
+    Object.keys(manifest.entries)
+      .sort()
+      .map((key) => [key, manifest.entries[key]])
+  )
+  writeFileSync(path, `${JSON.stringify({ version: 1, entries }, null, 2)}\n`)
+}
+
+export function hashSource(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}

--- a/apps/website/scripts/i18n-content/manifest.ts
+++ b/apps/website/scripts/i18n-content/manifest.ts
@@ -6,21 +6,19 @@ export interface TranslationManifest {
   entries: Record<string, Record<string, string>>
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 function isManifest(value: unknown): value is TranslationManifest {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    (value as { version?: unknown }).version === 1 &&
-    typeof (value as { entries?: unknown }).entries === 'object' &&
-    (value as { entries?: unknown }).entries !== null &&
-    Object.values((value as TranslationManifest).entries).every(
-      (locales) =>
-        typeof locales === 'object' &&
-        locales !== null &&
-        Object.values(locales).every(
-          (hash) => typeof hash === 'string' && /^[0-9a-f]{64}$/.test(hash)
-        )
-    )
+  if (!isPlainRecord(value) || value.version !== 1) return false
+  if (!isPlainRecord(value.entries)) return false
+  return Object.values(value.entries).every(
+    (locales) =>
+      isPlainRecord(locales) &&
+      Object.values(locales).every(
+        (hash) => typeof hash === 'string' && /^[0-9a-f]{64}$/.test(hash)
+      )
   )
 }
 

--- a/apps/website/scripts/i18n-content/protected-tokens.test.ts
+++ b/apps/website/scripts/i18n-content/protected-tokens.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { protectedTokens, tokenErrors } from './protected-tokens'
 
 describe('protectedTokens', () => {
-  it('extracts component tags by name, src/href values, and link URLs', () => {
+  it('extracts component tags by name, src/href/id values, and link URLs', () => {
     expect(
       protectedTokens(
         '<Figure src="https://x.test/a.png" alt="A" /> read [more](https://x.test/b)'
@@ -15,6 +15,19 @@ describe('protectedTokens', () => {
     expect(
       protectedTokens('<Figure src="https://x.test/a.png" alt="Old caption" />')
     ).not.toContain('Old caption')
+  })
+
+  it('keeps dotted and hyphenated component names distinct', () => {
+    const tokens = protectedTokens('<Hero.Title>x</Hero.Title> <my-widget />')
+    expect(tokens).toContain('<Hero.Title>')
+    expect(tokens).toContain('</Hero.Title>')
+    expect(tokens).toContain('<my-widget>')
+    expect(tokens).not.toContain('<Hero>')
+  })
+
+  it('protects an id attribute value, single- or double-quoted', () => {
+    expect(protectedTokens('<Section id="topic-1">')).toContain('topic-1')
+    expect(protectedTokens("<Section id='topic-1'>")).toContain('topic-1')
   })
 
   it('returns nothing for plain prose', () => {
@@ -44,9 +57,43 @@ describe('tokenErrors', () => {
     ])
   })
 
+  it('flags a section id that was translated or renumbered', () => {
+    expect(
+      tokenErrors('<Section id="topic-1">', '<Section id="話題-1">')
+    ).toEqual(['missing topic-1', 'added 話題-1'])
+  })
+
   it('flags a dropped component', () => {
     expect(
       tokenErrors('<Quote>Great tool</Quote>', '素晴らしいツール')
     ).toEqual(['missing </Quote>, <Quote>'])
+  })
+
+  it('flags a dropped component that survived elsewhere in the same document', () => {
+    expect(
+      tokenErrors('<Quote>a</Quote> <Quote>b</Quote>', '<Quote>a と b</Quote>')
+    ).toEqual(['missing </Quote>, <Quote>'])
+  })
+
+  it('reports the deficit count when more than one occurrence is missing', () => {
+    expect(
+      tokenErrors(
+        '<Quote>a</Quote> <Quote>b</Quote> <Quote>c</Quote>',
+        '<Quote>a</Quote>'
+      )
+    ).toEqual(['missing </Quote>×2, <Quote>×2'])
+  })
+
+  it('flags a dropped repeated markdown link', () => {
+    expect(
+      tokenErrors(
+        '[one](https://x.test/1) and [two](https://x.test/1)',
+        '[one](https://x.test/1)のみ'
+      )
+    ).toEqual(['missing https://x.test/1'])
+  })
+
+  it('flags an empty translation of a non-empty source', () => {
+    expect(tokenErrors('Save now', '')).toEqual(['empty translation'])
   })
 })

--- a/apps/website/scripts/i18n-content/protected-tokens.test.ts
+++ b/apps/website/scripts/i18n-content/protected-tokens.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { protectedTokens, tokenErrors } from './protected-tokens'
+
+describe('protectedTokens', () => {
+  it('extracts component tags by name, src/href values, and link URLs', () => {
+    expect(
+      protectedTokens(
+        '<Figure src="https://x.test/a.png" alt="A" /> read [more](https://x.test/b)'
+      )
+    ).toEqual(['<Figure>', 'https://x.test/a.png', 'https://x.test/b'])
+  })
+
+  it('does not protect non-URL attributes like alt or caption', () => {
+    expect(
+      protectedTokens('<Figure src="https://x.test/a.png" alt="Old caption" />')
+    ).not.toContain('Old caption')
+  })
+
+  it('returns nothing for plain prose', () => {
+    expect(protectedTokens('ComfyUI runs anywhere.')).toEqual([])
+  })
+})
+
+describe('tokenErrors', () => {
+  it('allows alt/caption text to be translated', () => {
+    expect(
+      tokenErrors(
+        '<Figure src="https://x.test/a.png" alt="USC campus" />',
+        '<Figure src="https://x.test/a.png" alt="USCキャンパス" />'
+      )
+    ).toEqual([])
+  })
+
+  it('flags a changed src URL', () => {
+    expect(
+      tokenErrors(
+        '<Figure src="https://x.test/a.png" />',
+        '<Figure src="https://x.test/translated.png" />'
+      )
+    ).toEqual([
+      'missing https://x.test/a.png',
+      'added https://x.test/translated.png'
+    ])
+  })
+
+  it('flags a dropped component', () => {
+    expect(
+      tokenErrors('<Quote>Great tool</Quote>', '素晴らしいツール')
+    ).toEqual(['missing </Quote>, <Quote>'])
+  })
+})

--- a/apps/website/scripts/i18n-content/protected-tokens.test.ts
+++ b/apps/website/scripts/i18n-content/protected-tokens.test.ts
@@ -84,6 +84,15 @@ describe('tokenErrors', () => {
     ).toEqual(['missing </Quote>×2, <Quote>×2'])
   })
 
+  it('flags a link repeated more times than the source', () => {
+    expect(
+      tokenErrors(
+        '[one](https://x.test/1)',
+        '[one](https://x.test/1) と [one](https://x.test/1)'
+      )
+    ).toEqual(['added https://x.test/1'])
+  })
+
   it('flags a dropped repeated markdown link', () => {
     expect(
       tokenErrors(

--- a/apps/website/scripts/i18n-content/protected-tokens.ts
+++ b/apps/website/scripts/i18n-content/protected-tokens.ts
@@ -1,10 +1,13 @@
 // MDX body content mixes prose with components (`<Section id="...">`,
 // `<Quote>`, `<Figure src="..." alt="..." caption="..." />`) and markdown
-// links. Component tag names/structure and `src`/`href` URLs must survive
-// translation byte-for-byte; everything else — including `alt`/`caption`
-// attributes — is human-readable text that should be translated.
-const tagPattern = /<(\/?)([a-zA-Z][a-zA-Z0-9]*)[^<>]*>/g
-const urlAttributePattern = /\b(?:src|href)="([^"]*)"/g
+// links. Component tag names/structure and `src`/`href`/`id` attribute
+// values must survive translation byte-for-byte — `id` is a load-bearing
+// anchor: it must keep matching the same `sections[].id` in frontmatter,
+// which the pipeline deliberately never translates. Everything else,
+// including `alt`/`caption` attributes, is human-readable text that should
+// translate freely.
+const tagPattern = /<(\/?)([a-zA-Z][a-zA-Z0-9._-]*)[^<>]*>/g
+const structuralAttributePattern = /\b(?:src|href|id)=["']([^"']*)["']/g
 const markdownLinkPattern = /\]\(([^)]+)\)/g
 
 function tagTokens(value: string): string[] {
@@ -13,25 +16,49 @@ function tagTokens(value: string): string[] {
   )
 }
 
-function uniqueMatches(value: string, pattern: RegExp): string[] {
-  return [...new Set([...value.matchAll(pattern)].map((match) => match[1]))]
+function rawTokens(value: string): string[] {
+  return [
+    ...tagTokens(value),
+    ...[...value.matchAll(structuralAttributePattern)].map((match) => match[1]),
+    ...[...value.matchAll(markdownLinkPattern)].map((match) => match[1])
+  ]
 }
 
 export function protectedTokens(value: string): string[] {
-  return [
-    ...new Set([
-      ...tagTokens(value),
-      ...uniqueMatches(value, urlAttributePattern),
-      ...uniqueMatches(value, markdownLinkPattern)
-    ])
-  ].sort()
+  return [...new Set(rawTokens(value))].sort()
+}
+
+function tokenCounts(value: string): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const token of rawTokens(value)) {
+    counts.set(token, (counts.get(token) ?? 0) + 1)
+  }
+  return counts
+}
+
+function describeDeficit(token: string, deficit: number): string {
+  return deficit > 1 ? `${token}×${deficit}` : token
 }
 
 export function tokenErrors(source: string, target: string): string[] {
-  const sourceTokens = protectedTokens(source)
-  const targetTokens = protectedTokens(target)
-  const missing = sourceTokens.filter((token) => !targetTokens.includes(token))
-  const added = targetTokens.filter((token) => !sourceTokens.includes(token))
+  const sourceCounts = tokenCounts(source)
+  const targetCounts = tokenCounts(target)
+  const allTokens = [
+    ...new Set([...sourceCounts.keys(), ...targetCounts.keys()])
+  ].sort()
+
+  const missing: string[] = []
+  const added: string[] = []
+  for (const token of allTokens) {
+    const sourceCount = sourceCounts.get(token) ?? 0
+    const targetCount = targetCounts.get(token) ?? 0
+    if (targetCount < sourceCount) {
+      missing.push(describeDeficit(token, sourceCount - targetCount))
+    } else if (targetCount > sourceCount) {
+      added.push(describeDeficit(token, targetCount - sourceCount))
+    }
+  }
+
   return [
     ...(missing.length ? [`missing ${missing.join(', ')}`] : []),
     ...(added.length ? [`added ${added.join(', ')}`] : []),

--- a/apps/website/scripts/i18n-content/protected-tokens.ts
+++ b/apps/website/scripts/i18n-content/protected-tokens.ts
@@ -1,0 +1,42 @@
+// MDX body content mixes prose with components (`<Section id="...">`,
+// `<Quote>`, `<Figure src="..." alt="..." caption="..." />`) and markdown
+// links. Component tag names/structure and `src`/`href` URLs must survive
+// translation byte-for-byte; everything else — including `alt`/`caption`
+// attributes — is human-readable text that should be translated.
+const tagPattern = /<(\/?)([a-zA-Z][a-zA-Z0-9]*)[^<>]*>/g
+const urlAttributePattern = /\b(?:src|href)="([^"]*)"/g
+const markdownLinkPattern = /\]\(([^)]+)\)/g
+
+function tagTokens(value: string): string[] {
+  return [...value.matchAll(tagPattern)].map(
+    ([, closing, name]) => `<${closing}${name}>`
+  )
+}
+
+function uniqueMatches(value: string, pattern: RegExp): string[] {
+  return [...new Set([...value.matchAll(pattern)].map((match) => match[1]))]
+}
+
+export function protectedTokens(value: string): string[] {
+  return [
+    ...new Set([
+      ...tagTokens(value),
+      ...uniqueMatches(value, urlAttributePattern),
+      ...uniqueMatches(value, markdownLinkPattern)
+    ])
+  ].sort()
+}
+
+export function tokenErrors(source: string, target: string): string[] {
+  const sourceTokens = protectedTokens(source)
+  const targetTokens = protectedTokens(target)
+  const missing = sourceTokens.filter((token) => !targetTokens.includes(token))
+  const added = targetTokens.filter((token) => !sourceTokens.includes(token))
+  return [
+    ...(missing.length ? [`missing ${missing.join(', ')}`] : []),
+    ...(added.length ? [`added ${added.join(', ')}`] : []),
+    ...(source.trim().length > 0 && target.trim().length === 0
+      ? ['empty translation']
+      : [])
+  ]
+}

--- a/apps/website/scripts/i18n-content/review.ts
+++ b/apps/website/scripts/i18n-content/review.ts
@@ -64,28 +64,34 @@ interface ReviewerOptions {
   onCompletion?: (completion: OpenAI.ChatCompletion) => void
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isVerdict(value: unknown): value is ReviewVerdict {
+  return (
+    isPlainRecord(value) &&
+    typeof value.pass === 'boolean' &&
+    (value.reason === undefined || typeof value.reason === 'string')
+  )
+}
+
 function parseVerdicts(
   content: string,
   requestedIds: ReadonlySet<string>
 ): Map<string, ReviewVerdict> {
   const parsed: unknown = JSON.parse(content)
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  if (!isPlainRecord(parsed)) {
     throw new Error('review response is not a JSON object')
   }
   const verdicts = new Map<string, ReviewVerdict>()
   for (const [id, value] of Object.entries(parsed)) {
-    if (!requestedIds.has(id)) continue
-    if (
-      !value ||
-      typeof value !== 'object' ||
-      typeof (value as { pass?: unknown }).pass !== 'boolean'
-    ) {
-      continue
-    }
-    const { pass, reason } = value as { pass: boolean; reason?: unknown }
+    if (!requestedIds.has(id) || !isVerdict(value)) continue
     verdicts.set(id, {
-      pass,
-      ...(typeof reason === 'string' && reason.length > 0 ? { reason } : {})
+      pass: value.pass,
+      ...(value.reason && value.reason.length > 0
+        ? { reason: value.reason }
+        : {})
     })
   }
   return verdicts

--- a/apps/website/scripts/i18n-content/review.ts
+++ b/apps/website/scripts/i18n-content/review.ts
@@ -1,0 +1,162 @@
+import OpenAI from 'openai'
+
+import type { OutputLocale, TranslationPipelineConfig } from './config'
+
+export interface ReviewItem {
+  id: string
+  context: string
+  source: string
+  translation: string
+}
+
+export interface ReviewVerdict {
+  pass: boolean
+  reason?: string
+}
+
+export type ReviewBatch = (
+  locale: OutputLocale,
+  items: readonly ReviewItem[]
+) => Promise<Map<string, ReviewVerdict>>
+
+function chunkBySize(
+  items: readonly ReviewItem[],
+  maxItems: number,
+  maxChars: number
+): ReviewItem[][] {
+  const chunks: ReviewItem[][] = []
+  let chunk: ReviewItem[] = []
+  let chunkChars = 0
+  for (const item of items) {
+    const itemChars = item.source.length + item.translation.length
+    if (
+      chunk.length > 0 &&
+      (chunk.length >= maxItems || chunkChars + itemChars > maxChars)
+    ) {
+      chunks.push(chunk)
+      chunk = []
+      chunkChars = 0
+    }
+    chunk.push(item)
+    chunkChars += itemChars
+  }
+  if (chunk.length > 0) chunks.push(chunk)
+  return chunks
+}
+
+function buildReviewPrompt(locale: OutputLocale): string {
+  return `You are a strict native-${locale.name} reviewer gating machine-translated marketing copy for ComfyUI's website before it ships. Reject anything you would not want a native speaker to see live.
+
+For each item, compare "source" (English) against "translation" (${locale.name}) and reject (pass: false) if any of these hold:
+- The translation contains leftover English words that are not established product/technical terms (e.g. ComfyUI, API, GPU, LoRA).
+- The translation reads like a literal machine translation rather than natural, professional ${locale.name} marketing copy.
+- The translation makes a claim, statistic, or superlative that is not already present in the source.
+- Any HTML tag (e.g. <strong>, <a href="...">) or {placeholder} from the source is missing, altered, or reordered in the translation.
+
+Respond with a JSON object mapping every item "id" to {"pass": boolean, "reason": string omitted when pass is true, one short sentence when pass is false}. Judge every id; no commentary outside the JSON object.`
+}
+
+interface ReviewerOptions {
+  apiKey: string
+  model: string
+  reasoningEffort: TranslationPipelineConfig['reasoningEffort']
+  fetchFn?: typeof fetch
+  onCompletion?: (completion: OpenAI.ChatCompletion) => void
+}
+
+function parseVerdicts(
+  content: string,
+  requestedIds: ReadonlySet<string>
+): Map<string, ReviewVerdict> {
+  const parsed: unknown = JSON.parse(content)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('review response is not a JSON object')
+  }
+  const verdicts = new Map<string, ReviewVerdict>()
+  for (const [id, value] of Object.entries(parsed)) {
+    if (!requestedIds.has(id)) continue
+    if (
+      !value ||
+      typeof value !== 'object' ||
+      typeof (value as { pass?: unknown }).pass !== 'boolean'
+    ) {
+      continue
+    }
+    const { pass, reason } = value as { pass: boolean; reason?: unknown }
+    verdicts.set(id, {
+      pass,
+      ...(typeof reason === 'string' && reason.length > 0 ? { reason } : {})
+    })
+  }
+  return verdicts
+}
+
+export function createOpenAiReviewer(options: ReviewerOptions): ReviewBatch {
+  const client = new OpenAI({
+    apiKey: options.apiKey,
+    fetch: options.fetchFn,
+    maxRetries: 3
+  })
+
+  return async (locale, items) => {
+    if (items.length === 0) return new Map()
+    const requestedIds = new Set(items.map((item) => item.id))
+    const completion = await client.chat.completions.create({
+      model: options.model,
+      reasoning_effort: options.reasoningEffort,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: buildReviewPrompt(locale) },
+        { role: 'user', content: JSON.stringify({ items }) }
+      ]
+    })
+    options.onCompletion?.(completion)
+    const content = completion.choices[0]?.message?.content
+    if (typeof content !== 'string') {
+      throw new Error(`${locale.code}: review response has no message content`)
+    }
+    return parseVerdicts(content, requestedIds)
+  }
+}
+
+// Items whose review call could not be parsed, or that the model never
+// returned a verdict for, are treated as rejected: shipping unreviewed
+// machine translation is worse than leaving the English source in place for
+// one more pipeline run.
+export async function reviewItems(
+  locale: OutputLocale,
+  items: readonly ReviewItem[],
+  reviewBatch: ReviewBatch,
+  config: Pick<
+    TranslationPipelineConfig,
+    'maxItemsPerRequest' | 'maxSourceCharsPerRequest'
+  >
+): Promise<Map<string, ReviewVerdict>> {
+  const chunks = chunkBySize(
+    items,
+    config.maxItemsPerRequest,
+    config.maxSourceCharsPerRequest
+  )
+  const results = new Map<string, ReviewVerdict>()
+  for (const chunk of chunks) {
+    let verdicts: Map<string, ReviewVerdict>
+    try {
+      verdicts = await reviewBatch(locale, chunk)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      verdicts = new Map(
+        chunk.map((item) => [item.id, { pass: false, reason }])
+      )
+    }
+    for (const item of chunk) {
+      results.set(
+        item.id,
+        verdicts.get(item.id) ?? {
+          pass: false,
+          reason: 'reviewer returned no verdict'
+        }
+      )
+    }
+  }
+  return results
+}

--- a/apps/website/scripts/i18n-content/translate.ts
+++ b/apps/website/scripts/i18n-content/translate.ts
@@ -1,0 +1,280 @@
+import OpenAI from 'openai'
+
+import type { OutputLocale, TranslationPipelineConfig } from './config'
+import { tokenErrors } from './protected-tokens'
+
+export interface TranslationItem {
+  id: string
+  context: string
+  source: string
+  preserve: string[]
+  retryNote?: string
+}
+
+export type TranslateBatch = (
+  locale: OutputLocale,
+  items: TranslationItem[]
+) => Promise<Record<string, string>>
+
+const maxNetworkRetries = 3
+const maxMalformedResponseRetries = 1
+
+// Mirrors the request pool in the app's own scripts/i18n/translate.ts: stop
+// dispatching once any task fails so a fatal error does not keep spending API
+// requests whose results nobody will consume; in-flight tasks settle before
+// the first failure is rethrown so no work outlives the call.
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let next = 0
+  let firstFailure: { reason: unknown } | undefined
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (!firstFailure && next < items.length) {
+        const index = next++
+        try {
+          results[index] = await task(items[index])
+        } catch (error) {
+          firstFailure ??= { reason: error }
+        }
+      }
+    }
+  )
+  await Promise.all(workers)
+  if (firstFailure) throw firstFailure.reason
+  return results
+}
+
+function chunkItems(
+  items: readonly TranslationItem[],
+  maxItems: number,
+  maxSourceChars: number
+): TranslationItem[][] {
+  const chunks: TranslationItem[][] = []
+  let chunk: TranslationItem[] = []
+  let chunkChars = 0
+  for (const item of items) {
+    const itemChars = item.source.length
+    if (
+      chunk.length > 0 &&
+      (chunk.length >= maxItems || chunkChars + itemChars > maxSourceChars)
+    ) {
+      chunks.push(chunk)
+      chunk = []
+      chunkChars = 0
+    }
+    chunk.push(item)
+    chunkChars += itemChars
+  }
+  if (chunk.length > 0) chunks.push(chunk)
+  return chunks
+}
+
+function buildSystemPrompt(locale: OutputLocale, glossary: string): string {
+  return `You are a professional localization translator for ComfyUI's marketing website (comfy.org).
+Translate each item's "source" string from English into ${locale.name}.
+
+Rules:
+- Respond with a JSON object that maps every item "id" to its translated string — every id, no other keys, no commentary.
+- Every substring listed in an item's "preserve" array must appear in the translation exactly as written, byte for byte. Never translate, transliterate, or renumber them.
+- Interpolation placeholders such as {name} and HTML tags such as <strong> stay exactly as written.
+- The "context" field is the key of the string in the website's translation map; use it to resolve ambiguity.
+- Match the brevity and confident, non-overclaiming tone of the source.
+
+${glossary}
+${locale.guidance ? `\n${locale.name} guidelines:\n${locale.guidance}\n` : ''}`
+}
+
+function parseBatchResponse(
+  content: string,
+  requestedIds: ReadonlySet<string>
+): Record<string, string> {
+  const parsed: unknown = JSON.parse(content)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('translation response is not a JSON object')
+  }
+  const record: Record<string, string> = {}
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === 'string' && requestedIds.has(key)) record[key] = value
+  }
+  return record
+}
+
+export interface RequestCounter {
+  fetch: typeof fetch
+  requestCount: () => number
+}
+
+export function createRequestCounter(
+  fetchFn: typeof fetch = globalThis.fetch
+): RequestCounter {
+  let requests = 0
+  const countingFetch: typeof fetch = async (input, init) => {
+    requests++
+    return fetchFn(input, init)
+  }
+  return { fetch: countingFetch, requestCount: () => requests }
+}
+
+function splitTruncatedBatch(items: TranslationItem[]): TranslationItem[][] {
+  const totalChars = items.reduce((sum, item) => sum + item.source.length, 0)
+  return chunkItems(
+    items,
+    Math.ceil(items.length / 2),
+    Math.ceil(totalChars / 2)
+  )
+}
+
+interface OpenAiTranslatorOptions {
+  apiKey: string
+  model: string
+  reasoningEffort: TranslationPipelineConfig['reasoningEffort']
+  glossary: string
+  maxTruncationSplitDepth: number
+  fetchFn?: typeof fetch
+  onCompletion?: (completion: OpenAI.ChatCompletion) => void
+}
+
+export function createOpenAiTranslator(
+  options: OpenAiTranslatorOptions
+): TranslateBatch {
+  const client = new OpenAI({
+    apiKey: options.apiKey,
+    fetch: options.fetchFn,
+    maxRetries: maxNetworkRetries
+  })
+
+  async function translateBatch(
+    locale: OutputLocale,
+    items: TranslationItem[],
+    splitDepth: number
+  ): Promise<Record<string, string>> {
+    if (items.length === 0) return {}
+    const requestedIds = new Set(items.map((item) => item.id))
+    let deferralReason = 'the request was not attempted'
+    for (let attempt = 0; attempt <= maxMalformedResponseRetries; attempt++) {
+      const completion = await client.chat.completions.create({
+        model: options.model,
+        reasoning_effort: options.reasoningEffort,
+        response_format: { type: 'json_object' },
+        messages: [
+          {
+            role: 'system',
+            content: buildSystemPrompt(locale, options.glossary)
+          },
+          { role: 'user', content: JSON.stringify({ items }) }
+        ]
+      })
+      options.onCompletion?.(completion)
+      const choice = completion.choices[0]
+      if (choice?.finish_reason === 'length') {
+        if (items.length === 1) {
+          deferralReason = `the response was truncated (finish_reason "length") for the single string ${items[0].context}`
+          continue
+        }
+        if (splitDepth >= options.maxTruncationSplitDepth) {
+          deferralReason = `${items.length} strings were still truncated (finish_reason "length") at maxTruncationSplitDepth ${options.maxTruncationSplitDepth}`
+          break
+        }
+        const settled = await Promise.allSettled(
+          splitTruncatedBatch(items).map((chunk) =>
+            translateBatch(locale, chunk, splitDepth + 1)
+          )
+        )
+        const merged: Record<string, string> = {}
+        for (const result of settled) {
+          if (result.status === 'rejected') throw result.reason
+          Object.assign(merged, result.value)
+        }
+        return merged
+      }
+      const content = choice?.message?.content
+      if (typeof content !== 'string') {
+        deferralReason = 'the response has no message content'
+        continue
+      }
+      try {
+        return parseBatchResponse(content, requestedIds)
+      } catch (error) {
+        deferralReason = error instanceof Error ? error.message : String(error)
+      }
+    }
+    console.warn(
+      `${locale.code}: deferring ${items.length} strings for retry: ${deferralReason}`
+    )
+    return {}
+  }
+
+  return (locale, items) => translateBatch(locale, items, 0)
+}
+
+export async function translateItems(
+  locale: OutputLocale,
+  items: readonly TranslationItem[],
+  translateBatch: TranslateBatch,
+  config: Pick<
+    TranslationPipelineConfig,
+    | 'maxItemsPerRequest'
+    | 'maxSourceCharsPerRequest'
+    | 'requestConcurrency'
+    | 'maxTranslationRounds'
+  >
+): Promise<Map<string, string>> {
+  const results = new Map<string, string>()
+  let remaining = [...items]
+
+  for (
+    let round = 0;
+    round < config.maxTranslationRounds && remaining.length > 0;
+    round++
+  ) {
+    const chunks = chunkItems(
+      remaining,
+      config.maxItemsPerRequest,
+      config.maxSourceCharsPerRequest
+    )
+    const responses = await mapWithConcurrency(
+      chunks,
+      config.requestConcurrency,
+      async (chunk) => {
+        const requested = new Set(chunk.map((item) => item.id))
+        const response = await translateBatch(locale, chunk)
+        return Object.entries(response).filter(([id]) => requested.has(id))
+      }
+    )
+    const translated = new Map(responses.flat())
+
+    const failed: TranslationItem[] = []
+    for (const item of remaining) {
+      const value = translated.get(item.id)
+      const errors =
+        value === undefined
+          ? ['no translation returned']
+          : tokenErrors(item.source, value)
+      if (value !== undefined && errors.length === 0) {
+        results.set(item.id, value)
+      } else {
+        failed.push({
+          ...item,
+          retryNote: `A previous attempt was rejected (${errors.join('; ')}). Reproduce every "preserve" substring exactly as written.`
+        })
+      }
+    }
+    remaining = failed
+  }
+
+  if (remaining.length > 0) {
+    const details = remaining
+      .map((item) => `  ${item.context}`)
+      .slice(0, 20)
+      .join('\n')
+    throw new Error(
+      `Translation into ${locale.code} failed for ${remaining.length} strings after ${config.maxTranslationRounds} attempts:\n${details}`
+    )
+  }
+  return results
+}

--- a/apps/website/scripts/i18n-content/update-content-translations.test.ts
+++ b/apps/website/scripts/i18n-content/update-content-translations.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { OutputLocale } from './config'
+import { discoverDocuments } from './document'
+import { hashSource } from './manifest'
+import { collectPending } from './update-content-translations'
+
+const locales: OutputLocale[] = [
+  { code: 'zh-CN', name: 'Simplified Chinese' },
+  { code: 'ja', name: 'Japanese' }
+]
+
+const faqFixture = `---
+question: "What are Partner Nodes?"
+order: 14
+---
+
+Partner Nodes let you run proprietary models.
+`
+
+function sourceHashOf(question: string, body: string): string {
+  return hashSource(`${question}\n${body}`)
+}
+
+describe('collectPending', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'i18n-content-pending-'))
+    mkdirSync(join(dir, 'faq', 'pricing', 'en'), { recursive: true })
+    writeFileSync(
+      join(dir, 'faq', 'pricing', 'en', 'partner-nodes.mdx'),
+      faqFixture
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('flags a document with no locale file at all', () => {
+    const refs = discoverDocuments(dir)
+
+    const { pending } = collectPending(
+      refs,
+      { version: 1, entries: {} },
+      locales
+    )
+
+    expect(pending).toEqual([
+      {
+        ref: refs[0],
+        locale: locales[0],
+        fields: [{ path: 'question', value: 'What are Partner Nodes?' }],
+        body: '\nPartner Nodes let you run proprietary models.\n',
+        sourceHash: sourceHashOf(
+          'What are Partner Nodes?',
+          '\nPartner Nodes let you run proprietary models.\n'
+        )
+      },
+      {
+        ref: refs[0],
+        locale: locales[1],
+        fields: [{ path: 'question', value: 'What are Partner Nodes?' }],
+        body: '\nPartner Nodes let you run proprietary models.\n',
+        sourceHash: sourceHashOf(
+          'What are Partner Nodes?',
+          '\nPartner Nodes let you run proprietary models.\n'
+        )
+      }
+    ])
+  })
+
+  it('bootstraps a baseline hash for a locale file the manifest has never seen', () => {
+    mkdirSync(join(dir, 'faq', 'pricing', 'zh-CN'), { recursive: true })
+    writeFileSync(
+      join(dir, 'faq', 'pricing', 'zh-CN', 'partner-nodes.mdx'),
+      faqFixture
+    )
+    const refs = discoverDocuments(dir)
+
+    const { pending, manifestUpdates } = collectPending(
+      refs,
+      { version: 1, entries: {} },
+      locales
+    )
+
+    expect(pending).toEqual([expect.objectContaining({ locale: locales[1] })])
+    expect(manifestUpdates.get('faq/pricing/partner-nodes')?.get('zh-CN')).toBe(
+      sourceHashOf(
+        'What are Partner Nodes?',
+        '\nPartner Nodes let you run proprietary models.\n'
+      )
+    )
+  })
+
+  it('leaves a document alone once its hash is recorded and unchanged', () => {
+    mkdirSync(join(dir, 'faq', 'pricing', 'ja'), { recursive: true })
+    writeFileSync(
+      join(dir, 'faq', 'pricing', 'ja', 'partner-nodes.mdx'),
+      faqFixture
+    )
+    const refs = discoverDocuments(dir)
+    const manifest = {
+      version: 1 as const,
+      entries: {
+        'faq/pricing/partner-nodes': {
+          ja: sourceHashOf(
+            'What are Partner Nodes?',
+            '\nPartner Nodes let you run proprietary models.\n'
+          )
+        }
+      }
+    }
+
+    const { pending } = collectPending(refs, manifest, [locales[1]])
+
+    expect(pending).toEqual([])
+  })
+})

--- a/apps/website/scripts/i18n-content/update-content-translations.test.ts
+++ b/apps/website/scripts/i18n-content/update-content-translations.test.ts
@@ -14,6 +14,8 @@ const locales: OutputLocale[] = [
   { code: 'ja', name: 'Japanese' }
 ]
 
+const faqBody = '\nPartner Nodes let you run proprietary models.\n'
+const faqFrontmatter = { question: 'What are Partner Nodes?', order: 14 }
 const faqFixture = `---
 question: "What are Partner Nodes?"
 order: 14
@@ -22,8 +24,11 @@ order: 14
 Partner Nodes let you run proprietary models.
 `
 
-function sourceHashOf(question: string, body: string): string {
-  return hashSource(`${question}\n${body}`)
+function sourceHashOf(
+  frontmatter: Record<string, unknown>,
+  body: string
+): string {
+  return hashSource(JSON.stringify({ frontmatter, body }))
 }
 
 describe('collectPending', () => {
@@ -55,22 +60,18 @@ describe('collectPending', () => {
       {
         ref: refs[0],
         locale: locales[0],
+        frontmatter: faqFrontmatter,
         fields: [{ path: 'question', value: 'What are Partner Nodes?' }],
-        body: '\nPartner Nodes let you run proprietary models.\n',
-        sourceHash: sourceHashOf(
-          'What are Partner Nodes?',
-          '\nPartner Nodes let you run proprietary models.\n'
-        )
+        body: faqBody,
+        sourceHash: sourceHashOf(faqFrontmatter, faqBody)
       },
       {
         ref: refs[0],
         locale: locales[1],
+        frontmatter: faqFrontmatter,
         fields: [{ path: 'question', value: 'What are Partner Nodes?' }],
-        body: '\nPartner Nodes let you run proprietary models.\n',
-        sourceHash: sourceHashOf(
-          'What are Partner Nodes?',
-          '\nPartner Nodes let you run proprietary models.\n'
-        )
+        body: faqBody,
+        sourceHash: sourceHashOf(faqFrontmatter, faqBody)
       }
     ])
   })
@@ -91,10 +92,7 @@ describe('collectPending', () => {
 
     expect(pending).toEqual([expect.objectContaining({ locale: locales[1] })])
     expect(manifestUpdates.get('faq/pricing/partner-nodes')?.get('zh-CN')).toBe(
-      sourceHashOf(
-        'What are Partner Nodes?',
-        '\nPartner Nodes let you run proprietary models.\n'
-      )
+      sourceHashOf(faqFrontmatter, faqBody)
     )
   })
 
@@ -109,10 +107,7 @@ describe('collectPending', () => {
       version: 1 as const,
       entries: {
         'faq/pricing/partner-nodes': {
-          ja: sourceHashOf(
-            'What are Partner Nodes?',
-            '\nPartner Nodes let you run proprietary models.\n'
-          )
+          ja: sourceHashOf(faqFrontmatter, faqBody)
         }
       }
     }
@@ -120,5 +115,28 @@ describe('collectPending', () => {
     const { pending } = collectPending(refs, manifest, [locales[1]])
 
     expect(pending).toEqual([])
+  })
+
+  it('re-queues a document whose English frontmatter changed even though no translatable field did', () => {
+    mkdirSync(join(dir, 'faq', 'pricing', 'ja'), { recursive: true })
+    writeFileSync(
+      join(dir, 'faq', 'pricing', 'ja', 'partner-nodes.mdx'),
+      faqFixture
+    )
+    const refs = discoverDocuments(dir)
+    const manifest = {
+      version: 1 as const,
+      entries: {
+        'faq/pricing/partner-nodes': {
+          // Recorded against order: 13 — the source now has order: 14, a
+          // non-translatable field, but it should still be enough to flag.
+          ja: sourceHashOf({ ...faqFrontmatter, order: 13 }, faqBody)
+        }
+      }
+    }
+
+    const { pending } = collectPending(refs, manifest, [locales[1]])
+
+    expect(pending).toEqual([expect.objectContaining({ locale: locales[1] })])
   })
 })

--- a/apps/website/scripts/i18n-content/update-content-translations.ts
+++ b/apps/website/scripts/i18n-content/update-content-translations.ts
@@ -4,39 +4,62 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import type { OutputLocale } from './config'
 import { translationPipelineConfig } from './config'
+import type {
+  BodySegment,
+  CustomersFrontmatter,
+  DocumentRef,
+  FaqFrontmatter,
+  TranslatableField
+} from './document'
+import {
+  applyFrontmatterTranslations,
+  discoverDocuments,
+  findMdxSyntaxErrors,
+  joinBody,
+  readDocument,
+  serializeDocument,
+  splitBody,
+  translatableFields
+} from './document'
 import { hashSource, loadManifest, saveManifest } from './manifest'
 import type { TranslationManifest } from './manifest'
-import { createOpenAiReviewer, reviewItems } from './review'
+import { protectedTokens } from './protected-tokens'
 import type { ReviewItem } from './review'
+import { createOpenAiReviewer, reviewItems } from './review'
+import type { TranslationItem } from './translate'
 import {
   createOpenAiTranslator,
   createRequestCounter,
   translateItems
 } from './translate'
-import type { TranslationItem } from './translate'
-import {
-  applyFrontmatterTranslations,
-  discoverDocuments,
-  readDocument,
-  serializeDocument,
-  translatableFields
-} from './document'
-import type { DocumentRef, TranslatableField } from './document'
-import { protectedTokens } from './protected-tokens'
 
 interface PendingDocument {
   ref: DocumentRef
   locale: OutputLocale
+  frontmatter: CustomersFrontmatter | FaqFrontmatter
   fields: TranslatableField[]
   body: string
   sourceHash: string
 }
 
-function documentSourceSignature(
-  fields: TranslatableField[],
+// Hashes the full document, including frontmatter fields the pipeline never
+// translates (cover, order, section ids): those still get copied through
+// into every generated locale file, so an English-only edit to one of them
+// must also mark the document pending, or the locale file's copy goes stale
+// forever. JSON.stringify (not a delimiter join) keeps the hash injective —
+// moving a newline across a field boundary changes the encoding.
+function fullDocumentSignature(
+  frontmatter: CustomersFrontmatter | FaqFrontmatter,
   body: string
 ): string {
-  return `${fields.map((field) => field.value).join('\n')}\n${body}`
+  return JSON.stringify({ frontmatter, body })
+}
+
+function translatableSignature(
+  fields: readonly TranslatableField[],
+  body: string
+): string {
+  return JSON.stringify({ fields, body })
 }
 
 function print(line: string): void {
@@ -57,13 +80,13 @@ export function collectPending(
   for (const ref of refs) {
     const { frontmatter, body } = readDocument(ref, ref.enPath)
     const fields = translatableFields(ref, frontmatter)
-    const sourceHash = hashSource(documentSourceSignature(fields, body))
+    const sourceHash = hashSource(fullDocumentSignature(frontmatter, body))
 
     for (const locale of outputLocales) {
       const recordedHash = manifest.entries[ref.id]?.[locale.code]
 
       if (!existsSync(ref.localePath(locale.code))) {
-        pending.push({ ref, locale, fields, body, sourceHash })
+        pending.push({ ref, locale, frontmatter, fields, body, sourceHash })
         continue
       }
       if (recordedHash === undefined) {
@@ -73,7 +96,7 @@ export function collectPending(
         continue
       }
       if (recordedHash !== sourceHash) {
-        pending.push({ ref, locale, fields, body, sourceHash })
+        pending.push({ ref, locale, frontmatter, fields, body, sourceHash })
       }
     }
   }
@@ -81,6 +104,59 @@ export function collectPending(
   return { pending, manifestUpdates }
 }
 
+function persistManifest(
+  manifestPath: string,
+  manifest: TranslationManifest,
+  manifestUpdates: ReadonlyMap<string, ReadonlyMap<string, string>>
+): void {
+  const nextEntries: TranslationManifest['entries'] = { ...manifest.entries }
+  for (const [id, locales] of manifestUpdates) {
+    nextEntries[id] = { ...nextEntries[id], ...Object.fromEntries(locales) }
+  }
+  saveManifest(manifestPath, { version: 1, entries: nextEntries })
+}
+
+function bodyTranslationItems(
+  contextId: string,
+  segments: readonly BodySegment[]
+): TranslationItem[] {
+  return segments.flatMap((segment, index) =>
+    segment.translatable
+      ? [
+          {
+            id: `body:${index}`,
+            context: `${contextId}: body section ${index}`,
+            source: segment.text,
+            preserve: protectedTokens(segment.text)
+          }
+        ]
+      : []
+  )
+}
+
+function assembleBody(
+  segments: readonly BodySegment[],
+  translations: ReadonlyMap<string, string>
+): string {
+  return joinBody(
+    segments.map((segment, index) =>
+      segment.translatable
+        ? {
+            ...segment,
+            text: translations.get(`body:${index}`) ?? segment.text
+          }
+        : segment
+    )
+  )
+}
+
+// A thrown error means translateItems could not produce a usable result
+// after every retry (bad API key, persistent malformed responses) — an
+// infrastructure failure, not a quality judgment, so it propagates instead
+// of being recorded as a rejection. reviewItems, by contrast, already
+// converts its own call failures into `pass: false` verdicts: a review
+// service being unreachable is a reason to hold a translation back, not to
+// abort the run.
 async function translateDocument(
   pending: PendingDocument,
   translateBatch: Parameters<typeof translateItems>[2],
@@ -90,6 +166,7 @@ async function translateDocument(
   | { outcome: 'written'; frontmatter: unknown; body: string }
   | { outcome: 'rejected'; reason: string }
 > {
+  const bodySegments = splitBody(pending.body)
   const items: TranslationItem[] = [
     ...pending.fields.map((field) => ({
       id: field.path,
@@ -97,28 +174,15 @@ async function translateDocument(
       source: field.value,
       preserve: protectedTokens(field.value)
     })),
-    {
-      id: 'body',
-      context: `${pending.ref.id}: body`,
-      source: pending.body,
-      preserve: protectedTokens(pending.body)
-    }
+    ...bodyTranslationItems(pending.ref.id, bodySegments)
   ]
 
-  let translations: Map<string, string>
-  try {
-    translations = await translateItems(
-      pending.locale,
-      items,
-      translateBatch,
-      config
-    )
-  } catch (error) {
-    return {
-      outcome: 'rejected',
-      reason: error instanceof Error ? error.message : String(error)
-    }
-  }
+  const translations = await translateItems(
+    pending.locale,
+    items,
+    translateBatch,
+    config
+  )
 
   const translatedFields = new Map(
     pending.fields.map((field) => [
@@ -126,13 +190,18 @@ async function translateDocument(
       translations.get(field.path) ?? field.value
     ])
   )
-  const translatedBody = translations.get('body') ?? pending.body
+  const translatedBody = assembleBody(bodySegments, translations)
+
+  const syntaxErrors = findMdxSyntaxErrors(translatedBody)
+  if (syntaxErrors.length > 0) {
+    return { outcome: 'rejected', reason: syntaxErrors.join('; ') }
+  }
 
   const reviewItem: ReviewItem = {
     id: pending.ref.id,
     context: pending.ref.id,
-    source: documentSourceSignature(pending.fields, pending.body),
-    translation: documentSourceSignature(
+    source: translatableSignature(pending.fields, pending.body),
+    translation: translatableSignature(
       pending.fields.map((field) => ({
         path: field.path,
         value: translatedFields.get(field.path) ?? field.value
@@ -151,12 +220,11 @@ async function translateDocument(
     return { outcome: 'rejected', reason: verdict?.reason ?? 'no verdict' }
   }
 
-  const { frontmatter } = readDocument(pending.ref, pending.ref.enPath)
   return {
     outcome: 'written',
     frontmatter: applyFrontmatterTranslations(
       pending.ref,
-      frontmatter,
+      pending.frontmatter,
       translatedFields
     ),
     body: translatedBody
@@ -187,10 +255,12 @@ async function run(argv: readonly string[]): Promise<void> {
         ? 'All website content translations are up to date.'
         : `Pending: ${pending.length} documents.`
     )
+    if (pending.length > 0) process.exitCode = 1
     return
   }
 
   if (pending.length === 0) {
+    persistManifest(manifestPath, manifest, manifestUpdates)
     print('All website content translations are up to date.')
     return
   }
@@ -221,32 +291,33 @@ async function run(argv: readonly string[]): Promise<void> {
   let written = 0
   let rejected = 0
 
-  for (const item of pending) {
-    const result = await translateDocument(
-      item,
-      translateBatch,
-      reviewBatch,
-      config
-    )
-    if (result.outcome === 'rejected') {
-      rejected++
-      print(`REJECTED ${item.locale.code}/${item.ref.id}: ${result.reason}`)
-      continue
+  try {
+    for (const item of pending) {
+      const result = await translateDocument(
+        item,
+        translateBatch,
+        reviewBatch,
+        config
+      )
+      if (result.outcome === 'rejected') {
+        rejected++
+        print(`REJECTED ${item.locale.code}/${item.ref.id}: ${result.reason}`)
+        continue
+      }
+      const outPath = item.ref.localePath(item.locale.code)
+      mkdirSync(dirname(outPath), { recursive: true })
+      writeFileSync(outPath, serializeDocument(result.frontmatter, result.body))
+      const localeHashes = manifestUpdates.get(item.ref.id) ?? new Map()
+      localeHashes.set(item.locale.code, item.sourceHash)
+      manifestUpdates.set(item.ref.id, localeHashes)
+      written++
     }
-    const outPath = item.ref.localePath(item.locale.code)
-    mkdirSync(dirname(outPath), { recursive: true })
-    writeFileSync(outPath, serializeDocument(result.frontmatter, result.body))
-    const localeHashes = manifestUpdates.get(item.ref.id) ?? new Map()
-    localeHashes.set(item.locale.code, item.sourceHash)
-    manifestUpdates.set(item.ref.id, localeHashes)
-    written++
+  } finally {
+    // Persist whatever completed even when a document further down the list
+    // throws, so a hard failure loses no more progress than it has to and
+    // the next run picks up exactly where this one stopped.
+    persistManifest(manifestPath, manifest, manifestUpdates)
   }
-
-  const nextEntries: TranslationManifest['entries'] = { ...manifest.entries }
-  for (const [id, locales] of manifestUpdates) {
-    nextEntries[id] = { ...nextEntries[id], ...Object.fromEntries(locales) }
-  }
-  saveManifest(manifestPath, { version: 1, entries: nextEntries })
 
   if (counter.requestCount() > 0) {
     print(`OpenAI usage: ${counter.requestCount()} HTTP requests.`)

--- a/apps/website/scripts/i18n-content/update-content-translations.ts
+++ b/apps/website/scripts/i18n-content/update-content-translations.ts
@@ -1,0 +1,267 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import type { OutputLocale } from './config'
+import { translationPipelineConfig } from './config'
+import { hashSource, loadManifest, saveManifest } from './manifest'
+import type { TranslationManifest } from './manifest'
+import { createOpenAiReviewer, reviewItems } from './review'
+import type { ReviewItem } from './review'
+import {
+  createOpenAiTranslator,
+  createRequestCounter,
+  translateItems
+} from './translate'
+import type { TranslationItem } from './translate'
+import {
+  applyFrontmatterTranslations,
+  discoverDocuments,
+  readDocument,
+  serializeDocument,
+  translatableFields
+} from './document'
+import type { DocumentRef, TranslatableField } from './document'
+import { protectedTokens } from './protected-tokens'
+
+interface PendingDocument {
+  ref: DocumentRef
+  locale: OutputLocale
+  fields: TranslatableField[]
+  body: string
+  sourceHash: string
+}
+
+function documentSourceSignature(
+  fields: TranslatableField[],
+  body: string
+): string {
+  return `${fields.map((field) => field.value).join('\n')}\n${body}`
+}
+
+function print(line: string): void {
+  process.stdout.write(`${line}\n`)
+}
+
+export function collectPending(
+  refs: readonly DocumentRef[],
+  manifest: TranslationManifest,
+  outputLocales: readonly OutputLocale[]
+): {
+  pending: PendingDocument[]
+  manifestUpdates: Map<string, Map<string, string>>
+} {
+  const pending: PendingDocument[] = []
+  const manifestUpdates = new Map<string, Map<string, string>>()
+
+  for (const ref of refs) {
+    const { frontmatter, body } = readDocument(ref, ref.enPath)
+    const fields = translatableFields(ref, frontmatter)
+    const sourceHash = hashSource(documentSourceSignature(fields, body))
+
+    for (const locale of outputLocales) {
+      const recordedHash = manifest.entries[ref.id]?.[locale.code]
+
+      if (!existsSync(ref.localePath(locale.code))) {
+        pending.push({ ref, locale, fields, body, sourceHash })
+        continue
+      }
+      if (recordedHash === undefined) {
+        const localeHashes = manifestUpdates.get(ref.id) ?? new Map()
+        localeHashes.set(locale.code, sourceHash)
+        manifestUpdates.set(ref.id, localeHashes)
+        continue
+      }
+      if (recordedHash !== sourceHash) {
+        pending.push({ ref, locale, fields, body, sourceHash })
+      }
+    }
+  }
+
+  return { pending, manifestUpdates }
+}
+
+async function translateDocument(
+  pending: PendingDocument,
+  translateBatch: Parameters<typeof translateItems>[2],
+  reviewBatch: Parameters<typeof reviewItems>[2],
+  config: typeof translationPipelineConfig
+): Promise<
+  | { outcome: 'written'; frontmatter: unknown; body: string }
+  | { outcome: 'rejected'; reason: string }
+> {
+  const items: TranslationItem[] = [
+    ...pending.fields.map((field) => ({
+      id: field.path,
+      context: `${pending.ref.id}: ${field.path}`,
+      source: field.value,
+      preserve: protectedTokens(field.value)
+    })),
+    {
+      id: 'body',
+      context: `${pending.ref.id}: body`,
+      source: pending.body,
+      preserve: protectedTokens(pending.body)
+    }
+  ]
+
+  let translations: Map<string, string>
+  try {
+    translations = await translateItems(
+      pending.locale,
+      items,
+      translateBatch,
+      config
+    )
+  } catch (error) {
+    return {
+      outcome: 'rejected',
+      reason: error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  const translatedFields = new Map(
+    pending.fields.map((field) => [
+      field.path,
+      translations.get(field.path) ?? field.value
+    ])
+  )
+  const translatedBody = translations.get('body') ?? pending.body
+
+  const reviewItem: ReviewItem = {
+    id: pending.ref.id,
+    context: pending.ref.id,
+    source: documentSourceSignature(pending.fields, pending.body),
+    translation: documentSourceSignature(
+      pending.fields.map((field) => ({
+        path: field.path,
+        value: translatedFields.get(field.path) ?? field.value
+      })),
+      translatedBody
+    )
+  }
+  const verdicts = await reviewItems(
+    pending.locale,
+    [reviewItem],
+    reviewBatch,
+    config
+  )
+  const verdict = verdicts.get(pending.ref.id)
+  if (!verdict?.pass) {
+    return { outcome: 'rejected', reason: verdict?.reason ?? 'no verdict' }
+  }
+
+  const { frontmatter } = readDocument(pending.ref, pending.ref.enPath)
+  return {
+    outcome: 'written',
+    frontmatter: applyFrontmatterTranslations(
+      pending.ref,
+      frontmatter,
+      translatedFields
+    ),
+    body: translatedBody
+  }
+}
+
+async function run(argv: readonly string[]): Promise<void> {
+  const check = argv.includes('--check')
+  const scriptDir = dirname(fileURLToPath(import.meta.url))
+  const contentDir = resolve(scriptDir, '../../src/content')
+  const manifestPath = resolve(contentDir, '.i18n-manifest.json')
+  const config = translationPipelineConfig
+
+  const refs = discoverDocuments(contentDir)
+  const manifest = loadManifest(manifestPath)
+  const { pending, manifestUpdates } = collectPending(
+    refs,
+    manifest,
+    config.outputLocales
+  )
+
+  if (check) {
+    for (const item of pending) {
+      print(`${item.locale.code}/${item.ref.id}: missing or stale`)
+    }
+    print(
+      pending.length === 0
+        ? 'All website content translations are up to date.'
+        : `Pending: ${pending.length} documents.`
+    )
+    return
+  }
+
+  if (pending.length === 0) {
+    print('All website content translations are up to date.')
+    return
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error(
+      `${pending.length} documents need translation but OPENAI_API_KEY is not set.`
+    )
+  }
+
+  const counter = createRequestCounter()
+  const translateBatch = createOpenAiTranslator({
+    apiKey,
+    fetchFn: counter.fetch,
+    model: config.model,
+    reasoningEffort: config.reasoningEffort,
+    glossary: config.glossary,
+    maxTruncationSplitDepth: config.maxTruncationSplitDepth
+  })
+  const reviewBatch = createOpenAiReviewer({
+    apiKey,
+    fetchFn: counter.fetch,
+    model: config.model,
+    reasoningEffort: config.reasoningEffort
+  })
+
+  let written = 0
+  let rejected = 0
+
+  for (const item of pending) {
+    const result = await translateDocument(
+      item,
+      translateBatch,
+      reviewBatch,
+      config
+    )
+    if (result.outcome === 'rejected') {
+      rejected++
+      print(`REJECTED ${item.locale.code}/${item.ref.id}: ${result.reason}`)
+      continue
+    }
+    const outPath = item.ref.localePath(item.locale.code)
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, serializeDocument(result.frontmatter, result.body))
+    const localeHashes = manifestUpdates.get(item.ref.id) ?? new Map()
+    localeHashes.set(item.locale.code, item.sourceHash)
+    manifestUpdates.set(item.ref.id, localeHashes)
+    written++
+  }
+
+  const nextEntries: TranslationManifest['entries'] = { ...manifest.entries }
+  for (const [id, locales] of manifestUpdates) {
+    nextEntries[id] = { ...nextEntries[id], ...Object.fromEntries(locales) }
+  }
+  saveManifest(manifestPath, { version: 1, entries: nextEntries })
+
+  if (counter.requestCount() > 0) {
+    print(`OpenAI usage: ${counter.requestCount()} HTTP requests.`)
+  }
+  print(
+    `Translated ${written} documents; ${rejected} held back by AI review (will retry next run).`
+  )
+}
+
+const invokedAsScript = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false
+if (invokedAsScript) {
+  run(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/apps/website/scripts/i18n-content/update-content-translations.ts
+++ b/apps/website/scripts/i18n-content/update-content-translations.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -306,7 +306,12 @@ async function run(argv: readonly string[]): Promise<void> {
       }
       const outPath = item.ref.localePath(item.locale.code)
       mkdirSync(dirname(outPath), { recursive: true })
-      writeFileSync(outPath, serializeDocument(result.frontmatter, result.body))
+      // Write beside the destination and rename into place, so a run that
+      // fails mid-write never leaves a partial file at outPath for the next
+      // run to bootstrap a baseline hash against.
+      const tmpPath = `${outPath}.tmp-${process.pid}`
+      writeFileSync(tmpPath, serializeDocument(result.frontmatter, result.body))
+      renameSync(tmpPath, outPath)
       const localeHashes = manifestUpdates.get(item.ref.id) ?? new Map()
       localeHashes.set(item.locale.code, item.sourceHash)
       manifestUpdates.set(item.ref.id, localeHashes)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,6 +1032,9 @@ importers:
       happy-dom:
         specifier: 'catalog:'
         version: 20.9.0
+      openai:
+        specifier: 'catalog:'
+        version: 7.4.0(ws@8.21.1)(zod@3.25.76)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.2
@@ -1053,6 +1056,9 @@ importers:
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.9(typescript@6.0.3)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.9.0
 
   packages/design-system:
     dependencies:


### PR DESCRIPTION
## Summary

Customer stories and FAQ entries live as MDX documents under `apps/website/src/content/{customers,faq}/{locale}/*.mdx`. `en` and `zh-CN` have full parity (11 + 26 docs each); `ja` has zero files. Adds an OpenAI-backed pipeline for this shape — a sibling to #16747, which covers `translations.ts`'s flat string map.

## Changes

- **What**: `apps/website/scripts/i18n-content/document.ts` discovers documents, splits frontmatter from body, and knows per-collection which frontmatter fields are translatable (customers: `title`/`category`/`description`/`sections[].label`; faq: `question`) versus structural (`cover`, `order`, section `id`s) — and reassembles a document from translated pieces.
- **What**: `protected-tokens.ts` guards component tag names (`<Figure>`, `<Quote>`, ...) and `src`/`href` URLs so they survive translation, while letting `alt`/`caption` text and markdown link labels translate freely — a plain "preserve every attribute" rule would leave `alt` and `caption` in English, which is exactly the accessibility/SEO text Japanese needs localized.
- **What**: `manifest.ts`/`translate.ts`/`review.ts` mirror the sibling PR's design (per-document-per-locale source-hash manifest for incremental reruns, chunked/retried OpenAI translation, a second independent AI review pass that rejects rather than ships a bad translation) but are self-contained rather than importing `apps/website/scripts/i18n/`.
- **What**: `.github/workflows/i18n-update-website-content.yaml` (manual `workflow_dispatch` only).
- **Dependencies**: `openai` and `yaml` (both already in the repo's pnpm catalog) added to `apps/website`'s devDependencies.

## Review Focus

- Duplicates the sibling PR's translate/review/manifest modules instead of importing them: these are two independent, separately reviewable PRs, and neither should have to wait on the other merging first.
- Every locale document is written as a brand-new file rather than edited in place, so there's no "existing translation" to fall back to if AI review rejects one — a rejected document is simply not generated this run and retries on the next one (unlike the sibling PR's strings, which fall back to English automatically via `t()`).
- Deliberately does **not** add new `/ja` page routes to consume the generated content — same scope boundary as the sibling PR (a separate SEO/indexing launch decision).
- `pnpm --filter website i18n-content:check` currently reports all 37 `en`/`zh-CN` documents' `zh-CN` side already covered (bootstraps as baseline) and all 37 `ja` sides pending — verified against the real content in this repo, not just fixtures.
