### PR TITLE
feat(agent): support outgoing CRDT awareness frames

### DIFF
--- a/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseServerDocFrame } from './docFrameClient'
+import type { DocFrameTransport } from './docFrameClient'
+import { DocFrameClient, parseServerDocFrame } from './docFrameClient'
+
+class TestTransport extends EventTarget implements DocFrameTransport {
+  readonly sent: string[] = []
+
+  send(frame: string): boolean {
+    this.sent.push(frame)
+    return true
+  }
+}
 
 function awarenessFrame(state: unknown, expiresAt: unknown = 123) {
   return {
@@ -94,5 +104,18 @@ describe('awareness frame validation', () => {
         expiresAt: 456
       }
     })
+  })
+
+  it('refuses to send awareness with an invalid actor or oversized state', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+
+    expect(client.sendAwareness('wf-1', 'not-an-actor', {})).toBe(false)
+    expect(
+      client.sendAwareness('wf-1', 'human:user:tab-a', {
+        value: 'x'.repeat(8 * 1024)
+      })
+    ).toBe(false)
+    expect(transport.sent).toEqual([])
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
@@ -116,6 +116,97 @@ describe('awareness frame validation', () => {
         value: 'x'.repeat(8 * 1024)
       })
     ).toBe(false)
-    expect(transport.sent).toEqual([])
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('refuses to send awareness with an invalid workflow id', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+
+    expect(client.sendAwareness('', 'human:user:tab-a')).toBe(false)
+    expect(client.sendAwareness('wf 1', 'human:user:tab-a')).toBe(false)
+    expect(client.sendAwareness('wf:1', 'human:user:tab-a')).toBe(false)
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('refuses to publish awareness as the reserved system actor', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+
+    expect(
+      client.sendAwareness('wf-1', 'system:mint', { cursor: [1, 2] })
+    ).toBe(false)
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('refuses to send awareness state that is not a plain object', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+
+    expect(
+      client.sendAwareness('wf-1', 'human:user:tab-a', [
+        1, 2
+      ] as unknown as Record<string, unknown>)
+    ).toBe(false)
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('treats a null state as absent, matching the inbound parser', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+
+    expect(client.sendAwareness('wf-1', 'human:user:tab-a', null)).toBe(true)
+    expect(JSON.parse(transport.sent[0]).data).not.toHaveProperty('state')
+  })
+
+  it('refuses to send cyclic awareness state without throwing', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+
+    expect(client.sendAwareness('wf-1', 'human:user:tab-a', cyclic)).toBe(false)
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('does not throw when state serializes differently on a second pass', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    let passes = 0
+    const state = {
+      toJSON() {
+        passes += 1
+        if (passes >= 2) throw new Error('second serialization pass')
+        return { cursor: [1, 2] }
+      }
+    }
+
+    expect(client.sendAwareness('wf-1', 'human:user:tab-a', state)).toBe(true)
+    expect(transport.sent).toHaveLength(1)
+  })
+
+  it('sends the exact state that passed the size check', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    const state = {
+      toJSON(key: string) {
+        return key === 'state' ? 'x'.repeat(9 * 1024) : { cursor: [1, 2] }
+      }
+    }
+
+    expect(client.sendAwareness('wf-1', 'human:user:tab-a', state)).toBe(true)
+    expect(JSON.parse(transport.sent[0]).data.state).toEqual({ cursor: [1, 2] })
+  })
+
+  it('rejects state the server would reject after HTML escaping', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+
+    expect(
+      client.sendAwareness('wf-1', 'human:user:tab-a', {
+        value: '<'.repeat(1400)
+      })
+    ).toBe(false)
+    expect(transport.sent).toHaveLength(0)
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -96,7 +96,7 @@ describe('doc frame client', () => {
     )
   })
 
-  it('encodes subscribe, unsubscribe and doc_ops protocol frames', () => {
+  it('encodes client-to-server protocol frames', () => {
     const transport = new TestTransport()
     const client = new DocFrameClient(transport)
     const stateVector = Uint8Array.from([1, 2, 3])
@@ -105,6 +105,11 @@ describe('doc frame client', () => {
     client.sendOps('wf-1', 'tab-a', [
       { op_id: 'op-1', actor: 'human:user:tab-a', type: 'node.move' }
     ])
+    client.sendAwareness('wf-1', 'human:user:tab-a', {
+      cursor: [10, 20],
+      selectedNodeIds: ['node-1']
+    })
+    client.sendAwareness('wf-1', 'human:user:tab-a')
     client.unsubscribe('wf-1')
 
     expect(transport.sent.map((frame) => JSON.parse(frame))).toEqual([
@@ -123,6 +128,26 @@ describe('doc frame client', () => {
           workflow_id: 'wf-1',
           tab: 'tab-a',
           ops: [{ op_id: 'op-1', actor: 'human:user:tab-a', type: 'node.move' }]
+        }
+      },
+      {
+        type: 'awareness',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          actor: 'human:user:tab-a',
+          state: {
+            cursor: [10, 20],
+            selectedNodeIds: ['node-1']
+          }
+        }
+      },
+      {
+        type: 'awareness',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          actor: 'human:user:tab-a'
         }
       },
       {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -449,6 +449,12 @@ export class DocFrameClient extends EventTarget {
     actor: string,
     state?: Record<string, unknown>
   ): boolean {
+    if (!isValidWorkflowId(workflowId) || !isValidActor(actor)) return false
+    if (state !== undefined) {
+      const stateSize = encodedJsonSize(state)
+      if (stateSize === null || stateSize > MAX_AWARENESS_STATE_BYTES)
+        return false
+    }
     return this.send('awareness', {
       v: DOC_PROTOCOL_VERSION,
       workflow_id: workflowId,

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -443,6 +443,20 @@ export class DocFrameClient extends EventTarget {
     })
   }
 
+  /** @returns whether the ephemeral awareness frame left the transport. */
+  sendAwareness(
+    workflowId: string,
+    actor: string,
+    state?: Record<string, unknown>
+  ): boolean {
+    return this.send('awareness', {
+      v: DOC_PROTOCOL_VERSION,
+      workflow_id: workflowId,
+      actor,
+      ...(state !== undefined && { state })
+    })
+  }
+
   destroy(): void {
     for (const [type, listener] of this.listeners)
       this.transport.removeEventListener(type, listener)

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -12,6 +12,7 @@ const MAX_DOC_OPS_PER_FRAME = 256
 const MAX_OP_ID_LENGTH = 128
 const MAX_ERROR_CODE_LENGTH = 128
 const MAX_ERROR_MESSAGE_LENGTH = 8 << 10
+const RESERVED_SYSTEM_ACTOR = 'system:mint'
 const BASE64_SINGLE_PADDING_END = /[AEIMQUYcgkosw048]=$/
 const BASE64_DOUBLE_PADDING_END = /[AQgw]==$/
 const utf8 = new TextEncoder()
@@ -182,9 +183,18 @@ function isValidActor(value: string): boolean {
     /[\0\n\r\t ]/.test(value)
   )
     return false
-  if (value === 'system:mint') return true
+  if (value === RESERVED_SYSTEM_ACTOR) return true
   const match = /^(?:agent|human):([^:]+):([^:]+)$/.exec(value)
   return match !== null
+}
+
+/**
+ * Inbound `doc_reset` frames legitimately carry the reserved identity, so
+ * `isValidActor` accepts it. The awareness actor key drives presence, so
+ * accepting it outbound would let any caller publish as the system.
+ */
+function isSendableActor(value: string): boolean {
+  return value !== RESERVED_SYSTEM_ACTOR && isValidActor(value)
 }
 
 /**
@@ -267,6 +277,34 @@ function encodedJsonSize(value: Record<string, unknown>): number | null {
   } catch {
     return null
   }
+}
+
+/**
+ * Outbound counterpart of `encodedJsonSize`. Receiving can afford the loose
+ * count above because the server is then the stricter of the two; sending
+ * inverts that margin, so bill `<`, `>` and `&` at the six bytes Go escapes
+ * them to rather than the one byte they occupy here.
+ *
+ * Returns the parsed round-trip of the very bytes that were measured. A getter,
+ * a key-sensitive `toJSON`, or a Proxy can otherwise serialize differently on
+ * the second pass, so sending the source object would put an unmeasured — and
+ * possibly throwing — value on the wire.
+ */
+function encodeAwarenessState(
+  value: Record<string, unknown>
+): Record<string, unknown> | null {
+  let encoded: string
+  try {
+    encoded = JSON.stringify(value)
+  } catch {
+    return null
+  }
+  if (typeof encoded !== 'string') return null
+  const escapeOverhead = (encoded.match(/[<>&]/g)?.length ?? 0) * 5
+  if (encoded.length + escapeOverhead > MAX_AWARENESS_STATE_BYTES) return null
+  if (utf8.encode(encoded).length + escapeOverhead > MAX_AWARENESS_STATE_BYTES)
+    return null
+  return parseRecord(JSON.parse(encoded))
 }
 
 export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
@@ -385,6 +423,7 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
 
 export class DocFrameClient extends EventTarget {
   private readonly listeners = new Map<string, EventListener>()
+  private readonly reportedAwarenessRejections = new Set<string>()
 
   constructor(private readonly transport: DocFrameTransport) {
     super()
@@ -443,24 +482,50 @@ export class DocFrameClient extends EventTarget {
     })
   }
 
-  /** @returns whether the ephemeral awareness frame left the transport. */
+  /**
+   * @returns whether the ephemeral awareness frame left the transport.
+   *
+   * `false` from the transport is transient and reconcilable. `false` from the
+   * validation below is not: the same arguments will always be refused, so a
+   * caller that retries will spin. Those rejections are reported rather than
+   * returned distinctly, mirroring the inbound malformed-frame discard.
+   */
   sendAwareness(
     workflowId: string,
     actor: string,
-    state?: Record<string, unknown>
+    state?: Record<string, unknown> | null
   ): boolean {
-    if (!isValidWorkflowId(workflowId) || !isValidActor(actor)) return false
-    if (state !== undefined) {
-      const stateSize = encodedJsonSize(state)
-      if (stateSize === null || stateSize > MAX_AWARENESS_STATE_BYTES)
-        return false
+    if (!isValidWorkflowId(workflowId))
+      return this.rejectAwareness('workflow_id')
+    if (!isSendableActor(actor)) return this.rejectAwareness('actor')
+
+    let encodedState: Record<string, unknown> | undefined
+    if (!isAbsent(state)) {
+      const record = parseRecord(state)
+      if (record === null) return this.rejectAwareness('state_shape')
+      const measured = encodeAwarenessState(record)
+      if (measured === null) return this.rejectAwareness('state_size')
+      encodedState = measured
     }
+
     return this.send('awareness', {
       v: DOC_PROTOCOL_VERSION,
       workflow_id: workflowId,
       actor,
-      ...(state !== undefined && { state })
+      ...(encodedState !== undefined && { state: encodedState })
     })
+  }
+
+  private rejectAwareness(reason: string): false {
+    if (!this.reportedAwarenessRejections.has(reason)) {
+      this.reportedAwarenessRejections.add(reason)
+      reportError(new Error('Discarded invalid outgoing awareness frame'), {
+        errorType: 'agent_crdt_invalid_outgoing_frame',
+        tags: { reason },
+        level: 'warning'
+      })
+    }
+    return false
   }
 
   destroy(): void {


### PR DESCRIPTION
## Summary

Lets the frontend send ephemeral `awareness` frames, with the outbound validation the receiver's limits require.

## Changes

- **What**: `DocFrameClient.sendAwareness(workflowId, actor, state?)` emits an `awareness` frame after validating the workflow id, the actor grammar, and the state's shape and serialized size. Invalid input is refused and reported, never thrown.
- **What**: Outbound size accounting mirrors Go's `encoding/json`, which escapes `<`, `>`, `&`, U+2028 and U+2029 to six-byte sequences. The client bills each at its escaped cost so it never sends a state the 8 KiB receiver would reject.
- **What**: Reserved `system:mint` publication is refused, and a `null` state is treated as absent to match the inbound parser.

## Review focus

The validation boundary is the substance here, and three parts of it are easy to get subtly wrong:

- **Escape accounting differs by measure.** `<` is one UTF-16 unit and one UTF-8 byte; U+2028 is one unit but three bytes. Both escape to six. `goEscapeOverhead` therefore returns separate `chars` and `bytes` adjustments rather than one number.
- **Every property read happens inside one exception boundary.** `encodeAwarenessState` owns the `try`, so a throwing getter or a revoked Proxy becomes a refusal rather than an exception escaping `sendAwareness`. Nothing touches `state`'s properties before it; the call site's `isPlainObject` only reads the prototype.
- **The state contract is a plain object, not "anything that is not an array".** A class instance or `Date` flattens to something the receiver cannot round-trip, so both are refused. `sendAwareness` takes `state?: unknown` deliberately: declaring a record would force callers with untyped state, and tests of rejected shapes, into assertions that tell the compiler something untrue.

## Known blocker, not addressed here

The outgoing wire shape is still built as a local object rather than from a shared or generated protocol contract, which is the pre-merge blocker in [this review thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16977#discussion_r3975196666). Neither the pinned `@comfyorg/comfy-multi-player` nor the generated ingest types defines the client awareness frame yet, and the cross-repository release order puts the shared contract and a compatible cloud consumer ahead of the frontend pin. Adding a local interface here would create exactly the second copy that review asks to avoid, so it is deliberately left alone. This PR should not merge before that contract exists.

## Tests

`docFrameClient.awareness.test.ts` covers the rejected shapes (array, class instance, `Date`, cyclic, throwing getter), the reserved actor, `null`-as-absent, the measured-bytes round trip, per-reason rejection telemetry, and both escaping boundaries.

The escaping boundaries are derived from Go's rule rather than from the implementation, so the client cannot quietly drift stricter than the server: `{"v":""}` is 8 bytes of envelope, each escape costs six bytes, the cap is 8 KiB, and 8192 - 8 = 8184 divides by 6 into exactly 1364. So 1364 is the last accepted count and 1365 the first rejected one, asserted for `<`, U+2028 and U+2029.
