### PR TITLE
feat(website): refresh platform page heroes and copy

### DIFF
--- a/apps/website/src/components/blocks/HeroSplit01.vue
+++ b/apps/website/src/components/blocks/HeroSplit01.vue
@@ -60,7 +60,7 @@ const {
 } = defineProps<{
   locale?: Locale
   class?: HTMLAttributes['class']
-  badgeText: string
+  badgeText?: string
   badgeLogoSrc?: string
   badgeLogoAlt?: string
   badgeShowLogo?: boolean
@@ -104,7 +104,7 @@ const {
     "
   >
     <div class="w-full lg:flex-1">
-      <div class="flex items-center gap-3">
+      <div v-if="badgeText || $slots.badge" class="flex items-center gap-3">
         <slot name="badge">
           <ProductHeroBadge
             :text="badgeText"

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7526,8 +7526,8 @@ Enterprise`
     'zh-CN': '开发者平台'
   },
   'home.platform.body': {
-    en: 'Scale your custom nodes in your Comfy workflows in custom environments through Comfy API.',
-    'zh-CN': '通过 Comfy API 在自定义环境中扩展你的 Comfy 工作流和自定义节点。'
+    en: 'Deploy your ComfyUI workflow as a production API. Thousands of models on one platform.',
+    'zh-CN': '将你的 ComfyUI 工作流部署为生产级 API。数千个模型，尽在一个平台。'
   },
   'home.platform.cta': {
     en: 'Explore the Developer Platform',
@@ -7705,8 +7705,8 @@ Enterprise`
     'zh-CN': '几分钟内上线'
   },
   'platform.serverlessDeploy.shipSubtitle': {
-    en: 'Easily package up your existing ComfyUI environment or a single workflow,\nthen deploy it to Comfy API.',
-    'zh-CN': '轻松打包现有的 ComfyUI 环境或单个工作流，然后部署到 Comfy API。'
+    en: 'Using our CLI and Skills, have your coding agent deploy everything in minutes.',
+    'zh-CN': '使用我们的 CLI 和 Skills，让你的编码智能体在几分钟内完成部署。'
   },
   'platform.serverlessDeploy.subtitle': {
     en: 'Builder packages your ComfyUI workflow and environment into a reproducible build. Deploy that build to Comfy API and scale it on demand.',
@@ -7810,9 +7810,9 @@ Enterprise`
     'zh-CN': 'Builder'
   },
   'platform.products.builder.description': {
-    en: 'Package custom nodes, models, and Python dependencies into a reproducible build. Run it on Comfy Desktop or deploy it to Comfy API.',
+    en: 'Package custom nodes, LoRAs, models, and Python dependencies into a reproducible build. Run it on Comfy Desktop or deploy it to Comfy API.',
     'zh-CN':
-      '将自定义节点、模型和 Python 依赖打包成可复现的构建。在 Comfy Desktop 上运行，或部署到 Comfy API。'
+      '将自定义节点、LoRA、模型和 Python 依赖打包成可复现的构建。在 Comfy Desktop 上运行，或部署到 Comfy API。'
   },
   'platform.products.builder.enterpriseCta': {
     en: 'Enterprise: Managed Builds',
@@ -7823,48 +7823,76 @@ Enterprise`
     'zh-CN': 'Models API'
   },
   'platform.products.models.description': {
-    en: 'Call partner models including Seedance, Minimax H3, Nano Banana, and GPT-Image-2. Access the latest models with a single API key.',
+    en: 'Use thousands of the latest models in one API. Call Seedance, Minimax H3, Nano Banana, and GPT-Image.',
     'zh-CN':
-      '调用合作伙伴模型——Seedance、Minimax H3、Nano Banana、GPT-Image-2——用一个 API 密钥即可访问最新模型。'
+      '在一个 API 中使用数千个最新模型。调用 Seedance、Minimax H3、Nano Banana 和 GPT-Image。'
+  },
+  'platform.modelsHero.heading': {
+    en: '1000+ media AI models in one API.',
+    'zh-CN': '1000+ 媒体 AI 模型，尽在一个 API。'
+  },
+  'platform.modelsHero.subtitle': {
+    en: 'Use state-of-the-art models for image, video, 3D, and audio. Ready for production.',
+    'zh-CN': '使用最先进的图像、视频、3D 和音频模型。生产环境就绪。'
+  },
+  'platform.builderHero.heading': {
+    en: 'Share ComfyUI Builds with your team',
+    'zh-CN': '与团队共享 ComfyUI Builds'
+  },
+  'platform.builderHero.subtitle': {
+    en: 'A Build lets you share ComfyUI custom nodes, LoRAs, models, and Python dependencies without hassle. Run them on your workstation, server, or datacenter.',
+    'zh-CN':
+      'Build 让你轻松共享 ComfyUI 自定义节点、LoRA、模型和 Python 依赖。可在工作站、服务器或数据中心运行。'
+  },
+  'platform.serverlessHero.heading': {
+    en: 'ComfyUI workflow to production API in minutes.',
+    'zh-CN': '几分钟内，将 ComfyUI 工作流变成生产级 API。'
+  },
+  'platform.serverlessHero.subtitle': {
+    en: 'Package all your custom nodes, LoRAs, models, and Python dependencies into an autoscaling endpoint.',
+    'zh-CN':
+      '将你的所有自定义节点、LoRA、模型和 Python 依赖打包成一个自动扩缩的端点。'
+  },
+  'platform.modelsGallery.ariaLabel': {
+    en: 'Sample outputs from partner models',
+    'zh-CN': '合作伙伴模型的示例输出'
   },
   'platform.modelsFeatures.heading': {
-    en: 'One key, every frontier model',
-    'zh-CN': '一个密钥，所有前沿模型'
+    en: 'Built for production',
+    'zh-CN': '为生产环境而建'
   },
   'platform.modelsFeatures.1.title': {
     en: 'Every frontier media model',
     'zh-CN': '所有前沿媒体模型'
   },
   'platform.modelsFeatures.1.description': {
-    en: '36+ partner providers — Nano Banana, Veo, Kling, Seedance, Flux, Sora, GPT Image, Runway, Luma, ElevenLabs and more — behind stable model IDs.',
+    en: '1000+ models — Seedance, GPT Image 2, Nano Banana, Kling, Minimax, Flux, ElevenLabs, and more with day 0 access.',
     'zh-CN':
-      '36+ 家合作伙伴——Nano Banana、Veo、Kling、Seedance、Flux、Sora、GPT Image、Runway、Luma、ElevenLabs 等——都在稳定的模型 ID 之后。'
+      '1000+ 模型——Seedance、GPT Image 2、Nano Banana、Kling、Minimax、Flux、ElevenLabs 等——首发日即可使用。'
   },
   'platform.modelsFeatures.3.title': {
     en: 'One credit pool',
     'zh-CN': '一个积分池'
   },
   'platform.modelsFeatures.3.description': {
-    en: 'Pay per use from the same balance that powers Cloud workflows and serverless GPUs. No subscription floor.',
-    'zh-CN':
-      '按用量付费，与 Cloud 工作流和无服务器 GPU 共用同一余额。没有订阅门槛。'
+    en: 'Pay per use from one credit pool for your team. No subscription required.',
+    'zh-CN': '按用量付费，团队共用同一积分池。无需订阅。'
   },
   'platform.modelsFeatures.5.title': {
-    en: 'Schemas to generate against',
-    'zh-CN': '可直接生成代码的 Schema'
+    en: 'No setup',
+    'zh-CN': '无需配置'
   },
   'platform.modelsFeatures.5.description': {
-    en: 'Every model publishes its own OpenAPI document — the same one the server validates your call against.',
-    'zh-CN':
-      '每个模型都发布自己的 OpenAPI 文档——服务器校验你的调用时用的正是同一份。'
+    en: 'Every model can be accessed via a simple API or SDK.',
+    'zh-CN': '每个模型都可通过简单的 API 或 SDK 访问。'
   },
   'platform.modelsFeatures.6.title': {
-    en: 'Cancel anytime',
-    'zh-CN': '随时取消'
+    en: 'No data retention',
+    'zh-CN': '不保留数据'
   },
   'platform.modelsFeatures.6.description': {
-    en: 'A queued request cancels immediately and costs nothing; in-progress calls get a best-effort cancel.',
-    'zh-CN': '排队中的请求立即取消且不产生费用；进行中的调用会尽力取消。'
+    en: 'You own your outputs. Your prompts and data are never retained.',
+    'zh-CN': '输出归你所有。你的提示词和数据永不保留。'
   },
   'platform.examples.heading': {
     en: 'Built on the Developer Platform',
@@ -8262,20 +8290,19 @@ Enterprise`
     'zh-CN': '让每个人都用上同一个 Comfy'
   },
   'platform.builderPillars.1.title': {
-    en: 'Consistency',
-    'zh-CN': '一致性'
+    en: 'It just works',
+    'zh-CN': '开箱即用'
   },
   'platform.builderPillars.1.description': {
-    en: 'Ensure your team is using the same consistent build. Deploy exact models, custom nodes, pip dependencies and get consistent results.',
-    'zh-CN':
-      '确保团队使用同一个一致的构建。部署完全一致的模型、自定义节点和 pip 依赖，获得一致的结果。'
+    en: 'Ensure your team uses the same environment. Share custom nodes, LoRAs, and models without hassle.',
+    'zh-CN': '确保团队使用同一环境。轻松共享自定义节点、LoRA 和模型。'
   },
   'platform.builderPillars.2.title': {
     en: 'Comfy Desktop',
     'zh-CN': 'Comfy Desktop'
   },
   'platform.builderPillars.2.description': {
-    en: 'Run builds locally on Desktop. Easily reinstall the same working build.',
+    en: 'Run Builds locally on Desktop. Easily reinstall the same working Build.',
     'zh-CN': '在 Desktop 上本地运行构建，随时轻松重装同一个可用构建。'
   },
   'platform.builderPillars.3.title': {
@@ -8287,13 +8314,12 @@ Enterprise`
     'zh-CN': '构建可以部署到 Comfy API，并以编程方式运行。'
   },
   'platform.builderPillars.4.title': {
-    en: 'Migrate in minutes',
-    'zh-CN': '几分钟内完成迁移'
+    en: 'Start in minutes',
+    'zh-CN': '几分钟内上手'
   },
   'platform.builderPillars.4.description': {
-    en: 'Easily migrate using the UI or your agent via Skills maintained by our team.',
-    'zh-CN':
-      '通过界面轻松迁移，或让你的智能体使用我们团队维护的 Skills 完成迁移。'
+    en: 'Have your coding agent do all of the work in minutes using our CLI and skills library.',
+    'zh-CN': '让你的编码智能体使用我们的 CLI 和技能库，在几分钟内完成全部工作。'
   },
   'platform.builderEnterprise.heading': {
     en: 'Builds vs. Managed Builds',
@@ -8345,8 +8371,8 @@ Enterprise`
     'zh-CN': '将规模与控制力最大化'
   },
   'platform.closing.headingAfterBadge': {
-    en: 'Scale your custom nodes in your Comfy workflows\nin custom environments through Comfy API.',
-    'zh-CN': '通过 Comfy API 在自定义环境中扩展你的 Comfy 工作流和自定义节点。'
+    en: 'Deploy your ComfyUI workflow as a production API.\nThousands of models on one platform.',
+    'zh-CN': '将你的 ComfyUI 工作流部署为生产级 API。数千个模型，尽在一个平台。'
   }
 } as const satisfies Record<
   string,

--- a/apps/website/src/pages/platform/models.astro
+++ b/apps/website/src/pages/platform/models.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 import ProductCardsSection from '../../components/common/ProductCardsSection.vue'
 import ClosingCtaSection from '../../templates/platform/ClosingCtaSection.vue'
 import ModelsApiFeaturesSection from '../../templates/platform/ModelsApiFeaturesSection.vue'
+import ModelsApiGallery from '../../templates/platform/ModelsApiGallery.vue'
 import ModelsApiHero from '../../templates/platform/ModelsApiHero.vue'
 import { t } from '../../i18n/translations'
 ---
@@ -12,6 +13,7 @@ import { t } from '../../i18n/translations'
   description={t('platform.products.models.description', 'en')}
 >
   <ModelsApiHero locale="en" client:load />
+  <ModelsApiGallery locale="en" client:visible />
   <ModelsApiFeaturesSection locale="en" />
   <ClosingCtaSection
     locale="en"

--- a/apps/website/src/pages/zh-CN/platform/models.astro
+++ b/apps/website/src/pages/zh-CN/platform/models.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro'
 import ProductCardsSection from '../../../components/common/ProductCardsSection.vue'
 import ClosingCtaSection from '../../../templates/platform/ClosingCtaSection.vue'
 import ModelsApiFeaturesSection from '../../../templates/platform/ModelsApiFeaturesSection.vue'
+import ModelsApiGallery from '../../../templates/platform/ModelsApiGallery.vue'
 import ModelsApiHero from '../../../templates/platform/ModelsApiHero.vue'
 import { t } from '../../../i18n/translations'
 ---
@@ -12,6 +13,7 @@ import { t } from '../../../i18n/translations'
   description={t('platform.products.models.description', 'zh-CN')}
 >
   <ModelsApiHero locale="zh-CN" client:load />
+  <ModelsApiGallery locale="zh-CN" client:visible />
   <ModelsApiFeaturesSection locale="zh-CN" />
   <ClosingCtaSection
     locale="zh-CN"

--- a/apps/website/src/templates/platform/BuilderHero.test.ts
+++ b/apps/website/src/templates/platform/BuilderHero.test.ts
@@ -11,11 +11,11 @@ describe('BuilderHero', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: t('platform.products.builder.title', 'en')
+        name: t('platform.builderHero.heading', 'en')
       })
     ).toBeTruthy()
     expect(
-      screen.getByText(t('platform.products.builder.description', 'en'))
+      screen.getByText(t('platform.builderHero.subtitle', 'en'))
     ).toBeTruthy()
   })
 })

--- a/apps/website/src/templates/platform/BuilderHero.vue
+++ b/apps/website/src/templates/platform/BuilderHero.vue
@@ -15,11 +15,9 @@ const ctas = platformCtas(locale)
   <HeroSplit01
     :locale="locale"
     compact
-    :badge-text="t('platform.products.builder.title', locale).toUpperCase()"
-    :badge-show-logo="false"
-    :title="t('platform.products.builder.title', locale)"
-    title-class="sr-only"
-    :subtitle="t('platform.products.builder.description', locale)"
+    :title="t('platform.builderHero.heading', locale)"
+    title-class="text-primary-comfy-yellow text-3xl/tight font-bold tracking-[-1.44px] md:text-4xl/tight lg:text-5xl/tight"
+    :subtitle="t('platform.builderHero.subtitle', locale)"
     :primary-cta="{
       label: ctas.getStarted.label,
       href: externalLinks.platformBuilds,

--- a/apps/website/src/templates/platform/LiveTerminal.test.ts
+++ b/apps/website/src/templates/platform/LiveTerminal.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { prefersReducedMotion } from '../../composables/useReducedMotion'
+import LiveTerminal from './LiveTerminal.vue'
+
+vi.mock('../../composables/useReducedMotion', () => ({
+  prefersReducedMotion: vi.fn()
+}))
+
+// The terminal only animates while on screen; happy-dom has no
+// IntersectionObserver, so report every observed element as visible.
+type ObserverEntry = { isIntersecting: boolean; time: number }
+
+class VisibleIntersectionObserver {
+  constructor(callback: (entries: ObserverEntry[]) => void) {
+    this.callback = callback
+  }
+  callback: (entries: ObserverEntry[]) => void
+  observe() {
+    this.callback([{ isIntersecting: true, time: 0 }])
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {}
+}
+
+const LINES = ['$ comfy up', '✔ Done']
+
+function transcript(): string {
+  return (
+    screen.getByRole('img', { name: 'Demo' }).textContent?.replace('▋', '') ??
+    ''
+  )
+}
+
+async function advance(ms: number): Promise<void> {
+  await vi.advanceTimersByTimeAsync(ms)
+  await nextTick()
+}
+
+describe('LiveTerminal', () => {
+  beforeEach(() => {
+    vi.mocked(prefersReducedMotion).mockReturnValue(false)
+    vi.stubGlobal('IntersectionObserver', VisibleIntersectionObserver)
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+  })
+
+  it('types commands out and lands output lines whole', async () => {
+    render(LiveTerminal, { props: { lines: LINES, label: 'Demo' } })
+    await nextTick()
+    expect(transcript()).toBe('')
+
+    // First keystroke after the command pause, then one every TYPE_MS.
+    await advance(500)
+    expect(transcript()).toBe('$')
+    await advance(35 * 9)
+    expect(transcript()).toBe('$ comfy up')
+
+    // The ✔ line lands whole after the output pause.
+    await advance(700)
+    expect(transcript()).toBe('$ comfy up✔ Done')
+  })
+
+  it('replays from the top after the hold', async () => {
+    render(LiveTerminal, { props: { lines: LINES, label: 'Demo' } })
+    await nextTick()
+
+    await advance(500 + 35 * 9 + 700)
+    expect(transcript()).toBe('$ comfy up✔ Done')
+
+    await advance(5000)
+    expect(transcript()).toBe('')
+    await advance(500)
+    expect(transcript()).toBe('$')
+  })
+
+  it('shows the full transcript statically under reduced motion', async () => {
+    vi.mocked(prefersReducedMotion).mockReturnValue(true)
+    render(LiveTerminal, { props: { lines: LINES, label: 'Demo' } })
+    await nextTick()
+
+    expect(transcript()).toBe('$ comfy up✔ Done')
+    await advance(10000)
+    expect(transcript()).toBe('$ comfy up✔ Done')
+  })
+})

--- a/apps/website/src/templates/platform/LiveTerminal.vue
+++ b/apps/website/src/templates/platform/LiveTerminal.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { useDocumentVisibility, useElementVisibility } from '@vueuse/core'
+import { computed, onScopeDispose, ref, useTemplateRef, watchEffect } from 'vue'
+
+import { prefersReducedMotion } from '../../composables/useReducedMotion'
+
+const TYPE_MS = 35
+const COMMAND_PAUSE_MS = 500
+const OUTPUT_PAUSE_MS = 700
+const REPLAY_HOLD_MS = 5000
+
+const { lines, label } = defineProps<{
+  lines: string[]
+  label: string
+}>()
+
+/** Reveal targets over the joined transcript: commands appear one keystroke
+ * at a time, output lines land whole after a beat, as if the run just
+ * finished that step. */
+const steps = computed(() => {
+  const targets: { upTo: number; delay: number }[] = []
+  let revealed = 0
+  for (const [index, line] of lines.entries()) {
+    const newline = index > 0 ? 1 : 0
+    if (line.startsWith('$')) {
+      for (let char = 1; char <= line.length; char++) {
+        targets.push({
+          upTo: revealed + newline + char,
+          delay: char === 1 ? COMMAND_PAUSE_MS : TYPE_MS
+        })
+      }
+    } else {
+      targets.push({
+        upTo: revealed + newline + line.length,
+        delay: OUTPUT_PAUSE_MS
+      })
+    }
+    revealed += newline + line.length
+  }
+  return targets
+})
+
+const transcript = computed(() => lines.join('\n'))
+const revealedCount = ref(0)
+
+const root = useTemplateRef<HTMLElement>('root')
+const onScreen = useElementVisibility(root)
+const documentVisibility = useDocumentVisibility()
+
+let timer: ReturnType<typeof setTimeout> | undefined
+let stepIndex = 0
+
+function schedule() {
+  clearTimeout(timer)
+  const step = steps.value[stepIndex]
+  if (step) {
+    timer = setTimeout(() => {
+      revealedCount.value = step.upTo
+      stepIndex += 1
+      schedule()
+    }, step.delay)
+  } else {
+    timer = setTimeout(() => {
+      revealedCount.value = 0
+      stepIndex = 0
+      schedule()
+    }, REPLAY_HOLD_MS)
+  }
+}
+
+watchEffect(() => {
+  if (
+    onScreen.value &&
+    documentVisibility.value === 'visible' &&
+    !prefersReducedMotion()
+  ) {
+    schedule()
+  } else {
+    clearTimeout(timer)
+  }
+})
+onScopeDispose(() => clearTimeout(timer))
+
+const visibleLines = computed(() => {
+  const text = prefersReducedMotion()
+    ? transcript.value
+    : transcript.value.slice(0, revealedCount.value)
+  return text.split('\n')
+})
+
+const panelHeight = computed(() => `${lines.length * 1.5 + 3}rem`)
+</script>
+
+<template>
+  <div ref="root" role="img" :aria-label="label">
+    <pre
+      aria-hidden="true"
+      class="text-2xs/relaxed text-primary-comfy-canvas h-[calc(var(--panel-h)*0.9)] scrollbar-none overflow-auto rounded-3xl bg-[#2a2230] p-4 font-mono whitespace-pre-wrap select-none sm:p-5 sm:text-xs/relaxed sm:whitespace-pre lg:h-(--panel-h) lg:p-6 lg:text-sm/relaxed"
+      :style="{ '--panel-h': panelHeight }"
+    ><code><template v-for="(line, index) in visibleLines" :key="index"><span
+          :class="cn(index > 0 && 'block')"
+        ><span class="text-primary-comfy-yellow">{{ line.slice(0, 1) }}</span>{{
+          line.slice(1)
+        }}</span></template><span
+        v-if="!prefersReducedMotion()"
+        class="text-primary-comfy-yellow animate-pulse"
+      >▋</span></code></pre>
+  </div>
+</template>

--- a/apps/website/src/templates/platform/ModelsApiGallery.test.ts
+++ b/apps/website/src/templates/platform/ModelsApiGallery.test.ts
@@ -1,12 +1,17 @@
 // @vitest-environment happy-dom
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import { t } from '../../i18n/translations'
 import ModelsApiGallery from './ModelsApiGallery.vue'
 
 describe('ModelsApiGallery', () => {
-  it('presents a card for each partner model', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+  })
+
+  it('presents a card for each partner model and rotates its clips', async () => {
     render(ModelsApiGallery, { props: { locale: 'en' } })
 
     for (const titleKey of [
@@ -17,5 +22,14 @@ describe('ModelsApiGallery', () => {
     ] as const) {
       expect(screen.getByText(t(titleKey, 'en'))).toBeTruthy()
     }
+
+    const seedanceClip = () =>
+      screen
+        .getByLabelText(t('cloud.aiModels.card.seedance25', 'en'))
+        .getAttribute('src')
+    const firstClip = seedanceClip()
+    await vi.advanceTimersByTimeAsync(6000)
+    await nextTick()
+    expect(seedanceClip()).not.toBe(firstClip)
   })
 })

--- a/apps/website/src/templates/platform/ModelsApiGallery.test.ts
+++ b/apps/website/src/templates/platform/ModelsApiGallery.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import { t } from '../../i18n/translations'
+import ModelsApiGallery from './ModelsApiGallery.vue'
+
+describe('ModelsApiGallery', () => {
+  it('presents a card for each partner model', () => {
+    render(ModelsApiGallery, { props: { locale: 'en' } })
+
+    for (const titleKey of [
+      'cloud.aiModels.card.seedance25',
+      'cloud.aiModels.card.minimaxH3',
+      'cloud.aiModels.card.nanoBananaPro',
+      'cloud.aiModels.card.gptImage2'
+    ] as const) {
+      expect(screen.getByText(t(titleKey, 'en'))).toBeTruthy()
+    }
+  })
+})

--- a/apps/website/src/templates/platform/ModelsApiGallery.vue
+++ b/apps/website/src/templates/platform/ModelsApiGallery.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { useIntervalFn } from '@vueuse/core'
+import { ref } from 'vue'
+
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import type { GalleryMedia, ModelsGalleryCard } from './modelsGalleryCards'
+import { modelsGalleryCards } from './modelsGalleryCards'
+
+const { locale = 'en', cards = modelsGalleryCards } = defineProps<{
+  locale?: Locale
+  cards?: ModelsGalleryCard[]
+}>()
+
+const rotationIndex = ref(0)
+
+useIntervalFn(() => {
+  rotationIndex.value += 1
+}, 6000)
+
+const activeMedia = (card: ModelsGalleryCard): GalleryMedia =>
+  card.media[rotationIndex.value % card.media.length]
+
+const isVideo = (media: GalleryMedia) => media.src.endsWith('.webm')
+</script>
+
+<template>
+  <section
+    class="max-w-9xl mx-auto px-6 pb-16 md:pb-24 lg:px-16"
+    :aria-label="t('platform.modelsGallery.ariaLabel', locale)"
+  >
+    <div class="grid grid-cols-2 gap-2 lg:grid-cols-4">
+      <div
+        v-for="card in cards"
+        :key="card.titleKey"
+        class="relative aspect-square overflow-hidden rounded-3xl bg-black/40"
+      >
+        <Transition
+          enter-active-class="transition-opacity duration-700"
+          enter-from-class="opacity-0"
+          leave-active-class="transition-opacity duration-700"
+          leave-to-class="opacity-0"
+        >
+          <video
+            v-if="isVideo(activeMedia(card))"
+            :key="activeMedia(card).src"
+            :src="activeMedia(card).src"
+            :poster="activeMedia(card).posterSrc"
+            :aria-label="t(card.titleKey, locale)"
+            class="absolute inset-0 size-full object-cover"
+            autoplay
+            loop
+            muted
+            playsinline
+          >
+            <track
+              v-if="activeMedia(card).trackSrc"
+              kind="descriptions"
+              :src="activeMedia(card).trackSrc"
+              srclang="en"
+              default
+            />
+          </video>
+          <img
+            v-else
+            :key="activeMedia(card).src"
+            :src="activeMedia(card).src"
+            :alt="t(card.titleKey, locale)"
+            class="absolute inset-0 size-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
+        </Transition>
+
+        <div
+          class="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent"
+        />
+
+        <div
+          class="absolute top-3 right-3 flex size-9 items-center justify-center rounded-xl bg-white/20 text-white backdrop-blur-sm lg:top-4 lg:right-4"
+        >
+          <span
+            class="inline-block size-4 bg-current"
+            :style="{
+              maskImage: `url(${card.badgeIcon})`,
+              maskSize: 'contain',
+              maskRepeat: 'no-repeat',
+              maskPosition: 'center'
+            }"
+          />
+        </div>
+
+        <p
+          class="text-primary-warm-white absolute bottom-3 left-4 text-base/tight font-medium whitespace-pre-line drop-shadow-[0_2px_8px_rgba(0,0,0,0.9)] lg:bottom-4 lg:text-lg"
+        >
+          {{ t(card.titleKey, locale) }}
+        </p>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/website/src/templates/platform/ModelsApiHero.test.ts
+++ b/apps/website/src/templates/platform/ModelsApiHero.test.ts
@@ -11,13 +11,14 @@ describe('ModelsApiHero', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: t('platform.products.models.title', 'en')
+        name: t('platform.modelsHero.heading', 'en')
       })
     ).toBeTruthy()
+    expect(screen.getByText(/state-of-the-art models for image/)).toBeTruthy()
     expect(
       screen.getAllByText('comfy.models.run', { exact: false }).length
     ).toBeGreaterThan(0)
-    expect(screen.getByText(t('nav.badgeComingSoon', 'en'))).toBeTruthy()
+    expect(screen.queryByText(t('nav.badgeComingSoon', 'en'))).toBeNull()
     expect(screen.queryByText(t('nav.badgeBeta', 'en'))).toBeNull()
   })
 })

--- a/apps/website/src/templates/platform/ModelsApiHero.vue
+++ b/apps/website/src/templates/platform/ModelsApiHero.vue
@@ -6,7 +6,6 @@ import { t } from '../../i18n/translations'
 import CodeTabs from './CodeTabs.vue'
 import { modelsApiCodeTabs } from './codeSamples'
 import { platformCtas } from './ctas'
-import PlatformHeroBadge from './PlatformHeroBadge.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
@@ -17,12 +16,10 @@ const ctas = platformCtas(locale)
   <HeroSplit01
     :locale="locale"
     compact
-    :badge-text="t('platform.hero.badge', locale)"
-    :badge-show-logo="false"
-    :title="t('platform.products.models.title', locale)"
-    title-class="sr-only"
+    :title="t('platform.modelsHero.heading', locale)"
+    title-class="text-primary-comfy-yellow text-3xl/tight font-bold tracking-[-1.44px] md:text-4xl/tight lg:text-5xl/tight"
     media-wrapper-class="hidden min-w-0 lg:block"
-    :subtitle="t('platform.products.models.description', locale)"
+    :subtitle="t('platform.modelsHero.subtitle', locale)"
     :primary-cta="ctas.getStarted"
     :secondary-cta="{
       label: ctas.docs.label,
@@ -30,13 +27,6 @@ const ctas = platformCtas(locale)
       target: '_blank'
     }"
   >
-    <template #badge>
-      <PlatformHeroBadge
-        :locale="locale"
-        :label="t('platform.products.models.title', locale)"
-        :status-label="t('nav.badgeComingSoon', locale)"
-      />
-    </template>
     <template #aboveCtas>
       <div class="mt-8 lg:hidden">
         <CodeTabs

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -1,18 +1,16 @@
 // @vitest-environment happy-dom
-import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { t } from '../../i18n/translations'
 import ServerlessDeploySection from './ServerlessDeploySection.vue'
 
-const commandLines = () =>
-  (screen.getByRole('tabpanel').textContent ?? '')
-    .split('\n')
-    .filter((line) => line.startsWith('$ '))
+vi.mock('../../composables/useReducedMotion', () => ({
+  prefersReducedMotion: () => true
+}))
 
 describe('ServerlessDeploySection', () => {
-  it('walks through the install flow first and the workflow flow on demand', async () => {
+  it('presents the deploy transcript as a live terminal', () => {
     render(ServerlessDeploySection, { props: { locale: 'en' } })
 
     expect(
@@ -22,26 +20,22 @@ describe('ServerlessDeploySection', () => {
       })
     ).toBeTruthy()
     expect(
-      screen.getByText(
-        /Easily package up your existing ComfyUI environment or a single workflow,\s+then deploy it to Comfy API\./
-      )
+      screen.getByText(t('platform.serverlessDeploy.shipSubtitle', 'en'))
     ).toBeTruthy()
-    expect(commandLines()).toEqual([
+
+    const terminal = screen.getByRole('img', {
+      name: t('platform.serverlessDeploy.heading', 'en')
+    })
+    const transcript = terminal.textContent ?? ''
+    for (const line of [
       '$ comfy build init',
+      '✔ Scanned this ComfyUI install — custom nodes, models, pinned deps',
       '$ comfy build push --release --target linux/nvidia',
-      '$ comfy deploy up'
-    ])
-
-    await userEvent.click(
-      screen.getByRole('tab', {
-        name: t('platform.serverlessDeploy.tabWorkflow', 'en')
-      })
-    )
-
-    expect(commandLines()).toEqual([
-      '$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2',
-      '$ comfy build push --release --target linux/nvidia',
-      '$ comfy deploy up'
-    ])
+      '✔ Build released',
+      '$ comfy deploy up',
+      '✔ Endpoint live → https://your-build.run.comfy.app'
+    ]) {
+      expect(transcript).toContain(line)
+    }
   })
 })

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -2,45 +2,22 @@
 import SectionHeader from '../../components/common/SectionHeader.vue'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
-import type { CodeTab } from './CodeTabs.vue'
-import CodeTabs from './CodeTabs.vue'
+import LiveTerminal from './LiveTerminal.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 // Command surface from comfy-cli's build + deploy stack (PRs #801-805):
-// `comfy build init` (or `--from-workflow`, which resolves no ComfyUI version
-// and so needs `--comfy-version` before a release can be cut), `build push
-// --release`, whose `--target` decides whether `deploy up` finds a deployable
-// artifact, and `deploy up`. All three default to the current directory.
-function terminalSegments(transcript: string): CodeTab['segments'] {
-  const lines = transcript.split('\n')
-  return lines.flatMap((line, index) => [
-    { values: [line.slice(0, 1)], highlight: true },
-    line.slice(1) + (index < lines.length - 1 ? '\n' : '')
-  ])
-}
-
-const deployTabs: Record<string, CodeTab> = {
-  install: {
-    name: t('platform.serverlessDeploy.tabInstall', locale),
-    segments: terminalSegments(`$ comfy build init
-✔ Scanned this ComfyUI install — custom nodes, models, pinned deps
-$ comfy build push --release --target linux/nvidia
-✔ Build released
-$ comfy deploy up
-✔ Endpoint live → https://your-build.run.comfy.app`)
-  },
-  workflow: {
-    name: t('platform.serverlessDeploy.tabWorkflow', locale),
-    segments:
-      terminalSegments(`$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2
-✔ Custom nodes and models resolved from your workflow
-$ comfy build push --release --target linux/nvidia
-✔ Build released
-$ comfy deploy up
-✔ Endpoint live → https://your-build.run.comfy.app`)
-  }
-}
+// `comfy build init`, `build push --release`, whose `--target` decides
+// whether `deploy up` finds a deployable artifact, and `deploy up`. All
+// three default to the current directory.
+const deployTranscript = [
+  '$ comfy build init',
+  '✔ Scanned this ComfyUI install — custom nodes, models, pinned deps',
+  '$ comfy build push --release --target linux/nvidia',
+  '✔ Build released',
+  '$ comfy deploy up',
+  '✔ Endpoint live → https://your-build.run.comfy.app'
+]
 </script>
 
 <template>
@@ -49,7 +26,7 @@ $ comfy deploy up
       {{ t('platform.serverlessDeploy.shipHeading', locale) }}
       <template #subtitle>
         <p
-          class="mx-auto mt-4 max-w-2xl text-sm whitespace-pre-line text-smoke-700"
+          class="text-smoke-700 mx-auto mt-4 max-w-2xl text-sm whitespace-pre-line"
         >
           {{ t('platform.serverlessDeploy.shipSubtitle', locale) }}
         </p>
@@ -57,12 +34,9 @@ $ comfy deploy up
     </SectionHeader>
 
     <div class="mx-auto mt-8 max-w-3xl">
-      <CodeTabs
-        :tabs="deployTabs"
+      <LiveTerminal
+        :lines="deployTranscript"
         :label="t('platform.serverlessDeploy.heading', locale)"
-        content-class="bg-[#2a2230]"
-        list-class="mx-auto sm:flex sm:w-fit"
-        trigger-class="px-2"
       />
     </div>
   </section>

--- a/apps/website/src/templates/platform/ServerlessHero.test.ts
+++ b/apps/website/src/templates/platform/ServerlessHero.test.ts
@@ -11,17 +11,14 @@ describe('ServerlessHero', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: t('platform.products.serverless.title', 'en')
+        name: t('platform.serverlessHero.heading', 'en')
       })
     ).toBeTruthy()
+    expect(screen.getByText(/into an autoscaling endpoint/)).toBeTruthy()
     expect(
       screen.getAllByRole('link', { name: t('platform.hero.getStarted', 'en') })
         .length
     ).toBeGreaterThan(0)
-    expect(screen.getByAltText('Comfy')).toBeTruthy()
-    expect(
-      screen.getByText(t('platform.products.serverless.badgeLabel', 'en'))
-    ).toBeTruthy()
-    expect(screen.getByText(t('nav.badgeBeta', 'en'))).toBeTruthy()
+    expect(screen.queryByText(t('nav.badgeBeta', 'en'))).toBeNull()
   })
 })

--- a/apps/website/src/templates/platform/ServerlessHero.vue
+++ b/apps/website/src/templates/platform/ServerlessHero.vue
@@ -3,7 +3,6 @@ import HeroSplit01 from '../../components/blocks/HeroSplit01.vue'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import { platformCtas } from './ctas'
-import PlatformHeroBadge from './PlatformHeroBadge.vue'
 import ServerlessIsometricStudy from './ServerlessIsometricStudy.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
@@ -15,31 +14,13 @@ const ctas = platformCtas(locale)
   <HeroSplit01
     :locale="locale"
     compact
-    beta
-    :badge-text="t('platform.hero.badge', locale)"
-    :title="t('platform.products.serverless.title', locale)"
-    title-class="sr-only"
-    :subtitle="t('platform.products.serverless.description', locale)"
+    :title="t('platform.serverlessHero.heading', locale)"
+    title-class="text-primary-comfy-yellow text-3xl/tight font-bold tracking-[-1.44px] md:text-4xl/tight lg:text-5xl/tight"
+    :subtitle="t('platform.serverlessHero.subtitle', locale)"
     :primary-cta="ctas.getStarted"
     :secondary-cta="ctas.docs"
     media-wrapper-class="hidden lg:block"
   >
-    <template #badge>
-      <PlatformHeroBadge :locale :status-label="t('nav.badgeBeta', locale)">
-        <template #label>
-          <img
-            src="/icons/logo.svg"
-            alt="Comfy"
-            width="173"
-            height="48"
-            class="h-5 w-auto brightness-0 md:h-9"
-          />
-          <span>{{
-            t('platform.products.serverless.badgeLabel', locale)
-          }}</span>
-        </template>
-      </PlatformHeroBadge>
-    </template>
     <template #aboveCtas>
       <div class="mt-8 rounded-3xl lg:hidden">
         <ServerlessIsometricStudy :locale />

--- a/apps/website/src/templates/platform/modelsGalleryCards.ts
+++ b/apps/website/src/templates/platform/modelsGalleryCards.ts
@@ -1,0 +1,70 @@
+import type { TranslationKey } from '../../i18n/translations'
+
+export interface GalleryMedia {
+  src: string
+  posterSrc?: string
+  trackSrc?: string
+}
+
+export interface ModelsGalleryCard {
+  titleKey: TranslationKey
+  badgeIcon: string
+  media: GalleryMedia[]
+}
+
+const SEEDANCE_BASE = 'https://media.comfy.org/website/seedance-2.5'
+const MINIMAX_BASE = 'https://media.comfy.org/website/minimax'
+const AI_MODELS_BASE = 'https://media.comfy.org/website/cloud/ai-models'
+
+export const modelsGalleryCards: ModelsGalleryCard[] = [
+  {
+    titleKey: 'cloud.aiModels.card.seedance25',
+    badgeIcon: '/icons/ai-models/bytedance.svg',
+    media: [
+      {
+        src: `${SEEDANCE_BASE}/city.webm`,
+        posterSrc: `${SEEDANCE_BASE}/city-poster.webp`
+      },
+      {
+        src: `${SEEDANCE_BASE}/balloons.webm`,
+        posterSrc: `${SEEDANCE_BASE}/balloons-poster.webp`
+      },
+      {
+        src: `${SEEDANCE_BASE}/shark.webm`,
+        posterSrc: `${SEEDANCE_BASE}/shark-poster.webp`
+      }
+    ]
+  },
+  {
+    titleKey: 'cloud.aiModels.card.minimaxH3',
+    badgeIcon: '/icons/ai-models/minimax.svg',
+    media: [
+      {
+        src: 'https://media.comfy.org/website/minimax-h3/hero-dragon-960.webm'
+      },
+      {
+        src: `${MINIMAX_BASE}/ice-rider.webm`,
+        posterSrc: `${MINIMAX_BASE}/ice-rider-poster.webp`
+      },
+      {
+        src: `${MINIMAX_BASE}/superhero.webm`,
+        posterSrc: `${MINIMAX_BASE}/superhero-poster.webp`
+      }
+    ]
+  },
+  {
+    titleKey: 'cloud.aiModels.card.nanoBananaPro',
+    badgeIcon: '/icons/ai-models/gemini.svg',
+    media: [{ src: `${AI_MODELS_BASE}/nano-banana-pro.webp` }]
+  },
+  {
+    titleKey: 'cloud.aiModels.card.gptImage2',
+    badgeIcon: '/icons/ai-models/openai.svg',
+    media: [
+      {
+        src: `${AI_MODELS_BASE}/gpt-image-2.webm`,
+        trackSrc: `${AI_MODELS_BASE}/gpt-image-2.vtt`
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Marketing refresh of the /platform product pages: visible bold yellow hero headlines replace the platform badge on the models, comfy-api, and builder pages, with updated copy throughout (en + zh-CN).

## Changes

- **What**: New hero headlines/subtitles for /platform/models, /platform/comfy-api, and /platform/builder; a rotating partner-model card gallery (Seedance, MiniMax H3, Nano Banana, GPT Image) on the models page; the deploy section's code tabs replaced with an animated, non-selectable live terminal; refreshed feature/pillar copy. `HeroSplit01`'s badge is now optional to support badge-less heroes.

## Review Focus

The live terminal and gallery animate only on screen and fall back to static content under prefers-reduced-motion.