### PR TITLE
fix(agent): restore dev panel keyboard focus

### DIFF
--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -106,12 +107,36 @@ describe('CrdtDevPanel', () => {
     const chipButton = chip()!
     await user.click(chipButton)
     expect(sheet()).toBeTruthy()
-    expect(screen.getByTestId('crdt-dev-panel-close')).toHaveFocus()
+    const closeButton = screen.getByTestId('crdt-dev-panel-close')
+    expect(closeButton).toHaveFocus()
+
+    const escapedToWindow = vi.fn()
+    window.addEventListener('keydown', escapedToWindow)
+
+    const verbosity = screen.getByTestId('crdt-dev-panel-verbosity')
+    await user.click(verbosity)
+    await user.keyboard('{Escape}')
+    expect(sheet()).toBeTruthy()
+    expect(escapedToWindow).not.toHaveBeenCalled()
+
+    verbosity.blur()
 
     await user.keyboard('{Escape}')
+    window.removeEventListener('keydown', escapedToWindow)
     expect(chip()).toBeTruthy()
     expect(sheet()).toBeNull()
     expect(chip()).toHaveFocus()
+    expect(escapedToWindow).not.toHaveBeenCalled()
+  })
+
+  it('focuses the close control when restoring an open panel', async () => {
+    localStorage.setItem('Comfy.Agent.CrdtDevPanel.open', 'true')
+
+    renderPanel()
+    await nextTick()
+
+    expect(sheet()).toBeTruthy()
+    expect(screen.getByTestId('crdt-dev-panel-close')).toHaveFocus()
   })
 
   it('replaces the instrument with a way to restore it when hidden', async () => {

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -99,16 +99,19 @@ describe('CrdtDevPanel', () => {
     expect(sheet()).toHaveTextContent('7')
   })
 
-  it('opens and closes back to the chip', async () => {
+  it('moves focus into the panel and restores it after Escape closes', async () => {
     const user = userEvent.setup()
     renderPanel()
 
-    await user.click(chip()!)
+    const chipButton = chip()!
+    await user.click(chipButton)
     expect(sheet()).toBeTruthy()
+    expect(screen.getByTestId('crdt-dev-panel-close')).toHaveFocus()
 
-    await user.click(screen.getByTestId('crdt-dev-panel-close'))
+    await user.keyboard('{Escape}')
     expect(chip()).toBeTruthy()
     expect(sheet()).toBeNull()
+    expect(chip()).toHaveFocus()
   })
 
   it('replaces the instrument with a way to restore it when hidden', async () => {

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { useClipboard } from '@vueuse/core'
+import { useClipboard, useEventListener } from '@vueuse/core'
 import {
   computed,
   nextTick,
@@ -218,8 +218,16 @@ function setOpen(value: boolean) {
   } catch {
     // Storage unavailable — the panel still toggles in-memory.
   }
-  void nextTick(() => (value ? closeButton.value : chipButton.value)?.focus())
 }
+
+function onDocumentKeydown(event: KeyboardEvent): void {
+  if (!open.value || event.key !== 'Escape') return
+  event.stopPropagation()
+  if (event.target instanceof HTMLSelectElement) return
+  setOpen(false)
+}
+
+useEventListener(document, 'keydown', onDocumentKeydown)
 
 // ── live document facts ───────────────────────────────────────────────────
 const docState = shallowRef<CrdtDebugSnapshot | null>(null)
@@ -243,6 +251,21 @@ onBeforeUnmount(() => {
   clearTimeout(reportCopyReset)
 })
 
+watch(
+  open,
+  (value) => {
+    const control = value ? closeButton.value : chipButton.value
+    control?.focus()
+  },
+  { flush: 'post' }
+)
+watch(
+  closeButton,
+  (button) => {
+    if (open.value) button?.focus()
+  },
+  { flush: 'post' }
+)
 watch(tab, poll)
 
 const docRows = computed<readonly (readonly [string, string])[]>(() => {
@@ -587,7 +610,6 @@ function fmtTime(at: number): string {
       v-else
       class="bg-agent-surface border-agent-border text-agent-fg flex min-h-0 grow flex-col overflow-hidden border-y"
       data-testid="crdt-dev-panel"
-      @keydown.esc="setOpen(false)"
     >
       <header
         class="border-agent-border flex h-8 shrink-0 items-center gap-2 border-b px-2"

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -8,6 +8,7 @@ import {
   onMounted,
   ref,
   shallowRef,
+  useTemplateRef,
   watch
 } from 'vue'
 
@@ -182,6 +183,8 @@ const HIDDEN_KEY = 'Comfy.Agent.CrdtDevPanel.hidden'
 const open = ref(readOpen())
 const tab = ref<'status' | 'log' | 'merge'>('status')
 const dismissed = ref(readHidden())
+const chipButton = useTemplateRef<HTMLButtonElement>('chipButton')
+const closeButton = useTemplateRef<HTMLButtonElement>('closeButton')
 
 function readOpen(): boolean {
   try {
@@ -215,6 +218,7 @@ function setOpen(value: boolean) {
   } catch {
     // Storage unavailable — the panel still toggles in-memory.
   }
+  void nextTick(() => (value ? closeButton.value : chipButton.value)?.focus())
 }
 
 // ── live document facts ───────────────────────────────────────────────────
@@ -561,6 +565,7 @@ function fmtTime(at: number): string {
 
     <button
       v-else-if="!open"
+      ref="chipButton"
       type="button"
       :title="S.open"
       class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover mr-4 mb-1 flex h-6 cursor-pointer items-center gap-1 self-end rounded-full border px-2 transition-colors"
@@ -582,6 +587,7 @@ function fmtTime(at: number): string {
       v-else
       class="bg-agent-surface border-agent-border text-agent-fg flex min-h-0 grow flex-col overflow-hidden border-y"
       data-testid="crdt-dev-panel"
+      @keydown.esc="setOpen(false)"
     >
       <header
         class="border-agent-border flex h-8 shrink-0 items-center gap-2 border-b px-2"
@@ -614,6 +620,7 @@ function fmtTime(at: number): string {
           <span class="icon-[lucide--eye-off] size-4" />
         </button>
         <button
+          ref="closeButton"
           type="button"
           :title="S.close"
           class="text-agent-fg-muted hover:text-agent-fg cursor-pointer"


### PR DESCRIPTION
## Summary

Restore predictable keyboard focus and Escape handling for the CRDT debug panel.

## Changes

- Move focus from the collapsed chip to the close button when opening, including restored-open mounts.
- Close on Escape even when no panel descendant has focus, without triggering host shortcuts.
- Preserve select-popup Escape without closing the panel.
- Cover the behavior in the existing component test.

## Review Focus

Focus restoration, document-level Escape containment, and compatibility with the current main-based debug instrument.

Supersedes #16658. Re-carried from `lane-fec-a11y-1`; original functional commit authored by cheap-drain and preserved via `cherry-pick -x`. The automated follow-up commit was intentionally omitted because it only changed `processedWidgetRenderModel.ts`, which contains a newer dedupe fix on main.

## Evidence

- `NODE_OPTIONS='--no-experimental-webstorage' pnpm test:unit src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts` - 11 tests passed at `e7afbaff1b`.
- `pnpm exec eslint src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts` - passed.
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts` - passed.
- `pnpm typecheck` - passed.
- `git merge-base --is-ancestor fdcc06bbaa3d263cdd5fc1a1541d9a68e5a6c642 e7afbaff1bf6a5a4752d2be7da102d08104d851f` - current `main` is an ancestor.
- `git diff --name-only origin/main...HEAD` - only `CrdtDevPanel.vue` and its test.
- `git diff origin/main...HEAD -- src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts` - empty.
- All four automated review threads discovered on superseded #16658 after its human approvals were fixed in `e7afbaff1b`, replied to with the carried fix, and resolved: focusless/restored-open Escape, propagation containment, closed/select handling, and discarded focus-promise removal.

## Current scope, TDD, and invariants

This remains wanted in current scope because the main-based `CrdtDevPanel` is the developer/QA operator instrument identified by `plans/qa-scenarios.md` scenario M13. Its keyboard path also satisfies the accessibility/input and keyboard/focus checks required by Tasks 3-4 of `plans/staged-agent-delivery-pilot.md`. The relevant technical-design constraint is `plans/technical-design.md` section 9: the surface must not contradict the CRDT end-state.

The change is presentation-only: it moves browser focus between the existing panel controls and handles Escape. It does not change shared-document writes, op identity/order, projection, transport, persistence, layout state, awareness, or optimistic overlays, so the CRDT KEEP-ALIVE invariants remain unchanged. Main's newer `processedWidgetRenderModel.ts` dedupe fix is preserved by the intentional empty diff recorded above.

Justification: [FE #16658](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16658) received two non-bot approvals before its base was retired; this PR re-carries that reviewed focus behavior onto `main`, and the recorded [bbc #388 ruling](https://github.com/christian-byrne/blocked-on-christian/issues/388#issuecomment-5536351759) explicitly authorizes previously approved dead-base re-carries after current-main integration, fresh CI, and scope/TDD/invariant verification.

<!-- authored-by:agent lane-prbase-1-0627 -->