### PR TITLE
ci(comfy-multi-player): stop running the stateless probe twice

### DIFF
--- a/.github/workflows/ci-comfy-multi-player.yaml
+++ b/.github/workflows/ci-comfy-multi-player.yaml
@@ -62,8 +62,11 @@ jobs:
           pnpm --filter @comfyorg/comfy-multi-player run check:profile-claims
           pnpm --filter @comfyorg/comfy-multi-player run check:coderabbit
 
+      # test/stateless.test.ts is already run as an explicit merge-blocking probe by
+      # check:stateless above, and it spawns fresh Node subprocesses, so exclude it here
+      # rather than paying for it twice.
       - name: Test package
-        run: pnpm --filter @comfyorg/comfy-multi-player test
+        run: pnpm --filter @comfyorg/comfy-multi-player test --exclude test/stateless.test.ts
 
       - name: Test clock ordering matrix
         run: pnpm --filter @comfyorg/comfy-multi-player run test:clock-matrix

--- a/.github/workflows/publish-comfy-multi-player.yaml
+++ b/.github/workflows/publish-comfy-multi-player.yaml
@@ -51,7 +51,8 @@ jobs:
           pnpm --filter @comfyorg/comfy-multi-player run check:coderabbit
           pnpm --filter @comfyorg/comfy-multi-player run check:imports
           pnpm --filter @comfyorg/comfy-multi-player run check:pins
-          pnpm --filter @comfyorg/comfy-multi-player test
+          # already covered as an explicit probe by check:stateless above
+          pnpm --filter @comfyorg/comfy-multi-player test --exclude test/stateless.test.ts
           pnpm --filter @comfyorg/comfy-multi-player run test:clock-matrix
 
       - name: Verify package contents


### PR DESCRIPTION
## Summary

`test/stateless.test.ts` runs twice in both comfy-multi-player workflows: once as the explicit probe inside `check:stateless`, and again as part of the unfiltered package test suite. The probe spawns fresh Node subprocesses, so the duplicate is the most expensive kind to pay for twice. This excludes it from the suite step and leaves `check:stateless` as the single behavioral probe.

## Changes

- **What**: `.github/workflows/ci-comfy-multi-player.yaml` "Test package" step and the `test` line inside `.github/workflows/publish-comfy-multi-player.yaml` "Verify package" now pass `--exclude test/stateless.test.ts`.
- **Why both reached the same file**: `packages/comfy-multi-player/scripts/check-stateless.mjs` spawns `vitest run test/stateless.test.ts --reporter=dot`, while `package.json` sets `"test": "vitest run"` and `vitest.config.ts` sets `include: ["test/**/*.test.ts"]`, so the unfiltered run re-collects it.

CI wiring only. No package script, no `vitest.config.ts`, no test source, and nothing in the probe's subprocess logic is touched. `check:stateless` keeps both halves it is unique for, the static purity lint and the explicit behavioral probe, so the statelessness contract stays merge-blocking.

## Review Focus

**The `--` separator would have made this a silent no-op.** `pnpm --filter <pkg> test -- --exclude test/stateless.test.ts` forwards a literal `--` ahead of the flag, and vitest's CLI treats a bare `--` as end-of-options, so the exclusion is silently ignored and the file still runs. Verified directly: `vitest list --filesOnly -- --exclude test/stateless.test.ts` reports 58 files in the standalone checkout, the same as an unfiltered list, while the separator-free form reports 57. The form used here has no `--`; pnpm 11 forwards the flag unchanged (confirmed against a scratch workspace whose script echoes `process.argv`).

**`--exclude` replaces vitest's default exclude list rather than extending it.** That is harmless here because `include` is already narrowed to `test/**/*.test.ts`, so the dropped `**/node_modules/**` and `**/dist/**` defaults cannot match anything the include glob reaches. Worth knowing if the include glob ever widens.

**Why the suite step gives up the file rather than `check:stateless` giving up its probe.** Removing the probe from `check-stateless.mjs` would leave the statelessness contract covered only implicitly, as one file inside a 70-file suite, and it would be a package script change rather than CI wiring. Keeping the explicit probe preserves the named, greppable, merge-blocking check.

## Verification

Run in this worktree at `c07ff94640`, Node 25.9.0, pnpm 11.13.1:

- `pnpm --filter @comfyorg/comfy-multi-player exec vitest list --filesOnly` — 71 files before, 70 with the new flag, and the one dropped file is `test/stateless.test.ts`
- `pnpm --filter @comfyorg/comfy-multi-player test --exclude test/stateless.test.ts` — 870 tests, all pass after `run build` (the one failure without a build is `test/purity.test.ts` asserting `dist/index.js` exists, which the workflow's earlier `typecheck` step already produces; it passes once built)
- `pnpm --filter @comfyorg/comfy-multi-player run check:stateless` — passes, 16 source files linted, probe passed
- `.github/workflows/*.yaml` both parse

## Provenance

This fixes [Comfy-Org/comfy-multi-player#153](https://github.com/Comfy-Org/comfy-multi-player/issues/153). It is opened here, based on [#16644](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16644), rather than on the standalone repo, because [#168](https://github.com/Comfy-Org/comfy-multi-player/pull/168) deleted that repo's entire `.github/workflows/` tree and declared it read-only history. The workflows this touches exist only on the migration branch, so it is the only writable copy. Same routing as [#16896](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16896).

Fixes Comfy-Org/comfy-multi-player#153
