### PR TITLE
fix: restore SaveImage search ranking

### DIFF
--- a/public/assets/sorted-custom-node-map.json
+++ b/public/assets/sorted-custom-node-map.json
@@ -17,6 +17,7 @@
   "PreviewGaussianSplat": 4320,
   "PreviewPointCloud": 4310,
   "SaveImageAdvanced": 4300,
+  "SaveImage": 1762,
   "SaveVideo": 4290,
   "Save3DAdvanced": 4280,
   "SaveText": 4270,

--- a/src/stores/nodeDefStore.frequency.test.ts
+++ b/src/stores/nodeDefStore.frequency.test.ts
@@ -1,0 +1,17 @@
+import axios from 'axios'
+import { describe, expect, it, vi } from 'vitest'
+
+import nodeFrequencies from '../../public/assets/sorted-custom-node-map.json' with { type: 'json' }
+import { useNodeFrequencyStore } from '@/stores/nodeDefStore'
+
+describe('useNodeFrequencyStore', () => {
+  it('loads independent rankings for both Save Image node definitions', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: nodeFrequencies })
+    const store = useNodeFrequencyStore()
+
+    await store.loadNodeFrequencies()
+
+    expect(store.getNodeFrequencyByName('SaveImage')).toBe(1762)
+    expect(store.getNodeFrequencyByName('SaveImageAdvanced')).toBe(4300)
+  })
+})


### PR DESCRIPTION
## Summary

Restore the core `SaveImage` node's independent search ranking, which was accidentally removed by #16851 while `SaveImageAdvanced` remained ranked.

## Changes

- **What**: Restore the previously validated `SaveImage` frequency alongside `SaveImageAdvanced` and cover both exact-name lookups.

## Review Focus

Confirm both distinct node definition names retain independent nonzero rankings, as requested in [the unresolved review thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16851#discussion_r3929016391).

## Evidence

- `pnpm test:unit src/stores/nodeDefStore.frequency.test.ts` — 1/1 passed
- `pnpm exec oxfmt --check public/assets/sorted-custom-node-map.json src/stores/nodeDefStore.frequency.test.ts` — passed
- `pnpm exec eslint src/stores/nodeDefStore.frequency.test.ts` — passed
- Commit hooks: oxfmt, type-aware oxlint, ESLint, typecheck — passed
- Push hook: knip — passed

<!-- authored-by:agent lane-evfail-70-0330 -->
