### PR TITLE
test(agent): cover subscription ack without sequence

### DIFF
--- a/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
@@ -24,13 +24,13 @@ const awarenessFrame = (expiresAt: unknown) => ({
 
 const sequencedFrame = (
   type: 'doc_subscribed' | 'doc_reset',
-  seq: unknown
+  seq?: unknown
 ) => ({
   type,
   data: {
     v: 1,
     workflow_id: 'wf-1',
-    seq,
+    ...(seq !== undefined && { seq }),
     ...(type === 'doc_subscribed' && { ok: true })
   }
 })
@@ -88,6 +88,13 @@ describe('doc frame numeric domains', () => {
       })
     }
   )
+
+  it('accepts doc_subscribed without seq', () => {
+    expect(parseServerDocFrame(sequencedFrame('doc_subscribed'))).toEqual({
+      type: 'doc_subscribed',
+      data: { workflowId: 'wf-1', ok: true }
+    })
+  })
 
   it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
     'omits an invalid doc_ops_result seq while preserving the result: %s',


### PR DESCRIPTION
## Summary

Restores explicit coverage that a `doc_subscribed` acknowledgement without optional `seq` metadata remains valid.

## Changes

- **What**: Makes the shared frame helper omit absent `seq` and adds the missing behavioral regression.

## Review Focus

This is intentionally parser-neutral and remains valid regardless of the invalid-present `seq` policy tracked separately by `phs-27`.

Source: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16487#discussion_r3907878722
Follow-up: #16932 (`phs-28`)
