### PR TITLE
refactor: extract createDefaultErrorMapper behind useApiRequest

### DIFF
--- a/src/composables/apiErrorMapper.test.ts
+++ b/src/composables/apiErrorMapper.test.ts
@@ -1,0 +1,111 @@
+import { AxiosError, AxiosHeaders } from 'axios'
+import { describe, expect, it } from 'vitest'
+
+import { createDefaultErrorMapper } from '@/composables/apiErrorMapper'
+
+function axiosErrorWithResponse(
+  status: number,
+  data?: { message?: string },
+  message = 'Request failed'
+) {
+  const config = { headers: new AxiosHeaders() }
+  return new AxiosError(message, undefined, config, undefined, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data
+  })
+}
+
+function axiosErrorWithoutResponse(message: string) {
+  return new AxiosError(message, AxiosError.ERR_NETWORK, {
+    headers: new AxiosHeaders()
+  })
+}
+
+const mapError = createDefaultErrorMapper({
+  formatFallback: (context, message) => `${context}: ${message}`,
+  statusMessages: {
+    401: 'Unauthorized',
+    404: (message) => `Not found: ${message || 'Resource not found'}`
+  },
+  responseFallback: ({ context, status, dataMessage, axiosMessage }) =>
+    `${context} [${status}]: ${dataMessage || axiosMessage}`
+})
+
+describe('createDefaultErrorMapper', () => {
+  it('formats a thrown Error with its own message', () => {
+    expect(mapError(new Error('boom'), 'Failed to load')).toBe(
+      'Failed to load: boom'
+    )
+  })
+
+  it('renders a thrown non-Error with String() by default', () => {
+    expect(mapError({ nope: true }, 'Failed to load')).toBe(
+      'Failed to load: [object Object]'
+    )
+  })
+
+  it('renders a thrown non-Error with unknownErrorMessage when configured', () => {
+    const mapper = createDefaultErrorMapper({
+      formatFallback: (context, message) => `${context}: ${message}`,
+      unknownErrorMessage: 'Unknown error occurred',
+      responseFallback: () => 'unused'
+    })
+
+    expect(mapper('just a string', 'Failed to load')).toBe(
+      'Failed to load: Unknown error occurred'
+    )
+  })
+
+  it('falls back to the axios message when there is no response', () => {
+    expect(
+      mapError(axiosErrorWithoutResponse('Network Error'), 'Failed to load')
+    ).toBe('Failed to load: Network Error')
+  })
+
+  it('prefers route-specific copy over the status table', () => {
+    expect(
+      mapError(axiosErrorWithResponse(404), 'Failed to load', {
+        404: 'No such release'
+      })
+    ).toBe('No such release')
+  })
+
+  it('uses a string status entry verbatim', () => {
+    expect(
+      mapError(axiosErrorWithResponse(401, { message: 'token expired' }), 'ctx')
+    ).toBe('Unauthorized')
+  })
+
+  it('passes the response body message to a function status entry', () => {
+    expect(
+      mapError(axiosErrorWithResponse(404, { message: 'pack 42' }), 'ctx')
+    ).toBe('Not found: pack 42')
+  })
+
+  it('calls a function status entry with undefined when the body has no message', () => {
+    expect(mapError(axiosErrorWithResponse(404, {}), 'ctx')).toBe(
+      'Not found: Resource not found'
+    )
+  })
+
+  it('falls back for a status with no route-specific or table entry', () => {
+    expect(
+      mapError(
+        axiosErrorWithResponse(500, { message: 'db down' }, 'Request failed'),
+        'Failed to load'
+      )
+    ).toBe('Failed to load [500]: db down')
+  })
+
+  it('passes the axios message through when the response body is absent', () => {
+    expect(
+      mapError(
+        axiosErrorWithResponse(503, undefined, 'Service Unavailable'),
+        'Failed to load'
+      )
+    ).toBe('Failed to load [503]: Service Unavailable')
+  })
+})

--- a/src/composables/apiErrorMapper.ts
+++ b/src/composables/apiErrorMapper.ts
@@ -1,0 +1,64 @@
+import axios from 'axios'
+
+import type { ApiErrorMapper } from '@/composables/useApiRequest'
+
+interface ResponseFallbackArgs {
+  context: string
+  status: number
+  dataMessage?: string
+  axiosMessage: string
+}
+
+export interface DefaultErrorMapperOptions {
+  /** Joins the context with a message for the non-axios and no-response guards. */
+  formatFallback: (context: string, message: string) => string
+  /** Rendered in place of a thrown non-`Error` value; defaults to `String(err)`. */
+  unknownErrorMessage?: string
+  /** Per-status copy; a function receives the response body's message when present. */
+  statusMessages?: Record<number, string | ((dataMessage?: string) => string)>
+  /** Final fallback when no route-specific or status entry matches. */
+  responseFallback: (args: ResponseFallbackArgs) => string
+}
+
+/**
+ * Builds the error mapper every axios-backed service shares: guard the
+ * non-axios and no-response cases, then resolve the status against the
+ * caller's route-specific copy, its own status table, and its fallback.
+ * Only the copy differs between services, so only the copy is configured.
+ */
+export function createDefaultErrorMapper({
+  formatFallback,
+  unknownErrorMessage,
+  statusMessages,
+  responseFallback
+}: DefaultErrorMapperOptions): ApiErrorMapper {
+  return (err, context, routeSpecificErrors) => {
+    if (!axios.isAxiosError<{ message?: string }>(err))
+      return formatFallback(
+        context,
+        err instanceof Error
+          ? err.message
+          : (unknownErrorMessage ?? String(err))
+      )
+
+    if (!err.response) return formatFallback(context, err.message)
+
+    const { status, data } = err.response
+    const dataMessage = data?.message
+
+    if (routeSpecificErrors?.[status]) return routeSpecificErrors[status]
+
+    const statusMessage = statusMessages?.[status]
+    if (statusMessage !== undefined)
+      return typeof statusMessage === 'function'
+        ? statusMessage(dataMessage)
+        : statusMessage
+
+    return responseFallback({
+      context,
+      status,
+      dataMessage,
+      axiosMessage: err.message
+    })
+  }
+}

--- a/src/platform/updates/common/releaseService.ts
+++ b/src/platform/updates/common/releaseService.ts
@@ -1,7 +1,7 @@
-import type { AxiosError } from 'axios'
 import axios from 'axios'
 import { watch } from 'vue'
 
+import { createDefaultErrorMapper } from '@/composables/apiErrorMapper'
 import { useApiRequest } from '@/composables/useApiRequest'
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import type { components, operations } from '@/types/comfyRegistryTypes'
@@ -9,9 +9,6 @@ import type { components, operations } from '@/types/comfyRegistryTypes'
 // Use generated types from OpenAPI spec
 export type ReleaseNote = components['schemas']['ReleaseNote']
 type GetReleasesParams = operations['getReleaseNotes']['parameters']['query']
-
-// Use generated error response type
-type ErrorResponse = components['schemas']['ErrorResponse']
 
 const releaseApiClient = axios.create({
   baseURL: getComfyApiBaseUrl(),
@@ -29,42 +26,19 @@ export const useReleaseService = () => {
     }
   )
 
-  const mapError = (
-    err: unknown,
-    context: string,
-    routeSpecificErrors?: Record<number, string>
-  ): string => {
-    if (!axios.isAxiosError(err))
-      return err instanceof Error
-        ? `${context}: ${err.message}`
-        : `${context}: Unknown error occurred`
-
-    const axiosError = err as AxiosError<ErrorResponse>
-
-    if (axiosError.response) {
-      const { status, data } = axiosError.response
-
-      if (routeSpecificErrors && routeSpecificErrors[status])
-        return routeSpecificErrors[status]
-
-      switch (status) {
-        case 400:
-          return `Bad request: ${data?.message || 'Invalid input'}`
-        case 401:
-          return 'Unauthorized: Authentication required'
-        case 403:
-          return `Forbidden: ${data?.message || 'Access denied'}`
-        case 404:
-          return `Not found: ${data?.message || 'Resource not found'}`
-        case 500:
-          return `Server error: ${data?.message || 'Internal server error'}`
-        default:
-          return `${context}: ${data?.message || axiosError.message}`
-      }
-    }
-
-    return `${context}: ${axiosError.message}`
-  }
+  const mapError = createDefaultErrorMapper({
+    formatFallback: (context, message) => `${context}: ${message}`,
+    unknownErrorMessage: 'Unknown error occurred',
+    statusMessages: {
+      400: (message) => `Bad request: ${message || 'Invalid input'}`,
+      401: 'Unauthorized: Authentication required',
+      403: (message) => `Forbidden: ${message || 'Access denied'}`,
+      404: (message) => `Not found: ${message || 'Resource not found'}`,
+      500: (message) => `Server error: ${message || 'Internal server error'}`
+    },
+    responseFallback: ({ context, dataMessage, axiosMessage }) =>
+      `${context}: ${dataMessage || axiosMessage}`
+  })
 
   const { isLoading, error, executeRequest } = useApiRequest({
     client: releaseApiClient,

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -1,6 +1,6 @@
-import type { AxiosError } from 'axios'
 import axios from 'axios'
 
+import { createDefaultErrorMapper } from '@/composables/apiErrorMapper'
 import { useApiRequest } from '@/composables/useApiRequest'
 import type { components, operations } from '@/types/comfyRegistryTypes'
 
@@ -21,44 +21,20 @@ const registryApiClient = axios.create({
  * Service for interacting with the Comfy Registry API
  */
 export const useComfyRegistryService = () => {
-  const mapError = (
-    err: unknown,
-    context: string,
-    routeSpecificErrors?: Record<number, string>
-  ): string => {
-    if (!axios.isAxiosError(err))
-      return err instanceof Error
-        ? `${context}: ${err.message}`
-        : `${context}: Unknown error occurred`
-
-    const axiosError = err as AxiosError<components['schemas']['ErrorResponse']>
-
-    if (axiosError.response) {
-      const { status, data } = axiosError.response
-
-      if (routeSpecificErrors && routeSpecificErrors[status])
-        return routeSpecificErrors[status]
-
-      switch (status) {
-        case 400:
-          return `Bad request: ${data?.message || 'Invalid input'}`
-        case 401:
-          return 'Unauthorized: Authentication required'
-        case 403:
-          return `Forbidden: ${data?.message || 'Access denied'}`
-        case 404:
-          return `Not found: ${data?.message || 'Resource not found'}`
-        case 409:
-          return `Conflict: ${data?.message || 'Resource conflict'}`
-        case 500:
-          return `Server error: ${data?.message || 'Internal server error'}`
-        default:
-          return `${context}: ${data?.message || axiosError.message}`
-      }
-    }
-
-    return `${context}: ${axiosError.message}`
-  }
+  const mapError = createDefaultErrorMapper({
+    formatFallback: (context, message) => `${context}: ${message}`,
+    unknownErrorMessage: 'Unknown error occurred',
+    statusMessages: {
+      400: (message) => `Bad request: ${message || 'Invalid input'}`,
+      401: 'Unauthorized: Authentication required',
+      403: (message) => `Forbidden: ${message || 'Access denied'}`,
+      404: (message) => `Not found: ${message || 'Resource not found'}`,
+      409: (message) => `Conflict: ${message || 'Resource conflict'}`,
+      500: (message) => `Server error: ${message || 'Internal server error'}`
+    },
+    responseFallback: ({ context, dataMessage, axiosMessage }) =>
+      `${context}: ${dataMessage || axiosMessage}`
+  })
 
   const { isLoading, error, executeRequest } = useApiRequest({
     client: registryApiClient,

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -1,7 +1,7 @@
-import type { AxiosError } from 'axios'
 import axios from 'axios'
 import { ref, watch } from 'vue'
 
+import { createDefaultErrorMapper } from '@/composables/apiErrorMapper'
 import { useApiRequest } from '@/composables/useApiRequest'
 import { attachUnifiedRemintInterceptor } from '@/platform/auth/unified/remintRetry'
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
@@ -24,8 +24,6 @@ type CustomerEventsResponseQuery =
 
 export type AuditLog = components['schemas']['AuditLog']
 
-type ErrorResponse = components['schemas']['ErrorResponse']
-
 const customerApiClient = axios.create({
   baseURL: getComfyApiBaseUrl(),
   headers: {
@@ -46,30 +44,11 @@ export const useCustomerEventsService = () => {
     }
   )
 
-  const mapError = (
-    err: unknown,
-    context: string,
-    routeSpecificErrors?: Record<number, string>
-  ): string => {
-    if (!axios.isAxiosError(err)) {
-      return `${context} failed: ${err instanceof Error ? err.message : String(err)}`
-    }
-
-    const axiosError = err as AxiosError<ErrorResponse>
-    if (!axiosError.response) {
-      return `${context} failed: ${axiosError.message}`
-    }
-
-    const status = axiosError.response.status
-    if (routeSpecificErrors?.[status]) {
-      return routeSpecificErrors[status]
-    }
-
-    return (
-      axiosError.response.data?.message ??
-      `${context} failed with status ${status}`
-    )
-  }
+  const mapError = createDefaultErrorMapper({
+    formatFallback: (context, message) => `${context} failed: ${message}`,
+    responseFallback: ({ context, status, dataMessage }) =>
+      dataMessage ?? `${context} failed with status ${status}`
+  })
 
   const { error, executeRequest } = useApiRequest({
     client: customerApiClient,

--- a/src/workbench/extensions/manager/services/comfyManagerService.ts
+++ b/src/workbench/extensions/manager/services/comfyManagerService.ts
@@ -1,7 +1,8 @@
-import type { AxiosError, AxiosInstance, AxiosResponse } from 'axios'
+import type { AxiosInstance, AxiosResponse } from 'axios'
 import axios from 'axios'
 import { v4 as uuidv4 } from 'uuid'
 
+import { createDefaultErrorMapper } from '@/composables/apiErrorMapper'
 import type { ExecuteRequestOptions } from '@/composables/useApiRequest'
 import { useApiRequest } from '@/composables/useApiRequest'
 import { reportError } from '@/platform/telemetry/reportError'
@@ -58,33 +59,12 @@ export const useComfyManagerService = () => {
     return managerState.isNewManagerUI.value
   }
 
-  const mapError = (
-    err: unknown,
-    context: string,
-    routeSpecificErrors?: Record<number, string>
-  ): string => {
-    if (!axios.isAxiosError(err)) {
-      return `${context} failed: ${err instanceof Error ? err.message : String(err)}`
-    }
-
-    const axiosError = err as AxiosError<{ message: string }>
-    if (!axiosError.response) {
-      return `${context} failed: ${axiosError.message}`
-    }
-
-    const status = axiosError.response.status
-    if (routeSpecificErrors?.[status]) {
-      return routeSpecificErrors[status]
-    }
-    if (status === 404) {
-      return 'Could not connect to ComfyUI-Manager'
-    }
-
-    return (
-      axiosError.response.data?.message ??
-      `${context} failed with status ${status}`
-    )
-  }
+  const mapError = createDefaultErrorMapper({
+    formatFallback: (context, message) => `${context} failed: ${message}`,
+    statusMessages: { 404: 'Could not connect to ComfyUI-Manager' },
+    responseFallback: ({ context, status, dataMessage }) =>
+      dataMessage ?? `${context} failed with status ${status}`
+  })
 
   const {
     isLoading,


### PR DESCRIPTION
**STACKED — merging lands on `matt/be-2254-extract-api-request-composable` (owned by @mattmillerai), NOT `main`.**

## ELI-5

Four services each wrote out the same "turn this error into a sentence" recipe. The recipe is now written once; each service just hands it its own words. Nobody sees a different message than before.

## Summary

Consolidate the four near-identical `mapError` implementations left per-service by the base PR into one `createDefaultErrorMapper` factory, keeping every service's user-facing copy verbatim.

## Changes

- **What**: New `src/composables/apiErrorMapper.ts` exporting `createDefaultErrorMapper`, which owns the shared skeleton — non-axios guard → no-response guard → `routeSpecificErrors[status]` → `statusMessages[status]` → `responseFallback`. `comfyRegistryService`, `releaseService`, `comfyManagerService` and `customerEventsService` now configure that factory with their existing copy instead of re-implementing the skeleton. Response data is typed `{ message?: string }` inside the factory, so the four per-service `AxiosError<…>` casts (and two now-unused `ErrorResponse` aliases) are gone. Net −91 lines of service code.
- **Breaking**: none — behavior-preserving. No rendered string changed and no copy was converged across services (registry keeps its `409`, release does not; manager keeps its `404`, customerEvents does not).

## Review Focus

Two lookups deliberately use *different* emptiness checks, because the originals did:

- `routeSpecificErrors?.[status]` is **truthy**-checked, so an empty-string route override falls through — as it did in all four originals.
- `statusMessages?.[status]` is checked with `!== undefined`, because it replaces a `switch` where the presence of a `case` is what fires it. A truthy check here would silently change an empty-string status entry into a fallback.

The two error families also differ on the non-axios, non-`Error` branch: registry/release render `Unknown error occurred`, manager/customerEvents render `String(err)`. That is carried by the optional `unknownErrorMessage` option (a string, defaulting to `String(err)`) rather than a `formatNonError` callback — a string keeps the four call-site configs smaller, which is what the spec asked for when it left the choice open.

`'Could not connect to ComfyUI-Manager'` appears on the `+` side of the diff but is a **move, not a new denial**: byte-identical to the removed literal and reachable under exactly the same condition (status 404, after the route-specific override). No capability is newly denied anywhere in this diff, so there is no negative claim to falsify.

Placement note: the pre-commit hook warns that `src/composables/` is a wound-down directory. Kept the file there anyway — it is the sibling of `useApiRequest.ts`, whose `ApiErrorMapper` type it implements, and splitting the two across directories would be worse than the warning.

## Verification

- `pnpm test:unit` on `comfyRegistryService.test.ts`, `releaseService.test.ts`, `customerEventsService.test.ts`, `comfyManagerService.test.ts` — 102 passed, **zero assertion edits**; `git status` confirms no test file under those paths is modified by this branch. Those suites pin the copy directly (`Unauthorized: Authentication required`, `Could not connect to ComfyUI-Manager`, `… failed with status 500`), so passing them unchanged is the behavior-preservation proof.
- New `apiErrorMapper.test.ts` — 10 tests covering both guards, lookup precedence, string-vs-function status entries, a function entry receiving `undefined`, and both fallback shapes.
- Downstream consumers `comfyRegistryStore.test.ts`, `comfyManagerStore.test.ts`, `useConflictDetection.test.ts` — 42 passed.
- `pnpm typecheck`, `pnpm knip`, `eslint`, `oxlint --type-aware`, `oxfmt` — all clean.

## Residual

- **The base PR is not merged, and has changes requested.** This PR is stacked on `matt/be-2254-extract-api-request-composable`, which is `BLOCKED` / `CHANGES_REQUESTED` at the time of writing. The `ApiErrorMapper` seam this factory plugs into exists only on that branch. If the base PR's mapper contract changes in response to its review, this branch needs a rebase and the four configs need re-checking against whatever the contract becomes; if the base PR is closed unmerged, close this one too. The follow-up work item is: re-verify this stack after the base PR settles.
- **Not attempted: converging the copy tables.** Registry and release differ only by a `409` entry; manager and customerEvents differ only by a `404` entry. Those near-duplicates are deliberate here — unifying them is a user-visible copy change, out of scope for a behavior-preserving consolidation, and worth its own ticket with product input on what each service should actually say.
- **Not attempted: the fetch-based error-body parsers.** A separate in-flight change routes those through `parseErrorResponse`. Different files, no overlap, and the axios mapper skeleton is deliberately not merged into it.
- **Sweep of what is NOT being fixed.** Four other non-test call sites in `src/` use `axios.isAxiosError` and are untouched, having been read and confirmed to be a different shape rather than skipped: `platform/workspace/api/workspaceApi.ts` (throws a structured `WorkspaceApiError` with a server `code`, not user-facing copy), `platform/workspace/api/capabilityRevision.ts` (publishes the response and rethrows), `platform/auth/unified/remintRetry.ts` (retry predicates and telemetry status), `stores/bootstrapStore.ts` (a 404 swallow). None implements the `ApiErrorMapper` contract, so none is a fifth instance of the duplication this PR removes.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** targeted `pnpm test:unit` on the 4 service suites + 3 consumer suites + the new factory suite — 154 passed, 0 failed, 0 assertion edits to pre-existing tests; `pnpm typecheck` clean; `pnpm knip` clean; `eslint` + `oxlint --type-aware` + `oxfmt` clean via lint-staged at commit time
- **Deviations:** the non-`Error` branch is configured with a string option (`unknownErrorMessage`) rather than the `formatNonError` callback the spec sketched — the spec left that choice open to whichever kept the four configs smallest. The factory lives in the sibling `apiErrorMapper.ts` rather than inside `useApiRequest.ts`, also an option the spec offered.
