### PR TITLE
test: stabilize free tier quota coverage

### DIFF
--- a/src/platform/cloud/subscription/composables/useFreeTierQuota.test.ts
+++ b/src/platform/cloud/subscription/composables/useFreeTierQuota.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import type { EffectScope } from 'vue'
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 vi.mock('@/platform/distribution/types', () => ({
@@ -13,47 +14,76 @@ vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({ flags: mockFlags })
 }))
 
-vi.mock('@/composables/node/usePriceBadge', () => ({
-  useCreditsBadgesInGraph: () => ref([])
+const mockApp = vi.hoisted((): { graph: { rootGraph: object } | null } => ({
+  graph: null
+}))
+vi.mock('@/scripts/app', () => ({
+  app: mockApp
+}))
+
+const mockGraphCreditsBadges = vi.hoisted(() =>
+  vi.fn((): readonly object[] => [])
+)
+vi.mock('@/systems/badgeSystem', () => ({
+  graphCreditsBadges: mockGraphCreditsBadges
 }))
 
 const mockRemoteConfig = vi.hoisted(() => ({
   value: { free_tier_balance: { allowance: 5, remaining: 5 } }
 }))
 vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
-  get remoteConfig() {
-    return ref(mockRemoteConfig.value)
-  }
+  remoteConfig: mockRemoteConfig
 }))
 
-async function loadQuota() {
-  vi.resetModules()
-  const { useFreeTierQuota } = await import('./useFreeTierQuota')
-  return useFreeTierQuota()
+const { useFreeTierQuota } = await import('./useFreeTierQuota')
+
+let scope: EffectScope | undefined
+
+function loadQuota() {
+  scope = effectScope()
+  return scope.run(useFreeTierQuota)!
 }
 
 describe('useFreeTierQuota', () => {
   beforeEach(() => {
     mockIsCloud.value = true
     mockFlags.freeTierJobAllowanceEnabled = true
+    mockApp.graph = null
+    mockGraphCreditsBadges.mockReturnValue([])
     mockRemoteConfig.value = {
       free_tier_balance: { allowance: 5, remaining: 5 }
     }
   })
 
-  it('enables the quota on Cloud when the flag and an allowance are present', async () => {
-    const quota = await loadQuota()
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+  })
+
+  it('enables the quota on Cloud when the flag and an allowance are present', () => {
+    const quota = loadQuota()
 
     expect(quota.quotaEnabled.value).toBe(true)
     expect(quota.freeTierExecutionPermitted.value).toBe(true)
   })
 
-  it('keeps the quota disabled off Cloud even when the flag and an allowance are present', async () => {
+  it('keeps the quota disabled off Cloud even when the flag and an allowance are present', () => {
     mockIsCloud.value = false
 
-    const quota = await loadQuota()
+    const quota = loadQuota()
 
     expect(quota.quotaEnabled.value).toBe(false)
+    expect(quota.freeTierExecutionPermitted.value).toBe(false)
+  })
+
+  it('disallows free-tier execution when the graph contains credit badges', () => {
+    mockApp.graph = { rootGraph: {} }
+    mockGraphCreditsBadges.mockReturnValue([{}])
+
+    const quota = loadQuota()
+
+    expect(quota.quotaEnabled.value).toBe(true)
+    expect(quota.hasInvalidNodes.value).toBe(true)
     expect(quota.freeTierExecutionPermitted.value).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Stabilizes `useFreeTierQuota` tests by replacing an obsolete mock with narrow mocks for the production app and badge boundaries.

## Changes

- **What**: Import the composable once, dispose its shared Vue scope between tests, and mock `app`/`graphCreditsBadges` instead of traversing the full app/LiteGraph graph after every module reset.
- **Coverage**: Verify a nonempty credit-badge list keeps quota enabled while marking nodes invalid and disallowing free-tier execution.

## Review Focus

The test-body duration across three isolated runs dropped from 10.01s/8.52s/8.34s (the first test timed out at 5s in all three) to 15ms/10ms/10ms. Three shuffled seeds and a `CI=true` run passed without retries.

## Validation

- `pnpm test:unit src/platform/cloud/subscription/composables/useFreeTierQuota.test.ts`
- shuffled seeds: 17, 8188, 16967
- `pnpm typecheck`
- `pnpm knip`
- targeted ESLint, Oxlint, Vitest cleanup lint, and oxfmt