### PR TITLE
test: preserve partner policy error identity

### DIFF
--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -36,17 +36,9 @@ vi.mock('@/composables/useFeatureFlags', () => ({
 
 vi.mock(
   '@/platform/workspace/api/partnerNodePolicyApi',
-  () =>
+  async (importOriginal) =>
     ({
-      PartnerNodePolicyApiError: class PartnerNodePolicyApiError extends Error {
-        constructor(
-          readonly status: number,
-          message: string
-        ) {
-          super(message)
-          this.name = 'PartnerNodePolicyApiError'
-        }
-      },
+      ...(await importOriginal<typeof PartnerNodePolicyApi>()),
       getPartnerNodePolicy: mockGetPartnerNodePolicy,
       getPartnerProviders: mockGetPartnerProviders,
       updatePartnerNodePolicy: mockUpdatePartnerNodePolicy


### PR DESCRIPTION
## Summary

Preserve the production `PartnerNodePolicyApiError` constructor in governance store tests so `instanceof` branches cannot pass against a copied fake.

## Changes

- **What**: Partially mock the partner policy API with `importOriginal`, overriding only its three request functions.

## Review Focus

The real error-class export is intentionally retained so the 403 and 422 mapping tests use production constructor identity.

## Validation

- `pnpm test:unit src/platform/workspace/api/partnerNodePolicyApi.test.ts src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts` (28 passed)
- `pnpm typecheck`
- Targeted Oxlint, ESLint, and oxfmt checks