### PR TITLE
Fix stale custom-node detection proof patches

### DIFF
--- a/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
@@ -2,7 +2,10 @@ diff --git a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderM
 index c09570c137..06c840aa80 100644
 --- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
 +++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
-@@ -361,3 +361,16 @@ function processWidget(
+@@ -358,6 +358,19 @@ function processWidget(
+   const widgetState = ctx.widgetValueStore.getWidget(id)
+   if (!widgetState) return null
+-
 +  // DETECTION PROOF (row 2, mount v2): hide ImpactInt's value widget only
 +  // in Vue Nodes. Expected: S2 red and every other tier remains green.
 +  const detectionProofTier = (
@@ -16,6 +19,7 @@ index c09570c137..06c840aa80 100644
 +    widgetState.name === 'value'
 +  )
 +    return null
++
    const liveWidget = ctx.liveWidgets.get(id)
    const type = liveWidget?.type ?? widgetState.type
    const renderState = ctx.widgetValueStore.getWidgetRenderState(id)

--- a/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
@@ -1,22 +1,21 @@
-diff --git a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-index e7e5549d59..4ca1314e3c 100644
---- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-@@ -316,4 +316,17 @@ export function computeProcessedWidgets({
-     isVisible: visible,
-     identity: { renderKey }
-   } of uniqueWidgets) {
-+    // DETECTION PROOF (row 2, mount v2): hide ImpactInt's value widget only
-+    // in Vue Nodes. Expected: S2 red and every other tier remains green.
-+    const detectionProofTier = (
-+      globalThis as {
-+        __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
-+      }
-+    ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
-+    if (
-+      detectionProofTier === 'S2' &&
-+      nodeData.type === 'ImpactInt' &&
-+      widget.name === 'value'
-+    )
-+      continue
-     const bareWidgetId = stripGraphPrefix(widget.nodeId ?? nodeId)
+diff --git a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+index c09570c137..06c840aa80 100644
+--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
++++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+@@ -361,3 +361,16 @@ function processWidget(
++  // DETECTION PROOF (row 2, mount v2): hide ImpactInt's value widget only
++  // in Vue Nodes. Expected: S2 red and every other tier remains green.
++  const detectionProofTier = (
++    globalThis as {
++      __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
++    }
++  ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
++  if (
++    detectionProofTier === 'S2' &&
++    ctx.nodeData.type === 'ImpactInt' &&
++    widgetState.name === 'value'
++  )
++    return null
+   const liveWidget = ctx.liveWidgets.get(id)
+   const type = liveWidget?.type ?? widgetState.type
+   const renderState = ctx.widgetValueStore.getWidgetRenderState(id)

--- a/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
@@ -2,23 +2,27 @@ diff --git a/src/lib/litegraph/src/LGraphNode.ts b/src/lib/litegraph/src/LGraphN
 index 306f11de20..4b9527aa76 100644
 --- a/src/lib/litegraph/src/LGraphNode.ts
 +++ b/src/lib/litegraph/src/LGraphNode.ts
-@@ -1183,6 +1183,19 @@ export class LGraphNode
-         let positionalIndex = 0
-         for (const widget of this.widgets) {
-           if (widget.serialize === false) continue
-+          // DETECTION PROOF (row 3, persistence): ImpactInt drops its last
-+          // widget value. Expected: S3 red and every other tier remains green.
-+          const detectionProofTier = (
-+            globalThis as {
-+              __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
-+            }
-+          ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
-+          if (
-+            detectionProofTier === 'S3' &&
-+            this.type === 'ImpactInt' &&
-+            positionalIndex >= restoration.positional.length - 1
-+          )
-+            break
-           const restored = useWidgetValueStore().getRestoredWidgetValue(
-             graphId,
-             this.id,
+@@ -2291,10 +2291,23 @@ export class LGraphNode
+     const positionalIndex =
+       this.widgets.filter((candidate) => candidate.serialize !== false).length -
+       1
+     const restored = useWidgetValueStore().getRestoredWidgetValue(
+       this.graph?.rootGraph.id ?? zeroUuid,
+       this.id,
+       widget.name,
+       positionalIndex
+     )
++    // DETECTION PROOF (row 3, persistence): ImpactInt drops its value
++    // widget value. Expected: S3 red and every other tier remains green.
++    const detectionProofTier = (
++      globalThis as {
++        __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
++      }
++    ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
++    if (
++      detectionProofTier === 'S3' &&
++      this.type === 'ImpactInt' &&
++      widget.name === 'value'
++    )
++      return widget
+     if (restored) widget.value = restored.value

--- a/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
@@ -1,28 +1,25 @@
 diff --git a/src/lib/litegraph/src/LGraphNode.ts b/src/lib/litegraph/src/LGraphNode.ts
-index 306f11de20..4b9527aa76 100644
+index 3fb1eec569..4603da81ae 100644
 --- a/src/lib/litegraph/src/LGraphNode.ts
 +++ b/src/lib/litegraph/src/LGraphNode.ts
-@@ -2291,10 +2291,23 @@ export class LGraphNode
-     const positionalIndex =
-       this.widgets.filter((candidate) => candidate.serialize !== false).length -
-       1
-     const restored = useWidgetValueStore().getRestoredWidgetValue(
-       this.graph?.rootGraph.id ?? zeroUuid,
-       this.id,
-       widget.name,
-       positionalIndex
-     )
-+    // DETECTION PROOF (row 3, persistence): ImpactInt drops its value
-+    // widget value. Expected: S3 red and every other tier remains green.
-+    const detectionProofTier = (
-+      globalThis as {
-+        __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
-+      }
-+    ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
-+    if (
-+      detectionProofTier === 'S3' &&
-+      this.type === 'ImpactInt' &&
-+      widget.name === 'value'
-+    )
-+      return widget
-     if (restored) widget.value = restored.value
+@@ -1191,6 +1191,20 @@ export class LGraphNode
+         let positionalIndex = 0
+         for (const widget of this.widgets) {
+           if (widget.serialize === false) continue
++          // DETECTION PROOF (row 3, persistence): ImpactInt drops its last
++          // widget value. Expected: S3 red and every other tier remains green.
++          const detectionProofTier = (
++            globalThis as {
++              __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
++            }
++          ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
++          if (
++            detectionProofTier === 'S3' &&
++            this.type === 'ImpactInt' &&
++            restoration.positional.length > 0 &&
++            positionalIndex >= restoration.positional.length - 1
++          )
++            break
+           const restored = useWidgetValueStore().getRestoredWidgetValue(
+             graphId,
+             this.id,

--- a/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
@@ -1,12 +1,11 @@
 diff --git a/src/lib/litegraph/src/LGraphNode.ts b/src/lib/litegraph/src/LGraphNode.ts
-index a928d93992..65563d0dd2 100644
+index 306f11de20..4b9527aa76 100644
 --- a/src/lib/litegraph/src/LGraphNode.ts
 +++ b/src/lib/litegraph/src/LGraphNode.ts
-@@ -987,7 +987,20 @@ export class LGraphNode
-         let i = 0
-         for (const widget of this.widgets ?? []) {
+@@ -1183,6 +1183,19 @@ export class LGraphNode
+         let positionalIndex = 0
+         for (const widget of this.widgets) {
            if (widget.serialize === false) continue
--          if (i >= info.widgets_values.length) break
 +          // DETECTION PROOF (row 3, persistence): ImpactInt drops its last
 +          // widget value. Expected: S3 red and every other tier remains green.
 +          const detectionProofTier = (
@@ -17,10 +16,9 @@ index a928d93992..65563d0dd2 100644
 +          if (
 +            detectionProofTier === 'S3' &&
 +            this.type === 'ImpactInt' &&
-+            i >= info.widgets_values.length - 1
++            positionalIndex >= restoration.positional.length - 1
 +          )
 +            break
-+          if (i >= info.widgets_values.length) break
-           widget.value = info.widgets_values[i++]
-         }
-       }
+           const restored = useWidgetValueStore().getRestoredWidgetValue(
+             graphId,
+             this.id,

--- a/scripts/cicd/custom-node-proof.test.ts
+++ b/scripts/cicd/custom-node-proof.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   assertNoCommittedSourceTierSwitch,
@@ -13,26 +13,34 @@ import {
 // The guard greps `src/` only, so this literal is inert here in `scripts/`.
 const SOURCE_TIER_SWITCH = '__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__'
 
-const fixtures: string[] = []
-
 /**
- * A throwaway git repo with one tracked `src/` file. `git grep` searches
- * tracked files, so the file is staged but never committed.
+ * Runs `fn` against a fresh temporary directory and removes it afterwards.
+ * The directory is scoped to the caller rather than registered in a
+ * module-level list, so no state is shared between test cases.
  */
-function sourceFixture(contents: string): string {
-  const root = mkdtempSync(join(tmpdir(), 'proof-switch-'))
-  fixtures.push(root)
-  mkdirSync(join(root, 'src'))
-  writeFileSync(join(root, 'src', 'node.ts'), contents)
-  spawnSync('git', ['init', '-q'], { cwd: root })
-  spawnSync('git', ['add', 'src/node.ts'], { cwd: root })
-  return root
+function withTempDir(prefix: string, fn: (root: string) => void): void {
+  const root = mkdtempSync(join(tmpdir(), prefix))
+  try {
+    fn(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 }
 
-afterEach(() => {
-  while (fixtures.length)
-    rmSync(fixtures.pop()!, { recursive: true, force: true })
-})
+/**
+ * Runs `fn` against a throwaway git repo with one tracked `src/` file.
+ * `git grep` searches tracked files, so the file is staged but never
+ * committed.
+ */
+function withSourceFixture(contents: string, fn: (root: string) => void): void {
+  withTempDir('proof-switch-', (root) => {
+    mkdirSync(join(root, 'src'))
+    writeFileSync(join(root, 'src', 'node.ts'), contents)
+    spawnSync('git', ['init', '-q'], { cwd: root })
+    spawnSync('git', ['add', 'src/node.ts'], { cwd: root })
+    fn(root)
+  })
+}
 
 describe('custom-node detection proof', () => {
   it('keeps the detection proof switch out of committed source', () => {
@@ -40,25 +48,28 @@ describe('custom-node detection proof', () => {
   })
 
   it('accepts a working tree whose src/ is free of the switch', () => {
-    const root = sourceFixture('export const value = 1\n')
-    expect(() => assertNoCommittedSourceTierSwitch(root)).not.toThrow()
+    withSourceFixture('export const value = 1\n', (root) => {
+      expect(() => assertNoCommittedSourceTierSwitch(root)).not.toThrow()
+    })
   })
 
   it('rejects a committed source-tier switch', () => {
-    const root = sourceFixture(
-      `export const tier = globalThis.${SOURCE_TIER_SWITCH}\n`
-    )
-    expect(() => assertNoCommittedSourceTierSwitch(root)).toThrow(
-      /detection proof switch leaked into src\//
+    withSourceFixture(
+      `export const tier = globalThis.${SOURCE_TIER_SWITCH}\n`,
+      (root) => {
+        expect(() => assertNoCommittedSourceTierSwitch(root)).toThrow(
+          /detection proof switch leaked into src\//
+        )
+      }
     )
   })
 
   it('rejects a working tree it cannot inspect', () => {
-    const root = mkdtempSync(join(tmpdir(), 'proof-switch-nogit-'))
-    fixtures.push(root)
-    expect(() => assertNoCommittedSourceTierSwitch(root)).toThrow(
-      /could not inspect src\//
-    )
+    withTempDir('proof-switch-nogit-', (root) => {
+      expect(() => assertNoCommittedSourceTierSwitch(root)).toThrow(
+        /could not inspect src\//
+      )
+    })
   })
 
   it('mutates only the calibrated S9 witness method', () => {

--- a/scripts/cicd/custom-node-proof.test.ts
+++ b/scripts/cicd/custom-node-proof.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { mutateExecutionSource, proofIdentity } from './custom-node-proof'
+import {
+  assertNoCommittedSourceTierSwitch,
+  mutateExecutionSource,
+  proofIdentity
+} from './custom-node-proof'
 
 describe('custom-node detection proof', () => {
+  it('keeps the detection proof switch out of committed source', () => {
+    expect(() => assertNoCommittedSourceTierSwitch()).not.toThrow()
+  })
+
   it('mutates only the calibrated S9 witness method', () => {
     const source = `class LoadAudioUpload:
     def load_audio(self, start_time=0, duration=0, **kwargs):

--- a/scripts/cicd/custom-node-proof.test.ts
+++ b/scripts/cicd/custom-node-proof.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   assertNoCommittedSourceTierSwitch,
@@ -6,9 +10,55 @@ import {
   proofIdentity
 } from './custom-node-proof'
 
+// The guard greps `src/` only, so this literal is inert here in `scripts/`.
+const SOURCE_TIER_SWITCH = '__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__'
+
+const fixtures: string[] = []
+
+/**
+ * A throwaway git repo with one tracked `src/` file. `git grep` searches
+ * tracked files, so the file is staged but never committed.
+ */
+function sourceFixture(contents: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'proof-switch-'))
+  fixtures.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'src', 'node.ts'), contents)
+  spawnSync('git', ['init', '-q'], { cwd: root })
+  spawnSync('git', ['add', 'src/node.ts'], { cwd: root })
+  return root
+}
+
+afterEach(() => {
+  while (fixtures.length)
+    rmSync(fixtures.pop()!, { recursive: true, force: true })
+})
+
 describe('custom-node detection proof', () => {
   it('keeps the detection proof switch out of committed source', () => {
     expect(() => assertNoCommittedSourceTierSwitch()).not.toThrow()
+  })
+
+  it('accepts a working tree whose src/ is free of the switch', () => {
+    const root = sourceFixture('export const value = 1\n')
+    expect(() => assertNoCommittedSourceTierSwitch(root)).not.toThrow()
+  })
+
+  it('rejects a committed source-tier switch', () => {
+    const root = sourceFixture(
+      `export const tier = globalThis.${SOURCE_TIER_SWITCH}\n`
+    )
+    expect(() => assertNoCommittedSourceTierSwitch(root)).toThrow(
+      /detection proof switch leaked into src\//
+    )
+  })
+
+  it('rejects a working tree it cannot inspect', () => {
+    const root = mkdtempSync(join(tmpdir(), 'proof-switch-nogit-'))
+    fixtures.push(root)
+    expect(() => assertNoCommittedSourceTierSwitch(root)).toThrow(
+      /could not inspect src\//
+    )
   })
 
   it('mutates only the calibrated S9 witness method', () => {

--- a/scripts/cicd/custom-node-proof.ts
+++ b/scripts/cicd/custom-node-proof.ts
@@ -70,11 +70,11 @@ function digest(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex')
 }
 
-export function assertNoCommittedSourceTierSwitch(): void {
+export function assertNoCommittedSourceTierSwitch(cwd?: string): void {
   const result = spawnSync(
     'git',
     ['grep', '-n', SOURCE_TIER_SWITCH, '--', 'src/'],
-    { encoding: 'utf8' }
+    { encoding: 'utf8', cwd }
   )
   if (result.status === 1) return
   if (result.status === 0)

--- a/scripts/cicd/custom-node-proof.ts
+++ b/scripts/cicd/custom-node-proof.ts
@@ -9,6 +9,8 @@ import {
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+const SOURCE_TIER_SWITCH = '__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__'
+
 const PROOFS = {
   '1': {
     witness: 'comfyui-impact-pack',
@@ -68,6 +70,18 @@ function digest(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex')
 }
 
+export function assertNoCommittedSourceTierSwitch(): void {
+  const result = spawnSync(
+    'git',
+    ['grep', '-n', SOURCE_TIER_SWITCH, '--', 'src/'],
+    { encoding: 'utf8' }
+  )
+  if (result.status === 1) return
+  if (result.status === 0)
+    throw new Error(`detection proof switch leaked into src/: ${result.stdout}`)
+  throw new Error(`could not inspect src/ for detection proof switches`)
+}
+
 function actionOutputs(values: Record<string, string>): void {
   const path = process.env.GITHUB_OUTPUT
   if (!path) throw new Error('GITHUB_OUTPUT is not set')
@@ -118,6 +132,7 @@ export function proofIdentity(input: {
 }
 
 function mutateSource(row: ProofRow): void {
+  assertNoCommittedSourceTierSwitch()
   const directory = join(
     'browser_tests',
     'tests',


### PR DESCRIPTION
## Summary

Refresh the S2 and S3 custom-node detection-proof mutations after their production ownership seams moved, restoring required `main` CI.

## Changes

- **What**: Retarget the Vue mount proof to `processedWidgetRenderModel.ts` and the persistence proof to the widget restoration loop.
- **Dependencies**: None.

## Review Focus

The mutations preserve their calibrated behavior: S2 hides only `ImpactInt.value` in Vue rendering; S3 drops only its final restored widget value.

Failed run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33858545246
Failed jobs: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33858545246/job/100977438067 and https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33858545246/job/100977438128

Verification: both patches apply through `custom-node-proof.ts`; patched sources pass Oxfmt and typecheck; focused proof tests pass 2/2; Knip passes in the push hook.