### PR TITLE
fix(ci): spill oversized unified reports across comments

### DIFF
--- a/.github/actions/upsert-comment-section/action.yaml
+++ b/.github/actions/upsert-comment-section/action.yaml
@@ -71,6 +71,98 @@ runs:
           const sectionStartsIn = (body) =>
             body.match(/<!-- section:[a-z0-9-]+:start -->/g) ?? []
 
+          // GitHub rejects an issue-comment body over 65536 characters with a
+          // 422, and the generated sections are unbounded — a single ci-metrics
+          // report has reached 244k on its own. Passing content by file path
+          // removed the ARG_MAX ceiling that used to bound it incidentally, so
+          // the size has to be enforced here instead.
+          //
+          // Trim section CONTENT only, never the markers: every section stays
+          // present and addressable, so the workflow that owns a trimmed
+          // section restores its full text on its next run.
+          const MAX_COMMENT_LENGTH = 65536
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+          const blockRegex =
+            /(<!-- section:([a-z0-9-]+):start -->\n?)([\s\S]*?)(\n?<!-- section:\2:end -->)/g
+          const truncationNotice = (omitted) =>
+            `\n\n_Truncated ${omitted} characters to fit GitHub's ${MAX_COMMENT_LENGTH}-character comment limit. Full output: ${runUrl}_`
+
+          const clampBody = (body) => {
+            if (body.length <= MAX_COMMENT_LENGTH) return body
+
+            // Split into ordered pieces so markers and any non-section text
+            // (the comment marker, spacing) round-trip untouched.
+            const pieces = []
+            let cursor = 0
+            for (const match of body.matchAll(blockRegex)) {
+              if (match.index > cursor) {
+                pieces.push({ text: body.slice(cursor, match.index) })
+              }
+              pieces.push({ open: match[1], content: match[3], close: match[4] })
+              cursor = match.index + match[0].length
+            }
+            pieces.push({ text: body.slice(cursor) })
+
+            const fixedLength = pieces.reduce(
+              (total, piece) =>
+                total +
+                (piece.text !== undefined
+                  ? piece.text.length
+                  : piece.open.length + piece.close.length),
+              0
+            )
+            const sections = pieces.filter((piece) => piece.text === undefined)
+
+            // Equal-share water filling, smallest section first: a section under
+            // its share releases the remainder to the larger ones, so one
+            // runaway report cannot starve every other workflow's section.
+            let remaining = Math.max(0, MAX_COMMENT_LENGTH - fixedLength)
+            const ordered = [...sections].sort(
+              (a, b) => a.content.length - b.content.length
+            )
+            ordered.forEach((section, index) => {
+              const share = Math.floor(remaining / (ordered.length - index))
+              if (section.content.length > share) {
+                // Size the reservation with the pre-trim count, which can only
+                // have at least as many digits as the final one, so the notice
+                // always fits the share it was budgeted from.
+                const reserved = truncationNotice(section.content.length).length
+                if (share <= reserved) {
+                  section.content = ''
+                } else {
+                  const keep = share - reserved
+                  section.content =
+                    section.content.slice(0, keep) +
+                    truncationNotice(section.content.length - keep)
+                }
+              }
+              remaining -= section.content.length
+            })
+
+            const clamped = pieces
+              .map((piece) =>
+                piece.text !== undefined
+                  ? piece.text
+                  : piece.open + piece.content + piece.close
+              )
+              .join('')
+
+            if (clamped.length > MAX_COMMENT_LENGTH) {
+              // Unreachable by the arithmetic above; a mangled tail still beats
+              // a 422 that reds the branch this report is only describing.
+              core.warning(
+                `upsert-comment-section: body still ${clamped.length} characters after trimming; hard-truncating`
+              )
+              return clamped.slice(0, MAX_COMMENT_LENGTH)
+            }
+            return clamped
+          }
+
+          // 422 is a validation failure (body too long, and similar): the same
+          // request will fail identically every time, so burning the retry
+          // budget on it only delays the error.
+          const isPermanent = (err) => err?.status === 422
+
           const findComment = async () => {
             const comments = await github.paginate(
               github.rest.issues.listComments,
@@ -97,7 +189,7 @@ runs:
                 await github.rest.issues.createComment({
                   ...context.repo,
                   issue_number: prNumber,
-                  body: `${commentMarker}\n${sectionBlock}`
+                  body: clampBody(`${commentMarker}\n${sectionBlock}`)
                 })
                 // Concurrent writers may have also created a comment; merge all
                 // sections from every duplicate into the lowest-id copy, verify,
@@ -138,7 +230,7 @@ runs:
                     await github.rest.issues.updateComment({
                       ...context.repo,
                       comment_id: canonical.id,
-                      body: mergedBody
+                      body: clampBody(mergedBody)
                     })
                     // Verify canonical has all sections before deleting duplicates
                     const verified = (await github.rest.issues.getComment({
@@ -165,16 +257,22 @@ runs:
                 }
                 return
               } catch (err) {
-                if (attempt === maxAttempts) throw err
+                if (isPermanent(err) || attempt === maxAttempts) throw err
                 continue // another writer likely created it first; retry updates
               }
             }
 
             const body = existing.body ?? ''
             const expectedSections = sectionStartsIn(body)
-            const updated = sectionRegex.test(body)
-              ? body.replace(sectionRegex, sectionBlock)
-              : body.trimEnd() + '\n\n' + sectionBlock
+            const updated = clampBody(
+              sectionRegex.test(body)
+                ? body.replace(sectionRegex, sectionBlock)
+                : body.trimEnd() + '\n\n' + sectionBlock
+            )
+            // Verify against what was actually written: clampBody may have
+            // trimmed our own section, and looking for the untrimmed block
+            // would read as a clobber and burn every remaining attempt.
+            const writtenBlock = updated.match(sectionRegex)?.[0] ?? sectionBlock
 
             try {
               await github.rest.issues.updateComment({
@@ -183,13 +281,13 @@ runs:
                 body: updated
               })
             } catch (err) {
-              if (attempt === maxAttempts) throw err
+              if (isPermanent(err) || attempt === maxAttempts) throw err
               continue // transient failure; retry
             }
 
             const current = (await findComment())?.body ?? ''
             const survived =
-              current.includes(sectionBlock) &&
+              current.includes(writtenBlock) &&
               expectedSections.every((s) => current.includes(s))
             if (survived) return
 

--- a/.github/actions/upsert-comment-section/action.yaml
+++ b/.github/actions/upsert-comment-section/action.yaml
@@ -60,236 +60,172 @@ runs:
           const sectionEnd = `<!-- section:${sectionName}:end -->`
           const sectionBlock = `${sectionStart}\n${sectionContent}\n${sectionEnd}`
 
-          // Escape special regex characters in delimiter strings
-          const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-          const sectionRegex = new RegExp(
-            `${escapeRegex(sectionStart)}[\\s\\S]*?${escapeRegex(sectionEnd)}`
-          )
-
-          // Every section-start marker in a body, used to detect whether a
-          // concurrent writer's section was lost across our write.
-          const sectionStartsIn = (body) =>
-            body.match(/<!-- section:[a-z0-9-]+:start -->/g) ?? []
-
-          // GitHub rejects an issue-comment body over 65536 characters with a
-          // 422, and the generated sections are unbounded — a single ci-metrics
-          // report has reached 244k on its own. Passing content by file path
-          // removed the ARG_MAX ceiling that used to bound it incidentally, so
-          // the size has to be enforced here instead.
-          //
-          // Trim section CONTENT only, never the markers: every section stays
-          // present and addressable, so the workflow that owns a trimmed
-          // section restores its full text on its next run.
-          const MAX_COMMENT_LENGTH = 65536
-          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-          const blockRegex =
-            /(<!-- section:([a-z0-9-]+):start -->\n?)([\s\S]*?)(\n?<!-- section:\2:end -->)/g
-          const truncationNotice = (omitted) =>
-            `\n\n_Truncated ${omitted} characters to fit GitHub's ${MAX_COMMENT_LENGTH}-character comment limit. Full output: ${runUrl}_`
-
-          const clampBody = (body) => {
-            if (body.length <= MAX_COMMENT_LENGTH) return body
-
-            // Split into ordered pieces so markers and any non-section text
-            // (the comment marker, spacing) round-trip untouched.
-            const pieces = []
-            let cursor = 0
-            for (const match of body.matchAll(blockRegex)) {
-              if (match.index > cursor) {
-                pieces.push({ text: body.slice(cursor, match.index) })
-              }
-              pieces.push({ open: match[1], content: match[3], close: match[4] })
-              cursor = match.index + match[0].length
+          const upsertSection = (body, start, end, block) => {
+            const startIndex = body.indexOf(start)
+            const endIndex = body.lastIndexOf(end)
+            if (startIndex === -1 || endIndex < startIndex) {
+              return body.trimEnd() + (body ? '\n\n' : '') + block
             }
-            pieces.push({ text: body.slice(cursor) })
-
-            const fixedLength = pieces.reduce(
-              (total, piece) =>
-                total +
-                (piece.text !== undefined
-                  ? piece.text.length
-                  : piece.open.length + piece.close.length),
-              0
+            return (
+              body.slice(0, startIndex) +
+              block +
+              body.slice(endIndex + end.length)
             )
-            const sections = pieces.filter((piece) => piece.text === undefined)
-
-            // Equal-share water filling, smallest section first: a section under
-            // its share releases the remainder to the larger ones, so one
-            // runaway report cannot starve every other workflow's section.
-            let remaining = Math.max(0, MAX_COMMENT_LENGTH - fixedLength)
-            const ordered = [...sections].sort(
-              (a, b) => a.content.length - b.content.length
-            )
-            ordered.forEach((section, index) => {
-              const share = Math.floor(remaining / (ordered.length - index))
-              if (section.content.length > share) {
-                // Size the reservation with the pre-trim count, which can only
-                // have at least as many digits as the final one, so the notice
-                // always fits the share it was budgeted from.
-                const reserved = truncationNotice(section.content.length).length
-                if (share <= reserved) {
-                  section.content = ''
-                } else {
-                  const keep = share - reserved
-                  section.content =
-                    section.content.slice(0, keep) +
-                    truncationNotice(section.content.length - keep)
-                }
-              }
-              remaining -= section.content.length
-            })
-
-            const clamped = pieces
-              .map((piece) =>
-                piece.text !== undefined
-                  ? piece.text
-                  : piece.open + piece.content + piece.close
-              )
-              .join('')
-
-            if (clamped.length > MAX_COMMENT_LENGTH) {
-              // Unreachable by the arithmetic above; a mangled tail still beats
-              // a 422 that reds the branch this report is only describing.
-              core.warning(
-                `upsert-comment-section: body still ${clamped.length} characters after trimming; hard-truncating`
-              )
-              return clamped.slice(0, MAX_COMMENT_LENGTH)
-            }
-            return clamped
           }
 
-          // 422 is a validation failure (body too long, and similar): the same
-          // request will fail identically every time, so burning the retry
-          // budget on it only delays the error.
-          const isPermanent = (err) => err?.status === 422
+          const MAX_COMMENT_LENGTH = 65536
+          const pageMarker = (index) =>
+            `${commentMarker}\n<!-- upsert-comment-section:page:${index} -->`
 
-          const findComment = async () => {
+          const parseManagedComment = (comment) => {
+            if (
+              comment.user?.login !== 'github-actions[bot]' ||
+              !comment.body?.startsWith(commentMarker)
+            ) {
+              return null
+            }
+            const tail = comment.body.slice(commentMarker.length)
+            const page = tail.match(
+              /^\n<!-- upsert-comment-section:page:(\d+) -->\n/
+            )
+            return page
+              ? {
+                  comment,
+                  index: Number(page[1]),
+                  content: tail.slice(page[0].length)
+                }
+              : { comment, index: 1, content: tail.replace(/^\n/, '') }
+          }
+
+          const paginateBody = (body) => {
+            const pages = []
+            let remaining = body
+            for (let index = 1; remaining || index === 1; index++) {
+              const prefix = pageMarker(index) + '\n'
+              const budget = MAX_COMMENT_LENGTH - prefix.length
+              let cut = Math.min(budget, remaining.length)
+              if (
+                cut > 0 &&
+                cut < remaining.length &&
+                /[\uD800-\uDBFF]/.test(remaining[cut - 1])
+              ) {
+                cut--
+              }
+              const newline = remaining.lastIndexOf('\n', cut - 1)
+              if (newline >= Math.floor(budget / 2)) cut = newline + 1
+              pages.push({ index, body: prefix + remaining.slice(0, cut) })
+              remaining = remaining.slice(cut)
+            }
+            return pages
+          }
+
+          const readManagedComments = async () => {
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { ...context.repo, issue_number: prNumber }
             )
-            return comments.find(
-              (c) =>
-                c.user?.login === 'github-actions[bot]' &&
-                c.body?.includes(commentMarker)
-            )
+            return comments
+              .map(parseManagedComment)
+              .filter(Boolean)
+              .sort((a, b) => a.comment.id - b.comment.id)
           }
 
-          // Several workflows share one comment via read-modify-write, which the
-          // REST API can't do atomically. Re-read immediately before each write
-          // and verify our section plus every previously-present section
-          // survived; on a detected clobber, re-read and retry so writers
-          // converge instead of silently dropping each other's sections.
+          const mergeDuplicateSections = (body, duplicate) => {
+            const names = [
+              ...duplicate.matchAll(
+                /<!-- section:([a-z0-9-]+):start -->/g
+              )
+            ].map((match) => match[1])
+            for (const name of new Set(names)) {
+              const start = `<!-- section:${name}:start -->`
+              const end = `<!-- section:${name}:end -->`
+              const startIndex = duplicate.indexOf(start)
+              const endIndex = duplicate.lastIndexOf(end)
+              if (startIndex === -1 || endIndex < startIndex) continue
+              const block = duplicate.slice(startIndex, endIndex + end.length)
+              body = upsertSection(body, start, end, block)
+            }
+            return body
+          }
+
           const maxAttempts = 5
           for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-            const existing = await findComment()
-
-            if (!existing) {
-              try {
-                await github.rest.issues.createComment({
-                  ...context.repo,
-                  issue_number: prNumber,
-                  body: clampBody(`${commentMarker}\n${sectionBlock}`)
-                })
-                // Concurrent writers may have also created a comment; merge all
-                // sections from every duplicate into the lowest-id copy, verify,
-                // then delete the rest so no report content is lost.
-                const allComments = await github.paginate(
-                  github.rest.issues.listComments,
-                  { ...context.repo, issue_number: prNumber }
-                )
-                const markers = allComments.filter(
-                  (c) =>
-                    c.user?.login === 'github-actions[bot]' &&
-                    c.body?.includes(commentMarker)
-                )
-                if (markers.length > 1) {
-                  markers.sort((a, b) => a.id - b.id)
-                  const canonical = markers[0]
-                  // Merge sections from all duplicates into the canonical body
-                  let mergedBody = canonical.body ?? ''
-                  for (const dup of markers.slice(1)) {
-                    const dupSections = (dup.body ?? '').match(
-                      /<!-- section:[a-z0-9-]+:start -->[\s\S]*?<!-- section:[a-z0-9-]+:end -->/g
-                    ) ?? []
-                    for (const block of dupSections) {
-                      const nameMatch = block.match(/<!-- section:([a-z0-9-]+):start -->/)
-                      if (!nameMatch) continue
-                      const name = nameMatch[1]
-                      const startTag = `<!-- section:${name}:start -->`
-                      const endTag = `<!-- section:${name}:end -->`
-                      const existingRegex = new RegExp(
-                        `${escapeRegex(startTag)}[\\s\\S]*?${escapeRegex(endTag)}`
-                      )
-                      mergedBody = existingRegex.test(mergedBody)
-                        ? mergedBody.replace(existingRegex, block)
-                        : mergedBody.trimEnd() + '\n\n' + block
-                    }
-                  }
-                  try {
-                    await github.rest.issues.updateComment({
-                      ...context.repo,
-                      comment_id: canonical.id,
-                      body: clampBody(mergedBody)
-                    })
-                    // Verify canonical has all sections before deleting duplicates
-                    const verified = (await github.rest.issues.getComment({
-                      ...context.repo,
-                      comment_id: canonical.id
-                    })).data.body ?? ''
-                    const allSections = markers.flatMap(
-                      (m) => sectionStartsIn(m.body ?? '')
-                    )
-                    const allPresent = allSections.every((s) => verified.includes(s))
-                    if (allPresent) {
-                      for (const dup of markers.slice(1)) {
-                        try {
-                          await github.rest.issues.deleteComment({
-                            ...context.repo,
-                            comment_id: dup.id
-                          })
-                        } catch (_) {}
-                      }
-                    }
-                  } catch (_) {
-                    // Leave duplicates rather than risk losing content
-                  }
-                }
-                return
-              } catch (err) {
-                if (isPermanent(err) || attempt === maxAttempts) throw err
-                continue // another writer likely created it first; retry updates
-              }
+            const managed = await readManagedComments()
+            const canonical = new Map()
+            for (const page of managed) {
+              if (!canonical.has(page.index)) canonical.set(page.index, page)
             }
 
-            const body = existing.body ?? ''
-            const expectedSections = sectionStartsIn(body)
-            const updated = clampBody(
-              sectionRegex.test(body)
-                ? body.replace(sectionRegex, sectionBlock)
-                : body.trimEnd() + '\n\n' + sectionBlock
+            let body = [...canonical.values()]
+              .sort((a, b) => a.index - b.index)
+              .map((page) => page.content)
+              .join('')
+            for (const duplicate of managed.filter(
+              (page) => canonical.get(page.index) !== page
+            )) {
+              body = mergeDuplicateSections(body, duplicate.content)
+            }
+
+            const updated = upsertSection(
+              body,
+              sectionStart,
+              sectionEnd,
+              sectionBlock
             )
-            // Verify against what was actually written: clampBody may have
-            // trimmed our own section, and looking for the untrimmed block
-            // would read as a clobber and burn every remaining attempt.
-            const writtenBlock = updated.match(sectionRegex)?.[0] ?? sectionBlock
+            const pages = paginateBody(updated)
 
             try {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: existing.id,
-                body: updated
-              })
+              const overflowFirst = [...pages.slice(1), pages[0]]
+              for (const page of overflowFirst) {
+                const existing = canonical.get(page.index)
+                if (existing) {
+                  if (existing.comment.body !== page.body) {
+                    await github.rest.issues.updateComment({
+                      ...context.repo,
+                      comment_id: existing.comment.id,
+                      body: page.body
+                    })
+                  }
+                } else {
+                  await github.rest.issues.createComment({
+                    ...context.repo,
+                    issue_number: prNumber,
+                    body: page.body
+                  })
+                }
+              }
             } catch (err) {
-              if (isPermanent(err) || attempt === maxAttempts) throw err
-              continue // transient failure; retry
+              if (attempt === maxAttempts) throw err
+              continue
             }
 
-            const current = (await findComment())?.body ?? ''
-            const survived =
-              current.includes(writtenBlock) &&
-              expectedSections.every((s) => current.includes(s))
-            if (survived) return
+            const currentPages = await readManagedComments()
+            const selected = pages.map((page) =>
+              currentPages.find(
+                (candidate) =>
+                  candidate.index === page.index &&
+                  candidate.comment.body === page.body
+              )
+            )
+            const current = selected
+              .filter(Boolean)
+              .map((page) => page.content)
+              .join('')
+            const survived = selected.every(Boolean) && current === updated
+            if (survived) {
+              const keep = new Set(selected.map((page) => page.comment.id))
+              for (const stale of currentPages.filter(
+                (page) => !keep.has(page.comment.id)
+              )) {
+                try {
+                  await github.rest.issues.deleteComment({
+                    ...context.repo,
+                    comment_id: stale.comment.id
+                  })
+                } catch (_) {}
+              }
+              return
+            }
 
             if (attempt === maxAttempts) {
               core.warning(

--- a/scripts/cicd/upsert-comment-section-size.test.ts
+++ b/scripts/cicd/upsert-comment-section-size.test.ts
@@ -1,0 +1,208 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { parse } from 'yaml'
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * GitHub rejects an issue-comment body over this many characters with a 422.
+ * The unified PR report is assembled from unbounded generated sections, so the
+ * action has to enforce the ceiling itself.
+ */
+const MAX_COMMENT_LENGTH = 65536
+
+const ACTION_PATH = join(
+  import.meta.dirname,
+  '../../.github/actions/upsert-comment-section/action.yaml'
+)
+
+/**
+ * Runs the action's real embedded `github-script` body, so the test exercises
+ * the shipped code rather than a re-implementation of it.
+ */
+function loadActionScript(): string {
+  const action = parse(readFileSync(ACTION_PATH, 'utf8'))
+  const step = action.runs.steps.find((s: { uses?: string }) =>
+    s.uses?.startsWith('actions/github-script')
+  )
+  if (!step?.with?.script) {
+    throw new Error('upsert-comment-section: github-script step not found')
+  }
+  return step.with.script
+}
+
+const actionScript = loadActionScript()
+
+interface Comment {
+  id: number
+  user: { login: string }
+  body: string
+}
+
+const COMMENT_MARKER = '<!-- COMFYUI_FRONTEND_PR_REPORT -->'
+
+function section(name: string, content: string) {
+  return `<!-- section:${name}:start -->\n${content}\n<!-- section:${name}:end -->`
+}
+
+function createHarness(options: {
+  comments?: Comment[]
+  updateRejection?: { status: number }
+}) {
+  const comments: Comment[] = options.comments ?? []
+  const updateComment = vi.fn(
+    async ({ comment_id, body }: { comment_id: number; body: string }) => {
+      if (options.updateRejection) throw options.updateRejection
+      const target = comments.find((c) => c.id === comment_id)
+      if (target) target.body = body
+      return { data: target }
+    }
+  )
+  const createComment = vi.fn(async ({ body }: { body: string }) => {
+    const created = {
+      id: comments.length + 1,
+      user: { login: 'github-actions[bot]' },
+      body
+    }
+    comments.push(created)
+    return { data: created }
+  })
+
+  const listComments = vi.fn(async () => ({ data: comments }))
+  const github = {
+    paginate: async (fn: typeof listComments) => (await fn()).data,
+    rest: {
+      issues: {
+        listComments,
+        createComment,
+        updateComment,
+        deleteComment: vi.fn(async () => ({})),
+        getComment: vi.fn(async ({ comment_id }: { comment_id: number }) => ({
+          data: comments.find((c) => c.id === comment_id)
+        }))
+      }
+    }
+  }
+
+  const core = { warning: vi.fn(), info: vi.fn() }
+  const context = {
+    repo: { owner: 'Comfy-Org', repo: 'ComfyUI_frontend' },
+    serverUrl: 'https://github.com',
+    runId: 33872270128
+  }
+
+  const run = (env: Record<string, string>) =>
+    new Function(
+      'github',
+      'context',
+      'core',
+      'process',
+      'require',
+      `"use strict"; return (async () => {\n${actionScript}\n})()`
+    )(github, context, core, { env }, require)
+
+  return { run, comments, createComment, updateComment, core }
+}
+
+const baseEnv = {
+  INPUT_PR_NUMBER: '15740',
+  INPUT_COMMENT_MARKER: COMMENT_MARKER
+}
+
+describe('upsert-comment-section comment size limit', () => {
+  it('clamps an oversized section on create', async () => {
+    const harness = createHarness({})
+
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'x'.repeat(244_310)
+    })
+
+    const [{ body }] = harness.createComment.mock.calls.map((call) => call[0])
+    expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH)
+    expect(body).toContain('<!-- section:ci-metrics:start -->')
+    expect(body).toContain('<!-- section:ci-metrics:end -->')
+    expect(body).toContain('Truncated')
+  })
+
+  it('repairs an already-oversized comment and keeps every section addressable', async () => {
+    // Reproduces comment 5385418044 on PR #15740: a 244k ci-metrics section
+    // alongside a small playwright section, which no longer accepts any write.
+    const harness = createHarness({
+      comments: [
+        {
+          id: 5385418044,
+          user: { login: 'github-actions[bot]' },
+          body: [
+            COMMENT_MARKER,
+            section('playwright', '✅ 1908 passed, 0 failed'),
+            section('ci-metrics', 'y'.repeat(244_310))
+          ].join('\n')
+        }
+      ]
+    })
+
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'z'.repeat(200_000)
+    })
+
+    expect(harness.updateComment).toHaveBeenCalledTimes(1)
+    const { body } = harness.updateComment.mock.calls[0][0]
+    expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH)
+
+    // The small section keeps its full content; only the runaway one is cut.
+    expect(body).toContain('✅ 1908 passed, 0 failed')
+    for (const name of ['playwright', 'ci-metrics']) {
+      expect(body).toContain(`<!-- section:${name}:start -->`)
+      expect(body).toContain(`<!-- section:${name}:end -->`)
+    }
+  })
+
+  it('leaves a section that already fits completely untouched', async () => {
+    const harness = createHarness({
+      comments: [
+        {
+          id: 1,
+          user: { login: 'github-actions[bot]' },
+          body: `${COMMENT_MARKER}\n${section('playwright', 'old')}`
+        }
+      ]
+    })
+
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'playwright',
+      INPUT_SECTION_CONTENT: '✅ 1908 passed, 0 failed'
+    })
+
+    const { body } = harness.updateComment.mock.calls[0][0]
+    expect(body).toContain(section('playwright', '✅ 1908 passed, 0 failed'))
+    expect(body).not.toContain('Truncated')
+  })
+
+  it('does not retry a 422, which fails identically every attempt', async () => {
+    const harness = createHarness({
+      comments: [
+        {
+          id: 1,
+          user: { login: 'github-actions[bot]' },
+          body: `${COMMENT_MARKER}\n${section('ci-metrics', 'old')}`
+        }
+      ],
+      updateRejection: { status: 422 }
+    })
+
+    await expect(
+      harness.run({
+        ...baseEnv,
+        INPUT_SECTION_NAME: 'ci-metrics',
+        INPUT_SECTION_CONTENT: 'new'
+      })
+    ).rejects.toMatchObject({ status: 422 })
+
+    expect(harness.updateComment).toHaveBeenCalledTimes(1)
+  })
+})

--- a/scripts/cicd/upsert-comment-section-size.test.ts
+++ b/scripts/cicd/upsert-comment-section-size.test.ts
@@ -155,6 +155,27 @@ describe('upsert-comment-section overflow comments', () => {
     )
   })
 
+  it('does not split a surrogate pair between comments', async () => {
+    const harness = createHarness({})
+    const pagePrefix = `${COMMENT_MARKER}\n<!-- upsert-comment-section:page:1 -->\n`
+    const sectionPrefix = '<!-- section:ci-metrics:start -->\n'
+    const firstPageBudget = MAX_COMMENT_LENGTH - pagePrefix.length
+    const content =
+      'x'.repeat(firstPageBudget - sectionPrefix.length - 1) + '📊' + 'tail'
+
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: content
+    })
+
+    expect(harness.comments).toHaveLength(2)
+    expect(harness.comments[0].body.at(-1)).not.toMatch(/[\uD800-\uDBFF]/)
+    expect(combinedContent(harness.comments)).toBe(
+      section('ci-metrics', content)
+    )
+  })
+
   it('migrates an oversized legacy comment without dropping another section', async () => {
     const oldContent = 'y'.repeat(244_310)
     const newContent = 'z'.repeat(200_000)

--- a/scripts/cicd/upsert-comment-section-size.test.ts
+++ b/scripts/cicd/upsert-comment-section-size.test.ts
@@ -4,11 +4,6 @@ import { join } from 'node:path'
 import { parse } from 'yaml'
 import { describe, expect, it, vi } from 'vitest'
 
-/**
- * GitHub rejects an issue-comment body over this many characters with a 422.
- * The unified PR report is assembled from unbounded generated sections, so the
- * action has to enforce the ceiling itself.
- */
 const MAX_COMMENT_LENGTH = 65536
 
 const ACTION_PATH = join(
@@ -16,10 +11,6 @@ const ACTION_PATH = join(
   '../../.github/actions/upsert-comment-section/action.yaml'
 )
 
-/**
- * Runs the action's real embedded `github-script` body, so the test exercises
- * the shipped code rather than a re-implementation of it.
- */
 function loadActionScript(): string {
   const action = parse(readFileSync(ACTION_PATH, 'utf8'))
   const step = action.runs.steps.find((s: { uses?: string }) =>
@@ -47,12 +38,16 @@ function section(name: string, content: string) {
 
 function createHarness(options: {
   comments?: Comment[]
-  updateRejection?: { status: number }
+  updateRejections?: number
 }) {
   const comments: Comment[] = options.comments ?? []
+  let updateRejections = options.updateRejections ?? 0
   const updateComment = vi.fn(
     async ({ comment_id, body }: { comment_id: number; body: string }) => {
-      if (options.updateRejection) throw options.updateRejection
+      if (updateRejections > 0) {
+        updateRejections--
+        throw { status: 422 }
+      }
       const target = comments.find((c) => c.id === comment_id)
       if (target) target.body = body
       return { data: target }
@@ -60,7 +55,7 @@ function createHarness(options: {
   )
   const createComment = vi.fn(async ({ body }: { body: string }) => {
     const created = {
-      id: comments.length + 1,
+      id: Math.max(0, ...comments.map((comment) => comment.id)) + 1,
       user: { login: 'github-actions[bot]' },
       body
     }
@@ -69,6 +64,13 @@ function createHarness(options: {
   })
 
   const listComments = vi.fn(async () => ({ data: comments }))
+  const deleteComment = vi.fn(
+    async ({ comment_id }: { comment_id: number }) => {
+      const index = comments.findIndex((comment) => comment.id === comment_id)
+      if (index !== -1) comments.splice(index, 1)
+      return {}
+    }
+  )
   const github = {
     paginate: async (fn: typeof listComments) => (await fn()).data,
     rest: {
@@ -76,7 +78,7 @@ function createHarness(options: {
         listComments,
         createComment,
         updateComment,
-        deleteComment: vi.fn(async () => ({})),
+        deleteComment,
         getComment: vi.fn(async ({ comment_id }: { comment_id: number }) => ({
           data: comments.find((c) => c.id === comment_id)
         }))
@@ -87,8 +89,7 @@ function createHarness(options: {
   const core = { warning: vi.fn(), info: vi.fn() }
   const context = {
     repo: { owner: 'Comfy-Org', repo: 'ComfyUI_frontend' },
-    serverUrl: 'https://github.com',
-    runId: 33872270128
+    serverUrl: 'https://github.com'
   }
 
   const run = (env: Record<string, string>) =>
@@ -101,7 +102,14 @@ function createHarness(options: {
       `"use strict"; return (async () => {\n${actionScript}\n})()`
     )(github, context, core, { env }, require)
 
-  return { run, comments, createComment, updateComment, core }
+  return {
+    run,
+    comments,
+    createComment,
+    updateComment,
+    deleteComment,
+    core
+  }
 }
 
 const baseEnv = {
@@ -109,26 +117,47 @@ const baseEnv = {
   INPUT_COMMENT_MARKER: COMMENT_MARKER
 }
 
-describe('upsert-comment-section comment size limit', () => {
-  it('clamps an oversized section on create', async () => {
+function combinedContent(comments: Comment[]) {
+  return [...comments]
+    .sort((a, b) => {
+      const page = (body: string) =>
+        Number(body.match(/upsert-comment-section:page:(\d+)/)?.[1] ?? 1)
+      return page(a.body) - page(b.body)
+    })
+    .map((comment) =>
+      comment.body.replace(
+        /^<!-- COMFYUI_FRONTEND_PR_REPORT -->\n(?:<!-- upsert-comment-section:page:\d+ -->\n)?/,
+        ''
+      )
+    )
+    .join('')
+}
+
+describe('upsert-comment-section overflow comments', () => {
+  it('preserves an oversized section across bounded comments', async () => {
     const harness = createHarness({})
+    const content = 'x'.repeat(244_310)
 
     await harness.run({
       ...baseEnv,
       INPUT_SECTION_NAME: 'ci-metrics',
-      INPUT_SECTION_CONTENT: 'x'.repeat(244_310)
+      INPUT_SECTION_CONTENT: content
     })
 
-    const [{ body }] = harness.createComment.mock.calls.map((call) => call[0])
-    expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH)
-    expect(body).toContain('<!-- section:ci-metrics:start -->')
-    expect(body).toContain('<!-- section:ci-metrics:end -->')
-    expect(body).toContain('Truncated')
+    expect(harness.comments.length).toBeGreaterThan(1)
+    expect(
+      harness.comments.every(
+        (comment) => comment.body.length <= MAX_COMMENT_LENGTH
+      )
+    ).toBe(true)
+    expect(combinedContent(harness.comments)).toBe(
+      section('ci-metrics', content)
+    )
   })
 
-  it('repairs an already-oversized comment and keeps every section addressable', async () => {
-    // Reproduces comment 5385418044 on PR #15740: a 244k ci-metrics section
-    // alongside a small playwright section, which no longer accepts any write.
+  it('migrates an oversized legacy comment without dropping another section', async () => {
+    const oldContent = 'y'.repeat(244_310)
+    const newContent = 'z'.repeat(200_000)
     const harness = createHarness({
       comments: [
         {
@@ -137,7 +166,7 @@ describe('upsert-comment-section comment size limit', () => {
           body: [
             COMMENT_MARKER,
             section('playwright', '✅ 1908 passed, 0 failed'),
-            section('ci-metrics', 'y'.repeat(244_310))
+            section('ci-metrics', oldContent)
           ].join('\n')
         }
       ]
@@ -146,22 +175,23 @@ describe('upsert-comment-section comment size limit', () => {
     await harness.run({
       ...baseEnv,
       INPUT_SECTION_NAME: 'ci-metrics',
-      INPUT_SECTION_CONTENT: 'z'.repeat(200_000)
+      INPUT_SECTION_CONTENT: newContent
     })
 
-    expect(harness.updateComment).toHaveBeenCalledTimes(1)
-    const { body } = harness.updateComment.mock.calls[0][0]
-    expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH)
-
-    // The small section keeps its full content; only the runaway one is cut.
-    expect(body).toContain('✅ 1908 passed, 0 failed')
-    for (const name of ['playwright', 'ci-metrics']) {
-      expect(body).toContain(`<!-- section:${name}:start -->`)
-      expect(body).toContain(`<!-- section:${name}:end -->`)
-    }
+    expect(combinedContent(harness.comments)).toBe(
+      [
+        section('playwright', '✅ 1908 passed, 0 failed'),
+        section('ci-metrics', newContent)
+      ].join('\n')
+    )
   })
 
-  it('leaves a section that already fits completely untouched', async () => {
+  it('updates marker-like and replacement-token content literally', async () => {
+    const content = [
+      "$& $` $' $$ $1",
+      '<!-- section:playwright:end -->',
+      'still part of the report'
+    ].join('\n')
     const harness = createHarness({
       comments: [
         {
@@ -175,15 +205,94 @@ describe('upsert-comment-section comment size limit', () => {
     await harness.run({
       ...baseEnv,
       INPUT_SECTION_NAME: 'playwright',
-      INPUT_SECTION_CONTENT: '✅ 1908 passed, 0 failed'
+      INPUT_SECTION_CONTENT: content
     })
 
-    const { body } = harness.updateComment.mock.calls[0][0]
-    expect(body).toContain(section('playwright', '✅ 1908 passed, 0 failed'))
-    expect(body).not.toContain('Truncated')
+    expect(combinedContent(harness.comments)).toBe(
+      section('playwright', content)
+    )
   })
 
-  it('does not retry a 422, which fails identically every attempt', async () => {
+  it('is idempotent when rerun with the same oversized content', async () => {
+    const harness = createHarness({})
+    const env = {
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'x'.repeat(140_000)
+    }
+
+    await harness.run(env)
+    const afterFirstRun = structuredClone(harness.comments)
+    const createCalls = harness.createComment.mock.calls.length
+    const updateCalls = harness.updateComment.mock.calls.length
+
+    await harness.run(env)
+
+    expect(harness.comments).toEqual(afterFirstRun)
+    expect(harness.createComment).toHaveBeenCalledTimes(createCalls)
+    expect(harness.updateComment).toHaveBeenCalledTimes(updateCalls)
+    expect(harness.deleteComment).not.toHaveBeenCalled()
+  })
+
+  it('removes stale overflow comments when content shrinks', async () => {
+    const harness = createHarness({})
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'x'.repeat(140_000)
+    })
+    expect(harness.comments.length).toBeGreaterThan(1)
+
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'small'
+    })
+
+    expect(harness.comments).toHaveLength(1)
+    expect(combinedContent(harness.comments)).toBe(
+      section('ci-metrics', 'small')
+    )
+  })
+
+  it('merges duplicate comments before deleting them', async () => {
+    const harness = createHarness({
+      comments: [
+        {
+          id: 1,
+          user: { login: 'github-actions[bot]' },
+          body: `${COMMENT_MARKER}\n${section('playwright', 'passed')}`
+        },
+        {
+          id: 2,
+          user: { login: 'github-actions[bot]' },
+          body: `${COMMENT_MARKER}\n${section('storybook', 'passed')}`
+        }
+      ]
+    })
+
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'passed'
+    })
+
+    expect(harness.comments).toHaveLength(1)
+    expect(combinedContent(harness.comments)).toContain(
+      section('playwright', 'passed')
+    )
+    expect(combinedContent(harness.comments)).toContain(
+      section('storybook', 'passed')
+    )
+    expect(combinedContent(harness.comments)).toContain(
+      section('ci-metrics', 'passed')
+    )
+    expect(harness.deleteComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 2 })
+    )
+  })
+
+  it('retries a transient 422 response', async () => {
     const harness = createHarness({
       comments: [
         {
@@ -192,17 +301,16 @@ describe('upsert-comment-section comment size limit', () => {
           body: `${COMMENT_MARKER}\n${section('ci-metrics', 'old')}`
         }
       ],
-      updateRejection: { status: 422 }
+      updateRejections: 1
     })
 
-    await expect(
-      harness.run({
-        ...baseEnv,
-        INPUT_SECTION_NAME: 'ci-metrics',
-        INPUT_SECTION_CONTENT: 'new'
-      })
-    ).rejects.toMatchObject({ status: 422 })
+    await harness.run({
+      ...baseEnv,
+      INPUT_SECTION_NAME: 'ci-metrics',
+      INPUT_SECTION_CONTENT: 'new'
+    })
 
-    expect(harness.updateComment).toHaveBeenCalledTimes(1)
+    expect(harness.updateComment).toHaveBeenCalledTimes(2)
+    expect(combinedContent(harness.comments)).toBe(section('ci-metrics', 'new'))
   })
 })


### PR DESCRIPTION
Repairs red `main` at [`9ff3fd7f0e`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/9ff3fd7f0e36b810a621288ceaf6e74e3846bedd).

The unified report on [#15740](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15740) reached 245,060 characters, so every later update failed GitHub's 65,536-character issue-comment limit.

## Change

The action now preserves the complete logical report while paging it across managed comments:

- Every physical comment stays within 65,536 characters. Overflow goes to a second comment and, for reports such as the 245k reproduction, further pages only when the API limit makes them unavoidable.
- Repeat runs update the same page comments without creating a comment wall. Shrinking content removes stale overflow pages after exact read-back verification.
- Legacy oversized comments and concurrent duplicate comments migrate without dropping sections.
- Literal slice replacement preserves `$&`, `$'`, and marker-like report text; page cuts do not split UTF-16 surrogate pairs.
- Transient 422 responses retain the normal retry path.

## Evidence

The test executes the action's real embedded `github-script` body. It covers oversized creation, legacy migration, exact content preservation, surrogate boundaries, repeat-run idempotency, overflow removal, duplicate merging, and transient retries.

- `scripts/cicd/upsert-comment-section-size.test.ts`: 8/8 passed
- `scripts/cicd/`: 113/113 passed
- `pnpm typecheck:scripts`: passed
- pre-commit `pnpm typecheck`, lint-staged checks, and pre-push `knip`: passed
- action YAML parse, changed-file lint/format, and `git diff --check`: passed

## Linear

Not created: emergency red-`main` repair during Quiet Week.

<!-- authored-by:agent operator-9c -->
