### PR TITLE
test(ci): make check-binary-size suite hermetic under parallel load

### DIFF
--- a/scripts/cicd/check-binary-size.test.ts
+++ b/scripts/cicd/check-binary-size.test.ts
@@ -76,7 +76,13 @@ function tempGitRepo() {
   }
 }
 
-describe('check-binary-size.sh', () => {
+describe('check-binary-size.sh', { timeout: 30_000 }, () => {
+  // Every test drives a chain of git subprocesses (init, config, commits) plus the
+  // script itself (two diffs, cat-file). Under a heavily loaded machine one link
+  // can stall long enough to trip vitest's default 5s test timeout — a pure
+  // load-sensitivity failure, not a defect the timeout exists to catch. A real
+  // script failure still surfaces in well under a second, so a generous ceiling
+  // keeps the suite hermetic under parallel load without masking regressions.
   it('passes when the range changes no binary files', () => {
     using repo = tempGitRepo()
     repo.write('notes.md', 'some prose\n')


### PR DESCRIPTION
One-line test-only fix: the `check-binary-size.sh` vitest suite gets an explicit 30s timeout so parallel-load stalls cannot trip vitest's default 5s test timeout.

## Evidence

Commands run at head `888bd2d28d` (Node 25, worker VM, load average 9-11 on 8 cores):

- `pnpm exec vitest run scripts/cicd/check-binary-size.test.ts --reporter=verbose` — 20/20 passed; per-test 43-250ms, far under the ceiling.
- Mechanism probe: a temporary test sleeping 6s inside the same `{ timeout: 30_000 }` describe options passed, while 6s exceeds the default 5s timeout — proving both the failure mode and that the new options signature applies under this repo's vitest version.
- `pnpm exec eslint scripts/cicd/check-binary-size.test.ts` — 0 warnings, 0 errors; `pnpm exec oxlint` — 0 warnings, 0 errors; `git diff --check` clean. Pre-commit hooks (oxfmt, oxlint type-aware, eslint, `pnpm typecheck`) all passed.

<details>
<summary>Full context for agent readers</summary>

Root cause: this suite spawns a chain of git subprocesses per test (`git init`, config, two commits) plus the script's own `git diff` calls. Under a heavily loaded machine (observed once in a local full-directory `vitest run scripts/cicd/` pass recorded in the program repo's `fleet/passes/pr-shepherd.md`: failed once, passed on two consecutive reruns of the identical tree), one subprocess link can stall past vitest's default 5000ms `testTimeout`. Outside CI the repo configures `retry: process.env.CI ? 2 : 0`, so CI's 2 retries mask the flake but a local full-directory run dies on the first occurrence. Investigation ruled out the suspected shared resources: every cicd test uses per-invocation `mkdtempSync` temp repos, the test already nulls `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`, and the limit is passed explicitly — no cross-worker state exists. The fix therefore removes the load-sensitivity instead: a 30s ceiling on the describe block. A genuinely broken script still fails in well under a second (observed ~100ms per test), so the change does not mask real regressions.

</details>

<!-- authored-by:agent lane-flaky-1-1245 -->
