### PR TITLE
fix(agent): scope selected nodes to their workflow

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -2888,7 +2888,10 @@ describe('AgentPanelRoot workflow binding', () => {
 
     expect(bodies[0]).toMatchObject({
       content: 'tune it',
-      selection: { node_ids: ['7'] }
+      selection: {
+        node_ids: ['7'],
+        workflow_id: 'wf-42'
+      }
     })
   })
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -183,11 +183,15 @@ const graphMutations = (workflowId: string) => {
 }
 const { focusNodeInstance } = useFocusNode()
 
+let cloudIdsByName = new Map<string, string>()
+
 function toSelectedNode(node: LGraphNode): SelectedNode {
+  const activeWorkflow = workflowStore.activeWorkflow
   return {
     id: String(node.id),
     locatorId: workflowStore.nodeToNodeLocatorId(node),
-    title: node.title || node.type
+    title: node.title || node.type,
+    workflowId: activeWorkflow ? cloudIdFor(activeWorkflow) : undefined
   }
 }
 
@@ -251,8 +255,6 @@ watch(
 function mentionableAssets() {
   return assetService.getInputAssetsIncludingPublic()
 }
-
-let cloudIdsByName = new Map<string, string>()
 
 async function refreshCloudWorkflowIds(): Promise<void> {
   try {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -683,6 +683,23 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(body.selection).toEqual({ node_ids: ['5', '6'] })
   })
 
+  it('(h3) identifies the workflow that owns the selected nodes', async () => {
+    const rest = fakeRest()
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    const tags: SelectedNode[] = [
+      { id: '5', title: 'KSampler', workflowId: 'wf-selected' }
+    ]
+    session.start()
+
+    await session.sendMessage('explain', undefined, tags)
+
+    const body = vi.mocked(rest.postMessage).mock.calls[0][1]
+    expect(body.selection).toEqual({
+      node_ids: ['5'],
+      workflow_id: 'wf-selected'
+    })
+  })
+
   it('(h4) the turn post never carries a draft field (upload retired)', async () => {
     const postMessage = vi.fn<AgentRestClient['postMessage']>(async () => ({
       thread_id: 'th-1',

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -31,6 +31,7 @@ interface SentAttachment {
 interface SentTag {
   id: string
   title: string
+  workflowId?: string
 }
 
 export interface WorkflowTurnContext {
@@ -218,7 +219,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
         tabs,
         selection:
           tags !== undefined && tags.length > 0
-            ? { node_ids: tags.map((tag) => tag.id) }
+            ? {
+                node_ids: tags.map((tag) => tag.id),
+                ...(tags[0].workflowId !== undefined
+                  ? { workflow_id: tags[0].workflowId }
+                  : {})
+              }
             : undefined,
         attachments: attachments?.map((attachment) => attachment.ref),
         ...(shouldSendDraft ? { draft } : {})

--- a/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
+++ b/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
@@ -7,6 +7,7 @@ export interface SelectedNode {
   id: string
   locatorId?: NodeLocatorId
   title: string
+  workflowId?: string
 }
 
 export function selectedNodeKey(node: SelectedNode): string {


### PR DESCRIPTION
Selected-node context now names its owning workflow, so the agent can distinguish a referenced node from the currently focused tab.

<details><summary>Full context for agent readers</summary>

## Changes

- Capture the selected node's cloud workflow ID when its reference chip is created.
- Send that ID as `selection.workflow_id` alongside `selection.node_ids`.
- Preserve the legacy node-only payload when no cloud workflow identity is available.

The agent service already accepts the selection as an open map and serializes every key into the turn prompt, so no cloud change is required.

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts src/workbench/extensions/agent/AgentPanelRoot.test.ts` — 173 passed.
- `pnpm typecheck` — passed.
- Scoped ESLint — passed.
- Rebased onto `origin/main` at `70e7e0269` before final verification.

Linear: https://linear.app/comfyorg/issue/PM-856/agent-doesnt-recognize-selected-nodes-belong-to-a-non-focused-tab

</details>

<!-- authored-by:agent lane-QAF-19-0752 -->