### PR TITLE
fix(billing): gate plan CTAs on the server capability set, not a client-derived one

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableCapabilityGating.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableCapabilityGating.spec.ts
@@ -1,0 +1,104 @@
+import type { Page } from '@playwright/test'
+import type { BillingCapabilities } from '@comfyorg/ingest-types'
+
+import {
+  cloudAppExpect,
+  cloudAppFixture as test
+} from '@e2e/fixtures/cloudAppFixture'
+import { createBillingCapabilities } from '@e2e/fixtures/data/billingCapabilities'
+import { APP_URL, setupCloudApp } from '@e2e/fixtures/utils/cloudAppSetup'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+/**
+ * The pricing table's plan CTAs are gated on the server capability set alone
+ * (FE-2030). These drive the real dialog against capability responses shaped
+ * like the INC-128 cohorts, so a regression shows up as a dead button rather
+ * than a changed expression.
+ */
+const OWNER = workspace('personal', 'owner')
+
+const BOOT_FEATURES = { billing_control_enabled: true }
+
+// The billing status the app boots with: an active paid plan, which is what
+// makes the cards read "Change to ..." rather than "Subscribe to ...".
+async function openPricingTable(
+  page: Page,
+  options: {
+    capabilities?: Partial<BillingCapabilities>
+    unresolved?: boolean
+    status?: number
+  } = {}
+) {
+  await setupCloudApp(page, {
+    workspace: OWNER,
+    features: BOOT_FEATURES,
+    billingCapabilities: options.unresolved
+      ? new Promise(() => {})
+      : createBillingCapabilities(OWNER.id, options.capabilities),
+    billingCapabilitiesStatus: options.status
+  })
+
+  await page.goto(`${APP_URL}/?pricing=1`)
+  await cloudAppExpect(
+    page.getByRole('heading', { name: 'Choose a Plan' })
+  ).toBeVisible()
+}
+
+const creatorCta = (page: Page) =>
+  page.getByRole('button', { name: 'Change to Creator Yearly' })
+
+test.describe('Pricing table capability gating', { tag: '@cloud' }, () => {
+  test('acts on the capability the server granted, not the one the tier implies', async ({
+    page
+  }) => {
+    // The legacy-rail shape: a paid tier the server lets subscribe, with
+    // change-seats cleared because there is no local subscription row.
+    await openPricingTable(page, {
+      capabilities: { can_subscribe_self_serve: true, can_change_seats: false }
+    })
+
+    await cloudAppExpect(creatorCta(page)).toBeEnabled()
+  })
+
+  // The closed direction cannot be reached from here: every entry point to the
+  // catalog is itself gated on can_subscribe_self_serve, so a resolved refusal
+  // withholds the dialog rather than opening it with dead cards. Asserting that
+  // is the negative control; the disabled CTA itself is covered in
+  // UnifiedPricingTable.test.ts, which can render the table directly.
+  test('withholds the catalog when the server refuses every lifecycle write', async ({
+    page
+  }) => {
+    await setupCloudApp(page, {
+      workspace: OWNER,
+      features: BOOT_FEATURES,
+      billingCapabilities: createBillingCapabilities(OWNER.id, {
+        can_subscribe_self_serve: false,
+        can_change_seats: false,
+        can_reactivate: false,
+        can_downgrade_to_personal: false
+      })
+    })
+
+    await page.goto(`${APP_URL}/?pricing=1`)
+
+    await cloudAppExpect(
+      page.getByRole('heading', { name: 'Choose a Plan' })
+    ).toBeHidden()
+  })
+
+  test('keeps the cards live while the capability read has not resolved', async ({
+    page
+  }) => {
+    await openPricingTable(page, { unresolved: true })
+
+    await cloudAppExpect(creatorCta(page)).toBeEnabled()
+  })
+
+  test('keeps the cards live when the capability read fails', async ({
+    page
+  }) => {
+    await openPricingTable(page, { status: 500 })
+
+    await cloudAppExpect(creatorCta(page)).toBeEnabled()
+  })
+})

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -29,10 +29,9 @@ const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
 const mockIsTeamPlan = ref(false)
 const mockCanManageSubscription = ref(true)
 const mockCanDowngradeToPersonal = ref(true)
-const mockCanReactivatePlan = ref(true)
-// the raw server capability, kept separate so a test can prove the component
-// follows the derived policy rather than this value
+const mockCanChangeSeats = ref(true)
 const mockRawCanReactivate = ref(true)
+const mockSnapshotAuthoritative = ref(true)
 const mockPermissions = ref({
   canManageSubscription: true,
   canManageSubscriptionLifecycle: true,
@@ -58,15 +57,15 @@ vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
     canSubscribeSelfServe: computed(() => mockCanManageSubscription.value),
     canReactivate: computed(() => mockRawCanReactivate.value),
-    canChangeSeats: computed(() => mockCanManageSubscription.value),
-    canDowngradeToPersonal: computed(() => mockCanDowngradeToPersonal.value)
+    canChangeSeats: computed(() => mockCanChangeSeats.value),
+    canDowngradeToPersonal: computed(() => mockCanDowngradeToPersonal.value),
+    snapshotAuthoritative: computed(() => mockSnapshotAuthoritative.value)
   })
 }))
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
-    permissions: computed(() => mockPermissions.value),
-    canReactivatePlan: computed(() => mockCanReactivatePlan.value)
+    permissions: computed(() => mockPermissions.value)
   })
 }))
 
@@ -98,8 +97,9 @@ function renderComponent(props: Record<string, unknown> = {}) {
 
 describe('UnifiedPricingTable plan CTA labels', () => {
   beforeEach(() => {
-    mockCanReactivatePlan.value = true
+    mockCanChangeSeats.value = true
     mockRawCanReactivate.value = true
+    mockSnapshotAuthoritative.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -229,8 +229,9 @@ describe('UnifiedPricingTable team plan CTA', () => {
   }
 
   beforeEach(() => {
-    mockCanReactivatePlan.value = true
+    mockCanChangeSeats.value = true
     mockRawCanReactivate.value = true
+    mockSnapshotAuthoritative.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -318,14 +319,16 @@ describe('UnifiedPricingTable team plan CTA', () => {
     expect(emitted().resubscribe).toBeTruthy()
   })
 
-  it('disables Resubscribe when the workspace may not reactivate', () => {
+  it('disables Resubscribe when the server permits no lifecycle write', () => {
     mockSubscription.value = {
       tier: 'TEAM',
       duration: 'ANNUAL',
       isCancelled: true
     }
     mockCurrentTeamCreditStop.value = TEAM_STOP
-    mockCanReactivatePlan.value = false
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
 
     renderComponent({ initialPlanMode: 'team' })
 
@@ -391,8 +394,9 @@ describe('UnifiedPricingTable outside Cloud', () => {
   }
 
   beforeEach(() => {
-    mockCanReactivatePlan.value = true
+    mockCanChangeSeats.value = true
     mockRawCanReactivate.value = true
+    mockSnapshotAuthoritative.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -539,5 +543,71 @@ describe('UnifiedPricingTable outside Cloud', () => {
     expect(
       screen.queryByRole('button', { name: 'Change to Standard Yearly' })
     ).toBeNull()
+  })
+})
+
+// INC-128. The server answers per workspace, not per plan card, so the table
+// must not decide which capability governs a card: a legacy-rail customer holds
+// a paid tier with no local subscription row, which reads as "change" here while
+// the server is in fact permitting a subscribe.
+describe('UnifiedPricingTable capability gating', () => {
+  beforeEach(() => {
+    mockCanChangeSeats.value = true
+    mockRawCanReactivate.value = true
+    mockSnapshotAuthoritative.value = true
+    mockSubscription.value = null
+    mockSubscriptionStatus.value = null
+    mockCurrentPlanSlug.value = null
+    mockCurrentTeamCreditStop.value = null
+    mockIsTeamPlan.value = false
+    mockCanManageSubscription.value = true
+    mockCanDowngradeToPersonal.value = true
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockDistributionTypes.isCloud = true
+  })
+
+  it('keeps a paid plan actionable when only change-seats is withheld', async () => {
+    const user = userEvent.setup()
+    mockSubscription.value = { tier: 'PRO', duration: 'ANNUAL' }
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+
+    const { emitted } = renderComponent()
+
+    const cta = screen.getByRole('button', { name: 'Change to Creator Yearly' })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().subscribe).toBeTruthy()
+  })
+
+  it('keeps the CTA live while the capability snapshot is unresolved', () => {
+    mockSubscription.value = { tier: 'FREE', duration: 'ANNUAL' }
+    mockSnapshotAuthoritative.value = false
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to Standard Yearly' })
+    ).toBeEnabled()
+  })
+
+  it('blocks the CTA when a resolved snapshot permits no lifecycle write', () => {
+    mockSubscription.value = { tier: 'FREE', duration: 'ANNUAL' }
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to Standard Yearly' })
+    ).toBeDisabled()
   })
 })

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -667,6 +667,18 @@ describe('UnifiedPricingTable plan-scope availability', () => {
     ).toBeEnabled()
   })
 
+  it('keeps personal cards actionable when only the downgrade is permitted', () => {
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+
+    renderComponent({ initialPlanMode: 'personal' })
+
+    expect(
+      screen.getByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeEnabled()
+  })
+
   it('withholds personal plans when a resolved snapshot denies the downgrade', () => {
     mockCanDowngradeToPersonal.value = false
 

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -329,6 +329,7 @@ describe('UnifiedPricingTable team plan CTA', () => {
     mockCanManageSubscription.value = false
     mockCanChangeSeats.value = false
     mockRawCanReactivate.value = false
+    mockCanDowngradeToPersonal.value = false
 
     renderComponent({ initialPlanMode: 'team' })
 
@@ -603,11 +604,61 @@ describe('UnifiedPricingTable capability gating', () => {
     mockCanManageSubscription.value = false
     mockCanChangeSeats.value = false
     mockRawCanReactivate.value = false
+    mockCanDowngradeToPersonal.value = false
 
     renderComponent()
 
     expect(
       screen.getByRole('button', { name: 'Subscribe to Standard Yearly' })
     ).toBeDisabled()
+  })
+})
+
+describe('UnifiedPricingTable plan-scope availability', () => {
+  beforeEach(() => {
+    mockCanChangeSeats.value = true
+    mockRawCanReactivate.value = true
+    mockSnapshotAuthoritative.value = true
+    mockSubscription.value = { tier: 'TEAM', duration: 'ANNUAL' }
+    mockSubscriptionStatus.value = null
+    mockCurrentPlanSlug.value = null
+    mockCurrentTeamCreditStop.value = {
+      id: 'team_700',
+      credits_monthly: 147_700,
+      stop_usd: 700
+    }
+    mockIsTeamPlan.value = true
+    mockCanManageSubscription.value = true
+    mockCanDowngradeToPersonal.value = true
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockDistributionTypes.isCloud = true
+  })
+
+  it('keeps personal plans reachable on a team plan while the snapshot is unresolved', () => {
+    mockSnapshotAuthoritative.value = false
+    mockCanDowngradeToPersonal.value = false
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+
+    renderComponent({ initialPlanMode: 'personal' })
+
+    expect(
+      screen.getByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeEnabled()
+  })
+
+  it('withholds personal plans when a resolved snapshot denies the downgrade', () => {
+    mockCanDowngradeToPersonal.value = false
+
+    renderComponent({ initialPlanMode: 'personal' })
+
+    expect(
+      screen.queryByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeNull()
   })
 })

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -599,6 +599,21 @@ describe('UnifiedPricingTable capability gating', () => {
     ).toBeEnabled()
   })
 
+  // can_downgrade_to_personal governs leaving a team plan for a personal one, so
+  // it must not stand in for permission to buy the team plan.
+  it('does not let the downgrade capability alone enable the team CTA', () => {
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+    mockCanDowngradeToPersonal.value = true
+
+    renderComponent({ initialPlanMode: 'team' })
+
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
+    ).toBeDisabled()
+  })
+
   it('blocks the CTA when a resolved snapshot permits no lifecycle write', () => {
     mockSubscription.value = { tier: 'FREE', duration: 'ANNUAL' }
     mockCanManageSubscription.value = false

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -599,6 +599,20 @@ describe('UnifiedPricingTable capability gating', () => {
     ).toBeEnabled()
   })
 
+  it('keeps the team CTA live while the capability snapshot is unresolved', () => {
+    mockSnapshotAuthoritative.value = false
+    mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+    mockCanDowngradeToPersonal.value = false
+
+    renderComponent({ initialPlanMode: 'team' })
+
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
+    ).toBeEnabled()
+  })
+
   // can_downgrade_to_personal governs leaving a team plan for a personal one, so
   // it must not stand in for permission to buy the team plan.
   it('does not let the downgrade capability alone enable the team CTA', () => {

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -483,14 +483,18 @@ const lifecycleActionPermitted = computed(() => {
   return (
     capabilities.canSubscribeSelfServe.value ||
     capabilities.canChangeSeats.value ||
-    capabilities.canReactivate.value
+    capabilities.canReactivate.value ||
+    capabilities.canDowngradeToPersonal.value
   )
 })
-const canDowngradeToPersonal = computed(() =>
-  isCloud
-    ? capabilities.canDowngradeToPersonal.value
-    : permissions.value.canDowngradeToPersonal
-)
+
+// Read on its own by the plan-scope toggle, which offers or withholds the whole
+// personal catalog rather than one CTA, so it keeps its own capability.
+const canDowngradeToPersonal = computed(() => {
+  if (!isCloud) return permissions.value.canDowngradeToPersonal
+  if (!capabilities.snapshotAuthoritative.value) return true
+  return capabilities.canDowngradeToPersonal.value
+})
 
 const planMode = ref<'personal' | 'team'>(initialPlanMode)
 
@@ -866,13 +870,10 @@ const getButtonSeverity = (
   return 'secondary'
 }
 
-const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean => {
-  if (!canSelectPersonalPlan.value) return false
-  if (isTeamPlan.value) return canDowngradeToPersonal.value
-  return (
-    offersTransition(isCurrentPlan(tierKey)) && lifecycleActionPermitted.value
-  )
-}
+const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean =>
+  canSelectPersonalPlan.value &&
+  offersTransition(isCurrentPlan(tierKey)) &&
+  lifecycleActionPermitted.value
 
 const isButtonDisabled = (tier: PricingTierConfig): boolean =>
   isLoading || !canUsePersonalPlanAction(tier.key)

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -483,8 +483,7 @@ const lifecycleActionPermitted = computed(() => {
   return (
     capabilities.canSubscribeSelfServe.value ||
     capabilities.canChangeSeats.value ||
-    capabilities.canReactivate.value ||
-    capabilities.canDowngradeToPersonal.value
+    capabilities.canReactivate.value
   )
 })
 

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -469,18 +469,23 @@ const emit = defineEmits<{
 
 const { t, n } = useI18n()
 const capabilities = useBillingCapabilities()
-const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { permissions } = useWorkspaceUI()
 
-const canSubscribeSelfServe = computed(() =>
-  isCloud
-    ? capabilities.canSubscribeSelfServe.value
-    : permissions.value.canManageSubscription
-)
-const canChangeSeats = computed(() =>
-  isCloud
-    ? capabilities.canChangeSeats.value
-    : permissions.value.canManageSubscription
-)
+// Every lifecycle CTA here resolves to a billing write the server authorizes on
+// its own, so the table asks whether any such write is permitted instead of
+// mapping each card to one capability itself — that mapping is policy, and the
+// response carries no plan dimension to derive it from. An unresolved snapshot
+// is not a denial: the CTA stays live and the checkout endpoint answers, the
+// same trade canOpenPricingSurface and canTopUp already make.
+const lifecycleActionPermitted = computed(() => {
+  if (!isCloud) return permissions.value.canManageSubscription
+  if (!capabilities.snapshotAuthoritative.value) return true
+  return (
+    capabilities.canSubscribeSelfServe.value ||
+    capabilities.canChangeSeats.value ||
+    capabilities.canReactivate.value
+  )
+})
 const canDowngradeToPersonal = computed(() =>
   isCloud
     ? capabilities.canDowngradeToPersonal.value
@@ -658,6 +663,12 @@ const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
 // held must not read as current — it is buyable again.
 const isEnded = computed(() => subscriptionStatus.value === 'ended')
 
+// An active current plan has nothing to transition to, which describes the card
+// rather than the actor's permission — so it stays a client-side check while
+// permission comes from lifecycleActionPermitted.
+const offersTransition = (isCurrent: boolean): boolean =>
+  !isCurrent || isCancelled.value
+
 const currentBillingCycle = ref<BillingCycle>('yearly')
 
 // Team credit stops: backend-sourced when the API supplies them, otherwise the
@@ -761,14 +772,17 @@ const teamButtonLabel = computed(() => {
   return t('subscription.teamPlan.changePlan')
 })
 
-const isTeamButtonDisabled = computed(() => {
-  if (isLoading) return true
-  if (!isTeamSubscribed.value) return !canSubscribeSelfServe.value
-  if (isTeamCurrentPlanSelected.value) {
-    return !isCancelled.value || !canReactivatePlan.value
-  }
-  return !canChangeSeats.value
-})
+// `isTeamCurrentPlanSelected` compares the slider against a stop an ended
+// subscription still reports, so it only means "current plan" while the team
+// plan is live — the same exclusion `isCurrentPlan` makes via `isEnded`.
+const isTeamButtonDisabled = computed(
+  () =>
+    isLoading ||
+    !offersTransition(
+      isTeamSubscribed.value && isTeamCurrentPlanSelected.value
+    ) ||
+    !lifecycleActionPermitted.value
+)
 
 // A subscriber moving off their current plan is a prorated change rather than a
 // fresh subscribe; re-subscribe and the locked current plan exit before the
@@ -855,12 +869,9 @@ const getButtonSeverity = (
 const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean => {
   if (!canSelectPersonalPlan.value) return false
   if (isTeamPlan.value) return canDowngradeToPersonal.value
-  if (isCurrentPlan(tierKey)) {
-    return isCancelled.value && canReactivatePlan.value
-  }
-  return hasActivePaidPlan(currentAccountTier.value)
-    ? canChangeSeats.value
-    : canSubscribeSelfServe.value
+  return (
+    offersTransition(isCurrentPlan(tierKey)) && lifecycleActionPermitted.value
+  )
 }
 
 const isButtonDisabled = (tier: PricingTierConfig): boolean =>

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -471,12 +471,15 @@ const { t, n } = useI18n()
 const capabilities = useBillingCapabilities()
 const { permissions } = useWorkspaceUI()
 
-// Every lifecycle CTA here resolves to a billing write the server authorizes on
-// its own, so the table asks whether any such write is permitted instead of
+// Every CTA here resolves to a billing write the server authorizes on its own,
+// so each catalog asks whether any write that reaches it is permitted instead of
 // mapping each card to one capability itself — that mapping is policy, and the
 // response carries no plan dimension to derive it from. An unresolved snapshot
 // is not a denial: the CTA stays live and the checkout endpoint answers, the
 // same trade canOpenPricingSurface and canTopUp already make.
+//
+// The team catalog is not reachable by downgrading to personal, so its gate
+// stops at the three writes that do reach it.
 const lifecycleActionPermitted = computed(() => {
   if (!isCloud) return permissions.value.canManageSubscription
   if (!capabilities.snapshotAuthoritative.value) return true
@@ -494,6 +497,12 @@ const canDowngradeToPersonal = computed(() => {
   if (!capabilities.snapshotAuthoritative.value) return true
   return capabilities.canDowngradeToPersonal.value
 })
+
+// A personal card is reachable by one further write the team catalog has no
+// counterpart for: leaving a team plan.
+const personalPlanActionPermitted = computed(
+  () => lifecycleActionPermitted.value || canDowngradeToPersonal.value
+)
 
 const planMode = ref<'personal' | 'team'>(initialPlanMode)
 
@@ -872,7 +881,7 @@ const getButtonSeverity = (
 const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean =>
   canSelectPersonalPlan.value &&
   offersTransition(isCurrentPlan(tierKey)) &&
-  lifecycleActionPermitted.value
+  personalPlanActionPermitted.value
 
 const isButtonDisabled = (tier: PricingTierConfig): boolean =>
   isLoading || !canUsePersonalPlanAction(tier.key)

--- a/src/storybook/mocks/useBillingCapabilities.ts
+++ b/src/storybook/mocks/useBillingCapabilities.ts
@@ -50,6 +50,7 @@ export function useBillingCapabilities() {
       () => capabilityState.canDowngradeToPersonal
     ),
     isReady: computed(() => true),
+    snapshotAuthoritative: computed(() => true),
     initialize: () => undefined,
     refresh: () => undefined
   }


### PR DESCRIPTION
## Summary

The pricing table decided *which* server capability governs each plan card from client-side state, then read it with a `?? false` default — so a workspace the server was permitting to subscribe rendered every card disabled. This gates on the server capability set directly. Labels are unchanged.

## Root cause

`GET /v1/billing/capabilities` answers a **workspace-scoped** question — seven booleans, with `resolved_for` carrying only `{user_id, workspace_id}`. The pricing table needs a **card-scoped** answer: "can this workspace move to Creator-Yearly right now?" Nothing in the response can produce that, so the component synthesized it.

`canUsePersonalPlanAction` picked the governing capability from `hasActivePaidPlan(tier)`, `isCurrentPlan()`, `isCancelled` and `isEnded`; `isTeamButtonDisabled` did the same job with a different expression off `isTeamSubscribed`. That selection is policy, and it fails in two ways:

**1. The client picks the wrong capability.** A legacy-rail workspace holds a paid tier with no local subscription row. `hasActivePaidPlan` is therefore true, so the table reads `can_change_seats` — false, because `ResolveBillingCapabilities`'s `!HasSubscription` branch clears it — and greys the card. That same branch leaves `can_subscribe_self_serve` **true**, which is what the server actually returns for these workspaces. The field that is true is never consulted.

**2. "Not yet known" renders as "denied."** `useBillingCapabilities` models five read states (`idle | pending | denied | unavailable | resolved`), collapses them to `null`, and `canSubscribeSelfServe`/`canChangeSeats` collapse that to `false`. A slow or failed read disables every plan button for anyone, including new signups. `canTopUp` three lines above deliberately falls open for owners, and `canOpenPricingSurface` falls open to membership — so we let people into a modal whose every button is dead by design.

The capability set is documented as *"Effective billing UI **guidance**"*, not an authorization boundary; every checkout endpoint resolves policy again on the write. Treating guidance as a hard gate is what turns a server "probably not" into a customer who cannot buy.

Both symptoms are invisible in monitoring: a disabled button emits nothing, and the endpoint returns HTTP 200 with the capability false. That is how 560 workspaces accumulated from 2026-02-10 without paging anyone.

```
                       BEFORE                                    AFTER
  ┌───────────────────────────────────────┐    ┌───────────────────────────────────────┐
  │ card ──> hasActivePaidPlan? ──┬─ yes ─→│    │ card ──> offersTransition?  (shape)   │
  │                               │        │    │            │                          │
  │                               │  can_change_seats        └──> lifecycleActionPermitted
  │                               └─ no ──→│    │                 = subscribe            │
  │                        can_subscribe_self_serve             ‖ change_seats           │
  │                                        │    │                 ‖ reactivate           │
  │  null/pending/failed ──> ?? false      │    │  unresolved ──> true (server decides)  │
  └───────────────────────────────────────┘    └───────────────────────────────────────┘
```

## Why this is better, not just different

Three properties hold after this change that did not hold before.

**The client can no longer invent a denial the server never made.** Two separate client decisions could each produce a dead button on their own: choosing which capability applies, and defaulting an absent answer to `false`. Both are gone. A CTA now goes dead on permission grounds only when a resolved server response permits no lifecycle write.

**The failure mode moves from silent lockout to loud rejection.** A wrongly disabled button emits nothing — no error, no telemetry, no page — which is exactly how this went unnoticed for seven months. A wrongly enabled button produces a failed checkout call that is visible in Datadog and answered by the server. Since the capability set is explicitly guidance and the write re-checks policy, trading the first failure mode for the second is the right direction for a billing surface.

**Divergence has one place to go wrong instead of two.** Personal and team carried two hand-written gate expressions over the same capabilities, already disagreeing on how each classified "current plan". They now derive from one base — the personal catalog is that base plus the single write only it can receive — so a capability change cannot fix one surface and silently miss the other.

## Changes

- **What**: Per-card capability selection is replaced by one gate per catalog, neither of which reads client subscription state. `lifecycleActionPermitted` (team catalog) asks whether the server permits any write that can reach it: `can_subscribe_self_serve || can_change_seats || can_reactivate`. `personalPlanActionPermitted` (personal catalog) adds `can_downgrade_to_personal`, the one further write that reaches a personal card. Which capabilities belong to a catalog is a static property of the surface, not a judgement about the customer. An unresolved snapshot (`!snapshotAuthoritative`) keeps the CTA live and lets the checkout endpoint enforce — the same trade `canOpenPricingSurface` and `canTopUp` already make. Non-Cloud still routes to workspace permissions.
- **What**: `canDowngradeToPersonal` gains the same unresolved-snapshot fallback. It also gates the plan-scope toggle, so under `?? false` a team-plan workspace lost every personal card *and the personal tab with it* before the server had answered — a whole catalog removed silently, not a greyed button.
- **What**: `offersTransition` keeps the one genuinely client-side check — an active current plan has no transition to offer. See Review Focus for why no server field replaces it today.
- **What**: Fixes the team CTA treating an ended subscription's still-reported credit stop as the current plan. `isTeamCurrentPlanSelected` was previously shadowed by the `!isTeamSubscribed` early return; composing the two flat conditions exposed it.
- **Breaking**: none.

Cohort outcomes, in the terms of INC-128:

| | server returns | before | after |
|---|---|---|---|
| legacy rail (9,868) | `subscribe: true`, `change_seats: false` | disabled | **enabled** |
| stranded checkout row (560) | all lifecycle capabilities false | disabled | disabled |
| unresolved / failed read | no answer | disabled | **enabled**, server enforces |
| team plan, unresolved read | no answer | personal tab **removed** | tab kept, CTAs live |
| team plan, downgrade permitted only | `downgrade: true`, rest false | personal cards disabled | **enabled** (team CTA stays disabled) |

It does not flip a single resolved denial into an allow.

## Review Focus

**This must not merge before #8399 is deployed.** Cause 1 of INC-128 is "a declined checkout leaves a `scheduled` row that wedges the customer." Failing open means more attempted checkouts, and any that decline before #8399 lands create new stranded rows on the path already producing 6–15/day.

**Open question, for whoever owns the checkout path (Wei Hai).** If a workspace with `can_subscribe_self_serve: false` calls the checkout-create endpoint directly, does the server reject it, or is the capability the only gate? `useWorkspaceUI.ts:209` asserts *"every checkout endpoint enforces its own policy"* and `canOpenPricingSurface` already relies on it, but I have not verified it in `cloud` and would rather not ship on the comment alone.

**One gate is deliberately loosened.** Resubscribe was gated on `canReactivatePlan` (the derived value with the legacy-rail membership fallback from #16091); it is now gated on the union. A cancelled subscriber with `can_reactivate: false` but `can_subscribe_self_serve: true` can now click it. That is intentional under "the write is the authorization boundary", and it is the change that depends most on the answer above. `disables Resubscribe when the server permits no lifecycle write` covers the closed direction.

**Why `offersTransition` stays client-side.** `GET /api/billing/plans` already returns `availability: {available, reason}` per plan, and `reason: same_plan` looks like a drop-in replacement. It is not. `currentPlanSlug` there comes from `GetBillingStatus().PlanSlug`, which is populated for `ended` and `canceled` subscriptions too, so the server marks both **unavailable**. Adopting it would stop an ended plan being buyable again and would disable Resubscribe — two new instances of the exact failure this PR removes. The client already corrects for both (`isCurrentPlan` returns false when `isEnded`; `offersTransition` allows a cancelled current plan). Making `same_plan` subscription-status-aware is the server-side prerequisite, and it belongs next to `Comfy-Org/cloud#6275`, which is already about making `available` agree with the write path.

An earlier revision of this description claimed a stranded `scheduled` row could reach `isCurrentPlan` via `/api/billing/status`. That was wrong and is removed: `GetBillingStatus` reads only `ws.ActiveSubscriptionID` and then explicitly skips `scheduled` (`common/repository/billing/workspace.go`), so the 560 cohort's leftover row cannot surface as a plan slug. The asymmetry with `GetCapabilitySubscription`, which deliberately *does* fall back to a scheduled row, is what makes Cause 1 a capability-side problem only.

**Explicitly out of scope.** Labels and the subscribe/resubscribe emit still derive from `isCurrentPlan` / `hasActivePaidPlan`. A wrong label is cosmetic and the server revalidates the action; a wrong gate locks someone out. Deciding labels from capabilities is tracked as [FE-2038](https://linear.app/comfyorg/issue/FE-2038/decide-pricing-button-labels-through-capabilities-api), pending Alex's read on whether the current fields cover every UX string. `availability`'s other reasons (`exceeds_max_seats`, and `annual_to_monthly_unsupported` from `cloud#6275`) are additive rather than corrective — they close false positives, not the false negatives this PR is about — so they are deferred too.

`Comfy-Org/cloud#8417` adds `denied_reasons`, which is what would let a disabled CTA say *why*. That is the missing half: this stops the wrong buttons being disabled, but a legitimately disabled one still carries no explanation.

## Tests

`pnpm vitest run src/platform/workspace src/platform/cloud/subscription src/composables/billing` — 99 files, 1854 tests, 1852 passing. The two failures are in `useFreeTierQuota.test.ts`, which fails identically on `origin/main` and shares no imports with the changed files. `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm knip` clean.

Seven regression tests added in `UnifiedPricingTable.test.ts` — one per row of the cohort table, plus the invariants worth pinning:

- `keeps a paid plan actionable when only change-seats is withheld` — the legacy-rail case
- `keeps the CTA live while the capability snapshot is unresolved`
- `keeps personal plans reachable on a team plan while the snapshot is unresolved`
- `blocks the CTA when a resolved snapshot permits no lifecycle write` — proves this is not a blanket fail-open
- `withholds personal plans when a resolved snapshot denies the downgrade` — the resolved-denial counterpart
- `does not let the downgrade capability alone enable the team CTA`
- `keeps personal cards actionable when only the downgrade is permitted` — the same capability on the surface it does govern
- `keeps the team CTA live while the capability snapshot is unresolved` — the same row, on the other surface

The last two guard a cross-repo invariant rather than a reachable bug: `ResolveBillingCapabilities` sets `CanDowngradeToPersonal = IsOriginalOwner && CanSubscribeSelfServe`, and every branch that clears subscribe clears downgrade first, so a true downgrade currently implies a true subscribe. Both directions of the catalog split are pinned so neither silently depends on that holding.

`browser_tests/tests/dialogs/pricingTableCapabilityGating.spec.ts` (`@cloud`) drives the real dialog against capability responses shaped like the cohorts, which the unit tests cannot do — they render the table directly, so they prove the expression but not that a customer reaches a live button. **Verified red on the pre-change component**: the legacy-rail, unresolved-read and failed-read cases all fail there.

The closed direction is deliberately unit-only, and the spec says why. Every entry point to the catalog — the `?pricing=` deep link, the settings panel link, the user popover — is itself gated on `canOpenPricingSurface`, which resolves to `can_subscribe_self_serve`. A resolved refusal therefore *withholds the dialog* rather than opening it with dead cards; the e2e asserts that as the negative control. It also means the dialog-with-every-button-dead state this incident reported is only reachable through an unresolved read, which is the route this PR fixes.

An earlier revision of this section claimed e2e was impossible because `browser_tests` could not construct the account shapes. That was wrong: `setupCloudApp` takes the capability response directly, including a never-resolving promise for the pending case.

## Screenshots

AS IS / TO BE captures from the real app to follow in a comment — capture takes a while and I did not want to hold the PR.
