### PR TITLE
test: make timer-setup storage cleanup safe under Node 25 built-in webstorage

### DIFF
--- a/scripts/vitestTimerSetup.webstorage.test.ts
+++ b/scripts/vitestTimerSetup.webstorage.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * vitest.timer.setup.ts clears storage between tests. Node >= 25 enables the
+ * Web Storage API by default, and its built-in `localStorage` object has no
+ * `clear()` unless `--localstorage-file` points at a valid path. A test
+ * environment that does not replace the global (a `node` environment, or a
+ * worker where the happy-dom environment failed to load) therefore crashes
+ * every file in the suite with
+ * `TypeError: globalThis.localStorage?.clear is not a function` if the setup
+ * uses a plain `clear()` call. The `?.()` optional call keeps happy-dom
+ * cleanup intact (its Storage always has `clear()`) and degrades to a no-op
+ * against the Node built-in.
+ *
+ * These checks pin both halves of that contract: the setup file must use the
+ * environment-safe call, and the safe form must not throw against the real
+ * Node runtime in a child process.
+ */
+describe('vitest.timer.setup.ts storage cleanup is environment-safe', () => {
+  it('uses the optional clear call for localStorage', () => {
+    const setup = readFileSync(
+      resolve(process.cwd(), 'vitest.timer.setup.ts'),
+      'utf8'
+    )
+
+    expect(setup).toContain('globalThis.localStorage?.clear?.()')
+    expect(setup).not.toContain('globalThis.localStorage?.clear()')
+  })
+
+  it('the cleanup form does not throw against the real Node runtime', () => {
+    // Runs in a fresh child process so the check observes the platform's
+    // built-in webstorage rather than the happy-dom environment vitest
+    // installs for this file.
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        ['-e', 'globalThis.localStorage?.clear?.()'],
+        {
+          stdio: 'ignore'
+        }
+      )
+    ).not.toThrow()
+  })
+})

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, vi } from 'vitest'
 beforeEach(() => {
   globalThis.document?.body.replaceChildren()
   globalThis.window?.history.replaceState({}, '', '/')
-  globalThis.localStorage?.clear()
+  // Node >= 25 enables the Web Storage API by default, and its built-in
+  // localStorage object has no clear() unless --localstorage-file points at a
+  // valid path. Test files run under whatever environment each declares, so
+  // the lookup can see the Node built-in instead of happy-dom's Storage; skip
+  // cleanup there rather than crashing the whole file (same optional-call
+  // style as the document/window lookups above).
+  globalThis.localStorage?.clear?.()
   globalThis.sessionStorage?.clear()
   vi.useFakeTimers()
 })


### PR DESCRIPTION
## What

`vitest.timer.setup.ts` cleared storage with `globalThis.localStorage?.clear()`. On Node >= 25 the Web Storage API is enabled by default, and the built-in `localStorage` object has **no `clear()`** unless `--localstorage-file` points at a valid path (`typeof globalThis.localStorage.clear` → `"undefined"`, with the warning `--localstorage-file was provided without a valid path`). Any test environment that does not replace the global — a per-file `node` environment, or a worker where the happy-dom environment fails to load — crashes the setup file and every file in the run with:

```
TypeError: globalThis.localStorage?.clear is not a function
```

This all-red failure mode was observed on 2026-09-04 in three separate checkouts on one machine while the happy-dom override was unavailable; `NODE_OPTIONS=--no-experimental-webstorage` was the only recovery.

## Change

Use the optional call, matching the `document?.` / `window?.` style already in this file:

- happy-dom Storage semantics are unchanged (`clear()` exists there, cleanup still runs — exercised by the whole existing suite);
- environments exposing the Node built-in degrade to a no-op instead of killing the suite.

## Regression check

New `scripts/vitestTimerSetup.webstorage.test.ts` pins both halves of the contract:

1. the setup file uses the environment-safe `localStorage?.clear?.()` form;
2. that form does not throw against the real Node runtime (executed in a child process, outside the happy-dom environment).

## Verification

- `env -u NODE_OPTIONS pnpm test:unit scripts/vitestTimerSetup.webstorage.test.ts src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts` → 56/56
- same with `NODE_OPTIONS=--no-experimental-webstorage` → 56/56
- `pnpm typecheck` → clean
- `oxlint` (0 warnings/errors) + `oxfmt --check` on the changed files → clean
- full `pnpm test:unit` at base `e6be49f53`: 1490 files / 20149 tests pass (3 pre-existing timing-flake failures unrelated to storage)