### PR TITLE
test(agent): re-enable panel keyboard lifecycle coverage

### DIFF
--- a/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
+++ b/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
@@ -69,7 +69,7 @@ test.describe(
         .toBe('false')
     })
 
-    test.fixme('supports keyboard activation and returns one complementary landmark', async ({
+    test('supports keyboard activation and returns one complementary landmark', async ({
       page
     }) => {
       await bootAgentApp(page, true)


### PR DESCRIPTION
## Summary

Re-enables the agent panel keyboard lifecycle E2E assertion now that #16912 removed the duplicate `agent-panel-title` id introduced before #16907 merged. This restores the coverage called out in #16907 comment 5534926025.

## Changes

- **What**: Changes the keyboard lifecycle case from `test.fixme` back to `test`, preserving its single-landmark, accessible-name, keyboard open, and keyboard close assertions.

## Review Focus

Confirm the cloud Playwright job executes and passes the restored test against the post-#16912 DOM.

## Evidence

- `pnpm exec oxfmt --check browser_tests/tests/agent/agentPanelLifecycle.spec.ts` — passed
- `pnpm exec oxlint browser_tests/tests/agent/agentPanelLifecycle.spec.ts` — 0 warnings/errors
- Commit hooks: `pnpm typecheck` and `pnpm typecheck:browser` — passed
- Push hook: `pnpm knip --cache` — passed
- [CI `playwright-tests (cloud)`](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33833984771/job/100904003632) — passed in 8m47s at exact head `5e07fb7c756749bd9dc7eaebeb734e2bf1a37771`

Refs #16907
Refs https://github.com/Comfy-Org/ComfyUI_frontend/pull/16907#issuecomment-5534926025
Refs #16912

<!-- authored-by:agent lane-evfail-72-0330 -->