### PR TITLE
fix(ci): preserve PR risk grades across label events

### DIFF
--- a/.github/workflows/ci-pr-risk.yml
+++ b/.github/workflows/ci-pr-risk.yml
@@ -22,8 +22,16 @@ concurrency:
   # Must carry the resolved target: on workflow_dispatch the event PR number is
   # empty, and on pull_request the inputs are empty — one expression serves
   # both. Trailing run_id keeps two no-input dispatches from cancelling each
-  # other. Keep a dispatched batch under ~40 numbers (255-char group cap).
-  group: ${{ github.workflow }}-${{ inputs.pr_numbers || inputs.pr_number || github.event.pull_request.number || github.run_id }}
+  # other. Irrelevant label events get unique groups so their skipped jobs
+  # cannot cancel an in-flight grade. Keep a dispatched batch under ~40
+  # numbers (255-char group cap).
+  group: >-
+    ${{ github.workflow }}-${{ inputs.pr_numbers || inputs.pr_number || github.event.pull_request.number || github.run_id }}-${{
+      contains(fromJSON('["labeled", "unlabeled"]'), github.event.action) &&
+      !startsWith(github.event.label.name, 'risk-dispute:') &&
+      github.run_id ||
+      'grade'
+    }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Keep advisory PR risk grading alive when unrelated labels are added or removed.

## Changes

- Give irrelevant `labeled`/`unlabeled` runs unique concurrency groups, matching the existing binary-size workflow pattern.
- Preserve cancellation for real grading events, including `risk-dispute:*` label changes.

## Review Focus

The concurrency expression is the only behavior change; the existing job gate remains unchanged.

## Evidence

- Reproduced on #16769: run 33853627739 was cancelled by skipped label-event run 33853749274.
- `python3` PyYAML parse: passed.
- `git diff --check`: passed.
- Live regression proof: the unrelated label run [33859975748](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33859975748) skipped without cancelling the already-running grade [33859934316](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33859934316).

<!-- authored-by:agent lane-shep-43-0940 -->