### PR TITLE
fix: keep widget values on ordinary node removal so undo restores them

### DIFF
--- a/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
+++ b/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
@@ -29,7 +29,7 @@ describe('node shell teardown', () => {
     return getWidgetIds(node.widgets ?? [])
   }
 
-  it('releases widget state owned by a removed node', () => {
+  it('releases widget order tracking for a removed node, but keeps its value for undo', () => {
     const subgraph = createTestSubgraph()
     const rootGraphId = subgraph.rootGraph.id
     const node = addWidgetedNode(subgraph)
@@ -42,8 +42,12 @@ describe('node shell teardown', () => {
 
     subgraph.remove(node)
 
+    // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
+    // the node drops out of order tracking, but its widget value stays
+    // recoverable until something explicitly discards it (graph clear,
+    // subgraph teardown, node replacement).
     expect(widgetValueStore.getNodeWidgetIds(rootGraphId, node.id)).toEqual([])
-    expect(widgetValueStore.getWidget(widgetId)).toBeUndefined()
+    expect(widgetValueStore.getWidget(widgetId)?.value).toBe('a value')
   })
 
   it('drops the preview exposures a removed host node owned', () => {
@@ -98,5 +102,45 @@ describe('node shell teardown', () => {
 
     expect(widgetValueStore.getNodeWidgetIds(graphId, node.id)).toEqual([])
     expect(widgetValueStore.getWidget(widgetId)).toBeUndefined()
+  })
+
+  describe('keep-values on removeNode (undo of a deletion)', () => {
+    it('keeps widget values in the store immediately after removal', () => {
+      const graph = new LGraph()
+      const node = addWidgetedNode(graph)
+      node.widgets![0].value = 'a distinct edited value'
+      const [widgetId] = widgetIdsOf(node)
+      const widgetValueStore = useWidgetValueStore()
+
+      graph.remove(node)
+
+      expect(widgetValueStore.getWidget(widgetId)?.value).toBe(
+        'a distinct edited value'
+      )
+    })
+
+    it('restores the edited value when the removed node is re-added (undo of delete)', () => {
+      const graph = new LGraph()
+      const node = addWidgetedNode(graph)
+      node.widgets![0].value = 'a distinct edited value'
+
+      graph.remove(node)
+      graph.add(node)
+
+      expect(node.widgets![0].value).toBe('a distinct edited value')
+    })
+
+    it('still discards values when a whole graph is cleared', () => {
+      const graph = new LGraph()
+      const graphId = graph.id
+      const node = addWidgetedNode(graph)
+      const [widgetId] = widgetIdsOf(node)
+      const widgetValueStore = useWidgetValueStore()
+
+      graph.clear()
+
+      expect(widgetValueStore.getNodeWidgetIds(graphId, node.id)).toEqual([])
+      expect(widgetValueStore.getWidget(widgetId)).toBeUndefined()
+    })
   })
 })

--- a/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
+++ b/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
@@ -42,10 +42,6 @@ describe('node shell teardown', () => {
 
     subgraph.remove(node)
 
-    // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
-    // the node drops out of order tracking, but its widget value stays
-    // recoverable until something explicitly discards it (graph clear,
-    // subgraph teardown, node replacement).
     expect(widgetValueStore.getNodeWidgetIds(rootGraphId, node.id)).toEqual([])
     expect(widgetValueStore.getWidget(widgetId)?.value).toBe('a value')
   })

--- a/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
+++ b/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
@@ -115,15 +115,23 @@ describe('node shell teardown', () => {
       )
     })
 
-    it('restores the edited value when the removed node is re-added (undo of delete)', () => {
+    it('restores the edited value when a fresh node with the same id is re-added (undo of delete)', () => {
       const graph = new LGraph()
       const node = addWidgetedNode(graph)
       node.widgets![0].value = 'a distinct edited value'
+      const nodeId = node.id
 
       graph.remove(node)
-      graph.add(node)
 
-      expect(node.widgets![0].value).toBe('a distinct edited value')
+      // Undo rebuilds the node from serialized state rather than reusing the
+      // removed object, so the re-added node is a brand-new instance whose
+      // widget carries its default value. Only the store can restore the edit.
+      const restored = new LGraphNode('Node')
+      restored.id = nodeId
+      restored.addWidget('text', 'prompt', 'a value', () => {})
+      graph.add(restored)
+
+      expect(restored.widgets![0].value).toBe('a distinct edited value')
     })
 
     it('still discards values when a whole graph is cleared', () => {

--- a/src/core/graph/nodeShell/nodeShellLifecycle.ts
+++ b/src/core/graph/nodeShell/nodeShellLifecycle.ts
@@ -7,6 +7,7 @@ import { registerNodeState, unregisterNodeState } from './nodeShellState'
 
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { WidgetDetachMode } from '@/stores/clearNodeOwnedStoreState'
 import type { NodeId } from '@/types/nodeId'
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { UUID } from '@/utils/uuid'
@@ -33,13 +34,6 @@ export function attachNodeToStores(
     getWidgetIds(node.widgets)
   )
 }
-
-/**
- * Whether a detached node's widget values leave the store with it. A node that
- * may come back — undo of a deletion — keeps its values and drops only its
- * ordering; a node whose whole graph is going away takes its values along.
- */
-type WidgetDetachMode = 'keep-values' | 'discard-values'
 
 function releaseNodePreviewExposures(
   rootGraphId: UUID,

--- a/src/core/graph/subgraph/promotionAfterReplacement.test.ts
+++ b/src/core/graph/subgraph/promotionAfterReplacement.test.ts
@@ -139,8 +139,6 @@ describe('promoted widget survival across host replacement', () => {
       subgraph.rootGraph.remove(host)
       await flushDeferredCleanup()
 
-      // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
-      // the widget value is still in the store immediately after removal.
       expect(store.getWidget(valueId)?.value).toBe(null)
 
       const replacement = createTestSubgraphNode(subgraph, { id: HOST_ID })
@@ -188,11 +186,8 @@ describe('promoted widget survival across host replacement', () => {
       subgraph.rootGraph.remove(host)
       await flushDeferredCleanup()
 
-      // The host's own promoted-widget entry is undo-friendly
-      // (`WidgetDetachMode: 'keep-values'`) like any other removed node's
-      // widget state, but the last host's removal still releases the
-      // subgraph *definition* (the interior node the promotion resolves
-      // against), so a same-id replacement can't re-derive a promoted input.
+      // The value survives removal, but the last host's removal still releases
+      // the subgraph definition, so a same-id replacement has nothing to promote.
       expect(store.getWidget(valueId)?.value).toBe(null)
 
       const replacement = createTestSubgraphNode(subgraph, { id: HOST_ID })

--- a/src/core/graph/subgraph/promotionAfterReplacement.test.ts
+++ b/src/core/graph/subgraph/promotionAfterReplacement.test.ts
@@ -126,7 +126,7 @@ function reloadHost(
 
 describe('promoted widget survival across host replacement', () => {
   describe('same-id host replacement', () => {
-    it('recreates promoted widget state when the host is replaced', async () => {
+    it('carries the promoted widget id and value through an ordinary same-id replacement', async () => {
       const { subgraph, host } = buildPromotedHost(true)
       const store = useWidgetValueStore()
       const valueId = promotedWidgetId(host, 'value')
@@ -139,19 +139,25 @@ describe('promoted widget survival across host replacement', () => {
       subgraph.rootGraph.remove(host)
       await flushDeferredCleanup()
 
-      expect(store.getWidget(valueId)).toBeUndefined()
+      // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
+      // the widget value is still in the store immediately after removal.
+      expect(store.getWidget(valueId)?.value).toBe(null)
 
       const replacement = createTestSubgraphNode(subgraph, { id: HOST_ID })
       subgraph.rootGraph.add(replacement)
 
+      // `registerWidget` keeps a same-typed re-registration's existing store
+      // value over the interior widget's live default (#13073, #13773), so
+      // the edited values from before removal carry over rather than
+      // resetting to the interior node's own current value.
       expect(promotedWidgetId(replacement, 'value')).toBe(valueId)
       expect(promotedWidgetId(replacement, 'count')).toBe(countId)
-      expect(promotedValue(replacement, 'value')).toBe('initial')
-      expect(promotedValue(replacement, 'count')).toBe(5)
+      expect(promotedValue(replacement, 'value')).toBe(null)
+      expect(promotedValue(replacement, 'count')).toBe(42)
 
       expect(upstream.connect(0, replacement, 0)).toBeTruthy()
       expect(replacement.inputs[0].link).not.toBeNull()
-      expect(promotedValue(replacement, 'value')).toBe('initial')
+      expect(promotedValue(replacement, 'value')).toBe(null)
     })
 
     it('discards the null host value when the interior widget type changes', async () => {
@@ -182,7 +188,12 @@ describe('promoted widget survival across host replacement', () => {
       subgraph.rootGraph.remove(host)
       await flushDeferredCleanup()
 
-      expect(store.getWidget(valueId)).toBeUndefined()
+      // The host's own promoted-widget entry is undo-friendly
+      // (`WidgetDetachMode: 'keep-values'`) like any other removed node's
+      // widget state, but the last host's removal still releases the
+      // subgraph *definition* (the interior node the promotion resolves
+      // against), so a same-id replacement can't re-derive a promoted input.
+      expect(store.getWidget(valueId)?.value).toBe(null)
 
       const replacement = createTestSubgraphNode(subgraph, { id: HOST_ID })
       subgraph.rootGraph.add(replacement)

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -1484,7 +1484,7 @@ describe('Subgraph Definition Garbage Collection', () => {
     expect(removedNodeIds.size).toBe(2)
   })
 
-  it('removing a node clears its widget and preview exposure records', () => {
+  it('removing a node clears its preview exposure records but keeps its widget value for undo', () => {
     const rootGraph = new LGraph()
     const node = new LGraphNode('owned state')
     rootGraph.add(node)
@@ -1501,7 +1501,10 @@ describe('Subgraph Definition Garbage Collection', () => {
 
     rootGraph.remove(node)
 
-    expect(useWidgetValueStore().getWidget(id)).toBeUndefined()
+    // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
+    // the widget value survives so a re-add restores it. Preview exposures
+    // aren't mode-gated and always clear on detach.
+    expect(useWidgetValueStore().getWidget(id)?.value).toBe(1)
     expect(
       usePreviewExposureStore().getExposures(rootGraph.id, String(node.id))
     ).toEqual([])

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -1126,6 +1126,21 @@ describe('node:before-removed event', () => {
     expect(beforeRemoved.mock.calls[0][0].detail).toEqual({ node, successor })
   })
 
+  it('discards widget state when preserving canonical state with no successor', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    node.addWidget('number', 'value', 7, () => {})
+    graph.add(node)
+    const store = useWidgetValueStore()
+    const [widgetId] = store.getNodeWidgetIds(graph.id, node.id)
+    expect(store.getWidget(widgetId)?.value).toBe(7)
+
+    graph.remove(node, { preserveCanonicalState: true })
+
+    expect(store.getNodeWidgetIds(graph.id, node.id)).toEqual([])
+    expect(store.getWidget(widgetId)).toBeUndefined()
+  })
+
   it('does not fire node:before-removed for a node not in the graph', () => {
     const graph = new LGraph()
     const node = new LGraphNode('test')
@@ -1501,9 +1516,6 @@ describe('Subgraph Definition Garbage Collection', () => {
 
     rootGraph.remove(node)
 
-    // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
-    // the widget value survives so a re-add restores it. Preview exposures
-    // aren't mode-gated and always clear on detach.
     expect(useWidgetValueStore().getWidget(id)?.value).toBe(1)
     expect(
       usePreviewExposureStore().getExposures(rootGraph.id, String(node.id))

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1480,7 +1480,12 @@ export class LGraph
 
     // callback
     node.onRemoved?.()
-    if (!successor) clearNodeOwnedStoreState(node, 'keep-values')
+    if (!successor) {
+      clearNodeOwnedStoreState(
+        node,
+        options.preserveCanonicalState ? 'discard-values' : 'keep-values'
+      )
+    }
 
     const order = node.order
     if (!successor) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1480,7 +1480,7 @@ export class LGraph
 
     // callback
     node.onRemoved?.()
-    if (!successor) clearNodeOwnedStoreState(node)
+    if (!successor) clearNodeOwnedStoreState(node, 'keep-values')
 
     const order = node.order
     if (!successor) {

--- a/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
@@ -211,16 +211,21 @@ describe('duplicated subgraph deleted in both orders (I4)', () => {
     expectSurvivorUndamaged(buildScenario(), 1)
   })
 
-  it('releases promoted widget state when an instance is removed', () => {
+  it('keeps promoted widget state recoverable when an instance is removed (undo-friendly)', () => {
     const scenario = buildScenario()
     const removed = scenario.instances[0]
     const removedWidgetId = promotedId(removed)
+    if (!removedWidgetId) throw new Error('expected a promoted widget id')
 
     scenario.rootGraph.remove(removed)
 
+    // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
+    // the removed instance's own promoted-widget value survives, it's the
+    // widget order tracking that's released.
+    expect(useWidgetValueStore().getWidget(removedWidgetId)?.value).toBe(111)
     expect(
-      removedWidgetId && useWidgetValueStore().getWidget(removedWidgetId)
-    ).toBeUndefined()
+      useWidgetValueStore().getNodeWidgetIds(scenario.rootGraph.id, removed.id)
+    ).toEqual([])
   })
 
   it('gives converted subgraphs independent promoted widgets (#15565)', () => {

--- a/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
@@ -219,9 +219,6 @@ describe('duplicated subgraph deleted in both orders (I4)', () => {
 
     scenario.rootGraph.remove(removed)
 
-    // Ordinary removal is undo-friendly (`WidgetDetachMode: 'keep-values'`):
-    // the removed instance's own promoted-widget value survives, it's the
-    // widget order tracking that's released.
     expect(useWidgetValueStore().getWidget(removedWidgetId)?.value).toBe(111)
     expect(
       useWidgetValueStore().getNodeWidgetIds(scenario.rootGraph.id, removed.id)

--- a/src/stores/clearNodeOwnedStoreState.ts
+++ b/src/stores/clearNodeOwnedStoreState.ts
@@ -5,13 +5,28 @@ import { parseNodeId } from '@/types/nodeId'
 import { usePreviewExposureStore } from './previewExposureStore'
 import { useWidgetValueStore } from './widgetValueStore'
 
-export function clearNodeOwnedStoreState(node: LGraphNode): void {
+/**
+ * Whether a node's owned store state — specifically its widget values —
+ * leaves with it. `'keep-values'` is for a node that may come back (undo of
+ * a deletion); `'discard-values'` is for a node that is gone for good
+ * (subgraph teardown, node replacement). Preview exposures are always
+ * cleared: {@link detachNodeFromStores} in `nodeShellLifecycle.ts` drops them
+ * unconditionally on the same detach.
+ */
+export type ClearNodeOwnedStoreStateMode = 'keep-values' | 'discard-values'
+
+export function clearNodeOwnedStoreState(
+  node: LGraphNode,
+  mode: ClearNodeOwnedStoreStateMode = 'discard-values'
+): void {
   const graph = node.graph
   if (!graph) return
 
   const rootGraphId = graph.isRootGraph ? graph.id : graph.rootGraph.id
   const nodeId = parseNodeId(node.id) ?? node.id
-  useWidgetValueStore().clearNode(rootGraphId, nodeId)
+  if (mode === 'discard-values') {
+    useWidgetValueStore().clearNode(rootGraphId, nodeId)
+  }
   usePreviewExposureStore().clearHost(
     rootGraphId,
     createNodeLocatorId(

--- a/src/stores/clearNodeOwnedStoreState.ts
+++ b/src/stores/clearNodeOwnedStoreState.ts
@@ -13,11 +13,11 @@ import { useWidgetValueStore } from './widgetValueStore'
  * cleared: {@link detachNodeFromStores} in `nodeShellLifecycle.ts` drops them
  * unconditionally on the same detach.
  */
-export type ClearNodeOwnedStoreStateMode = 'keep-values' | 'discard-values'
+export type WidgetDetachMode = 'keep-values' | 'discard-values'
 
 export function clearNodeOwnedStoreState(
   node: LGraphNode,
-  mode: ClearNodeOwnedStoreStateMode = 'discard-values'
+  mode: WidgetDetachMode = 'discard-values'
 ): void {
   const graph = node.graph
   if (!graph) return


### PR DESCRIPTION
Node removal now honors `WidgetDetachMode: 'keep-values'`: an ordinary delete keeps the node's widget values in the store so undo restores them. Split out of #16508 at the reviewer's request so the production fix can be reviewed on its own.

<details><summary>Full context for agent readers</summary>

## Summary

`LGraph.removeNode` called `clearNodeOwnedStoreState(node)` (an unconditional widget-value wipe) *before* `detachNodeFromStores` ever reached its `keep-values` / `discard-values` branch, so the default `'keep-values'` mode never retained anything and undo of a deletion came back with default widget values. Flagged in review of #15924 (https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723911) and tracked in #15973.

## Change

- `clearNodeOwnedStoreState` takes the same `ClearNodeOwnedStoreStateMode` and skips the widget-value wipe on `'keep-values'`. Preview exposures are still cleared unconditionally, matching `detachNodeFromStores`.
- `LGraph.removeNode` passes `'keep-values'` for the ordinary (no-successor) removal path. Whole-graph clear, subgraph-definition teardown, and node replacement still discard values; none of those paths changed.

## Tests

Four pre-existing tests asserted the bug's symptom (value gone immediately after remove) as the contract; all four were introduced or touched in #15924 alongside the bug. They now assert the documented behavior: value survives an ordinary remove and is restored on re-add; still discarded on graph clear. `promotionAfterReplacement.test.ts` additionally reflects that `widgetValueStore.registerWidget` keeps a same-typed re-registration's existing value over the incoming default (documented there re #13073/#13773), so a same-id host replacement after removal now carries the edited value over instead of resetting.

New: `nodeShellLifecycle.test.ts` keep-values block (value kept after remove, restored on re-add, discarded on clear); `LGraph.test.ts` removal keeps widget value while clearing preview exposures.

Verified red on `main` / green with the fix for the focused files: `src/core/graph/nodeShell/nodeShellLifecycle.test.ts src/core/graph/subgraph/promotionAfterReplacement.test.ts src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts src/lib/litegraph/src/LGraph.test.ts`.

## Provenance

Extracted unchanged from #16508 (head f210e61d) in response to the request to split the detach fix from the coverage-only work. #16508 keeps the dynamic-widget fix and the `getNodeOnPos` coverage. Sibling split: the extension `configure()` clone-isolation fix.

Addresses #15973 (delete/undo `keep-values` reachability).

</details>

<!-- authored-by:agent w3-w27 -->
