### PR TITLE
ci: allow manual dispatch of CI: Tests Unit

### DIFF
--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
   merge_group:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` to `CI: Tests Unit` so the unit suite can be re-run manually against an exact ref.

## Changes

- **What**: `.github/workflows/ci-tests-unit.yaml` gains a `workflow_dispatch:` trigger, matching `ci-tests-e2e.yaml` and `ci-tests-storybook.yaml`, which already have one.

## Review Focus

The motivating case is observable on `main` right now. Push-event runs of `CI: Tests Unit` (workflow `196119077`) and `CI: Tests E2E` (`196119074`) both stop at [`1a3fe7ce02`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/1a3fe7ce02) (2026-09-04T04:11:29Z), while six later `main` commits (`fdcc06bbaa`, `1e22cf8fb0`, `133ff87dce`, `70e7e0269b`, `922976b87a`, `9ff3fd7f0e`) produced no push-triggered run of either workflow. `CI: Tests Storybook` fired on push for those same commits, and both workflows are `active` and healthy on `pull_request`, so this is not a disabled workflow or a path filter.

`CI: Tests E2E` could be recovered immediately because it already accepts manual dispatch ([run 33873793412](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33873793412) at `9ff3fd7f0e`). `CI: Tests Unit` could not, which is the gap this closes. This does not diagnose why the push trigger stopped firing; it only makes the unit result recoverable when it does.

Note the `concurrency` group is `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so on a busy `main` a queued post-merge unit run is cancelled by the next merge regardless. That is a separate question from this change, but it is the reason an on-demand path is worth having.
