### PR TITLE
fix: unwind graph loads when workflow activation rejects

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/platform/workflow/management/stores/comfyWorkflow'
 import { ComfyWorkflow as ComfyWorkflowClass } from '@/platform/workflow/management/stores/comfyWorkflow'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { defaultGraph } from '@/scripts/defaultGraph'
+import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -2007,6 +2007,103 @@ describe('useWorkflowService', () => {
           rootGraphId,
           existingWorkflow.path
         )
+      })
+    })
+  })
+
+  describe('recoverFailedGraphLoad', () => {
+    const openPaths = (store: ReturnType<typeof useWorkflowStore>) =>
+      store.openWorkflows.map((open) => open?.path)
+
+    function createPhantomWorkflow(path: string) {
+      const phantom = new ComfyWorkflowClass({
+        path,
+        modified: Date.now(),
+        size: 100
+      })
+      vi.spyOn(phantom, 'load').mockRejectedValue(
+        new Error('Failed to load file')
+      )
+      return phantom
+    }
+
+    it('drops the tab a rejected activation opened and keeps the retained workflow', async () => {
+      const workflowStore = useWorkflowStore()
+      const retained = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/retained.json'
+      })
+      const phantom = createPhantomWorkflow('workflows/dup.json')
+      workflowStore.attachWorkflow(retained, 0)
+      workflowStore.attachWorkflow(phantom)
+      workflowStore.activeWorkflow = retained as LoadedComfyWorkflow
+      const service = useWorkflowService()
+
+      await expect(
+        service.afterLoadNewGraph('dup', makeWorkflowData())
+      ).rejects.toThrow('Failed to load file')
+      // The store appends the tab before awaiting the fetch that rejected.
+      expect(openPaths(workflowStore)).toContain('workflows/dup.json')
+
+      vi.mocked(app.loadGraphData).mockClear()
+      await service.recoverFailedGraphLoad('workflows/dup.json')
+
+      expect(openPaths(workflowStore)).not.toContain('workflows/dup.json')
+      expect(workflowStore.activeWorkflow?.path).toBe('workflows/retained.json')
+      const calls = vi.mocked(app.loadGraphData).mock.calls
+      expect(calls).toHaveLength(1)
+      expect(calls[0][3]).toMatchObject({ path: 'workflows/retained.json' })
+      expect(calls[0][0]).toEqual(retained.activeState)
+    })
+
+    it('keeps a tab that was already open before the failed activation', async () => {
+      const workflowStore = useWorkflowStore()
+      const retained = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/retained.json'
+      })
+      const alreadyOpen = createPhantomWorkflow('workflows/dup.json')
+      workflowStore.attachWorkflow(retained, 0)
+      // Already a tab - an unloaded session restore, with a draft of its own.
+      workflowStore.attachWorkflow(alreadyOpen, 1)
+      workflowStore.activeWorkflow = retained as LoadedComfyWorkflow
+      const service = useWorkflowService()
+
+      await expect(
+        service.afterLoadNewGraph('dup', makeWorkflowData())
+      ).rejects.toThrow('Failed to load file')
+      await service.recoverFailedGraphLoad('workflows/dup.json')
+
+      expect(openPaths(workflowStore)).toContain('workflows/dup.json')
+      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalledWith(
+        'workflows/dup.json'
+      )
+    })
+
+    it('falls back to a blank graph when nothing is retained', async () => {
+      const workflowStore = useWorkflowStore()
+      workflowStore.activeWorkflow = null
+      vi.mocked(app.loadGraphData).mockClear()
+
+      await useWorkflowService().recoverFailedGraphLoad()
+
+      const calls = vi.mocked(app.loadGraphData).mock.calls
+      expect(calls).toHaveLength(1)
+      expect(calls[0][0]).toBe(blankGraph)
+    })
+
+    it('reports and swallows a failure of the recovery load itself', async () => {
+      const workflowStore = useWorkflowStore()
+      workflowStore.activeWorkflow = null
+      const recoveryError = new Error('recovery load failed')
+      vi.mocked(app.loadGraphData).mockRejectedValueOnce(recoveryError)
+
+      await expect(
+        useWorkflowService().recoverFailedGraphLoad()
+      ).resolves.toBeUndefined()
+
+      expect(reportErrorMock).toHaveBeenCalledWith(recoveryError, {
+        errorType: 'workflow_load_recovery_failure'
       })
     })
   })

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -76,6 +76,12 @@ function adoptRootGraphId(workflowData: ComfyWorkflowJSON): UUID | null {
 // loading per document; the contract tests transfer.
 let workflowLoadTail: Promise<unknown> = Promise.resolve()
 let pendingWorkflowLoads = 0
+// Guards the recovery load in `recoverFailedGraphLoad` against recursing
+// into itself when it, too, fails to activate.
+let recoveringFailedGraphLoad = false
+// The tabs that were already open when the in-flight activation began, so a
+// recovery only ever drops one that activation itself added.
+let tabsOpenBeforeActivation = new Set<string>()
 const pendingWorkflowLoadsByPath = new Map<string, Promise<unknown>>()
 // Object identity, not path: a mid-close rename would strand a path key.
 const closingWorkflowCounts = new Map<ComfyWorkflow, number>()
@@ -371,10 +377,18 @@ export const useWorkflowService = () => {
    * state so selection, canvas, and change tracking agree again. No
    * retry loop: a failure here leaves the first failure's dialog
    * standing.
+   *
+   * Loads directly rather than through `queueWorkflowLoad`: a caller may
+   * already be inside a queued load, and chaining onto the tail it is
+   * itself holding would deadlock.
+   *
+   * @param failedPath The path of the workflow whose load failed, when known.
+   * @returns true when the retained workflow was repainted.
    */
-  const restoreRetainedWorkflow = async (failed: ComfyWorkflow) => {
+  const repaintRetainedWorkflow = async (failedPath?: string) => {
     const retained = workflowStore.activeWorkflow
-    if (!retained || retained.path === failed.path || !retained.isLoaded) return
+    if (!retained || retained.path === failedPath || !retained.isLoaded)
+      return false
     await app.loadGraphData(
       toRaw(retained.activeState) as ComfyWorkflowJSON,
       /* clean=*/ true,
@@ -386,6 +400,62 @@ export const useWorkflowService = () => {
         skipAssetScans: true
       }
     )
+    return true
+  }
+
+  const openTabPaths = () =>
+    new Set(
+      workflowStore.openWorkflows
+        .map((open) => open?.path)
+        .filter((path): path is string => !!path)
+    )
+
+  /**
+   * `workflowStore.openWorkflow` appends the tab before awaiting the file
+   * fetch, so an activation that rejected mid-fetch leaves an unloaded tab
+   * behind for a workflow the editor never painted. Closing a persisted
+   * workflow only unloads it; the file itself is untouched.
+   *
+   * A tab that was already open before the failed activation is the user's,
+   * not the activation's: closing it would also discard its draft.
+   */
+  const dropPhantomWorkflowTab = async (failedPath?: string) => {
+    if (!failedPath || tabsOpenBeforeActivation.has(failedPath)) return
+    const phantom = workflowStore.openWorkflows.find(
+      (open) => open?.path === failedPath
+    )
+    if (!phantom || phantom.isLoaded || workflowStore.isActive(phantom)) return
+    await workflowStore.closeWorkflow(phantom)
+  }
+
+  /**
+   * Unwind a graph load whose activation rejected after the nodes were
+   * already built: `afterLoadNewGraph` throws when it opens a
+   * persisted-but-unloaded workflow of the same base name and that file
+   * fails to fetch, leaving the canvas showing a graph no workflow owns
+   * plus the phantom tab above.
+   *
+   * Drops that tab and repaints whatever the editor was showing before the
+   * failed load, falling back to a blank graph when nothing is retained.
+   * The recovery load never recurses into recovery, and its own failures
+   * are reported and swallowed so the original error is the one that
+   * surfaces.
+   *
+   * @param failedPath The path the failed load was activating, when known.
+   */
+  const recoverFailedGraphLoad = async (failedPath?: string) => {
+    if (recoveringFailedGraphLoad) return
+    recoveringFailedGraphLoad = true
+    try {
+      await dropPhantomWorkflowTab(failedPath)
+      if (!(await repaintRetainedWorkflow(failedPath)))
+        await app.loadGraphData(blankGraph)
+    } catch (error) {
+      console.error('[workflowService] graph load recovery failed', error)
+      reportError(error, { errorType: 'workflow_load_recovery_failure' })
+    } finally {
+      recoveringFailedGraphLoad = false
+    }
   }
 
   const openWorkflow = (
@@ -428,7 +498,7 @@ export const useWorkflowService = () => {
           // Same invariant as the catch: a failed load's intent must not
           // stay newest (guarded no-op when the publish already superseded).
           useSubgraphNavigationStore().endWorkflowNavigation(navigationIntentId)
-          await restoreRetainedWorkflow(workflow)
+          await repaintRetainedWorkflow(workflow.path)
           return false
         }
         showPendingWarnings(undefined, {
@@ -655,6 +725,7 @@ export const useWorkflowService = () => {
     workflowData: ComfyWorkflowJSON,
     shareId?: string
   ) => {
+    tabsOpenBeforeActivation = openTabPaths()
     await activateLoadedWorkflow(value, workflowData, shareId)
     useNodeOutputStore().restorePreviewsForWorkflow(
       useWorkspaceStore().workflow.activeWorkflow?.path
@@ -882,6 +953,7 @@ export const useWorkflowService = () => {
     duplicateWorkflow,
     showPendingWarnings,
     afterLoadNewGraph,
-    beforeLoadNewGraph
+    beforeLoadNewGraph,
+    recoverFailedGraphLoad
   }
 }

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -130,6 +130,7 @@ const {
   mockWorkflowService: {
     beforeLoadNewGraph: vi.fn<WorkflowService['beforeLoadNewGraph']>(),
     afterLoadNewGraph: vi.fn<WorkflowService['afterLoadNewGraph']>(),
+    recoverFailedGraphLoad: vi.fn<WorkflowService['recoverFailedGraphLoad']>(),
     showPendingWarnings: vi.fn<WorkflowService['showPendingWarnings']>()
   }
 }))
@@ -266,6 +267,9 @@ async function useRealWorkflowService(): Promise<WorkflowService> {
   mockWorkflowService.afterLoadNewGraph.mockImplementation(
     real.afterLoadNewGraph
   )
+  mockWorkflowService.recoverFailedGraphLoad.mockImplementation(
+    real.recoverFailedGraphLoad
+  )
   mockWorkflowService.showPendingWarnings.mockImplementation(
     real.showPendingWarnings
   )
@@ -323,6 +327,7 @@ describe('ComfyApp', () => {
     vi.mocked(extractFilesFromDragEvent).mockResolvedValue([])
     mockImportA1111.mockResolvedValue('imported')
     mockWorkflowService.afterLoadNewGraph.mockResolvedValue()
+    mockWorkflowService.recoverFailedGraphLoad.mockResolvedValue()
     mockSettingStore.get.mockImplementation((key: string) =>
       key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
     )
@@ -392,6 +397,36 @@ describe('ComfyApp', () => {
       )
     })
 
+    it('unwinds the load and resolves false when activation rejects', async () => {
+      app.canvasElRef.value = document.createElement('canvas')
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      const activationError = new Error('Failed to load file')
+      mockWorkflowService.afterLoadNewGraph.mockRejectedValueOnce(
+        activationError
+      )
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+      await expect(
+        app.loadGraphData(createWorkflowGraphData(), true, true, 'dup', {
+          workflowNavigationId: 11
+        })
+      ).resolves.toBe(false)
+
+      expect(mockWorkflowService.recoverFailedGraphLoad).toHaveBeenCalledWith(
+        'workflows/dup.json'
+      )
+      expect(showDialog).toHaveBeenCalledOnce()
+      // Extensions only ever see a fully activated graph.
+      expect(
+        mockExtensionService.invokeExtensionsAsync
+      ).not.toHaveBeenCalledWith('afterLoadGraph')
+      // The finally still repairs the URL on the handled-failure path.
+      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+        'workflow-load',
+        11
+      )
+    })
+
     it('notifies extensions once on each side of a graph load, in order', async () => {
       app.canvasElRef.value = document.createElement('canvas')
       Reflect.set(app, 'rootGraphInternal', new LGraph())
@@ -431,6 +466,25 @@ describe('ComfyApp', () => {
           ([hook]) => hook
         )
       ).toEqual(['beforeLoadGraph', 'afterConfigureGraph', 'afterLoadGraph'])
+    })
+
+    it('unwinds an API JSON import and rethrows when activation rejects', async () => {
+      app.canvasElRef.value = document.createElement('canvas')
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const activationError = new Error('Failed to load file')
+      mockWorkflowService.afterLoadNewGraph.mockRejectedValueOnce(
+        activationError
+      )
+
+      await expect(app.loadApiJson({}, 'dup')).rejects.toBe(activationError)
+
+      expect(mockWorkflowService.recoverFailedGraphLoad).toHaveBeenCalledWith(
+        'workflows/dup.json'
+      )
+      // The callers report; no second toast is raised here.
+      expect(mockToastStore.addAlert).not.toHaveBeenCalled()
     })
   })
 
@@ -1826,6 +1880,29 @@ describe('ComfyApp', () => {
       await app.handleFile(createTestFile('a1111.png', 'image/png'))
 
       expect(missingNodesStore.missingNodesError).toBeNull()
+    })
+
+    it('unwinds the import and rethrows when activation rejects', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        parameters: 'positive\nNegative prompt: negative\nSteps: 20'
+      })
+      mockImportA1111.mockResolvedValue('imported')
+      const activationError = new Error('Failed to load file')
+      mockWorkflowService.afterLoadNewGraph.mockRejectedValueOnce(
+        activationError
+      )
+
+      await expect(
+        app.handleFile(createTestFile('a1111.png', 'image/png'))
+      ).rejects.toBe(activationError)
+
+      expect(mockWorkflowService.recoverFailedGraphLoad).toHaveBeenCalledWith(
+        'workflows/a1111.json'
+      )
+      // ui.ts / the drop handler report; no second toast is raised here.
+      expect(mockToastStore.addAlert).not.toHaveBeenCalled()
     })
 
     it.for(['not-a1111', 'core-nodes-unavailable'] as const)(

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -10,7 +10,7 @@ import { useCanvasPositionConversion } from '@/composables/element/useCanvasPosi
 import { promotedInputSource } from '@/core/graph/subgraph/promotedInputWidget'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { setBackendNodeText, st, t } from '@/i18n'
-import { normalizeI18nKey } from '@/utils/formatUtil'
+import { appendJsonExt, normalizeI18nKey } from '@/utils/formatUtil'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
 import { createMutationView } from '@/lib/litegraph/src/infrastructure/createMutationView'
@@ -1246,6 +1246,32 @@ export class ComfyApp {
     }
   }
 
+  /**
+   * Hand a freshly built graph to the workflow service.
+   *
+   * Activation can reject after the nodes exist - opening a
+   * persisted-but-unloaded workflow of the same base name fetches its file,
+   * which can fail - leaving the canvas showing a graph no workflow owns and
+   * a phantom tab for the path that never loaded. Unwind that before
+   * rethrowing, so the original error is still what callers report.
+   */
+  private async activateLoadedGraph(
+    value: string | ComfyWorkflow | null,
+    workflowData: ComfyWorkflowJSON,
+    shareId?: string
+  ) {
+    try {
+      await useWorkflowService().afterLoadNewGraph(value, workflowData, shareId)
+    } catch (error) {
+      await useWorkflowService().recoverFailedGraphLoad(
+        typeof value === 'string'
+          ? ComfyWorkflow.basePath + appendJsonExt(value)
+          : undefined
+      )
+      throw error
+    }
+  }
+
   async loadGraphData(
     graphData?: ComfyWorkflowJSON,
     clean: boolean = true,
@@ -1556,11 +1582,22 @@ export class ComfyApp {
       }
       useTelemetry()?.trackWorkflowOpened(telemetryPayload)
       useTelemetry()?.trackWorkflowImported(telemetryPayload)
-      await useWorkflowService().afterLoadNewGraph(
-        workflow,
-        this.rootGraph.serialize() as unknown as ComfyWorkflowJSON,
-        effectiveShareId
-      )
+      try {
+        await this.activateLoadedGraph(
+          workflow,
+          this.rootGraph.serialize() as unknown as ComfyWorkflowJSON,
+          effectiveShareId
+        )
+      } catch (error) {
+        useDialogService().showErrorDialog(error, {
+          title: t('errorDialog.loadWorkflowTitle'),
+          reportType: 'loadWorkflowError'
+        })
+        console.error(error)
+        // Resolves rather than throws, as for a configure failure: the
+        // close/replacement guards read this outcome.
+        return false
+      }
       await useExtensionService().invokeExtensionsAsync('afterLoadGraph')
       // Capture the workflow this load activated before the asset-scan awaits
       // below can hand control back and let the user switch to another one.
@@ -2171,7 +2208,7 @@ export class ComfyApp {
         'afterConfigureGraph',
         []
       )
-      await useWorkflowService().afterLoadNewGraph(
+      await this.activateLoadedGraph(
         fileName,
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
       )
@@ -2461,7 +2498,7 @@ export class ComfyApp {
       'afterConfigureGraph',
       missingNodeTypes
     )
-    await useWorkflowService().afterLoadNewGraph(
+    await this.activateLoadedGraph(
       fileName,
       this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
     )


### PR DESCRIPTION
## ELI-5

If you drop a workflow file whose name matches a saved workflow that hasn't been opened yet, ComfyUI fetches that saved file to reuse its tab. When the fetch fails, the editor used to end up in a broken in-between state: the canvas showed the freshly built nodes, but no workflow owned them, the previously active tab was still selected with its change tracking switched off, and an extra empty tab had appeared for the file that never loaded. This makes the failure clean up after itself: the extra tab goes away, the canvas goes back to what you were looking at, and you get one error instead of a wedged editor.

## Summary

`useWorkflowService().afterLoadNewGraph(...)` can reject *after* the nodes are built, and nothing unwound the load. This adds a recovery step and routes all three graph-entry paths in `app.ts` through it.

## Changes

- **What**:
  - `workflowService.ts` gains `recoverFailedGraphLoad(failedPath?)`. It drops the tab the failed activation itself opened, then repaints the retained active workflow from its saved state — falling back to a blank graph when nothing is retained. `restoreRetainedWorkflow` is refactored into `repaintRetainedWorkflow(failedPath?)` so the repaint has a single implementation shared with the existing configure-failure path.
  - `app.ts` gains a private `activateLoadedGraph(value, workflowData, shareId?)` that calls `afterLoadNewGraph`, recovers on rejection, and rethrows. The three direct `afterLoadNewGraph` awaits (`loadGraphData`, the A1111 branch of `handleFile`, `loadApiJson`) now go through it.
  - `loadGraphData` catches the rethrow, shows `errorDialog.loadWorkflowTitle` and resolves `false` — the same contract as the configure-failure catch above it, so `openWorkflow`'s `loaded === false` branch and `closeWorkflow`'s `=== false` guard treat activation failure like configure failure. The `finally` URL repair is untouched.
  - `loadApiJson` and the A1111 branch let the rethrow propagate; their callers already report it (the drop handler's `dropFileError` toast, `ui.ts`'s `showErrorOnFileLoad`). No new toasts.
  - `invokeExtensionsAsync('afterLoadGraph')` still runs only after a successful activation, so extensions never see a half-activated graph.

## Review Focus

- **The recovery must not close a tab it did not create.** The store appends the tab *before* awaiting the fetch, so after a rejection a phantom tab and a legitimately-restored-but-unloaded tab look identical (open, not active, not loaded). Closing the latter would also drop its draft via `workflowStore.closeWorkflow` → `removeDraft`. `afterLoadNewGraph` therefore snapshots the open tab paths before activating, and the recovery only drops a path that was not already open. `workflowService.test.ts` covers both sides; without the snapshot, the "keeps a tab that was already open" case fails.
- **Deviation from the plan: the blank fallback calls `app.loadGraphData(blankGraph)` directly rather than `loadBlankWorkflow()`.** `loadBlankWorkflow` goes through `queueWorkflowLoad`, and recovery frequently runs *inside* a queued load (`openWorkflow` → `loadGraphData` → activation), so chaining onto the tail it is itself holding would deadlock. This matches what the pre-existing repaint already did for the same reason.
- **Recursion.** A module-level flag makes the recovery load itself non-recovering; any error it raises is `reportError`-ed and swallowed so the original activation error is what surfaces.
- **Known benign redundancy.** When activation fails inside `service.openWorkflow`, recovery repaints the retained workflow and then `openWorkflow`'s own `loaded === false` branch repaints it again. Both paint identical state, so the effect is one wasted configure rather than a visible change; deduplicating it would mean teaching `loadGraphData` to report *why* it returned false, which is wider than this change.
- `onGraphLoadError` is deliberately **not** invoked for activation failures — it is currently a configure-stage hook, and firing it after `afterConfigureGraph` has already run would change what extensions observe.

## Verification

- `pnpm test:unit src/scripts/app.test.ts src/platform/workflow/core/services/workflowService.test.ts`: 197 passed, 1 skipped. All 7 new tests were confirmed red against the un-patched source and green with it.
- Related suites (`workflowStore`, `workflowActionsService`, `useWorkflowPersistenceV2`, `useTemplateWorkflows`, `WorkflowTabs`, `changeTracker`, `ui`, `subgraphNavigationStore`, `usePaste`, `LinearPreview`, `useSharedWorkflowUrlLoader`, `queueStore.loadWorkflow`, `nodeOutputStore.workflowSwitch`, `useWorkflowActionsMenu`): 302 passed.
- The pre-existing `app.test.ts` case "resolves false, not rejects, when graph configure fails" still passes.
- Sweep of the half not fixed: all 3 `afterLoadNewGraph` call sites in `src/` are converted; 0 remain outside `activateLoadedGraph`.
- No capability is denied by this change (no new refusal path, no "unsupported" surface) — the diff only adds recovery around an existing throw and rethrows the original error, so the negative-claim falsification check does not apply.

## Residual

- **Not fixed here: the producer.** `loadApiJson` binding onto a same-named persisted workflow at all is a separate, complementary concern (removing one source of this failure rather than unwinding it) and is deliberately out of scope. This PR adds the unwind for *all* string-name producers; it does not stop the binding.
- **Not exercised: the real fetch failure.** Tests stub `ComfyWorkflow.load` to reject. The concrete throw sites this recovery is built for — `UserFile.load`'s non-200 branch in `src/stores/userFileStore.ts` and the empty/corrupt-content asserts in `src/platform/workflow/management/stores/comfyWorkflow.ts` — were read but never driven end-to-end through a mocked `api.getUserData`, and there is no e2e coverage of dropping a file whose base name collides with a persisted workflow whose fetch fails. The unwind is verified at the service boundary, not against a live 404.
- **Overlapping open PR #16507** adds a `using graphLoadSettlement = beginGraphLoadScope()` line to the same three regions of `app.ts`. This branch is cut from `main` rather than stacked on it because #16507 is still open; whichever lands second will need a small manual merge in those three regions. The two changes are independent — the scope should wrap the activation helper, not replace it.
- **Open PR #10834** touches one condition in `isSameActiveWorkflowLoad`, in the same branch of `activateLoadedWorkflow` that produces this failure. No behavioural overlap with this change, but it edits adjacent lines.
- **Unreadable source material.** The upstream read-only investigation this work was specified from, and its comment thread, are not reachable from the environment this PR was authored in; the implementation follows the written plan, and the line references in it were re-verified against `main` rather than taken on trust.
- **Concurrency edge.** The recursion flag and the open-tabs snapshot are module-level. Two graph loads failing concurrently would leave the second one's phantom tab in place (the flag short-circuits its recovery). Loads are serialised through `queueWorkflowLoad` on the store paths and awaited sequentially on the file-drop path, so this is not reachable today; both degradations are toward doing nothing rather than toward closing a tab wrongly.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `pnpm test:unit src/scripts/app.test.ts src/platform/workflow/core/services/workflowService.test.ts`: 197 passed, 1 skipped, 0 failed; 14 related suites: 302 passed, 0 failed; `pnpm typecheck`: clean; `pnpm lint`: 0 errors, 189 pre-existing warnings; `pnpm format:check`: clean; `pnpm knip`: clean.
- **Deviations:** the blank-graph fallback calls `app.loadGraphData(blankGraph)` instead of `loadBlankWorkflow()` (deadlock, explained under Review Focus); the phantom-tab drop is additionally gated on the tab not having been open before the failed activation, which the written plan did not require and without which the recovery would discard a user's restored tab and its draft.
