### PR TITLE
fix(agent): remove duplicate agent-panel-title id left by #16904 after #16903

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -986,14 +986,6 @@ function onPanelDrop(event: DragEvent): void {
     @dragover="onPanelDragOver"
     @drop="onPanelDrop"
   >
-    <!--
-      `DockedAgentPanel` labels its `role="complementary"` landmark with an
-      unconditional `aria-labelledby="agent-panel-title"`, but only its
-      `AgentPanelLoadError` fallback renders that id. On the success path the
-      reference dangled, so the landmark had no accessible name. Carry the same
-      `agent.title` string here so the name resolves whichever branch renders.
-    -->
-    <h2 id="agent-panel-title" class="sr-only">{{ t('agent.title') }}</h2>
     <input
       ref="fileInput"
       type="file"


### PR DESCRIPTION
- Removes the duplicate `id="agent-panel-title"` that #16904 added to `AgentPanelRoot.vue`.
- #16903 (merged 16 min earlier) already fixed the dangling `aria-labelledby` on `PanelHeader.vue:36`; both together mount two elements with the same id on the success path.
- Pure revert of 34b6558fa; no other change.

<details><summary>Full context for agent readers</summary>

**Why:** `DockedAgentPanel` sets `aria-labelledby="agent-panel-title"` unconditionally. #16903 put the id on the success-path `<h1>` in `PanelHeader.vue`; #16904 independently added an `sr-only <h2>` with the same id in `AgentPanelRoot.vue`. `AgentPanelRoot` renders `AgentPanel` → `PanelHeader`, so after both merges main has two elements with `id="agent-panel-title"` whenever the panel loads successfully. Duplicate ids are invalid HTML and make `aria-labelledby` resolution browser-dependent.

**Test coverage:** `browser_tests/tests/agent/agentPanelLifecycle.spec.ts:84` asserts `toHaveCount(1)` and would receive 2, but #16907 marked that test `test.fixme` at 5764cd31a7 minutes later, so CI no longer surfaces it. Once this lands, re-enabling that test is a candidate follow-up (not included here to keep this a pure revert).

**Verification:** `git revert 34b6558fa` applied cleanly (8 deletions, one file); `rg agent-panel-title src/workbench/extensions/agent/AgentPanelRoot.vue` → 0 matches on this branch; `PanelHeader.vue:36` retains the id.

Related: #16903, #16904, #16907.

</details>

<!-- authored-by:agent desktop-commander -->
