### PR TITLE
fix(agent): latch schema gate until explicit reset (re-carry of #16663)

### DIFF
--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -854,6 +854,56 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     error.mockRestore()
   })
 
+  it('retains a schema error after a compatible continuation resumes dispatch', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { transport, bridge, projected, schemaErrors } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+
+    const host = initDoc(new Y.Doc())
+    const incompatibleNode = new Y.Map<unknown>()
+    incompatibleNode.set('type', 'SchemaV2Node')
+    nodesMap(host).set('incompatible', incompatibleNode)
+    metaMap(host).set('schema_version', 2)
+    const incompatibleUpdate = Y.encodeStateAsUpdate(host)
+    const incompatibleState = Y.encodeStateVector(host)
+    const follower = bridge.follower
+
+    transport.deliver('doc_update', docUpdateFrame(incompatibleUpdate))
+
+    const retainedError = bridge.lastSchemaError
+    expect(retainedError).toBeInstanceOf(FollowerSchemaError)
+    expect(nodesMap(follower.doc).get('incompatible')?.get('type')).toBe(
+      'SchemaV2Node'
+    )
+    expect(projected).toHaveLength(0)
+
+    metaMap(host).set('schema_version', 1)
+    const compatibleNode = new Y.Map<unknown>()
+    compatibleNode.set('type', 'SchemaV1Node')
+    nodesMap(host).set('compatible', compatibleNode)
+    const compatibleUpdate = Y.encodeStateAsUpdate(host, incompatibleState)
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(compatibleUpdate, WORKFLOW_ID, 2)
+    )
+
+    expect(bridge.follower).toBe(follower)
+    expect(nodesMap(follower.doc).get('incompatible')?.get('type')).toBe(
+      'SchemaV2Node'
+    )
+    expect(nodesMap(follower.doc).get('compatible')?.get('type')).toBe(
+      'SchemaV1Node'
+    )
+    expect(projected).toEqual([
+      expect.objectContaining({ seq: 2, update: compatibleUpdate })
+    ])
+    expect(schemaErrors).toEqual([{ workflowId: WORKFLOW_ID, found: 2 }])
+    expect(bridge.lastSchemaError).toBe(retainedError)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
+    error.mockRestore()
+  })
+
   it('refuses a doc that declares no schema_version at all', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { transport, bridge, projected, schemaErrors } = wire()

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -854,7 +854,7 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     error.mockRestore()
   })
 
-  it('retains a schema error after a compatible continuation resumes dispatch', () => {
+  it('keeps the read gate closed until an explicit reset replaces the doc', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { transport, bridge, projected, schemaErrors } = wire()
     transport.open = true
@@ -897,17 +897,42 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     expect(nodesMap(follower.doc).get('incompatible')?.get('type')).toBe(
       'SchemaV3Node'
     )
-    expect(nodesMap(follower.doc).get('compatible')?.get('type')).toBe(
-      'SchemaV2Node'
-    )
-    expect(projected).toEqual([
-      expect.objectContaining({ seq: 2, update: compatibleUpdate })
-    ])
+    expect(nodesMap(follower.doc).has('compatible')).toBe(false)
+    expect(follower.updatesApplied).toBe(1)
+    expect(bridge.lastSequence).toBe(1)
+    expect(projected).toHaveLength(0)
     expect(schemaErrors).toEqual([
       { workflowId: WORKFLOW_ID, found: SCHEMA_VERSION + 1 }
     ])
     expect(bridge.lastSchemaError).toBe(retainedError)
     expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
+
+    transport.deliver('doc_reset', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      seq: 2
+    })
+
+    expect(bridge.follower).not.toBe(follower)
+    expect(bridge.follower.updatesApplied).toBe(0)
+    expect(bridge.follower.doc.getMap('nodes').size).toBe(0)
+    expect(bridge.lastSchemaError).toBeNull()
+    const subscribes = transport.framesOfType('doc_subscribe') as {
+      data: { state_vector_b64: string }
+    }[]
+    expect(subscribes).toHaveLength(2)
+    expect(subscribes[1].data.state_vector_b64).toBe(
+      encodeBase64(Y.encodeStateVector(new Y.Doc()))
+    )
+
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+
+    expect(bridge.follower.updatesApplied).toBe(1)
+    expect(projected).toEqual([expect.objectContaining({ seq: 1 })])
+    expect(schemaErrors).toEqual([
+      { workflowId: WORKFLOW_ID, found: SCHEMA_VERSION + 1 }
+    ])
+    expect(bridge.lastSchemaError).toBeNull()
     error.mockRestore()
   })
 

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -860,11 +860,16 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     transport.open = true
     bridge.subscribe(WORKFLOW_ID)
 
-    const host = initDoc(new Y.Doc())
+    // Adapted from #16663 (which ran on the frozen base's package API):
+    // `initDoc`/`metaMap` are module-private in @comfyorg/comfy-multi-player
+    // 0.2.1, so the host doc is minted via the public surface and the meta map
+    // is reached through Yjs directly. Version literals are reader-relative:
+    // this build reads SCHEMA_VERSION, so "too new" is SCHEMA_VERSION + 1.
+    const host = mint({ nodes: [], links: [] }, { types: {} })
     const incompatibleNode = new Y.Map<unknown>()
-    incompatibleNode.set('type', 'SchemaV2Node')
+    incompatibleNode.set('type', 'SchemaV3Node')
     nodesMap(host).set('incompatible', incompatibleNode)
-    metaMap(host).set('schema_version', 2)
+    host.getMap('meta').set('schema_version', SCHEMA_VERSION + 1)
     const incompatibleUpdate = Y.encodeStateAsUpdate(host)
     const incompatibleState = Y.encodeStateVector(host)
     const follower = bridge.follower
@@ -874,13 +879,13 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     const retainedError = bridge.lastSchemaError
     expect(retainedError).toBeInstanceOf(FollowerSchemaError)
     expect(nodesMap(follower.doc).get('incompatible')?.get('type')).toBe(
-      'SchemaV2Node'
+      'SchemaV3Node'
     )
     expect(projected).toHaveLength(0)
 
-    metaMap(host).set('schema_version', 1)
+    host.getMap('meta').set('schema_version', SCHEMA_VERSION)
     const compatibleNode = new Y.Map<unknown>()
-    compatibleNode.set('type', 'SchemaV1Node')
+    compatibleNode.set('type', 'SchemaV2Node')
     nodesMap(host).set('compatible', compatibleNode)
     const compatibleUpdate = Y.encodeStateAsUpdate(host, incompatibleState)
     transport.deliver(
@@ -890,15 +895,17 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
 
     expect(bridge.follower).toBe(follower)
     expect(nodesMap(follower.doc).get('incompatible')?.get('type')).toBe(
-      'SchemaV2Node'
+      'SchemaV3Node'
     )
     expect(nodesMap(follower.doc).get('compatible')?.get('type')).toBe(
-      'SchemaV1Node'
+      'SchemaV2Node'
     )
     expect(projected).toEqual([
       expect.objectContaining({ seq: 2, update: compatibleUpdate })
     ])
-    expect(schemaErrors).toEqual([{ workflowId: WORKFLOW_ID, found: 2 }])
+    expect(schemaErrors).toEqual([
+      { workflowId: WORKFLOW_ID, found: SCHEMA_VERSION + 1 }
+    ])
     expect(bridge.lastSchemaError).toBe(retainedError)
     expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
     error.mockRestore()

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -236,6 +236,11 @@ export class LayoutFollowerBridge extends EventTarget {
     const update = event.detail as DocUpdate
     if (update.workflowId !== this.sentWorkflowId) return
 
+    // The first incompatible frame is already in the Y.Doc. Same-lineage
+    // updates cannot remove those CRDT bytes, so keep the read gate latched
+    // until an explicit doc_reset replaces the lineage.
+    if (this.schemaError !== null) return
+
     // A stale/duplicate frame cannot advance the replica. Ignoring it also
     // prevents a replayed Yjs frame from spuriously re-running ECS effects.
     // The one exception is the subscribe's own catch-up (seq == ackSeq) when
@@ -280,11 +285,11 @@ export class LayoutFollowerBridge extends EventTarget {
     if (isCatchUp) this.catchUpPending = false
     this.follower.applyRemoteUpdate(update.update)
 
-    // KA-11 read-time gate. The merge itself is unconditional — Yjs bytes are
-    // integrated or they are not — but nothing downstream may READ a doc whose
-    // declared schema this build was not written against. Failing closed here,
-    // before the frame is re-dispatched, is what keeps a v2 doc from being
-    // half-projected onto the canvas by a v1 reader.
+    // KA-11 read-time gate. The frame must merge before its schema can be
+    // checked, but nothing downstream may READ a doc whose declared schema
+    // this build was not written against. Failing closed here, before the
+    // frame is re-dispatched, is what keeps a v2 doc from being half-projected
+    // onto the canvas by a v1 reader.
     try {
       assertReadableSchema(this.follower.doc)
     } catch (error) {


### PR DESCRIPTION
Schema failures now latch the read gate closed.
Only explicit `doc_reset` replaces and rebaselines the follower.
Supersedes #16663; all 3 source hunks and 5 source records are accounted.

<details><summary>Full context for agent readers</summary>

## Summary

Re-carry of #16663 onto `main`. The first incompatible frame is already merged before its schema can be checked, so the bridge now quarantines that follower: later same-lineage `doc_update` frames are ignored before stale/gap detection, sequence advancement, Yjs merge, or redispatch. `lastSchemaError` and disconnected state therefore remain consistent with the closed projection gate.

Recovery is deliberately restricted to the existing explicit-lineage-break path. A `doc_reset` replaces the follower, clears the schema error, resubscribes from an empty state vector, announces `follower_replaced`, and allows readable updates on the fresh lineage.

## Source-thread dispositions

- [Fail-open through merged incompatible bytes](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16663#discussion_r3920014389): fixed by latching the gate; same-lineage updates cannot reopen it.
- [Contradictory error/disconnected state while dispatch resumes](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16663#discussion_r3920014391): fixed because dispatch remains withheld until reset clears the error.
- [Missing rebaseline after a withheld update](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16663#discussion_r3920014393): fixed through the explicit reset's zero-vector resubscribe; ignored continuations do not advance `lastSeq`.
- [Two unrelated trailing-comma removals](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16663#discussion_r3920014395): intentionally dropped and recorded in the [central ledger](https://github.com/christian-byrne/in-app-agent-program/blob/main/program/intentional-drop-log.md#fe-16663--schema-recovery-re-carry-formatter-omissions), matching Christian's [source closure disposition](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16663#issuecomment-5535501765).

## Source-hunk accounting

- 1/3 source hunks carried/evolved: the 50-line characterization was cherry-picked with `-x` as `244ed8227`, adapted to main's public package surface in `32ca091c2`, then converted into the recovery regression in [`aaf2317c2b`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/aaf2317c2bba4ef7d6c70479b63d9d0d62a7dabe).
- 2/3 source hunks intentionally dropped: the function-parameter and options-object trailing-comma removals in `processedWidgetRenderModel.ts`.
- Residual: zero. The source's four review threads now carry exact successor replies and are resolved; the fifth record is the source-author closure/supersession comment.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm test:unit src/workbench/extensions/agent/crdt/followerSubscription.test.ts` — 33/33 passed.
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts src/workbench/extensions/agent/crdt/followerSubscription.test.ts` — passed.
- `pnpm exec eslint --no-cache src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts src/workbench/extensions/agent/crdt/followerSubscription.test.ts` — passed.
- `pnpm typecheck` — passed.
- Commit hook: oxfmt, type-aware oxlint, ESLint, and typecheck passed.
- Push hook: knip passed.

Original test attribution: `cheap-drain <christian@ampcode.com>`; source commit `8e1df6cbcf` was preserved through the `-x` cherry-pick.

<!-- authored-by:agent lane-evfail-85-0653 -->
</details>