### PR TITLE
perf(agent): avoid redundant subgraph definition reads

### DIFF
--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -6,7 +6,10 @@ import * as Y from 'yjs'
 import { createTestSubgraphData } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
 
-import { readSubgraphDefinitions } from './agentSubgraphDefinitions'
+import {
+  readSubgraphDefinitionIds,
+  readSubgraphDefinitions
+} from './agentSubgraphDefinitions'
 
 const CATALOG: WidgetCatalog = {
   types: {
@@ -136,6 +139,16 @@ describe('readSubgraphDefinitions', () => {
     const [projected] = readSubgraphDefinitions(seed(outer))
 
     expect(projected.definitions).toEqual({ subgraphs: [inner] })
+  })
+
+  it('projects top-level and nested definition ids without reading bodies', () => {
+    const inner = createTestSubgraphData({ nodes: [interiorNode(1)] as never })
+    const outer = createTestSubgraphData({
+      nodes: [interiorNode(2, inner.id)] as never,
+      definitions: { subgraphs: [inner] }
+    })
+
+    expect(readSubgraphDefinitionIds(seed(outer))).toEqual([outer.id, inner.id])
   })
 
   it('skips definition and node entries that are not records', () => {

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -103,6 +103,37 @@ function readDefinition(source: Y.Map<unknown>): ExportedSubgraph {
   return definition as unknown as ExportedSubgraph
 }
 
+function readField(source: unknown, key: string): unknown {
+  if (source instanceof Y.Map) return source.get(key)
+  if (typeof source !== 'object' || source === null || !(key in source)) {
+    return undefined
+  }
+  return Reflect.get(source, key)
+}
+
+function readList(source: unknown): unknown[] {
+  if (source instanceof Y.Array) return source.toArray()
+  return Array.isArray(source) ? source : []
+}
+
+function collectDefinitionIds(source: unknown, ids: string[]): void {
+  const id = readField(source, 'id')
+  if (typeof id === 'string') ids.push(id)
+  const nested = readField(readField(source, 'definitions'), 'subgraphs')
+  for (const definition of readList(nested)) {
+    collectDefinitionIds(definition, ids)
+  }
+}
+
+export function readSubgraphDefinitionIds(doc: Y.Doc): string[] {
+  const ids: string[] = []
+  if (!doc.share.has(DEFINITIONS_ROOT)) return ids
+  doc.getMap<unknown>(DEFINITIONS_ROOT).forEach((value) => {
+    if (value instanceof Y.Map) collectDefinitionIds(value, ids)
+  })
+  return ids
+}
+
 /**
  * Project the subgraph definitions the op layer minted into the follower doc
  * back to the `ExportedSubgraph` shape `LGraph.createSubgraphs()` consumes,

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -64,6 +64,9 @@ const definitionsState = vi.hoisted(() => ({
   fakeDefinitions: [
     { id: '11111111-1111-4111-8111-111111111111' } as ExportedSubgraph
   ],
+  readSubgraphDefinitionIds: vi.fn(() => [
+    '11111111-1111-4111-8111-111111111111'
+  ]),
   readSubgraphDefinitions: vi.fn(() => definitionsState.fakeDefinitions)
 }))
 
@@ -117,6 +120,7 @@ vi.mock('./agentNodeMaterializer', () => ({
 }))
 
 vi.mock('./agentSubgraphDefinitions', () => ({
+  readSubgraphDefinitionIds: definitionsState.readSubgraphDefinitionIds,
   readSubgraphDefinitions: definitionsState.readSubgraphDefinitions
 }))
 
@@ -207,6 +211,7 @@ describe('useAgentCrdtFollower', () => {
     sessionStorage.clear()
     bridgeState.current = null
     materializerState.reconcileAgentAdapters.mockReset().mockReturnValue([])
+    definitionsState.readSubgraphDefinitionIds.mockClear()
     definitionsState.readSubgraphDefinitions.mockClear()
   })
 
@@ -669,8 +674,10 @@ describe('useAgentCrdtFollower', () => {
   describe('live-graph reconcile', () => {
     // The materializer is module-mocked, so the graph only needs to be a
     // distinct reference the composable hands through.
-    const fakeGraph = {} as MaterializableGraph
     const { fakeDefinitions } = definitionsState
+    const fakeGraph = {
+      rootGraph: { subgraphs: new Map() }
+    } as unknown as MaterializableGraph
 
     it('reconciles the live graph after every applied frame', () => {
       const { unmount } = mountFollower('wf-1', true, () => fakeGraph)
@@ -686,6 +693,27 @@ describe('useAgentCrdtFollower', () => {
       // doc_reset remint (which swaps the FollowerDoc) is read fresh.
       expect(definitionsState.readSubgraphDefinitions).toHaveBeenCalledWith(
         bridge().follower.doc
+      )
+      unmount()
+    })
+
+    it('does not deep-copy definitions for a frame when all are registered', () => {
+      const registeredGraph = {
+        rootGraph: {
+          subgraphs: new Map([[fakeDefinitions[0].id, {}]])
+        }
+      } as unknown as MaterializableGraph
+      const { unmount } = mountFollower('wf-1', true, () => registeredGraph)
+
+      dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 9 })
+
+      expect(definitionsState.readSubgraphDefinitionIds).toHaveBeenCalledWith(
+        bridge().follower.doc
+      )
+      expect(definitionsState.readSubgraphDefinitions).not.toHaveBeenCalled()
+      expect(materializerState.reconcileAgentAdapters).toHaveBeenCalledWith(
+        registeredGraph,
+        []
       )
       unmount()
     })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -7,7 +7,10 @@ import { createUuidv4 } from '@/utils/uuid'
 
 import type { MaterializableGraph } from './agentNodeMaterializer'
 import { reconcileAgentAdapters } from './agentNodeMaterializer'
-import { readSubgraphDefinitions } from './agentSubgraphDefinitions'
+import {
+  readSubgraphDefinitionIds,
+  readSubgraphDefinitions
+} from './agentSubgraphDefinitions'
 import { recordDevEvent } from './devPanelLog'
 import { wireLog } from './crdtLog'
 import type { CrdtDebugSnapshot } from './crdtSnapshot'
@@ -582,10 +585,14 @@ export function useAgentCrdtFollower(
   function reconcileLiveGraph(docId: string): void {
     const graph = getGraph()
     if (!graph) return
-    const nodeIds = reconcileAgentAdapters(
-      graph,
-      readSubgraphDefinitions(bridge.follower.doc)
+    const definitionIds = readSubgraphDefinitionIds(bridge.follower.doc)
+    const hasMissingDefinition = definitionIds.some(
+      (id) => !graph.rootGraph.subgraphs.has(id)
     )
+    const definitions = hasMissingDefinition
+      ? readSubgraphDefinitions(bridge.follower.doc)
+      : []
+    const nodeIds = reconcileAgentAdapters(graph, definitions)
     if (nodeIds.length > 0) {
       recordDevEvent('agent_node_adapters_materialized', {
         workflowId: docId,


### PR DESCRIPTION
Avoids full subgraph-definition deep copies on unrelated CRDT frames. Registered definitions now take an ID-only fast path.

<details><summary>Full context for agent readers</summary>

## Summary

`reconcileLiveGraph` first projects top-level and nested definition IDs. It materializes full definitions only when at least one ID is absent from the live root graph; ordinary node/widget frames still reconcile adapters with an empty definition list.

Addresses item 3 of #16932 and the performance finding in #16922.

## Review Focus

- ID projection traverses nested definition metadata without reading interior node/link/widget bodies.
- Missing definitions retain the existing full-reader and registration path.
- A regression proves a widget-style applied frame does not invoke the full reader once definitions are registered.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm exec vitest run src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts` — 2 files, 62 tests passed
- `pnpm exec eslint src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- Commit hooks: oxfmt, type-aware oxlint, ESLint, typecheck — passed
- Pre-push hook: knip — passed

</details>

<!-- authored-by:agent lane-ev122-3-1245 -->
