### PR TITLE
test(agent): run slice03 canvas primitive specs against main

### DIFF
--- a/browser_tests/tests/agent/slice03CanvasPrimitives.spec.ts
+++ b/browser_tests/tests/agent/slice03CanvasPrimitives.spec.ts
@@ -3,8 +3,14 @@ import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 
-// These cases are intentionally staged behind fixme until the stacked canvas
-// slice lands on main: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186
+// These cases cover canvas selection / navigation behaviour that exists on
+// main. They were originally gated behind slice PR 16186
+// (https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186), which stayed an
+// open draft and is no longer the landing target for this surface, so the gate
+// could never fire. They run against main directly now; all helpers they use
+// (nodeOps.getSerializedGraph/getSelectedGraphNodesCount, NodeReference
+// centerOnNode/getPosition/click, canvasOps.getOffset/getNodeGeometry/
+// expectSlotsTrackedNode, fitToViewInstant) already exist on main.
 test.describe(
   'Agent canvas primitives from slice 03',
   { tag: '@agent' },
@@ -12,11 +18,6 @@ test.describe(
     test('select-only preserves the semantic workflow graph', async ({
       comfyPage
     }) => {
-      test.fixme(
-        true,
-        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
-      )
-
       const node = await comfyPage.nodeOps.getFirstNodeRef()
       expect(node).not.toBeNull()
       if (!node) return
@@ -35,11 +36,6 @@ test.describe(
     test('focuses a known node without changing its graph data', async ({
       comfyPage
     }) => {
-      test.fixme(
-        true,
-        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
-      )
-
       const node = await comfyPage.nodeOps.getFirstNodeRef()
       expect(node).not.toBeNull()
       if (!node) return
@@ -54,11 +50,6 @@ test.describe(
     test('fits the complete graph when a node is selected', async ({
       comfyPage
     }) => {
-      test.fixme(
-        true,
-        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
-      )
-
       const node = await comfyPage.nodeOps.getFirstNodeRef()
       expect(node).not.toBeNull()
       if (!node) return
@@ -72,11 +63,6 @@ test.describe(
     test('moves one selected node and keeps its connection slots aligned', async ({
       comfyPage
     }) => {
-      test.fixme(
-        true,
-        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
-      )
-
       const node = await comfyPage.nodeOps.getFirstNodeRef()
       expect(node).not.toBeNull()
       if (!node) return


### PR DESCRIPTION
## What

Enables the four agent e2e specs in `browser_tests/tests/agent/slice03CanvasPrimitives.spec.ts` that were `test.fixme`-gated on slice PR #16186 merging, and re-points the file header at main.

## Why

#16186 (`[agent-v1 03/18]` canvas primitives slice) remains an open draft, untouched since 2026-09-02, and is no longer the landing target for this surface — so the stated activation condition ("after slice PR 16186 merges") cannot fire, and four tests stay permanently dormant.

Per-test decision: every assertion in all four specs depends only on helpers that already exist on main —
- `nodeOps.getFirstNodeRef` / `getSerializedGraph` / `getSelectedGraphNodesCount` (`browser_tests/fixtures/helpers/NodeOperationsHelper.ts`)
- `NodeReference.centerOnNode()` / `getPosition()` / `click('title')` (`browser_tests/fixtures/utils/litegraphUtils.ts`)
- `canvasOps.getOffset` / `getNodeGeometry` / `expectSlotsTrackedNode` (`browser_tests/fixtures/helpers/CanvasHelper.ts`)
- `fitToViewInstant` (`browser_tests/fixtures/utils/fitToView.ts`)

No spec body calls any API introduced by #16186 (its select-only mode / viewport-occlusion primitives), so the gate is wrong rather than early: the specs run against main directly.

## Evidence

- `git fetch origin nathaniel/agent-v1/03-canvas-primitives && git diff --stat origin/main...FETCH_HEAD` — slice PR adds `LGraphCanvas` select-only mode, `DragAndScale` viewport insets, CRDT follower, etc.; none of it is referenced by the spec's imports or bodies.
- `grep` confirms all four helper surfaces above exist at main `9ff3fd7f0e`.
- `playwright test browser_tests/tests/agent/slice03CanvasPrimitives.spec.ts --list --project=chromium` — 4 tests collected, 0 skipped.
- `eslint`, `oxlint`, `oxfmt --check` on the changed file — all clean.

CI (the 16-shard e2e job with a real backend) is the arbiter of the runtime assertions; a failure there would be a real main-reachable behaviour finding, not a gate issue.

<!-- authored-by:agent lane-phs-26-0847 -->
