### PR TITLE
fix: restore canvas lock after space-bar pan and add real-canvas selection harness

### DIFF
--- a/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
@@ -70,8 +70,7 @@ vi.mock(import('@/utils/colorUtil'), () => ({
 vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   getItemsColorOption: vi.fn(() => null),
   isLGraphNode: vi.fn((item) => item?.type === 'LGraphNode'),
-  isLGraphGroup: vi.fn((item) => item?.type === 'LGraphGroup'),
-  isReroute: vi.fn(() => false)
+  isLGraphGroup: vi.fn((item) => item?.type === 'LGraphGroup')
 }))
 
 describe('ColorPickerButton', () => {

--- a/src/lib/litegraph/src/LGraphCanvas.selection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.selection.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Positionable, Rect } from '@/lib/litegraph/src/interfaces'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+import {
+  LGraph,
+  LGraphCanvas,
+  LGraphGroup,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
+
+vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
+  layoutStore: {
+    querySlotAtPoint: vi.fn(),
+    queryRerouteAtPoint: vi.fn(),
+    queryLinkSegmentAtPoint: vi.fn(),
+    getNodeLayoutRef: vi.fn(() => ({ value: null })),
+    getNodeLayout: vi.fn(),
+    getSlotLayout: vi.fn(),
+    setSource: vi.fn(),
+    batchUpdateNodeBounds: vi.fn(),
+    applyOperation: vi.fn(),
+    allocateZIndex: vi.fn(() => 0),
+    readNodeRect: vi.fn(() => false),
+    contentSizeOf: vi.fn(),
+    getGroupLayout: vi.fn()
+  }
+}))
+
+type Modifiers = Partial<
+  Pick<MouseEventInit, 'shiftKey' | 'ctrlKey' | 'metaKey' | 'altKey'>
+>
+
+function createCanvas(graph: LGraph): LGraphCanvas {
+  const canvasElement = document.createElement('canvas')
+  canvasElement.width = 800
+  canvasElement.height = 600
+  canvasElement.getContext = vi
+    .fn()
+    .mockReturnValue(createMockCanvasRenderingContext2D())
+  canvasElement.getBoundingClientRect = vi.fn().mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 800,
+    height: 600
+  })
+  return new LGraphCanvas(canvasElement, graph, { skip_render: true })
+}
+
+function addNode(graph: LGraph, title: string, x: number, y: number) {
+  const node = new LGraphNode(title)
+  node.pos = [x, y]
+  node.size = [100, 60]
+  node.updateArea()
+  graph.add(node)
+  return node
+}
+
+function addGroup(graph: LGraph, title: string, bounds: Rect) {
+  const group = new LGraphGroup(title)
+  group._bounding.set(bounds)
+  graph.add(group)
+  return group
+}
+
+function pointerEvent(
+  type: 'pointerdown' | 'pointerup',
+  x: number,
+  y: number,
+  modifiers: Modifiers
+): PointerEvent {
+  const event = new MouseEvent(type, {
+    button: 0,
+    buttons: type === 'pointerdown' ? 1 : 0,
+    clientX: x,
+    clientY: y,
+    ...modifiers
+  })
+  Object.defineProperty(event, 'isPrimary', { value: true })
+  Object.defineProperty(event, 'pointerId', { value: 1 })
+  return event as PointerEvent
+}
+
+function click(
+  canvas: LGraphCanvas,
+  x: number,
+  y: number,
+  modifiers: Modifiers = {}
+) {
+  canvas.visible_nodes = [...canvas.graph!.nodes]
+  canvas.processMouseDown(pointerEvent('pointerdown', x, y, modifiers))
+  canvas.processMouseUp(pointerEvent('pointerup', x, y, modifiers))
+}
+
+function marquee(
+  canvas: LGraphCanvas,
+  from: [number, number],
+  to: [number, number],
+  modifiers: Modifiers
+) {
+  const initialSelection = new Set<Positionable>(canvas.selectedItems)
+  const dragRect: Rect = [from[0], from[1], to[0] - from[0], to[1] - from[1]]
+  const event = {
+    canvasX: to[0],
+    canvasY: to[1],
+    ...modifiers
+  } as CanvasPointerEvent
+  if (canvas.liveSelection) {
+    canvas['handleLiveSelect'](event, dragRect, initialSelection)
+  } else {
+    canvas['_handleMultiSelect'](event, dragRect)
+  }
+}
+
+function keyEvent(type: 'keydown' | 'keyup', key: string): KeyboardEvent {
+  const event = new KeyboardEvent(type, { key })
+  Object.defineProperty(event, 'target', { value: { localName: 'div' } })
+  return event
+}
+
+function selectedTitles(canvas: LGraphCanvas): string[] {
+  return [...canvas.selectedItems]
+    .map((item) => ('title' in item ? String(item.title) : String(item)))
+    .sort()
+}
+
+describe('LGraphCanvas selection', () => {
+  let graph: LGraph
+  let canvas: LGraphCanvas
+  let a: LGraphNode
+  let b: LGraphNode
+  let onSelectionChange: NonNullable<LGraphCanvas['onSelectionChange']>
+
+  beforeEach(() => {
+    LiteGraph.vueNodesMode = false
+    graph = new LGraph()
+    canvas = createCanvas(graph)
+    a = addNode(graph, 'A', 20, 40)
+    b = addNode(graph, 'B', 300, 40)
+    onSelectionChange = vi.fn()
+    canvas.onSelectionChange = onSelectionChange
+  })
+
+  describe('click', () => {
+    it.for<{ name: string; modifiers: Modifiers; expected: string[] }>([
+      { name: 'plain click replaces', modifiers: {}, expected: ['B'] },
+      {
+        name: 'shift click adds',
+        modifiers: { shiftKey: true },
+        expected: ['A', 'B']
+      },
+      {
+        name: 'ctrl click adds',
+        modifiers: { ctrlKey: true },
+        expected: ['A', 'B']
+      },
+      {
+        name: 'meta click adds',
+        modifiers: { metaKey: true },
+        expected: ['A', 'B']
+      }
+    ])('$name', ({ modifiers, expected }) => {
+      click(canvas, 60, 60)
+      click(canvas, 340, 60, modifiers)
+
+      expect(selectedTitles(canvas)).toEqual(expected)
+    })
+
+    it.fails('a replacing click reports one change', () => {
+      click(canvas, 60, 60)
+      click(canvas, 340, 60)
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(2)
+    })
+
+    it('ctrl click on a selected item removes it', () => {
+      click(canvas, 60, 60)
+      click(canvas, 340, 60, { ctrlKey: true })
+      click(canvas, 60, 60, { ctrlKey: true })
+
+      expect(selectedTitles(canvas)).toEqual(['B'])
+      expect(a.selected).toBe(false)
+    })
+
+    it('plain click on empty canvas clears', () => {
+      click(canvas, 60, 60)
+      click(canvas, 600, 500)
+
+      expect(canvas.selectedItems.size).toBe(0)
+      expect(a.selected).toBe(false)
+    })
+
+    it.fails('a clearing click reports one change', () => {
+      click(canvas, 60, 60)
+      click(canvas, 600, 500)
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(2)
+    })
+
+    it('modifier click on empty canvas keeps the selection', () => {
+      click(canvas, 60, 60)
+      click(canvas, 600, 500, { shiftKey: true })
+
+      expect(selectedTitles(canvas)).toEqual(['A'])
+    })
+
+    it('click on a group title selects the group only', () => {
+      const group = addGroup(graph, 'G', [0, 0, 500, 300])
+
+      click(canvas, 250, 10)
+
+      expect(selectedTitles(canvas)).toEqual(['G'])
+      expect(group.selected).toBe(true)
+      expect(a.selected).toBeFalsy()
+    })
+
+    it('click on a node inside a group selects the node only', () => {
+      addGroup(graph, 'G', [0, 0, 500, 300])
+
+      click(canvas, 60, 60)
+
+      expect(selectedTitles(canvas)).toEqual(['A'])
+    })
+
+    it('keeps item flags, selected_nodes and highlighted links aligned', () => {
+      a.addOutput('out', 'number')
+      b.addInput('in', 'number')
+      a.connect(0, b, 0)
+
+      click(canvas, 60, 60)
+      click(canvas, 340, 60, { shiftKey: true })
+      expect(Object.keys(canvas.highlighted_links)).toHaveLength(1)
+      expect(Object.keys(canvas.selected_nodes)).toHaveLength(2)
+
+      click(canvas, 600, 500)
+      expect(Object.keys(canvas.highlighted_links)).toHaveLength(0)
+      expect(Object.keys(canvas.selected_nodes)).toHaveLength(0)
+      expect(a.selected).toBe(false)
+      expect(b.selected).toBe(false)
+    })
+  })
+
+  describe('programmatic API', () => {
+    it.fails('select() reports the change', () => {
+      canvas.select(a)
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(1)
+    })
+
+    it.fails('deselect() reports the change', () => {
+      canvas.select(a)
+      canvas.deselect(a)
+
+      expect(onSelectionChange).toHaveBeenCalledTimes(2)
+    })
+
+    it('deselectAll() reports only when something was selected', () => {
+      canvas.deselectAll()
+      expect(onSelectionChange).not.toHaveBeenCalled()
+
+      canvas.select(a)
+      canvas.deselectAll()
+      expect(onSelectionChange).toHaveBeenCalledTimes(1)
+      expect(a.selected).toBe(false)
+    })
+  })
+
+  describe('marquee', () => {
+    beforeEach(() => {
+      addNode(graph, 'C', 300, 300)
+    })
+
+    describe.for([{ liveSelection: false }, { liveSelection: true }])(
+      'liveSelection=$liveSelection',
+      ({ liveSelection }) => {
+        beforeEach(() => {
+          canvas.liveSelection = liveSelection
+        })
+
+        it('plain marquee replaces the selection', () => {
+          click(canvas, 60, 60)
+
+          marquee(canvas, [250, 0], [450, 400], {})
+
+          expect(selectedTitles(canvas)).toEqual(['B', 'C'])
+          expect(a.selected).toBe(false)
+        })
+
+        it('shift marquee adds to the selection', () => {
+          click(canvas, 60, 60)
+
+          marquee(canvas, [250, 0], [450, 400], { shiftKey: true })
+
+          expect(selectedTitles(canvas)).toEqual(['A', 'B', 'C'])
+        })
+
+        it('alt marquee removes from the selection', () => {
+          click(canvas, 60, 60)
+          click(canvas, 340, 60, { shiftKey: true })
+          click(canvas, 340, 320, { shiftKey: true })
+
+          marquee(canvas, [250, 0], [450, 100], { altKey: true })
+
+          expect(selectedTitles(canvas)).toEqual(['A', 'C'])
+          expect(b.selected).toBe(false)
+        })
+      }
+    )
+
+    it.fails('shift+alt marquee resolves the same way in both modes', () => {
+      click(canvas, 60, 60)
+      canvas.liveSelection = false
+      marquee(canvas, [250, 0], [450, 400], { shiftKey: true, altKey: true })
+      const classic = selectedTitles(canvas)
+
+      click(canvas, 60, 60)
+      canvas.liveSelection = true
+      marquee(canvas, [250, 0], [450, 400], { shiftKey: true, altKey: true })
+
+      expect(selectedTitles(canvas)).toEqual(classic)
+    })
+
+    it.fails('classic marquee requests a redraw', () => {
+      canvas.liveSelection = false
+      const setDirty = vi.spyOn(canvas, 'setDirty')
+
+      marquee(canvas, [250, 0], [450, 400], {})
+
+      expect(setDirty).toHaveBeenCalled()
+    })
+  })
+
+  describe('groups with groupSelectChildren', () => {
+    let group: LGraphGroup
+
+    beforeEach(() => {
+      canvas.groupSelectChildren = true
+      group = addGroup(graph, 'G', [0, 0, 500, 300])
+      group.recomputeInsideNodes()
+    })
+
+    it('selecting the group selects its children', () => {
+      click(canvas, 250, 10)
+
+      expect(selectedTitles(canvas)).toEqual(['A', 'B', 'G'])
+    })
+
+    it.fails('nested groups receive onSelected', () => {
+      const inner = addGroup(graph, 'Inner', [10, 30, 200, 200])
+      inner.recomputeInsideNodes()
+      group.recomputeInsideNodes()
+      const onSelected = vi.fn()
+      Object.assign(inner, { onSelected })
+
+      canvas.select(group)
+
+      expect(inner.selected).toBe(true)
+      expect(onSelected).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('space bar pan override', () => {
+    it.for([{ readOnly: true }, { readOnly: false }])(
+      'restores read_only=$readOnly after release',
+      ({ readOnly }) => {
+        canvas.read_only = readOnly
+
+        canvas.processKey(keyEvent('keydown', ' '))
+        expect(canvas.read_only).toBe(true)
+
+        canvas.processKey(keyEvent('keyup', ' '))
+        expect(canvas.read_only).toBe(readOnly)
+      }
+    )
+  })
+})

--- a/src/lib/litegraph/src/LGraphCanvas.selection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.selection.test.ts
@@ -11,23 +11,7 @@ import {
 } from '@/lib/litegraph/src/litegraph'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
-  layoutStore: {
-    querySlotAtPoint: vi.fn(),
-    queryRerouteAtPoint: vi.fn(),
-    queryLinkSegmentAtPoint: vi.fn(),
-    getNodeLayoutRef: vi.fn(() => ({ value: null })),
-    getNodeLayout: vi.fn(),
-    getSlotLayout: vi.fn(),
-    setSource: vi.fn(),
-    batchUpdateNodeBounds: vi.fn(),
-    applyOperation: vi.fn(),
-    allocateZIndex: vi.fn(() => 0),
-    readNodeRect: vi.fn(() => false),
-    contentSizeOf: vi.fn(),
-    getGroupLayout: vi.fn()
-  }
-}))
+vi.mock(import('@/renderer/core/layout/store/layoutStore'))
 
 type Modifiers = Partial<
   Pick<MouseEventInit, 'shiftKey' | 'ctrlKey' | 'metaKey' | 'altKey'>
@@ -109,6 +93,7 @@ function marquee(
   } as CanvasPointerEvent
   if (canvas.liveSelection) {
     canvas['handleLiveSelect'](event, dragRect, initialSelection)
+    canvas['finalizeLiveSelect']()
   } else {
     canvas['_handleMultiSelect'](event, dragRect)
   }
@@ -322,13 +307,12 @@ describe('LGraphCanvas selection', () => {
       expect(selectedTitles(canvas)).toEqual(classic)
     })
 
-    it.fails('classic marquee requests a redraw', () => {
-      canvas.liveSelection = false
-      const setDirty = vi.spyOn(canvas, 'setDirty')
+    it.fails('live marquee reports one change', () => {
+      canvas.liveSelection = true
 
       marquee(canvas, [250, 0], [450, 400], {})
 
-      expect(setDirty).toHaveBeenCalled()
+      expect(onSelectionChange).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -374,5 +358,13 @@ describe('LGraphCanvas selection', () => {
         expect(canvas.read_only).toBe(readOnly)
       }
     )
+
+    it('ignores a release without a matching press', () => {
+      canvas.read_only = true
+
+      canvas.processKey(keyEvent('keyup', ' '))
+
+      expect(canvas.read_only).toBe(true)
+    })
   })
 })

--- a/src/lib/litegraph/src/LGraphCanvas.selection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.selection.test.ts
@@ -366,5 +366,20 @@ describe('LGraphCanvas selection', () => {
 
       expect(canvas.read_only).toBe(true)
     })
+
+    it('clears held state when the graph is detached before release', () => {
+      canvas.processKey(keyEvent('keydown', ' '))
+      graph.detachCanvas(canvas)
+
+      canvas.processKey(keyEvent('keyup', ' '))
+      expect(canvas.read_only).toBe(false)
+
+      new LGraph().attachCanvas(canvas)
+      canvas.read_only = true
+      canvas.processKey(keyEvent('keydown', ' '))
+      canvas.processKey(keyEvent('keyup', ' '))
+
+      expect(canvas.read_only).toBe(true)
+    })
   })
 })

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3971,15 +3971,16 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         // space
         const held = this._spaceKeyHeld
         this._spaceKeyHeld = null
-        this.read_only = held?.readOnly ?? false
-        this.dragging_canvas =
-          (held?.draggingCanvas ?? false) && this.pointer.isDown
-        if (
-          this.pointer.isDown &&
-          (this.isDragging || this.linkConnector.isConnecting)
-        ) {
-          this._autoPan?.updatePointer(this.mouse[0], this.mouse[1])
-          this._autoPan?.start()
+        if (held) {
+          this.read_only = held.readOnly
+          this.dragging_canvas = held.draggingCanvas && this.pointer.isDown
+          if (
+            this.pointer.isDown &&
+            (this.isDragging || this.linkConnector.isConnecting)
+          ) {
+            this._autoPan?.updatePointer(this.mouse[0], this.mouse[1])
+            this._autoPan?.start()
+          }
         }
       }
 

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -416,9 +416,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     this._setCursor(cursor)
   }
 
-  // Whether the canvas was previously being dragged prior to pressing space key.
-  // null if space key is not pressed.
-  private _previously_dragging_canvas: boolean | null = null
+  private _spaceKeyHeld: { draggingCanvas: boolean; readOnly: boolean } | null =
+    null
 
   // #region Legacy accessors
   /** @deprecated @inheritdoc {@link LGraphCanvasState.readOnly} */
@@ -595,7 +594,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   pause_rendering: boolean
   clear_background: boolean
   clear_background_color: string
-  render_only_selected: boolean
   show_info: boolean
   /** Additional text appended to the canvas info overlay (rendered by {@link renderInfo}). */
   info_text: string | undefined
@@ -979,7 +977,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     this.clear_background = true
     this.clear_background_color = '#222'
 
-    this.render_only_selected = true
     this.show_info = true
     this.allow_dragcanvas = true
     this.allow_dragnodes = true
@@ -3944,11 +3941,12 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       // TODO: Switch
       if (e.key === ' ') {
         // space
+        this._spaceKeyHeld ??= {
+          draggingCanvas: this.dragging_canvas,
+          readOnly: this.read_only
+        }
         this.read_only = true
         this._autoPan?.stop()
-        if (this._previously_dragging_canvas === null) {
-          this._previously_dragging_canvas = this.dragging_canvas
-        }
         this.dragging_canvas =
           this.pointer.isDown || !!this.linkConnector.renderLinks.length
         block_default = true
@@ -3971,10 +3969,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     } else if (e.type == 'keyup') {
       if (e.key === ' ') {
         // space
-        this.read_only = false
+        const held = this._spaceKeyHeld
+        this._spaceKeyHeld = null
+        this.read_only = held?.readOnly ?? false
         this.dragging_canvas =
-          (this._previously_dragging_canvas ?? false) && this.pointer.isDown
-        this._previously_dragging_canvas = null
+          (held?.draggingCanvas ?? false) && this.pointer.isDown
         if (
           this.pointer.isDown &&
           (this.isDragging || this.linkConnector.isConnecting)

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3930,6 +3930,22 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   processKey(e: KeyboardEvent): void {
     this._shiftDown = e.shiftKey
 
+    if (e.type == 'keyup' && e.key === ' ') {
+      const held = this._spaceKeyHeld
+      this._spaceKeyHeld = null
+      if (held) {
+        this.read_only = held.readOnly
+        this.dragging_canvas = held.draggingCanvas && this.pointer.isDown
+        if (
+          this.pointer.isDown &&
+          (this.isDragging || this.linkConnector.isConnecting)
+        ) {
+          this._autoPan?.updatePointer(this.mouse[0], this.mouse[1])
+          this._autoPan?.start()
+        }
+      }
+    }
+
     const { graph } = this
     if (!graph) return
 
@@ -3967,23 +3983,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         node.onKeyDown?.(e)
       }
     } else if (e.type == 'keyup') {
-      if (e.key === ' ') {
-        // space
-        const held = this._spaceKeyHeld
-        this._spaceKeyHeld = null
-        if (held) {
-          this.read_only = held.readOnly
-          this.dragging_canvas = held.draggingCanvas && this.pointer.isDown
-          if (
-            this.pointer.isDown &&
-            (this.isDragging || this.linkConnector.isConnecting)
-          ) {
-            this._autoPan?.updatePointer(this.mouse[0], this.mouse[1])
-            this._autoPan?.start()
-          }
-        }
-      }
-
       for (const node of Object.values(this.selected_nodes)) {
         node.onKeyUp?.(e)
       }

--- a/src/renderer/core/canvas/canvasStore.ts
+++ b/src/renderer/core/canvas/canvasStore.ts
@@ -18,7 +18,7 @@ import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMuta
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { app } from '@/scripts/app'
 import type { NodeId } from '@/types/nodeId'
-import { isLGraphGroup, isLGraphNode, isReroute } from '@/utils/litegraphUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 function currentTransform(): LGraphCanvas['ds'] | null {
   return app.canvas.ds
@@ -97,10 +97,6 @@ export const useCanvasStore = defineStore('canvas', () => {
       originalOnChanged = undefined
     }
   }
-
-  const nodeSelected = computed(() => selectedItems.value.some(isLGraphNode))
-  const groupSelected = computed(() => selectedItems.value.some(isLGraphGroup))
-  const rerouteSelected = computed(() => selectedItems.value.some(isReroute))
 
   const getCanvas = () => {
     if (!canvas.value) throw new Error('getCanvas: canvas is null')
@@ -206,9 +202,6 @@ export const useCanvasStore = defineStore('canvas', () => {
     canvas,
     selectedItems,
     selectedNodeIds,
-    nodeSelected,
-    groupSelected,
-    rerouteSelected,
     appScalePercentage,
     linearMode,
     isReadOnly,

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -7,7 +7,6 @@ import {
   LGraphGroup,
   LGraphNode,
   LiteGraph,
-  Reroute,
   isColorable
 } from '@/lib/litegraph/src/litegraph'
 import type {
@@ -151,10 +150,6 @@ export const isLGraphNode = (item: unknown): item is LGraphNode => {
 
 export const isLGraphGroup = (item: unknown): item is LGraphGroup => {
   return item instanceof LGraphGroup
-}
-
-export const isReroute = (item: unknown): item is Reroute => {
-  return item instanceof Reroute
 }
 
 /**


### PR DESCRIPTION
## Summary

Step 1 of the FE-2040 selection overhaul (ADR-CANVAS-SELECTION-0028, stacked on #17013): a real-`LGraphCanvas` selection test matrix that encodes intended behaviour with the known defects marked `it.fails`, plus the one bug fix and dead-code removal small enough to ship alongside it.

## Changes

- **What**:
  - `LGraphCanvas.processKey`: space keydown snapshots `read_only` alongside `dragging_canvas`; keyup restores both. Previously keyup wrote `read_only = false` unconditionally, so holding space to pan unlocked a canvas locked via `Comfy.Canvas.Lock`.
  - New `LGraphCanvas.selection.test.ts`: drives `processMouseDown`/`processMouseUp`, `_handleMultiSelect`/`handleLiveSelect`, `processKey`, and the `select`/`deselect`/`deselectAll` API on the real canvas. 20 passing rows; 7 `it.fails` rows for defects the later PRs fix:
    - `select()` / `deselect()` do not report through `onSelectionChange`
    - a replacing click and a clearing click each report `onSelectionChange` twice (found while writing the harness; not in the ADR list)
    - Shift+Alt marquee resolves differently in classic vs live mode
    - classic marquee never requests a redraw
    - nested groups never receive `onSelected`
  - Deleted: `render_only_selected` (no readers), `canvasStore.nodeSelected/groupSelected/rerouteSelected` (no readers), `isReroute` (only used by those computeds; knip).

## Review Focus

- `_previously_dragging_canvas: boolean | null` is replaced by `_spaceKeyHeld: { draggingCanvas, readOnly } | null` rather than adding a second field.
- `it.fails` rows are assertions of intended behaviour, not skips; each one should flip green (and then have `.fails` removed) in the PR that fixes it. A row for "toggling a group off deselects its children" was deliberately left out: the current cascade-on-select-only behaviour is an explicit in-code decision and the ADR's group design (PR 5) supersedes it.
- Non-test diff is 26 lines.

Linear: https://linear.app/comfyorg/issue/FE-2040

