### PR TITLE
fix: stop falling through to A1111 parameters when a workflow load fails

### DIFF
--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -2629,6 +2629,63 @@ describe('ComfyApp', () => {
       consoleError.mockRestore()
     })
 
+    it('propagates a workflow load failure instead of importing A1111 parameters', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        workflow: createWorkflowGraphData(),
+        parameters: 'positive\nNegative prompt: negative\nSteps: 20'
+      })
+      const loadFailure = new Error('activation failed')
+      vi.spyOn(app, 'loadGraphData').mockRejectedValue(loadFailure)
+
+      await expect(
+        app.handleFile(createTestFile('both.png', 'image/png'))
+      ).rejects.toThrow(loadFailure)
+
+      expect(mockImportA1111).not.toHaveBeenCalled()
+    })
+
+    it('still falls back to A1111 parameters when the workflow fails to parse', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      const graph = new LGraph()
+      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        workflow: 'not json',
+        parameters
+      })
+
+      await app.handleFile(createTestFile('both.png', 'image/png'))
+
+      expect(mockImportA1111).toHaveBeenCalledWith(
+        graph,
+        parameters,
+        expect.any(Function)
+      )
+      consoleError.mockRestore()
+    })
+
+    it('reports an api prompt load failure instead of importing A1111 parameters', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        prompt: { '1': { class_type: 'KSampler', inputs: {} } },
+        parameters: 'positive\nNegative prompt: negative\nSteps: 20'
+      })
+      vi.spyOn(app, 'loadApiJson').mockRejectedValue(new Error('load failed'))
+
+      await app.handleFile(createTestFile('api.png', 'image/png'))
+
+      expect(mockImportA1111).not.toHaveBeenCalled()
+      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
+      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        t('toastMessages.fileLoadError', { fileName: 'api.png' })
+      )
+      consoleError.mockRestore()
+    })
+
     it.for([
       {
         outcome: 'core-nodes-unavailable' as const,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -33,6 +33,7 @@ import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { installNodeAddedTelemetry } from '@/platform/telemetry/nodeAdded/installNodeAddedTelemetry'
+import { reportError } from '@/platform/telemetry/reportError'
 import { normalizeExecutionTriggerSource } from '@/platform/telemetry/types'
 import { getExecutionContext } from '@/platform/telemetry/utils/getExecutionContext'
 import { groupMissingNodesByPack } from '@/platform/telemetry/utils/groupMissingNodesByPack'
@@ -2081,22 +2082,14 @@ export class ComfyApp {
     if (workflow) {
       let workflowObj: ComfyWorkflowJSON | undefined = undefined
       try {
-        workflowObj =
+        const parsed =
           typeof workflow === 'string'
             ? parseJsonWithNonFinite<ComfyWorkflowJSON>(workflow)
             : (workflow as ComfyWorkflowJSON)
 
         // Only load workflow if parsing succeeded AND validation passed
-        if (
-          workflowObj &&
-          typeof workflowObj === 'object' &&
-          !Array.isArray(workflowObj)
-        ) {
-          await this.loadGraphData(workflowObj, true, true, fileName, {
-            openSource,
-            deferWarnings: options?.deferWarnings
-          })
-          return
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          workflowObj = parsed
         } else {
           console.error(
             'Invalid workflow structure, trying parameters fallback'
@@ -2106,22 +2099,42 @@ export class ComfyApp {
         console.error('Failed to parse workflow:', err)
         // Fall through to check parameters as fallback
       }
+
+      // Loaded outside the parse try so a load failure never falls through
+      if (workflowObj) {
+        await this.loadGraphData(workflowObj, true, true, fileName, {
+          openSource,
+          deferWarnings: options?.deferWarnings
+        })
+        return
+      }
     }
 
     if (prompt) {
+      let promptObj: ComfyApiWorkflow | undefined = undefined
       try {
-        const promptObj =
+        const parsed =
           typeof prompt === 'string'
             ? parseJsonWithNonFinite<ComfyApiWorkflow>(prompt)
             : prompt
-        if (this.isApiJson(promptObj)) {
-          await this.loadApiJson(promptObj, fileName, {
-            deferWarnings: options?.deferWarnings
-          })
-          return
+        if (this.isApiJson(parsed)) {
+          promptObj = parsed
         }
       } catch (err) {
         console.error('Failed to parse prompt:', err)
+      }
+
+      if (promptObj) {
+        try {
+          await this.loadApiJson(promptObj, fileName, {
+            deferWarnings: options?.deferWarnings
+          })
+        } catch (err) {
+          console.error('Failed to load API prompt:', err)
+          reportError(err, { errorType: 'api_prompt_load_failure' })
+          this.showErrorOnFileLoad(file)
+        }
+        return
       }
       // Fall through to parameters as a last resort
     }


### PR DESCRIPTION
## ELI-5

Dropping a ComfyUI-generated PNG on the canvas could load two different workflows on top of each other. Those PNGs usually carry both a real ComfyUI `workflow` and an A1111 `parameters` string. `handleFile` tried the workflow first, but it wrapped *reading* the workflow and *loading* it in the same `try` — so if the load itself blew up, the code logged "Failed to parse workflow" (a lie: parsing was fine) and quietly moved on to import the A1111 parameters instead, starting a second, unrelated load on top of the half-loaded first one. Now reading and loading are separated: an unreadable workflow still falls back to A1111 exactly as before, but a *load* failure stops there and reports itself.

## Changes

- **What**: In `handleFile`, split metadata parsing from graph loading in both the `workflow` and `prompt` branches. Parsing stays inside the `try` (a parse/validation failure keeps today's fall-through to `prompt` → `parameters`); the load now runs outside it. A `loadGraphData` rejection propagates to the caller instead of being swallowed — both call sites already report it (the drop handler toasts `dropFileError`, the file-input button logs and calls `showErrorOnFileLoad`). A `loadApiJson` rejection is reported via `reportError(..., 'api_prompt_load_failure')` plus `showErrorOnFileLoad`, then returns. The `parameters` branch is untouched.
- **Tests**: three cases in `describe('handleFile')` — a rejecting `loadGraphData` alongside `parameters` propagates and never calls `importA1111`; an unparseable `workflow` alongside `parameters` still falls through to `importA1111`; a rejecting `loadApiJson` alongside `parameters` never calls `importA1111` and raises exactly one file-load error toast. The first and third are red on `main` and green here; the second is a regression guard on preserved behaviour and is green either way.

## Review Focus

The behavioural delta is narrow and intentional: the only case that changes is a *load* rejection. When `loadGraphData` or `loadApiJson` resolves — including resolving `false`, where `loadGraphData` shows its own dialog — the control flow is identical to before. Chesterton's Fence on the fall-through: it was introduced by #7154, whose stated intent was "add validation to prevent JSON **parse** errors from crashing imports" and whose whole purpose was to stop A1111 `parameters` from replacing a real workflow in exactly these dual-metadata PNGs. Falling back to A1111 after a *load* failure inverts that intent, so this change restores it rather than contradicting it.

Sweep of the portion not being fixed: there are 17 other `app.loadGraphData` call sites in `src/`. The two that parse-then-load already use the correct shape — `usePaste.ts` parses inside a `try` and loads outside it, and `useSharedWorkflowUrlLoader.ts` has a dedicated catch around the load only — so `handleFile` was the sole instance of this defect and no follow-up call sites are left behind.

## Residual

- **Partial-state unwind after a failed load is NOT fixed here.** This PR stops the *second, unrelated* load from starting; it does not clean up whatever the first, failed load left behind. `loadGraphData` has already run `beforeLoadNewGraph` and torn down the outgoing graph by the time it can reject, so a user whose workflow fails to load now gets an error toast over a possibly half-cleared canvas rather than an A1111 graph over a half-cleared canvas. Unwinding that partial state is a sibling piece of work, tracked separately, and is deliberately out of scope — this PR touches only the branch structure in `handleFile`.
- **Textual overlap with open PR #13957.** That PR adds the same `api_prompt_load_failure` catch, but nested inside the old single `try`; it has not merged. Whichever of the two lands second will conflict in that one hunk. The catch body here is byte-identical to #13957's (`console.error` + `reportError` + `showErrorOnFileLoad`) so the resolution is mechanical: keep this PR's outer structure and #13957's catch body, which are the same three lines.
- **Unexercised artifact — the originating investigation and its findings.** The work item this came from cites a sibling investigation whose findings comment carries the underlying evidence (the specific activation failure that makes `loadGraphData` reject). That comment is not reachable from this environment, so the concrete production repro was taken on trust from the summary rather than read first-hand. The branch structure being fixed is independently verifiable from the code, but the claim "activation failure is what makes `loadGraphData` reject in practice" is not something this PR verified.
- **No end-to-end verification against a real dual-metadata PNG.** All verification is unit-level, with `getWorkflowDataFromFile` mocked to return `{ workflow, parameters }` and `{ prompt, parameters }`. No actual ComfyUI-generated PNG carrying both a `workflow` chunk and an A1111 `parameters` chunk was dropped on a running canvas, and no browser test covers this path. Someone with such a file and a reproducible load failure should confirm the user-visible outcome is a single error toast.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `pnpm vitest run src/scripts/app.test.ts src/scripts/ui.test.ts`: 91 passed, 1 skipped, 0 failed; the two new failure-path tests confirmed red on stashed source before the fix. `pnpm typecheck` (vue-tsc --noEmit): clean, exit 0. `pnpm exec oxfmt --check` on both changed files: clean. ESLint and oxlint are both no-ops on these paths — `src/scripts/*` is in `.oxlintrc.json`'s ignore list and matches the ESLint ignore pattern, so lint cannot cover this diff.
- **Deviations:** none against the specified plan; the `console.error('Failed to load API prompt:', err)` line in the new catch is not in the plan's shorthand for the catch shape but is present in #13957's, and was added to keep the two hunks identical.
