### PR TITLE
fix(agent): materialize agent-added subgraphs through the subgraph-created lifecycle

### DIFF
--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -1611,6 +1611,19 @@ describe('Subgraph Definition Garbage Collection', () => {
     expect(rootGraph.subgraphs.has(subgraphId)).toBe(false)
   })
 
+  it('releases the subgraph definition when an inner removal lifecycle throws', () => {
+    const rootGraph = new LGraph()
+    const { subgraph, innerNodes } = createSubgraphWithNodes(rootGraph, 1)
+    innerNodes[0].onRemoved = () => {
+      throw new Error('extension cleanup failed')
+    }
+
+    expect(() => rootGraph.releaseSubgraphs([subgraph])).toThrow(
+      'extension cleanup failed'
+    )
+    expect(rootGraph.subgraphs.has(subgraph.id)).toBe(false)
+  })
+
   function createNestedDefinitionFixture() {
     const rootGraph = new LGraph()
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1540,20 +1540,23 @@ export class LGraph
    * the same id can be registered again later.
    */
   releaseSubgraphs(subgraphs: readonly Subgraph[]): void {
-    for (const subgraph of subgraphs) {
-      const nodes: LGraphNode[] = []
-      visitGraphNodes(subgraph, (node) => nodes.push(node))
-      fireNodeRemovalLifecycles(nodes)
+    try {
+      for (const subgraph of subgraphs) {
+        const nodes: LGraphNode[] = []
+        visitGraphNodes(subgraph, (node) => nodes.push(node))
+        fireNodeRemovalLifecycles(nodes)
+      }
+    } finally {
+      for (const subgraph of subgraphs) {
+        unregisterAllLinkTopologies(subgraph)
+        unregisterAllRerouteChains(subgraph)
+        detachAllNodesFromStores(subgraph)
+        useExecutionOrderStore().clearGraph(graphScopeOf(subgraph))
+        useGraphMetadataStore().clear(this.rootGraph.id, subgraph.id)
+        this.rootGraph.subgraphs.delete(subgraph.id)
+      }
+      detachGraphLayouts(subgraphs)
     }
-    for (const subgraph of subgraphs) {
-      unregisterAllLinkTopologies(subgraph)
-      unregisterAllRerouteChains(subgraph)
-      detachAllNodesFromStores(subgraph)
-      useExecutionOrderStore().clearGraph(graphScopeOf(subgraph))
-      useGraphMetadataStore().clear(this.rootGraph.id, subgraph.id)
-      this.rootGraph.subgraphs.delete(subgraph.id)
-    }
-    detachGraphLayouts(subgraphs)
   }
 
   /**

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1475,21 +1475,7 @@ export class LGraph
     }
 
     if (node.isSubgraphNode()) {
-      const releasedSubgraphs = findReleasableSubgraphs(this.rootGraph, node)
-      for (const subgraph of releasedSubgraphs) {
-        const nodes: LGraphNode[] = []
-        visitGraphNodes(subgraph, (node) => nodes.push(node))
-        fireNodeRemovalLifecycles(nodes)
-      }
-      for (const subgraph of releasedSubgraphs) {
-        unregisterAllLinkTopologies(subgraph)
-        unregisterAllRerouteChains(subgraph)
-        detachAllNodesFromStores(subgraph)
-        useExecutionOrderStore().clearGraph(graphScopeOf(subgraph))
-        useGraphMetadataStore().clear(this.rootGraph.id, subgraph.id)
-        this.rootGraph.subgraphs.delete(subgraph.id)
-      }
-      detachGraphLayouts(releasedSubgraphs)
+      this.releaseSubgraphs(findReleasableSubgraphs(this.rootGraph, node))
     }
 
     // callback
@@ -1542,6 +1528,32 @@ export class LGraph
     this.change()
 
     this.updateExecutionOrder()
+  }
+
+  /**
+   * Tears down subgraph definitions that no longer have (or never gained) a
+   * live instance: fires interior node removal lifecycles, unregisters their
+   * store state and metadata, and drops them from {@link subgraphs}.
+   *
+   * Used when the last {@link SubgraphNode} of a definition is removed, and
+   * to roll back a definition whose {@link createSubgraph} failed part-way so
+   * the same id can be registered again later.
+   */
+  releaseSubgraphs(subgraphs: readonly Subgraph[]): void {
+    for (const subgraph of subgraphs) {
+      const nodes: LGraphNode[] = []
+      visitGraphNodes(subgraph, (node) => nodes.push(node))
+      fireNodeRemovalLifecycles(nodes)
+    }
+    for (const subgraph of subgraphs) {
+      unregisterAllLinkTopologies(subgraph)
+      unregisterAllRerouteChains(subgraph)
+      detachAllNodesFromStores(subgraph)
+      useExecutionOrderStore().clearGraph(graphScopeOf(subgraph))
+      useGraphMetadataStore().clear(this.rootGraph.id, subgraph.id)
+      this.rootGraph.subgraphs.delete(subgraph.id)
+    }
+    detachGraphLayouts(subgraphs)
   }
 
   /**

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -87,6 +87,8 @@ class ThrowsOnConfigureNode extends LGraphNode {
   override onConfigure(): void {
     if (configureShouldThrow) throw new Error('interior node rejected')
   }
+
+  override onRemoved(): void {}
 }
 
 class ThrowsOnAddedNode extends LGraphNode {
@@ -1140,6 +1142,36 @@ describe('reconcileAgentAdapters', () => {
       expect(materialized).toEqual([toNodeId(2)])
       expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(DummyNode)
       expect(graph.getNodeById(toNodeId(1))).toBeUndefined()
+    })
+
+    it('still reconciles root nodes when definition rollback lifecycle cleanup throws', () => {
+      configureShouldThrow = true
+      vi.spyOn(ThrowsOnConfigureNode.prototype, 'onRemoved').mockImplementation(
+        () => {
+          throw new Error('extension cleanup failed')
+        }
+      )
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7, 'throws-on-configure')] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id), nodePayload(2)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+
+      expect(() =>
+        reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+      ).not.toThrow()
+      expect(graph.subgraphs.has(definition.id)).toBe(false)
+      expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(DummyNode)
+      expect(reportError).toHaveBeenCalledExactlyOnceWith(
+        expect.any(AggregateError),
+        {
+          errorType: 'agent_subgraph_definitions_failed',
+          context: { graphId: graph.id, definitionId: definition.id }
+        }
+      )
     })
 
     it('retries a failed definition on the next reconcile and reports it once', () => {

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -15,11 +15,13 @@ import {
   LGraph,
   LGraphNode,
   LiteGraph,
-  LLink
+  LLink,
+  SubgraphNode
 } from '@/lib/litegraph/src/litegraph'
 import {
   createTestSubgraphData,
-  createTestSubgraphNode
+  createTestSubgraphNode,
+  enableSubgraphNodeCreation
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { reportError } from '@/platform/telemetry/reportError'
 // Mirrors the production bridge in AgentPanelRoot.vue, which takes the same
@@ -41,6 +43,7 @@ import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 
 import { reconcileAgentAdapters } from './agentNodeMaterializer'
+import { readSubgraphDefinitions } from './agentSubgraphDefinitions'
 import { EcsFollowerAdapter } from './ecsFollowerAdapter'
 import { FollowerDoc } from './followerDoc'
 import type { GraphOperation } from './graphOperations'
@@ -807,6 +810,83 @@ describe('reconcileAgentAdapters', () => {
           old: 7
         })
       ])
+    })
+  })
+
+  describe('subgraph definitions', () => {
+    /**
+     * Deliver a full-document frame minted from `workflow` to a fresh follower
+     * bound to `graph`, the way the first frame of a session (or a reseed
+     * after `doc_reset`) arrives.
+     */
+    function seedDocument(graph: LGraph, workflow: Parameters<typeof mint>[0]) {
+      const host = mint(workflow, CATALOG)
+      const follower = new FollowerDoc()
+      const adapter = new EcsFollowerAdapter(
+        remoteMutations(graphScopeOf(graph))
+      )
+      adapter.bind('workflow', follower)
+      const update = Y.encodeStateAsUpdate(host)
+      follower.applyRemoteUpdate(update)
+      expect(
+        adapter.applyFrame({
+          workflowId: 'workflow',
+          seq: 1,
+          update,
+          actor: 'agent:test',
+          opIds: []
+        })
+      ).toBe(true)
+      return { host, follower, adapter }
+    }
+
+    let disableSubgraphNodeCreation: () => void
+    let graph: LGraph
+    let created: ReturnType<typeof vi.fn<(event: Event) => void>>
+
+    beforeEach(() => {
+      graph = new LGraph()
+      // Unit-test analog of the `subgraph-created` handler in `app.ts` that
+      // registers each new subgraph as a node type.
+      disableSubgraphNodeCreation = enableSubgraphNodeCreation(graph)
+      created = vi.fn<(event: Event) => void>()
+      graph.events.addEventListener('subgraph-created', created)
+    })
+
+    afterEach(() => {
+      disableSubgraphNodeCreation()
+    })
+
+    /**
+     * Regression: an agent-seeded workflow carrying `definitions.subgraphs`
+     * materialized its subgraph instance as a `has_errors` "missing node"
+     * placeholder because the follower only read the root `nodes`/`links`
+     * maps. The definition never reached `LGraph.createSubgraphs`, so
+     * `subgraph-created` never fired and no `SubgraphNode` type was registered.
+     */
+    it('regression: materializes an agent-added subgraph instance as a SubgraphNode via the subgraph-created lifecycle', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7)] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+
+      expect(
+        reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+      ).toEqual([toNodeId(1)])
+
+      expect(graph.subgraphs.has(definition.id)).toBe(true)
+      expect(created).toHaveBeenCalledOnce()
+      const instance = graph.getNodeById(toNodeId(1))
+      expect(instance).toBeInstanceOf(SubgraphNode)
+      expect(instance?.has_errors).toBeFalsy()
+      expect((instance as SubgraphNode).subgraph.nodes).toHaveLength(1)
+      // Interior nodes belong to the subgraph, never to the root scope.
+      expect(graph._nodes).toHaveLength(1)
+      expect(reportError).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -88,7 +88,10 @@ const REMOTE: RemoteMutationContext = {
   opId: 'op-test'
 }
 const CATALOG: WidgetCatalog = {
-  types: { dummy: { widget_order: [] } }
+  types: {
+    dummy: { widget_order: [] },
+    'widget-node': { widget_order: ['value'] }
+  }
 }
 
 function agentOperation(id: string, version: number, payload: object) {
@@ -887,6 +890,81 @@ describe('reconcileAgentAdapters', () => {
       // Interior nodes belong to the subgraph, never to the root scope.
       expect(graph._nodes).toHaveLength(1)
       expect(reportError).not.toHaveBeenCalled()
+    })
+
+    it('registers a definition once across repeated reconciles', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7)] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      const definitions = readSubgraphDefinitions(follower.doc)
+
+      reconcileAgentAdapters(graph, definitions)
+      const subgraph = graph.subgraphs.get(definition.id)
+      const instance = graph.getNodeById(toNodeId(1))
+
+      // Every applied frame reconciles again with the same definitions.
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([])
+
+      expect(created).toHaveBeenCalledOnce()
+      expect(graph.subgraphs.get(definition.id)).toBe(subgraph)
+      expect(graph.getNodeById(toNodeId(1))).toBe(instance)
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
+    it('carries interior widget values into the instantiated subgraph', () => {
+      const definition = createTestSubgraphData({
+        nodes: [
+          { ...nodePayload(7, 'widget-node'), widgets_values: [42] }
+        ] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+
+      const instance = graph.getNodeById(toNodeId(1)) as SubgraphNode
+      const interior = instance.subgraph.getNodeById(toNodeId(7))
+      expect(interior?.widgets?.[0]?.value).toBe(42)
+    })
+
+    it('reports a definition that fails to register and still reconciles root nodes', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7)] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id), nodePayload(2)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      vi.spyOn(graph, 'createSubgraphs').mockImplementation(() => {
+        throw new Error('definition rejected')
+      })
+
+      const materialized = reconcileAgentAdapters(
+        graph,
+        readSubgraphDefinitions(follower.doc)
+      )
+
+      expect(reportError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'definition rejected' }),
+        {
+          errorType: 'agent_subgraph_definitions_failed',
+          context: { graphId: graph.id, definitionIds: [definition.id] }
+        }
+      )
+      // The plain node still materializes; the instance degrades to the
+      // error placeholder instead of taking the whole reconcile down.
+      expect(materialized).toEqual([toNodeId(1), toNodeId(2)])
+      expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(DummyNode)
+      expect(graph.getNodeById(toNodeId(1))?.has_errors).toBe(true)
     })
   })
 })

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -935,6 +935,43 @@ describe('reconcileAgentAdapters', () => {
       expect(interior?.widgets?.[0]?.value).toBe(42)
     })
 
+    it('matches widget values to definitions by id when one definition nests another', () => {
+      // createSubgraphs hoists nested definitions into its return value, so
+      // the created subgraphs outnumber the definitions handed in.
+      const inner = createTestSubgraphData({
+        nodes: [
+          { ...nodePayload(30, 'widget-node'), widgets_values: [1] }
+        ] as never
+      })
+      const outer = createTestSubgraphData({
+        nodes: [
+          { ...nodePayload(20, 'widget-node'), widgets_values: [2] },
+          nodePayload(21, inner.id)
+        ] as never,
+        definitions: { subgraphs: [inner] }
+      })
+      const sibling = createTestSubgraphData({
+        nodes: [
+          { ...nodePayload(10, 'widget-node'), widgets_values: [3] }
+        ] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, outer.id), nodePayload(2, sibling.id)],
+        links: [],
+        definitions: { subgraphs: [outer, sibling] }
+      })
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+
+      const widgetValue = (definitionId: string, nodeId: number) =>
+        graph.subgraphs.get(definitionId)?.getNodeById(toNodeId(nodeId))
+          ?.widgets?.[0]?.value
+      expect(widgetValue(inner.id, 30)).toBe(1)
+      expect(widgetValue(outer.id, 20)).toBe(2)
+      expect(widgetValue(sibling.id, 10)).toBe(3)
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
     it('reports a definition that fails to register and still reconciles root nodes', () => {
       const definition = createTestSubgraphData({
         nodes: [nodePayload(7)] as never

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -67,6 +67,28 @@ class WidgetNode extends LGraphNode {
   }
 }
 
+/** Widget values observed by `onConfigure`, in configure order. */
+const configuredWidgetValues: unknown[] = []
+
+class ConfigureCapturingWidgetNode extends WidgetNode {
+  override onConfigure(): void {
+    configuredWidgetValues.push(this.widgets?.[0]?.value)
+  }
+}
+
+/** Toggled per test; a definition holding this type fails to instantiate. */
+let configureShouldThrow = false
+
+class ThrowsOnConfigureNode extends LGraphNode {
+  constructor() {
+    super('throws-on-configure')
+  }
+
+  override onConfigure(): void {
+    if (configureShouldThrow) throw new Error('interior node rejected')
+  }
+}
+
 class ThrowsOnAddedNode extends LGraphNode {
   constructor() {
     super('throws-on-added')
@@ -90,7 +112,9 @@ const REMOTE: RemoteMutationContext = {
 const CATALOG: WidgetCatalog = {
   types: {
     dummy: { widget_order: [] },
-    'widget-node': { widget_order: ['value'] }
+    'widget-node': { widget_order: ['value'] },
+    'configure-capture': { widget_order: ['value'] },
+    'throws-on-configure': { widget_order: [] }
   }
 }
 
@@ -178,7 +202,11 @@ beforeEach(() => {
   setActivePinia(createTestingPinia({ stubActions: false }))
   LiteGraph.registerNodeType('dummy', DummyNode)
   LiteGraph.registerNodeType('widget-node', WidgetNode)
+  LiteGraph.registerNodeType('configure-capture', ConfigureCapturingWidgetNode)
+  LiteGraph.registerNodeType('throws-on-configure', ThrowsOnConfigureNode)
   LiteGraph.registerNodeType('throws-on-added', ThrowsOnAddedNode)
+  configuredWidgetValues.length = 0
+  configureShouldThrow = false
 })
 
 describe('reconcileAgentAdapters', () => {
@@ -1041,17 +1069,54 @@ describe('reconcileAgentAdapters', () => {
       expect(reportError).not.toHaveBeenCalled()
     })
 
-    it('reports a definition that fails to register and still reconciles root nodes', () => {
+    it('restores interior widget values inside configure(), before onConfigure runs', () => {
       const definition = createTestSubgraphData({
-        nodes: [nodePayload(7)] as never
+        nodes: [
+          { ...nodePayload(7, 'configure-capture'), widgets_values: [42] }
+        ] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      expect(LiteGraph.namedValuesRestore).toBe(false)
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+
+      // A custom node's onConfigure must see the seeded value, the same as it
+      // does on the human load path, not the widget default.
+      expect(configuredWidgetValues).toEqual([42])
+      // The named-restore switch is scoped to registration, not left on.
+      expect(LiteGraph.namedValuesRestore).toBe(false)
+    })
+
+    it('leaves the named-restore switch as it found it when registration throws', () => {
+      configureShouldThrow = true
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7, 'throws-on-configure')] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+
+      expect(reportError).toHaveBeenCalledOnce()
+      expect(LiteGraph.namedValuesRestore).toBe(false)
+    })
+
+    it('reports a definition that fails to register and still reconciles the other root nodes', () => {
+      configureShouldThrow = true
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7, 'throws-on-configure')] as never
       })
       const { follower } = seedDocument(graph, {
         nodes: [nodePayload(1, definition.id), nodePayload(2)],
         links: [],
         definitions: { subgraphs: [definition] }
-      })
-      vi.spyOn(graph, 'createSubgraphs').mockImplementation(() => {
-        throw new Error('definition rejected')
       })
 
       const materialized = reconcileAgentAdapters(
@@ -1059,18 +1124,138 @@ describe('reconcileAgentAdapters', () => {
         readSubgraphDefinitions(follower.doc)
       )
 
-      expect(reportError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'definition rejected' }),
+      expect(reportError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ message: 'interior node rejected' }),
         {
           errorType: 'agent_subgraph_definitions_failed',
-          context: { graphId: graph.id, definitionIds: [definition.id] }
+          context: { graphId: graph.id, definitionId: definition.id }
         }
       )
-      // The plain node still materializes; the instance degrades to the
-      // error placeholder instead of taking the whole reconcile down.
-      expect(materialized).toEqual([toNodeId(1), toNodeId(2)])
+      // createSubgraphs registers a definition before configuring it. A
+      // failed one is rolled back so the map only holds definitions that
+      // finished the lifecycle.
+      expect(graph.subgraphs.has(definition.id)).toBe(false)
+      // The plain node still materializes. The instance waits for its
+      // definition instead of binding to the half-configured attempt.
+      expect(materialized).toEqual([toNodeId(2)])
       expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(DummyNode)
-      expect(graph.getNodeById(toNodeId(1))?.has_errors).toBe(true)
+      expect(graph.getNodeById(toNodeId(1))).toBeUndefined()
+    })
+
+    it('retries a failed definition on the next reconcile and reports it once', () => {
+      configureShouldThrow = true
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7, 'throws-on-configure')] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      const definitions = readSubgraphDefinitions(follower.doc)
+
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([])
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([])
+      // Same definition, same failure: one report, not one per frame.
+      expect(reportError).toHaveBeenCalledOnce()
+
+      configureShouldThrow = false
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([toNodeId(1)])
+
+      expect(graph.subgraphs.has(definition.id)).toBe(true)
+      const instance = graph.getNodeById(toNodeId(1))
+      expect(instance).toBeInstanceOf(SubgraphNode)
+      expect(instance?.has_errors).toBeFalsy()
+      expect((instance as SubgraphNode).subgraph).toBe(
+        graph.subgraphs.get(definition.id)
+      )
+    })
+
+    it('registers a valid sibling when another definition in the same frame fails', () => {
+      configureShouldThrow = true
+      const bad = createTestSubgraphData({
+        nodes: [nodePayload(7, 'throws-on-configure')] as never
+      })
+      const good = createTestSubgraphData({
+        nodes: [nodePayload(8)] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, bad.id), nodePayload(2, good.id)],
+        links: [],
+        definitions: { subgraphs: [bad, good] }
+      })
+
+      const materialized = reconcileAgentAdapters(
+        graph,
+        readSubgraphDefinitions(follower.doc)
+      )
+
+      expect(materialized).toEqual([toNodeId(2)])
+      expect(graph.subgraphs.has(bad.id)).toBe(false)
+      expect(graph.subgraphs.has(good.id)).toBe(true)
+      expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(SubgraphNode)
+      expect(reportError).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+        errorType: 'agent_subgraph_definitions_failed',
+        context: { graphId: graph.id, definitionId: bad.id }
+      })
+    })
+
+    it('keeps a live nested definition and registers a missing one under an existing outer', () => {
+      const inner = createTestSubgraphData({
+        nodes: [nodePayload(30)] as never
+      })
+      const outer = createTestSubgraphData({
+        nodes: [nodePayload(21, inner.id)] as never,
+        definitions: { subgraphs: [inner] }
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, outer.id)],
+        links: [],
+        definitions: { subgraphs: [outer] }
+      })
+      const definitions = readSubgraphDefinitions(follower.doc)
+
+      // The user (or an earlier frame) already has the inner definition live.
+      const liveInner = graph.createSubgraph(inner)
+      reconcileAgentAdapters(graph, definitions)
+      expect(graph.subgraphs.get(inner.id)).toBe(liveInner)
+      expect(graph.subgraphs.has(outer.id)).toBe(true)
+
+      // And the mirror: the outer is live but its nested definition is not.
+      const graph2 = new LGraph()
+      const disable2 = enableSubgraphNodeCreation(graph2)
+      try {
+        graph2.createSubgraph({ ...outer, definitions: undefined })
+        expect(graph2.subgraphs.has(inner.id)).toBe(false)
+        reconcileAgentAdapters(graph2, definitions)
+        expect(graph2.subgraphs.has(inner.id)).toBe(true)
+      } finally {
+        disable2()
+      }
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
+    it('reports and skips a definition whose id is not a UUID instead of remapping it', () => {
+      const definition = {
+        ...createTestSubgraphData({ nodes: [nodePayload(7)] as never }),
+        id: 'legacy-subgraph'
+      }
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+
+      // createSubgraphs would silently mint a UUID for it, leaving the root
+      // node's `type` pointing at an id the doc never registered.
+      expect(graph.subgraphs.size).toBe(0)
+      expect(created).not.toHaveBeenCalled()
+      expect(reportError).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+        errorType: 'agent_subgraph_definitions_failed',
+        context: { graphId: graph.id, definitionId: 'legacy-subgraph' }
+      })
     })
   })
 })

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -972,6 +972,75 @@ describe('reconcileAgentAdapters', () => {
       expect(reportError).not.toHaveBeenCalled()
     })
 
+    it('keeps a registered definition when a later frame nests a copy of it', () => {
+      const inner = createTestSubgraphData({
+        nodes: [nodePayload(30, 'widget-node')] as never
+      })
+      const outer = createTestSubgraphData({
+        nodes: [nodePayload(21, inner.id)] as never,
+        definitions: { subgraphs: [inner] }
+      })
+      const first = seedDocument(graph, {
+        nodes: [nodePayload(1, inner.id)],
+        links: [],
+        definitions: { subgraphs: [inner] }
+      })
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(first.follower.doc))
+      const registered = graph.subgraphs.get(inner.id)
+      const instance = graph.getNodeById(toNodeId(1)) as SubgraphNode
+      expect(instance.subgraph).toBe(registered)
+
+      const second = seedDocument(graph, {
+        nodes: [nodePayload(1, inner.id), nodePayload(2, outer.id)],
+        links: [],
+        definitions: { subgraphs: [inner, outer] }
+      })
+      reconcileAgentAdapters(
+        graph,
+        readSubgraphDefinitions(second.follower.doc)
+      )
+
+      expect(graph.subgraphs.get(inner.id)).toBe(registered)
+      expect(graph.subgraphs.has(outer.id)).toBe(true)
+      expect(created).toHaveBeenCalledTimes(2)
+      expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(SubgraphNode)
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
+    it('registers the missing child of an already registered parent', () => {
+      const inner = createTestSubgraphData({
+        nodes: [nodePayload(30, 'widget-node')] as never
+      })
+      const outer = createTestSubgraphData({
+        nodes: [nodePayload(21, 'widget-node')] as never
+      })
+      const first = seedDocument(graph, {
+        nodes: [nodePayload(1, outer.id)],
+        links: [],
+        definitions: { subgraphs: [outer] }
+      })
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(first.follower.doc))
+      const registered = graph.subgraphs.get(outer.id)
+
+      const second = seedDocument(graph, {
+        nodes: [nodePayload(1, outer.id), nodePayload(2, inner.id)],
+        links: [],
+        definitions: {
+          subgraphs: [{ ...outer, definitions: { subgraphs: [inner] } }]
+        }
+      })
+      reconcileAgentAdapters(
+        graph,
+        readSubgraphDefinitions(second.follower.doc)
+      )
+
+      expect(graph.subgraphs.get(outer.id)).toBe(registered)
+      expect(graph.subgraphs.has(inner.id)).toBe(true)
+      expect(created).toHaveBeenCalledTimes(2)
+      expect(graph.getNodeById(toNodeId(2))).toBeInstanceOf(SubgraphNode)
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
     it('reports a definition that fails to register and still reconciles root nodes', () => {
       const definition = createTestSubgraphData({
         nodes: [nodePayload(7)] as never

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -946,6 +946,33 @@ describe('reconcileAgentAdapters', () => {
       expect(reportError).not.toHaveBeenCalled()
     })
 
+    it('does not treat a definition payload as an edit to an existing subgraph', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7)] as never
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+      const registered = graph.subgraphs.get(definition.id)
+
+      reconcileAgentAdapters(graph, [
+        {
+          ...definition,
+          name: 'replacement must not apply',
+          nodes: [nodePayload(8)] as never
+        }
+      ])
+
+      expect(graph.subgraphs.get(definition.id)).toBe(registered)
+      expect(registered?.nodes.map((node) => node.id)).toEqual([toNodeId(7)])
+      expect(created).toHaveBeenCalledOnce()
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
     it('carries interior widget values into the instantiated subgraph', () => {
       const definition = createTestSubgraphData({
         nodes: [

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -72,9 +72,7 @@ function registerSubgraphDefinitions(
   definitions: ExportedSubgraph[]
 ): void {
   const rootGraph = graph.rootGraph
-  const missing = definitions.filter(
-    (definition) => !rootGraph.subgraphs.has(definition.id)
-  )
+  const missing = pruneRegistered(definitions, rootGraph)
   if (missing.length === 0) return
   try {
     // createSubgraphs hoists nested `definitions.subgraphs` into its return
@@ -99,6 +97,33 @@ function registerSubgraphDefinitions(
       }
     })
   }
+}
+
+/**
+ * Definitions the root graph does not have yet, at every nesting level.
+ *
+ * `LGraph.createSubgraphs()` hoists nested definitions and registers each one
+ * unconditionally, replacing a live definition of the same id and firing
+ * `subgraph-created` again for it. So a registered definition must be pruned
+ * wherever it appears, and the missing children of a registered parent are
+ * hoisted to the top level so they still register.
+ */
+function pruneRegistered(
+  definitions: ExportedSubgraph[],
+  rootGraph: MaterializableGraph['rootGraph']
+): ExportedSubgraph[] {
+  return definitions.flatMap((definition) => {
+    const nested = definition.definitions?.subgraphs ?? []
+    const missingNested = pruneRegistered(nested, rootGraph)
+    if (rootGraph.subgraphs.has(definition.id)) return missingNested
+    if (missingNested.length === nested.length) return [definition]
+    return [
+      {
+        ...definition,
+        definitions: { ...definition.definitions, subgraphs: missingNested }
+      }
+    ]
+  })
 }
 
 /** Each definition plus every definition nested under its `definitions`. */

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -146,7 +146,16 @@ function tryCreateSubgraph(
     // constructor remints the id on the next attempt when it finds that
     // metadata, so the retry would never land under the document's id.
     const halfBuilt = rootGraph.subgraphs.get(definition.id)
-    if (halfBuilt) rootGraph.releaseSubgraphs([halfBuilt])
+    if (halfBuilt) {
+      try {
+        rootGraph.releaseSubgraphs([halfBuilt])
+      } catch (rollbackCause) {
+        return new AggregateError(
+          [cause, rollbackCause],
+          `Agent subgraph definition ${definition.id} failed to register and roll back`
+        )
+      }
+    }
     return cause
   }
 }

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -1,4 +1,4 @@
-import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraph, Subgraph } from '@/lib/litegraph/src/LGraph'
 import { materializeLinkAdapter } from '@/lib/litegraph/src/LLink'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
@@ -77,7 +77,10 @@ function registerSubgraphDefinitions(
   )
   if (missing.length === 0) return
   try {
-    rootGraph.createSubgraphs(missing)
+    const created = rootGraph.createSubgraphs(missing)
+    for (const [index, subgraph] of created.entries()) {
+      applyInteriorWidgetValues(subgraph, missing[index])
+    }
   } catch (cause) {
     reportError(cause, {
       errorType: 'agent_subgraph_definitions_failed',
@@ -86,6 +89,33 @@ function registerSubgraphDefinitions(
         definitionIds: missing.map((definition) => definition.id)
       }
     })
+  }
+}
+
+/**
+ * Restore interior widget values the op layer stores by name.
+ *
+ * `LGraphNode.configure()` only honours `widgets_values_named` behind the
+ * experimental `Comfy.Workflow.NamedValuesRestore` setting (or a class-level
+ * fallback order), and the follower has no widget catalog to project the
+ * names positionally the way the package's `project()` does. Assign them the
+ * same way `configure()` would have, before any instance is materialized.
+ *
+ * Nodes are matched by position, not id: `LGraph.configure()` creates one
+ * live node per serialised entry in order and may remint an id that collides
+ * with a node the root graph already owns.
+ */
+function applyInteriorWidgetValues(
+  subgraph: Subgraph,
+  definition: ExportedSubgraph
+): void {
+  for (const [index, serialised] of (definition.nodes ?? []).entries()) {
+    const named = serialised.widgets_values_named
+    const widgets = subgraph.nodes[index]?.widgets
+    if (!named || !widgets) continue
+    for (const widget of widgets) {
+      if (Object.hasOwn(named, widget.name)) widget.value = named[widget.name]
+    }
   }
 }
 

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -46,9 +46,47 @@ export type MaterializableGraph = Pick<
  */
 export function reconcileAgentAdapters(
   graph: MaterializableGraph,
-  _subgraphDefinitions: ExportedSubgraph[] = []
+  subgraphDefinitions: ExportedSubgraph[] = []
 ): NodeId[] {
-  return runMintPortsSuppressed(() => reconcile(graph))
+  return runMintPortsSuppressed(() => {
+    registerSubgraphDefinitions(graph, subgraphDefinitions)
+    return reconcile(graph)
+  })
+}
+
+/**
+ * Register agent-seeded subgraph definitions the root graph does not know yet.
+ *
+ * This is the same entry point the human load path uses
+ * (`useSubgraphService().loadSubgraphs` → `rootGraph.createSubgraphs`), so each
+ * definition dispatches `subgraph-created` and the app handler registers the
+ * definition id as a `SubgraphNode` type before any root node of that type is
+ * materialized. Without it `LiteGraph.createNode(definitionId)` returns null
+ * and the instance degrades to an error placeholder.
+ *
+ * Definitions already present on the root graph are left untouched: v1 treats
+ * agent-seeded definitions as static after creation.
+ */
+function registerSubgraphDefinitions(
+  graph: MaterializableGraph,
+  definitions: ExportedSubgraph[]
+): void {
+  const rootGraph = graph.rootGraph
+  const missing = definitions.filter(
+    (definition) => !rootGraph.subgraphs.has(definition.id)
+  )
+  if (missing.length === 0) return
+  try {
+    rootGraph.createSubgraphs(missing)
+  } catch (cause) {
+    reportError(cause, {
+      errorType: 'agent_subgraph_definitions_failed',
+      context: {
+        graphId: graph.id,
+        definitionIds: missing.map((definition) => definition.id)
+      }
+    })
+  }
 }
 
 function reconcile(graph: MaterializableGraph): NodeId[] {

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -1,11 +1,13 @@
-import type { LGraph, Subgraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import { materializeLinkAdapter } from '@/lib/litegraph/src/LLink'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { topologicalSortSubgraphs } from '@/lib/litegraph/src/subgraph/subgraphDeduplication'
 import type {
   ExportedSubgraph,
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
 import { reportError } from '@/platform/telemetry/reportError'
+import { isUuidShapedSubgraphId } from '@/schemas/subgraphIdSchema'
 import { useLinkStore } from '@/stores/linkStore'
 import { useNodeDataStore } from '@/stores/nodeDataStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -49,121 +51,150 @@ export function reconcileAgentAdapters(
   subgraphDefinitions: ExportedSubgraph[] = []
 ): NodeId[] {
   return runMintPortsSuppressed(() => {
-    registerSubgraphDefinitions(graph, subgraphDefinitions)
-    return reconcile(graph)
+    const pending = registerSubgraphDefinitions(graph, subgraphDefinitions)
+    return reconcile(graph, pending)
   })
 }
+
+/**
+ * Definition ids already reported as failing to register, per root graph, so
+ * a definition that keeps failing across reconcile frames is reported once.
+ */
+const reportedDefinitionFailures = new WeakMap<LGraph, Set<string>>()
 
 /**
  * Register agent-seeded subgraph definitions the root graph does not know yet.
  *
  * This is the same entry point the human load path uses
- * (`useSubgraphService().loadSubgraphs` → `rootGraph.createSubgraphs`), so each
- * definition dispatches `subgraph-created` and the app handler registers the
- * definition id as a `SubgraphNode` type before any root node of that type is
- * materialized. Without it `LiteGraph.createNode(definitionId)` returns null
- * and the instance degrades to an error placeholder.
+ * (`useSubgraphService().loadSubgraphs` → `rootGraph.createSubgraph(s)`), so
+ * each definition dispatches `subgraph-created` and the app handler registers
+ * the definition id as a `SubgraphNode` type before any root node of that type
+ * is materialized. Without it `LiteGraph.createNode(definitionId)` returns
+ * null and the instance degrades to an error placeholder.
  *
- * Definitions already present on the root graph are left untouched: v1 treats
- * agent-seeded definitions as static after creation.
+ * Definitions are registered one at a time, leaves before the definitions
+ * that nest them, so a definition that throws while configuring is rolled off
+ * the root graph (and retried on the next frame) without taking a healthy
+ * sibling down with it. Definitions already present on the root graph are left
+ * untouched: v1 treats agent-seeded definitions as static after creation.
+ *
+ * @returns ids of definitions from the document that are still not registered
+ * on the root graph.
  */
 function registerSubgraphDefinitions(
   graph: MaterializableGraph,
   definitions: ExportedSubgraph[]
-): void {
+): Set<string> {
   const rootGraph = graph.rootGraph
-  const missing = pruneRegistered(definitions, rootGraph)
-  if (missing.length === 0) return
-  try {
-    // createSubgraphs hoists nested `definitions.subgraphs` into its return
-    // value, so match created subgraphs back to definitions by id rather
-    // than by position.
-    const byId = new Map(
-      flattenDefinitions(missing).map((definition) => [
-        definition.id,
-        definition
-      ])
-    )
-    for (const subgraph of rootGraph.createSubgraphs(missing)) {
-      const definition = byId.get(subgraph.id)
-      if (definition) applyInteriorWidgetValues(subgraph, definition)
+  // Filter after flattening: a live nested definition must not be recreated
+  // just because its outer is missing, and a missing nested definition must
+  // still register when its outer is already live.
+  const missing = flattenDefinitions(definitions).filter(
+    (definition) => !rootGraph.subgraphs.has(definition.id)
+  )
+  const pending = new Set(missing.map((definition) => definition.id))
+  if (missing.length === 0) return pending
+
+  const reported =
+    reportedDefinitionFailures.get(rootGraph) ??
+    reportedDefinitionFailures.set(rootGraph, new Set()).get(rootGraph)!
+
+  for (const definition of topologicalSortSubgraphs(missing)) {
+    const failure = tryCreateSubgraph(rootGraph, definition)
+    if (failure === undefined) {
+      pending.delete(definition.id)
+      reported.delete(definition.id)
+      continue
     }
-  } catch (cause) {
-    reportError(cause, {
+    if (reported.has(definition.id)) continue
+    reported.add(definition.id)
+    reportError(failure, {
       errorType: 'agent_subgraph_definitions_failed',
-      context: {
-        graphId: graph.id,
-        definitionIds: missing.map((definition) => definition.id)
-      }
+      context: { graphId: graph.id, definitionId: definition.id }
     })
+  }
+  return pending
+}
+
+/**
+ * Register one definition on the root graph.
+ *
+ * @returns the failure when the definition could not be registered, after
+ * rolling any half-built entry back off the root graph so the next frame can
+ * retry it; `undefined` on success.
+ */
+function tryCreateSubgraph(
+  rootGraph: LGraph,
+  definition: ExportedSubgraph
+): unknown {
+  // createSubgraphs remints a non-UUID id, which would leave every node typed
+  // by the document's id pointing at a definition that never registers. The
+  // op layer only mints UUIDs; treat anything else as a broken document
+  // rather than silently diverging from it.
+  if (!isUuidShapedSubgraphId(definition.id)) {
+    return new Error(
+      `Agent subgraph definition id is not a UUID: ${definition.id}`
+    )
+  }
+  try {
+    withNamedValuesRestore(() => rootGraph.createSubgraph(definition))
+    return undefined
+  } catch (cause) {
+    // createSubgraph registers the definition before configuring it. Tear the
+    // half-built entry down through the same path node removal uses: a bare
+    // map delete would leave its graph metadata behind, and the Subgraph
+    // constructor remints the id on the next attempt when it finds that
+    // metadata, so the retry would never land under the document's id.
+    const halfBuilt = rootGraph.subgraphs.get(definition.id)
+    if (halfBuilt) rootGraph.releaseSubgraphs([halfBuilt])
+    return cause
   }
 }
 
 /**
- * Definitions the root graph does not have yet, at every nesting level.
- *
- * `LGraph.createSubgraphs()` hoists nested definitions and registers each one
- * unconditionally, replacing a live definition of the same id and firing
- * `subgraph-created` again for it. So a registered definition must be pruned
- * wherever it appears, and the missing children of a registered parent are
- * hoisted to the top level so they still register.
+ * Each definition plus every definition nested under its `definitions`, with
+ * the nesting stripped so each one registers on its own.
  */
-function pruneRegistered(
-  definitions: ExportedSubgraph[],
-  rootGraph: MaterializableGraph['rootGraph']
-): ExportedSubgraph[] {
-  return definitions.flatMap((definition) => {
-    const nested = definition.definitions?.subgraphs ?? []
-    const missingNested = pruneRegistered(nested, rootGraph)
-    if (rootGraph.subgraphs.has(definition.id)) return missingNested
-    if (missingNested.length === nested.length) return [definition]
-    return [
-      {
-        ...definition,
-        definitions: { ...definition.definitions, subgraphs: missingNested }
-      }
-    ]
-  })
-}
-
-/** Each definition plus every definition nested under its `definitions`. */
 function flattenDefinitions(
   definitions: ExportedSubgraph[]
 ): ExportedSubgraph[] {
   return definitions.flatMap((definition) => [
-    definition,
+    { ...definition, definitions: undefined },
     ...flattenDefinitions(definition.definitions?.subgraphs ?? [])
   ])
 }
 
 /**
- * Restore interior widget values the op layer stores by name.
+ * Run `fn` with `LGraphNode.configure()` honouring `widgets_values_named`.
  *
- * `LGraphNode.configure()` only honours `widgets_values_named` behind the
- * experimental `Comfy.Workflow.NamedValuesRestore` setting (or a class-level
- * fallback order), and the follower has no widget catalog to project the
- * names positionally the way the package's `project()` does. Assign them the
- * same way `configure()` would have, before any instance is materialized.
- *
- * Nodes are matched by position, not id: `LGraph.configure()` creates one
- * live node per serialised entry in order and may remint an id that collides
- * with a node the root graph already owns.
+ * The op layer stores interior widget values by name and the follower has no
+ * widget catalog to project them positionally the way the package's
+ * `project()` does. Named restore is otherwise gated behind the experimental
+ * `Comfy.Workflow.NamedValuesRestore` setting; enabling it only while the
+ * agent's definitions configure lets values land inside `configure()`, before
+ * `onConfigure`, exactly as they do for a human-loaded workflow.
  */
-function applyInteriorWidgetValues(
-  subgraph: Subgraph,
-  definition: ExportedSubgraph
-): void {
-  for (const [index, serialised] of (definition.nodes ?? []).entries()) {
-    const named = serialised.widgets_values_named
-    const widgets = subgraph.nodes[index]?.widgets
-    if (!named || !widgets) continue
-    for (const widget of widgets) {
-      if (Object.hasOwn(named, widget.name)) widget.value = named[widget.name]
-    }
+function withNamedValuesRestore<T>(fn: () => T): T {
+  const previous = LiteGraph.namedValuesRestore
+  LiteGraph.namedValuesRestore = true
+  try {
+    return fn()
+  } finally {
+    LiteGraph.namedValuesRestore = previous
   }
 }
 
-function reconcile(graph: MaterializableGraph): NodeId[] {
+/**
+ * @param pendingDefinitions definition ids the document seeds but the root
+ * graph could not register. Nodes typed by one stay unmaterialized rather
+ * than degrading to a placeholder: a `subgraph-created` handler may already
+ * have bound the type to the rolled-back `Subgraph`, and the record is picked
+ * up as soon as the definition registers.
+ */
+function reconcile(
+  graph: MaterializableGraph,
+  pendingDefinitions: Set<string>
+): NodeId[] {
   const scope = graphScopeOf(graph)
   // Remote connect registers canonical topology without importing LiteGraph.
   // Install its facade before node.configure() can query links; otherwise the
@@ -188,6 +219,7 @@ function reconcile(graph: MaterializableGraph): NodeId[] {
     if (live && nodeStore.ownsNode(scope, live._state)) continue
     const serialised = state.lastSerialization
     if (!serialised) continue
+    if (pendingDefinitions.has(state.type)) continue
     if (
       materialize(graph, scope, state, serialised, orphansById.get(state.id))
     ) {

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -77,9 +77,18 @@ function registerSubgraphDefinitions(
   )
   if (missing.length === 0) return
   try {
-    const created = rootGraph.createSubgraphs(missing)
-    for (const [index, subgraph] of created.entries()) {
-      applyInteriorWidgetValues(subgraph, missing[index])
+    // createSubgraphs hoists nested `definitions.subgraphs` into its return
+    // value, so match created subgraphs back to definitions by id rather
+    // than by position.
+    const byId = new Map(
+      flattenDefinitions(missing).map((definition) => [
+        definition.id,
+        definition
+      ])
+    )
+    for (const subgraph of rootGraph.createSubgraphs(missing)) {
+      const definition = byId.get(subgraph.id)
+      if (definition) applyInteriorWidgetValues(subgraph, definition)
     }
   } catch (cause) {
     reportError(cause, {
@@ -90,6 +99,16 @@ function registerSubgraphDefinitions(
       }
     })
   }
+}
+
+/** Each definition plus every definition nested under its `definitions`. */
+function flattenDefinitions(
+  definitions: ExportedSubgraph[]
+): ExportedSubgraph[] {
+  return definitions.flatMap((definition) => [
+    definition,
+    ...flattenDefinitions(definition.definitions?.subgraphs ?? [])
+  ])
 }
 
 /**

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -1,7 +1,10 @@
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import { materializeLinkAdapter } from '@/lib/litegraph/src/LLink'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type {
+  ExportedSubgraph,
+  ISerialisedNode
+} from '@/lib/litegraph/src/types/serialisation'
 import { reportError } from '@/platform/telemetry/reportError'
 import { useLinkStore } from '@/stores/linkStore'
 import { useNodeDataStore } from '@/stores/nodeDataStore'
@@ -36,9 +39,15 @@ export type MaterializableGraph = Pick<
  * which matches the op layer: remote operations are applied against the root
  * scope, so subgraph-owned nodes are neither adopted nor detached here.
  *
+ * @param subgraphDefinitions `definitions.subgraphs` the agent seeded into the
+ * document. Root nodes typed by a definition id can only materialize once the
+ * definition is registered on the root graph.
  * @returns ids that received a new live node.
  */
-export function reconcileAgentAdapters(graph: MaterializableGraph): NodeId[] {
+export function reconcileAgentAdapters(
+  graph: MaterializableGraph,
+  _subgraphDefinitions: ExportedSubgraph[] = []
+): NodeId[] {
   return runMintPortsSuppressed(() => reconcile(graph))
 }
 

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -41,7 +41,7 @@ export type MaterializableGraph = Pick<
  * which matches the op layer: remote operations are applied against the root
  * scope, so subgraph-owned nodes are neither adopted nor detached here.
  *
- * @param subgraphDefinitions `definitions.subgraphs` the agent seeded into the
+ * @param subgraphDefinitions explicitly created definitions present in the
  * document. Root nodes typed by a definition id can only materialize once the
  * definition is registered on the root graph.
  * @returns ids that received a new live node.
@@ -63,7 +63,8 @@ export function reconcileAgentAdapters(
 const reportedDefinitionFailures = new WeakMap<LGraph, Set<string>>()
 
 /**
- * Register agent-seeded subgraph definitions the root graph does not know yet.
+ * Register explicitly created subgraph definitions the root graph does not
+ * know yet.
  *
  * This is the same entry point the human load path uses
  * (`useSubgraphService().loadSubgraphs` → `rootGraph.createSubgraph(s)`), so
@@ -76,7 +77,8 @@ const reportedDefinitionFailures = new WeakMap<LGraph, Set<string>>()
  * that nest them, so a definition that throws while configuring is rolled off
  * the root graph (and retried on the next frame) without taking a healthy
  * sibling down with it. Definitions already present on the root graph are left
- * untouched: v1 treats agent-seeded definitions as static after creation.
+ * untouched: edits address interior nodes through normal node operations, not
+ * by replacing an existing definition.
  *
  * @returns ids of definitions from the document that are still not registered
  * on the root graph.

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -1,0 +1,152 @@
+import { mint } from '@comfyorg/comfy-multi-player'
+import type { WidgetCatalog } from '@comfyorg/comfy-multi-player'
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+
+import { createTestSubgraphData } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
+
+import { readSubgraphDefinitions } from './agentSubgraphDefinitions'
+
+const CATALOG: WidgetCatalog = {
+  types: {
+    dummy: { widget_order: [] },
+    'widget-node': { widget_order: ['seed', 'steps'] }
+  }
+}
+
+function interiorNode(id: number, type = 'dummy', extra: object = {}) {
+  return {
+    id,
+    type,
+    pos: [0, 0],
+    size: [100, 80],
+    inputs: [],
+    outputs: [],
+    ...extra
+  }
+}
+
+function interiorLink(id: number, origin: number, target: number) {
+  return {
+    id,
+    origin_id: origin,
+    origin_slot: 0,
+    target_id: target,
+    target_slot: 0,
+    type: 'IMAGE'
+  }
+}
+
+function seed(...definitions: ExportedSubgraph[]): Y.Doc {
+  return mint(
+    {
+      nodes: [],
+      links: [],
+      definitions: { subgraphs: definitions }
+    },
+    CATALOG
+  )
+}
+
+describe('readSubgraphDefinitions', () => {
+  it('returns nothing for a document without definitions', () => {
+    expect(readSubgraphDefinitions(new Y.Doc())).toEqual([])
+    expect(readSubgraphDefinitions(seed())).toEqual([])
+  })
+
+  it('projects a definition back to the shape it was minted from', () => {
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(3), interiorNode(1)] as never,
+      links: [interiorLink(9, 3, 1), interiorLink(4, 1, 3)] as never
+    })
+
+    const [projected] = readSubgraphDefinitions(seed(definition))
+
+    expect(projected).toEqual(definition)
+  })
+
+  it('keeps interior nodes and links in mint order, not key order', () => {
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(10), interiorNode(2), interiorNode(7)] as never,
+      links: [
+        interiorLink(30, 10, 2),
+        interiorLink(5, 2, 7),
+        interiorLink(12, 7, 10)
+      ] as never
+    })
+
+    const [projected] = readSubgraphDefinitions(seed(definition))
+
+    expect(projected.nodes?.map((node) => node.id)).toEqual([10, 2, 7])
+    expect(projected.links?.map((link) => link.id)).toEqual([30, 5, 12])
+  })
+
+  it('emits catalogued widget values by name and opaque ones positionally', () => {
+    const definition = createTestSubgraphData({
+      nodes: [
+        interiorNode(1, 'widget-node', { widgets_values: [42, 20] }),
+        interiorNode(2, 'unknown-node', { widgets_values: ['a', 'b'] })
+      ] as never
+    })
+
+    const [projected] = readSubgraphDefinitions(seed(definition))
+
+    expect(projected.nodes?.[0]).toMatchObject({
+      widgets_values_named: { seed: 42, steps: 20 }
+    })
+    expect(projected.nodes?.[0]).not.toHaveProperty('widgets_values')
+    expect(projected.nodes?.[1]).toMatchObject({ widgets_values: ['a', 'b'] })
+    expect(projected.nodes?.[1]).not.toHaveProperty('widgets_values_named')
+  })
+
+  it('drops the op layer incarnation stamp from interior nodes', () => {
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(1)] as never
+    })
+    const doc = seed(definition)
+    const stored = doc
+      .getMap<Y.Map<unknown>>('definitions')
+      .get(definition.id)
+      ?.get('nodes') as Y.Map<Y.Map<unknown>>
+    expect(stored.get('1')?.has('__incarnation')).toBe(true)
+
+    const [projected] = readSubgraphDefinitions(doc)
+
+    expect(projected.nodes?.[0]).not.toHaveProperty('__incarnation')
+  })
+
+  it('passes nested definitions through untouched', () => {
+    const inner = createTestSubgraphData({ nodes: [interiorNode(1)] as never })
+    const outer = createTestSubgraphData({
+      nodes: [interiorNode(2, inner.id)] as never,
+      definitions: { subgraphs: [inner] }
+    })
+
+    const [projected] = readSubgraphDefinitions(seed(outer))
+
+    expect(projected.definitions).toEqual({ subgraphs: [inner] })
+  })
+
+  it('skips definition and node entries that are not records', () => {
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(1)] as never
+    })
+    const doc = seed(definition)
+    doc.transact(() => {
+      const definitions = doc.getMap<unknown>('definitions')
+      definitions.set('not-a-definition', 'nope')
+      const stored = definitions.get(definition.id) as Y.Map<unknown>
+      ;(stored.get('nodes') as Y.Map<unknown>).set('99', 'nope')
+      stored.set('node_order', [
+        ...(stored.get('node_order') as string[]),
+        '99'
+      ])
+    })
+
+    const projected = readSubgraphDefinitions(doc)
+
+    expect(projected).toHaveLength(1)
+    expect(projected[0]?.nodes?.map((node) => node.id)).toEqual([1])
+  })
+})

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -149,4 +149,38 @@ describe('readSubgraphDefinitions', () => {
     expect(projected).toHaveLength(1)
     expect(projected[0]?.nodes?.map((node) => node.id)).toEqual([1])
   })
+
+  it('reads a node named twice in the order register once', () => {
+    // mintDefinition pushes one register entry per input node, so two interior
+    // nodes sharing an id leave a two-entry register over a one-key map.
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(1), interiorNode(1), interiorNode(2)] as never,
+      links: [interiorLink(5, 1, 2), interiorLink(5, 1, 2)] as never
+    })
+
+    const [projected] = readSubgraphDefinitions(seed(definition))
+
+    expect(projected.nodes?.map((node) => node.id)).toEqual([1, 2])
+    expect(projected.links?.map((link) => link.id)).toEqual([5])
+  })
+
+  it('skips a node whose widgets entry is not a map, as the package does', () => {
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(1), interiorNode(2)] as never
+    })
+    const doc = seed(definition)
+    doc.transact(() => {
+      const stored = doc
+        .getMap<unknown>('definitions')
+        .get(definition.id) as Y.Map<unknown>
+      const first = (stored.get('nodes') as Y.Map<unknown>).get(
+        '1'
+      ) as Y.Map<unknown>
+      first.set('widgets', 'nope')
+    })
+
+    const [projected] = readSubgraphDefinitions(doc)
+
+    expect(projected.nodes?.map((node) => node.id)).toEqual([2])
+  })
 })

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -193,4 +193,36 @@ describe('readSubgraphDefinitions', () => {
 
     expect(projected.nodes?.map((node) => node.id)).toEqual([2])
   })
+
+  it('reads shared types the package never mints instead of throwing', () => {
+    // Nothing in this reader may throw: it runs as a bare argument inside the
+    // follower's frame reconcile, so one unreadable value would stall every
+    // node on the canvas. `structuredClone` throws on any Y type; a doc host
+    // folding in a raw update can put any of them into a value slot.
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(1)] as never
+    })
+    const doc = seed(definition)
+    doc.transact(() => {
+      const stored = doc
+        .getMap<unknown>('definitions')
+        .get(definition.id) as Y.Map<unknown>
+      const node = (stored.get('nodes') as Y.Map<unknown>).get(
+        '1'
+      ) as Y.Map<unknown>
+      const text = new Y.Text()
+      node.set('title', text)
+      text.insert(0, 'from text')
+      const fragment = new Y.XmlFragment()
+      stored.set('extra', fragment)
+      fragment.insert(0, [new Y.XmlText('markup')])
+      stored.set('sub', new Y.Doc())
+    })
+
+    const [projected] = readSubgraphDefinitions(doc)
+
+    expect(projected.nodes?.[0]?.title).toBe('from text')
+    expect(projected.extra).toBe('markup')
+    expect(projected).toHaveProperty('sub', {})
+  })
 })

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -225,4 +225,30 @@ describe('readSubgraphDefinitions', () => {
     expect(projected.extra).toBe('markup')
     expect(projected).toHaveProperty('sub', {})
   })
+
+  it('drops a `__proto__` key instead of assigning through it', () => {
+    const definition = createTestSubgraphData({
+      nodes: [interiorNode(1)] as never
+    })
+    const doc = seed(definition)
+    doc.transact(() => {
+      const stored = doc
+        .getMap<unknown>('definitions')
+        .get(definition.id) as Y.Map<unknown>
+      stored.set('__proto__', { polluted: true })
+      const node = (stored.get('nodes') as Y.Map<unknown>).get(
+        '1'
+      ) as Y.Map<unknown>
+      node.set('__proto__', { polluted: true })
+    })
+
+    const [projected] = readSubgraphDefinitions(doc)
+
+    expect(Object.getPrototypeOf(projected)).toBe(Object.prototype)
+    expect(Object.getPrototypeOf(projected.nodes?.[0])).toBe(Object.prototype)
+    expect(projected).not.toHaveProperty('polluted')
+    expect(projected.nodes?.[0]).not.toHaveProperty('polluted')
+    expect(Object.keys(projected)).not.toContain('__proto__')
+    expect(Object.keys(projected.nodes?.[0] ?? {})).not.toContain('__proto__')
+  })
 })

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -55,6 +55,16 @@ describe('readSubgraphDefinitions', () => {
     expect(readSubgraphDefinitions(seed())).toEqual([])
   })
 
+  it('does not create the definitions root on a document that lacks it', () => {
+    const doc = new Y.Doc()
+
+    readSubgraphDefinitions(doc)
+
+    // `Y.Doc.getMap` defines the shared type as a side effect; a reader must
+    // leave the document's shape alone.
+    expect(doc.share.has('definitions')).toBe(false)
+  })
+
   it('projects a definition back to the shape it was minted from', () => {
     const definition = createTestSubgraphData({
       nodes: [interiorNode(3), interiorNode(1)] as never,

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -22,6 +22,15 @@ const LINK_ORDER = 'link_order'
 const NODE_INCARNATION = '__incarnation'
 
 /**
+ * Own-key filter shared by both record readers. Assigning through
+ * `record['__proto__']` swaps the record's prototype, so a document carrying
+ * that key would hand LiteGraph an object whose inherited keys it never wrote.
+ */
+function isReadableKey(key: string): boolean {
+  return key !== '__proto__'
+}
+
+/**
  * A value slot's JSON view. Every shared type, and a subdocument, answers
  * `toJSON()`; `structuredClone` throws on all of them, and this reader runs
  * as a bare argument inside the follower's frame reconcile, where one throw
@@ -60,7 +69,7 @@ function readInteriorNode(source: unknown): Record<string, unknown> | null {
   }
   const node: Record<string, unknown> = {}
   source.forEach((value, key) => {
-    if (key === NODE_INCARNATION) return
+    if (key === NODE_INCARNATION || !isReadableKey(key)) return
     if (key === 'widgets' && value instanceof Y.Map) {
       node.widgets_values_named = value.toJSON()
     } else if (key === OPAQUE_WIDGETS_KEY) {
@@ -75,7 +84,7 @@ function readInteriorNode(source: unknown): Record<string, unknown> | null {
 function readDefinition(source: Y.Map<unknown>): ExportedSubgraph {
   const definition: Record<string, unknown> = {}
   source.forEach((value, key) => {
-    if (key === NODE_ORDER || key === LINK_ORDER) return
+    if (key === NODE_ORDER || key === LINK_ORDER || !isReadableKey(key)) return
     if (key === 'nodes' && value instanceof Y.Map) {
       definition.nodes = orderedKeys(source.get(NODE_ORDER), value).flatMap(
         (id) => {

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -27,10 +27,8 @@ function plain(value: unknown): unknown {
 }
 
 /**
- * Register entries that name a record, first occurrence only. LiteGraph keeps
- * only the first entry per id when it normalizes a definition, and the
- * positional widget restore in `agentNodeMaterializer` needs the list read
- * here to have the same length as the list LiteGraph configures.
+ * Register entries that name a record, first occurrence only, matching what
+ * LiteGraph keeps when it normalizes a definition.
  */
 function orderedKeys(register: unknown, map: Y.Map<unknown>): string[] {
   const order = Array.isArray(register)
@@ -97,6 +95,11 @@ function readDefinition(source: Y.Map<unknown>): ExportedSubgraph {
  */
 export function readSubgraphDefinitions(doc: Y.Doc): ExportedSubgraph[] {
   const definitions: ExportedSubgraph[] = []
+  // `doc.getMap` defines the root when it is absent. A document that never
+  // seeded definitions must keep its shape, so only read a root that exists.
+  // (For a root that arrived over the wire, `getMap` upgrades the untyped
+  // shared type in place; that is a read-side view, not new content.)
+  if (!doc.share.has(DEFINITIONS_ROOT)) return definitions
   doc.getMap<unknown>(DEFINITIONS_ROOT).forEach((value) => {
     if (value instanceof Y.Map) definitions.push(readDefinition(value))
   })

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -14,6 +14,13 @@ const DEFINITIONS_ROOT = 'definitions'
 const NODE_ORDER = 'node_order'
 const LINK_ORDER = 'link_order'
 
+/**
+ * Per-node bookkeeping the op layer's applier stamps on every node record
+ * (`NODE_INCARNATION_KEY`, not exported by the package). Its own `project()`
+ * drops it; so does this reader.
+ */
+const NODE_INCARNATION = '__incarnation'
+
 function plain(value: unknown): unknown {
   if (value instanceof Y.Map || value instanceof Y.Array) return value.toJSON()
   return structuredClone(value)
@@ -35,6 +42,7 @@ function readInteriorNode(source: unknown): Record<string, unknown> | null {
   if (!(source instanceof Y.Map)) return null
   const node: Record<string, unknown> = {}
   source.forEach((value, key) => {
+    if (key === NODE_INCARNATION) return
     if (key === 'widgets' && value instanceof Y.Map) {
       node.widgets_values_named = value.toJSON()
     } else if (key === OPAQUE_WIDGETS_KEY) {

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -21,8 +21,17 @@ const LINK_ORDER = 'link_order'
  */
 const NODE_INCARNATION = '__incarnation'
 
+/**
+ * A value slot's JSON view. Every shared type, and a subdocument, answers
+ * `toJSON()`; `structuredClone` throws on all of them, and this reader runs
+ * as a bare argument inside the follower's frame reconcile, where one throw
+ * would stall every node on the canvas. The package only mints maps and
+ * arrays; the rest arrive through a doc host folding in a raw update.
+ */
 function plain(value: unknown): unknown {
-  if (value instanceof Y.Map || value instanceof Y.Array) return value.toJSON()
+  if (value instanceof Y.AbstractType || value instanceof Y.Doc) {
+    return value.toJSON()
+  }
   return structuredClone(value)
 }
 

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -1,0 +1,85 @@
+import { OPAQUE_WIDGETS_KEY } from '@comfyorg/comfy-multi-player'
+import * as Y from 'yjs'
+
+import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
+
+/**
+ * Root map the op layer mints `definitions.subgraphs` into, keyed by
+ * definition id. `@comfyorg/comfy-multi-player` reads it through its private
+ * `definitionsMap()`, which is not part of the package's public surface.
+ */
+const DEFINITIONS_ROOT = 'definitions'
+
+/** Mint-order registers kept beside the interior `nodes`/`links` maps. */
+const NODE_ORDER = 'node_order'
+const LINK_ORDER = 'link_order'
+
+function plain(value: unknown): unknown {
+  if (value instanceof Y.Map || value instanceof Y.Array) return value.toJSON()
+  return structuredClone(value)
+}
+
+function orderedKeys(register: unknown, map: Y.Map<unknown>): string[] {
+  const order = Array.isArray(register)
+    ? register.filter((key): key is string => typeof key === 'string')
+    : [...map.keys()].sort()
+  return order.filter((key) => map.has(key))
+}
+
+/**
+ * Interior node record → serialised node. Named widget values go to
+ * `widgets_values_named`, the only name-keyed slot `LGraphNode.configure()`
+ * reads; the opaque positional form stays `widgets_values`.
+ */
+function readInteriorNode(source: unknown): Record<string, unknown> | null {
+  if (!(source instanceof Y.Map)) return null
+  const node: Record<string, unknown> = {}
+  source.forEach((value, key) => {
+    if (key === 'widgets' && value instanceof Y.Map) {
+      node.widgets_values_named = value.toJSON()
+    } else if (key === OPAQUE_WIDGETS_KEY) {
+      node.widgets_values = plain(value)
+    } else {
+      node[key] = plain(value)
+    }
+  })
+  return node
+}
+
+function readDefinition(source: Y.Map<unknown>): ExportedSubgraph {
+  const definition: Record<string, unknown> = {}
+  source.forEach((value, key) => {
+    if (key === NODE_ORDER || key === LINK_ORDER) return
+    if (key === 'nodes' && value instanceof Y.Map) {
+      definition.nodes = orderedKeys(source.get(NODE_ORDER), value).flatMap(
+        (id) => {
+          const node = readInteriorNode(value.get(id))
+          return node ? [node] : []
+        }
+      )
+    } else if (key === 'links' && value instanceof Y.Map) {
+      definition.links = orderedKeys(source.get(LINK_ORDER), value).map((id) =>
+        plain(value.get(id))
+      )
+    } else {
+      definition[key] = plain(value)
+    }
+  })
+  return definition as unknown as ExportedSubgraph
+}
+
+/**
+ * Project the subgraph definitions the op layer minted into the follower doc
+ * back to the `ExportedSubgraph` shape `LGraph.createSubgraphs()` consumes,
+ * interior nodes and links in mint order.
+ *
+ * Mirrors the package's own `projectDefinition()` so that what the agent
+ * seeded and what the canvas instantiates agree byte-for-byte on structure.
+ */
+export function readSubgraphDefinitions(doc: Y.Doc): ExportedSubgraph[] {
+  const definitions: ExportedSubgraph[] = []
+  doc.getMap<unknown>(DEFINITIONS_ROOT).forEach((value) => {
+    if (value instanceof Y.Map) definitions.push(readDefinition(value))
+  })
+  return definitions
+}

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -26,20 +26,31 @@ function plain(value: unknown): unknown {
   return structuredClone(value)
 }
 
+/**
+ * Register entries that name a record, first occurrence only. LiteGraph keeps
+ * only the first entry per id when it normalizes a definition, and the
+ * positional widget restore in `agentNodeMaterializer` needs the list read
+ * here to have the same length as the list LiteGraph configures.
+ */
 function orderedKeys(register: unknown, map: Y.Map<unknown>): string[] {
   const order = Array.isArray(register)
     ? register.filter((key): key is string => typeof key === 'string')
     : [...map.keys()].sort()
-  return order.filter((key) => map.has(key))
+  return [...new Set(order)].filter((key) => map.has(key))
 }
 
 /**
  * Interior node record → serialised node. Named widget values go to
  * `widgets_values_named`, the only name-keyed slot `LGraphNode.configure()`
- * reads; the opaque positional form stays `widgets_values`.
+ * reads; the opaque positional form stays `widgets_values`. A record whose
+ * `widgets` is not a map cannot be read and is skipped, as the package's
+ * `tryProjectNode()` skips it.
  */
 function readInteriorNode(source: unknown): Record<string, unknown> | null {
   if (!(source instanceof Y.Map)) return null
+  if (source.has('widgets') && !(source.get('widgets') instanceof Y.Map)) {
+    return null
+  }
   const node: Record<string, unknown> = {}
   source.forEach((value, key) => {
     if (key === NODE_INCARNATION) return

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -61,7 +61,9 @@ const materializerState = vi.hoisted(() => ({
 // The reader is module-mocked too: these tests only check that the composable
 // hands whatever it read from the bridge's doc through to the materializer.
 const definitionsState = vi.hoisted(() => ({
-  fakeDefinitions: [] as ExportedSubgraph[],
+  fakeDefinitions: [
+    { id: '11111111-1111-4111-8111-111111111111' } as ExportedSubgraph
+  ],
   readSubgraphDefinitions: vi.fn(() => definitionsState.fakeDefinitions)
 }))
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -14,6 +14,7 @@ import type { Ref } from 'vue'
 import { render } from '@testing-library/vue'
 
 import type { GraphMutations } from '@/core/graph/graphMutations'
+import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
 import type { NodeId } from '@/types/nodeId'
 import { toNodeId } from '@/types/nodeId'
 
@@ -55,6 +56,13 @@ const adapterState = vi.hoisted(() => ({
 
 const materializerState = vi.hoisted(() => ({
   reconcileAgentAdapters: vi.fn(() => [] as NodeId[])
+}))
+
+// The reader is module-mocked too: these tests only check that the composable
+// hands whatever it read from the bridge's doc through to the materializer.
+const definitionsState = vi.hoisted(() => ({
+  fakeDefinitions: [] as ExportedSubgraph[],
+  readSubgraphDefinitions: vi.fn(() => definitionsState.fakeDefinitions)
 }))
 
 const apiState = vi.hoisted(() => {
@@ -104,6 +112,10 @@ vi.mock('./ecsFollowerAdapter', () => ({
 
 vi.mock('./agentNodeMaterializer', () => ({
   reconcileAgentAdapters: materializerState.reconcileAgentAdapters
+}))
+
+vi.mock('./agentSubgraphDefinitions', () => ({
+  readSubgraphDefinitions: definitionsState.readSubgraphDefinitions
 }))
 
 vi.mock('./devPanelLog', () => ({
@@ -193,6 +205,7 @@ describe('useAgentCrdtFollower', () => {
     sessionStorage.clear()
     bridgeState.current = null
     materializerState.reconcileAgentAdapters.mockReset().mockReturnValue([])
+    definitionsState.readSubgraphDefinitions.mockClear()
   })
 
   it('subscribes immediately to a bound workflow and reports it in status', () => {
@@ -655,6 +668,7 @@ describe('useAgentCrdtFollower', () => {
     // The materializer is module-mocked, so the graph only needs to be a
     // distinct reference the composable hands through.
     const fakeGraph = {} as MaterializableGraph
+    const { fakeDefinitions } = definitionsState
 
     it('reconciles the live graph after every applied frame', () => {
       const { unmount } = mountFollower('wf-1', true, () => fakeGraph)
@@ -663,7 +677,13 @@ describe('useAgentCrdtFollower', () => {
 
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledTimes(1)
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledWith(
-        fakeGraph
+        fakeGraph,
+        fakeDefinitions
+      )
+      // Definitions come from the doc the bridge currently follows, so a
+      // doc_reset remint (which swaps the FollowerDoc) is read fresh.
+      expect(definitionsState.readSubgraphDefinitions).toHaveBeenCalledWith(
+        bridge().follower.doc
       )
       unmount()
     })
@@ -702,7 +722,8 @@ describe('useAgentCrdtFollower', () => {
 
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledTimes(1)
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledWith(
-        fakeGraph
+        fakeGraph,
+        fakeDefinitions
       )
       unmount()
     })
@@ -738,7 +759,8 @@ describe('useAgentCrdtFollower', () => {
       await nextTick()
 
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledWith(
-        fakeGraph
+        fakeGraph,
+        fakeDefinitions
       )
       unmount()
     })
@@ -756,7 +778,8 @@ describe('useAgentCrdtFollower', () => {
 
       expect(adapterState.clearForReset).toHaveBeenCalled()
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledWith(
-        fakeGraph
+        fakeGraph,
+        fakeDefinitions
       )
       unmount()
     })
@@ -768,7 +791,8 @@ describe('useAgentCrdtFollower', () => {
 
       expect(adapterState.clearForReset).toHaveBeenCalled()
       expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledWith(
-        fakeGraph
+        fakeGraph,
+        fakeDefinitions
       )
       unmount()
     })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -7,6 +7,7 @@ import { createUuidv4 } from '@/utils/uuid'
 
 import type { MaterializableGraph } from './agentNodeMaterializer'
 import { reconcileAgentAdapters } from './agentNodeMaterializer'
+import { readSubgraphDefinitions } from './agentSubgraphDefinitions'
 import { recordDevEvent } from './devPanelLog'
 import { wireLog } from './crdtLog'
 import type { CrdtDebugSnapshot } from './crdtSnapshot'
@@ -581,7 +582,10 @@ export function useAgentCrdtFollower(
   function reconcileLiveGraph(docId: string): void {
     const graph = getGraph()
     if (!graph) return
-    const nodeIds = reconcileAgentAdapters(graph)
+    const nodeIds = reconcileAgentAdapters(
+      graph,
+      readSubgraphDefinitions(bridge.follower.doc)
+    )
     if (nodeIds.length > 0) {
       recordDevEvent('agent_node_adapters_materialized', {
         workflowId: docId,


### PR DESCRIPTION
Agent-added subgraph landed as a `missingNode` placeholder. Now instantiates through `LGraph.createSubgraph()` → `subgraph-created` → `registerNewSubgraph`, same as the human path.

Short-term, frontend-only fix for agent subgraph creation (PM scope S4). Long-term plan and the PM's immediate scope (S1 widget edits / S2 slot connects on existing subgraphs, which a spike shows are broken only in the frontend follower): [TDD: Agent subgraph editing across cli, cmp, cloud, and frontend](https://app.notion.com/p/TDD-Agent-subgraph-editing-across-cli-cmp-cloud-and-frontend-V1-follower-fixes-V2-V4-op-vocabu-3d16d73d365081719b85ed515af98276). Deferred review findings: #16932.

<details><summary>Full context for agent readers</summary>

## Symptom

Agent (CRDT follower) adds a subgraph → the follower doc gets a root node whose `type` is the definition UUID plus a `definitions.subgraphs` entry. `ecsFollowerAdapter.ts` only reads root `nodesMap`/`linksMap`, so `agentNodeMaterializer.ts` (#16652) called `LiteGraph.createNode(uuid)` → `null` → `missingNode()` with `has_errors=true`. The definition was never registered, so `rootGraph.createSubgraph` → `subgraph-created` → `app.ts` handler → `useSubgraphService().registerNewSubgraph` never ran. Nothing in that path is agent-aware; it is purely that the definition was never handed to LiteGraph.

## Root causes (two independent breaks)

- **Break A (op layer, out of scope here):** the operation layer has no explicit `define_subgraph` creation operation, so the cloud agent falls back to a whole-doc reseed (`Mint` + `doc_reset`). Per the ruling in [blocked-on-Christian #393](https://github.com/christian-byrne/blocked-on-christian/issues/393#issuecomment-5536331996), `add_node` remains definition-free; after explicit creation, structural edits use the same node-id operations as non-subgraph nodes.
- **Break B (frontend, fixed here):** the follower never projected `definitions.subgraphs` from the Y.Doc back into `ExportedSubgraph[]` and never registered them before reconciling root nodes.

## Fix

- New `agentSubgraphDefinitions.ts`: pure reader `readSubgraphDefinitions(doc)` → `ExportedSubgraph[]`. Mirrors the package's private `projectDefinition()`: interior `nodes`/`links` in `node_order`/`link_order` mint order (lexicographic fallback, filtered to present keys, same as the package), catalogued widget values → `widgets_values_named`, `OPAQUE_WIDGETS_KEY` → positional `widgets_values`, nested `definitions` passthrough, and the applier's `__incarnation` stamp dropped (the package does not export `NODE_INCARNATION_KEY`, so the string is hardcoded with a comment). Hardening from review: guards with `doc.share.has('definitions')` so reading never creates the map; `plain()` calls `toJSON()` on any `Y.AbstractType`/`Y.Doc` slot so the reader cannot throw on a shared-type value; a `__proto__` key is dropped from interior node and definition records.
- `agentNodeMaterializer.ts`: `reconcileAgentAdapters(graph, subgraphDefinitions = [])` flattens definitions (nested included), filters out ids already in `rootGraph.subgraphs`, topologically sorts, then registers each missing definition **one at a time** via `tryCreateSubgraph` inside `runMintPortsSuppressed`, *before* reconciling root nodes, so `LiteGraph.createNode(uuid)` resolves to a `SubgraphNode`.
- Failure semantics per definition: a non-UUID id is skipped and reported (`reportError`, `errorType: 'agent_subgraph_definitions_failed'`, context `{ graphId, definitionId }`, non-thrown per ADR 0019) rather than reminted into an id the doc does not know. A `createSubgraph` throw calls the new `LGraph.releaseSubgraphs()` so nothing half-built stays in the map; the id stays pending, is retried on the next frame, and is reported once. Root nodes typed by a pending definition are skipped that frame (not placeholdered) so a later success instantiates them correctly.
- Interior widget values: `withNamedValuesRestore` scopes `LiteGraph.namedValuesRestore = true` around `createSubgraph` so `LGraphNode.configure()` honours `widgets_values_named` during configuration (custom `onConfigure` sees the real values). Previously values were assigned positionally after configure, which was both late and wrong once LiteGraph renumbers colliding interior ids.
- `litegraph`: `LGraph.releaseSubgraphs(subgraphs)` extracted from the existing last-`SubgraphNode`-removed path and made public; the removal path calls it unchanged, and the materializer uses it for rollback.
- `useAgentCrdtFollower.ts`: `reconcileLiveGraph` now passes `readSubgraphDefinitions(bridge.follower.doc)` on every reconcile.

## Limitations / decisions to veto

- Interior node ids may be reminted on collision exactly as on the human load path; the agent's doc is not updated to reflect that. Root/interior id scoping is a design decision → #16932 item 2.
- Definition payloads are creation-only: payloads for an already registered id are not re-applied. Subsequent edits target nodes by id through ordinary operations. `doc_reset`/`follower_replaced` still do not remove stale definitions → #16932 item 1.
- Definitions are read in full every frame; incremental read → #16932 item 3.
- `orderedKeys` deliberately matches the package projector byte-for-byte (`node_order ?? sorted keys`); divergence belongs in the package.
- `'__incarnation'` is duplicated in FE because the package does not export it.
- `__proto__` is dropped rather than using null-prototype objects because the output goes to LiteGraph, which expects ordinary objects.
- Placeholders for genuinely unknown node types stay silent, as before.
- Break A remains: until the op layer has explicit `define_subgraph` creation, the agent will still reseed the whole doc to add a subgraph. This PR makes that reseed land correctly; it does not make the op incremental or add subgraph semantics to other operations.

## Tests (TDD: RED and GREEN are separate commits)

- `agentNodeMaterializer.test.ts` — `describe('subgraph definitions')`: integration through real `mint` → `FollowerDoc` → `EcsFollowerAdapter.applyFrame` → `reconcileAgentAdapters` → real `LGraph`. Covers: instantiates a `SubgraphNode` (not `missingNode`) and emits `subgraph-created`; registers once across repeated reconciles; nested definitions; interior widget values visible during `configure`; non-UUID id skipped and reported; a throwing definition is rolled back, retried, reported once, and does not block sibling definitions or root nodes.
- `agentSubgraphDefinitions.test.ts`: empty doc (and `doc.share` untouched); round-trip `toEqual` with the minted definition; mint order for nodes/links; named vs opaque widgets; `__incarnation` stripped; nested definitions passthrough; non-record entries skipped; shared-type slots read via `toJSON`; `__proto__` dropped.
- `useAgentCrdtFollower.test.ts`: reconcile is called with the definitions read from the follower doc.

No browser e2e in this PR. The independent review disputes the original "not feasible in-repo" claim: `browser_tests/fixtures/ws.ts` plus the agent API fixture should allow a deterministic Playwright test that crosses reader → materializer → `SubgraphNode`. Tracked as #16932 item 4 so it lands alongside the definition-lifecycle design rather than only the happy path. Manual verification against a CRDT ephemeral is still pending.

## Review rounds

Self-review, adversarial cross-model review, independent blind review ([review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16922#pullrequestreview-5109126412)), CodeRabbit, and cursor-review lens fleet. Every thread has a reply naming the fixing commit or the deferral issue.

## Evidence (at 48ccdba)

```
$ pnpm vitest run src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts \
    src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts \
    src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
 Tests  96 passed (96)

$ pnpm typecheck   # passed
$ pnpm format && pnpm lint   # clean
```

Broad agent suite at d08ab2c: 96 files, 1478 passed, 1 expected fail (pre-existing `.fails`).

RED verified per commit: `c584b0c` adds the failure-semantics tests and fails on `e08eeb8`; `d08ab2c` turns them green.

Ruling alignment at `f15d3a66e`: the targeted materializer suite passes (38 tests), `pnpm typecheck` passes, and the added regression proves that a later definition payload cannot edit an already registered subgraph.

## Related

- #16652 (root-node materializer this builds on), #16818, #16897
- #16932 (deferred follow-ups)
- Linear PM-718, PM-313; program decision DQ-18
</details>

<!-- authored-by:agent lane-ruling-393-1-0614 -->

