### PR TITLE
fix(agent): ignore stale ask answer failures

### DIFF
--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -603,6 +603,44 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(conversationStore.threadId).toBe('th-2')
   })
 
+  it('surfaces a non-409 answer failure after returning to the originating thread', async () => {
+    let rejectAnswer: ((reason?: unknown) => void) | undefined
+    const answerAsk = vi.fn<AgentRestClient['answerAsk']>(
+      () =>
+        new Promise<AgentAnswerAccepted>((_, reject) => {
+          rejectAnswer = reject
+        })
+    )
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ answerAsk }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('build it')
+    emit(runApproval('msg-1'))
+
+    const pendingAnswer = session.answerAsk('turn-1:call-1', 'run')
+    await vi.waitFor(() => expect(answerAsk).toHaveBeenCalledOnce())
+    await session.loadThread('th-2')
+    await session.loadThread('th-1')
+
+    rejectAnswer?.(new AgentApiError('backend blip', 500, undefined))
+    await pendingAnswer
+
+    const conversationStore = useAgentConversationStore()
+    expect(conversationStore.threadId).toBe('th-1')
+    expect(
+      conversationStore.messages[0].parts.some(
+        (part) => part.type === 'runApproval'
+      )
+    ).toBe(true)
+    expect(session.answeringAskIds.value.has('turn-1:call-1')).toBe(false)
+    expect(session.notices.value).toEqual([
+      { level: 'error', text: 'backend blip' }
+    ])
+  })
+
   it('retains and re-enables an approval after a non-409 answer failure', async () => {
     const answerAsk = vi
       .fn<AgentRestClient['answerAsk']>()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -519,11 +519,47 @@ describe('useAgentSession (v1 composition root)', () => {
 
     const conversationStore = useAgentConversationStore()
     const ingest = vi.spyOn(conversationStore, 'ingest')
-    const answeringStateAfterSwitch = session.answeringAskIds.value
     rejectAnswer?.(new AgentApiError('already answered', 409, undefined))
     await pendingAnswer
 
-    expect(session.answeringAskIds.value).toBe(answeringStateAfterSwitch)
+    expect(session.answeringAskIds.value.has('turn-1:call-1')).toBe(false)
+    expect(ingest).not.toHaveBeenCalled()
+    expect(session.notices.value).toEqual([])
+    expect(reportError).not.toHaveBeenCalled()
+    expect(conversationStore.threadId).toBe('th-2')
+  })
+
+  it('reports a stale non-409 answer failure without mutating the new thread', async () => {
+    let rejectAnswer: ((reason?: unknown) => void) | undefined
+    const answerAsk = vi.fn<AgentRestClient['answerAsk']>(
+      () =>
+        new Promise<AgentAnswerAccepted>((_, reject) => {
+          rejectAnswer = reject
+        })
+    )
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ answerAsk }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('build it')
+    emit(runApproval('msg-1'))
+
+    const pendingAnswer = session.answerAsk('turn-1:call-1', 'run')
+    await vi.waitFor(() => expect(answerAsk).toHaveBeenCalledOnce())
+    await session.loadThread('th-2')
+
+    const conversationStore = useAgentConversationStore()
+    const ingest = vi.spyOn(conversationStore, 'ingest')
+    rejectAnswer?.(new AgentApiError('backend blip', 500, undefined))
+    await pendingAnswer
+
+    expect(reportError).toHaveBeenCalledWith(expect.any(AgentApiError), {
+      errorType: 'agent_ask_answer_failed'
+    })
+    expect(session.answeringAskIds.value.has('turn-1:call-1')).toBe(false)
+    expect(session.notices.value).toEqual([])
     expect(ingest).not.toHaveBeenCalled()
     expect(conversationStore.threadId).toBe('th-2')
   })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -496,6 +496,38 @@ describe('useAgentSession (v1 composition root)', () => {
     ).toBe(false)
   })
 
+  it('ignores a stale answer failure after switching threads', async () => {
+    let rejectAnswer: ((reason?: unknown) => void) | undefined
+    const answerAsk = vi.fn<AgentRestClient['answerAsk']>(
+      () =>
+        new Promise<AgentAnswerAccepted>((_, reject) => {
+          rejectAnswer = reject
+        })
+    )
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ answerAsk }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('build it')
+    emit(runApproval('msg-1'))
+
+    const pendingAnswer = session.answerAsk('turn-1:call-1', 'run')
+    await vi.waitFor(() => expect(answerAsk).toHaveBeenCalledOnce())
+    await session.loadThread('th-2')
+
+    const conversationStore = useAgentConversationStore()
+    const ingest = vi.spyOn(conversationStore, 'ingest')
+    const answeringStateAfterSwitch = session.answeringAskIds.value
+    rejectAnswer?.(new AgentApiError('already answered', 409, undefined))
+    await pendingAnswer
+
+    expect(session.answeringAskIds.value).toBe(answeringStateAfterSwitch)
+    expect(ingest).not.toHaveBeenCalled()
+    expect(conversationStore.threadId).toBe('th-2')
+  })
+
   it('retains and re-enables an approval after a non-409 answer failure', async () => {
     const answerAsk = vi
       .fn<AgentRestClient['answerAsk']>()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -554,6 +554,7 @@ describe('useAgentSession (v1 composition root)', () => {
     const pendingAnswer = session.answerAsk('turn-1:call-1', 'run')
     await vi.waitFor(() => expect(answerAsk).toHaveBeenCalledOnce())
     session.stop()
+    session.start()
 
     const conversationStore = useAgentConversationStore()
     const ingest = vi.spyOn(conversationStore, 'ingest')

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -496,7 +496,7 @@ describe('useAgentSession (v1 composition root)', () => {
     ).toBe(false)
   })
 
-  it('ignores a stale answer failure after switching threads', async () => {
+  it('records a 409 resolution after switching threads', async () => {
     let rejectAnswer: ((reason?: unknown) => void) | undefined
     const answerAsk = vi.fn<AgentRestClient['answerAsk']>(
       () =>
@@ -517,16 +517,21 @@ describe('useAgentSession (v1 composition root)', () => {
     await vi.waitFor(() => expect(answerAsk).toHaveBeenCalledOnce())
     await session.loadThread('th-2')
 
-    const conversationStore = useAgentConversationStore()
-    const ingest = vi.spyOn(conversationStore, 'ingest')
     rejectAnswer?.(new AgentApiError('already answered', 409, undefined))
     await pendingAnswer
 
+    const conversationStore = useAgentConversationStore()
     expect(session.answeringAskIds.value.has('turn-1:call-1')).toBe(false)
-    expect(ingest).not.toHaveBeenCalled()
     expect(session.notices.value).toEqual([])
     expect(reportError).not.toHaveBeenCalled()
     expect(conversationStore.threadId).toBe('th-2')
+
+    await session.loadThread('th-1')
+    expect(
+      conversationStore.messages[0].parts.some(
+        (part) => part.type === 'runApproval'
+      )
+    ).toBe(false)
   })
 
   it('reports a stale non-409 answer failure without mutating the new thread', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -561,7 +561,9 @@ describe('useAgentSession (v1 composition root)', () => {
     rejectAnswer?.(new AgentApiError('already answered', 409, undefined))
     await pendingAnswer
 
-    expect(ingest).not.toHaveBeenCalled()
+    expect(ingest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'agent_ask_resolved' })
+    )
   })
 
   it('reports a stale non-409 answer failure without mutating the new thread', async () => {
@@ -595,7 +597,9 @@ describe('useAgentSession (v1 composition root)', () => {
     })
     expect(session.answeringAskIds.value.has('turn-1:call-1')).toBe(false)
     expect(session.notices.value).toEqual([])
-    expect(ingest).not.toHaveBeenCalled()
+    expect(ingest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'agent_ask_resolved' })
+    )
     expect(conversationStore.threadId).toBe('th-2')
   })
 

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -534,6 +534,35 @@ describe('useAgentSession (v1 composition root)', () => {
     ).toBe(false)
   })
 
+  it('ignores a 409 resolution after the session stops', async () => {
+    let rejectAnswer: ((reason?: unknown) => void) | undefined
+    const answerAsk = vi.fn<AgentRestClient['answerAsk']>(
+      () =>
+        new Promise<AgentAnswerAccepted>((_, reject) => {
+          rejectAnswer = reject
+        })
+    )
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ answerAsk }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('build it')
+    emit(runApproval('msg-1'))
+
+    const pendingAnswer = session.answerAsk('turn-1:call-1', 'run')
+    await vi.waitFor(() => expect(answerAsk).toHaveBeenCalledOnce())
+    session.stop()
+
+    const conversationStore = useAgentConversationStore()
+    const ingest = vi.spyOn(conversationStore, 'ingest')
+    rejectAnswer?.(new AgentApiError('already answered', 409, undefined))
+    await pendingAnswer
+
+    expect(ingest).not.toHaveBeenCalled()
+  })
+
   it('reports a stale non-409 answer failure without mutating the new thread', async () => {
     let rejectAnswer: ((reason?: unknown) => void) | undefined
     const answerAsk = vi.fn<AgentRestClient['answerAsk']>(

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -385,6 +385,8 @@ export function useAgentSession(deps: AgentSessionDeps) {
       answeringAskIds.value.has(askId)
     )
       return
+    const answerOwnedGeneration = ownedGeneration
+    const answerSessionGeneration = sessionGeneration
     const generation = loadGeneration
     const isCurrent = () =>
       generation === loadGeneration && ownedGeneration === sessionGeneration
@@ -397,7 +399,11 @@ export function useAgentSession(deps: AgentSessionDeps) {
       // the failure lands on a thread the user already left.
       setAskAnswering(askId, false)
       if (error instanceof AgentApiError && error.status === 409) {
-        if (ownedGeneration !== sessionGeneration) return
+        if (
+          answerOwnedGeneration !== ownedGeneration ||
+          answerSessionGeneration !== sessionGeneration
+        )
+          return
         conversationStore.ingest({
           type: 'agent_ask_resolved',
           data: {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -392,9 +392,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
       await rest.answerAsk(currentThreadId, askId, [selection])
       // Keep the actions disabled until the canonical resolution frame arrives.
     } catch (error) {
-      if (!isCurrent()) return
+      // A failed answer must never wedge the ask in answeringAskIds, even when
+      // the failure lands on a thread the user already left.
       setAskAnswering(askId, false)
       if (error instanceof AgentApiError && error.status === 409) {
+        // Another path resolved the ask; only rehydrate the visible thread.
+        if (!isCurrent()) return
         conversationStore.ingest({
           type: 'agent_ask_resolved',
           data: {
@@ -407,7 +410,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
         })
         return
       }
+      // A backend failure to record the answer is real telemetry regardless of
+      // which thread is on screen; only the user-facing notice is thread-local.
       reportError(error, { errorType: 'agent_ask_answer_failed' })
+      if (!isCurrent()) return
       pushError(error instanceof Error ? error.message : String(error))
     }
   }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -212,7 +212,8 @@ export function useAgentSession(deps: AgentSessionDeps) {
     unsubscribeStatus?.()
     unsubscribe = null
     unsubscribeStatus = null
-    const stoppedGeneration = ownedGeneration
+    if (ownedGeneration !== sessionGeneration) return
+    const stoppedGeneration = ++sessionGeneration
     queueMicrotask(() => {
       if (stoppedGeneration !== sessionGeneration) return
       conversationStore.abortActiveTurn()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -396,8 +396,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
       // the failure lands on a thread the user already left.
       setAskAnswering(askId, false)
       if (error instanceof AgentApiError && error.status === 409) {
-        // Another path resolved the ask; only rehydrate the visible thread.
-        if (!isCurrent()) return
+        if (ownedGeneration !== sessionGeneration) return
         conversationStore.ingest({
           type: 'agent_ask_resolved',
           data: {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -384,11 +384,15 @@ export function useAgentSession(deps: AgentSessionDeps) {
       answeringAskIds.value.has(askId)
     )
       return
+    const generation = loadGeneration
+    const isCurrent = () =>
+      generation === loadGeneration && ownedGeneration === sessionGeneration
     setAskAnswering(askId, true)
     try {
       await rest.answerAsk(currentThreadId, askId, [selection])
       // Keep the actions disabled until the canonical resolution frame arrives.
     } catch (error) {
+      if (!isCurrent()) return
       setAskAnswering(askId, false)
       if (error instanceof AgentApiError && error.status === 409) {
         conversationStore.ingest({

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -395,8 +395,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
       await rest.answerAsk(currentThreadId, askId, [selection])
       // Keep the actions disabled until the canonical resolution frame arrives.
     } catch (error) {
-      // A failed answer must never wedge the ask in answeringAskIds, even when
-      // the failure lands on a thread the user already left.
       setAskAnswering(askId, false)
       if (error instanceof AgentApiError && error.status === 409) {
         if (
@@ -416,8 +414,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
         })
         return
       }
-      // A backend failure to record the answer is real telemetry regardless of
-      // which thread is on screen; only the user-facing notice is thread-local.
       reportError(error, { errorType: 'agent_ask_answer_failed' })
       if (!isCurrent()) return
       pushError(error instanceof Error ? error.message : String(error))

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -387,9 +387,11 @@ export function useAgentSession(deps: AgentSessionDeps) {
       return
     const answerOwnedGeneration = ownedGeneration
     const answerSessionGeneration = sessionGeneration
-    const generation = loadGeneration
-    const isCurrent = () =>
-      generation === loadGeneration && ownedGeneration === sessionGeneration
+    const isAnswerSessionLive = () =>
+      answerOwnedGeneration === ownedGeneration &&
+      answerSessionGeneration === sessionGeneration
+    const isAnswerThreadOnScreen = () =>
+      isAnswerSessionLive() && conversationStore.threadId === currentThreadId
     setAskAnswering(askId, true)
     try {
       await rest.answerAsk(currentThreadId, askId, [selection])
@@ -397,11 +399,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
     } catch (error) {
       setAskAnswering(askId, false)
       if (error instanceof AgentApiError && error.status === 409) {
-        if (
-          answerOwnedGeneration !== ownedGeneration ||
-          answerSessionGeneration !== sessionGeneration
-        )
-          return
+        if (!isAnswerSessionLive()) return
         conversationStore.ingest({
           type: 'agent_ask_resolved',
           data: {
@@ -415,7 +413,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         return
       }
       reportError(error, { errorType: 'agent_ask_answer_failed' })
-      if (!isCurrent()) return
+      if (!isAnswerThreadOnScreen()) return
       pushError(error instanceof Error ? error.message : String(error))
     }
   }


### PR DESCRIPTION
Prevents late Ask-answer failures from mutating a session the user has left.

- Gates the 409 resolution on the originating session, and the visible error notice on the originating session and thread.
- Always clears the answering flag and always reports to telemetry, so a stale failure cannot strand the approval or hide a real backend error.
- Adds unit and browser regressions for the thread-switch, stop/restart and new-chat paths.

<details><summary>Full context for agent readers</summary>

## Summary

`answerAsk()` captures the owning session generation before awaiting `rest.answerAsk()`, and the failure path now decides each mutation separately instead of running them all unconditionally:

- `setAskAnswering(askId, false)` always runs, so a late failure cannot leave the approval permanently disabled across `stop()`/`start()`.
- The 409 `agent_ask_resolved` ingest runs only while the originating session is still current.
- `reportError` always runs. A 5xx is a real backend failure to record the user's approval whether or not that conversation is still on screen.
- `pushError`, the user-visible notice, runs only when the originating session is current and `conversationStore.threadId` still equals the thread the answer was sent from. Navigation history alone is not the predicate, so leaving `th-1` and returning still surfaces the failure.

`stop()` also no longer invalidates a session it does not own: it bumps `sessionGeneration` only when `ownedGeneration === sessionGeneration`, so a stale instance's teardown cannot cancel the live instance's turn.

## Changes

- **What**: the failure handling above, extracted into `handleAnswerAskError`, `isSessionGenerationCurrent` and `isAnswerThreadOnScreen` in `useAgentSession.ts`.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

The guard is additive with the identity-generation work in [#16768](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16768): that branch increments `loadGeneration` on identity changes, so its conflict resolution must preserve these session-generation checks. [#17324](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17324) carries the same obligation in this file.

## Evidence

Verified at `20c1509396`, which merges current `main`:

- `pnpm install --frozen-lockfile` — clean.
- `pnpm exec vitest run src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts` — 80 passed, 2 expected fail (82 total), with `NODE_OPTIONS=--no-experimental-webstorage`.
- `pnpm typecheck` and `pnpm typecheck:browser` — clean.
- `pnpm exec eslint` and `pnpm exec oxfmt --check` on the changed spec — clean.
- `pnpm knip --cache` — clean.
- `pnpm exec playwright test --list browser_tests/tests/agent/agentPanel.spec.ts` — 10 tests discovered, including `does not surface an ask failure after starting a new chat`.

</details>

<!-- authored-by:agent lane-phs-24-0836 -->
