### PR TITLE
fix: split subfolder from filename in getMediaUrl for correct /api/view thumbnails

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -283,6 +283,20 @@ describe('useWidgetSelectItems', () => {
       )
       expect(dropdownItems.value[0].preview_url).toContain('type=input')
     })
+
+    it('splits subfolder from filename in preview URL', () => {
+      const { dropdownItems } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => ['subfolder/nested/img_001.png'],
+          modelValue: ref('subfolder/nested/img_001.png'),
+          assetKind: () => 'image'
+        })
+      )
+      const url = dropdownItems.value[0].preview_url
+      expect(url).toContain('filename=img_001.png')
+      expect(url).toContain('subfolder=subfolder%2Fnested')
+      expect(url).toContain('type=input')
+    })
   })
 
   describe('cloud asset mode', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
@@ -28,6 +28,7 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import type { AssetKind } from '@/types/widgetTypes'
 import { getMediaTypeFromFilename } from '@/utils/formatUtil'
+import { parseImageWidgetValue } from '@/utils/imageUtil'
 import type { PagedList } from '@/utils/pagedList'
 
 function getDisplayLabel(
@@ -48,13 +49,19 @@ function assetKindToMediaType(kind: AssetKind): string {
   return kind === 'mesh' ? '3D' : kind
 }
 
+/** Builds an `/api/view` preview URL, splitting any subfolder prefix out of `filename`. */
 function getMediaUrl(
   filename: string,
   type: 'input' | 'output',
   assetKind: AssetKind | undefined
 ): string {
   if (!['image', 'video', 'audio'].includes(assetKind ?? '')) return ''
-  const params = new URLSearchParams({ filename, type })
+  const parsed = parseImageWidgetValue(filename)
+  const params = new URLSearchParams({
+    filename: parsed.filename,
+    type: parsed.type !== 'input' ? parsed.type : type
+  })
+  if (parsed.subfolder) params.set('subfolder', parsed.subfolder)
   appendCloudResParam(params, filename)
   return `/api/view?${params}`
 }


### PR DESCRIPTION
## Summary

Fix broken thumbnails in the image combo dropdown for values containing subfolder paths (e.g. `subfolder/image.png`).

Supersedes #12438, which was closed due to branch drift — this branch is rebased onto current main and contains only the single focused commit.

## Changes

`getMediaUrl` in `useWidgetSelectItems.ts` now uses the existing `parseImageWidgetValue` utility to split subfolder-prefixed filenames into separate `filename` and `subfolder` query parameters when constructing `/api/view` URLs. Added a test case for nested subfolder paths.

## Review Focus

The `/api/view` endpoint calls `os.path.basename(filename)` on the filename param, stripping any embedded path components. It already supports a separate `subfolder` query parameter (and `parseImageWidgetValue` already exists for exactly this split), but `getMediaUrl` wasn't using it. Flat filenames are unaffected — `parseImageWidgetValue` returns an empty subfolder string and no param is added.

Fixes #12437

**E2E test rationale:** The fix modifies pure URL construction logic in getMediaUrl, which is fully validated by the added unit test. An E2E regression test would require a backend serving images from nested subfolders to verify thumbnail rendering, making it fragile and environment-dependent. The unit test directly asserts the correct filename and subfolder query parameter splitting, which is the root cause of the bug.