### PR TITLE
fix: avoid unnecessary Dependabot catalog rewrites

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    versioning-strategy: 'increase-if-necessary'
     schedule:
       interval: 'weekly'
     labels:


### PR DESCRIPTION
## Summary

Preserve compatible pnpm catalog ranges so Dependabot does not corrupt their lockfile entries while raising unnecessary minimum versions.

## Changes

- **What**: Set npm updates to `increase-if-necessary`; compatible minor and patch updates now change only the lockfile.
- **Dependencies**: None.

## Review Focus

This works around [dependabot-core#14339](https://github.com/dependabot/dependabot-core/issues/14339), which caused the frozen-install failures seen in [#17012](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17012) and other recent catalog update PRs. Updates outside the existing range can still change the catalog when required.