### PR TITLE
ci: require tracking for browser test skips

### DIFF
--- a/.github/workflows/ci-check-ai-co-authors.yaml
+++ b/.github/workflows/ci-check-ai-co-authors.yaml
@@ -23,4 +23,4 @@ jobs:
         run: node --test scripts/check-test-skip-accountability.test.mjs
 
       - name: Check browser test skips have restoration tracking
-        run: node scripts/check-test-skip-accountability.mjs
+        run: node scripts/check-test-skip-accountability.mjs --base-sha "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/ci-check-ai-co-authors.yaml
+++ b/.github/workflows/ci-check-ai-co-authors.yaml
@@ -20,7 +20,7 @@ jobs:
         run: bash .github/scripts/check-ai-co-authors.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
 
       - name: Test browser skip accountability checker
-        run: node --test scripts/check-test-skip-accountability.test.mjs
+        run: node --test scripts/check-test-skip-accountability.self-test.mjs
 
       - name: Check browser test skips have restoration tracking
         run: node scripts/check-test-skip-accountability.mjs --base-sha "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/ci-check-ai-co-authors.yaml
+++ b/.github/workflows/ci-check-ai-co-authors.yaml
@@ -18,3 +18,9 @@ jobs:
 
       - name: Check commits for AI co-author trailers
         run: bash .github/scripts/check-ai-co-authors.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+
+      - name: Test browser skip accountability checker
+        run: node --test scripts/check-test-skip-accountability.test.mjs
+
+      - name: Check browser test skips have restoration tracking
+        run: node scripts/check-test-skip-accountability.mjs

--- a/.github/workflows/ci-check-ai-co-authors.yaml
+++ b/.github/workflows/ci-check-ai-co-authors.yaml
@@ -2,6 +2,7 @@ name: Check AI Co-Authors
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-check-ai-co-authors.yaml
+++ b/.github/workflows/ci-check-ai-co-authors.yaml
@@ -23,4 +23,4 @@ jobs:
         run: node --test scripts/check-test-skip-accountability.self-test.mjs
 
       - name: Check browser test skips have restoration tracking
-        run: node scripts/check-test-skip-accountability.mjs --base-sha "${{ github.event.pull_request.base.sha }}"
+        run: node scripts/check-test-skip-accountability.mjs --base-sha "${{ github.event.pull_request.base.sha }}" --head-sha "${{ github.event.pull_request.head.sha }}"

--- a/scripts/check-test-skip-accountability.mjs
+++ b/scripts/check-test-skip-accountability.mjs
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+
+const args = process.argv.slice(2)
+
+const readArgument = (name) => {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+const readDiff = () => {
+  const diffFile = readArgument('--diff-file')
+  if (diffFile) return readFileSync(diffFile, 'utf8')
+
+  return execFileSync(
+    'git',
+    ['diff', '--unified=0', 'origin/main...HEAD', '--', 'browser_tests'],
+    { encoding: 'utf8' }
+  )
+}
+
+const readPullRequestBody = () => {
+  const bodyFile = readArgument('--body-file')
+  if (bodyFile) return readFileSync(bodyFile, 'utf8')
+
+  if (process.env.GITHUB_EVENT_PATH) {
+    const event = JSON.parse(
+      readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')
+    )
+    return event.pull_request?.body ?? ''
+  }
+
+  return execFileSync('gh', ['pr', 'view', '--json', 'body', '--jq', '.body'], {
+    encoding: 'utf8'
+  })
+}
+
+const addedSkipPattern = /^\+(?!\+\+\+).*\btest\.(?:fixme|skip)\s*\(/m
+const trackingLinkPattern =
+  /(?:https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+|(?:^|[\s([])#\d+)/m
+
+const diff = readDiff()
+if (!addedSkipPattern.test(diff)) process.exit(0)
+
+const body = readPullRequestBody()
+if (!trackingLinkPattern.test(body)) {
+  process.stderr.write(
+    'Added test.fixme()/test.skip() calls in browser_tests must name the tracking issue or follow-up PR that will restore the test. Add an issue/PR link to the pull request body.\n'
+  )
+  process.exit(1)
+}

--- a/scripts/check-test-skip-accountability.mjs
+++ b/scripts/check-test-skip-accountability.mjs
@@ -42,7 +42,7 @@ const readPullRequestBody = () => {
   })
 }
 
-const addedSkipPattern = /^\+\s*test\.(?:fixme|skip)\s*\(/m
+const addedSkipPattern = /^\+[ \t]*test\.(?:fixme|skip)[ \t]*\(/m
 const trackingLinkPattern =
   /(?:https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+|(?:^|[\s([])#\d+)/m
 

--- a/scripts/check-test-skip-accountability.mjs
+++ b/scripts/check-test-skip-accountability.mjs
@@ -15,7 +15,13 @@ const readDiff = () => {
 
   return execFileSync(
     'git',
-    ['diff', '--unified=0', 'origin/main...HEAD', '--', 'browser_tests'],
+    [
+      'diff',
+      '--unified=0',
+      `${readArgument('--base-sha') ?? 'origin/main'}...HEAD`,
+      '--',
+      'browser_tests'
+    ],
     { encoding: 'utf8' }
   )
 }
@@ -36,7 +42,7 @@ const readPullRequestBody = () => {
   })
 }
 
-const addedSkipPattern = /^\+(?!\+\+\+).*\btest\.(?:fixme|skip)\s*\(/m
+const addedSkipPattern = /^\+\s*test\.(?:fixme|skip)\s*\(/m
 const trackingLinkPattern =
   /(?:https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+|(?:^|[\s([])#\d+)/m
 

--- a/scripts/check-test-skip-accountability.mjs
+++ b/scripts/check-test-skip-accountability.mjs
@@ -42,12 +42,53 @@ const readPullRequestBody = () => {
   })
 }
 
-const addedSkipPattern = /^\+[ \t]*test\.(?:describe\.)?(?:fixme|skip)[ \t]*\(/m
+const stringLiteralPattern =
+  /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`/g
+const skipCallPattern = /\btest\.(?:describe\.)?(?:fixme|skip)[ \t]*\(/
 const trackingLinkPattern =
   /(?:https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+|(?:^|[\s([])#\d+)/m
 
+const executableAddedSource = function* (diff) {
+  let insideBlockComment = false
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('@@')) {
+      insideBlockComment = false
+      continue
+    }
+    if (!line.startsWith('+') || line.startsWith('+++')) continue
+
+    let source = line.slice(1).replace(stringLiteralPattern, "''")
+
+    if (insideBlockComment) {
+      const blockEnd = source.indexOf('*/')
+      if (blockEnd === -1) continue
+      source = source.slice(blockEnd + 2)
+      insideBlockComment = false
+    }
+
+    source = source.replace(/\/\*[\s\S]*?\*\//g, ' ')
+
+    const blockStart = source.indexOf('/*')
+    if (blockStart !== -1) {
+      insideBlockComment = true
+      source = source.slice(0, blockStart)
+    }
+
+    const lineCommentStart = source.indexOf('//')
+    if (lineCommentStart !== -1) source = source.slice(0, lineCommentStart)
+
+    if (source.trimStart().startsWith('*')) continue
+
+    yield source
+  }
+}
+
 const diff = readDiff()
-if (!addedSkipPattern.test(diff)) process.exit(0)
+const addsSkip = [...executableAddedSource(diff)].some((source) =>
+  skipCallPattern.test(source)
+)
+if (!addsSkip) process.exit(0)
 
 const body = readPullRequestBody()
 if (!trackingLinkPattern.test(body)) {

--- a/scripts/check-test-skip-accountability.mjs
+++ b/scripts/check-test-skip-accountability.mjs
@@ -42,7 +42,7 @@ const readPullRequestBody = () => {
   })
 }
 
-const addedSkipPattern = /^\+[ \t]*test\.(?:fixme|skip)[ \t]*\(/m
+const addedSkipPattern = /^\+[ \t]*test\.(?:describe\.)?(?:fixme|skip)[ \t]*\(/m
 const trackingLinkPattern =
   /(?:https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+|(?:^|[\s([])#\d+)/m
 

--- a/scripts/check-test-skip-accountability.mjs
+++ b/scripts/check-test-skip-accountability.mjs
@@ -13,15 +13,12 @@ const readDiff = () => {
   const diffFile = readArgument('--diff-file')
   if (diffFile) return readFileSync(diffFile, 'utf8')
 
+  const baseSha = readArgument('--base-sha') ?? 'origin/main'
+  const headSha = readArgument('--head-sha') ?? 'HEAD'
+
   return execFileSync(
     'git',
-    [
-      'diff',
-      '--unified=0',
-      `${readArgument('--base-sha') ?? 'origin/main'}...HEAD`,
-      '--',
-      'browser_tests'
-    ],
+    ['diff', '--unified=0', `${baseSha}...${headSha}`, '--', 'browser_tests'],
     { encoding: 'utf8' }
   )
 }

--- a/scripts/check-test-skip-accountability.self-test.mjs
+++ b/scripts/check-test-skip-accountability.self-test.mjs
@@ -5,10 +5,10 @@ import { fileURLToPath, URL } from 'node:url'
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 
-const directory = fileURLToPath(new URL('.', import.meta.url))
-const script = `${directory}check-test-skip-accountability.mjs`
+const scriptDirectory = fileURLToPath(new URL('.', import.meta.url))
+const script = `${scriptDirectory}check-test-skip-accountability.mjs`
 const fixture = (name) =>
-  `${directory}fixtures/test-skip-accountability/${name}`
+  `${scriptDirectory}fixtures/test-skip-accountability/${name}`
 
 const runChecker = (body, diff = 'added-fixme.diff') =>
   spawnSync(

--- a/scripts/check-test-skip-accountability.self-test.mjs
+++ b/scripts/check-test-skip-accountability.self-test.mjs
@@ -31,7 +31,7 @@ describe('test skip accountability checker', () => {
     assert.equal(result.status, 0, result.stderr)
   })
 
-  it('ignores skip-like text in comments and strings', () => {
+  it('ignores non-executable and unchanged skip calls', () => {
     const result = runChecker('unlinked-body.md', 'non-executable-skips.diff')
 
     assert.equal(result.status, 0, result.stderr)

--- a/scripts/check-test-skip-accountability.self-test.mjs
+++ b/scripts/check-test-skip-accountability.self-test.mjs
@@ -38,6 +38,16 @@ describe('test skip accountability checker', () => {
     assert.match(result.stderr, /tracking issue or follow-up PR/)
   })
 
+  it('rejects an added skip that follows other tokens on the line', () => {
+    const result = runChecker(
+      'unlinked-body.md',
+      'inline-conditional-skip.diff'
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /tracking issue or follow-up PR/)
+  })
+
   it('ignores non-executable and unchanged skip calls', () => {
     const result = runChecker('unlinked-body.md', 'non-executable-skips.diff')
 

--- a/scripts/check-test-skip-accountability.self-test.mjs
+++ b/scripts/check-test-skip-accountability.self-test.mjs
@@ -31,6 +31,13 @@ describe('test skip accountability checker', () => {
     assert.equal(result.status, 0, result.stderr)
   })
 
+  it('rejects an added block-level describe skip without tracking', () => {
+    const result = runChecker('unlinked-body.md', 'added-describe-skip.diff')
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /tracking issue or follow-up PR/)
+  })
+
   it('ignores non-executable and unchanged skip calls', () => {
     const result = runChecker('unlinked-body.md', 'non-executable-skips.diff')
 

--- a/scripts/check-test-skip-accountability.test.mjs
+++ b/scripts/check-test-skip-accountability.test.mjs
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+import { fileURLToPath, URL } from 'node:url'
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+const directory = fileURLToPath(new URL('.', import.meta.url))
+const script = `${directory}check-test-skip-accountability.mjs`
+const fixture = (name) =>
+  `${directory}fixtures/test-skip-accountability/${name}`
+
+const runChecker = (body) =>
+  spawnSync(
+    process.execPath,
+    [
+      script,
+      '--diff-file',
+      fixture('added-fixme.diff'),
+      '--body-file',
+      fixture(body)
+    ],
+    { encoding: 'utf8' }
+  )
+
+describe('test skip accountability checker', () => {
+  it('rejects an added fixme without restoration tracking', () => {
+    const result = runChecker('unlinked-body.md')
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /tracking issue or follow-up PR/)
+  })
+
+  it('accepts an added fixme with a linked tracking issue', () => {
+    const result = runChecker('linked-body.md')
+
+    assert.equal(result.status, 0, result.stderr)
+  })
+})

--- a/scripts/check-test-skip-accountability.test.mjs
+++ b/scripts/check-test-skip-accountability.test.mjs
@@ -10,16 +10,10 @@ const script = `${directory}check-test-skip-accountability.mjs`
 const fixture = (name) =>
   `${directory}fixtures/test-skip-accountability/${name}`
 
-const runChecker = (body) =>
+const runChecker = (body, diff = 'added-fixme.diff') =>
   spawnSync(
     process.execPath,
-    [
-      script,
-      '--diff-file',
-      fixture('added-fixme.diff'),
-      '--body-file',
-      fixture(body)
-    ],
+    [script, '--diff-file', fixture(diff), '--body-file', fixture(body)],
     { encoding: 'utf8' }
   )
 
@@ -33,6 +27,12 @@ describe('test skip accountability checker', () => {
 
   it('accepts an added fixme with a linked tracking issue', () => {
     const result = runChecker('linked-body.md')
+
+    assert.equal(result.status, 0, result.stderr)
+  })
+
+  it('ignores skip-like text in comments and strings', () => {
+    const result = runChecker('unlinked-body.md', 'non-executable-skips.diff')
 
     assert.equal(result.status, 0, result.stderr)
   })

--- a/scripts/fixtures/test-skip-accountability/added-describe-skip.diff
+++ b/scripts/fixtures/test-skip-accountability/added-describe-skip.diff
@@ -1,0 +1,7 @@
+diff --git a/browser_tests/tests/example.spec.ts b/browser_tests/tests/example.spec.ts
+index 1111111..2222222 100644
+--- a/browser_tests/tests/example.spec.ts
++++ b/browser_tests/tests/example.spec.ts
+@@ -1 +1 @@
+-test.describe('suite', () => {
++test.describe.skip('suite', () => {

--- a/scripts/fixtures/test-skip-accountability/added-fixme.diff
+++ b/scripts/fixtures/test-skip-accountability/added-fixme.diff
@@ -1,0 +1,7 @@
+diff --git a/browser_tests/tests/example.spec.ts b/browser_tests/tests/example.spec.ts
+index 1111111..2222222 100644
+--- a/browser_tests/tests/example.spec.ts
++++ b/browser_tests/tests/example.spec.ts
+@@ -1 +1 @@
+-test('works', async () => {})
++test.fixme('works', async () => {})

--- a/scripts/fixtures/test-skip-accountability/inline-conditional-skip.diff
+++ b/scripts/fixtures/test-skip-accountability/inline-conditional-skip.diff
@@ -1,0 +1,7 @@
+diff --git a/browser_tests/tests/example.spec.ts b/browser_tests/tests/example.spec.ts
+index 1111111..2222222 100644
+--- a/browser_tests/tests/example.spec.ts
++++ b/browser_tests/tests/example.spec.ts
+@@ -1,0 +2,2 @@
++test('works', async ({ comfyPage }) => {
++  if (isUnsupported) test.skip('flaky on webkit')

--- a/scripts/fixtures/test-skip-accountability/linked-body.md
+++ b/scripts/fixtures/test-skip-accountability/linked-body.md
@@ -1,0 +1,3 @@
+Temporarily disable the failing browser test to unblock CI.
+
+Restore tracking: #12345

--- a/scripts/fixtures/test-skip-accountability/linked-body.md
+++ b/scripts/fixtures/test-skip-accountability/linked-body.md
@@ -1,3 +1,5 @@
+# Pull request summary
+
 Temporarily disable the failing browser test to unblock CI.
 
 Restore tracking: #12345

--- a/scripts/fixtures/test-skip-accountability/non-executable-skips.diff
+++ b/scripts/fixtures/test-skip-accountability/non-executable-skips.diff
@@ -1,0 +1,8 @@
+diff --git a/browser_tests/tests/example.spec.ts b/browser_tests/tests/example.spec.ts
+index 1111111..2222222 100644
+--- a/browser_tests/tests/example.spec.ts
++++ b/browser_tests/tests/example.spec.ts
+@@ -1,0 +2,3 @@
++// test.skip('documented example')
++/* test.fixme('another example') */
++const note = "test.skip('not executable')"

--- a/scripts/fixtures/test-skip-accountability/non-executable-skips.diff
+++ b/scripts/fixtures/test-skip-accountability/non-executable-skips.diff
@@ -2,7 +2,9 @@ diff --git a/browser_tests/tests/example.spec.ts b/browser_tests/tests/example.s
 index 1111111..2222222 100644
 --- a/browser_tests/tests/example.spec.ts
 +++ b/browser_tests/tests/example.spec.ts
-@@ -1,0 +2,3 @@
+@@ -1,1 +2,5 @@
 +// test.skip('documented example')
 +/* test.fixme('another example') */
 +const note = "test.skip('not executable')"
++
+ test.skip('existing skip')

--- a/scripts/fixtures/test-skip-accountability/non-executable-skips.diff
+++ b/scripts/fixtures/test-skip-accountability/non-executable-skips.diff
@@ -2,9 +2,16 @@ diff --git a/browser_tests/tests/example.spec.ts b/browser_tests/tests/example.s
 index 1111111..2222222 100644
 --- a/browser_tests/tests/example.spec.ts
 +++ b/browser_tests/tests/example.spec.ts
-@@ -1,1 +2,5 @@
+@@ -1,1 +2,11 @@
 +// test.skip('documented example')
 +/* test.fixme('another example') */
 +const note = "test.skip('not executable')"
-+
++const inlineNote = `we never test.fixme(here)`
++expect(label).toBe('run test.skip(x) manually')
++/**
++ * test.skip('jsdoc continuation')
++ */
++/*
++test.fixme('inside an added block comment')
++*/
  test.skip('existing skip')

--- a/scripts/fixtures/test-skip-accountability/unlinked-body.md
+++ b/scripts/fixtures/test-skip-accountability/unlinked-body.md
@@ -1,0 +1,1 @@
+Temporarily disable the failing browser test to unblock CI.

--- a/scripts/fixtures/test-skip-accountability/unlinked-body.md
+++ b/scripts/fixtures/test-skip-accountability/unlinked-body.md
@@ -1,1 +1,3 @@
+# Pull request summary
+
 Temporarily disable the failing browser test to unblock CI.


### PR DESCRIPTION
Browser-test skips now require restoration tracking.
Unlinked `test.fixme()` / `test.skip()` additions fail CI.
Fixture-backed checks cover both outcomes.

<details><summary>Full context for agent readers</summary>

## Summary

PR #16907 temporarily disabled a browser test with an empty body, leaving no durable pointer to the work that would restore it. This adds a deterministic pull-request guard for newly added `test.fixme()` and `test.skip()` calls under `browser_tests/**`.

## Changes

- Read added browser-test lines between the pull request base SHA and the pull request head SHA (`origin/main...HEAD` locally). `actions/checkout` resolves `HEAD` to `refs/pull/<n>/merge`, so the head SHA is passed explicitly.
- Detect skip calls anywhere in executable added source, including `test.describe.skip()` / `test.describe.fixme()` and calls that follow other tokens on the line. String literals, line comments and block comments are excluded, as are unchanged lines.
- Read the pull request body from the GitHub event payload in CI, with `gh pr view` as the local fallback.
- Reject new skips unless the body contains a GitHub issue or pull request reference.
- Re-run on `edited`, so adding the tracking link to the body clears the check without an extra push.
- Exercise the checker against committed linked and unlinked fixtures in the PR workflow.

## Review Focus

The guard applies only to newly added browser-test skips. Existing skips remain untouched.

Nothing lints top-level `scripts/`: `pnpm lint` runs `eslint src` and `oxlint:main` targets `src browser_tests tools/oxlint-plugins`. A green `pnpm lint` says nothing about this file, so the gates that matter here are the self-test, `node --check`, and `oxfmt`. The self-test is likewise outside the Vitest `scripts/**/*.{test,spec}.*` glob (the name ends `-test.mjs`, not `.test.mjs`) because it uses `node:test`; the dedicated workflow step is what runs it.

## Evidence

- `node --test scripts/check-test-skip-accountability.self-test.mjs` -> `tests 5 / pass 5 / fail 0`.
- `node --check` on both scripts -> clean.
- `oxfmt --check scripts/check-test-skip-accountability.mjs scripts/check-test-skip-accountability.self-test.mjs` -> "All matched files use the correct format."
- Non-line-start skip (`if (isUnsupported) test.skip(...)`), unlinked body: exit 0 at 458ea0f5f5, exit 1 at HEAD.
- `test.describe.skip(...)`, unlinked body: exit 0 at 458ea0f5f5, exit 1 at HEAD.
- `non-executable-skips.diff` grown to seven guard lines (single/double/template strings, a string argument to `expect`, a line comment, a single-line block comment, a JSDoc continuation, an added multi-line block comment). A naive match-anywhere pattern flags all seven; the checker flags none, and still exits 1 when one real skip is appended to that same fixture.
- Wrong-range regression, reproduced in a scratch repo with `HEAD` on a simulated merge ref, main carrying a `test.fixme` added after `base.sha`, and a PR that adds only a docs file: `base...HEAD` exits 1 (innocent PR fails), `--head-sha` exits 0, and `--head-sha` against a branch that really adds a skip still exits 1.

</details>

<!-- authored-by:agent lane-fixmeguard-1-1040 -->
