### PR TITLE
test(agent): guard #agent-panel-title to exactly one in the fast suite

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1914,6 +1914,29 @@ describe('AgentPanelRoot greeting', () => {
   })
 })
 
+describe('AgentPanelRoot a11y id guard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    ws.clear()
+  })
+
+  // R-193 residual: a duplicated #agent-panel-title (the FE #16912 regression
+  // class) reached main unnoticed because the fast suite never asserted the id
+  // count. Assert the document-level count, not a getBy* query, so a second
+  // copy of the id fails loudly here instead of only in the Playwright suite
+  // (agentPanelLifecycle.spec.ts, still test.fixme pending FE #16919).
+  it('renders exactly one #agent-panel-title on the success path', async () => {
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    expect(await screen.findByText(i18n.global.t('agent.title'))).toBeVisible()
+    // Document-level count is the point: the guard must see any duplicate id
+    // anywhere in the document, not just within the panel subtree.
+    /* eslint-disable testing-library/no-node-access */
+    expect(document.querySelectorAll('#agent-panel-title')).toHaveLength(1)
+    /* eslint-enable testing-library/no-node-access */
+  })
+})
+
 describe('AgentPanelRoot workflow binding', () => {
   beforeEach(() => {
     setActivePinia(createPinia())


### PR DESCRIPTION
## Why

A duplicated `#agent-panel-title` (the FE #16912 regression class) reached main unnoticed because the fast unit suite is provably blind to the id count — 76 files / 1013 tests passed identically on both the duplicate and clean heads (`reports/e2e-support/2026-09-04-0300Z-dup-id-and-branch-health.md` in the program repo). The only guard was the Playwright lifecycle spec (`browser_tests/tests/agent/agentPanelLifecycle.spec.ts:68`), still `test.fixme` pending FE #16919 human approval.

## What

Adds one unit assertion beside `AgentPanelRoot.vue` in `AgentPanelRoot.test.ts`: mount the panel on the success path and assert `document.querySelectorAll('#agent-panel-title')` has length exactly 1.

- Document-level count on purpose, so a duplicate id anywhere in the document fails, not just one inside the panel subtree.
- Does not touch `agentPanelLifecycle.spec.ts` — FE #16919 owns its restore.

## Verification

- New test passes at current main (`9ff3fd7f0e`): `1 passed`.
- Negative control: with a second `#agent-panel-title` element injected into `PanelHeader.vue`, the test fails (`1 failed`); reverting the injection restores green.
- Full `AgentPanelRoot.test.ts`: 119 passed.
- `eslint` and `oxfmt --check` clean on the touched file.

Residual from R-193 (todo `a11yguard-1`).