### PR TITLE
fix(agent): reorder add-menu so assets entry precedes add-nodes (PM-855)

### DIFF
--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -511,7 +511,17 @@ defineExpose({
               class="agent-scope bg-agent-surface-raised z-1100 box-border w-max min-w-[186px] rounded-[10px] border border-white/10 p-1 font-inter shadow-lg"
             >
               <DropdownMenuItem
+                v-if="canOpenAssets"
                 class="text-agent-fg data-highlighted:bg-agent-surface-hover mb-0.5 box-border flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[14px]/5 font-normal outline-none"
+                @select="emit('openAssets')"
+              >
+                <span class="icon-[comfy--image-ai-edit] size-4 shrink-0" />
+                <span class="whitespace-nowrap">
+                  {{ t('agent.addFromAssets') }}
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                class="text-agent-fg data-highlighted:bg-agent-surface-hover box-border flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[14px]/5 font-normal outline-none"
                 @select="emit('selectNodes')"
               >
                 <span
@@ -519,16 +529,6 @@ defineExpose({
                 />
                 <span class="whitespace-nowrap">
                   {{ t('agent.addNodesFromGraph') }}
-                </span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                v-if="canOpenAssets"
-                class="text-agent-fg data-highlighted:bg-agent-surface-hover box-border flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[14px]/5 font-normal outline-none"
-                @select="emit('openAssets')"
-              >
-                <span class="icon-[comfy--image-ai-edit] size-4 shrink-0" />
-                <span class="whitespace-nowrap">
-                  {{ t('agent.addFromAssets') }}
                 </span>
               </DropdownMenuItem>
               <DropdownMenuSeparator


### PR DESCRIPTION
## Summary

User feedback ([PM-855](https://linear.app/comfyorg/issue/PM-855/reorder-add-node-and-drag-asset-controls-to-reduce-misclicks), #comfy-agent-user-feedback 2026-09-04T02:54:19Z): the "add nodes from graph" entry sits closest to the prompt box in the composer add-menu, and fast mouse movement toward the prompt box misclicks it. This swaps the two add-menu entries so "Add from assets panel" renders first (top), above "Add nodes from graph".

## Changes

- `src/workbench/extensions/agent/components/agent/Composer.vue`: swapped the "Add from assets panel" and "Add nodes from graph" `DropdownMenuItem` blocks inside the "Add to prompt" menu. No handler, prop, i18n key, or conditional logic changed; the `mb-0.5` spacer class moved with the assets entry.

## Verification

- `pnpm vitest run src/workbench/extensions/agent/components/agent/Composer.test.ts` — 46/46 pass (tests anchor menu items by role/name; no test or e2e asserts the old order, confirmed by search).
- Menu emits unchanged: `openAssets` / `selectNodes` / `attach` all fire as before; keyboard navigation follows DOM order (now assets → nodes → attach).

Tracked by todo row `QAF-23` (queue-worker pass, 2026-09-04).