### PR TITLE
fix(billing): close two gaps CodeRabbit found after #16123 merged

### DIFF
--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -384,6 +384,27 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     ).toBeNull()
   })
 
+  it('hides verification once a resumed challenge is processing', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        embeddedCheckoutEnabled: true,
+        authenticationState: 'processing',
+        // A stale action_url can still be present while the server catches up
+        // to a challenge this or another tab already resumed; the button must
+        // stay hidden so the customer never reopens a moving intent.
+        actionUrl: 'https://verify.example/sensitive-token'
+      },
+      global: globalOptions
+    })
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'subscription.preview.completeVerification'
+      })
+    ).toBeNull()
+  })
+
   it('shows reconciliation support guidance with the operation id', () => {
     render(SubscriptionAddPaymentPreviewWorkspace, {
       props: {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -250,7 +250,11 @@
       </div>
 
       <Button
-        v-if="actionUrl && authenticationState !== 'failed_retryable'"
+        v-if="
+          actionUrl &&
+          authenticationState !== 'failed_retryable' &&
+          authenticationState !== 'processing'
+        "
         variant="inverted"
         size="lg"
         class="w-full rounded-lg"

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -206,6 +206,27 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     ).toBeNull()
   })
 
+  it('hides verification once a resumed challenge is processing', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({}),
+        embeddedCheckoutEnabled: true,
+        authenticationState: 'processing',
+        // A stale action_url can still be present while the server catches up
+        // to a challenge this or another tab already resumed; the button must
+        // stay hidden so the customer never reopens a moving intent.
+        actionUrl: 'https://verify.example/sensitive-token'
+      },
+      global: globalOptions
+    })
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'subscription.preview.completeVerification'
+      })
+    ).toBeNull()
+  })
+
   it('renders a scheduled downgrade with the after-that block and no charge', () => {
     render(SubscriptionTransitionPreviewWorkspace, {
       props: {

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -251,7 +251,11 @@
       </div>
 
       <Button
-        v-if="actionUrl && authenticationState !== 'failed_retryable'"
+        v-if="
+          actionUrl &&
+          authenticationState !== 'failed_retryable' &&
+          authenticationState !== 'processing'
+        "
         variant="inverted"
         size="lg"
         class="w-full rounded-lg"

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -2569,6 +2569,40 @@ describe('billingOperationStore', () => {
 
       expect((await terminal).status).toBe('succeeded')
     })
+
+    it('does not close the dialog for a later attempt when a dismissed topup succeeds', async () => {
+      let opAResolved = false
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementation(
+        async (opId: string) => ({
+          id: opId,
+          status:
+            opId === 'op-a' && opAResolved
+              ? ('succeeded' as const)
+              : ('pending' as const),
+          started_at: new Date().toISOString()
+        })
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-a', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+      store.dismissOperation('op-a')
+
+      mockCloseDialog.mockClear()
+      mockSettingsDialogShow.mockClear()
+
+      void store.startOperation('op-b', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+
+      // op-a's next poll now reports succeeded, after op-b has started; it
+      // must not reach for a dialog op-b now owns.
+      opAResolved = true
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(store.getOperation('op-a')?.status).toBe('succeeded')
+      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(mockSettingsDialogShow).not.toHaveBeenCalled()
+    })
   })
 
   describe('multiple operations', () => {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -2603,6 +2603,35 @@ describe('billingOperationStore', () => {
       expect(mockCloseDialog).not.toHaveBeenCalled()
       expect(mockSettingsDialogShow).not.toHaveBeenCalled()
     })
+
+    it('does not close the dialog when dismissed while the post-success refresh is in flight', async () => {
+      let resolveFetchStatus!: () => void
+      mockFetchStatus.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFetchStatus = resolve
+          })
+      )
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+
+      // handleSuccess is now awaiting the post-success refresh; the customer
+      // dismisses before it resolves, so the dismissal must still be honored
+      // even though it captured `operation` before this await.
+      store.dismissOperation('op-1')
+      resolveFetchStatus()
+      await terminal
+
+      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(mockSettingsDialogShow).not.toHaveBeenCalled()
+    })
   })
 
   describe('multiple operations', () => {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -742,8 +742,16 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     // so leave it open. Top-ups have no such step: close and surface settings.
     // A dismissed operation's dialog is already closed and may now belong to a
     // different attempt, so this late success only notifies — it must not
-    // reach for UI that has moved on without it.
-    if (operation.type === 'topup' && !operation.dismissed) {
+    // reach for UI that has moved on without it. Re-read the operation: the
+    // refresh above just awaited, and dismissOperation() replaces the map
+    // entry rather than mutating it, so the local `operation` captured before
+    // that await can still read dismissed: false after a dismissal.
+    const currentOperation = operations.value.get(opId)
+    if (
+      operation.type === 'topup' &&
+      currentOperation &&
+      !currentOperation.dismissed
+    ) {
       useDialogStore().closeDialog({ key: 'top-up-credits' })
       useSettingsDialog().show(isCloud ? 'workspace' : 'credits')
     }

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -740,7 +740,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     // A subscription checkout shows its own success step in the pricing dialog,
     // so leave it open. Top-ups have no such step: close and surface settings.
-    if (operation.type === 'topup') {
+    // A dismissed operation's dialog is already closed and may now belong to a
+    // different attempt, so this late success only notifies — it must not
+    // reach for UI that has moved on without it.
+    if (operation.type === 'topup' && !operation.dismissed) {
       useDialogStore().closeDialog({ key: 'top-up-credits' })
       useSettingsDialog().show(isCloud ? 'workspace' : 'credits')
     }


### PR DESCRIPTION
## Summary

#16123 (FE-1920) merged automatically via the merge queue right after dante01yoon's approval landed — in the narrow window between that and CodeRabbit's final re-review, which found two more real issues in the same code. Both are fixed here since the original branch was deleted on merge.

## Changes

- **`handleSuccess()` guarded against a dismissed operation.** `dismissOperation()` (added in #16123) lets a customer walk away from a `failed_retryable` top-up while it keeps polling in the background, so a late success can still resolve. But `handleSuccess()` unconditionally closed the shared `top-up-credits` dialog and opened settings on a topup success — if the customer had since started a *second* top-up in that same dialog, the first operation's late success would yank them out of the second attempt. Skipped the close/navigate for a dismissed operation; status updates, telemetry, balance refresh, the success toast, and terminal resolution are unaffected. Added a regression test: dismiss operation A, start operation B, resolve A — asserts the dialog/settings calls never fire.
- **The embedded verification CTA also excludes `processing`, not just `failed_retryable`.** A resumed challenge's stale `action_url` can still be echoed by a poll response before the server's own state catches up — the auto-handled-echo guard in the store only suppresses this for a challenge the *current* tab resumed itself, not one resumed elsewhere (another tab/device). Excluded `processing` alongside `failed_retryable` in both `SubscriptionAddPaymentPreviewWorkspace.vue` and `SubscriptionTransitionPreviewWorkspace.vue`, with a test for each.

## Context

Both findings are from CodeRabbit's review at https://github.com/Comfy-Org/ComfyUI_frontend/pull/16123#pullrequestreview-... (the review posted after the merge queue had already picked up the approved head). Verified against the code rather than applied blindly — traced why each is a real, reachable gap before fixing.

Full suite of all 8 touched test files: 370/370 passing. `typecheck`/`lint` clean.