### PR TITLE
test: keep arrange session default under test

### DIFF
--- a/src/composables/graph/useArrangeSession.test.ts
+++ b/src/composables/graph/useArrangeSession.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as ArrangeNodesModule from '@/composables/graph/useArrangeNodes'
 import { useArrangeSession } from '@/composables/graph/useArrangeSession'
 
 const mockArrangeNodes = vi.fn()
 
-vi.mock('@/composables/graph/useArrangeNodes', () => ({
-  DEFAULT_ARRANGE_GAP: 12,
+vi.mock('@/composables/graph/useArrangeNodes', async (importOriginal) => ({
+  ...(await importOriginal<typeof ArrangeNodesModule>()),
   useArrangeNodes: () => ({ arrangeNodes: mockArrangeNodes })
 }))
 


### PR DESCRIPTION
## Summary

Keep the arrange session tests coupled to the production default while mocking only the arrange-operation boundary.

## Changes

- **What**: Partially mock `useArrangeNodes` so the real `DEFAULT_ARRANGE_GAP` export remains under test. The literal assertions intentionally preserve the expected default behavior and now fail if production drifts.

## Review Focus

A temporary production change from 12 to 13 passed all 5 tests before this change; it now fails the 2 default/reset behaviors.

## Validation

- `pnpm test:unit src/composables/graph/useArrangeSession.test.ts src/composables/graph/useArrangeNodes.test.ts` (13 passed)
- `pnpm typecheck`
- `pnpm exec eslint src/composables/graph/useArrangeSession.test.ts`
- `pnpm exec oxfmt --check src/composables/graph/useArrangeSession.test.ts`
- `pnpm knip --cache` (push hook)