### PR TITLE
fix: hand extension configure hooks a shallow copy of the serialized object

### DIFF
--- a/docs/extensions/serialization-callbacks-migration.md
+++ b/docs/extensions/serialization-callbacks-migration.md
@@ -18,6 +18,11 @@ connection-timing hooks see
 `node.widgets` and widget value storage see
 [Widget system migration](widgets-migration.md).
 
+`onConfigure` now receives an isolated copy of the serialized data. Mutating
+that callback argument, including nested fields, does not change the caller's
+workflow JSON and is not persisted. Extensions that previously relied on those
+mutations must store custom state on `node.properties` or `graph.extra` instead.
+
 ## Store custom data in properties or extra
 
 Use `node.properties` for per-node extension data and `graph.extra` for

--- a/docs/extensions/serialization-callbacks-migration.md
+++ b/docs/extensions/serialization-callbacks-migration.md
@@ -18,10 +18,13 @@ connection-timing hooks see
 `node.widgets` and widget value storage see
 [Widget system migration](widgets-migration.md).
 
-`onConfigure` now receives an isolated copy of the serialized data. Mutating
-that callback argument, including nested fields, does not change the caller's
-workflow JSON and is not persisted. Extensions that previously relied on those
-mutations must store custom state on `node.properties` or `graph.extra` instead.
+`onConfigure` now receives a shallow copy of the serialized data rather than
+the caller's own object. Adding, removing, or reassigning top-level keys on the
+callback argument does not change the caller's workflow JSON and is not
+persisted. Nested objects (for example `inputs`, `pos`, `properties`) are still
+shared with the caller, so mutating them in place still leaks; extensions that
+relied on either kind of mutation must store custom state on `node.properties`
+or `graph.extra` instead.
 
 ## Store custom data in properties or extra
 

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -294,6 +294,7 @@ describe('LGraph Serialisation', () => {
     node.onConfigure = (data) => {
       configuredData = data
       Object.assign(data, { mutated: true })
+      data.pos[0] = 999
     }
 
     node.configure(saved)

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -282,22 +282,27 @@ describe('LGraph Serialisation', () => {
     expect(Reflect.get(node, 'legacyData')).toEqual({ retained: true })
   })
 
-  test('passes the original serialized object to configure hooks', ({
+  test('passes an isolated clone, not the caller live serialized object, to configure hooks', ({
     expect
   }) => {
     const node = new LGraphNode('Extended')
     const saved = Object.assign(node.serialize(), {
       legacyData: { retained: true }
     })
+    const savedSnapshot = JSON.parse(JSON.stringify(saved))
     let configuredData: object | undefined
     node.onConfigure = (data) => {
       configuredData = data
+      Object.assign(data, { mutated: true })
     }
 
     node.configure(saved)
 
-    expect(configuredData).toBe(saved)
+    expect(configuredData).not.toBe(saved)
     expect(Reflect.get(node, 'legacyData')).toEqual({ retained: true })
+    // The hook's mutation of its argument must not leak back to the caller's
+    // object (https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898).
+    expect(saved).toEqual(savedSnapshot)
   })
 
   test('does not apply unsafe extension keys to the configure view', ({

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -282,28 +282,26 @@ describe('LGraph Serialisation', () => {
     expect(Reflect.get(node, 'legacyData')).toEqual({ retained: true })
   })
 
-  test('passes an isolated clone, not the caller live serialized object, to configure hooks', ({
+  test('passes a shallow copy, not the caller live serialized object, to configure hooks', ({
     expect
   }) => {
     const node = new LGraphNode('Extended')
     const saved = Object.assign(node.serialize(), {
       legacyData: { retained: true }
     })
-    const savedSnapshot = JSON.parse(JSON.stringify(saved))
     let configuredData: object | undefined
     node.onConfigure = (data) => {
       configuredData = data
       Object.assign(data, { mutated: true })
-      data.pos[0] = 999
     }
 
     node.configure(saved)
 
     expect(configuredData).not.toBe(saved)
     expect(Reflect.get(node, 'legacyData')).toEqual({ retained: true })
-    // The hook's mutation of its argument must not leak back to the caller's
-    // object (https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898).
-    expect(saved).toEqual(savedSnapshot)
+    // The hook's top-level mutation of its argument must not leak back to the
+    // caller's object (https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898).
+    expect(saved).not.toHaveProperty('mutated')
   })
 
   test('does not apply unsafe extension keys to the configure view', ({

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -299,8 +299,6 @@ describe('LGraph Serialisation', () => {
 
     expect(configuredData).not.toBe(saved)
     expect(Reflect.get(node, 'legacyData')).toEqual({ retained: true })
-    // The hook's top-level mutation of its argument must not leak back to the
-    // caller's object (https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898).
     expect(saved).not.toHaveProperty('mutated')
   })
 

--- a/src/lib/litegraph/src/extensionPersistence.test.ts
+++ b/src/lib/litegraph/src/extensionPersistence.test.ts
@@ -1,0 +1,80 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+
+/**
+ * https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898
+ *
+ * `extensionConfigureView` used to `Object.assign` the extensions-namespaced
+ * payload directly onto the caller's serialized node object and hand that
+ * same live object to `onConfigure`. An extension mutating its argument, or
+ * simply the namespaced payload being promoted onto it, polluted the
+ * caller's workflow JSON in place.
+ */
+function nodeWithNamespacedExtension(): ISerialisedNode {
+  return {
+    id: 1,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    extensions: { myExt: { note: 'hello' } }
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+})
+
+describe('LGraphNode.configure onConfigure hook isolation', () => {
+  it('hands onConfigure a clone, not the caller live serialized object', () => {
+    const node = new LGraphNode('TestNode')
+    const canonical = nodeWithNamespacedExtension()
+    const canonicalSnapshot = JSON.parse(JSON.stringify(canonical))
+
+    let hookArg: unknown
+    node.onConfigure = (data) => {
+      hookArg = data
+      Object.assign(data, { mutated: true })
+    }
+
+    node.configure(canonical)
+
+    expect(hookArg).not.toBe(canonical)
+    expect(canonical).toEqual(canonicalSnapshot)
+  })
+
+  it('does not promote namespaced extension keys to top-level fields on serialize', () => {
+    const node = new LGraphNode('TestNode')
+    node.configure(nodeWithNamespacedExtension())
+
+    const serialized = node.serialize()
+
+    expect(serialized).not.toHaveProperty('myExt')
+    expect(serialized.extensions).toEqual({ myExt: { note: 'hello' } })
+  })
+
+  it('keeps a missing-node placeholder free of promoted keys after onConfigure mutates its view', () => {
+    const node = new LGraphNode('TestNode')
+    node.onConfigure = (data) => {
+      Object.assign(data, { mutated: true })
+    }
+    const info = nodeWithNamespacedExtension()
+
+    node.configure(info)
+    // Missing-node placeholders retain the caller's object as their
+    // last-serialization fallback (see `LGraph.ts`'s `last_serialization =
+    // n_info` assignments).
+    node.last_serialization = info
+
+    const reserialized = node.serialize()
+
+    expect(reserialized).not.toHaveProperty('myExt')
+    expect(reserialized).not.toHaveProperty('mutated')
+  })
+})

--- a/src/lib/litegraph/src/extensionPersistence.test.ts
+++ b/src/lib/litegraph/src/extensionPersistence.test.ts
@@ -2,7 +2,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode, NodeInputSlot } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 
 /**
@@ -63,6 +63,32 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
     const serialized = node.serialize()
     expect(serialized).not.toHaveProperty('myExt')
     expect(serialized.extensions).toEqual({ myExt: { note: 'hello' } })
+  })
+
+  it('accepts a serialized object that still holds live slot instances', () => {
+    // `ComfyNode.configure` (litegraphService) fills `data.inputs` with the
+    // node's live `NodeInputSlot` instances before calling
+    // `LGraphNode.configure`. Those carry a node back-reference and only
+    // become plain data through `toJSON()`, so the view must not
+    // `structuredClone` them (DataCloneError) and must hand the hook the JSON
+    // shape.
+    const node = new LGraphNode('TestNode')
+    node.addInput('in', 'number')
+    const info: ISerialisedNode = {
+      ...nodeWithNamespacedExtension(),
+      inputs: [new NodeInputSlot({ name: 'in', type: 'number' }, node)]
+    }
+
+    let hookArg: ISerialisedNode | undefined
+    node.onConfigure = (data) => {
+      hookArg = data
+    }
+
+    expect(() => node.configure(info)).not.toThrow()
+    expect(hookArg?.inputs?.[0]).toEqual(
+      JSON.parse(JSON.stringify(info.inputs?.[0]))
+    )
+    expect(hookArg?.inputs?.[0]).not.toBe(info.inputs?.[0])
   })
 
   it('keeps a missing-node placeholder free of promoted keys after onConfigure mutates its view', () => {

--- a/src/lib/litegraph/src/extensionPersistence.test.ts
+++ b/src/lib/litegraph/src/extensionPersistence.test.ts
@@ -49,12 +49,18 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
     expect(canonical).toEqual(canonicalSnapshot)
   })
 
-  it('does not promote namespaced extension keys to top-level fields on serialize', () => {
+  it('does not promote namespaced extension keys onto the caller serialized object', () => {
     const node = new LGraphNode('TestNode')
-    node.configure(nodeWithNamespacedExtension())
+    // The configure view is only built when a hook is installed.
+    node.onConfigure = () => {}
+    const info = nodeWithNamespacedExtension()
+
+    node.configure(info)
+
+    expect(info).not.toHaveProperty('myExt')
+    expect(info.extensions).toEqual({ myExt: { note: 'hello' } })
 
     const serialized = node.serialize()
-
     expect(serialized).not.toHaveProperty('myExt')
     expect(serialized.extensions).toEqual({ myExt: { note: 'hello' } })
   })

--- a/src/lib/litegraph/src/extensionPersistence.test.ts
+++ b/src/lib/litegraph/src/extensionPersistence.test.ts
@@ -32,21 +32,24 @@ beforeEach(() => {
 })
 
 describe('LGraphNode.configure onConfigure hook isolation', () => {
-  it('hands onConfigure a clone, not the caller live serialized object', () => {
+  it('hands onConfigure a shallow copy, not the caller live serialized object', () => {
     const node = new LGraphNode('TestNode')
     const canonical = nodeWithNamespacedExtension()
-    const canonicalSnapshot = JSON.parse(JSON.stringify(canonical))
 
     let hookArg: unknown
     node.onConfigure = (data) => {
       hookArg = data
       Object.assign(data, { mutated: true })
+      Reflect.deleteProperty(data, 'size')
     }
 
     node.configure(canonical)
 
     expect(hookArg).not.toBe(canonical)
-    expect(canonical).toEqual(canonicalSnapshot)
+    expect(canonical).not.toHaveProperty('mutated')
+    expect(canonical).not.toHaveProperty('myExt')
+    expect(canonical.size).toEqual([200, 100])
+    expect(canonical.extensions).toEqual({ myExt: { note: 'hello' } })
   })
 
   it('does not promote namespaced extension keys onto the caller serialized object', () => {
@@ -68,15 +71,16 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
   it('accepts a serialized object that still holds live slot instances', () => {
     // `ComfyNode.configure` (litegraphService) fills `data.inputs` with the
     // node's live `NodeInputSlot` instances before calling
-    // `LGraphNode.configure`. Those carry a node back-reference and only
-    // become plain data through `toJSON()`, so the view must not
-    // `structuredClone` them (DataCloneError) and must hand the hook the JSON
-    // shape.
+    // `LGraphNode.configure`. Those carry a node back-reference, so the view
+    // must not `structuredClone` them (DataCloneError). The shallow copy
+    // passes nested values through unchanged, so the hook sees the same
+    // shapes it always did.
     const node = new LGraphNode('TestNode')
     node.addInput('in', 'number')
+    const liveSlot = new NodeInputSlot({ name: 'in', type: 'number' }, node)
     const info: ISerialisedNode = {
       ...nodeWithNamespacedExtension(),
-      inputs: [new NodeInputSlot({ name: 'in', type: 'number' }, node)]
+      inputs: [liveSlot]
     }
 
     let hookArg: ISerialisedNode | undefined
@@ -85,10 +89,9 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
     }
 
     expect(() => node.configure(info)).not.toThrow()
-    expect(hookArg?.inputs?.[0]).toEqual(
-      JSON.parse(JSON.stringify(info.inputs?.[0]))
-    )
-    expect(hookArg?.inputs?.[0]).not.toBe(info.inputs?.[0])
+    expect(hookArg).not.toBe(info)
+    expect(hookArg?.inputs).toBe(info.inputs)
+    expect(hookArg?.inputs?.[0]).toBe(liveSlot)
   })
 
   it('keeps a missing-node placeholder free of promoted keys after onConfigure mutates its view', () => {

--- a/src/lib/litegraph/src/extensionPersistence.test.ts
+++ b/src/lib/litegraph/src/extensionPersistence.test.ts
@@ -5,15 +5,6 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { LGraphNode, NodeInputSlot } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 
-/**
- * https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898
- *
- * `extensionConfigureView` used to `Object.assign` the extensions-namespaced
- * payload directly onto the caller's serialized node object and hand that
- * same live object to `onConfigure`. An extension mutating its argument, or
- * simply the namespaced payload being promoted onto it, polluted the
- * caller's workflow JSON in place.
- */
 function nodeWithNamespacedExtension(): ISerialisedNode {
   return {
     id: 1,
@@ -54,8 +45,9 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
 
   it('does not promote namespaced extension keys onto the caller serialized object', () => {
     const node = new LGraphNode('TestNode')
-    // The configure view is only built when a hook is installed.
-    node.onConfigure = () => {}
+    node.onConfigure = (data) => {
+      expect(Reflect.get(data, 'myExt')).toEqual({ note: 'hello' })
+    }
     const info = nodeWithNamespacedExtension()
 
     node.configure(info)
@@ -69,12 +61,6 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
   })
 
   it('accepts a serialized object that still holds live slot instances', () => {
-    // `ComfyNode.configure` (litegraphService) fills `data.inputs` with the
-    // node's live `NodeInputSlot` instances before calling
-    // `LGraphNode.configure`. Those carry a node back-reference, so the view
-    // must not `structuredClone` them (DataCloneError). The shallow copy
-    // passes nested values through unchanged, so the hook sees the same
-    // shapes it always did.
     const node = new LGraphNode('TestNode')
     node.addInput('in', 'number')
     const liveSlot = new NodeInputSlot({ name: 'in', type: 'number' }, node)
@@ -102,9 +88,6 @@ describe('LGraphNode.configure onConfigure hook isolation', () => {
     const info = nodeWithNamespacedExtension()
 
     node.configure(info)
-    // Missing-node placeholders retain the caller's object as their
-    // last-serialization fallback (see `LGraph.ts`'s `last_serialization =
-    // n_info` assignments).
     node.last_serialization = info
 
     const reserialized = node.serialize()

--- a/src/lib/litegraph/src/extensionPersistence.ts
+++ b/src/lib/litegraph/src/extensionPersistence.ts
@@ -214,7 +214,7 @@ export const extensionConfigureView = <T extends object>(
   canonical: T
 ): T =>
   Object.assign(
-    { ...canonical },
+    structuredClone(canonical),
     structuredClone(payloads.get(owner)?.namespaced),
     structuredClone(payloads.get(owner)?.legacy)
   )

--- a/src/lib/litegraph/src/extensionPersistence.ts
+++ b/src/lib/litegraph/src/extensionPersistence.ts
@@ -209,12 +209,22 @@ export const runExtensionSerializeHook = <T extends object>(
   return canonical
 }
 
+/**
+ * Deep-copies a serialized object the way it would appear in workflow JSON.
+ *
+ * `node.serialize()` returns live slot instances that serialize through
+ * `toJSON()`, so `structuredClone` would throw (`DataCloneError`) on them and
+ * would not honour `toJSON()` even where it succeeds. A JSON round trip is the
+ * faithful "serialized view" clone.
+ */
+const cloneSerialised = <T>(value: T): T => JSON.parse(JSON.stringify(value))
+
 export const extensionConfigureView = <T extends object>(
   owner: object,
   canonical: T
 ): T =>
   Object.assign(
-    structuredClone(canonical),
+    cloneSerialised(canonical),
     structuredClone(payloads.get(owner)?.namespaced),
     structuredClone(payloads.get(owner)?.legacy)
   )

--- a/src/lib/litegraph/src/extensionPersistence.ts
+++ b/src/lib/litegraph/src/extensionPersistence.ts
@@ -214,7 +214,7 @@ export const extensionConfigureView = <T extends object>(
   canonical: T
 ): T =>
   Object.assign(
-    canonical,
+    { ...canonical },
     structuredClone(payloads.get(owner)?.namespaced),
     structuredClone(payloads.get(owner)?.legacy)
   )

--- a/src/lib/litegraph/src/extensionPersistence.ts
+++ b/src/lib/litegraph/src/extensionPersistence.ts
@@ -210,21 +210,22 @@ export const runExtensionSerializeHook = <T extends object>(
 }
 
 /**
- * Deep-copies a serialized object the way it would appear in workflow JSON.
+ * Builds the object handed to `onConfigure`.
  *
- * `node.serialize()` returns live slot instances that serialize through
- * `toJSON()`, so `structuredClone` would throw (`DataCloneError`) on them and
- * would not honour `toJSON()` even where it succeeds. A JSON round trip is the
- * faithful "serialized view" clone.
+ * The view is a shallow copy of the caller's serialized object: adding,
+ * removing, or reassigning top-level keys on it (including the extension
+ * payload promoted onto it here) never reaches the caller or its later
+ * `serialize()` output. Nested values are intentionally shared as-is rather
+ * than cloned: `ComfyNode.configure` passes live slot instances in
+ * `data.inputs`, and any clone boundary (`structuredClone`, JSON) would either
+ * throw on them or rewrite the value shapes hooks already receive.
  */
-const cloneSerialised = <T>(value: T): T => JSON.parse(JSON.stringify(value))
-
 export const extensionConfigureView = <T extends object>(
   owner: object,
   canonical: T
 ): T =>
   Object.assign(
-    cloneSerialised(canonical),
+    { ...canonical },
     structuredClone(payloads.get(owner)?.namespaced),
     structuredClone(payloads.get(owner)?.legacy)
   )

--- a/src/lib/litegraph/src/extensionPersistence.ts
+++ b/src/lib/litegraph/src/extensionPersistence.ts
@@ -209,17 +209,6 @@ export const runExtensionSerializeHook = <T extends object>(
   return canonical
 }
 
-/**
- * Builds the object handed to `onConfigure`.
- *
- * The view is a shallow copy of the caller's serialized object: adding,
- * removing, or reassigning top-level keys on it (including the extension
- * payload promoted onto it here) never reaches the caller or its later
- * `serialize()` output. Nested values are intentionally shared as-is rather
- * than cloned: `ComfyNode.configure` passes live slot instances in
- * `data.inputs`, and any clone boundary (`structuredClone`, JSON) would either
- * throw on them or rewrite the value shapes hooks already receive.
- */
 export const extensionConfigureView = <T extends object>(
   owner: object,
   canonical: T


### PR DESCRIPTION
Extension `configure()` hooks now receive a shallow copy of the serialized node/graph object instead of the caller's live reference, so a hook that reassigns or adds top-level fields (or the payload promotion itself) no longer pollutes the caller's workflow JSON. No serialization boundary is introduced inside `configure`: live `NodeInputSlot` instances and other callback value shapes pass through untouched. Split out of #16508 at the reviewer's request.

<details><summary>Full context for agent readers</summary>

## Summary

`extensionConfigureView` `Object.assign`'d the namespaced/legacy extension payload directly onto the caller's live serialized object and handed that object to `onConfigure`. Any hook mutation of its argument, and the promotion of namespaced keys to top-level fields, leaked back into the caller's data. Flagged in review of #15924 (https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723898) and tracked in #15973.

## Change

`extensionConfigureView` now builds the view as `Object.assign({ ...canonical }, structuredClone(namespaced), structuredClone(legacy))` and hands that to `onConfigure`. This is a shallow copy of the canonical object: it isolates object identity and keeps promoted extension keys off the caller's object (the two consequences raised in the #15924 review), without re-encoding anything. Nested values (`inputs`, `pos`, `properties`, `widgets_values`, ...) stay shared with the caller by design; in-place mutation of those still reaches the caller's data, and the migration doc says so and points extensions at `node.properties` / `graph.extra` for their own state.

An earlier revision of this PR used a JSON round trip for a deep copy. That was dropped after review: `JSON.stringify` is a new failure and representation boundary in the middle of `configure` (circular references and BigInt throw; `undefined`, dates and class instances are rewritten), and `configure` previously guaranteed the callback saw the supported value shapes. The extension payloads themselves are still validated as JSON and `structuredClone`d as before; the `cloneSerialised` helper is gone.

## Tests

- `extensionPersistence.test.ts` (new): `onConfigure` receives a copy, not the caller's object, and top-level adds/reassigns/deletes on the view do not reach the caller (including `size` and `extensions`); a serialized object holding live slot instances configures without throwing and the hook sees the same `inputs` array and slot instance the caller passed; serialize does not promote namespaced keys to top-level fields; a missing-node placeholder stays free of promoted keys after `onConfigure` mutates its view.
- `LGraph.serialise.test.ts`: the existing "passes the original serialized object" test now asserts the hook gets a copy and that a top-level field added by the hook is absent from the saved workflow.

No test asserts JSON-derived shapes. Verified green for `src/lib/litegraph/src/extensionPersistence.test.ts src/lib/litegraph/src/LGraph.serialise.test.ts src/services/litegraphService.lateRegistration.test.ts` (28 tests), plus typecheck, lint and format.

## Provenance

Extracted from #16508 (head f210e61d) in response to the request to split the configure-isolation fix from the coverage-only work. #16508 keeps the dynamic-widget fix and the `getNodeOnPos` coverage. Sibling split: the `removeNode` `keep-values` fix.

Addresses #15973 (isolation for extension `configure()`).

</details>

<!-- authored-by:agent w3-w29 -->
