### PR TITLE
test: clean up subgraph promotion expected failures

### DIFF
--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
-import { TestIds } from '@e2e/fixtures/selectors'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 import {
   getPromotedWidgetNames,
@@ -180,42 +179,7 @@ test.describe(
     )
 
     test.describe('Promoted Widget Reactivity', { tag: ['@vue-nodes'] }, () => {
-      test.fail(
-        'Promoted and interior widgets stay in sync across navigation',
-        async ({ comfyPage }) => {
-          await comfyPage.workflow.loadWorkflow(
-            'subgraphs/subgraph-with-promoted-text-widget'
-          )
-
-          const testContent = 'promoted-value-sync-test'
-
-          const promotedTextarea = comfyPage.vueNodes
-            .getNodeLocator('11')
-            .getByRole('textbox', { name: 'text' })
-          await promotedTextarea.fill(testContent)
-
-          await comfyPage.vueNodes.enterSubgraph('11')
-
-          const interiorTextarea = comfyPage.page
-            .locator('[data-node-id]')
-            .getByRole('textbox', { name: 'text' })
-            .first()
-          await expect(interiorTextarea).toHaveValue(testContent)
-
-          const updatedInteriorContent = 'interior-value-sync-test'
-          await interiorTextarea.fill(updatedInteriorContent)
-
-          await comfyPage.subgraph.exitViaBreadcrumb()
-
-          await expect(
-            comfyPage.vueNodes
-              .getNodeLocator('11')
-              .getByRole('textbox', { name: 'text' })
-          ).toHaveValue(updatedInteriorContent)
-        }
-      )
-
-      // Open bug #14495 — drop `test.fail` when the fix lands.
+      // https://github.com/Comfy-Org/ComfyUI_frontend/issues/14495
       test('Promoted STRING widget edit survives a rebind of the interior link', async ({
         comfyPage
       }) => {
@@ -605,7 +569,7 @@ test.describe(
       })
     })
 
-    test.fail(
+    test(
       'Promoted text widget is removed when source node is deleted inside the subgraph',
       { tag: '@vue-nodes' },
       async ({ comfyPage }) => {
@@ -629,7 +593,7 @@ test.describe(
           .poll(() => getPromotedWidgetNames(comfyPage, subgraphNodeId))
           .toContain('text')
         await expect(
-          subgraphNode.getByTestId(TestIds.widgets.domWidgetTextarea)
+          subgraphNode.getByRole('textbox', { name: 'text' })
         ).toBeVisible()
 
         await comfyPage.vueNodes.enterSubgraph(subgraphNodeId)
@@ -646,7 +610,7 @@ test.describe(
           comfyPage.vueNodes.getNodeLocator(subgraphNodeId)
         await expect(subgraphNodeAfter).toBeVisible()
         await expect(
-          subgraphNodeAfter.getByTestId(TestIds.widgets.domWidgetTextarea)
+          subgraphNodeAfter.getByRole('textbox', { name: 'text' })
         ).toBeHidden()
       }
     )


### PR DESCRIPTION
## Summary

Remove obsolete or invalid expected failures from the subgraph promotion browser tests.

## Changes

- **What**: Remove the obsolete host-to-interior widget sync test because the widgets are separate entities.
- **What**: Replace stale test-id locators with semantic textbox locators and restore the passing source-node deletion test.
- **What**: Link the remaining promoted-widget rebind failure to issue #14495.

## Review Focus

Confirm that the source-node deletion test now reaches its final assertion and that #14495 remains scoped to host-value preservation across a rebind.