### PR TITLE
fix(agent): preserve subscribe retry backoff

### DIFF
--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -492,6 +492,19 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('does not bypass refused-subscribe backoff on status frames', () => {
+    vi.useFakeTimers()
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: false })
+
+    apiState.target.dispatchEvent(new Event('status'))
+    expect(bridge().reconcile).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(500)
+    expect(bridge().resubscribe).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
   it('drops to disconnected on a schema error without touching the binding', () => {
     const { unmount, status } = mountFollower('wf-1')
     dispatchFrame('doc_subscribed', { ok: true })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -555,9 +555,11 @@ export function useAgentCrdtFollower(
    * on every accepted connection, first one included, so it is the earliest
    * signal available that the socket can now carry a frame. `reconcile()` is a
    * no-op once intent and reality agree, so the extra `status` traffic costs
-   * nothing.
+   * nothing unless a refused subscribe has a scheduled retry. In that case,
+   * the retry timer owns the next attempt and its backoff.
    */
   const onSocketActivity: EventListener = () => {
+    if (subscribeRetryTimer !== null) return
     bridge.reconcile()
   }
 


### PR DESCRIPTION
Prevents socket status frames from bypassing a refused subscription's bounded retry timer and backoff. Adds focused coverage proving status activity stays inert until the scheduled retry runs.

This is the current-main-compatible residual from `6d1059776475`; the predecessor behavior remains carried by #16637.

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — 49/49 passed
- `pnpm exec eslint src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — passed
- `pnpm exec oxfmt --check ...` — passed
- `pnpm typecheck` — passed
- `pnpm knip` — passed
- `git diff --check` — passed

<!-- authored-by:agent lane-salvbatch-8-residuals-1510 -->
