### PR TITLE
Blocked subscribe audiences get a dialog that says who to ask

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2977,6 +2977,18 @@
       "memberRunTooltip": "Contact your workspace owner to resubscribe",
       "runLabel": "Run"
     },
+    "managedByOwner": {
+      "memberTitle": "This workspace's plan is managed by its owner",
+      "memberDescription": "Ask your workspace owner to make changes to the workspace's plan.",
+      "memberCta": "Ok, got it"
+    },
+    "salesManaged": {
+      "planTitle": "Your plan is managed with our sales team",
+      "planDescription": "Subscriptions for this workspace are handled by our sales team. Reach out to make changes to your plan.",
+      "outOfCreditsTitle": "This workspace is out of credits",
+      "outOfCreditsDescription": "Credits for this workspace are managed with our sales team. Reach out to add more.",
+      "contactSales": "Contact sales"
+    },
     "paymentRecovery": {
       "title": "Subscription paused",
       "ownerDescription": "Update your payment method to restore the workspace's subscription and run workflows.",

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -31,12 +31,16 @@ vi.mock('vue-router', () => ({
 }))
 
 const mockShowPricingTable = vi.hoisted(() => vi.fn())
+const mockShowMemberDialog = vi.hoisted(() => vi.fn(() => true))
+const mockShowSalesManagedDialog = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock(
   '@/platform/cloud/subscription/composables/useSubscriptionDialog',
   () => ({
     useSubscriptionDialog: () => ({
-      showPricingTable: mockShowPricingTable
+      showPricingTable: mockShowPricingTable,
+      showMemberDialog: mockShowMemberDialog,
+      showSalesManagedDialog: mockShowSalesManagedDialog
     })
   })
 )
@@ -48,23 +52,27 @@ const mockTeamCreditStops = vi.hoisted(() => ({
   value: null as TeamCreditStops | null
 }))
 const mockFetchPlans = vi.hoisted(() => vi.fn())
+const mockSubscription = vi.hoisted(() => ({
+  value: null as { tier: string } | null
+}))
+const mockFetchStatus = vi.hoisted(() => vi.fn(async () => undefined))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     teamCreditStops: mockTeamCreditStops,
-    fetchPlans: mockFetchPlans
+    fetchPlans: mockFetchPlans,
+    subscription: mockSubscription,
+    fetchStatus: mockFetchStatus
   })
 }))
 
-const mockCanOpenPricingSurface = vi.hoisted(() => ({ value: true }))
 const mockInitializeCapabilities = vi.hoisted(() =>
   vi.fn(async () => undefined)
 )
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
-    permissions: mockPermissions,
-    canOpenPricingSurface: mockCanOpenPricingSurface
+    permissions: mockPermissions
   })
 }))
 
@@ -94,12 +102,18 @@ describe('usePricingTableUrlLoader', () => {
   beforeEach(() => {
     mockRouteQuery.value = {}
     mockPermissions.value = { canManageSubscription: true }
-    mockCanOpenPricingSurface.value = true
     mockInitializeCapabilities.mockClear()
     mockInitializeCapabilities.mockResolvedValue(undefined)
     mockTeamCreditStops.value = TEAM_CREDIT_STOPS
     mockFetchPlans.mockResolvedValue(undefined)
+    mockSubscription.value = { tier: 'TEAM' }
+    mockFetchStatus.mockClear()
+    mockFetchStatus.mockResolvedValue(undefined)
     mockShowPricingTable.mockResolvedValue(undefined)
+    mockShowMemberDialog.mockClear()
+    mockShowMemberDialog.mockReturnValue(true)
+    mockShowSalesManagedDialog.mockClear()
+    mockShowSalesManagedDialog.mockReturnValue(false)
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -125,29 +139,82 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
-  it('never opens for a sales-managed workspace, even from a deep link', async () => {
+  it('routes a sales-managed owner to the contact-sales dialog, never the table', async () => {
     mockRouteQuery.value = { pricing: '1' }
-    mockCanOpenPricingSurface.value = false
+    mockShowSalesManagedDialog.mockReturnValue(true)
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
+    expect(mockShowSalesManagedDialog).toHaveBeenCalledOnce()
     expect(mockShowPricingTable).not.toHaveBeenCalled()
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
   it('resolves the capability snapshot before deciding', async () => {
     mockRouteQuery.value = { pricing: '1' }
-    mockCanOpenPricingSurface.value = true
-    mockInitializeCapabilities.mockImplementation(async () => {
-      mockCanOpenPricingSurface.value = false
-    })
+    mockShowSalesManagedDialog.mockReturnValue(true)
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
     expect(mockInitializeCapabilities).toHaveBeenCalledOnce()
+    expect(mockInitializeCapabilities.mock.invocationCallOrder[0]).toBeLessThan(
+      mockShowSalesManagedDialog.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('fetches the subscription tier before the sales-managed decision when unknown', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockSubscription.value = null
+    mockFetchStatus.mockImplementation(async () => {
+      mockSubscription.value = { tier: 'ENTERPRISE' }
+    })
+    mockShowSalesManagedDialog.mockReturnValue(true)
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockFetchStatus).toHaveBeenCalledOnce()
+    expect(mockFetchStatus.mock.invocationCallOrder[0]).toBeLessThan(
+      mockShowSalesManagedDialog.mock.invocationCallOrder[0]
+    )
     expect(mockShowPricingTable).not.toHaveBeenCalled()
+  })
+
+  it('skips the tier fetch when the subscription is already loaded', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockFetchStatus).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).toHaveBeenCalled()
+  })
+
+  it('still opens the table when the tier fetch fails (footer notice explains)', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockSubscription.value = null
+    mockFetchStatus.mockRejectedValue(new Error('status unavailable'))
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'deep_link' })
+    )
+  })
+
+  it('opens the table for a denied self-serve owner - the footer notice explains', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockShowSalesManagedDialog.mockReturnValue(false)
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'deep_link' })
+    )
   })
 
   it('opens on the team tab for ?pricing=team', async () => {
@@ -190,13 +257,14 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
-  it('is a silent no-op for a member', async () => {
+  it('routes a member to the member dialog instead of a silent no-op', async () => {
     mockRouteQuery.value = { pricing: '1' }
     mockPermissions.value = { canManageSubscription: false }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
+    expect(mockShowMemberDialog).toHaveBeenCalledOnce()
     expect(mockShowPricingTable).not.toHaveBeenCalled()
   })
 
@@ -211,6 +279,7 @@ describe('usePricingTableUrlLoader', () => {
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
+    expect(mockShowMemberDialog).toHaveBeenCalledOnce()
     expect(mockShowPricingTable).not.toHaveBeenCalled()
     expect(mockRouterReplace).toHaveBeenCalledWith({
       query: { other: 'param' }

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -95,16 +95,20 @@ export function getPricingCheckoutSelection(
  * selected personal tier or Team credit stop with a billing cycle to open its
  * confirmation.
  *
- * Gated to workspace owners (`canManageSubscription`); a member is a silent
- * no-op with the param stripped. Survives the login redirect via the
+ * Every audience denial routes to a visible destination (DES-974 item 6):
+ * members get the status-aware member dialog, sales-managed owners get the
+ * contact-sales dialog, and a denied or unreadable capability snapshot opens
+ * the table anyway — its footer notice explains the state. Only malformed
+ * param values stay silent. Survives the login redirect via the
  * preserved-query system, like the invite URL loader.
  */
 export function usePricingTableUrlLoader() {
   const route = useRoute()
   const router = useRouter()
   const subscriptionDialog = useSubscriptionDialog()
-  const { teamCreditStops, fetchPlans } = useBillingContext()
-  const { permissions, canOpenPricingSurface } = useWorkspaceUI()
+  const { teamCreditStops, fetchPlans, subscription, fetchStatus } =
+    useBillingContext()
+  const { permissions } = useWorkspaceUI()
   const { initialize: initializeCapabilities } = useBillingCapabilities()
 
   /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
@@ -140,12 +144,24 @@ export function usePricingTableUrlLoader() {
     // gets stripped above.
     if (typeof param !== 'string' || !param) return
 
-    if (!permissions.value.canManageSubscription) return
+    if (!permissions.value.canManageSubscription) {
+      subscriptionDialog.showMemberDialog()
+      return
+    }
 
-    // The loader can run before the capability snapshot resolves; a
-    // sales-managed workspace must not see the table through that gap.
+    // The loader can run before the capability snapshot or subscription tier
+    // resolves; a sales-managed owner must not see the table through that gap.
     await initializeCapabilities()
-    if (!canOpenPricingSurface.value) return
+    if (!subscription.value) {
+      try {
+        await fetchStatus()
+      } catch {
+        // Tier stays unknown; fall through and open the table.
+      }
+    }
+    if (subscriptionDialog.showSalesManagedDialog()) return
+    // A denied (settling) or unreadable capability snapshot still opens the
+    // table — its footer notice explains and offers the retry.
 
     const teamCheckoutRequest = getTeamCheckoutRequest(
       param,
@@ -161,7 +177,10 @@ export function usePricingTableUrlLoader() {
           error
         )
       }
-      if (!permissions.value.canManageSubscription) return
+      if (!permissions.value.canManageSubscription) {
+        subscriptionDialog.showMemberDialog()
+        return
+      }
       if (!teamCreditStops.value) {
         subscriptionDialog.showPricingTable({
           reason: 'deep_link',
@@ -199,7 +218,10 @@ export function usePricingTableUrlLoader() {
         : undefined
 
     if (!initialCheckout && !['1', 'team', 'personal'].includes(param)) return
-    if (!permissions.value.canManageSubscription) return
+    if (!permissions.value.canManageSubscription) {
+      subscriptionDialog.showMemberDialog()
+      return
+    }
 
     subscriptionDialog.showPricingTable({
       reason: 'deep_link',

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -11,6 +11,10 @@ import {
   savePendingSubscriptionCheckout
 } from '@/platform/workspace/utils/pendingSubscriptionCheckout'
 
+import PlanManagedMemberDialog from '@/platform/workspace/components/PlanManagedMemberDialog.vue'
+import SalesManagedOwnerDialog from '@/platform/workspace/components/SalesManagedOwnerDialog.vue'
+import SubscriptionInactiveMemberDialog from '@/platform/workspace/components/SubscriptionInactiveMemberDialog.vue'
+
 import { useSubscriptionDialog } from './useSubscriptionDialog'
 
 const mockCloseDialog = vi.fn()
@@ -42,8 +46,9 @@ const mockCurrentTeamCreditStop = vi.hoisted(() => ({
   value: null as TeamCreditStopSummary | null
 }))
 const mockSubscription = vi.hoisted(() => ({
-  value: null as Pick<SubscriptionInfo, 'duration'> | null
+  value: null as Partial<Pick<SubscriptionInfo, 'duration' | 'tier'>> | null
 }))
+const mockIsWorkspaceSubscribed = vi.hoisted(() => ({ value: false }))
 const mockSubscriptionStatus = vi.hoisted(() => ({
   value: null as BillingSubscriptionStatus | null
 }))
@@ -107,6 +112,9 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
     },
     get isInPersonalWorkspace() {
       return mockIsInPersonalWorkspace.value
+    },
+    get isWorkspaceSubscribed() {
+      return mockIsWorkspaceSubscribed.value
     }
   })
 }))
@@ -187,6 +195,7 @@ describe('useSubscriptionDialog', () => {
     mockCurrentTeamCreditStop.value = null
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
+    mockIsWorkspaceSubscribed.value = false
     sessionStorage.clear()
   })
 
@@ -496,6 +505,72 @@ describe('useSubscriptionDialog', () => {
       expect(props).toHaveProperty('onClose')
       expect(props).not.toHaveProperty('reason')
       expect(props).not.toHaveProperty('initialPlanMode')
+    })
+
+    it('keeps the reactivation dialog for a member of an inactive workspace', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanManageSubscription.value = false
+      mockIsWorkspaceSubscribed.value = false
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledTimes(1)
+      const loader = mockShowLayoutDialog.mock.calls[0][0].component
+      expect((await loader()).default).toBe(SubscriptionInactiveMemberDialog)
+    })
+
+    it('shows the managed-by-owner dialog to a member of an active workspace', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanManageSubscription.value = false
+      mockIsWorkspaceSubscribed.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledTimes(1)
+      const loader = mockShowLayoutDialog.mock.calls[0][0].component
+      expect((await loader()).default).toBe(PlanManagedMemberDialog)
+      expect(mockTrackSubscription).not.toHaveBeenCalled()
+    })
+
+    it('redirects a sales-managed owner to the contact-sales dialog, never the table', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanManageSubscription.value = true
+      mockSubscription.value = { tier: 'ENTERPRISE' }
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable({ reason: 'deep_link' })
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledTimes(1)
+      const loader = mockShowLayoutDialog.mock.calls[0][0].component
+      expect((await loader()).default).toBe(SalesManagedOwnerDialog)
+      expect(mockTrackSubscription).not.toHaveBeenCalled()
+    })
+
+    it('guards show() the same way for a sales-managed owner', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockSubscription.value = { tier: 'ENTERPRISE' }
+      const { show } = useSubscriptionDialog()
+
+      show()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledTimes(1)
+      const loader = mockShowLayoutDialog.mock.calls[0][0].component
+      expect((await loader()).default).toBe(SalesManagedOwnerDialog)
+    })
+
+    it('leaves the legacy billing rail unguarded by tier', () => {
+      mockShouldUseWorkspaceBilling.value = false
+      mockSubscription.value = { tier: 'ENTERPRISE' }
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable({ reason: 'deep_link' })
+
+      expect(mockTrackSubscription).toHaveBeenCalledWith(
+        'modal_opened',
+        expect.objectContaining({ reason: 'deep_link' })
+      )
     })
 
     it('does not track on non-cloud', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -1,4 +1,5 @@
 import { defineAsyncComponent } from 'vue'
+import type { Component } from 'vue'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
@@ -8,6 +9,7 @@ import {
   getStopDiscountedMonthlyUsd,
   mapApiTeamCreditStops
 } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
+import { isSalesManagedTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
@@ -73,18 +75,10 @@ export const useSubscriptionDialog = () => {
     })
   }
 
-  function showInactiveMemberDialog(): boolean {
-    if (!shouldUseWorkspaceBilling.value) return false
-
-    const { permissions } = useWorkspaceUI()
-    if (permissions.value.canManageSubscription) return false
-
+  function showMemberNoticeDialog(component: Component) {
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
-      component: defineAsyncComponent(
-        () =>
-          import('@/platform/workspace/components/SubscriptionInactiveMemberDialog.vue')
-      ),
+      component,
       props: { onClose: hide },
       dialogComponentProps: {
         renderer: 'reka',
@@ -92,12 +86,58 @@ export const useSubscriptionDialog = () => {
           'w-[min(360px,95vw)] max-w-[min(360px,95vw)] sm:max-w-[min(360px,95vw)] border-0 bg-transparent shadow-none'
       }
     })
+  }
+
+  /**
+   * Members never see the self-serve table. The copy is status-aware: an
+   * inactive workspace asks for a reactivation, an active one just says the
+   * owner manages the plan (no false "subscription is inactive" alarm).
+   */
+  function showMemberDialog(): boolean {
+    if (!shouldUseWorkspaceBilling.value) return false
+
+    const { permissions } = useWorkspaceUI()
+    if (permissions.value.canManageSubscription) return false
+
+    showMemberNoticeDialog(
+      workspaceStore.isWorkspaceSubscribed
+        ? defineAsyncComponent(
+            () =>
+              import('@/platform/workspace/components/PlanManagedMemberDialog.vue')
+          )
+        : defineAsyncComponent(
+            () =>
+              import('@/platform/workspace/components/SubscriptionInactiveMemberDialog.vue')
+          )
+    )
+    return true
+  }
+
+  /**
+   * A sales-managed (Enterprise or unrecognized-tier) owner never sees the
+   * self-serve table — its catalog prices don't apply to a negotiated
+   * contract. Redirects to the contact-sales dialog instead.
+   */
+  function showSalesManagedDialog(): boolean {
+    if (!shouldUseWorkspaceBilling.value) return false
+
+    // Resolved lazily to avoid the useBillingContext import cycle (see below).
+    const { subscription } = useBillingContext()
+    if (!isSalesManagedTier(subscription.value?.tier)) return false
+
+    showMemberNoticeDialog(
+      defineAsyncComponent(
+        () =>
+          import('@/platform/workspace/components/SalesManagedOwnerDialog.vue')
+      )
+    )
     return true
   }
 
   function showPricingTable(options?: SubscriptionDialogOptions) {
     if (!isCloud) return
-    if (showInactiveMemberDialog()) return
+    if (showMemberDialog()) return
+    if (showSalesManagedDialog()) return
 
     trackModalOpened(options?.reason)
 
@@ -205,8 +245,6 @@ export const useSubscriptionDialog = () => {
   }
 
   function show(options?: SubscriptionDialogOptions) {
-    if (isCloud && showInactiveMemberDialog()) return
-
     showPricingTable(options)
   }
 
@@ -338,6 +376,8 @@ export const useSubscriptionDialog = () => {
   return {
     show,
     showPricingTable,
+    showMemberDialog,
+    showSalesManagedDialog,
     hide,
     startTeamWorkspaceUpgradeFlow,
     resumePendingPricingFlow

--- a/src/platform/workspace/components/PlanManagedMemberDialog.test.ts
+++ b/src/platform/workspace/components/PlanManagedMemberDialog.test.ts
@@ -1,0 +1,60 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import PlanManagedMemberDialog from './PlanManagedMemberDialog.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { close: 'Close' },
+      subscription: {
+        managedByOwner: {
+          memberTitle: "This workspace's plan is managed by its owner",
+          memberDescription:
+            "Ask your workspace owner to make changes to the workspace's plan.",
+          memberCta: 'Ok, got it'
+        }
+      }
+    }
+  }
+})
+
+function renderComponent(onClose = vi.fn()) {
+  render(PlanManagedMemberDialog, {
+    props: { onClose },
+    global: { plugins: [i18n] }
+  })
+  return onClose
+}
+
+describe('PlanManagedMemberDialog', () => {
+  it('renders the managed-by-owner copy without an inactive alarm', () => {
+    renderComponent()
+    expect(
+      screen.getByText("This workspace's plan is managed by its owner")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Ask your workspace owner to make changes to the workspace's plan."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/inactive/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Ok, got it' })
+    ).toBeInTheDocument()
+  })
+
+  it('calls onClose from the CTA and the header close button', async () => {
+    const user = userEvent.setup()
+    const onClose = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Ok, got it' }))
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/platform/workspace/components/PlanManagedMemberDialog.vue
+++ b/src/platform/workspace/components/PlanManagedMemberDialog.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    class="flex flex-col overflow-hidden rounded-2xl border border-border-default bg-base-background"
+    data-testid="member-plan-managed-message"
+  >
+    <div
+      class="flex h-12 items-center gap-2 border-b border-border-default p-4"
+    >
+      <p class="m-0 min-w-0 flex-1 font-inter text-sm text-base-foreground">
+        {{ $t('subscription.managedByOwner.memberTitle') }}
+      </p>
+      <button
+        type="button"
+        :aria-label="$t('g.close')"
+        class="flex size-4 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent text-base-foreground"
+        @click="onClose"
+      >
+        <i class="icon-[lucide--x] size-3" />
+      </button>
+    </div>
+
+    <div class="p-4">
+      <p class="m-0 font-inter text-sm text-muted-foreground">
+        {{ $t('subscription.managedByOwner.memberDescription') }}
+      </p>
+    </div>
+
+    <div class="flex items-center justify-end p-4">
+      <Button variant="secondary" size="lg" @click="onClose">
+        {{ $t('subscription.managedByOwner.memberCta') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+const { onClose } = defineProps<{
+  onClose: () => void
+}>()
+</script>

--- a/src/platform/workspace/components/SalesManagedOwnerDialog.test.ts
+++ b/src/platform/workspace/components/SalesManagedOwnerDialog.test.ts
@@ -1,0 +1,95 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SalesManagedOwnerDialog from './SalesManagedOwnerDialog.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { close: 'Close' },
+      subscription: {
+        salesManaged: {
+          planTitle: 'Your plan is managed with our sales team',
+          planDescription:
+            'Subscriptions for this workspace are handled by our sales team. Reach out to make changes to your plan.',
+          outOfCreditsTitle: 'This workspace is out of credits',
+          outOfCreditsDescription:
+            'Credits for this workspace are managed with our sales team. Reach out to add more.',
+          contactSales: 'Contact sales'
+        }
+      }
+    }
+  }
+})
+
+function renderComponent(props: { outOfCredits?: boolean } = {}) {
+  const onClose = vi.fn()
+  render(SalesManagedOwnerDialog, {
+    props: { onClose, ...props },
+    global: { plugins: [i18n] }
+  })
+  return onClose
+}
+
+describe('SalesManagedOwnerDialog', () => {
+  beforeEach(() => {
+    vi.stubGlobal('open', vi.fn())
+  })
+
+  it('renders the plan-managed copy with a Contact sales CTA by default', () => {
+    renderComponent()
+    expect(
+      screen.getByText('Your plan is managed with our sales team')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Subscriptions for this workspace are handled by our sales team. Reach out to make changes to your plan.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Contact sales' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the out-of-credits copy for the out-of-credits variant', () => {
+    renderComponent({ outOfCredits: true })
+    expect(
+      screen.getByText('This workspace is out of credits')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Credits for this workspace are managed with our sales team. Reach out to add more.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Contact sales' })
+    ).toBeInTheDocument()
+  })
+
+  it('opens the enterprise contact page from Contact sales', async () => {
+    const user = userEvent.setup()
+    const onClose = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Contact sales' }))
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://comfy.org/cloud/enterprise/',
+      '_blank',
+      'noopener,noreferrer'
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('dismisses via the header close button', async () => {
+    const user = userEvent.setup()
+    const onClose = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/platform/workspace/components/SalesManagedOwnerDialog.vue
+++ b/src/platform/workspace/components/SalesManagedOwnerDialog.vue
@@ -1,0 +1,59 @@
+<template>
+  <div
+    class="flex flex-col overflow-hidden rounded-2xl border border-border-default bg-base-background"
+    data-testid="sales-managed-owner-message"
+  >
+    <div
+      class="flex h-12 items-center gap-2 border-b border-border-default p-4"
+    >
+      <p class="m-0 min-w-0 flex-1 font-inter text-sm text-base-foreground">
+        {{
+          outOfCredits
+            ? $t('subscription.salesManaged.outOfCreditsTitle')
+            : $t('subscription.salesManaged.planTitle')
+        }}
+      </p>
+      <button
+        type="button"
+        :aria-label="$t('g.close')"
+        class="flex size-4 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent text-base-foreground"
+        @click="onClose"
+      >
+        <i class="icon-[lucide--x] size-3" />
+      </button>
+    </div>
+
+    <div class="p-4">
+      <p class="m-0 font-inter text-sm text-muted-foreground">
+        {{
+          outOfCredits
+            ? $t('subscription.salesManaged.outOfCreditsDescription')
+            : $t('subscription.salesManaged.planDescription')
+        }}
+      </p>
+    </div>
+
+    <div class="flex items-center justify-end p-4">
+      <Button variant="secondary" size="lg" @click="contactSales">
+        {{ $t('subscription.salesManaged.contactSales') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+// Same enterprise-discussions URL as the pricing table footer blurb.
+const ENTERPRISE_URL = 'https://comfy.org/cloud/enterprise/'
+
+const { onClose, outOfCredits = false } = defineProps<{
+  onClose: () => void
+  /** Out-of-credits copy instead of the plan-managed copy. */
+  outOfCredits?: boolean
+}>()
+
+function contactSales() {
+  window.open(ENTERPRISE_URL, '_blank', 'noopener,noreferrer')
+}
+</script>

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -11,7 +11,9 @@ const state = vi.hoisted(() => ({
   canTopUp: true,
   canSubscribeSelfServe: false,
   isReady: true,
-  initialize: vi.fn()
+  initialize: vi.fn(),
+  tier: null as string | null,
+  canManageSubscription: false
 }))
 
 vi.mock('@/stores/dialogStore', () => ({
@@ -35,7 +37,22 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    type: { value: state.type }
+    type: { value: state.type },
+    subscription: {
+      get value() {
+        return state.tier === null ? null : { tier: state.tier }
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: {
+      get value() {
+        return { canManageSubscription: state.canManageSubscription }
+      }
+    }
   })
 }))
 
@@ -74,6 +91,8 @@ vi.mock(
   })
 )
 
+import InsufficientCreditsMemberDialog from '@/platform/workspace/components/InsufficientCreditsMemberDialog.vue'
+import SalesManagedOwnerDialog from '@/platform/workspace/components/SalesManagedOwnerDialog.vue'
 import { useDialogService } from '@/services/dialogService'
 
 describe('showTopUpCreditsDialog', () => {
@@ -83,6 +102,8 @@ describe('showTopUpCreditsDialog', () => {
     state.canSubscribeSelfServe = false
     state.isReady = true
     state.initialize = vi.fn()
+    state.tier = null
+    state.canManageSubscription = false
     mockIsCloud.value = true
   })
 
@@ -115,6 +136,57 @@ describe('showTopUpCreditsDialog', () => {
     expect(closeDialog).toHaveBeenCalledWith({
       key: 'insufficient-credits-member'
     })
+  })
+
+  it('routes a sales-managed owner to the contact-sales notice, not the member copy', async () => {
+    state.canTopUp = false
+    state.canSubscribeSelfServe = false
+    state.tier = 'ENTERPRISE'
+    state.canManageSubscription = true
+
+    await useDialogService().showTopUpCreditsDialog({
+      isInsufficientCredits: true
+    })
+
+    const [args] = showDialog.mock.calls[0]
+    expect(args.key).toBe('insufficient-credits-member')
+    expect(args.component).toBe(SalesManagedOwnerDialog)
+    expect(args.props.outOfCredits).toBe(true)
+    expect(args.dialogComponentProps.headless).toBe(true)
+
+    args.props.onClose()
+    expect(closeDialog).toHaveBeenCalledWith({
+      key: 'insufficient-credits-member'
+    })
+  })
+
+  it('keeps the member copy for a member of a sales-managed workspace', async () => {
+    state.canTopUp = false
+    state.canSubscribeSelfServe = false
+    state.tier = 'ENTERPRISE'
+    state.canManageSubscription = false
+
+    await useDialogService().showTopUpCreditsDialog({
+      isInsufficientCredits: true
+    })
+
+    const [args] = showDialog.mock.calls[0]
+    expect(args.component).toBe(InsufficientCreditsMemberDialog)
+    expect(args.props).not.toHaveProperty('outOfCredits')
+  })
+
+  it('keeps the member copy for a self-serve workspace owner with top-up denied', async () => {
+    state.canTopUp = false
+    state.canSubscribeSelfServe = false
+    state.tier = 'TEAM'
+    state.canManageSubscription = true
+
+    await useDialogService().showTopUpCreditsDialog({
+      isInsufficientCredits: true
+    })
+
+    const [args] = showDialog.mock.calls[0]
+    expect(args.component).toBe(InsufficientCreditsMemberDialog)
   })
 
   it('uses the server capability on legacy billing', async () => {

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -7,8 +7,11 @@ import ErrorDialogContent from '@/components/dialog/content/ErrorDialogContent.v
 import PromptDialogContent from '@/components/dialog/content/PromptDialogContent.vue'
 import TopUpCreditsDialogContentLegacy from '@/components/dialog/content/TopUpCreditsDialogContentLegacy.vue'
 import InsufficientCreditsMemberDialog from '@/platform/workspace/components/InsufficientCreditsMemberDialog.vue'
+import SalesManagedOwnerDialog from '@/platform/workspace/components/SalesManagedOwnerDialog.vue'
 import TopUpCreditsDialogContentWorkspace from '@/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { isSalesManagedTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import { t } from '@/i18n'
 import { useTelemetry } from '@/platform/telemetry'
 import { isCloud } from '@/platform/distribution/types'
@@ -343,7 +346,7 @@ export const useDialogService = () => {
   async function showTopUpCreditsDialog(options?: {
     isInsufficientCredits?: boolean
   }) {
-    const { type } = useBillingContext()
+    const { type, subscription } = useBillingContext()
     const { canTopUp, canSubscribeSelfServe, isReady, initialize } =
       useBillingCapabilities()
     // A capability read still in flight has to be awaited here, or a top-up
@@ -360,10 +363,18 @@ export const useDialogService = () => {
     }
 
     if (!canTopUp.value && type.value === 'workspace') {
+      // A sales-managed owner IS the workspace admin — "ask your admins to add
+      // credits" is the wrong audience. Route them to sales instead.
+      const isSalesManagedOwner =
+        isSalesManagedTier(subscription.value?.tier) &&
+        useWorkspaceUI().permissions.value.canManageSubscription
       return dialogStore.showDialog({
         key: 'insufficient-credits-member',
-        component: InsufficientCreditsMemberDialog,
+        component: isSalesManagedOwner
+          ? SalesManagedOwnerDialog
+          : InsufficientCreditsMemberDialog,
         props: {
+          ...(isSalesManagedOwner ? { outOfCredits: true } : {}),
           onClose: () =>
             dialogStore.closeDialog({ key: 'insufficient-credits-member' })
         },


### PR DESCRIPTION
## Summary

Blocked subscribe audiences now get a dialog that says who to ask instead of a silent or mislabeled dead end (dialog half of DES-974; the footer pill half shipped in #16928).

## Changes

- **What**:
  - Sales-managed (Enterprise/unrecognized-tier) owners opening any pricing entry point now see "Your plan is managed with our sales team" with a Contact sales button instead of a self-serve table with every card dead.
  - An enterprise owner who runs out of credits is no longer told "your workspace admins need to add more credits" — they get the sales-team out-of-credits variant.
  - Members of an active workspace no longer get the false "subscription is inactive" alarm; they see "This workspace's plan is managed by its owner". Inactive workspaces keep today's reactivation copy.
  - Every `?pricing` deep-link denial now lands somewhere visible: members → status-aware member dialog, sales-managed owners → contact-sales dialog, capability-denied or unreadable snapshot → the table opens and #16928's footer pill explains.

## Review Focus

- Guard order in `useSubscriptionDialog.showPricingTable`: member guard before tier guard, so a member of an enterprise workspace gets member copy.
- The URL loader fetches the subscription tier (when not yet loaded) before the sales-managed decision; a failed fetch falls through to the table rather than silently bailing.

Fixes FE-2037

## Screenshots (if applicable)

Copy and layout match Figma frames 6643:29650, 6643:29663, 6646:29403 (360px member-dialog family).
