### PR TITLE
fix(agent): remap subgraph IDs reserved by root records

### DIFF
--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
@@ -47,6 +47,15 @@ interface SubgraphNormalizationReservations {
   rerouteIds: Set<number>
 }
 
+export type SubgraphNodeIdRemaps = ReadonlyMap<
+  string,
+  ReadonlyMap<NodeId, SerializedNodeId>
+>
+
+export interface SubgraphNodeDeduplicationResult extends DeduplicationResult {
+  nodeIdRemaps: Map<string, Map<NodeId, SerializedNodeId>>
+}
+
 export function normalizeSubgraphDefinitions(
   subgraphs: ExportedSubgraph[],
   reservations: SubgraphNormalizationReservations,
@@ -203,21 +212,25 @@ function firstById<T, Id>(
  */
 export function deduplicateSubgraphNodeIds(
   subgraphs: ExportedSubgraph[],
-  reservedNodeIds: Set<number>,
+  reservedNodeIds: ReadonlySet<SerializedNodeId>,
   state: LGraphState,
   rootNodes?: ISerialisedNode[]
-): DeduplicationResult {
+): SubgraphNodeDeduplicationResult {
   const clonedSubgraphs = structuredClone(subgraphs)
   const clonedRootNodes = rootNodes ? structuredClone(rootNodes) : undefined
 
-  deduplicateClonedSubgraphNodeIds(
+  const nodeIdRemaps = deduplicateClonedSubgraphNodeIds(
     clonedSubgraphs,
     new Set([...reservedNodeIds].map(toNodeId)),
     state,
     clonedRootNodes
   )
 
-  return { subgraphs: clonedSubgraphs, rootNodes: clonedRootNodes }
+  return {
+    subgraphs: clonedSubgraphs,
+    rootNodes: clonedRootNodes,
+    nodeIdRemaps
+  }
 }
 
 function deduplicateClonedSubgraphNodeIds(
@@ -225,7 +238,7 @@ function deduplicateClonedSubgraphNodeIds(
   reservedNodeIdKeys: Set<NodeId>,
   state: LGraphState,
   clonedRootNodes?: ISerialisedNode[]
-): void {
+): Map<string, Map<NodeId, SerializedNodeId>> {
   const usedNodeIdKeys = new Set(reservedNodeIdKeys)
   const usedNodeIds = new Set<number>()
   for (const id of reservedNodeIdKeys) {
@@ -260,6 +273,7 @@ function deduplicateClonedSubgraphNodeIds(
   if (clonedRootNodes) {
     patchProxyWidgets(clonedRootNodes, subgraphIdSet, remapBySubgraph)
   }
+  return remapBySubgraph
 }
 
 /**
@@ -353,6 +367,13 @@ function patchPromotedWidgets(
     const newId = remappedIds.get(toNodeId(widget.id))
     if (newId !== undefined) widget.id = newId
   }
+}
+
+export function patchSubgraphProxyWidgetIds(
+  rootNodes: ISerialisedNode[],
+  remapBySubgraph: SubgraphNodeIdRemaps
+): void {
+  patchProxyWidgets(rootNodes, new Set(remapBySubgraph.keys()), remapBySubgraph)
 }
 
 export function collectReservedGroupIds(
@@ -584,8 +605,8 @@ export function topologicalSortSubgraphs(
 /** Patches legacy proxyWidgets in root-level SubgraphNode instances. */
 function patchProxyWidgets(
   rootNodes: ISerialisedNode[],
-  subgraphIdSet: Set<string>,
-  remapBySubgraph: Map<string, Map<NodeId, SerializedNodeId>>
+  subgraphIdSet: ReadonlySet<string>,
+  remapBySubgraph: SubgraphNodeIdRemaps
 ): void {
   for (const node of rootNodes) {
     if (!subgraphIdSet.has(node.type)) continue

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -922,6 +922,49 @@ describe('reconcileAgentAdapters', () => {
       expect(reportError).not.toHaveBeenCalled()
     })
 
+    it('reserves same-frame root ids before remapping colliding subgraph interiors', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7, 'widget-node')] as never,
+        widgets: [{ id: 7, name: 'value' }]
+      })
+      const rootNode = {
+        ...nodePayload(7, definition.id),
+        properties: { proxyWidgets: [['7', 'value']] }
+      }
+      const { follower } = seedDocument(graph, {
+        nodes: [rootNode],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      const definitions = readSubgraphDefinitions(follower.doc)
+
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([toNodeId(7)])
+
+      const instance = graph.getNodeById(toNodeId(7))
+      expect(instance).toBeInstanceOf(SubgraphNode)
+      const subgraph = (instance as SubgraphNode).subgraph
+      const interior = subgraph.nodes[0]
+      expect(interior.id).not.toBe(toNodeId(7))
+      expect(definitions[0].nodes?.[0].id).toBe(7)
+      expect(toNodeId(subgraph.widgets[0].id)).toBe(interior.id)
+      expect(instance?.properties.proxyWidgets).toEqual([
+        [String(interior.id), 'value']
+      ])
+
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([])
+      expect(graph.getNodeById(toNodeId(7))).toBe(instance)
+      expect(subgraph.nodes[0]).toBe(interior)
+
+      const mutations = remoteMutations(graphScopeOf(graph))
+      mutations.deleteNode(toNodeId(7), [], REMOTE)
+      mutations.addNode(rootNode, { ...REMOTE, opId: 'op-recreate-7' })
+      expect(reconcileAgentAdapters(graph, definitions)).toEqual([toNodeId(7)])
+      expect(graph.getNodeById(toNodeId(7))?.properties.proxyWidgets).toEqual([
+        [String(interior.id), 'value']
+      ])
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
     it('registers a definition once across repeated reconciles', () => {
       const definition = createTestSubgraphData({
         nodes: [nodePayload(7)] as never

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -23,6 +23,7 @@ import {
   createTestSubgraphNode,
   enableSubgraphNodeCreation
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import { reportError } from '@/platform/telemetry/reportError'
 // Mirrors the production bridge in AgentPanelRoot.vue, which takes the same
 // exemption to drive the real layout store.
@@ -185,9 +186,12 @@ function nodePayload(id: number, type = 'dummy') {
     type,
     pos: [0, 0],
     size: [100, 80],
+    flags: {},
+    order: 0,
+    mode: 0,
     inputs: [],
     outputs: []
-  }
+  } satisfies ISerialisedNode
 }
 
 /** Commit a remote add to the stores only, the way a follower frame does. */
@@ -924,7 +928,7 @@ describe('reconcileAgentAdapters', () => {
 
     it('reserves same-frame root ids before remapping colliding subgraph interiors', () => {
       const definition = createTestSubgraphData({
-        nodes: [nodePayload(7, 'widget-node')] as never,
+        nodes: [nodePayload(7, 'widget-node')],
         widgets: [{ id: 7, name: 'value' }]
       })
       const rootNode = {
@@ -967,7 +971,7 @@ describe('reconcileAgentAdapters', () => {
 
     it('patches root proxyWidgets once when a remint chains into a later interior id', () => {
       const definition = createTestSubgraphData({
-        nodes: [nodePayload(7, 'widget-node'), nodePayload(8)] as never,
+        nodes: [nodePayload(7, 'widget-node'), nodePayload(8)],
         widgets: [{ id: 7, name: 'value' }]
       })
       const rootNode = {

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -965,6 +965,39 @@ describe('reconcileAgentAdapters', () => {
       expect(reportError).not.toHaveBeenCalled()
     })
 
+    it('patches root proxyWidgets once when a remint chains into a later interior id', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7, 'widget-node'), nodePayload(8)] as never,
+        widgets: [{ id: 7, name: 'value' }]
+      })
+      const rootNode = {
+        ...nodePayload(7, definition.id),
+        properties: { proxyWidgets: [['7', 'value']] }
+      }
+      const { follower } = seedDocument(graph, {
+        nodes: [rootNode],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      // Mint from the colliding id so 7 -> 8 collides with interior 8 -> 9.
+      graph.state.lastNodeId = 7
+
+      expect(
+        reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+      ).toEqual([toNodeId(7)])
+
+      const instance = graph.getNodeById(toNodeId(7)) as SubgraphNode
+      const subgraph = instance.subgraph
+      const interiorIds = subgraph.nodes.map(({ id }) => id)
+      expect(new Set(interiorIds).size).toBe(2)
+      expect(interiorIds).not.toContain(toNodeId(7))
+      expect(toNodeId(subgraph.widgets[0].id)).toBe(interiorIds[0])
+      expect(instance.properties.proxyWidgets).toEqual([
+        [String(interiorIds[0]), 'value']
+      ])
+      expect(reportError).not.toHaveBeenCalled()
+    })
+
     it('registers a definition once across repeated reconciles', () => {
       const definition = createTestSubgraphData({
         nodes: [nodePayload(7)] as never

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -71,7 +71,10 @@ export function reconcileAgentAdapters(
  */
 const reportedDefinitionFailures = new WeakMap<LGraph, Set<string>>()
 
-/** Interior remints retained for later root-node reprojections. */
+/**
+ * Maps document interior IDs to local projection IDs. Source `proxyWidgets`
+ * must retain document IDs and never serialize these local remints back.
+ */
 const registeredDefinitionNodeIdRemaps = new WeakMap<
   LGraph,
   Map<string, Map<NodeId, SerializedNodeId>>

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -1,7 +1,11 @@
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import { materializeLinkAdapter } from '@/lib/litegraph/src/LLink'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { topologicalSortSubgraphs } from '@/lib/litegraph/src/subgraph/subgraphDeduplication'
+import {
+  deduplicateSubgraphNodeIds,
+  patchSubgraphProxyWidgetIds,
+  topologicalSortSubgraphs
+} from '@/lib/litegraph/src/subgraph/subgraphDeduplication'
 import type {
   ExportedSubgraph,
   ISerialisedNode
@@ -13,10 +17,12 @@ import { useNodeDataStore } from '@/stores/nodeDataStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { GraphScope } from '@/types/graphScopeId'
 import { graphScopeOf } from '@/types/graphScopeId'
-import type { NodeId } from '@/types/nodeId'
+import type { NodeId, SerializedNodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
 import type { NodeState } from '@/types/nodeState'
 import { widgetId } from '@/types/widgetId'
 import type { WidgetStateInit } from '@/types/widgetState'
+import { toRaw } from 'vue'
 
 import { runMintPortsSuppressed } from './mintPortWiring'
 
@@ -51,8 +57,11 @@ export function reconcileAgentAdapters(
   subgraphDefinitions: ExportedSubgraph[] = []
 ): NodeId[] {
   return runMintPortsSuppressed(() => {
-    const pending = registerSubgraphDefinitions(graph, subgraphDefinitions)
-    return reconcile(graph, pending)
+    const { pending, rootNodes } = registerSubgraphDefinitions(
+      graph,
+      subgraphDefinitions
+    )
+    return reconcile(graph, pending, rootNodes)
   })
 }
 
@@ -61,6 +70,12 @@ export function reconcileAgentAdapters(
  * a definition that keeps failing across reconcile frames is reported once.
  */
 const reportedDefinitionFailures = new WeakMap<LGraph, Set<string>>()
+
+/** Interior remints retained for later root-node reprojections. */
+const registeredDefinitionNodeIdRemaps = new WeakMap<
+  LGraph,
+  Map<string, Map<NodeId, SerializedNodeId>>
+>()
 
 /**
  * Register explicitly created subgraph definitions the root graph does not
@@ -80,13 +95,16 @@ const reportedDefinitionFailures = new WeakMap<LGraph, Set<string>>()
  * untouched: edits address interior nodes through normal node operations, not
  * by replacing an existing definition.
  *
- * @returns ids of definitions from the document that are still not registered
- * on the root graph.
+ * @returns ids still awaiting registration plus root serializations patched to
+ * follow any interior node remints performed before registration.
  */
 function registerSubgraphDefinitions(
   graph: MaterializableGraph,
   definitions: ExportedSubgraph[]
-): Set<string> {
+): {
+  pending: Set<string>
+  rootNodes: ReadonlyMap<NodeId, ISerialisedNode>
+} {
   const rootGraph = graph.rootGraph
   // Filter after flattening: a live nested definition must not be recreated
   // just because its outer is missing, and a missing nested definition must
@@ -95,17 +113,61 @@ function registerSubgraphDefinitions(
     (definition) => !rootGraph.subgraphs.has(definition.id)
   )
   const pending = new Set(missing.map((definition) => definition.id))
-  if (missing.length === 0) return pending
+  const registeredRemaps =
+    registeredDefinitionNodeIdRemaps.get(rootGraph) ??
+    registeredDefinitionNodeIdRemaps.set(rootGraph, new Map()).get(rootGraph)!
+  if (missing.length === 0 && registeredRemaps.size === 0) {
+    return { pending, rootNodes: new Map() }
+  }
+
+  // Root records reach the canonical stores before their live adapters. Give
+  // their IDs priority while definitions are normalized so an interior
+  // collision is reminted before Subgraph.configure() binds links and widget
+  // references to it. Waiting for LGraph.add() to discover the store collision
+  // remints only the node, leaving those references on the root record's ID.
+  const scope = graphScopeOf(graph)
+  const records = useNodeDataStore().getGraphNodesFor(
+    scope.rootGraphId,
+    scope.owningGraphId
+  )
+  const serialisedRootNodes = records.flatMap(({ lastSerialization }) =>
+    lastSerialization ? [toRaw(lastSerialization)] : []
+  )
+  const reservedNodeIds = new Set<SerializedNodeId>([
+    ...[rootGraph, ...rootGraph.subgraphs.values()].flatMap(({ nodes }) =>
+      nodes.map(({ id }) => id)
+    ),
+    ...records.map(({ id }) => id)
+  ])
+  const normalized =
+    missing.length > 0
+      ? deduplicateSubgraphNodeIds(
+          missing,
+          reservedNodeIds,
+          rootGraph.state,
+          serialisedRootNodes
+        )
+      : undefined
+  const rootNodes =
+    normalized?.rootNodes ??
+    serialisedRootNodes.map((node) =>
+      registeredRemaps.has(node.type) ? structuredClone(node) : node
+    )
 
   const reported =
     reportedDefinitionFailures.get(rootGraph) ??
     reportedDefinitionFailures.set(rootGraph, new Set()).get(rootGraph)!
 
-  for (const definition of topologicalSortSubgraphs(missing)) {
+  for (const definition of topologicalSortSubgraphs(
+    normalized?.subgraphs ?? []
+  )) {
     const failure = tryCreateSubgraph(rootGraph, definition)
     if (failure === undefined) {
       pending.delete(definition.id)
       reported.delete(definition.id)
+      const remappedIds = normalized?.nodeIdRemaps.get(definition.id)
+      if (remappedIds) registeredRemaps.set(definition.id, remappedIds)
+      else registeredRemaps.delete(definition.id)
       continue
     }
     if (reported.has(definition.id)) continue
@@ -115,7 +177,11 @@ function registerSubgraphDefinitions(
       context: { graphId: graph.id, definitionId: definition.id }
     })
   }
-  return pending
+  patchSubgraphProxyWidgetIds(rootNodes, registeredRemaps)
+  return {
+    pending,
+    rootNodes: new Map(rootNodes.map((node) => [toNodeId(node.id), node]))
+  }
 }
 
 /**
@@ -204,7 +270,8 @@ function withNamedValuesRestore<T>(fn: () => T): T {
  */
 function reconcile(
   graph: MaterializableGraph,
-  pendingDefinitions: Set<string>
+  pendingDefinitions: Set<string>,
+  normalizedRootNodes: ReadonlyMap<NodeId, ISerialisedNode>
 ): NodeId[] {
   const scope = graphScopeOf(graph)
   // Remote connect registers canonical topology without importing LiteGraph.
@@ -228,7 +295,8 @@ function reconcile(
   for (const state of records) {
     const live = graph._nodes_by_id[state.id]
     if (live && nodeStore.ownsNode(scope, live._state)) continue
-    const serialised = state.lastSerialization
+    const serialised =
+      normalizedRootNodes.get(state.id) ?? state.lastSerialization
     if (!serialised) continue
     if (pendingDefinitions.has(state.type)) continue
     if (

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -141,18 +141,8 @@ function registerSubgraphDefinitions(
   ])
   const normalized =
     missing.length > 0
-      ? deduplicateSubgraphNodeIds(
-          missing,
-          reservedNodeIds,
-          rootGraph.state,
-          serialisedRootNodes
-        )
+      ? deduplicateSubgraphNodeIds(missing, reservedNodeIds, rootGraph.state)
       : undefined
-  const rootNodes =
-    normalized?.rootNodes ??
-    serialisedRootNodes.map((node) =>
-      registeredRemaps.has(node.type) ? structuredClone(node) : node
-    )
 
   const reported =
     reportedDefinitionFailures.get(rootGraph) ??
@@ -177,6 +167,12 @@ function registerSubgraphDefinitions(
       context: { graphId: graph.id, definitionId: definition.id }
     })
   }
+  // Patch root proxyWidgets once, from the remaps that actually registered.
+  // Letting deduplicateSubgraphNodeIds patch them too would re-apply a chained
+  // remint (7->8, 8->9) and point the proxy at the wrong interior node.
+  const rootNodes = serialisedRootNodes.map((node) =>
+    registeredRemaps.has(node.type) ? structuredClone(node) : node
+  )
   patchSubgraphProxyWidgetIds(rootNodes, registeredRemaps)
   return {
     pending,


### PR DESCRIPTION
Keeps document root node IDs authoritative.
Remaps colliding subgraph interior IDs before registration.
Preserves exposed-widget and proxy references across reconciliation.

<details><summary>Full context for agent readers</summary>

## Problem

Agent subgraph definitions are registered before pending root records become live. A definition interior can therefore claim a node ID that a same-frame root record also owns. Late graph insertion remints the interior after exposed-widget and legacy proxy references were normalized, leaving those references stale.

## Decision

Reserve IDs from same-scope store-only root records before registering missing definitions. Reuse the existing subgraph deduplicator to remint colliding interiors first, patch exposed-widget and root proxy references, and cache successful remaps so root reprojection remains stable. Document/root IDs stay authoritative, and serialized definition inputs are not mutated.

This addresses the collision item in #16932 and the deferred review thread in #16922. It supersedes the collision-rejection portion of draft #16970; #16973 carries that draft's lifecycle work.

## Evidence

- Failing-first regression on `9ff3fd7f0e`: exposed widget stayed on `7` after the interior reminted to `8`; late insertion also logged `Cannot change the ID of populated graph`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts` — 61 passed
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts` — 39 passed
- `pnpm typecheck` — passed
- targeted ESLint — passed
- `pnpm exec oxfmt --check` on changed files — passed
- `git diff --check` — passed
- commit and push hooks: Knip, oxfmt, type-aware oxlint, ESLint, and typecheck — passed

## End-to-end coverage

No Playwright case was added because the defect is a same-frame ordering race between store projection and in-memory subgraph registration, before any rendered interaction. The focused materializer test deterministically creates the pending root/interior collision, asserts every serialized reference, repeats reconciliation, and recreates the root. Browser automation cannot force this ordering without reaching through the same internal seam, so it would duplicate the unit test rather than exercise a user-observable path.

</details>

<!-- authored-by:agent lane-ev122-2-1245 -->