### PR TITLE
feat(billing): members get the ending heads-up too

### DIFF
--- a/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
+++ b/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_TEAM_MEMBERS,
   INACTIVE_TEAM_BILLING_STATUS,
   TEAM_BILLING_STATUS,
+  TEAM_MEMBER_WORKSPACE,
   TEAM_WORKSPACE
 } from '@e2e/fixtures/data/cloudWorkspace'
 import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
@@ -59,6 +60,14 @@ const CANCELLED_ACTIVE_ENTERPRISE_STATUS = {
 
 const ENDING_SOON_ENTERPRISE_STATUS = {
   ...ACTIVE_ENTERPRISE_STATUS,
+  cancel_at: ENDING_SOON_CANCEL_AT,
+  subscription_status: 'canceled'
+} satisfies BillingStatusResponse
+
+// A cancelled self-serve team: unlike Enterprise there is no notice window,
+// so the ending banner shows as soon as the cancellation lands.
+const CANCELLED_TEAM_STATUS = {
+  ...TEAM_BILLING_STATUS,
   cancel_at: ENDING_SOON_CANCEL_AT,
   subscription_status: 'canceled'
 } satisfies BillingStatusResponse
@@ -399,5 +408,40 @@ test.describe('Unrecognized billing tier regression', { tag: '@cloud' }, () => {
       content.getByRole('button', { name: 'Add credits' })
     ).toBeVisible()
     expect(pageErrors).toEqual([])
+  })
+})
+
+// FE-2036: the member ending variant is informational only — a heads-up, not
+// a call to action. Uses the same harness as the Enterprise cases above;
+// createWorkspaceBillingCapabilities resolves the member's capability set
+// (can_reactivate false) from the workspace role on its own.
+test.describe('Member ending banner', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('shows a team member the informational ending notice with no action', async ({
+    page
+  }) => {
+    const workspace = new CloudWorkspaceMockHelper(page)
+    await workspace.setup(
+      DEFAULT_TEAM_MEMBERS,
+      TEAM_MEMBER_WORKSPACE,
+      CANCELLED_TEAM_STATUS
+    )
+    await enableBillingControl(page)
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(
+      content.getByText('Your team plan ends on', { exact: false })
+    ).toBeVisible()
+    await expect(
+      content.getByText('You can run workflows until then.')
+    ).toBeVisible()
+    // Not the owner variant: no Reactivate action, no owner body.
+    await expect(
+      content.getByRole('button', { name: 'Reactivate plan' })
+    ).toHaveCount(0)
+    await expect(
+      content.getByText('Reactivate to keep your shared credits and seats.')
+    ).toHaveCount(0)
   })
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3222,6 +3222,7 @@
       "ending": {
         "title": "Your team plan ends on {date}",
         "body": "Members keep full access until then. Reactivate to keep your shared credits and seats.",
+        "memberBody": "You can run workflows until then.",
         "enterpriseTitle": "Your Enterprise plan ends on {date}",
         "enterpriseBody": "Members keep full access until then. Reach out to our sales team to extend.",
         "reactivate": "Reactivate plan"

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -143,6 +143,7 @@ const i18n = createI18n({
           ending: {
             title: 'Your team plan ends on {date}',
             body: 'Members keep full access until then. Reactivate to keep your shared credits and seats.',
+            memberBody: 'You can run workflows until then.',
             enterpriseTitle: 'Your Enterprise plan ends on {date}',
             enterpriseBody:
               'Members keep full access until then. Reach out to our sales team to extend.',
@@ -388,7 +389,7 @@ describe('BillingStatusBanner', () => {
     expect(state.handleResubscribe).toHaveBeenCalledTimes(1)
   })
 
-  it('does not expose reactivation controls to a member', () => {
+  it('shows members the ending notice without reactivation controls', () => {
     state.subscription = {
       hasFunds: true,
       isCancelled: true,
@@ -397,12 +398,46 @@ describe('BillingStatusBanner', () => {
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
     state.canReactivate = false
+    // Pin the gate itself: a rail that resolves reactivation true still must
+    // not surface the action to a member.
+    state.canReactivatePlan = true
     renderBanner()
 
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Your team plan ends on'
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'You can run workflows until then.'
+    )
+    // The member notice is title and body only: no Reactivate, no dismiss.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('keeps the ending banner non-dismissible for owners and members alike', () => {
+    state.subscription = {
+      hasFunds: true,
+      isCancelled: true,
+      endDate: '2026-08-01T00:00:00Z'
+    }
+    state.canReactivatePlan = true
+    const { unmount } = renderBanner()
+
     expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
+      screen.getByRole('button', { name: 'Reactivate plan' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Dismiss' })
     ).not.toBeInTheDocument()
+    unmount()
+
+    state.canManageSubscription = false
+    state.canManageSubscriptionLifecycle = false
+    renderBanner()
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Your team plan ends on'
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('hides reactivation when the server denies it to a client-side owner', () => {
@@ -467,6 +502,29 @@ describe('BillingStatusBanner', () => {
       expect(
         screen.queryByRole('button', { name: 'Reactivate plan' })
       ).not.toBeInTheDocument()
+    })
+
+    it('keeps members quiet outside the window too', () => {
+      enterpriseEndingIn(30)
+      state.canManageSubscription = false
+      renderBanner()
+
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
+
+    it('gives members informational copy inside the window', () => {
+      enterpriseEndingIn(10)
+      state.canManageSubscription = false
+      state.canReactivatePlan = true
+      renderBanner()
+
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Your Enterprise plan ends on'
+      )
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'You can run workflows until then.'
+      )
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -154,11 +154,14 @@ const banner = computed<BannerView | null>(() => {
       // An Enterprise contract renews through sales, not self-serve
       // reactivation, so it gets its own copy and never a Reactivate action —
       // even where the legacy rail would resolve canReactivatePlan true.
+      // Members get informational copy on both rails, with no action to take.
       if (isEnterprisePlan.value) {
         return {
           muted: true,
           title: t(`${bs}.ending.enterpriseTitle`, { date: planEndDate.value }),
-          body: t(`${bs}.ending.enterpriseBody`),
+          body: canManage.value
+            ? t(`${bs}.ending.enterpriseBody`)
+            : t(`${bs}.ending.memberBody`),
           action: null,
           dismissible: false
         }
@@ -166,8 +169,11 @@ const banner = computed<BannerView | null>(() => {
       return {
         muted: true,
         title: t(`${bs}.ending.title`, { date: planEndDate.value }),
-        body: t(`${bs}.ending.body`),
-        action: canReactivatePlan.value ? 'reactivate' : null,
+        body: canManage.value
+          ? t(`${bs}.ending.body`)
+          : t(`${bs}.ending.memberBody`),
+        action:
+          canManage.value && canReactivatePlan.value ? 'reactivate' : null,
         dismissible: false
       }
     default:

--- a/src/platform/workspace/composables/deriveBillingBanner.test.ts
+++ b/src/platform/workspace/composables/deriveBillingBanner.test.ts
@@ -121,14 +121,14 @@ describe('deriveBillingBanner', () => {
     ).toBeNull()
   })
 
-  it('hides the ending banner from members', () => {
+  it('shows the ending banner to members too', () => {
     expect(
       derive({
         isCancelled: true,
         endDate: '2026-08-01T00:00:00Z',
         canManage: false
       })
-    ).toBeNull()
+    ).toBe('ending')
   })
 
   it('shows no banner for an inactive subscription (that is a run-lock modal)', () => {
@@ -179,13 +179,24 @@ describe('deriveBillingBanner', () => {
       ).toBe('ending')
     })
 
-    it('hides the notice from members even inside the window', () => {
+    it('shows the notice to members on the owner schedule', () => {
       expect(
         derive(
           {
             ...enterprise,
             isCancelled: true,
             endDate: daysFromNow(10),
+            canManage: false
+          },
+          NOW
+        )
+      ).toBe('ending')
+      expect(
+        derive(
+          {
+            ...enterprise,
+            isCancelled: true,
+            endDate: daysFromNow(30),
             canManage: false
           },
           NOW

--- a/src/platform/workspace/composables/deriveBillingBanner.test.ts
+++ b/src/platform/workspace/composables/deriveBillingBanner.test.ts
@@ -131,6 +131,24 @@ describe('deriveBillingBanner', () => {
     ).toBe('ending')
   })
 
+  it('gives the single slot to out of credits ahead of the ending notice for members', () => {
+    const memberOfCancelledTeamOutOfCredits: Partial<BillingBannerInputs> = {
+      isCancelled: true,
+      endDate: '2026-08-01T00:00:00Z',
+      hasFunds: false,
+      canManage: false
+    }
+    expect(derive(memberOfCancelledTeamOutOfCredits)).toBe('outOfCredits')
+    // Only once the credits notice is dismissed does the ending heads-up
+    // take the slot.
+    expect(
+      derive({
+        ...memberOfCancelledTeamOutOfCredits,
+        outOfCreditsDismissed: true
+      })
+    ).toBe('ending')
+  })
+
   it('shows no banner for an inactive subscription (that is a run-lock modal)', () => {
     expect(
       derive({

--- a/src/platform/workspace/composables/useBillingBanner.ts
+++ b/src/platform/workspace/composables/useBillingBanner.ts
@@ -54,10 +54,11 @@ export function deriveBillingBanner(
   if (inputs.isEnterprise) {
     if (!inputs.canAccessSubscriptionFeatures) return null
     if (!inputs.billingControlEnabled) return null
+    // The window is role-independent: members and owners see the notice on
+    // the same day, so nobody learns about the end date from the run lock.
     if (
       inputs.isCancelled &&
       inputs.endDate &&
-      inputs.canManage &&
       isWithinEnterpriseEndingNotice(inputs.endDate, now)
     ) {
       return 'ending'
@@ -83,7 +84,9 @@ export function deriveBillingBanner(
   if (inputs.hasFunds === false && !inputs.outOfCreditsDismissed) {
     return 'outOfCredits'
   }
-  if (inputs.isCancelled && inputs.endDate && inputs.canManage) {
+  // Members see the ending notice too, not just the owners who can act on
+  // it: better a heads-up now than a run lock on the end date.
+  if (inputs.isCancelled && inputs.endDate) {
     return 'ending'
   }
 


### PR DESCRIPTION
Members of a cancelled team or ending enterprise workspace now get the same heads-up owners do — today they see nothing and find out when the workspace goes inactive under them. Their banner is informational: title plus body, nothing to click; owners keep exactly what they have.

| | Team (self-serve) | Enterprise |
|---|---|---|
| Owner (unchanged) | "Your team plan ends on {date}" + owner body, Reactivate action | Enterprise title + sales body, no action, 14-day notice window |
| Member (new) | Same title, body "You can run workflows until then.", no action | Enterprise title, same member body, no action, same 14-day window |

No dismissal on either variant — design clarified that the "Don't show again" layer in the Figma frame is a hidden stale layer, not part of the rendered design. The member banner is title + body only and persists exactly like the owner banner, so `useBillingBanner`'s dismiss stays out-of-credits-only.

Derivation change is confined to the `'ending'` outcomes of `deriveBillingBanner` (drops the `canManage` gate on both the team branch and the Enterprise notice-window branch). The Enterprise notice window is role-independent: members and owners see it on the same day. All other banner kinds untouched.

Two base-branch tests asserted the old member gap ("hides the ending banner from members" and the Enterprise member variant); those flipped to assert the new behavior, everything else is additive.

Stacked on #16934 (`comfydesigner/enterprise-ending-threshold`), rebased on its Cursor-review fixes (Enterprise-strict scoping, `ENTERPRISE_ENDING_NOTICE_DAYS`, reactive clock) — only the last commit is new here.

Linear: FE-2036

## Rollout
`billing_control_enabled` is a PostHog percentage rollout (sticky per user), so this banner is live on merge for the flagged slice — members of cancelled team workspaces in that slice see it immediately, with no threshold damping (the Enterprise path has the 14-day window; the team path shows on cancellation by design, per FE-2036). Sonam and Hunter notified before merge.