### PR TITLE
fix(ci): trust complete ecosystem matrix verdicts

### DIFF
--- a/.github/workflows/ci-ecosystem-matrix.yaml
+++ b/.github/workflows/ci-ecosystem-matrix.yaml
@@ -368,7 +368,10 @@ jobs:
   # MATRIX_EXPECT_SHARDS makes a dead shard withhold rather than PASS. Every
   # criterion is a ratio, so three shards produce a perfectly plausible
   # number, and on PASS that partial population would be saved as the
-  # baseline the next run is measured against.
+  # baseline the next run is measured against. The aggregate therefore trusts
+  # these verdicts rather than the raw matrix job result: a shard can time out
+  # after uploading a complete artifact, while a missing artifact still makes
+  # the corresponding verdict fail closed.
   matrix-verdict:
     name: matrix-verdict (${{ matrix.renderer }})
     needs: [changes, corpus, ecosystem-matrix]
@@ -587,7 +590,6 @@ jobs:
           for check in \
             "pin-status:$PIN_STATUS_RESULT" \
             "corpus:$CORPUS_RESULT" \
-            "shards:$SHARDS_RESULT" \
             "verdicts:$VERDICTS_RESULT" \
             "detection-proofs:$PROOFS_RESULT"; do
             if [ "${check#*:}" != success ]; then
@@ -597,5 +599,8 @@ jobs:
           if [ "${#failures[@]}" -ne 0 ]; then
             echo "::error::ecosystem matrix did not pass completely: ${failures[*]}"
             exit 1
+          fi
+          if [ "$SHARDS_RESULT" != success ]; then
+            echo "::notice::raw shard result was $SHARDS_RESULT; complete artifacts passed both renderer verdicts"
           fi
           echo 'ecosystem matrix passed in both renderers with both detection proofs'

--- a/scripts/registry-census/README.md
+++ b/scripts/registry-census/README.md
@@ -274,8 +274,16 @@ The required gate is red. In order:
 `Custom Nodes Ecosystem Matrix test` for every pull request and merge-queue
 candidate. Branch protection should require that aggregate, not the internal
 legacy and Vue `matrix-verdict` jobs. On a relevant change, a red, skipped, or
-cancelled dependency makes the aggregate red. On an irrelevant pull request,
-the aggregate passes only after all expensive dependencies report skipped.
+cancelled `pin-status`, `corpus`, `matrix-verdict`, or `matrix-detection-proof`
+makes the aggregate red. The shard jobs are the one exception: their raw result
+is reported as a notice rather than gated, because verdict completeness already
+supersedes it. `MATRIX_EXPECT_SHARDS` fails each verdict closed unless all four
+shard manifests are present, every manifest entry has a row, and no row lacks a
+manifest entry — so a shard that dies before its artifact is complete still reds
+the aggregate through its own verdict, while one that dies after uploading a
+complete artifact has cost the run no measurement. On an irrelevant pull
+request, the aggregate passes only after all expensive dependencies report
+skipped.
 
 ## Detection proof (counter-evidence)
 


### PR DESCRIPTION
## Summary

Prevent a raw shard timeout from reddening the required ecosystem-matrix gate after both fail-closed renderer verdicts have confirmed complete, passing artifacts.

## Changes

- **What**: Make the aggregate gate trust the legacy and Vue verdict jobs for shard completeness instead of independently requiring the raw matrix job result to be `success`.
- **Diagnostics**: Emit a notice when raw shard status is non-success but both renderer verdicts pass.
- **Docs**: Update the blast-radius contract in `scripts/registry-census/README.md` to name the four dependencies that still red the aggregate and record why the shard jobs are exempt.

## Review Focus

`matrix-verdict` still sets `MATRIX_EXPECT_SHARDS=4`; missing manifests, missing rows, unreadable rows, or incomplete populations withhold the verdict and keep the aggregate red. The irrelevant-change path still requires the shard job to be skipped.

## Evidence

- [Run 33844375786 attempt 1](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33844375786) reproduced the boundary: legacy shard 1 timed out after uploading all 524 rows, `matrix-verdict (legacy)` passed, and the aggregate failed only on `shards:cancelled`.
- `python3 -m unittest discover -s scripts/registry-census -p 'test_*.py'`: 52 passed, including dead/missing-shard fail-closed coverage.
- Extracted aggregate-step simulation: `SHARDS_RESULT=cancelled`, both verdicts `success` -> exit 0; `SHARDS_RESULT=failure`, verdicts `failure` -> exit 1.
- `pnpm exec oxfmt --check .github/workflows/ci-ecosystem-matrix.yaml`: passed.
- `./scripts/cicd/check-yaml.sh`: exit 0; only the existing `supported_nodes.yaml:1082` comment-indentation warning.
- Push-time `pnpm knip`: passed.

<!-- authored-by:agent lane-shep-39-0752 -->

