### PR TITLE
feat: port concurrent job execution to current main

### DIFF
--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -416,6 +416,17 @@ describe('TopMenuSection', () => {
       configureSettings(pinia, true)
       const executionStore = useExecutionStore(pinia)
       executionStore.activeJobId = 'job-1'
+      executionStore.nodeProgressStatesByJob = {
+        'job-1': {
+          'node-1': {
+            value: 50,
+            max: 100,
+            state: 'running',
+            node_id: 'node-1',
+            prompt_id: 'job-1'
+          }
+        }
+      }
 
       const ComfyActionbarStub = createComfyActionbarStub(actionbarTarget)
 

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -32,16 +32,56 @@
         <Suspense @resolve="comfyRunButtonResolved">
           <ComfyRunButton v-coachmark="FIRST_RUN_COACH_IDS.runButton" />
         </Suspense>
-        <Button
-          v-tooltip.bottom="cancelJobTooltipConfig"
-          variant="destructive"
-          size="icon"
-          :disabled="isExecutionIdle"
-          :aria-label="t('menu.interrupt')"
-          @click="cancelCurrentJob"
-        >
-          <i class="icon-[lucide--x] size-4" />
-        </Button>
+        <template v-if="showConcurrentControls">
+          <div
+            class="flex items-center gap-1 rounded-lg bg-secondary-background px-2 py-1"
+          >
+            <span class="text-sm font-normal tabular-nums">
+              {{ t('menu.nRunning', { count: n(runningCount) }) }}
+            </span>
+            <Button
+              v-tooltip.bottom="cancelJobTooltipConfig"
+              variant="destructive"
+              size="icon"
+              :aria-label="t('menu.interrupt')"
+              @click="cancelCurrentJob"
+            >
+              <i class="icon-[lucide--x] size-4" />
+            </Button>
+          </div>
+          <div
+            v-if="queuedCount > 0"
+            class="flex items-center gap-1 rounded-lg bg-secondary-background px-2 py-1"
+          >
+            <span class="text-sm font-normal tabular-nums">
+              {{ t('menu.nQueued', { count: n(queuedCount) }) }}
+            </span>
+            <Button
+              v-tooltip.bottom="clearQueueTooltipConfig"
+              variant="destructive"
+              size="icon"
+              :aria-label="
+                t('sideToolbar.queueProgressOverlay.clearQueueTooltip')
+              "
+              @click="handleClearQueue"
+            >
+              <i class="icon-[lucide--list-x] size-4" />
+            </Button>
+          </div>
+        </template>
+
+        <template v-else>
+          <Button
+            v-tooltip.bottom="cancelJobTooltipConfig"
+            variant="destructive"
+            size="icon"
+            :disabled="isExecutionIdle"
+            :aria-label="t('menu.interrupt')"
+            @click="cancelCurrentJob"
+          >
+            <i class="icon-[lucide--x] size-4" />
+          </Button>
+        </template>
         <Button
           v-tooltip.bottom="queueHistoryTooltipConfig"
           variant="secondary"
@@ -111,6 +151,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import QueueInlineProgress from '@/components/queue/QueueInlineProgress.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useQueueFeatureFlags } from '@/composables/queue/useQueueFeatureFlags'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
 import { buildTooltipConfig } from '@/composables/useTooltipConfig'
 import FreeTierQuota from '@/platform/cloud/subscription/components/FreeTierQuota.vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -148,6 +189,14 @@ const { t, n } = useI18n()
 const { isIdle: isExecutionIdle } = storeToRefs(executionStore)
 const { activeJobsCount } = storeToRefs(queueStore)
 const { activeSidebarTabId } = storeToRefs(sidebarTabStore)
+
+const { isConcurrentExecutionEnabled } = useConcurrentExecution()
+
+const runningCount = computed(() => executionStore.runningJobIds.length)
+const queuedCount = computed(() => queueStore.pendingTasks.length)
+const showConcurrentControls = computed(
+  () => isConcurrentExecutionEnabled.value && !executionStore.isIdle
+)
 
 const position = computed(() => settingStore.get('Comfy.UseNewMenu'))
 const visible = computed(() => position.value !== 'Disabled')
@@ -377,6 +426,9 @@ watch(isDragging, (dragging) => {
 
 const cancelJobTooltipConfig = computed(() =>
   buildTooltipConfig(t('menu.interrupt'))
+)
+const clearQueueTooltipConfig = computed(() =>
+  buildTooltipConfig(t('sideToolbar.queueProgressOverlay.clearQueueTooltip'))
 )
 const queueHistoryTooltipConfig = computed(() =>
   buildTooltipConfig(

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -62,6 +62,39 @@
               {{ item.label }}
             </Button>
           </DropdownMenuItem>
+          <DropdownMenuSeparator
+            v-if="isParallelToggleVisible"
+            class="m-1 h-px bg-border-subtle"
+          />
+          <DropdownMenuItem
+            v-if="isParallelToggleVisible"
+            :disabled="isParallelToggleDisabled"
+            class="flex items-center gap-3 rounded-sm px-2 py-1.5 outline-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-secondary-background-hover"
+            @select.prevent="toggleParallel"
+          >
+            <div class="flex flex-col select-none">
+              <div class="flex items-center gap-1.5">
+                <span class="text-sm text-text-primary">{{
+                  t('menu.parallelExecution')
+                }}</span>
+                <StatusBadge :label="t('g.new')" class="text-[10px]" />
+              </div>
+              <span class="text-text-muted text-xs">{{
+                t('menu.parallelUpTo', { count: maxConcurrentJobs })
+              }}</span>
+            </div>
+            <SwitchRoot
+              :checked="parallelToggleChecked"
+              :disabled="isParallelToggleDisabled"
+              class="relative ml-auto h-5 w-9 shrink-0 cursor-pointer rounded-full bg-secondary-background transition-colors data-disabled:cursor-not-allowed data-[state=checked]:bg-primary-background"
+              @click.stop
+              @update:checked="onParallelToggle"
+            >
+              <SwitchThumb
+                class="block size-4 translate-x-0.5 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-[18px]"
+              />
+            </SwitchRoot>
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenuPortal>
     </DropdownMenuRoot>
@@ -74,16 +107,21 @@ import {
   DropdownMenuItem,
   DropdownMenuPortal,
   DropdownMenuRoot,
-  DropdownMenuTrigger
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  SwitchRoot,
+  SwitchThumb
 } from 'reka-ui'
 import { storeToRefs } from 'pinia'
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import BatchCountEdit from '@/components/actionbar/BatchCountEdit.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import TinyChevronIcon from '@/components/actionbar/TinyChevronIcon.vue'
 import Button from '@/components/ui/button/Button.vue'
 import ButtonGroup from '@/components/ui/button-group/ButtonGroup.vue'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
@@ -256,6 +294,23 @@ const queueButtonTooltip = computed(() => {
   }
   return t('menu.runWorkflow')
 })
+
+const { isFeatureEnabled, isUserEnabled, maxConcurrentJobs, setUserEnabled } =
+  useConcurrentExecution()
+
+const isParallelToggleVisible = isFeatureEnabled
+const isParallelToggleDisabled = computed(
+  () => selectedQueueMode.value !== 'disabled'
+)
+const parallelToggleChecked = isUserEnabled
+
+function onParallelToggle(checked: boolean) {
+  void setUserEnabled(checked)
+}
+
+function toggleParallel() {
+  onParallelToggle(!parallelToggleChecked.value)
+}
 
 const commandStore = useCommandStore()
 const queuePrompt = async (e: Event) => {

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -124,6 +124,7 @@ import ButtonGroup from '@/components/ui/button-group/ButtonGroup.vue'
 import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import {
@@ -304,12 +305,18 @@ const isParallelToggleDisabled = computed(
 )
 const parallelToggleChecked = isUserEnabled
 
-function onParallelToggle(checked: boolean) {
-  void setUserEnabled(checked)
+async function onParallelToggle(checked: boolean) {
+  try {
+    await setUserEnabled(checked)
+  } catch (error) {
+    reportError(error, {
+      errorType: 'concurrent_execution_setting_update_failed'
+    })
+  }
 }
 
 function toggleParallel() {
-  onParallelToggle(!parallelToggleChecked.value)
+  void onParallelToggle(!parallelToggleChecked.value)
 }
 
 const commandStore = useCommandStore()

--- a/src/components/dialog/ConcurrentExecutionDialog.vue
+++ b/src/components/dialog/ConcurrentExecutionDialog.vue
@@ -1,0 +1,58 @@
+<template>
+  <Dialog v-model:open="visible">
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>
+            {{ $t('concurrentExecution.onboarding.title') }}
+          </DialogTitle>
+          <DialogClose />
+        </DialogHeader>
+        <p class="px-4 py-2 text-sm text-text-secondary">
+          {{ $t('concurrentExecution.onboarding.description') }}
+        </p>
+        <DialogFooter>
+          <Button autofocus @click="dismiss">
+            {{ $t('concurrentExecution.onboarding.gotIt') }}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </DialogPortal>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import Button from '@/components/ui/button/Button.vue'
+import Dialog from '@/components/ui/dialog/Dialog.vue'
+import DialogClose from '@/components/ui/dialog/DialogClose.vue'
+import DialogContent from '@/components/ui/dialog/DialogContent.vue'
+import DialogFooter from '@/components/ui/dialog/DialogFooter.vue'
+import DialogHeader from '@/components/ui/dialog/DialogHeader.vue'
+import DialogOverlay from '@/components/ui/dialog/DialogOverlay.vue'
+import DialogPortal from '@/components/ui/dialog/DialogPortal.vue'
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
+
+const { isConcurrentExecutionEnabled, hasSeenOnboarding, markOnboardingSeen } =
+  useConcurrentExecution()
+
+const dismissed = ref(false)
+
+const visible = computed({
+  get: () =>
+    isConcurrentExecutionEnabled.value &&
+    !hasSeenOnboarding.value &&
+    !dismissed.value,
+  set: () => {
+    dismissed.value = true
+  }
+})
+
+async function dismiss() {
+  await markOnboardingSeen()
+  dismissed.value = true
+}
+</script>

--- a/src/components/dialog/ConcurrentExecutionDialog.vue
+++ b/src/components/dialog/ConcurrentExecutionDialog.vue
@@ -35,6 +35,7 @@ import DialogOverlay from '@/components/ui/dialog/DialogOverlay.vue'
 import DialogPortal from '@/components/ui/dialog/DialogPortal.vue'
 import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
 import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
+import { reportError } from '@/platform/telemetry/reportError'
 
 const { isConcurrentExecutionEnabled, hasSeenOnboarding, markOnboardingSeen } =
   useConcurrentExecution()
@@ -52,7 +53,13 @@ const visible = computed({
 })
 
 async function dismiss() {
-  await markOnboardingSeen()
-  dismissed.value = true
+  try {
+    await markOnboardingSeen()
+    dismissed.value = true
+  } catch (error) {
+    reportError(error, {
+      errorType: 'concurrent_execution_onboarding_dismiss_failed'
+    })
+  }
 }
 </script>

--- a/src/components/dialog/ConcurrentExecutionDialog.vue
+++ b/src/components/dialog/ConcurrentExecutionDialog.vue
@@ -46,8 +46,8 @@ const visible = computed({
     isConcurrentExecutionEnabled.value &&
     !hasSeenOnboarding.value &&
     !dismissed.value,
-  set: () => {
-    dismissed.value = true
+  set: (open) => {
+    if (!open) void dismiss()
   }
 })
 

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable testing-library/prefer-user-event -- fireEvent needed: fake timers require fireEvent for mouseEnter/mouseLeave */
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import type * as RekaUi from 'reka-ui'
 
@@ -13,6 +13,11 @@ import type { JobGroup, JobListItem } from '@/composables/queue/useJobList'
 import JobAssetsList from './JobAssetsList.vue'
 
 const hoisted = vi.hoisted(() => ({
+  concurrentExecutionEnabled: { value: false },
+  executionStore: {
+    focusedJobId: null as string | null,
+    setFocusedJob: vi.fn()
+  },
   jobDetailsPopoverStub: {
     name: 'JobDetailsPopover',
     props: {
@@ -22,6 +27,16 @@ const hoisted = vi.hoisted(() => ({
     template:
       '<div class="job-details-popover-stub" :data-job-id="jobId" :data-workflow-id="workflowId" />'
   }
+}))
+
+vi.mock('@/composables/useConcurrentExecution', () => ({
+  useConcurrentExecution: () => ({
+    isConcurrentExecutionEnabled: hoisted.concurrentExecutionEnabled
+  })
+}))
+
+vi.mock('@/stores/executionStore', () => ({
+  useExecutionStore: () => hoisted.executionStore
 }))
 
 vi.mock('@/components/queue/job/JobDetailsPopover.vue', () => ({
@@ -236,6 +251,12 @@ function renderJobAssetsList({
 }
 
 describe('JobAssetsList', () => {
+  beforeEach(() => {
+    hoisted.concurrentExecutionEnabled.value = false
+    hoisted.executionStore.focusedJobId = null
+    hoisted.executionStore.setFocusedJob.mockReset()
+  })
+
   it('renders grouped headers alongside job rows', () => {
     const displayedJobGroups: TestJobGroup[] = [
       {
@@ -361,6 +382,18 @@ describe('JobAssetsList', () => {
     await user.dblClick(stubRoot)
 
     expect(onViewItem).not.toHaveBeenCalled()
+  })
+
+  it('keeps a focus control visible for running concurrent jobs', async () => {
+    hoisted.concurrentExecutionEnabled.value = true
+    const job = buildJob({ state: 'running' })
+    const { user } = renderJobAssetsList({ jobs: [job] })
+
+    await user.click(
+      screen.getByRole('button', { name: 'queue.jobItem.focusTooltip' })
+    )
+
+    expect(hoisted.executionStore.setFocusedJob).toHaveBeenCalledWith(job.id)
   })
 
   it('emits viewItem from the View button for completed jobs without preview output', async () => {

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -9,6 +9,7 @@ import type * as RekaUi from 'reka-ui'
 import './testUtils/mockTanstackVirtualizer'
 
 import type { JobGroup, JobListItem } from '@/composables/queue/useJobList'
+import type { JobId } from '@/schemas/apiSchema'
 
 import JobAssetsList from './JobAssetsList.vue'
 
@@ -16,7 +17,7 @@ const hoisted = vi.hoisted(() => ({
   concurrentExecutionEnabled: { value: false },
   executionStore: {
     focusedJobId: null as string | null,
-    setFocusedJob: vi.fn()
+    setFocusedJob: vi.fn<(jobId: JobId | null) => void>()
   },
   jobDetailsPopoverStub: {
     name: 'JobDetailsPopover',

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -254,7 +254,9 @@ describe('JobAssetsList', () => {
   beforeEach(() => {
     hoisted.concurrentExecutionEnabled.value = false
     hoisted.executionStore.focusedJobId = null
-    hoisted.executionStore.setFocusedJob.mockReset()
+    hoisted.executionStore.setFocusedJob.mockImplementation((jobId) => {
+      hoisted.executionStore.focusedJobId = jobId
+    })
   })
 
   it('renders grouped headers alongside job rows', () => {
@@ -394,6 +396,7 @@ describe('JobAssetsList', () => {
     )
 
     expect(hoisted.executionStore.setFocusedJob).toHaveBeenCalledWith(job.id)
+    expect(hoisted.executionStore.focusedJobId).toBe(job.id)
   })
 
   it('emits viewItem from the View button for completed jobs without preview output', async () => {

--- a/src/components/queue/job/JobAssetsList.vue
+++ b/src/components/queue/job/JobAssetsList.vue
@@ -47,9 +47,33 @@
               @preview-click="emitViewItem(row.job)"
               @click.stop
             >
-              <template v-if="hoveredJobId === row.job.id" #actions>
+              <template
+                v-if="
+                  hoveredJobId === row.job.id || isFocusableRunningJob(row.job)
+                "
+                #actions
+              >
                 <Button
-                  v-if="isCancelable(row.job)"
+                  v-if="isFocusableRunningJob(row.job)"
+                  v-tooltip.top="focusTooltipConfig"
+                  variant="textonly"
+                  size="icon"
+                  :aria-label="t('queue.jobItem.focusTooltip')"
+                  @click.stop="executionStore.setFocusedJob(row.job.id)"
+                >
+                  <i
+                    :class="
+                      cn(
+                        'size-4',
+                        isFocusedJob(row.job)
+                          ? 'icon-[lucide--eye] text-text-primary'
+                          : 'icon-[lucide--eye-off] text-text-secondary'
+                      )
+                    "
+                  />
+                </Button>
+                <Button
+                  v-if="hoveredJobId === row.job.id && isCancelable(row.job)"
                   variant="destructive"
                   size="icon"
                   :aria-label="t('g.cancel')"
@@ -58,7 +82,9 @@
                   <i class="icon-[lucide--x] size-4" />
                 </Button>
                 <Button
-                  v-else-if="isFailedDeletable(row.job)"
+                  v-else-if="
+                    hoveredJobId === row.job.id && isFailedDeletable(row.job)
+                  "
                   variant="destructive"
                   size="icon"
                   :aria-label="t('g.delete')"
@@ -67,7 +93,9 @@
                   <i class="icon-[lucide--trash-2] size-4" />
                 </Button>
                 <Button
-                  v-else-if="row.job.state === 'completed'"
+                  v-else-if="
+                    hoveredJobId === row.job.id && row.job.state === 'completed'
+                  "
                   variant="textonly"
                   size="sm"
                   @click.stop="emitCompletedViewItem(row.job)"
@@ -75,6 +103,7 @@
                   {{ t('menuLabels.View') }}
                 </Button>
                 <Button
+                  v-if="hoveredJobId === row.job.id"
                   variant="secondary"
                   size="icon"
                   :aria-label="t('g.more')"
@@ -111,7 +140,10 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import JobDetailsHoverPopover from '@/components/queue/job/JobDetailsHoverPopover.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { JobGroup, JobListItem } from '@/composables/queue/useJobList'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
+import { buildTooltipConfig } from '@/composables/useTooltipConfig'
 import AssetsListItem from '@/platform/assets/components/AssetsListItem.vue'
+import { useExecutionStore } from '@/stores/executionStore'
 import { cn } from '@comfyorg/tailwind-utils'
 import { iconForJobState } from '@/utils/queueDisplay'
 import { isActiveJobState } from '@/utils/queueUtil'
@@ -139,6 +171,11 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const executionStore = useExecutionStore()
+const { isConcurrentExecutionEnabled } = useConcurrentExecution()
+const focusTooltipConfig = computed(() =>
+  buildTooltipConfig(t('queue.jobItem.focusTooltip'))
+)
 const scrollContainer = ref<HTMLElement | null>(null)
 const hoveredJobId = ref<string | null>(null)
 const activeRowElement = ref<HTMLElement | null>(null)
@@ -324,6 +361,14 @@ function onJobEnter(job: JobListItem, event: MouseEvent) {
 
 function isCancelable(job: JobListItem) {
   return job.showClear !== false && isActiveJobState(job.state)
+}
+
+function isFocusableRunningJob(job: JobListItem) {
+  return isConcurrentExecutionEnabled.value && job.state === 'running'
+}
+
+function isFocusedJob(job: JobListItem) {
+  return job.id === executionStore.focusedJobId
 }
 
 function isFailedDeletable(job: JobListItem) {

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -106,6 +106,8 @@ vi.mock('@/stores/queueStore', () => ({
 
 let executionStoreMock: {
   activeJobId: string | null
+  focusedJobId: string | null
+  runningJobIds: string[]
   executingNode: null | { title?: string; type?: string }
   isJobInitializing: (jobId?: string | number) => boolean
 }
@@ -117,6 +119,8 @@ const ensureExecutionStore = () => {
   if (!executionStoreMock) {
     executionStoreMock = reactive({
       activeJobId: null as string | null,
+      focusedJobId: null as string | null,
+      runningJobIds: [] as string[],
       executingNode: null as null | { title?: string; type?: string },
       isJobInitializing: (jobId?: string | number) =>
         isJobInitializingMock(jobId)
@@ -477,6 +481,8 @@ describe('useJobList', () => {
     ]
 
     executionStoreMock.activeJobId = 'active'
+    executionStoreMock.focusedJobId = 'active'
+    executionStoreMock.runningJobIds = ['active']
     executionStoreMock.executingNode = { title: 'Render Node' }
     totalPercent.value = 80
     currentNodePercent.value = 40

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -484,7 +484,7 @@ describe('useJobList', () => {
 
     executionStoreMock.activeJobId = 'active'
     executionStoreMock.focusedJobId = 'active'
-    executionStoreMock.runningJobIds = ['active']
+    executionStoreMock.runningJobIds = ['active', 'other']
     executionStoreMock.executingNode = { title: 'Render Node' }
     totalPercent.value = 80
     currentNodePercent.value = 40

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -209,6 +209,8 @@ const resetStores = () => {
 
   const executionStore = ensureExecutionStore()
   executionStore.activeJobId = null
+  executionStore.focusedJobId = null
+  executionStore.runningJobIds = []
   executionStore.executingNode = null
 
   const jobPreviewStore = ensureJobPreviewStore()

--- a/src/composables/queue/useJobList.ts
+++ b/src/composables/queue/useJobList.ts
@@ -277,9 +277,9 @@ export function useJobList() {
         locale: locale.value,
         formatClockTimeFn: formatClockTime,
         isActive,
-        totalPercent: isActive ? totalPercent.value : undefined,
-        currentNodePercent: isActive ? currentNodePercent.value : undefined,
-        currentNodeName: isActive ? currentNodeName.value : undefined,
+        totalPercent: isFocused ? totalPercent.value : undefined,
+        currentNodePercent: isFocused ? currentNodePercent.value : undefined,
+        currentNodeName: isFocused ? currentNodeName.value : undefined,
         showAddedHint,
         isCloud
       })
@@ -294,13 +294,13 @@ export function useJobList() {
         showClear: display.showClear,
         taskRef: task,
         progressTotalPercent:
-          state === 'running' && isActive ? totalPercent.value : undefined,
+          state === 'running' && isFocused ? totalPercent.value : undefined,
         progressCurrentPercent:
-          state === 'running' && isActive
+          state === 'running' && isFocused
             ? currentNodePercent.value
             : undefined,
         runningNodeName:
-          state === 'running' && isActive ? currentNodeName.value : undefined,
+          state === 'running' && isFocused ? currentNodeName.value : undefined,
         executionTimeMs: task.executionTime,
         computeHours:
           task.executionTime !== undefined

--- a/src/composables/queue/useJobList.ts
+++ b/src/composables/queue/useJobList.ts
@@ -259,8 +259,12 @@ export function useJobList() {
 
   const jobItems = computed<JobListItem[]>(() => {
     return filteredTaskEntries.value.map(({ task, state }) => {
-      const isActive =
-        String(task.jobId ?? '') === String(executionStore.activeJobId ?? '')
+      const isRunning = executionStore.runningJobIds.includes(
+        String(task.jobId ?? '')
+      )
+      const isFocused =
+        String(task.jobId ?? '') === String(executionStore.focusedJobId ?? '')
+      const isActive = isRunning || isFocused
       const showAddedHint = shouldShowAddedHint(task, state)
       const promptKey = taskIdToKey(task.jobId)
       const promptPreviewUrl =

--- a/src/composables/useConcurrentExecution.ts
+++ b/src/composables/useConcurrentExecution.ts
@@ -1,0 +1,46 @@
+import { computed } from 'vue'
+
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+export function useConcurrentExecution() {
+  const settingStore = useSettingStore()
+  const { flags } = useFeatureFlags()
+
+  const isFeatureEnabled = computed(() => flags.concurrentExecutionEnabled)
+
+  const isUserEnabled = computed(() =>
+    settingStore.get('Comfy.Cloud.ConcurrentExecution')
+  )
+
+  const isConcurrentExecutionEnabled = computed(
+    () => isFeatureEnabled.value && isUserEnabled.value
+  )
+
+  const maxConcurrentJobs = computed(() => flags.maxConcurrentJobs)
+
+  const hasSeenOnboarding = computed(() =>
+    settingStore.get('Comfy.Cloud.ConcurrentExecution.OnboardingSeen')
+  )
+
+  async function setUserEnabled(enabled: boolean) {
+    await settingStore.set('Comfy.Cloud.ConcurrentExecution', enabled)
+  }
+
+  async function markOnboardingSeen() {
+    await settingStore.set(
+      'Comfy.Cloud.ConcurrentExecution.OnboardingSeen',
+      true
+    )
+  }
+
+  return {
+    isFeatureEnabled,
+    isUserEnabled,
+    isConcurrentExecutionEnabled,
+    maxConcurrentJobs,
+    hasSeenOnboarding,
+    setUserEnabled,
+    markOnboardingSeen
+  }
+}

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -78,6 +78,7 @@ vi.mock('@/scripts/app', () => {
 vi.mock('@/scripts/api', () => ({
   api: {
     dispatchCustomEvent: vi.fn(),
+    interrupt: vi.fn(),
     apiURL: vi.fn(() => 'http://localhost:8188'),
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
@@ -159,8 +160,18 @@ vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
   }))
 }))
 
+const mockExecutionState = vi.hoisted(() => ({
+  activeJobId: 'active-job' as string | null,
+  focusedJobId: 'focused-job' as string | null,
+  concurrentEnabled: { value: false }
+}))
 vi.mock('@/stores/executionStore', () => ({
-  useExecutionStore: vi.fn(() => ({}))
+  useExecutionStore: vi.fn(() => mockExecutionState)
+}))
+vi.mock('@/composables/useConcurrentExecution', () => ({
+  useConcurrentExecution: () => ({
+    isConcurrentExecutionEnabled: mockExecutionState.concurrentEnabled
+  })
 }))
 
 const mockToastAdd = vi.hoisted(() => vi.fn())
@@ -353,6 +364,29 @@ describe('useCoreCommands', () => {
     // Mock global confirm
     global.confirm = vi.fn().mockReturnValue(true)
     mockRunMintPortsIntentionalClear.mockClear()
+    mockExecutionState.activeJobId = 'active-job'
+    mockExecutionState.focusedJobId = 'focused-job'
+    mockExecutionState.concurrentEnabled.value = false
+  })
+
+  describe('Interrupt command', () => {
+    function findInterruptCommand() {
+      return useCoreCommands().find((cmd) => cmd.id === 'Comfy.Interrupt')!
+    }
+
+    it('interrupts the active job in sequential mode', async () => {
+      await findInterruptCommand().function()
+
+      expect(api.interrupt).toHaveBeenCalledWith('active-job')
+    })
+
+    it('interrupts the focused job in concurrent mode', async () => {
+      mockExecutionState.concurrentEnabled.value = true
+
+      await findInterruptCommand().function()
+
+      expect(api.interrupt).toHaveBeenCalledWith('focused-job')
+    })
   })
 
   describe('ClearWorkflow command', () => {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -347,7 +347,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Interrupt',
       category: 'essentials' as const,
       function: async () => {
-        await api.interrupt(executionStore.activeJobId)
+        await api.interrupt(executionStore.focusedJobId)
         toastStore.add({
           severity: 'info',
           summary: t('g.interrupted'),

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -4,6 +4,7 @@ import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteG
 import { visibleCanvasViewport } from '@/composables/canvas/visibleCanvasViewport'
 import { useSubgraphOperations } from '@/composables/graph/useSubgraphOperations'
 import { startModelNodeDragFromAsset } from '@/composables/node/startModelNodeDragFromAsset'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useModelSelectorDialog } from '@/composables/useModelSelectorDialog'
 import { useRunButtonTelemetry } from '@/composables/useRunButtonTelemetry'
@@ -106,6 +107,7 @@ export function useCoreCommands(): ComfyCommand[] {
   const toastStore = useToastStore()
   const canvasStore = useCanvasStore()
   const executionStore = useExecutionStore()
+  const { isConcurrentExecutionEnabled } = useConcurrentExecution()
   const modelStore = useModelStore()
   const missingModelStore = useMissingModelStore()
   const telemetry = useTelemetry()
@@ -347,7 +349,11 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Interrupt',
       category: 'essentials' as const,
       function: async () => {
-        await api.interrupt(executionStore.focusedJobId)
+        await api.interrupt(
+          isConcurrentExecutionEnabled.value
+            ? executionStore.focusedJobId
+            : executionStore.activeJobId
+        )
         toastStore.add({
           severity: 'info',
           summary: t('g.interrupted'),

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -45,7 +45,9 @@ export enum ServerFeatureFlag {
   CHURNKEY_APP_ID = 'churnkey_app_id',
   SIGNUP_TURNSTILE = 'signup_turnstile',
   SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags',
-  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled'
+  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled',
+  CONCURRENT_EXECUTION_ENABLED = 'concurrent_execution_enabled',
+  MAX_CONCURRENT_JOBS = 'max_concurrent_jobs'
 }
 
 function reportFeatureFlagEvaluation<T>(flagKey: string, value: T): T {
@@ -292,6 +294,23 @@ export function useFeatureFlags() {
         false
       )
     },
+    get concurrentExecutionEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.CONCURRENT_EXECUTION_ENABLED,
+        remoteConfig.value.concurrent_execution_enabled,
+        false
+      )
+    },
+    get maxConcurrentJobs() {
+      return Math.max(
+        1,
+        resolveFlag(
+          ServerFeatureFlag.MAX_CONCURRENT_JOBS,
+          remoteConfig.value.max_concurrent_jobs,
+          1
+        )
+      )
+    },
     get assetsEnabled() {
       return isCloud || resolveFlag('assets', undefined, false)
     }
@@ -348,6 +367,9 @@ export function startFeatureFlagTelemetry() {
       [ServerFeatureFlag.SIGNUP_TURNSTILE]: flags.signupTurnstileMode,
       [ServerFeatureFlag.SUPPORTS_MODEL_TYPE_TAGS]: flags.supportsModelTypeTags,
       [ServerFeatureFlag.ONBOARDING_TOUR_ENABLED]: flags.onboardingTourEnabled,
+      [ServerFeatureFlag.CONCURRENT_EXECUTION_ENABLED]:
+        flags.concurrentExecutionEnabled,
+      [ServerFeatureFlag.MAX_CONCURRENT_JOBS]: flags.maxConcurrentJobs,
       assets: flags.assetsEnabled
     }
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -146,6 +146,7 @@
     "save": "Save",
     "saveAnyway": "Save Anyway",
     "saving": "Saving",
+    "new": "New",
     "no": "No",
     "on": "On",
     "off": "Off",
@@ -1137,7 +1138,18 @@
     "settings": "Settings",
     "help": "Help",
     "queue": "Queue Panel",
-    "fullscreen": "Fullscreen"
+    "fullscreen": "Fullscreen",
+    "nRunning": "{count} running",
+    "nQueued": "{count} queued",
+    "parallelExecution": "Run jobs in parallel",
+    "parallelUpTo": "Up to {count}"
+  },
+  "concurrentExecution": {
+    "onboarding": {
+      "title": "Run Jobs in Parallel",
+      "description": "You can now run multiple workflows at the same time. Use the eye icon in the queue to control which job's progress is shown on the canvas.",
+      "gotIt": "Got it"
+    }
   },
   "tabMenu": {
     "duplicateTab": "Duplicate Tab",
@@ -1435,6 +1447,9 @@
     "jobAddedToQueue": "Job queued",
     "jobQueueing": "Job queuing",
     "completedIn": "Finished in {duration}",
+    "jobItem": {
+      "focusTooltip": "Progress currently shown on canvas"
+    },
     "jobMenu": {
       "openAsWorkflowNewTab": "Open as workflow in new tab",
       "openWorkflowNewTab": "Open workflow in new tab",

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -131,6 +131,8 @@ export type RemoteConfig = {
   v1_payment_recovery?: boolean
   churnkey_app_id?: string
   sentry_dsn?: string
+  max_concurrent_jobs?: number
+  concurrent_execution_enabled?: boolean
   turnstile_sitekey?: string
   // Raw, unvalidated wire value (a server typo like 'enfroce' is possible).
   // Always funnel it through normalizeTurnstileMode before trusting it as a

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1313,5 +1313,21 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'boolean',
     defaultValue: false,
     versionAdded: '1.42.0'
+  },
+  {
+    id: 'Comfy.Cloud.ConcurrentExecution',
+    name: 'Run jobs in parallel',
+    tooltip:
+      'When enabled, multiple workflow runs execute concurrently instead of queuing sequentially.',
+    type: isCloud ? 'boolean' : 'hidden',
+    defaultValue: true,
+    versionAdded: '1.42.0'
+  },
+  {
+    id: 'Comfy.Cloud.ConcurrentExecution.OnboardingSeen',
+    name: 'Concurrent execution onboarding dialog seen',
+    type: 'hidden',
+    defaultValue: false,
+    versionAdded: '1.42.0'
   }
 ]

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -36,6 +36,9 @@ vi.mock('@/stores/executionStore', () => ({
     get activeJobId() {
       return activeJobIdRef.value
     },
+    get focusedJobId() {
+      return activeJobIdRef.value
+    },
     get jobIdToSessionWorkflowPath() {
       return jobIdToWorkflowPathRef.value
     }

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 
 import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 
 const activeJobIdRef = ref<string | null>(null)
+const focusedJobIdRef = ref<string | null>(null)
 const previewsRef = ref<Record<string, { url: string; nodeId?: string }>>({})
 const isAppModeRef = ref(true)
 const activeWorkflowPathRef = ref<string>('workflows/test-workflow.json')
@@ -37,7 +38,7 @@ vi.mock('@/stores/executionStore', () => ({
       return activeJobIdRef.value
     },
     get focusedJobId() {
-      return activeJobIdRef.value
+      return focusedJobIdRef.value
     },
     get jobIdToSessionWorkflowPath() {
       return jobIdToWorkflowPathRef.value
@@ -91,6 +92,7 @@ function makeExecutedDetail(
 describe('linearOutputStore', () => {
   beforeEach(() => {
     activeJobIdRef.value = null
+    focusedJobIdRef.value = null
     previewsRef.value = {}
     isAppModeRef.value = true
     activeWorkflowPathRef.value = 'workflows/test-workflow.json'
@@ -147,6 +149,35 @@ describe('linearOutputStore', () => {
     const imageItems = store.inProgressItems.filter((i) => i.state === 'image')
     expect(imageItems).toHaveLength(1)
     expect(imageItems[0].output).toBeDefined()
+  })
+
+  it('routes executed events to the focused job', async () => {
+    const store = useLinearOutputStore()
+    setJobWorkflowPath('job-active', 'workflows/test-workflow.json')
+    setJobWorkflowPath('job-focused', 'workflows/test-workflow.json')
+    activeJobIdRef.value = 'job-active'
+    focusedJobIdRef.value = 'job-focused'
+    await nextTick()
+
+    apiTarget.dispatchEvent(
+      new CustomEvent('executed', {
+        detail: makeExecutedDetail('job-active')
+      })
+    )
+    expect(store.inProgressItems.every((item) => item.state === 'skeleton')).toBe(
+      true
+    )
+
+    apiTarget.dispatchEvent(
+      new CustomEvent('executed', {
+        detail: makeExecutedDetail('job-focused')
+      })
+    )
+    expect(
+      store.inProgressItems.some(
+        (item) => item.jobId === 'job-focused' && item.state === 'image'
+      )
+    ).toBe(true)
   })
 
   it('does not create trailing skeleton after executed output', () => {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -10,6 +10,9 @@ const previewsRef = ref<Record<string, { url: string; nodeId?: string }>>({})
 const isAppModeRef = ref(true)
 const activeWorkflowPathRef = ref<string>('workflows/test-workflow.json')
 const jobIdToWorkflowPathRef = ref(new Map<string, string>())
+const queuedJobsRef = ref<Record<string, { nodes: Record<string, boolean> }>>(
+  {}
+)
 const selectedOutputsRef = ref<string[]>([])
 
 const { apiTarget } = vi.hoisted(() => ({
@@ -42,6 +45,9 @@ vi.mock('@/stores/executionStore', () => ({
     },
     get jobIdToSessionWorkflowPath() {
       return jobIdToWorkflowPathRef.value
+    },
+    get queuedJobs() {
+      return queuedJobsRef.value
     }
   })
 }))
@@ -105,6 +111,7 @@ describe('linearOutputStore', () => {
     isAppModeRef.value = true
     activeWorkflowPathRef.value = 'workflows/test-workflow.json'
     jobIdToWorkflowPathRef.value = new Map()
+    queuedJobsRef.value = {}
     selectedOutputsRef.value = []
   })
 
@@ -407,6 +414,10 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
+    queuedJobsRef.value = {
+      'job-1': { nodes: {} },
+      'job-2': { nodes: {} }
+    }
     activeJobIdRef.value = 'job-1'
     await nextTick()
 
@@ -424,6 +435,23 @@ describe('linearOutputStore', () => {
 
     expect(store.pendingResolve.has('job-1')).toBe(true)
     expect(store.inProgressItems.some((i) => i.jobId === 'job-2')).toBe(true)
+  })
+
+  it('clears a tracked job removed during reconnect reconciliation', async () => {
+    const store = useLinearOutputStore()
+
+    setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
+    queuedJobsRef.value = { 'job-1': { nodes: {} } }
+    activeJobIdRef.value = 'job-1'
+    await nextTick()
+
+    expect(store.inProgressItems.some((i) => i.jobId === 'job-1')).toBe(true)
+
+    queuedJobsRef.value = {}
+    activeJobIdRef.value = null
+    await nextTick()
+
+    expect(store.inProgressItems.some((i) => i.jobId === 'job-1')).toBe(false)
   })
 
   it('two sequential runs: selection clears after each resolve', () => {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -89,6 +89,14 @@ function makeExecutedDetail(
   }
 }
 
+function completeJob(jobId: string) {
+  apiTarget.dispatchEvent(
+    new CustomEvent('execution_success', {
+      detail: { prompt_id: jobId, timestamp: 0 }
+    })
+  )
+}
+
 describe('linearOutputStore', () => {
   beforeEach(() => {
     activeJobIdRef.value = null
@@ -164,9 +172,9 @@ describe('linearOutputStore', () => {
         detail: makeExecutedDetail('job-active')
       })
     )
-    expect(store.inProgressItems.every((item) => item.state === 'skeleton')).toBe(
-      true
-    )
+    expect(
+      store.inProgressItems.every((item) => item.state === 'skeleton')
+    ).toBe(true)
 
     apiTarget.dispatchEvent(
       new CustomEvent('executed', {
@@ -394,7 +402,7 @@ describe('linearOutputStore', () => {
     expect(store.inProgressItems[0].latentPreviewUrl).toBe('blob:preview-1')
   })
 
-  it('completes previous job on direct job transition', async () => {
+  it('completes a job only after its terminal event', async () => {
     const { nextTick } = await import('vue')
     const store = useLinearOutputStore()
 
@@ -409,9 +417,12 @@ describe('linearOutputStore', () => {
     activeJobIdRef.value = 'job-2'
     await nextTick()
 
-    // job-1 should have been completed
+    expect(store.pendingResolve.has('job-1')).toBe(false)
+    expect(store.inProgressItems.some((i) => i.jobId === 'job-1')).toBe(true)
+
+    completeJob('job-1')
+
     expect(store.pendingResolve.has('job-1')).toBe(true)
-    // job-2 should have started
     expect(store.inProgressItems.some((i) => i.jobId === 'job-2')).toBe(true)
   })
 
@@ -663,6 +674,7 @@ describe('linearOutputStore', () => {
     // Switch away — job finishes while we're gone
     isAppModeRef.value = false
     await nextTick()
+    completeJob('job-1')
     activeJobIdRef.value = null
     await nextTick()
 
@@ -983,6 +995,7 @@ describe('linearOutputStore', () => {
       await nextTick()
 
       // While away: job A finishes, job B starts
+      completeJob('job-a')
       setJobWorkflowPath('job-b', 'workflows/app-a.json')
       activeJobIdRef.value = 'job-b'
       await nextTick()
@@ -1014,6 +1027,7 @@ describe('linearOutputStore', () => {
       await nextTick()
 
       // Job finishes, no new job
+      completeJob('job-a')
       activeJobIdRef.value = null
       await nextTick()
 
@@ -1123,11 +1137,12 @@ describe('linearOutputStore', () => {
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Job ends, new job starts — all while in app mode
+      completeJob('job-a')
       setJobWorkflowPath('job-b', 'workflows/app-a.json')
       activeJobIdRef.value = 'job-b'
       await nextTick()
 
-      // job-a completed via activeJobId watcher, now pending resolve
+      // job-a completed from its terminal event, now pending resolve
       expect(store.pendingResolve.has('job-a')).toBe(true)
 
       // Switch away — tracked job is now job-b which is still active, so
@@ -1253,6 +1268,7 @@ describe('linearOutputStore', () => {
       await nextTick()
 
       // Dog finishes, cat starts (activeJobId transitions on dog tab)
+      completeJob('job-dog')
       activeJobIdRef.value = 'job-cat'
       await nextTick()
 

--- a/src/renderer/extensions/linearMode/linearOutputStore.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.ts
@@ -306,8 +306,19 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
   // Watching both ensures onJobStart fires once the mapping is available.
   watch(
     [displayedJobId, () => executionStore.jobIdToSessionWorkflowPath],
-    ([jobId]) => {
+    ([jobId], [oldJobId]) => {
       if (!isAppMode.value) return
+      // Reconnect reconciliation removes stale jobs without a terminal event.
+      // Complete only jobs absent from execution state; changing focus between
+      // concurrently running jobs must preserve their in-progress output.
+      if (
+        oldJobId &&
+        oldJobId !== jobId &&
+        !executionStore.queuedJobs[oldJobId] &&
+        !pendingResolve.value.has(oldJobId)
+      ) {
+        onJobComplete(oldJobId)
+      }
       // Guard with trackedJobId to avoid double-starting when the
       // path mapping arrives after activeJobId was already set.
       if (

--- a/src/renderer/extensions/linearMode/linearOutputStore.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.ts
@@ -6,7 +6,13 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { flattenNodeOutput } from '@/renderer/extensions/linearMode/flattenNodeOutput'
 import type { InProgressItem } from '@/renderer/extensions/linearMode/linearModeTypes'
 import type { ResultItemImpl } from '@/stores/queueStore'
-import type { ExecutedWsMessage, JobId } from '@/schemas/apiSchema'
+import type {
+  ExecutedWsMessage,
+  ExecutionErrorWsMessage,
+  ExecutionInterruptedWsMessage,
+  ExecutionSuccessWsMessage,
+  JobId
+} from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { useAppModeStore } from '@/stores/appModeStore'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -266,17 +272,42 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
     onNodeExecuted(jobId, detail)
   }
 
+  function completeJobFromTerminalEvent(jobId: JobId) {
+    if (inProgressItems.value.some((item) => item.jobId === jobId)) {
+      onJobComplete(jobId)
+    }
+  }
+
+  function handleExecutionSuccess({
+    detail
+  }: CustomEvent<ExecutionSuccessWsMessage>) {
+    completeJobFromTerminalEvent(detail.prompt_id)
+  }
+
+  function handleExecutionError({
+    detail
+  }: CustomEvent<ExecutionErrorWsMessage>) {
+    completeJobFromTerminalEvent(detail.prompt_id)
+  }
+
+  function handleExecutionInterrupted({
+    detail
+  }: CustomEvent<ExecutionInterruptedWsMessage>) {
+    completeJobFromTerminalEvent(detail.prompt_id)
+  }
+
+  api.addEventListener('execution_success', handleExecutionSuccess)
+  api.addEventListener('execution_error', handleExecutionError)
+  api.addEventListener('execution_interrupted', handleExecutionInterrupted)
+
   // Watch both the displayed job and the path mapping together. The path mapping
   // may arrive after the job ID due to a race between WebSocket
   // (execution_start) and the HTTP response (queuePrompt > storeJob).
   // Watching both ensures onJobStart fires once the mapping is available.
   watch(
     [displayedJobId, () => executionStore.jobIdToSessionWorkflowPath],
-    ([jobId], [oldJobId]) => {
+    ([jobId]) => {
       if (!isAppMode.value) return
-      if (oldJobId && oldJobId !== jobId) {
-        onJobComplete(oldJobId)
-      }
       // Guard with trackedJobId to avoid double-starting when the
       // path mapping arrives after activeJobId was already set.
       if (
@@ -302,12 +333,6 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
   )
 
   function reconcileOnEnter() {
-    // Complete any tracked job that finished while we were away.
-    // The activeJobId watcher couldn't fire onJobComplete because
-    // isAppMode was false at the time.
-    if (trackedJobId.value && trackedJobId.value !== displayedJobId.value) {
-      onJobComplete(trackedJobId.value)
-    }
     // Start tracking the current job only if it belongs to this
     // workflow — otherwise we'd adopt another tab's job.
     if (
@@ -337,15 +362,6 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
     }
   }
 
-  function cleanupOnLeave() {
-    // If the tracked job already finished (no longer the active job),
-    // complete it now to clean up skeletons/latents. If it's still
-    // running, preserve all items for tab switching.
-    if (trackedJobId.value && trackedJobId.value !== displayedJobId.value) {
-      onJobComplete(trackedJobId.value)
-    }
-  }
-
   watch(
     isAppMode,
     (active, wasActive) => {
@@ -354,7 +370,6 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
         reconcileOnEnter()
       } else if (wasActive) {
         api.removeEventListener('executed', handleExecuted)
-        cleanupOnLeave()
       }
     },
     { immediate: true }

--- a/src/renderer/extensions/linearMode/linearOutputStore.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.ts
@@ -256,21 +256,22 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
 
   // --- Event bindings (only active in app mode) ---
 
+  const displayedJobId = computed(
+    () => executionStore.focusedJobId ?? executionStore.activeJobId
+  )
+
   function handleExecuted({ detail }: CustomEvent<ExecutedWsMessage>) {
     const jobId = detail.prompt_id
-    if (jobId !== executionStore.activeJobId) return
+    if (jobId !== displayedJobId.value) return
     onNodeExecuted(jobId, detail)
   }
 
-  // Watch both activeJobId and the path mapping together. The path mapping
-  // may arrive after activeJobId due to a race between WebSocket
+  // Watch both the displayed job and the path mapping together. The path mapping
+  // may arrive after the job ID due to a race between WebSocket
   // (execution_start) and the HTTP response (queuePrompt > storeJob).
   // Watching both ensures onJobStart fires once the mapping is available.
   watch(
-    [
-      () => executionStore.activeJobId,
-      () => executionStore.jobIdToSessionWorkflowPath
-    ],
+    [displayedJobId, () => executionStore.jobIdToSessionWorkflowPath],
     ([jobId], [oldJobId]) => {
       if (!isAppMode.value) return
       if (oldJobId && oldJobId !== jobId) {
@@ -292,7 +293,7 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
     () => jobPreviewStore.nodePreviewsByPromptId,
     (previews) => {
       if (!isAppMode.value) return
-      const jobId = executionStore.activeJobId
+      const jobId = displayedJobId.value
       if (!jobId) return
       const preview = previews[jobId]
       if (preview) onLatentPreview(jobId, preview.url, preview.nodeId)
@@ -304,20 +305,17 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
     // Complete any tracked job that finished while we were away.
     // The activeJobId watcher couldn't fire onJobComplete because
     // isAppMode was false at the time.
-    if (
-      trackedJobId.value &&
-      trackedJobId.value !== executionStore.activeJobId
-    ) {
+    if (trackedJobId.value && trackedJobId.value !== displayedJobId.value) {
       onJobComplete(trackedJobId.value)
     }
     // Start tracking the current job only if it belongs to this
     // workflow — otherwise we'd adopt another tab's job.
     if (
-      executionStore.activeJobId &&
-      trackedJobId.value !== executionStore.activeJobId &&
-      isJobForActiveWorkflow(executionStore.activeJobId)
+      displayedJobId.value &&
+      trackedJobId.value !== displayedJobId.value &&
+      isJobForActiveWorkflow(displayedJobId.value)
     ) {
-      onJobStart(executionStore.activeJobId)
+      onJobStart(displayedJobId.value)
     }
 
     // Clear stale selection from another workflow's job.
@@ -343,10 +341,7 @@ export const useLinearOutputStore = defineStore('linearOutput', () => {
     // If the tracked job already finished (no longer the active job),
     // complete it now to clean up skeletons/latents. If it's still
     // running, preserve all items for tab switching.
-    if (
-      trackedJobId.value &&
-      trackedJobId.value !== executionStore.activeJobId
-    ) {
+    if (trackedJobId.value && trackedJobId.value !== displayedJobId.value) {
       onJobComplete(trackedJobId.value)
     }
   }

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -485,7 +485,9 @@ const zSettings = z.object({
   'Comfy.RightSidePanel.IsOpen': z.boolean(),
   'Comfy.RightSidePanel.ShowErrorsTab': z.boolean(),
   'Comfy.Node.AlwaysShowAdvancedWidgets': z.boolean(),
-  'LiteGraph.Group.SelectChildrenOnClick': z.boolean()
+  'LiteGraph.Group.SelectChildrenOnClick': z.boolean(),
+  'Comfy.Cloud.ConcurrentExecution': z.boolean(),
+  'Comfy.Cloud.ConcurrentExecution.OnboardingSeen': z.boolean()
 })
 
 export type EmbeddingsResponse = z.infer<typeof zEmbeddingsResponse>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -903,6 +903,18 @@ export class ComfyApp {
       if (!displayNodeExecutionId) return
       const blobUrl = createSharedObjectUrl(blob)
       useJobPreviewStore().setPreviewUrl(jobId, blobUrl, displayNodeId)
+
+      // Only render preview on canvas if this is the focused job
+      const executionStore = useExecutionStore()
+      if (
+        jobId &&
+        executionStore.focusedJobId &&
+        jobId !== executionStore.focusedJobId
+      ) {
+        releaseSharedObjectUrl(blobUrl)
+        return
+      }
+
       // Ensure clean up if `executing` event is missed.
       revokePreviewsByExecutionId(displayNodeExecutionId)
       // Preview cleanup is handled in progress_state event to support multiple concurrent previews

--- a/src/services/autoQueueService.test.ts
+++ b/src/services/autoQueueService.test.ts
@@ -164,6 +164,22 @@ describe('setupAutoQueueHandler', () => {
     expect(mocks.queuePrompt).toHaveBeenCalledTimes(1)
   })
 
+  it('suppresses a deferred queue when concurrent execution becomes enabled', async () => {
+    const listener = setupAndGetAutoQueueGraphChangedListener()
+    const queueCountStore = useQueuePendingTaskCountStore()
+    listener(new Event('autoQueueGraphChanged'))
+    listener(new Event('autoQueueGraphChanged'))
+    expect(mocks.queuePrompt).toHaveBeenCalledTimes(1)
+
+    mocks.concurrentExecutionEnabled = true
+    queueCountStore.count = 1
+    await nextTick()
+    queueCountStore.count = 0
+    await nextTick()
+
+    expect(mocks.queuePrompt).toHaveBeenCalledTimes(1)
+  })
+
   it('does not re-queue when a busy processor reports the item as not run yet', async () => {
     const listener = setupAndGetAutoQueueGraphChangedListener()
 

--- a/src/services/autoQueueService.test.ts
+++ b/src/services/autoQueueService.test.ts
@@ -17,7 +17,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/composables/useConcurrentExecution', () => ({
   useConcurrentExecution: () => ({
     isConcurrentExecutionEnabled: {
-      value: mocks.concurrentExecutionEnabled
+      get value() {
+        return mocks.concurrentExecutionEnabled
+      }
     }
   })
 }))
@@ -148,6 +150,18 @@ describe('setupAutoQueueHandler', () => {
     listener(new Event('autoQueueGraphChanged'))
 
     expect(mocks.queuePrompt).not.toHaveBeenCalled()
+  })
+
+  it('responds to concurrent execution changes after setup', () => {
+    const listener = setupAndGetAutoQueueGraphChangedListener()
+
+    mocks.concurrentExecutionEnabled = true
+    listener(new Event('autoQueueGraphChanged'))
+    expect(mocks.queuePrompt).not.toHaveBeenCalled()
+
+    mocks.concurrentExecutionEnabled = false
+    listener(new Event('autoQueueGraphChanged'))
+    expect(mocks.queuePrompt).toHaveBeenCalledTimes(1)
   })
 
   it('does not re-queue when a busy processor reports the item as not run yet', async () => {

--- a/src/services/autoQueueService.test.ts
+++ b/src/services/autoQueueService.test.ts
@@ -10,7 +10,16 @@ const mocks = vi.hoisted(() => ({
     vi.fn<(event: string, listener: (event: Event) => void) => void>(),
   queuePrompt: vi.fn(() => Promise.resolve(true)),
   lastExecutionError: null as object | null,
-  gateBlocks: false
+  gateBlocks: false,
+  concurrentExecutionEnabled: false
+}))
+
+vi.mock('@/composables/useConcurrentExecution', () => ({
+  useConcurrentExecution: () => ({
+    isConcurrentExecutionEnabled: {
+      value: mocks.concurrentExecutionEnabled
+    }
+  })
 }))
 
 vi.mock('@/composables/billing/usePartnerNodesRunGate', () => ({
@@ -59,6 +68,7 @@ describe('setupAutoQueueHandler', () => {
     useQueuePendingTaskCountStore().count = 0
     mocks.lastExecutionError = null
     mocks.gateBlocks = false
+    mocks.concurrentExecutionEnabled = false
   })
 
   it('queues on autoQueueGraphChanged instead of graphChanged', () => {
@@ -129,6 +139,15 @@ describe('setupAutoQueueHandler', () => {
     mocks.gateBlocks = false
     listener(new Event('autoQueueGraphChanged'))
     expect(mocks.queuePrompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not auto-queue while concurrent execution is enabled', () => {
+    mocks.concurrentExecutionEnabled = true
+    const listener = setupAndGetAutoQueueGraphChangedListener()
+
+    listener(new Event('autoQueueGraphChanged'))
+
+    expect(mocks.queuePrompt).not.toHaveBeenCalled()
   })
 
   it('does not re-queue when a busy processor reports the item as not run yet', async () => {

--- a/src/services/autoQueueService.ts
+++ b/src/services/autoQueueService.ts
@@ -1,4 +1,5 @@
 import { partnerRunGateBlocksAutoQueue } from '@/composables/billing/usePartnerNodesRunGate'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import {
@@ -10,6 +11,7 @@ import { useQueuePendingTaskCountStore } from '@/stores/queueStore'
 export function setupAutoQueueHandler() {
   const queueCountStore = useQueuePendingTaskCountStore()
   const queueSettingsStore = useQueueSettingsStore()
+  const { isConcurrentExecutionEnabled } = useConcurrentExecution()
 
   let graphHasChanged = false
   let internalCount = 0 // Use an internal counter here so it is instantly updated when re-queuing
@@ -17,7 +19,8 @@ export function setupAutoQueueHandler() {
     // Skip the whole submission while gated: never enqueue a prompt the gate
     // would drop, and never treat queuePrompt's false as gate rejection — it
     // also means the item was queued behind an active processor.
-    if (partnerRunGateBlocksAutoQueue()) return
+    if (isConcurrentExecutionEnabled.value || partnerRunGateBlocksAutoQueue())
+      return
     if (queueSettingsStore.mode === 'change') {
       if (internalCount) {
         graphHasChanged = true
@@ -38,6 +41,7 @@ export function setupAutoQueueHandler() {
       if (
         !internalCount &&
         !app.lastExecutionError &&
+        !isConcurrentExecutionEnabled.value &&
         !partnerRunGateBlocksAutoQueue()
       ) {
         if (

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -23,7 +23,8 @@ const {
   mockTrackExecutionError,
   mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
-  mockTrackSharedWorkflowRun
+  mockTrackSharedWorkflowRun,
+  mockConcurrentExecutionEnabled
 } = await vi.hoisted(async () => {
   const { shallowRef } = await import('vue')
   return {
@@ -36,7 +37,8 @@ const {
     mockTrackExecutionError: vi.fn(),
     mockTrackExecutionOutcome: vi.fn(),
     mockTrackExecutionSuccess: vi.fn(),
-    mockTrackSharedWorkflowRun: vi.fn()
+    mockTrackSharedWorkflowRun: vi.fn(),
+    mockConcurrentExecutionEnabled: shallowRef(false)
   }
 })
 
@@ -57,9 +59,16 @@ vi.mock('@/composables/useAppMode', async (importOriginal) => {
   }
 })
 
+vi.mock('@/composables/useConcurrentExecution', () => ({
+  useConcurrentExecution: () => ({
+    isConcurrentExecutionEnabled: mockConcurrentExecutionEnabled
+  })
+}))
+
 beforeEach(() => {
   mockAppModeState.mode.value = 'graph'
   mockAppModeState.isAppMode.value = false
+  mockConcurrentExecutionEnabled.value = false
 })
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { toNodeId } from '@/types/nodeId'
@@ -2726,6 +2735,84 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       fire('notification', { id: 'job-9', value: 'Hello' })
 
       expect(store.initializingJobIds.has('job-9')).toBe(false)
+    })
+  })
+
+  describe('concurrent execution', () => {
+    beforeEach(() => {
+      mockConcurrentExecutionEnabled.value = true
+    })
+
+    it('routes node completion events to the job named by prompt_id', () => {
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+      fire('execution_start', { prompt_id: 'job-2', timestamp: 0 })
+
+      fire('execution_cached', {
+        prompt_id: 'job-1',
+        nodes: ['cached-node'],
+        timestamp: 0
+      })
+      fire('executed', {
+        prompt_id: 'job-2',
+        node: 'executed-node',
+        display_node: 'executed-node',
+        output: {}
+      })
+
+      expect(store.queuedJobs['job-1']?.nodes['cached-node']).toBe(true)
+      expect(store.queuedJobs['job-2']?.nodes['executed-node']).toBe(true)
+    })
+
+    it('keeps other jobs running and advances focus when one completes', () => {
+      const runningNode = (promptId: string, nodeId: string) => ({
+        value: 1,
+        max: 10,
+        state: 'running' as const,
+        node_id: nodeId,
+        prompt_id: promptId,
+        display_node_id: nodeId
+      })
+
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+      fire('progress_state', {
+        prompt_id: 'job-1',
+        nodes: { n1: runningNode('job-1', 'n1') }
+      })
+      fire('execution_start', { prompt_id: 'job-2', timestamp: 0 })
+      fire('progress_state', {
+        prompt_id: 'job-2',
+        nodes: { n2: runningNode('job-2', 'n2') }
+      })
+
+      expect(store.focusedJobId).toBe('job-1')
+      expect(store.isConcurrentExecutionActive).toBe(true)
+
+      fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(store.activeJobId).toBe('job-2')
+      expect(store.focusedJobId).toBe('job-2')
+      expect(store.queuedJobs['job-2']).toBeDefined()
+      expect(store.isIdle).toBe(false)
+    })
+
+    it('shows progress for the explicitly focused job', () => {
+      store.nodeProgressStatesByJob = {
+        'job-1': {
+          n1: {
+            value: 3,
+            max: 10,
+            state: 'running',
+            node_id: 'n1',
+            prompt_id: 'job-1',
+            display_node_id: 'n1'
+          }
+        }
+      }
+
+      store.setFocusedJob('job-1')
+
+      expect(store.focusedJobId).toBe('job-1')
+      expect(store.nodeProgressStates.n1?.value).toBe(3)
     })
   })
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1711,6 +1711,62 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
     })
   })
 
+  it('finds executing node info from the focused concurrent job', () => {
+    mockConcurrentExecutionEnabled.value = true
+    store.storeJob({
+      id: 'job-1',
+      nodes: ['1'],
+      promptOutput: {
+        '1': createPromptNode('First Node', 'FirstNode')
+      },
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
+    })
+    store.storeJob({
+      id: 'job-2',
+      nodes: ['2'],
+      promptOutput: {
+        '2': createPromptNode('Second Node', 'SecondNode')
+      },
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
+    })
+    store.nodeProgressStatesByJob = {
+      'job-1': {
+        '1': {
+          state: 'running',
+          value: 0,
+          max: 100,
+          display_node_id: '1',
+          prompt_id: 'job-1',
+          node_id: '1'
+        }
+      },
+      'job-2': {
+        '2': {
+          state: 'running',
+          value: 0,
+          max: 100,
+          display_node_id: '2',
+          prompt_id: 'job-2',
+          node_id: '2'
+        }
+      }
+    }
+
+    store.setFocusedJob('job-1')
+    expect(store.executingNode).toEqual({
+      title: 'First Node',
+      type: 'FirstNode'
+    })
+
+    store.setFocusedJob('job-2')
+    expect(store.executingNode).toEqual({
+      title: 'Second Node',
+      type: 'SecondNode'
+    })
+  })
+
   it('should return null when no node is executing', () => {
     store.nodeProgressStates = {}
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -2799,6 +2799,18 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       mockConcurrentExecutionEnabled.value = true
     })
 
+    it('is active from execution start until the terminal event', () => {
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(store.runningJobIds).toEqual(['job-1'])
+      expect(store.isIdle).toBe(false)
+
+      fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(store.runningJobIds).toEqual([])
+      expect(store.isIdle).toBe(true)
+    })
+
     it('routes node completion events to the job named by prompt_id', () => {
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
       fire('execution_start', { prompt_id: 'job-2', timestamp: 0 })

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -1140,13 +1140,9 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   const runningJobIds = computed<JobId[]>(() => {
-    const result: JobId[] = []
-    for (const [pid, nodes] of Object.entries(nodeProgressStatesByJob.value)) {
-      if (Object.values(nodes).some((n) => n.state === 'running')) {
-        result.push(pid)
-      }
-    }
-    return result
+    return Object.entries(queuedJobs.value)
+      .filter(([, job]) => job.executionStartedAt !== undefined)
+      .map(([jobId]) => jobId)
   })
 
   const runningWorkflowCount = computed<number>(

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -3,6 +3,7 @@ import { computed, ref, shallowRef, watch } from 'vue'
 
 import { useNodeProgressText } from '@/composables/node/useNodeProgressText'
 import { useAppMode } from '@/composables/useAppMode'
+import { useConcurrentExecution } from '@/composables/useConcurrentExecution'
 import { isCloud } from '@/platform/distribution/types'
 import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useTelemetry } from '@/platform/telemetry'
@@ -139,9 +140,11 @@ export const useExecutionStore = defineStore('execution', () => {
   const canvasStore = useCanvasStore()
   const executionErrorStore = useExecutionErrorStore()
   const { mode, isAppMode } = useAppMode()
+  const { isConcurrentExecutionEnabled } = useConcurrentExecution()
 
   const clientId = ref<string | null>(null)
   const activeJobId = ref<JobId | null>(null)
+  const focusedJobId = ref<JobId | null>(null)
   const queuedJobs = ref<Record<JobId, QueuedJob>>({})
   // This is the progress of all nodes in the currently executing workflow
   const nodeProgressStates = ref<Record<string, NodeProgressState>>({})
@@ -400,7 +403,7 @@ export const useExecutionStore = defineStore('execution', () => {
   const executingNode = computed<ExecutionNodeInfo | null>(() => {
     if (!executingNodeId.value) return null
 
-    return activeJob.value?.nodeLookup?.[String(executingNodeId.value)] ?? null
+    return currentJob.value?.nodeLookup?.[String(executingNodeId.value)] ?? null
   })
 
   // This is the progress of the currently executing node (for backward compatibility)
@@ -415,20 +418,32 @@ export const useExecutionStore = defineStore('execution', () => {
     () => queuedJobs.value[activeJobId.value ?? '']
   )
 
+  const focusedJob = computed<QueuedJob | undefined>(
+    () => queuedJobs.value[focusedJobId.value ?? '']
+  )
+
+  const currentJob = computed(() =>
+    isConcurrentExecutionEnabled.value ? focusedJob.value : activeJob.value
+  )
+
   const totalNodesToExecute = computed<number>(() => {
-    if (!activeJob.value) return 0
-    return Object.values(activeJob.value.nodes).length
+    if (!currentJob.value) return 0
+    return Object.values(currentJob.value.nodes).length
   })
 
-  const isIdle = computed<boolean>(() => !activeJobId.value)
+  const isIdle = computed<boolean>(() =>
+    isConcurrentExecutionEnabled.value
+      ? runningJobIds.value.length === 0
+      : !activeJobId.value
+  )
 
   const nodesExecuted = computed<number>(() => {
-    if (!activeJob.value) return 0
-    return Object.values(activeJob.value.nodes).filter(Boolean).length
+    if (!currentJob.value) return 0
+    return Object.values(currentJob.value.nodes).filter(Boolean).length
   })
 
   const executionProgress = computed<number>(() => {
-    if (!activeJob.value) return 0
+    if (!currentJob.value) return 0
     const total = totalNodesToExecute.value
     const done = nodesExecuted.value
     return total > 0 ? done / total : 0
@@ -477,6 +492,14 @@ export const useExecutionStore = defineStore('execution', () => {
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
     clearInitializationByJobId(activeJobId.value)
 
+    if (
+      !isConcurrentExecutionEnabled.value ||
+      !focusedJobId.value ||
+      !queuedJobs.value[focusedJobId.value]
+    ) {
+      setFocusedJob(activeJobId.value)
+    }
+
     // Ensure path mapping exists — execution_start can arrive via WebSocket
     // before the HTTP response from queuePrompt triggers storeJob.
     if (!jobIdToSessionWorkflowPath.value.has(activeJobId.value)) {
@@ -500,9 +523,10 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionCached(e: CustomEvent<ExecutionCachedWsMessage>) {
-    if (!activeJob.value) return
+    const job = queuedJobs.value[e.detail.prompt_id]
+    if (!job) return
     for (const n of e.detail.nodes) {
-      activeJob.value.nodes[n] = true
+      job.nodes[n] = true
     }
   }
 
@@ -519,13 +543,14 @@ export const useExecutionStore = defineStore('execution', () => {
     })
     const workflow = jobIdToWorkflow.get(jobId)
     if (workflow) clearWorkflowStatus(workflow)
-    if (activeJobId.value) clearInitializationByJobId(activeJobId.value)
+    clearInitializationByJobId(jobId)
     resetExecutionState(jobId)
   }
 
   function handleExecuted(e: CustomEvent<ExecutedWsMessage>) {
-    if (!activeJob.value) return
-    activeJob.value.nodes[e.detail.node] = true
+    const job = queuedJobs.value[e.detail.prompt_id]
+    if (!job) return
+    job.nodes[e.detail.node] = true
   }
 
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
@@ -563,7 +588,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (!activeJob.value) return
 
     // Update the executing nodes list
-    if (e.detail == null) {
+    if (e.detail == null && !isConcurrentExecutionEnabled.value) {
       activeJobId.value = null
     }
   }
@@ -602,7 +627,11 @@ export const useExecutionStore = defineStore('execution', () => {
   )
 
   function handleProgressState(e: CustomEvent<ProgressStateWsMessage>) {
-    progressStateCoalescer.push(e.detail)
+    if (isConcurrentExecutionEnabled.value) {
+      applyProgressState(e.detail)
+    } else {
+      progressStateCoalescer.push(e.detail)
+    }
   }
 
   function applyProgressState(detail: ProgressStateWsMessage) {
@@ -629,6 +658,10 @@ export const useExecutionStore = defineStore('execution', () => {
       [jobId]: nodes
     }
     evictOldProgressJobs()
+
+    if (isConcurrentExecutionEnabled.value && jobId !== focusedJobId.value)
+      return
+
     nodeProgressStates.value = nodes
 
     // If we have progress for the currently executing node, update it for backwards compatibility
@@ -648,6 +681,11 @@ export const useExecutionStore = defineStore('execution', () => {
   }, 'raf:progress')
 
   function handleProgress(e: CustomEvent<ProgressWsMessage>) {
+    if (
+      isConcurrentExecutionEnabled.value &&
+      e.detail.prompt_id !== focusedJobId.value
+    )
+      return
     progressCoalescer.push(e.detail)
   }
 
@@ -890,23 +928,46 @@ export const useExecutionStore = defineStore('execution', () => {
    * Reset execution-related state after a run completes or is stopped.
    */
   function resetExecutionState(jobIdParam?: JobId | null) {
-    cancelPendingProgressUpdates()
-
-    executionIdToLocatorCache.clear()
-    nodeProgressStates.value = {}
     const jobId = jobIdParam ?? activeJobId.value ?? null
     const runErrorKey = jobId ? runErrorKeyForJob(jobId) : undefined
+    const resetsFocusedJob = !jobIdParam || jobId === focusedJobId.value
+
+    if (!isConcurrentExecutionEnabled.value || resetsFocusedJob) {
+      cancelPendingProgressUpdates()
+      executionIdToLocatorCache.clear()
+    }
+
     if (jobId) {
       const map = { ...nodeProgressStatesByJob.value }
       delete map[jobId]
       nodeProgressStatesByJob.value = map
       useJobPreviewStore().clearPreview(jobId)
       jobIdToWorkflow.delete(jobId)
+      delete queuedJobs.value[jobId]
     }
-    if (jobId) delete queuedJobs.value[jobId]
-    activeJobId.value = null
-    _executingNodeProgress.value = null
+
+    if (isConcurrentExecutionEnabled.value) {
+      if (!jobIdParam || jobId === activeJobId.value) {
+        activeJobId.value = runningJobIds.value[0] ?? null
+      }
+      if (resetsFocusedJob) {
+        setFocusedJob(runningJobIds.value[0] ?? null)
+      }
+    } else {
+      activeJobId.value = null
+      focusedJobId.value = null
+      nodeProgressStates.value = {}
+      _executingNodeProgress.value = null
+    }
     executionErrorStore.clearPromptError(runErrorKey)
+  }
+
+  function setFocusedJob(jobId: JobId | null) {
+    focusedJobId.value = jobId
+    nodeProgressStates.value = jobId
+      ? (nodeProgressStatesByJob.value[jobId] ?? {})
+      : {}
+    _executingNodeProgress.value = null
   }
 
   function getNodeIdIfExecuting(nodeId: string | number) {
@@ -921,8 +982,10 @@ export const useExecutionStore = defineStore('execution', () => {
     if (!text || !nodeId) return
 
     // Filter: only accept progress for the active prompt
-    if (prompt_id && activeJobId.value && prompt_id !== activeJobId.value)
-      return
+    const visibleJobId = isConcurrentExecutionEnabled.value
+      ? focusedJobId.value
+      : activeJobId.value
+    if (prompt_id && visibleJobId && prompt_id !== visibleJobId) return
 
     // Handle execution node IDs for subgraphs
     const currentId = getNodeIdIfExecuting(nodeId)
@@ -1090,6 +1153,10 @@ export const useExecutionStore = defineStore('execution', () => {
     () => runningJobIds.value.length
   )
 
+  const isConcurrentExecutionActive = computed(
+    () => runningJobIds.value.length > 1
+  )
+
   const isActiveWorkflowRunning = computed(() => {
     if (!activeJobId.value) return false
     const path = workflowStore.activeWorkflow?.path
@@ -1101,10 +1168,13 @@ export const useExecutionStore = defineStore('execution', () => {
     isIdle,
     clientId,
     activeJobId,
+    focusedJobId,
     queuedJobs,
     executingNodeId,
     executingNodeIds,
     activeJob,
+    focusedJob,
+    isConcurrentExecutionActive,
     totalNodesToExecute,
     nodesExecuted,
     executionProgress,
@@ -1125,6 +1195,7 @@ export const useExecutionStore = defineStore('execution', () => {
     bindExecutionEvents,
     unbindExecutionEvents,
     storeJob,
+    setFocusedJob,
     registerJobWorkflowIdMapping,
     uniqueExecutingNodeIdStrings,
     // Raw executing progress data for backward compatibility in ComfyApp.

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -9,7 +9,11 @@ import { useReconnectingNotification } from '@/composables/useReconnectingNotifi
 import type * as DistTypes from '@/platform/distribution/types'
 import type * as I18nModule from '@/i18n'
 
-const apiMock = vi.hoisted(() => new EventTarget())
+const apiMock = vi.hoisted(() =>
+  Object.assign(new EventTarget(), {
+    getServerFeature: vi.fn(() => undefined)
+  })
+)
 const distribution = vi.hoisted(() => ({ isCloud: false }))
 
 vi.mock('@/scripts/api', () => ({ api: apiMock }))

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -29,6 +29,7 @@
   <ManagerProgressToast />
   <DesktopCloudNotificationController />
   <UnloadWindowConfirmDialog v-if="!isDesktop" />
+  <ConcurrentExecutionDialog />
   <MenuHamburger />
   <TourOverlay v-if="graphReady" />
   <FirstRunTour />
@@ -50,6 +51,7 @@ import {
 
 import { runWhenGlobalIdle } from '@/base/common/async'
 import MenuHamburger from '@/components/MenuHamburger.vue'
+import ConcurrentExecutionDialog from '@/components/dialog/ConcurrentExecutionDialog.vue'
 import UnloadWindowConfirmDialog from '@/components/dialog/UnloadWindowConfirmDialog.vue'
 import GraphCanvas from '@/components/graph/GraphCanvas.vue'
 import PartnerNodesEducationCard from '@/components/actionbar/PartnerNodesEducationCard.vue'


### PR DESCRIPTION
## Summary

Ports the concurrent job execution work from #9789 onto current `main` without carrying the historical branch's unrelated merge conflicts.

- separates the latest active job from the job whose progress is focused on canvas
- routes execution/progress events by `prompt_id` and keeps concurrent jobs independent
- adds feature-flagged parallel controls, running/queued counts, focus controls, and onboarding
- disables auto-queue while parallel execution is enabled

## Source

Salvaged from #9789 (`concurrent-job-execution` at `2abee13fe6a8b1a158ddab18fdd48dc43010b1f8`). The old branch is not merged into this branch; this is a clean current-main port.

## Verification

- 263 focused tests passed across execution store, auto-queue, queue list, linear output, actionbar, queue button, and top menu
- `pnpm typecheck`
- `pnpm lint` (commit hook)
- `pnpm exec oxfmt --write` (commit hook)
- `knip --cache` (pre-push hook)
- `git diff --check`

## Review notes

The feature remains disabled unless both the server flag and cloud user setting are enabled. Existing single-job behavior remains the fallback when the flag is off.
