### PR TITLE
fix(ci): refresh custom-node detection mutations

### DIFF
--- a/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
@@ -1,22 +1,20 @@
-diff --git a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-index e7e5549d59..4ca1314e3c 100644
---- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-@@ -316,4 +316,17 @@ export function computeProcessedWidgets({
-     isVisible: visible,
-     identity: { renderKey }
-   } of uniqueWidgets) {
-+    // DETECTION PROOF (row 2, mount v2): hide ImpactInt's value widget only
-+    // in Vue Nodes. Expected: S2 red and every other tier remains green.
-+    const detectionProofTier = (
-+      globalThis as {
-+        __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
-+      }
-+    ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
-+    if (
-+      detectionProofTier === 'S2' &&
-+      nodeData.type === 'ImpactInt' &&
-+      widget.name === 'value'
-+    )
-+      continue
-     const bareWidgetId = stripGraphPrefix(widget.nodeId ?? nodeId)
+diff --git a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+index c09570c137..69fece57f3 100644
+--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
++++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+@@ -361,3 +361,15 @@ function processWidget(
++  const detectionProofTier = (
++    globalThis as {
++      __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
++    }
++  ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
++  if (
++    detectionProofTier === 'S2' &&
++    ctx.nodeData.type === 'ImpactInt' &&
++    widgetState.name === 'value'
++  )
++    return null
++
+   const liveWidget = ctx.liveWidgets.get(id)
+   const type = liveWidget?.type ?? widgetState.type
+   const renderState = ctx.widgetValueStore.getWidgetRenderState(id)

--- a/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
@@ -1,14 +1,11 @@
 diff --git a/src/lib/litegraph/src/LGraphNode.ts b/src/lib/litegraph/src/LGraphNode.ts
-index a928d93992..65563d0dd2 100644
+index 306f11de20..154e838564 100644
 --- a/src/lib/litegraph/src/LGraphNode.ts
 +++ b/src/lib/litegraph/src/LGraphNode.ts
-@@ -987,7 +987,20 @@ export class LGraphNode
-         let i = 0
-         for (const widget of this.widgets ?? []) {
+@@ -1183,6 +1183,17 @@ export class LGraphNode
+         let positionalIndex = 0
+         for (const widget of this.widgets) {
            if (widget.serialize === false) continue
--          if (i >= info.widgets_values.length) break
-+          // DETECTION PROOF (row 3, persistence): ImpactInt drops its last
-+          // widget value. Expected: S3 red and every other tier remains green.
 +          const detectionProofTier = (
 +            globalThis as {
 +              __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
@@ -17,10 +14,9 @@ index a928d93992..65563d0dd2 100644
 +          if (
 +            detectionProofTier === 'S3' &&
 +            this.type === 'ImpactInt' &&
-+            i >= info.widgets_values.length - 1
++            positionalIndex >= restoration.positional.length - 1
 +          )
 +            break
-+          if (i >= info.widgets_values.length) break
-           widget.value = info.widgets_values[i++]
-         }
-       }
+           const restored = useWidgetValueStore().getRestoredWidgetValue(
+             graphId,
+             this.id,


### PR DESCRIPTION
Repairs the custom-node detection-proof fixtures that made frontend `main` red in push run [33858545246](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33858545246). Tracks program row `cifix-16919`.

## What

- Retargets the S2 DOM-render mutation from removed `useProcessedWidgets.ts` code to the current `processedWidgetRenderModel.ts` widget render path.
- Retargets the S3 persistence mutation from the removed legacy `widgets_values` restore loop to the current positional restoration path in `LGraphNode.ts`.
- Preserves each proof's intended behavior: only `ImpactInt.value` is suppressed, under its matching proof-tier global.

## Evidence

- All four checked-in source mutation fixtures pass `git apply --check` at parent `9ff3fd7f0e`.
- S2 mutated tree: `pnpm typecheck` passes.
- S3 mutated tree: `pnpm typecheck` passes.
- `pnpm vitest run scripts/cicd/custom-node-proof.test.ts`: 2/2 passed.
- `git diff --check` passes; pre-commit lint-staged and pre-push `knip --cache` pass.

## Linear

Not created: this is an emergency red-`main` repair during Quiet Week.

<!-- authored-by:agent operator-8d -->