### PR TITLE
fix: report DOM widget mount failures

### DIFF
--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -278,12 +278,13 @@ describe('native DOM widget interaction lifecycle', () => {
     const widgetState = createWidgetState(false)
     const input = document.createElement('input')
     Object.assign(widgetState.widget, { element: input })
-    const appendChild = vi
-      .spyOn(HTMLElement.prototype, 'appendChild')
-      .mockImplementation(function (this: HTMLElement, child: Node) {
-        if (child === input) throw new Error('mount failed')
-        return Node.prototype.appendChild.call(this, child)
-      })
+    vi.spyOn(HTMLElement.prototype, 'appendChild').mockImplementation(function (
+      this: HTMLElement,
+      child: Node
+    ) {
+      if (child === input) throw new Error('mount failed')
+      return Node.prototype.appendChild.call(this, child)
+    })
 
     const rendered = render(DomWidget, {
       props: { widgetState }
@@ -309,7 +310,6 @@ describe('native DOM widget interaction lifecycle', () => {
     })
     expect(rendered.container).not.toContainElement(input)
 
-    appendChild.mockRestore()
     rendered.unmount()
   })
 

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -271,7 +271,6 @@ describe('DomWidget position update matrix', () => {
 describe('native DOM widget interaction lifecycle', () => {
   afterEach(() => {
     useDomWidgetStore().clear()
-    vi.mocked(reportError).mockClear()
   })
 
   it('reports and contains DOM widget mount failures', async () => {
@@ -298,8 +297,7 @@ describe('native DOM widget interaction lifecycle', () => {
         failure_kind: 'caught_unexpected',
         feature_area: 'canvas',
         operation: 'render',
-        outcome: 'failed',
-        assert_mode: 'soft'
+        outcome: 'failed'
       },
       context: {
         nodeId: 1,

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -5,6 +5,7 @@ import { nextTick, reactive, ref } from 'vue'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import type { DomWidgetState } from '@/stores/domWidgetStore'
@@ -12,6 +13,10 @@ import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import DomWidget from './DomWidget.vue'
+
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: vi.fn()
+}))
 
 beforeEach(() => {
   useCanvasStore().canvas = fromPartial({
@@ -266,6 +271,46 @@ describe('DomWidget position update matrix', () => {
 describe('native DOM widget interaction lifecycle', () => {
   afterEach(() => {
     useDomWidgetStore().clear()
+    vi.mocked(reportError).mockClear()
+  })
+
+  it('reports and contains DOM widget mount failures', async () => {
+    const widgetState = createWidgetState(false)
+    const input = document.createElement('input')
+    Object.assign(widgetState.widget, { element: input })
+    const appendChild = vi
+      .spyOn(HTMLElement.prototype, 'appendChild')
+      .mockImplementation(function (this: HTMLElement, child: Node) {
+        if (child === input) throw new Error('mount failed')
+        return Node.prototype.appendChild.call(this, child)
+      })
+
+    const rendered = render(DomWidget, {
+      props: { widgetState }
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(reportError).toHaveBeenCalledWith(new Error('mount failed'), {
+      errorType: 'canvas_dom_widget_mount_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'canvas',
+        operation: 'render',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: {
+        nodeId: 1,
+        visible: true,
+        hasElement: true
+      },
+      level: 'error'
+    })
+    expect(rendered.container).not.toContainElement(input)
+
+    appendChild.mockRestore()
+    rendered.unmount()
   })
 
   it('preserves selection and outside-click focus behavior, then removes listeners', async () => {

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -5,7 +5,6 @@ import { nextTick, reactive, ref } from 'vue'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { reportError } from '@/platform/telemetry/reportError'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import type { DomWidgetState } from '@/stores/domWidgetStore'
@@ -13,9 +12,10 @@ import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import DomWidget from './DomWidget.vue'
+import { reportDomWidgetMountFailure } from './domWidgetMountReporting'
 
-vi.mock(import('@/platform/telemetry/reportError'), () => ({
-  reportError: vi.fn()
+vi.mock(import('./domWidgetMountReporting'), () => ({
+  reportDomWidgetMountFailure: vi.fn()
 }))
 
 beforeEach(() => {
@@ -273,8 +273,7 @@ describe('native DOM widget interaction lifecycle', () => {
     useDomWidgetStore().clear()
   })
 
-  it('reports and contains DOM widget mount failures', async () => {
-    const widgetState = createWidgetState(false)
+  function renderWithUnmountableElement(widgetState: DomWidgetState) {
     const input = document.createElement('input')
     Object.assign(widgetState.widget, { element: input })
     vi.spyOn(HTMLElement.prototype, 'appendChild').mockImplementation(function (
@@ -285,28 +284,67 @@ describe('native DOM widget interaction lifecycle', () => {
       return Node.prototype.appendChild.call(this, child)
     })
 
+    const escapedErrors: unknown[] = []
     const rendered = render(DomWidget, {
-      props: { widgetState }
+      props: { widgetState },
+      global: { config: { errorHandler: (error) => escapedErrors.push(error) } }
     })
+
+    return { rendered, escapedErrors }
+  }
+
+  it('reports a mount failure on the initial mount', async () => {
+    const widgetState = createWidgetState(false)
+    const { rendered, escapedErrors } =
+      renderWithUnmountableElement(widgetState)
     await nextTick()
     await nextTick()
 
-    expect(reportError).toHaveBeenCalledWith(new Error('mount failed'), {
-      errorType: 'canvas_dom_widget_mount_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'canvas',
-        operation: 'render',
-        outcome: 'failed'
-      },
-      context: {
-        nodeId: 1,
-        visible: true,
-        hasElement: true
-      },
-      level: 'error'
-    })
-    expect(rendered.container).not.toContainElement(input)
+    expect(reportDomWidgetMountFailure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: 'mount failed' }),
+      {
+        nodeId: widgetState.widget.node.id,
+        nodeType: widgetState.widget.node.type,
+        widgetName: 'test_widget'
+      }
+    )
+    expect(escapedErrors).toEqual([])
+
+    rendered.unmount()
+  })
+
+  it('reports a mount failure when the widget becomes visible', async () => {
+    const widgetState = createWidgetState(false)
+    widgetState.visible = false
+    const { rendered, escapedErrors } =
+      renderWithUnmountableElement(widgetState)
+    await nextTick()
+    await nextTick()
+    vi.mocked(reportDomWidgetMountFailure).mockClear()
+
+    widgetState.visible = true
+    await nextTick()
+
+    expect(reportDomWidgetMountFailure).toHaveBeenCalledOnce()
+    expect(escapedErrors).toEqual([])
+
+    rendered.unmount()
+  })
+
+  it('reports a mount failure when linear mode is left', async () => {
+    Object.assign(useCanvasStore(), { linearMode: true })
+    const widgetState = createWidgetState(false)
+    const { rendered, escapedErrors } =
+      renderWithUnmountableElement(widgetState)
+    await nextTick()
+    await nextTick()
+    vi.mocked(reportDomWidgetMountFailure).mockClear()
+
+    Object.assign(useCanvasStore(), { linearMode: false })
+    await nextTick()
+
+    expect(reportDomWidgetMountFailure).toHaveBeenCalledOnce()
+    expect(escapedErrors).toEqual([])
 
     rendered.unmount()
   })

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -193,8 +193,7 @@ onMounted(() => {
         failure_kind: 'caught_unexpected',
         feature_area: 'canvas',
         operation: 'render',
-        outcome: 'failed',
-        assert_mode: 'soft'
+        outcome: 'failed'
       },
       context: {
         nodeId: widget.node.id,

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -27,6 +27,7 @@ import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
 import { useDomClipping } from '@/composables/element/useDomClipping'
 import { findFirstNode } from '@/lib/litegraph/src/utils/collections'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { isComponentWidget, isDOMWidget } from '@/scripts/domWidget'
 import type { DomWidgetState } from '@/stores/domWidgetStore'
@@ -186,7 +187,22 @@ onMounted(() => {
   nextTick(() => {
     mountElementIfVisible()
   }).catch((error) => {
-    console.error('Error mounting DOM widget element:', error)
+    reportError(error, {
+      errorType: 'canvas_dom_widget_mount_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'canvas',
+        operation: 'render',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: {
+        nodeId: widget.node.id,
+        visible: widgetState.visible,
+        hasElement: Boolean(widgetElement.value)
+      },
+      level: 'error'
+    })
   })
 })
 

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -27,10 +27,11 @@ import { useAbsolutePosition } from '@/composables/element/useAbsolutePosition'
 import { useDomClipping } from '@/composables/element/useDomClipping'
 import { findFirstNode } from '@/lib/litegraph/src/utils/collections'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { reportError } from '@/platform/telemetry/reportError'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { isComponentWidget, isDOMWidget } from '@/scripts/domWidget'
 import type { DomWidgetState } from '@/stores/domWidgetStore'
+
+import { reportDomWidgetMountFailure } from './domWidgetMountReporting'
 
 const { widgetState } = defineProps<{
   widgetState: DomWidgetState
@@ -178,31 +179,21 @@ const mountElementIfVisible = () => {
     return
   }
 
-  widget.element.classList.add('h-full', 'w-full')
-  widgetElement.value.appendChild(widget.element)
+  try {
+    widget.element.classList.add('h-full', 'w-full')
+    widgetElement.value.appendChild(widget.element)
+  } catch (error) {
+    reportDomWidgetMountFailure(error, {
+      nodeId: widget.node.id,
+      nodeType: widget.node.type,
+      widgetName: widget.name
+    })
+  }
 }
 
 // Check on mount - but only after next tick to ensure visibility is calculated
 onMounted(() => {
-  nextTick(() => {
-    mountElementIfVisible()
-  }).catch((error) => {
-    reportError(error, {
-      errorType: 'canvas_dom_widget_mount_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'canvas',
-        operation: 'render',
-        outcome: 'failed'
-      },
-      context: {
-        nodeId: widget.node.id,
-        visible: widgetState.visible,
-        hasElement: Boolean(widgetElement.value)
-      },
-      level: 'error'
-    })
-  })
+  void nextTick(mountElementIfVisible)
 })
 
 // And watch for visibility changes

--- a/src/components/graph/widgets/domWidgetMountReporting.test.ts
+++ b/src/components/graph/widgets/domWidgetMountReporting.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { toNodeId } from '@/types/nodeId'
+
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: mockReportError
+}))
+
+async function loadReporter() {
+  vi.resetModules()
+  return (await import('./domWidgetMountReporting')).reportDomWidgetMountFailure
+}
+
+const context = {
+  nodeId: toNodeId(7),
+  nodeType: 'PreviewImage',
+  widgetName: 'preview'
+}
+
+describe('reportDomWidgetMountFailure', () => {
+  beforeEach(() => {
+    mockReportError.mockClear()
+  })
+
+  it('reports the failure with the node and widget that could not mount', async () => {
+    const report = await loadReporter()
+
+    report(new Error('appendChild failed'), context)
+
+    expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: 'appendChild failed' }),
+      expect.objectContaining({
+        errorType: 'canvas_dom_widget_mount_failed',
+        context
+      })
+    )
+  })
+
+  it('deduplicates a systemic cause so every widget in a graph reports once', async () => {
+    const report = await loadReporter()
+
+    for (let nodeId = 0; nodeId < 50; nodeId++) {
+      report(new Error('appendChild failed'), {
+        ...context,
+        nodeId: toNodeId(nodeId)
+      })
+    }
+
+    expect(mockReportError).toHaveBeenCalledOnce()
+  })
+
+  it('caps distinct failures per session', async () => {
+    const report = await loadReporter()
+
+    for (let i = 0; i < 25; i++) report(new Error(`failure ${i}`), context)
+
+    expect(mockReportError).toHaveBeenCalledTimes(20)
+  })
+})

--- a/src/components/graph/widgets/domWidgetMountReporting.ts
+++ b/src/components/graph/widgets/domWidgetMountReporting.ts
@@ -1,0 +1,33 @@
+import { reportError } from '@/platform/telemetry/reportError'
+import type { NodeId } from '@/types/nodeId'
+
+const MAX_REPORTS_PER_SESSION = 20
+
+const reportedMessages = new Set<string>()
+
+type DomWidgetMountContext = {
+  nodeId: NodeId
+  nodeType: string | undefined
+  widgetName: string
+}
+
+/**
+ * Whatever breaks `appendChild` for one DOM widget usually breaks it for every
+ * DOM widget in the graph, and widgets remount on each visibility flip, so
+ * reports are deduplicated by message and capped per session.
+ */
+export function reportDomWidgetMountFailure(
+  error: unknown,
+  context: DomWidgetMountContext
+): void {
+  const message = error instanceof Error ? error.message : String(error)
+  if (reportedMessages.has(message)) return
+  if (reportedMessages.size >= MAX_REPORTS_PER_SESSION) return
+  reportedMessages.add(message)
+
+  reportError(error, {
+    errorType: 'canvas_dom_widget_mount_failed',
+    context,
+    level: 'error'
+  })
+}


### PR DESCRIPTION
Reports failed native DOM-widget mounts. Mount behavior remains unchanged.

<details><summary>Full context for agent readers</summary>

## Changes

- Guard `mountElementIfVisible()` itself rather than the `onMounted` call site, so all three callers are instrumented: `onMounted`, the `widgetState.visible` watcher, and `whenever(() => !canvasStore.linearMode, ...)`. The visibility transitions are the common runtime trigger, so instrumenting only the first tick would have under-counted.
- Report through `reportDomWidgetMountFailure`, which deduplicates by message and caps at 20 reports per session, mirroring `reportAssertFailure` in `assertFailureReporter.ts`. A systemic `appendChild` break emits one event for the graph, not one per widget per remount.
- Identify failures by the `canvas_dom_widget_mount_failed` `errorType` slug alone, with `nodeId`/`nodeType`/`widgetName` context. No tag block: there is no established `failure_kind`/`feature_area`/`outcome` taxonomy in the repo to match. Those keys appear at a single other site, nothing types them, `outcome` values already conflict across existing call sites (`failed`/`failure`/`success`), and the typed `DiagnosticTags` is unmerged (#17001). `errorType` is the contract `src/AGENTS.md` documents.
- No `console.error` alongside the report. Since #17085, `reportError` writes the console line for every report and its docblock forbids callers pairing their own, because RUM auto-captures `console.error` and the pair yields two console lines and two RUM events per failure.
- Component regressions for all three mount paths, plus unit coverage of the dedupe and session cap.

## Evidence

- `pnpm vitest run src/components/graph/widgets/` — 44/44 passed.
- Mutation-verified red-then-green: reverting the guard to the previous `onMounted`-only form fails the visibility-watcher and linear-mode tests; removing the dedupe guard fails the dedupe and cap tests.
- The assertion previously claiming "containment" was verified vacuous by mutation - it passed against the unfixed `console.error` code, since the spy throws on `appendChild` so the element is never in the container under any implementation. It is replaced with an assertion that no error escapes to Vue's `config.errorHandler`.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed (0 errors, 225 pre-existing warnings, none in changed files).
- `pnpm knip` — passed.

</details>

<!-- authored-by:agent lane-tele-7-0638 -->
