### PR TITLE
test: localize AgentPanelRoot timer ownership

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -3,8 +3,13 @@ import { fromPartial } from '@total-typescript/shoehorn'
 
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createPinia,
+  disposePinia,
+  getActivePinia,
+  setActivePinia
+} from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 
 // jsdom does not implement ResizeObserver (happy-dom does); stub it before the
@@ -294,6 +299,7 @@ import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTab
 import AgentPanelRoot from './AgentPanelRoot.vue'
 
 beforeEach(() => {
+  vi.useRealTimers()
   Element.prototype.scrollIntoView = vi.fn()
   URL.createObjectURL = vi.fn(() => 'blob:mock-url')
   URL.revokeObjectURL = vi.fn()
@@ -314,6 +320,11 @@ beforeEach(() => {
   workflowService.saveWorkflowAs.mockClear()
   workflowService.openWorkflow.mockClear()
   focusNodeInstance.mockReset()
+})
+
+afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
@@ -2092,12 +2103,13 @@ describe('AgentPanelRoot workflow binding', () => {
       })
     )
 
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     await renderAndSend('work here')
+    vi.useFakeTimers({ shouldAdvanceTime: false })
 
     const activity = useWorkflowTabActivityStore()
     expect(activity.creatingTab).toBe(false)
 
-    vi.useFakeTimers()
     ws.emit('agent_active_tab', {
       workflow_id: 'wf-new',
       name: 'Fresh',
@@ -2115,7 +2127,6 @@ describe('AgentPanelRoot workflow binding', () => {
     await vi.advanceTimersByTimeAsync(1)
     expect(activity.creatingTab).toBe(false)
     expect(hostStores.workflow.tabs.get('workflows/Fresh.json')).toBeDefined()
-    vi.useRealTimers()
   })
 
   it('lowers the creating flag when a newer focus event supersedes the fetch', async () => {


### PR DESCRIPTION
## Summary

Use real timers by default in `AgentPanelRoot.test.ts` and keep fake timers local to the 500 ms tab-creation contract.

## Changes

- **What**: Opt the file's ordinary interaction tests out of the globally auto-advancing fake clock. The one timer-contract test owns its fake clock, switches to manual advancement for the 499/500 ms boundary, and relies on Vitest's standard cleanup to restore real timers. Dispose each test's active Pinia so its real `useTimestamp` interval cannot leak.

## Review focus

This changes timer ownership only in `AgentPanelRoot.test.ts`. It does not migrate the rest of the suite away from global fake timers.

Three sequential local runs on the same orb:

- File test time median: 41.374 s before, 21.191 s after (48.8% lower).
- Process wall time median: 52.890 s before, 34.240 s after (35.3% lower).
- Raw file times: 41.557/41.374/41.360 s before, 20.933/22.151/21.191 s after.

All 118 tests passed in each normal run and with shuffled seeds 1701, 2903, and 4127. Typecheck, targeted ESLint/Oxlint/format, and Knip pass. Vitest's async-leak detector reports the same eight import/plugin promises before and after, with no timer leaks after this change.