### PR TITLE
feat(agent): add CRDT dev panel clipboard controls

### DIFF
--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -1,7 +1,15 @@
-// @vitest-environment jsdom
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { writeText } = vi.hoisted(() => ({
+  writeText: vi.fn<(value: string) => Promise<void>>(() => Promise.resolve())
+}))
+
+vi.mock('@vueuse/core', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useClipboard: () => ({ copy: writeText })
+}))
 
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 import CrdtDevPanel from './CrdtDevPanel.vue'
@@ -13,12 +21,19 @@ import {
 } from './devPanelLog'
 
 vi.mock('@/scripts/api', () => ({
-  api: { apiURL: (route: string) => `/api${route}` }
+  api: {
+    apiURL: (route: string) => `/api${route}`,
+    clientId: 'client-test-1',
+    api_host: 'localhost:8188',
+    api_base: ''
+  }
 }))
-
-const writeText = vi.fn<(value: string) => Promise<void>>(() =>
-  Promise.resolve()
-)
+vi.mock('@/scripts/app', () => ({
+  app: { rootGraph: { serialize: () => ({ nodes: [], links: [] }) } }
+}))
+vi.mock('@/stores/extensionStore', () => ({
+  useExtensionStore: () => ({ extensions: [] })
+}))
 
 const status: AgentCrdtStatus = {
   enabled: true,
@@ -98,9 +113,7 @@ describe('CrdtDevPanel clipboard controls', () => {
     })
     expect(screen.getByText(`${full.slice(0, 200)}…`)).toBeInTheDocument()
 
-    await user.click(
-      screen.getByRole('button', { name: 'Copy log detail' })
-    )
+    await user.click(screen.getByRole('button', { name: 'Copy log detail' }))
 
     expect(writeText).toHaveBeenCalledExactlyOnceWith(full)
   })

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+import CrdtDevPanel from './CrdtDevPanel.vue'
+import {
+  clearDevEvents,
+  devEvents,
+  recordDevEvent,
+  stringifyDevEvents
+} from './devPanelLog'
+
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: (route: string) => `/api${route}` }
+}))
+
+const writeText = vi.fn<(value: string) => Promise<void>>(() =>
+  Promise.resolve()
+)
+
+const status: AgentCrdtStatus = {
+  enabled: true,
+  connected: true,
+  workflowId: 'doc-123',
+  updatesApplied: 1,
+  lastFrameType: 'doc_update',
+  outcomes: {
+    received: 1,
+    applied: 1,
+    skipped: 0,
+    errored: 0,
+    gap: 0,
+    reset: 0,
+    dropped: 0
+  }
+}
+
+function renderPanel(overrides: Partial<AgentCrdtStatus> = {}) {
+  localStorage.setItem('Comfy.Agent.CrdtDevPanel.open', 'true')
+  return render(CrdtDevPanel, {
+    props: { status: { ...status, ...overrides } }
+  })
+}
+
+describe('CrdtDevPanel clipboard controls', () => {
+  beforeEach(() => {
+    clearDevEvents()
+    localStorage.clear()
+    writeText.mockClear()
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+  })
+
+  it('copies the displayed document id', async () => {
+    renderPanel()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Copy document id' })
+    )
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith('doc-123')
+  })
+
+  it('copies each node id surfaced by doc_nodes_changed', async () => {
+    const user = userEvent.setup()
+    recordDevEvent('doc_nodes_changed', {
+      added: ['node-added'],
+      removed: ['node-removed']
+    })
+    renderPanel()
+    await user.click(screen.getByTestId('crdt-dev-panel-tab-log'))
+
+    await user.click(
+      screen.getByRole('button', { name: 'Copy node id node-added' })
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Copy node id node-removed' })
+    )
+
+    expect(writeText).toHaveBeenNthCalledWith(1, 'node-added')
+    expect(writeText).toHaveBeenNthCalledWith(2, 'node-removed')
+  })
+
+  it('copies the full log detail while displaying a truncated excerpt', async () => {
+    const user = userEvent.setup()
+    const detail = { value: 'x'.repeat(220), bytes: new Uint8Array(3) }
+    recordDevEvent('doc_update', detail)
+    renderPanel()
+    await user.click(screen.getByTestId('crdt-dev-panel-tab-log'))
+
+    const full = JSON.stringify({
+      value: 'x'.repeat(220),
+      bytes: 'Uint8Array(3)'
+    })
+    expect(screen.getByText(`${full.slice(0, 200)}…`)).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Copy log detail' })
+    )
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith(full)
+  })
+
+  it('shows transient Copied feedback only on the button that succeeded', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      recordDevEvent('doc_nodes_changed', { added: ['node-a'], removed: [] })
+      renderPanel()
+
+      const docButton = screen.getByRole('button', {
+        name: 'Copy document id'
+      })
+      expect(docButton).toHaveTextContent('Copy')
+
+      await userEvent.click(docButton)
+
+      expect(docButton).toHaveTextContent('Copied')
+
+      await vi.advanceTimersByTimeAsync(1600)
+
+      expect(docButton).toHaveTextContent('Copy')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('gives no Copied feedback when the clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('NotAllowedError'))
+    renderPanel()
+
+    const docButton = screen.getByRole('button', { name: 'Copy document id' })
+    await userEvent.click(docButton)
+
+    expect(writeText).toHaveBeenCalledOnce()
+    expect(docButton).toHaveTextContent('Copy')
+  })
+
+  it('preserves full filtered-log copying', async () => {
+    const user = userEvent.setup()
+    recordDevEvent('doc_update', { seq: 7 })
+    recordDevEvent('doc_reset', { reason: 'remint' })
+    renderPanel()
+    await user.click(screen.getByTestId('crdt-dev-panel-tab-log'))
+
+    await user.selectOptions(
+      screen.getByTestId('crdt-dev-panel-filter'),
+      'doc_update'
+    )
+    await user.click(screen.getByRole('button', { name: 'Copy log' }))
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith(
+      stringifyDevEvents(devEvents.value.filter((e) => e.kind === 'doc_update'))
+    )
+  })
+
+  it('omits unavailable controls without writing', async () => {
+    const user = userEvent.setup()
+    recordDevEvent('doc_nodes_changed', undefined)
+    renderPanel({ workflowId: null })
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy document id' })
+    ).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('crdt-dev-panel-tab-log'))
+    expect(
+      screen.queryByRole('button', { name: /^Copy node id / })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Copy log detail' })
+    ).not.toBeInTheDocument()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -13,6 +13,7 @@ vi.mock('@vueuse/core', async (importOriginal) => ({
 
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 import CrdtDevPanel from './CrdtDevPanel.vue'
+import { setCrdtDebugEnabled } from './crdtDebugGate'
 import {
   clearDevEvents,
   devEvents,
@@ -61,6 +62,7 @@ function renderPanel(overrides: Partial<AgentCrdtStatus> = {}) {
 
 describe('CrdtDevPanel clipboard controls', () => {
   beforeEach(() => {
+    setCrdtDebugEnabled(true)
     clearDevEvents()
     localStorage.clear()
     writeText.mockClear()
@@ -141,15 +143,26 @@ describe('CrdtDevPanel clipboard controls', () => {
     }
   })
 
-  it('gives no Copied feedback when the clipboard write fails', async () => {
-    writeText.mockRejectedValueOnce(new Error('NotAllowedError'))
-    renderPanel()
+  it('shows transient Copy failed feedback when the clipboard write fails', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      writeText.mockRejectedValueOnce(new Error('NotAllowedError'))
+      renderPanel()
 
-    const docButton = screen.getByRole('button', { name: 'Copy document id' })
-    await userEvent.click(docButton)
+      const docButton = screen.getByRole('button', {
+        name: 'Copy document id'
+      })
+      await userEvent.click(docButton)
 
-    expect(writeText).toHaveBeenCalledOnce()
-    expect(docButton).toHaveTextContent('Copy')
+      expect(writeText).toHaveBeenCalledOnce()
+      expect(docButton).toHaveTextContent('Copy failed')
+
+      await vi.advanceTimersByTimeAsync(1600)
+
+      expect(docButton).toHaveTextContent(/^Copy$/)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('preserves full filtered-log copying', async () => {

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -367,7 +367,7 @@ function verdictLabel(entry: MergeTraceEntry): string {
 type CopyState = 'idle' | 'busy' | 'done' | 'failed'
 const logCopyState = ref<CopyState>('idle')
 const reportCopyState = ref<CopyState>('idle')
-const copiedKey = ref<string | null>(null)
+const itemCopy = ref<{ key: string; state: 'done' | 'failed' } | null>(null)
 const reportSources = ref<ReportSources>({ ...DEFAULT_REPORT_SOURCES })
 const { copy } = useClipboard({ legacy: true })
 
@@ -394,14 +394,15 @@ async function writeClipboard(text: string): Promise<boolean> {
 }
 
 async function copyItem(key: string, text: string) {
-  if (!(await writeClipboard(text))) return
-  copiedKey.value = key
+  const ok = await writeClipboard(text)
+  itemCopy.value = { key, state: ok ? 'done' : 'failed' }
   clearTimeout(itemCopyReset)
-  itemCopyReset = setTimeout(() => (copiedKey.value = null), 1600)
+  itemCopyReset = setTimeout(() => (itemCopy.value = null), 1600)
 }
 
-function itemCopyLabel(key: string): string {
-  return copiedKey.value === key ? S.copied : S.copy
+function itemCopyLabel(key: string, idle: string = S.copy): string {
+  if (itemCopy.value?.key !== key) return idle
+  return itemCopy.value.state === 'done' ? S.copied : S.copyFailed
 }
 
 function flashLogCopyState(ok: boolean) {
@@ -850,11 +851,7 @@ function fmtTime(at: number): string {
                   :aria-label="`${S.copy} node id ${nodeId}`"
                   @click="copyItem(`node:${row.event.seq}:${nodeId}`, nodeId)"
                 >
-                  {{
-                    copiedKey === `node:${row.event.seq}:${nodeId}`
-                      ? S.copied
-                      : nodeId
-                  }}
+                  {{ itemCopyLabel(`node:${row.event.seq}:${nodeId}`, nodeId) }}
                 </button>
               </div>
             </div>

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -87,6 +87,9 @@ const S = {
   allLevels: 'all levels',
   allKinds: 'all kinds',
   clear: 'Clear',
+  copy: 'Copy',
+  copyDocumentId: 'Copy document id',
+  copyLogDetail: 'Copy log detail',
   copyLog: 'Copy log',
   copyReport: 'Copy full report',
   copying: 'Collecting…',
@@ -222,6 +225,7 @@ const docState = shallowRef<CrdtDebugSnapshot | null>(null)
 let pollHandle: ReturnType<typeof setInterval> | undefined
 let logCopyReset: ReturnType<typeof setTimeout> | undefined
 let reportCopyReset: ReturnType<typeof setTimeout> | undefined
+let itemCopyReset: ReturnType<typeof setTimeout> | undefined
 
 function poll() {
   if (!open.value || tab.value !== 'status') return
@@ -237,6 +241,7 @@ onBeforeUnmount(() => {
   if (pollHandle !== undefined) clearInterval(pollHandle)
   clearTimeout(logCopyReset)
   clearTimeout(reportCopyReset)
+  clearTimeout(itemCopyReset)
 })
 
 watch(tab, poll)
@@ -271,9 +276,26 @@ const matchingEvents = computed<readonly DevEvent[]>(() =>
   )
 )
 
-// Newest first, capped for render cost — the copy actions use the full set.
-const visibleEvents = computed(() =>
-  [...matchingEvents.value].reverse().slice(0, 150)
+interface LogRow {
+  event: DevEvent
+  detail: string
+  excerpt: string
+  nodeIds: readonly string[]
+}
+
+const visibleLogRows = computed<readonly LogRow[]>(() =>
+  [...matchingEvents.value]
+    .reverse()
+    .slice(0, 150)
+    .map((event) => {
+      const detail = stringifyDetail(event.detail)
+      return {
+        event,
+        detail,
+        excerpt: truncateDetail(detail),
+        nodeIds: eventNodeIds(event)
+      }
+    })
 )
 
 const level = ref<CrdtLogLevel>(crdtLogLevel())
@@ -345,6 +367,7 @@ function verdictLabel(entry: MergeTraceEntry): string {
 type CopyState = 'idle' | 'busy' | 'done' | 'failed'
 const logCopyState = ref<CopyState>('idle')
 const reportCopyState = ref<CopyState>('idle')
+const copiedKey = ref<string | null>(null)
 const reportSources = ref<ReportSources>({ ...DEFAULT_REPORT_SOURCES })
 const { copy } = useClipboard({ legacy: true })
 
@@ -368,6 +391,17 @@ async function writeClipboard(text: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+async function copyItem(key: string, text: string) {
+  if (!(await writeClipboard(text))) return
+  copiedKey.value = key
+  clearTimeout(itemCopyReset)
+  itemCopyReset = setTimeout(() => (copiedKey.value = null), 1600)
+}
+
+function itemCopyLabel(key: string): string {
+  return copiedKey.value === key ? S.copied : S.copy
 }
 
 function flashLogCopyState(ok: boolean) {
@@ -522,22 +556,30 @@ const chipLabel = computed(
   () => `CRDT ${status.connected ? 'live' : 'off'} · ${status.updatesApplied}`
 )
 
-function fmtDetail(detail: unknown, limit = 400): string {
+function stringifyDetail(detail: unknown): string {
   try {
     const raw = JSON.stringify(detail, (_key, value) =>
       value instanceof Uint8Array ? `Uint8Array(${value.length})` : value
     )
-    if (raw === undefined) return ''
-    return raw.length > limit ? `${raw.slice(0, limit)}…` : raw
+    return raw ?? ''
   } catch {
     return String(detail)
   }
 }
 
-function eventDetail(event: DevEvent): string {
-  return expanded.value === event.seq
-    ? fmtDetail(event.detail, 20_000)
-    : fmtDetail(event.detail)
+function truncateDetail(detail: string, limit = 200): string {
+  return detail.length > limit ? `${detail.slice(0, limit)}…` : detail
+}
+
+function eventNodeIds(event: DevEvent): string[] {
+  if (event.kind !== 'doc_nodes_changed') return []
+  const detail = event.detail as {
+    added?: unknown[]
+    removed?: unknown[]
+  } | null
+  return [...(detail?.added ?? []), ...(detail?.removed ?? [])].filter(
+    (id): id is string => typeof id === 'string'
+  )
 }
 
 function fmtTime(at: number): string {
@@ -660,7 +702,18 @@ function fmtTime(at: number): string {
                   <td class="text-agent-fg-muted pr-2 align-top">
                     {{ row[0] }}
                   </td>
-                  <td class="break-all">{{ row[1]() }}</td>
+                  <td class="break-all">
+                    {{ row[1]() }}
+                    <button
+                      v-if="row[0] === 'doc id' && status.workflowId"
+                      type="button"
+                      class="border-agent-border hover:bg-agent-surface-hover ml-1 cursor-pointer rounded-sm border px-1.5 py-0.5"
+                      :aria-label="S.copyDocumentId"
+                      @click="copyItem(`doc:${status.workflowId}`, status.workflowId)"
+                    >
+                      {{ itemCopyLabel(`doc:${status.workflowId}`) }}
+                    </button>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -738,38 +791,62 @@ function fmtTime(at: number): string {
           </div>
 
           <div class="space-y-1" data-testid="crdt-dev-panel-log">
-            <button
-              v-for="event in visibleEvents"
-              :key="event.seq"
-              type="button"
-              class="border-agent-border hover:bg-agent-surface-hover block w-full cursor-pointer border-b pb-1 text-left"
-              @click="expanded = expanded === event.seq ? null : event.seq"
+            <div
+              v-for="row in visibleLogRows"
+              :key="row.event.seq"
+              class="border-agent-border border-b pb-1"
             >
-              <div class="flex items-baseline gap-1">
-                <span class="text-agent-fg-muted">{{ fmtTime(event.at) }}</span>
-                <span
-                  :class="
-                    cn(
-                      'border-agent-border rounded-sm border px-1',
-                      event.level === 'warn' &&
-                        'text-agent-danger border-agent-danger'
-                    )
-                  "
-                  >{{ event.scope }}</span
-                >
-                <span class="font-bold">{{ event.kind }}</span>
-              </div>
-              <div
-                :class="
-                  cn(
-                    'text-agent-fg-muted break-all',
-                    expanded !== event.seq && 'line-clamp-2'
-                  )
+              <button
+                type="button"
+                class="hover:bg-agent-surface-hover block w-full cursor-pointer text-left"
+                @click="
+                  expanded = expanded === row.event.seq ? null : row.event.seq
                 "
               >
-                {{ eventDetail(event) }}
+                <div class="flex items-baseline gap-1">
+                  <span class="text-agent-fg-muted">{{ fmtTime(row.event.at) }}</span>
+                  <span
+                    :class="
+                      cn(
+                        'border-agent-border rounded-sm border px-1',
+                        row.event.level === 'warn' &&
+                          'text-agent-danger border-agent-danger'
+                      )
+                    "
+                    >{{ row.event.scope }}</span
+                  >
+                  <span class="font-bold">{{ row.event.kind }}</span>
+                </div>
+                <div class="text-agent-fg-muted break-all">
+                  {{ expanded === row.event.seq ? row.detail : row.excerpt }}
+                </div>
+              </button>
+              <div v-if="row.detail || row.nodeIds.length" class="mt-1 flex flex-wrap gap-1">
+                <button
+                  v-if="row.detail"
+                  type="button"
+                  class="border-agent-border hover:bg-agent-surface-hover cursor-pointer rounded-sm border px-1.5 py-0.5"
+                  :aria-label="S.copyLogDetail"
+                  @click="copyItem(`detail:${row.event.seq}`, row.detail)"
+                >
+                  {{ itemCopyLabel(`detail:${row.event.seq}`) }}
+                </button>
+                <button
+                  v-for="nodeId in row.nodeIds"
+                  :key="nodeId"
+                  type="button"
+                  class="border-agent-border hover:bg-agent-surface-hover cursor-pointer rounded-sm border px-1.5 py-0.5"
+                  :aria-label="`${S.copy} node id ${nodeId}`"
+                  @click="copyItem(`node:${row.event.seq}:${nodeId}`, nodeId)"
+                >
+                  {{
+                    copiedKey === `node:${row.event.seq}:${nodeId}`
+                      ? S.copied
+                      : nodeId
+                  }}
+                </button>
               </div>
-            </button>
+            </div>
           </div>
         </template>
 
@@ -850,7 +927,7 @@ function fmtTime(at: number): string {
               </div>
               <div class="text-agent-fg-muted break-all">
                 {{ S.survivingWidgets }}:
-                {{ fmtDetail(simulation.survivingWidgets) }}
+                {{ truncateDetail(stringifyDetail(simulation.survivingWidgets)) }}
               </div>
             </section>
 

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -709,7 +709,9 @@ function fmtTime(at: number): string {
                       type="button"
                       class="border-agent-border hover:bg-agent-surface-hover ml-1 cursor-pointer rounded-sm border px-1.5 py-0.5"
                       :aria-label="S.copyDocumentId"
-                      @click="copyItem(`doc:${status.workflowId}`, status.workflowId)"
+                      @click="
+                        copyItem(`doc:${status.workflowId}`, status.workflowId)
+                      "
                     >
                       {{ itemCopyLabel(`doc:${status.workflowId}`) }}
                     </button>
@@ -804,7 +806,9 @@ function fmtTime(at: number): string {
                 "
               >
                 <div class="flex items-baseline gap-1">
-                  <span class="text-agent-fg-muted">{{ fmtTime(row.event.at) }}</span>
+                  <span class="text-agent-fg-muted">{{
+                    fmtTime(row.event.at)
+                  }}</span>
                   <span
                     :class="
                       cn(
@@ -818,10 +822,17 @@ function fmtTime(at: number): string {
                   <span class="font-bold">{{ row.event.kind }}</span>
                 </div>
                 <div class="text-agent-fg-muted break-all">
-                  {{ expanded === row.event.seq ? row.detail : row.excerpt }}
+                  {{
+                    expanded === row.event.seq
+                      ? truncateDetail(row.detail, 20_000)
+                      : row.excerpt
+                  }}
                 </div>
               </button>
-              <div v-if="row.detail || row.nodeIds.length" class="mt-1 flex flex-wrap gap-1">
+              <div
+                v-if="row.detail || row.nodeIds.length"
+                class="mt-1 flex flex-wrap gap-1"
+              >
                 <button
                   v-if="row.detail"
                   type="button"
@@ -927,7 +938,9 @@ function fmtTime(at: number): string {
               </div>
               <div class="text-agent-fg-muted break-all">
                 {{ S.survivingWidgets }}:
-                {{ truncateDetail(stringifyDetail(simulation.survivingWidgets)) }}
+                {{
+                  truncateDetail(stringifyDetail(simulation.survivingWidgets))
+                }}
               </div>
             </section>
 


### PR DESCRIPTION
## Summary

Re-carry the CRDT dev panel clipboard controls from #16666 onto the current main-based panel.

## Changes

- **What**: Add copy controls for the document ID, full event details, and node IDs surfaced by `doc_nodes_changed`, with per-button success and failure feedback.
- **What**: Change collapsed event details from main's 400-character, two-line-clamped view to a capped 200-character excerpt. Keep the 20,000-character expanded display limit while copying the full untruncated detail.
- **What**: Keep filtered full-log copying and the current report collector behavior unchanged.

## Current scope and contract

- **Why this remains wanted**: Development-only CRDT observability needs copyable document IDs, full event details, and node IDs so testers and operators can correlate and share gap, reset, and drop evidence.
- **TDD mapping**: Serves [`docs/DEV-SETUP.md` §3, S5 / `CRDT-RM-5`](https://github.com/christian-byrne/in-app-agent-program/blob/main/docs/DEV-SETUP.md#3-in-app-debugging): latency/performance and observability, including gap/reset/drop metrics.
- **Preserved invariants**: This is presentation and clipboard behavior only. It adds no shared-document write, op minting, transport, persistence, mutation, or authority seam. Raw Yjs updates remain host-to-follower only; presence remains ephemeral; layout remains separate from the semantic document; optimistic overlays remain presentation-only. Filtered full-log copying and report collection remain unchanged.

## Review Focus

Confirm individual detail copies contain the full untruncated value, failed clipboard writes show failure feedback, and collapsed rows use the intentional 200-character excerpt.

Supersedes #16666. Original implementation and review fix by Christian Byrne in `118958f3e9` and `1b9583c8c1`; adapted to the current panel structure on `main`.

## Evidence

- Rebased onto `main` at `fdcc06bbaa3d263cdd5fc1a1541d9a68e5a6c642`; GitHub compare reports `behind_by: 0` for head `082063a4cc8e88899c496df78c20dee1b74ff9bc`.
- `pnpm test:unit src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts` — 2 files, 17 tests passed at the rebased head.
- `pnpm exec eslint src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts` — passed at the rebased head.
- Commit hook: Oxfmt, Stylelint, type-aware Oxlint, ESLint, `pnpm typecheck` — passed.
- Push hook: `pnpm knip --cache` — passed.
- `git diff origin/main -- src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts` — empty; the frozen-base formatter hunk was not carried.

<!-- authored-by:agent lane-prbase-7-0357 -->
<!-- authored-by:agent lane-prbase-7-0623 -->