### PR TITLE
fix(ci): PR Backport cleanup fails because gh pr edit needs read:org, which PR_GH_TOKEN lacks

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -383,7 +383,13 @@ jobs:
 
               if [ -n "${PR_NUM}" ]; then
                 if [ "${PR_AUTHOR_IS_BOT}" != "true" ]; then
-                  gh pr edit "${PR_NUM}" --add-assignee "${PR_AUTHOR}" \
+                  # REST, not `gh pr edit`: that command resolves `author`,
+                  # `assignees` and team `slug`/`name` over GraphQL, which needs
+                  # `read:org`. PR_GH_TOKEN does not carry it, so every
+                  # `gh pr edit` here failed and backports went unassigned.
+                  gh api --silent --method POST \
+                    "repos/${{ github.repository }}/issues/${PR_NUM}/assignees" \
+                    -f "assignees[]=${PR_AUTHOR}" \
                     || echo "::warning::Failed to assign @${PR_AUTHOR} to PR #${PR_NUM}"
                 fi
                 gh pr merge "${PR_NUM}" --auto --squash --repo "${{ github.repository }}" \
@@ -541,4 +547,28 @@ jobs:
 
       - name: Remove needs-backport label
         if: steps.filter-targets.outputs.skip != 'true' && success()
-        run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
+        env:
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          # REST, not `gh pr edit --remove-label`: that command resolves label
+          # and team `slug`/`name` fields over GraphQL, which needs `read:org`.
+          # PR_GH_TOKEN does not carry that scope, so this step failed after
+          # every otherwise-successful backport — reddening a job whose
+          # backport PRs had already been created, and leaving the label on,
+          # which re-arms the `labeled` trigger.
+          set -euo pipefail
+
+          # Read the labels into a variable first rather than piping straight
+          # into grep: under a pipe, a failed read is indistinguishable from a
+          # PR that simply does not carry the label, and would exit 0 here.
+          LABELS=$(gh api --paginate \
+            "repos/${GH_REPO}/issues/${PR_NUMBER}/labels" --jq '.[].name')
+
+          if ! printf '%s\n' "${LABELS}" | grep -qx 'needs-backport'; then
+            echo "Label 'needs-backport' already absent from PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          gh api --silent --method DELETE \
+            "repos/${GH_REPO}/issues/${PR_NUMBER}/labels/needs-backport"

--- a/scripts/cicd/backport-token-scopes.test.ts
+++ b/scripts/cicd/backport-token-scopes.test.ts
@@ -87,11 +87,14 @@ const labelStepViolations = (run: string): string[] => {
   const code = stripComments(run)
   const violations: string[] = []
 
-  const read = code.search(/\w+=\$\(\s*gh api/)
+  const labelRead = code.match(
+    /\b([A-Za-z_]\w*)=\$\(\s*gh api[^)]*["'][^"'\n]*\/labels["'][^)]*\)/
+  )
+  const read = labelRead?.index ?? -1
   const check = code.search(/grep -qx ['"]needs-backport['"]/)
   const del = code.search(/gh api[^\n]*--method DELETE/)
   const absentBranch = code.match(
-    /^\s*if\s+!\s+[^\n]*grep -qx ['"]needs-backport['"][^\n]*;\s*then\s*$([\s\S]*?)^\s*fi\s*$/m
+    /^\s*if\s+!\s+[^\n]*printf[^\n]*\$\{?([A-Za-z_]\w*)\}?[^\n]*\|\s*grep -qx ['"]needs-backport['"][^\n]*;\s*then\s*$([\s\S]*?)^\s*fi\s*$/m
   )
 
   if (!/^\s*set -euo pipefail\s*$/m.test(code)) {
@@ -102,6 +105,9 @@ const labelStepViolations = (run: string): string[] => {
   }
   if (check === -1) {
     violations.push('does not test for the needs-backport label')
+  }
+  if (labelRead && absentBranch && labelRead[1] !== absentBranch[1]) {
+    violations.push('does not check the fetched label list')
   }
   if (del === -1) {
     violations.push('does not delete the label over REST')
@@ -122,7 +128,7 @@ const labelStepViolations = (run: string): string[] => {
   if (check !== -1 && del !== -1 && check > del) {
     violations.push('deletes the label before checking for it')
   }
-  if (!absentBranch || !/^\s*exit 0\s*$/m.test(absentBranch[1])) {
+  if (!absentBranch || !/^\s*exit 0\s*$/m.test(absentBranch[2])) {
     violations.push('does not exit 0 inside the absent-label branch')
   } else if (
     del !== -1 &&
@@ -203,6 +209,11 @@ describe('backport workflow token scopes', () => {
       'exits when the label is present',
       `set -euo pipefail\nLABELS=$(gh api "$R/labels" --jq '.[].name')\nif printf '%s\\n' "$LABELS" | grep -qx 'needs-backport'; then\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
       'does not exit 0 inside the absent-label branch'
+    ],
+    [
+      'checks a variable other than the fetched label list',
+      `set -euo pipefail\nLABELS=$(gh api "$R/labels" --jq '.[].name')\nif ! printf '%s\\n' "$OTHER" | grep -qx 'needs-backport'; then\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
+      'does not check the fetched label list'
     ]
   ])('rejects a cleanup step that %s', ([, script, expected]) => {
     expect(labelStepViolations(script)).toContain(expected)

--- a/scripts/cicd/backport-token-scopes.test.ts
+++ b/scripts/cicd/backport-token-scopes.test.ts
@@ -90,7 +90,9 @@ const labelStepViolations = (run: string): string[] => {
   const read = code.search(/\w+=\$\(\s*gh api/)
   const check = code.search(/grep -qx ['"]needs-backport['"]/)
   const del = code.search(/gh api[^\n]*--method DELETE/)
-  const earlyExit = code.search(/^\s*exit 0\s*$/m)
+  const absentBranch = code.match(
+    /^\s*if\s+!\s+[^\n]*grep -qx ['"]needs-backport['"][^\n]*;\s*then\s*$([\s\S]*?)^\s*fi\s*$/m
+  )
 
   if (!/^\s*set -euo pipefail\s*$/m.test(code)) {
     violations.push('does not set -euo pipefail')
@@ -120,12 +122,16 @@ const labelStepViolations = (run: string): string[] => {
   if (check !== -1 && del !== -1 && check > del) {
     violations.push('deletes the label before checking for it')
   }
-  // An already-absent label is the desired end state, so the step short-circuits
-  // rather than letting the DELETE 404 fail the job under `set -e`.
-  if (earlyExit === -1) {
-    violations.push('does not exit 0 when the label is already absent')
-  } else if (del !== -1 && earlyExit > del) {
-    violations.push('exits early only after it has already deleted')
+  if (!absentBranch || !/^\s*exit 0\s*$/m.test(absentBranch[1])) {
+    violations.push('does not exit 0 inside the absent-label branch')
+  } else if (
+    del !== -1 &&
+    absentBranch.index !== undefined &&
+    del < absentBranch.index + absentBranch[0].length
+  ) {
+    violations.push(
+      'deletes the label before the absent-label branch completes'
+    )
   }
 
   return violations
@@ -192,6 +198,11 @@ describe('backport workflow token scopes', () => {
       'omits strict shell mode',
       `LABELS=$(gh api "$R/labels" --jq '.[].name')\nif ! printf '%s\\n' "$LABELS" | grep -qx 'needs-backport'; then\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
       'does not set -euo pipefail'
+    ],
+    [
+      'exits when the label is present',
+      `set -euo pipefail\nLABELS=$(gh api "$R/labels" --jq '.[].name')\nif printf '%s\\n' "$LABELS" | grep -qx 'needs-backport'; then\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
+      'does not exit 0 inside the absent-label branch'
     ]
   ])('rejects a cleanup step that %s', ([, script, expected]) => {
     expect(labelStepViolations(script)).toContain(expected)

--- a/scripts/cicd/backport-token-scopes.test.ts
+++ b/scripts/cicd/backport-token-scopes.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `gh pr edit` resolves `author`, `assignees`, `labels` and team `slug`/`name`
+ * over GraphQL, and GitHub requires `read:org` for those fields. PR_GH_TOKEN
+ * carries `repo`/`workflow` but not `read:org`, so every `gh pr edit` in the
+ * backport path failed:
+ *
+ *   - `--add-assignee` was guarded by `|| echo ::warning`, so backport PRs
+ *     silently went unassigned for as long as the token lacked the scope.
+ *   - `--remove-label` was unguarded, so it failed the whole job *after* the
+ *     backport PRs had already been created, and left `needs-backport` on the
+ *     source PR — which re-arms the workflow's own `labeled` trigger.
+ *
+ * The equivalent REST endpoints need only `repo`. This pins the workflows that
+ * run under PR_GH_TOKEN to REST so the scope requirement cannot creep back in.
+ */
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  run?: string
+  env?: Record<string, string>
+}
+
+interface WorkflowJob {
+  env?: Record<string, string>
+  steps?: WorkflowStep[]
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>
+}
+
+/** `gh pr edit` subcommands whose GraphQL selection requires `read:org`. */
+const ORG_SCOPED_FLAGS = [
+  '--add-assignee',
+  '--remove-assignee',
+  '--add-label',
+  '--remove-label'
+]
+
+const WORKFLOW = '.github/workflows/pr-backport.yaml'
+
+const readWorkflow = (path: string) =>
+  parse(readFileSync(path, 'utf8')) as Workflow
+
+/**
+ * Full-line `#` comments are dropped so the guard reads executable shell only.
+ * Without this, the comment explaining *why* a step avoids `gh pr edit` would
+ * itself trip the check. Trailing `#` is deliberately left alone: it occurs
+ * inside strings here (`"PR #${PR_NUM}"`) and stripping it would corrupt them.
+ */
+const stripComments = (run: string) =>
+  run
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n')
+
+const runScripts = (workflow: Workflow) =>
+  Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .filter((step) => typeof step.run === 'string')
+    .map((step) => ({
+      name: step.name ?? '<unnamed step>',
+      run: stripComments(step.run!)
+    }))
+
+describe('backport workflow token scopes', () => {
+  it('runs under PR_GH_TOKEN, which does not carry read:org', () => {
+    const workflow = readWorkflow(WORKFLOW)
+    const job = workflow.jobs?.backport
+
+    expect(job?.env?.GH_TOKEN).toBe(
+      '${{ secrets.PR_GH_TOKEN || secrets.GH_TOKEN }}'
+    )
+  })
+
+  // On failure this reports the offending step names. The remedy is the REST
+  // equivalent: `gh api .../issues/{n}/assignees` or `.../labels/{name}`.
+  it.for(ORG_SCOPED_FLAGS)('never reaches for `gh pr edit %s`', (flag) => {
+    const offenders = runScripts(readWorkflow(WORKFLOW))
+      .filter(({ run }) => /\bgh pr edit\b/.test(run) && run.includes(flag))
+      .map(({ name }) => name)
+
+    expect(offenders).toEqual([])
+  })
+
+  it('assigns the backport PR through the REST assignees endpoint', () => {
+    const step = runScripts(readWorkflow(WORKFLOW)).find(({ run }) =>
+      run.includes('/assignees')
+    )
+
+    expect(step).toBeDefined()
+    expect(step!.run).toMatch(/gh api[^\n]*--method POST/)
+    expect(step!.run).toContain('issues/${PR_NUM}/assignees')
+  })
+
+  it('removes needs-backport through the REST labels endpoint, tolerating an already-absent label', () => {
+    const workflow = readWorkflow(WORKFLOW)
+    const step = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .find((step) => step.name === 'Remove needs-backport label')
+
+    expect(step).toBeDefined()
+
+    const run = step!.run ?? ''
+    expect(run).toMatch(/gh api[^\n]*--method DELETE/)
+    expect(run).toContain('labels/needs-backport')
+    // A label that is already gone is the desired end state, not a failure:
+    // the delete endpoint 404s in that case and `bash -e` would fail the job.
+    expect(run).toContain('already absent')
+    expect(run).toMatch(/exit 0/)
+  })
+})

--- a/scripts/cicd/backport-token-scopes.test.ts
+++ b/scripts/cicd/backport-token-scopes.test.ts
@@ -67,6 +67,70 @@ const runScripts = (workflow: Workflow) =>
       run: stripComments(step.run!)
     }))
 
+const labelStepRun = () => {
+  const step = Object.values(readWorkflow(WORKFLOW).jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .find((step) => step.name === 'Remove needs-backport label')
+
+  expect(step).toBeDefined()
+  return step!.run ?? ''
+}
+
+/**
+ * The cleanup step's contract is an *order*, not a set of substrings: read the
+ * label list, decide from what was read, and only then delete. Asserting the
+ * pieces individually would pass on a script that deletes first, or that calls
+ * the label absent before reading anything. Each negative control below trips
+ * exactly one of these.
+ */
+const labelStepViolations = (run: string): string[] => {
+  const code = stripComments(run)
+  const violations: string[] = []
+
+  const read = code.search(/\w+=\$\(\s*gh api/)
+  const check = code.search(/grep -qx ['"]needs-backport['"]/)
+  const del = code.search(/gh api[^\n]*--method DELETE/)
+  const earlyExit = code.search(/^\s*exit 0\s*$/m)
+
+  if (!/^\s*set -euo pipefail\s*$/m.test(code)) {
+    violations.push('does not set -euo pipefail')
+  }
+  if (read === -1) {
+    violations.push('does not read the label list into a variable')
+  }
+  if (check === -1) {
+    violations.push('does not test for the needs-backport label')
+  }
+  if (del === -1) {
+    violations.push('does not delete the label over REST')
+  }
+  if (!code.includes('labels/needs-backport')) {
+    violations.push('does not target the needs-backport label endpoint')
+  }
+  // A failed read must not read as "absent": under a pipe the exit status is
+  // grep's, so an API error would take the already-absent branch and exit 0.
+  if (/gh api[^\n|]*\|\s*grep/.test(code)) {
+    violations.push(
+      'pipes the label read straight into grep, so a failed read reads as absence'
+    )
+  }
+  if (read !== -1 && check !== -1 && read > check) {
+    violations.push('checks for the label before reading it')
+  }
+  if (check !== -1 && del !== -1 && check > del) {
+    violations.push('deletes the label before checking for it')
+  }
+  // An already-absent label is the desired end state, so the step short-circuits
+  // rather than letting the DELETE 404 fail the job under `set -e`.
+  if (earlyExit === -1) {
+    violations.push('does not exit 0 when the label is already absent')
+  } else if (del !== -1 && earlyExit > del) {
+    violations.push('exits early only after it has already deleted')
+  }
+
+  return violations
+}
+
 describe('backport workflow token scopes', () => {
   it('runs under PR_GH_TOKEN, which does not carry read:org', () => {
     const workflow = readWorkflow(WORKFLOW)
@@ -98,19 +162,38 @@ describe('backport workflow token scopes', () => {
   })
 
   it('removes needs-backport through the REST labels endpoint, tolerating an already-absent label', () => {
-    const workflow = readWorkflow(WORKFLOW)
-    const step = Object.values(workflow.jobs ?? {})
-      .flatMap((job) => job.steps ?? [])
-      .find((step) => step.name === 'Remove needs-backport label')
+    expect(labelStepViolations(labelStepRun())).toEqual([])
+  })
 
-    expect(step).toBeDefined()
-
-    const run = step!.run ?? ''
-    expect(run).toMatch(/gh api[^\n]*--method DELETE/)
-    expect(run).toContain('labels/needs-backport')
-    // A label that is already gone is the desired end state, not a failure:
-    // the delete endpoint 404s in that case and `bash -e` would fail the job.
-    expect(run).toContain('already absent')
-    expect(run).toMatch(/exit 0/)
+  // Negative controls. Substring assertions alone would pass on every one of
+  // these, which is why the contract above is expressed as ordering.
+  it.for([
+    [
+      'decides from a label list it never read',
+      `set -euo pipefail\nif ! printf '%s\\n' "$LABELS" | grep -qx 'needs-backport'; then\n  echo "already absent"\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
+      'does not read the label list into a variable'
+    ],
+    [
+      'reads the label list only after deciding from it',
+      `set -euo pipefail\nif ! printf '%s\\n' "$LABELS" | grep -qx 'needs-backport'; then\n  echo "already absent"\n  exit 0\nfi\nLABELS=$(gh api "$R/labels" --jq '.[].name')\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
+      'checks for the label before reading it'
+    ],
+    [
+      'deletes first and checks afterwards',
+      `set -euo pipefail\ngh api --silent --method DELETE "$R/labels/needs-backport"\nLABELS=$(gh api "$R/labels" --jq '.[].name')\nprintf '%s\\n' "$LABELS" | grep -qx 'needs-backport'`,
+      'deletes the label before checking for it'
+    ],
+    [
+      'treats a failed label read as absence by piping into grep',
+      `set -euo pipefail\nif ! gh api "$R/labels" --jq '.[].name' | grep -qx 'needs-backport'; then\n  echo "already absent"\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
+      'pipes the label read straight into grep, so a failed read reads as absence'
+    ],
+    [
+      'omits strict shell mode',
+      `LABELS=$(gh api "$R/labels" --jq '.[].name')\nif ! printf '%s\\n' "$LABELS" | grep -qx 'needs-backport'; then\n  exit 0\nfi\ngh api --silent --method DELETE "$R/labels/needs-backport"`,
+      'does not set -euo pipefail'
+    ]
+  ])('rejects a cleanup step that %s', ([, script, expected]) => {
+    expect(labelStepViolations(script)).toContain(expected)
   })
 })


### PR DESCRIPTION
## Summary

Every `gh pr edit` call in `PR Backport` runs under `PR_GH_TOKEN`, which carries `repo`/`workflow` but not `read:org`. `gh pr edit` resolves `author`, `assignees`, `labels` and team `slug`/`name` over GraphQL, and GitHub requires `read:org` for those fields, so the calls fail unconditionally. This swaps them for the equivalent REST endpoints, which need only `repo`.

## Changes

- **`.github/workflows/pr-backport.yaml`** — replaces `gh pr edit --add-assignee` with `POST repos/{repo}/issues/{n}/assignees`, and `gh pr edit --remove-label` with a `GET` of the issue labels followed by `DELETE repos/{repo}/issues/{n}/labels/needs-backport`.
- The label step now runs under `set -euo pipefail` and reads the label list into a variable before matching it, rather than piping `gh api` straight into `grep` — under a pipe a failed read is indistinguishable from a PR that simply does not carry the label, and would exit 0. It exits early when the label is already absent, so the step is idempotent.
- **`scripts/cicd/backport-token-scopes.test.ts`** (new) — parses the workflow and asserts no step running under `PR_GH_TOKEN` uses an org-scoped `gh pr edit` flag (`--add-assignee`, `--remove-assignee`, `--add-label`, `--remove-label`), so the scope requirement cannot creep back in.

## Impact

The two call sites failed differently, which is why only one of them was visible:

- `--add-assignee` was guarded by `|| echo "::warning::..."`, so backport PRs silently went unassigned for as long as the token lacked the scope.
- `--remove-label` was unguarded, so it failed the whole job *after* the backport PRs had already been created, and left `needs-backport` on the source PR — which re-arms the workflow's own `labeled` trigger.

## Review Focus

Whether the early-exit branch in the label step is the behavior we want when `needs-backport` is already absent (it exits 0 rather than attempting the `DELETE` and tolerating a 404).

## Evidence

Failing run [33894812018](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33894812018) (job `101095073415`, step `Remove needs-backport label`), on source PR [#16725](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16725):

```
Run gh pr edit 16725 --remove-label "needs-backport"
GraphQL: Your token has not been granted the required scopes to execute this query.
The 'login' field requires one of the following scopes: ['read:org'], but your token
has only been granted the: ['codespace', 'delete:packages', 'delete_repo', 'project',
'repo', 'user', 'workflow', 'write:packages'] scopes.
##[error]Process completed with exit code 1.
```

The same run shows the guarded `--add-assignee` calls emitting the identical GraphQL scope error earlier in the job without failing it. Reproduced on run [33892334363](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33892334363), same failing step.
