### PR TITLE
fix(ci): validate backports with mergedAt

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -52,13 +52,12 @@ jobs:
           # Validate PR exists and is merged. The gh error is surfaced rather
           # than discarded: an auth failure and a genuinely missing PR are
           # indistinguishable once it is swallowed.
-          if ! PR_VIEW_ERR=$(gh pr view "${{ inputs.pr_number }}" --json merged 2>&1 >/dev/null); then
-            echo "::error::PR #${{ inputs.pr_number }} not found or inaccessible: ${PR_VIEW_ERR}"
+          if ! MERGED_AT=$(gh pr view "${{ inputs.pr_number }}" --json mergedAt --jq '.mergedAt' 2>&1); then
+            echo "::error::PR #${{ inputs.pr_number }} not found or inaccessible: ${MERGED_AT}"
             exit 1
           fi
 
-          MERGED=$(gh pr view "${{ inputs.pr_number }}" --json merged --jq '.merged')
-          if [ "$MERGED" != "true" ]; then
+          if [ -z "$MERGED_AT" ]; then
             echo "::error::PR #${{ inputs.pr_number }} is not merged. Only merged PRs can be backported."
             exit 1
           fi

--- a/scripts/cicd/pr-backport-workflow.test.ts
+++ b/scripts/cicd/pr-backport-workflow.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  run?: string
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>
+}
+
+describe('PR backport workflow', () => {
+  it('uses a supported field to validate merged pull requests', () => {
+    const workflow = parse(
+      readFileSync('.github/workflows/pr-backport.yaml', 'utf8')
+    ) as Workflow
+    const validationScript = workflow.jobs?.backport.steps?.find(
+      (step) => step.name === 'Validate inputs for manual triggers'
+    )?.run
+
+    expect(validationScript).toContain('--json mergedAt')
+    expect(validationScript).not.toMatch(/--json merged(?:\s|$)/)
+  })
+})


### PR DESCRIPTION
## Summary

Restores manual PR backport dispatches by querying the supported `mergedAt` field instead of the unsupported `merged` field.

## Changes

- **What**: Validate merged PRs from a non-null `mergedAt`; add a workflow regression test that rejects `--json merged`.

## Review Focus

Confirm manual dispatch reports inaccessible, unmerged, and merged PRs distinctly.

Red-main evidence: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33892240975/job/101086446967