### PR TITLE
fix(telemetry): report desktop cloud notification failures

### DIFF
--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -28,12 +28,18 @@ const electron = {
   getPlatform: vi.fn(() => 'darwin')
 }
 
+const errorReporter = vi.hoisted(() => vi.fn())
+
 vi.mock('@/platform/distribution/types', () => ({
   isDesktop: true
 }))
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => settingStore
+}))
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: errorReporter
 }))
 
 vi.mock('@/services/dialogService', () => ({
@@ -122,6 +128,88 @@ describe('DesktopCloudNotificationController', () => {
 
     dialogOpen.resolve()
     await vi.advanceTimersByTimeAsync(0)
+
+    unmount()
+  })
+
+  it('reports a settings load failure without scheduling the notification', async () => {
+    const error = new Error('load failed')
+    settingStore.load.mockRejectedValue(error)
+
+    const { unmount } = render(DesktopCloudNotificationController)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(errorReporter).toHaveBeenCalledWith(error, {
+      errorType: 'cloud_notification_settings_load_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'cloud',
+        operation: 'load',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: { platform: 'darwin', is_disposed: false },
+      level: 'error'
+    })
+    expect(settingStore.set).not.toHaveBeenCalled()
+    expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('reports a notification failure and resets its shown state', async () => {
+    const error = new Error('show failed')
+    dialogService.showCloudNotification.mockRejectedValue(error)
+
+    const { unmount } = render(DesktopCloudNotificationController)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(errorReporter).toHaveBeenCalledWith(error, {
+      errorType: 'cloud_notification_show_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'cloud',
+        operation: 'render',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: { platform: 'darwin', is_disposed: false },
+      level: 'error'
+    })
+    expect(settingStore.set).toHaveBeenLastCalledWith(
+      'Comfy.Desktop.CloudNotificationShown',
+      false
+    )
+
+    unmount()
+  })
+
+  it('reports a failure to reset the notification shown state', async () => {
+    const showError = new Error('show failed')
+    const resetError = new Error('reset failed')
+    dialogService.showCloudNotification.mockRejectedValue(showError)
+    settingStore.set.mockImplementation(
+      async (_key: string, value: boolean) => {
+        if (!value) throw resetError
+        settingState.shown = value
+      }
+    )
+
+    const { unmount } = render(DesktopCloudNotificationController)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(errorReporter).toHaveBeenNthCalledWith(2, resetError, {
+      errorType: 'cloud_notification_state_reset_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'cloud',
+        operation: 'save',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: { platform: 'darwin', is_disposed: false },
+      level: 'error'
+    })
 
     unmount()
   })

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
@@ -3,6 +3,7 @@ import { onMounted, onUnmounted } from 'vue'
 
 import { isDesktop } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useDialogService } from '@/services/dialogService'
 import { electronAPI } from '@/utils/envUtil'
 
@@ -13,12 +14,24 @@ let isDisposed = false
 let cloudNotificationTimer: ReturnType<typeof setTimeout> | undefined
 
 async function scheduleCloudNotification() {
-  if (!isDesktop || electronAPI()?.getPlatform() !== 'darwin') return
+  const platform = electronAPI()?.getPlatform()
+  if (!isDesktop || platform !== 'darwin') return
 
   try {
     await settingStore.load()
   } catch (error) {
-    console.warn('[CloudNotification] Failed to load settings', error)
+    reportError(error, {
+      errorType: 'cloud_notification_settings_load_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'cloud',
+        operation: 'load',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: { platform, is_disposed: isDisposed },
+      level: 'error'
+    })
     return
   }
 
@@ -33,14 +46,33 @@ async function scheduleCloudNotification() {
       if (isDisposed) return
       await dialogService.showCloudNotification()
     } catch (error) {
-      console.warn('[CloudNotification] Failed to show', error)
+      reportError(error, {
+        errorType: 'cloud_notification_show_failed',
+        tags: {
+          failure_kind: 'caught_unexpected',
+          feature_area: 'cloud',
+          operation: 'render',
+          outcome: 'failed',
+          assert_mode: 'soft'
+        },
+        context: { platform, is_disposed: isDisposed },
+        level: 'error'
+      })
       await settingStore
         .set('Comfy.Desktop.CloudNotificationShown', false)
         .catch((resetError) => {
-          console.warn(
-            '[CloudNotification] Failed to reset shown state',
-            resetError
-          )
+          reportError(resetError, {
+            errorType: 'cloud_notification_state_reset_failed',
+            tags: {
+              failure_kind: 'caught_unexpected',
+              feature_area: 'cloud',
+              operation: 'save',
+              outcome: 'failed',
+              assert_mode: 'soft'
+            },
+            context: { platform, is_disposed: isDisposed },
+            level: 'error'
+          })
         })
     }
   }, 2000)


### PR DESCRIPTION
Desktop cloud-notification failures now emit durable, privacy-safe telemetry.

<details><summary>Full context for agent readers</summary>

## Summary

Replace three console-only macOS Desktop cloud-notification failure paths with structured `reportError` events while preserving the existing abort and shown-state reset behavior.

## Changes

- `DesktopCloudNotificationController.vue:20` → `cloud_notification_settings_load_failed`
- `DesktopCloudNotificationController.vue:47` → `cloud_notification_show_failed`
- `DesktopCloudNotificationController.vue:62` → `cloud_notification_state_reset_failed`
- Emit the `caught_unexpected` alert family with only bounded `platform` and `is_disposed` context.
- Add focused coverage for each failure and the existing fallback behavior.

## Review Focus

Each event uses `feature_area: cloud`, `outcome: failed`, `assert_mode: soft`, level `error`, and the operation appropriate to its boundary (`load`, `render`, or `save`). No settings values, identifiers, paths, prompts, tokens, or raw errors enter tags or context. The canonical telemetry registry remains in the existing ADR carrier, #16784, so this PR does not duplicate that ADR.

## Evidence

- `pnpm test:unit src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts` — 6/6 passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed with pre-existing repository warnings only (0 errors).
- `pnpm knip` — passed in the pre-push hook.
- `pnpm exec oxfmt --check src/platform/cloud/notification/components/DesktopCloudNotificationController.vue src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts` — passed.
- `git diff --check` — passed.

</details>

<!-- authored-by:agent lane-tele-13-1607 -->
