### PR TITLE
ci: 2/x add feature flag policy shadow gate

### DIFF
--- a/.github/workflows/ci-feature-flag-policy.yaml
+++ b/.github/workflows/ci-feature-flag-policy.yaml
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # pull_request_target keeps this checkout on trusted base-branch code.
+      # Never execute code from the pull request or its selected base branch.
       - name: Checkout policy
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/ci-feature-flag-policy.yaml
+++ b/.github/workflows/ci-feature-flag-policy.yaml
@@ -1,0 +1,53 @@
+name: 'CI: Feature Flag Policy'
+
+on:
+  pull_request_target:
+    types:
+      [
+        opened,
+        synchronize,
+        reopened,
+        ready_for_review,
+        edited,
+        labeled,
+        unlabeled
+      ]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate.
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+concurrency:
+  group: feature-flag-policy-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    name: Publish feature-flag-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # pull_request_target keeps this checkout on trusted base-branch code.
+      - name: Checkout policy
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Evaluate policy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node --experimental-strip-types scripts/cicd/feature-flag-policy.ts

--- a/.github/workflows/ci-pr-risk.yml
+++ b/.github/workflows/ci-pr-risk.yml
@@ -64,5 +64,6 @@ jobs:
       # kill switch that needs no PR).
       enabled: true
       label_map: 'R0=risk:low,R1=risk:medium,R2=risk:high,R3=risk:xhigh,unknown=risk:unknown'
+      check_run: true
       pr_number: ${{ inputs.pr_number }}
       pr_numbers: ${{ inputs.pr_numbers }}

--- a/scripts/cicd/feature-flag-policy.test.ts
+++ b/scripts/cicd/feature-flag-policy.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  evaluatePolicy,
+  hasFailClosedDefault,
+  parsePolicyFields,
+  riskFromLabels,
+  runtimePathsFor
+} from './feature-flag-policy'
+
+const validBody = `
+## Feature flag
+
+- **Cloud runtime change**: yes
+- **Flag**: safe_feature
+- **Flag source**: new
+- **Default-OFF code evidence**: src/composables/useFeatureFlags.ts:100
+- **Production-OFF evidence**: https://flags.example/safe_feature
+- **Flag-OFF behavior**: Existing behavior remains unchanged.
+- **Flag-OFF test**: src/safeFeature.test.ts:test off path
+- **Exception**: none
+- **Exception evidence**: N/A
+`
+
+const registry = `
+export enum ServerFeatureFlag {
+  SAFE_FEATURE = 'safe_feature'
+}
+const enabled = resolveFlag(
+  ServerFeatureFlag.SAFE_FEATURE,
+  remoteConfig.value.safe_feature,
+  false
+)
+`
+
+describe('parsePolicyFields', () => {
+  it('reads the fixed template fields', () => {
+    expect(parsePolicyFields(validBody).fields).toMatchObject({
+      cloudRuntimeChange: 'yes',
+      flag: 'safe_feature',
+      exception: 'none'
+    })
+  })
+
+  it('rejects a missing section', () => {
+    expect(parsePolicyFields('## Summary\nNo policy').errors).toContain(
+      'Missing `## Feature flag` section.'
+    )
+  })
+
+  it('rejects duplicate fields', () => {
+    const duplicate = validBody.replace(
+      '- **Flag**: safe_feature',
+      '- **Flag**: unsafe_feature\n- **Flag**: safe_feature'
+    )
+    expect(parsePolicyFields(duplicate).errors).toContain(
+      'Policy fields must be unique.'
+    )
+  })
+})
+
+describe('runtimePathsFor', () => {
+  const riskMap = {
+    path_rules: [
+      { class: 'core-infra', paths: ['src/core/**'] },
+      { class: 'tests', paths: ['**/*.test.ts'] },
+      { class: 'docs', paths: ['**/*.md'] }
+    ]
+  }
+
+  it('lets explicit non-runtime classes win over overlapping runtime classes', () => {
+    expect(
+      runtimePathsFor(
+        [
+          { filename: 'src/core/runtime.ts' },
+          { filename: 'src/core/runtime.test.ts' },
+          { filename: 'docs/policy.md' }
+        ],
+        riskMap
+      )
+    ).toEqual(['src/core/runtime.ts'])
+  })
+
+  it('treats unclassified files as runtime instead of silently exempting them', () => {
+    expect(
+      runtimePathsFor([{ filename: 'src/components/NewUi.vue' }], riskMap)
+    ).toEqual(['src/components/NewUi.vue'])
+  })
+})
+
+describe('hasFailClosedDefault', () => {
+  it('accepts a registered flag with a false fallback', () => {
+    expect(hasFailClosedDefault('safe_feature', registry, registry)).toBe(true)
+  })
+
+  it('rejects a nightly-on fallback', () => {
+    const unsafe = registry.replace('false', 'isNightly')
+    expect(hasFailClosedDefault('safe_feature', unsafe, unsafe)).toBe(false)
+  })
+})
+
+describe('riskFromLabels', () => {
+  it('uses a dispute label as the effective grade', () => {
+    expect(riskFromLabels(['risk:xhigh', 'risk-dispute:medium'])).toBe('medium')
+  })
+
+  it('rejects conflicting dispute labels', () => {
+    expect(riskFromLabels(['risk-dispute:medium', 'risk-dispute:high'])).toBe(
+      'conflict'
+    )
+  })
+})
+
+describe('evaluatePolicy', () => {
+  it('passes low-risk changes without parsing the template', () => {
+    expect(
+      evaluatePolicy({
+        body: '',
+        labels: [],
+        risk: 'low',
+        runtimePaths: ['src/runtime.ts']
+      }).verdict
+    ).toBe('pass')
+  })
+
+  it('passes mechanically exempt high-risk changes', () => {
+    expect(
+      evaluatePolicy({
+        body: '',
+        labels: [],
+        risk: 'xhigh',
+        runtimePaths: []
+      }).verdict
+    ).toBe('pass')
+  })
+
+  it('requires complete default-off containment for runtime changes', () => {
+    expect(
+      evaluatePolicy({
+        body: validBody,
+        labels: [],
+        risk: 'high',
+        runtimePaths: ['src/runtime.ts'],
+        registrySource: registry,
+        evidenceSource: registry,
+        testPathExists: true
+      })
+    ).toMatchObject({ verdict: 'pass', requiresAi: true })
+  })
+
+  it('rejects prose that names no registered flag', () => {
+    expect(
+      evaluatePolicy({
+        body: validBody.replaceAll('safe_feature', 'invented_flag'),
+        labels: [],
+        risk: 'high',
+        runtimePaths: ['src/runtime.ts'],
+        registrySource: registry,
+        evidenceSource: registry,
+        testPathExists: true
+      }).reasons
+    ).toContain('The named flag is not registered with a fail-closed default.')
+  })
+
+  it('requires the test evidence to name a test file', () => {
+    const body = validBody.replace(
+      'src/safeFeature.test.ts:test off path',
+      'src/safeFeature.ts:test off path'
+    )
+    expect(
+      evaluatePolicy({
+        body,
+        labels: [],
+        risk: 'high',
+        runtimePaths: ['src/runtime.ts'],
+        registrySource: registry,
+        evidenceSource: registry,
+        testPathExists: true
+      }).reasons
+    ).toContain('`Flag-OFF test` must reference a test file.')
+  })
+
+  it('requires the explicit label for a human exception', () => {
+    const exceptionBody = validBody
+      .replace('- **Exception**: none', '- **Exception**: contract')
+      .replace(
+        '- **Exception evidence**: N/A',
+        '- **Exception evidence**: Validation link and rollback steps.'
+      )
+    expect(
+      evaluatePolicy({
+        body: exceptionBody,
+        labels: [],
+        risk: 'xhigh',
+        runtimePaths: ['src/runtime.ts']
+      }).reasons
+    ).toContain('An exception requires the `flag-exempt` label.')
+    expect(
+      evaluatePolicy({
+        body: exceptionBody,
+        labels: ['flag-exempt'],
+        risk: 'xhigh',
+        runtimePaths: ['src/runtime.ts']
+      }).verdict
+    ).toBe('pass')
+  })
+})

--- a/scripts/cicd/feature-flag-policy.test.ts
+++ b/scripts/cicd/feature-flag-policy.test.ts
@@ -203,5 +203,17 @@ describe('evaluatePolicy', () => {
         runtimePaths: ['src/runtime.ts']
       }).verdict
     ).toBe('pass')
+
+    expect(
+      evaluatePolicy({
+        body: exceptionBody.replace(
+          'Validation link and rollback steps.',
+          'n/a'
+        ),
+        labels: ['flag-exempt'],
+        risk: 'xhigh',
+        runtimePaths: ['src/runtime.ts']
+      }).reasons
+    ).toContain('`Exception evidence` must include validation and rollback.')
   })
 })

--- a/scripts/cicd/feature-flag-policy.test.ts
+++ b/scripts/cicd/feature-flag-policy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 import {
   evaluatePolicy,
   hasFailClosedDefault,
-  inferFlags,
   parseDeclaredFlag,
   riskFromLabels,
   runtimePathsFor
@@ -26,11 +25,6 @@ const enabled = resolveFlag(
   false
 )
 `
-const safePatch = `
-@@ -1,0 +1,2 @@
-+const enabled = flags.get(ServerFeatureFlag.SAFE_FEATURE)
-`
-
 describe('parseDeclaredFlag', () => {
   it('accepts a declared or blank flag', () => {
     expect(parseDeclaredFlag(declaredBody)).toEqual({
@@ -75,20 +69,6 @@ describe('runtimePathsFor', () => {
     expect(
       runtimePathsFor([{ filename: 'src/components/NewUi.vue' }], riskMap)
     ).toEqual(['src/components/NewUi.vue'])
-  })
-})
-
-describe('inferFlags', () => {
-  it('infers a unique flag from added code', () => {
-    expect(inferFlags(registry, [safePatch])).toEqual(['safe_feature'])
-  })
-
-  it('returns every candidate when the diff is ambiguous', () => {
-    const patch = `${safePatch}+flags.get(ServerFeatureFlag.OTHER_FEATURE)\n`
-    expect(inferFlags(registry, [patch])).toEqual([
-      'safe_feature',
-      'other_feature'
-    ])
   })
 })
 
@@ -161,40 +141,29 @@ describe('evaluatePolicy', () => {
     ).toBe('pass')
   })
 
-  it('infers a registered default-off flag', () => {
-    expect(
-      evaluatePolicy({ ...runtimeInput, body: blankBody, patches: [safePatch] })
-    ).toMatchObject({
-      verdict: 'pass',
-      requiresAi: true,
-      flag: 'safe_feature',
-      flagOrigin: 'existing',
-      flagDiscovery: 'inferred'
-    })
-  })
-
   it('accepts an explicit registered default-off flag', () => {
     expect(
-      evaluatePolicy({ ...runtimeInput, body: declaredBody, patches: [] })
+      evaluatePolicy({ ...runtimeInput, body: declaredBody })
     ).toMatchObject({
       verdict: 'pass',
       requiresAi: true,
       flag: 'safe_feature',
-      flagDiscovery: 'declared'
+      flagOrigin: 'existing'
     })
   })
 
-  it('asks the author only when no single flag can be identified', () => {
-    expect(
-      evaluatePolicy({ ...runtimeInput, body: blankBody, patches: [] })
-    ).toMatchObject({ verdict: 'inconclusive', requiresAi: true })
+  it('requires the author to provide the flag', () => {
+    expect(evaluatePolicy({ ...runtimeInput, body: blankBody })).toMatchObject({
+      verdict: 'fail',
+      requiresAi: false,
+      reasons: ['The author must provide the `Flag` field.']
+    })
   })
 
   it('rejects an explicit flag without a fail-closed registration', () => {
     const result = evaluatePolicy({
       ...runtimeInput,
-      body: declaredBody.replace('safe_feature', 'invented_flag'),
-      patches: []
+      body: declaredBody.replace('safe_feature', 'invented_flag')
     })
     expect(result.verdict).toBe('fail')
     expect(result.reasons).toContain(

--- a/scripts/cicd/feature-flag-policy.test.ts
+++ b/scripts/cicd/feature-flag-policy.test.ts
@@ -3,28 +3,22 @@ import { describe, expect, it } from 'vitest'
 import {
   evaluatePolicy,
   hasFailClosedDefault,
-  parsePolicyFields,
+  inferFlags,
+  parseDeclaredFlag,
   riskFromLabels,
   runtimePathsFor
 } from './feature-flag-policy'
 
-const validBody = `
+const blankBody = `
 ## Feature flag
 
-- **Cloud runtime change**: yes
-- **Flag**: safe_feature
-- **Flag source**: new
-- **Default-OFF code evidence**: src/composables/useFeatureFlags.ts:100
-- **Production-OFF evidence**: https://flags.example/safe_feature
-- **Flag-OFF behavior**: Existing behavior remains unchanged.
-- **Flag-OFF test**: src/safeFeature.test.ts:test off path
-- **Exception**: none
-- **Exception evidence**: N/A
+- **Flag**:
 `
-
+const declaredBody = blankBody.replace('**Flag**:', '**Flag**: safe_feature')
 const registry = `
 export enum ServerFeatureFlag {
-  SAFE_FEATURE = 'safe_feature'
+  SAFE_FEATURE = 'safe_feature',
+  OTHER_FEATURE = 'other_feature'
 }
 const enabled = resolveFlag(
   ServerFeatureFlag.SAFE_FEATURE,
@@ -32,29 +26,25 @@ const enabled = resolveFlag(
   false
 )
 `
+const safePatch = `
+@@ -1,0 +1,2 @@
++const enabled = flags.get(ServerFeatureFlag.SAFE_FEATURE)
+`
 
-describe('parsePolicyFields', () => {
-  it('reads the fixed template fields', () => {
-    expect(parsePolicyFields(validBody).fields).toMatchObject({
-      cloudRuntimeChange: 'yes',
+describe('parseDeclaredFlag', () => {
+  it('accepts a declared or blank flag', () => {
+    expect(parseDeclaredFlag(declaredBody)).toEqual({
       flag: 'safe_feature',
-      exception: 'none'
+      errors: []
     })
+    expect(parseDeclaredFlag(blankBody)).toEqual({ flag: null, errors: [] })
+    expect(parseDeclaredFlag('## Summary')).toEqual({ flag: null, errors: [] })
   })
 
-  it('rejects a missing section', () => {
-    expect(parsePolicyFields('## Summary\nNo policy').errors).toContain(
-      'Missing `## Feature flag` section.'
-    )
-  })
-
-  it('rejects duplicate fields', () => {
-    const duplicate = validBody.replace(
-      '- **Flag**: safe_feature',
-      '- **Flag**: unsafe_feature\n- **Flag**: safe_feature'
-    )
-    expect(parsePolicyFields(duplicate).errors).toContain(
-      'Policy fields must be unique.'
+  it('rejects duplicate flag fields', () => {
+    const duplicate = `${declaredBody}- **Flag**: other_feature\n`
+    expect(parseDeclaredFlag(duplicate).errors).toContain(
+      'The `Flag` field must be unique.'
     )
   })
 })
@@ -88,14 +78,32 @@ describe('runtimePathsFor', () => {
   })
 })
 
-describe('hasFailClosedDefault', () => {
-  it('accepts a registered flag with a false fallback', () => {
-    expect(hasFailClosedDefault('safe_feature', registry, registry)).toBe(true)
+describe('inferFlags', () => {
+  it('infers a unique flag from added code', () => {
+    expect(inferFlags(registry, [safePatch])).toEqual(['safe_feature'])
   })
 
-  it('rejects a nightly-on fallback', () => {
-    const unsafe = registry.replace('false', 'isNightly')
-    expect(hasFailClosedDefault('safe_feature', unsafe, unsafe)).toBe(false)
+  it('returns every candidate when the diff is ambiguous', () => {
+    const patch = `${safePatch}+flags.get(ServerFeatureFlag.OTHER_FEATURE)\n`
+    expect(inferFlags(registry, [patch])).toEqual([
+      'safe_feature',
+      'other_feature'
+    ])
+  })
+})
+
+describe('hasFailClosedDefault', () => {
+  it('accepts a registered flag with a false fallback', () => {
+    expect(hasFailClosedDefault('safe_feature', registry)).toBe(true)
+  })
+
+  it('rejects a non-fail-closed fallback', () => {
+    expect(
+      hasFailClosedDefault(
+        'safe_feature',
+        registry.replace('false', 'isNightly')
+      )
+    ).toBe(false)
   })
 })
 
@@ -112,6 +120,14 @@ describe('riskFromLabels', () => {
 })
 
 describe('evaluatePolicy', () => {
+  const runtimeInput = {
+    labels: [],
+    risk: 'high' as const,
+    runtimePaths: ['src/runtime.ts'],
+    registrySource: registry,
+    baseRegistrySource: registry
+  }
+
   it('passes low-risk changes without parsing the template', () => {
     expect(
       evaluatePolicy({
@@ -134,86 +150,55 @@ describe('evaluatePolicy', () => {
     ).toBe('pass')
   })
 
-  it('requires complete default-off containment for runtime changes', () => {
+  it('accepts a labeled exception without template evidence', () => {
     expect(
       evaluatePolicy({
-        body: validBody,
-        labels: [],
-        risk: 'high',
-        runtimePaths: ['src/runtime.ts'],
-        registrySource: registry,
-        evidenceSource: registry,
-        testPathExists: true
-      })
-    ).toMatchObject({ verdict: 'pass', requiresAi: true })
-  })
-
-  it('rejects prose that names no registered flag', () => {
-    expect(
-      evaluatePolicy({
-        body: validBody.replaceAll('safe_feature', 'invented_flag'),
-        labels: [],
-        risk: 'high',
-        runtimePaths: ['src/runtime.ts'],
-        registrySource: registry,
-        evidenceSource: registry,
-        testPathExists: true
-      }).reasons
-    ).toContain('The named flag is not registered with a fail-closed default.')
-  })
-
-  it('requires the test evidence to name a test file', () => {
-    const body = validBody.replace(
-      'src/safeFeature.test.ts:test off path',
-      'src/safeFeature.ts:test off path'
-    )
-    expect(
-      evaluatePolicy({
-        body,
-        labels: [],
-        risk: 'high',
-        runtimePaths: ['src/runtime.ts'],
-        registrySource: registry,
-        evidenceSource: registry,
-        testPathExists: true
-      }).reasons
-    ).toContain('`Flag-OFF test` must reference a test file.')
-  })
-
-  it('requires the explicit label for a human exception', () => {
-    const exceptionBody = validBody
-      .replace('- **Exception**: none', '- **Exception**: contract')
-      .replace(
-        '- **Exception evidence**: N/A',
-        '- **Exception evidence**: Validation link and rollback steps.'
-      )
-    expect(
-      evaluatePolicy({
-        body: exceptionBody,
-        labels: [],
-        risk: 'xhigh',
-        runtimePaths: ['src/runtime.ts']
-      }).reasons
-    ).toContain('An exception requires the `flag-exempt` label.')
-    expect(
-      evaluatePolicy({
-        body: exceptionBody,
+        body: '',
         labels: ['flag-exempt'],
         risk: 'xhigh',
         runtimePaths: ['src/runtime.ts']
       }).verdict
     ).toBe('pass')
+  })
 
+  it('infers a registered default-off flag', () => {
     expect(
-      evaluatePolicy({
-        body: exceptionBody.replace(
-          'Validation link and rollback steps.',
-          'n/a'
-        ),
-        labels: ['flag-exempt'],
-        risk: 'xhigh',
-        runtimePaths: ['src/runtime.ts']
-      }).reasons
-    ).toContain('`Exception evidence` must include validation and rollback.')
+      evaluatePolicy({ ...runtimeInput, body: blankBody, patches: [safePatch] })
+    ).toMatchObject({
+      verdict: 'pass',
+      requiresAi: true,
+      flag: 'safe_feature',
+      flagOrigin: 'existing',
+      flagDiscovery: 'inferred'
+    })
+  })
+
+  it('accepts an explicit registered default-off flag', () => {
+    expect(
+      evaluatePolicy({ ...runtimeInput, body: declaredBody, patches: [] })
+    ).toMatchObject({
+      verdict: 'pass',
+      requiresAi: true,
+      flag: 'safe_feature',
+      flagDiscovery: 'declared'
+    })
+  })
+
+  it('asks the author only when no single flag can be identified', () => {
+    expect(
+      evaluatePolicy({ ...runtimeInput, body: blankBody, patches: [] })
+    ).toMatchObject({ verdict: 'inconclusive', requiresAi: true })
+  })
+
+  it('rejects an explicit flag without a fail-closed registration', () => {
+    const result = evaluatePolicy({
+      ...runtimeInput,
+      body: declaredBody.replace('safe_feature', 'invented_flag'),
+      patches: []
+    })
+    expect(result.verdict).toBe('fail')
+    expect(result.reasons).toContain(
+      'Flag `invented_flag` is not registered with a fail-closed default.'
+    )
   })
 })

--- a/scripts/cicd/feature-flag-policy.ts
+++ b/scripts/cicd/feature-flag-policy.ts
@@ -17,45 +17,25 @@ interface PullFile {
   patch?: string
 }
 
-interface PolicyFields {
-  cloudRuntimeChange: string
-  flag: string
-  flagSource: string
-  defaultOffEvidence: string
-  productionOffEvidence: string
-  offBehavior: string
-  offTest: string
-  exception: string
-  exceptionEvidence: string
-}
-
 export interface PolicyInput {
   body: string
   labels: string[]
   risk: RiskTier | null
   runtimePaths: string[]
   registrySource?: string
-  evidenceSource?: string
-  testPathExists?: boolean
+  baseRegistrySource?: string
+  patches?: string[]
 }
 
 export interface PolicyResult {
   verdict: 'pass' | 'fail' | 'inconclusive'
   requiresAi: boolean
   reasons: string[]
+  flag?: string
+  flagOrigin?: 'new' | 'existing'
+  flagDiscovery?: 'declared' | 'inferred'
 }
 
-const FIELD_NAMES = [
-  'Cloud runtime change',
-  'Flag',
-  'Flag source',
-  'Default-OFF code evidence',
-  'Production-OFF evidence',
-  'Flag-OFF behavior',
-  'Flag-OFF test',
-  'Exception',
-  'Exception evidence'
-] as const
 const EXEMPT_CLASSES = new Set([
   'risk-map',
   'codeowners',
@@ -68,32 +48,15 @@ const EXEMPT_CLASSES = new Set([
   'storybook',
   'tests'
 ])
-const EXCEPTION_REASONS = new Set([
-  'ci',
-  'codeowners',
-  'dependency',
-  'release',
-  'backport',
-  'revert',
-  'risk-map',
-  'flag-rollout',
-  'test-only',
-  'non-cloud',
-  'contract'
-])
 const PLACEHOLDERS = new Set([
   'key',
+  'auto',
   'n/a',
   'na',
   'none',
   'not applicable',
   'tbd',
-  'todo',
-  'url',
-  'path:line',
-  'path:test',
-  'description',
-  'validation and rollback plan'
+  'todo'
 ])
 
 function clean(value: string): string {
@@ -109,43 +72,54 @@ function isFilled(value: string): boolean {
   )
 }
 
-export function parsePolicyFields(body: string): {
-  fields: PolicyFields | null
+export function parseDeclaredFlag(body: string): {
+  flag: string | null
   errors: string[]
 } {
   const heading = /^## Feature flag\s*$/im.exec(body)
-  if (!heading)
-    return { fields: null, errors: ['Missing `## Feature flag` section.'] }
+  if (!heading) return { flag: null, errors: [] }
 
   const rest = body.slice(heading.index + heading[0].length)
   const section = rest.slice(0, /^## /m.exec(rest)?.index)
-  const entries = [...section.matchAll(/^- \*\*([^*]+)\*\*:\s*(.+?)\s*$/gm)]
-    .filter((match) =>
-      FIELD_NAMES.includes(match[1] as (typeof FIELD_NAMES)[number])
-    )
-    .map((match) => [match[1], clean(match[2])])
-  const values = new Map(entries)
-  const errors = FIELD_NAMES.filter((name) => !values.has(name)).map(
-    (name) => `Missing field: ${name}.`
-  )
-  if (values.size !== entries.length)
-    errors.push('Policy fields must be unique.')
-  if (errors.length > 0) return { fields: null, errors }
+  const values = [
+    ...section.matchAll(/^- \*\*Flag\*\*:[ \t]*(.*?)[ \t]*$/gm)
+  ].map((match) => clean(match[1]))
+  if (values.length > 1)
+    return { flag: null, errors: ['The `Flag` field must be unique.'] }
 
-  return {
-    fields: {
-      cloudRuntimeChange: values.get('Cloud runtime change')!,
-      flag: values.get('Flag')!,
-      flagSource: values.get('Flag source')!,
-      defaultOffEvidence: values.get('Default-OFF code evidence')!,
-      productionOffEvidence: values.get('Production-OFF evidence')!,
-      offBehavior: values.get('Flag-OFF behavior')!,
-      offTest: values.get('Flag-OFF test')!,
-      exception: values.get('Exception')!,
-      exceptionEvidence: values.get('Exception evidence')!
-    },
-    errors: []
-  }
+  const value = values[0] ?? ''
+  return { flag: isFilled(value) ? value : null, errors: [] }
+}
+
+export function inferFlags(
+  registrySource: string,
+  patches: string[]
+): string[] {
+  const registry = new Map(
+    [
+      ...registrySource.matchAll(/([A-Z][A-Z0-9_]*)\s*=\s*['"]([^'"]+)['"]/g)
+    ].map((match) => [match[1], match[2]] as const)
+  )
+  const added = patches
+    .flatMap((patch) => patch.split('\n'))
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+    .join('\n')
+  const members = [
+    ...added.matchAll(/ServerFeatureFlag\.([A-Z][A-Z0-9_]*)/g)
+  ].map((match) => match[1])
+  const registered = [
+    ...added.matchAll(/([A-Z][A-Z0-9_]*)\s*=\s*['"]([^'"]+)['"]/g)
+  ]
+    .filter((match) => registry.get(match[1]) === match[2])
+    .map((match) => match[1])
+
+  return [
+    ...new Set(
+      [...members, ...registered]
+        .map((member) => registry.get(member))
+        .filter((flag): flag is string => Boolean(flag))
+    )
+  ]
 }
 
 export function runtimePathsFor(
@@ -172,15 +146,14 @@ function escapeRegExp(value: string): string {
 
 export function hasFailClosedDefault(
   flag: string,
-  registrySource: string,
-  evidenceSource: string
+  registrySource: string
 ): boolean {
   const member = new RegExp(
     `([A-Z][A-Z0-9_]*)\\s*=\\s*['"]${escapeRegExp(flag)}['"]`
   ).exec(registrySource)?.[1]
   if (!member) return false
 
-  const source = `${registrySource}\n${evidenceSource}`.replace(/\s+/g, ' ')
+  const source = registrySource.replace(/\s+/g, ' ')
   const key = `ServerFeatureFlag\\.${member}`
   const off = `(?:false|'off'|"off"|''|"")`
   return [
@@ -211,81 +184,66 @@ export function evaluatePolicy(input: PolicyInput): PolicyResult {
       reasons: ['All changed paths are mechanically outside runtime scope.']
     }
 
-  const parsed = parsePolicyFields(input.body)
-  if (!parsed.fields)
-    return { verdict: 'fail', requiresAi: false, reasons: parsed.errors }
-  const fields = parsed.fields
-
-  if (input.labels.includes('flag-exempt')) {
-    const errors: string[] = []
-    if (!EXCEPTION_REASONS.has(fields.exception))
-      errors.push('`Exception` must name an allowed reason.')
-    if (!isFilled(fields.exceptionEvidence))
-      errors.push('`Exception evidence` must include validation and rollback.')
+  if (input.labels.includes('flag-exempt'))
     return {
-      verdict: errors.length ? 'fail' : 'pass',
+      verdict: 'pass',
       requiresAi: false,
-      reasons: errors.length
-        ? errors
-        : [`Approved flag exception: ${fields.exception}.`]
+      reasons: [
+        '`flag-exempt` is present; validation and rollback remain reviewer-owned.'
+      ]
     }
-  }
 
-  const errors: string[] = []
-  if (fields.exception !== 'none')
-    errors.push('An exception requires the `flag-exempt` label.')
-  if (fields.cloudRuntimeChange !== 'yes')
-    errors.push('In-scope paths require `Cloud runtime change: yes`.')
-  if (!isFilled(fields.flag)) errors.push('`Flag` must name the rollout key.')
-  if (!['new', 'existing'].includes(fields.flagSource))
-    errors.push('`Flag source` must be `new` or `existing`.')
-  if (!isFilled(fields.defaultOffEvidence))
-    errors.push('`Default-OFF code evidence` is required.')
-  if (!fields.productionOffEvidence.startsWith('https://'))
-    errors.push('`Production-OFF evidence` must be an HTTPS URL.')
-  if (!isFilled(fields.offBehavior))
-    errors.push('`Flag-OFF behavior` must describe the unchanged path.')
-  if (!isFilled(fields.offTest))
-    errors.push('`Flag-OFF test` must identify an automated test.')
-  else if (!isTestPath(fields.offTest))
-    errors.push('`Flag-OFF test` must reference a test file.')
+  const declared = parseDeclaredFlag(input.body)
+  if (declared.errors.length)
+    return { verdict: 'fail', requiresAi: false, reasons: declared.errors }
+
+  const inferred = input.registrySource
+    ? inferFlags(input.registrySource, input.patches ?? [])
+    : []
+  const flag = declared.flag ?? (inferred.length === 1 ? inferred[0] : null)
+  if (!flag)
+    return {
+      verdict: 'inconclusive',
+      requiresAi: true,
+      reasons: [
+        inferred.length > 1
+          ? 'Multiple flags were found; the author must set `Flag`.'
+          : 'No flag was found; the author must set `Flag` if review cannot infer it.'
+      ]
+    }
+
   if (
-    isFilled(fields.flag) &&
-    (!input.registrySource ||
-      !input.evidenceSource ||
-      !hasFailClosedDefault(
-        fields.flag,
-        input.registrySource,
-        input.evidenceSource
-      ))
+    !input.registrySource ||
+    !hasFailClosedDefault(flag, input.registrySource)
   )
-    errors.push('The named flag is not registered with a fail-closed default.')
-  if (input.testPathExists === false)
-    errors.push('The referenced OFF-path test does not exist.')
+    return {
+      verdict: 'fail',
+      requiresAi: false,
+      reasons: [
+        `Flag \`${flag}\` is not registered with a fail-closed default.`
+      ],
+      flag
+    }
+
+  const flagOrigin =
+    input.baseRegistrySource &&
+    new RegExp(`=\\s*['"]${escapeRegExp(flag)}['"]`).test(
+      input.baseRegistrySource
+    )
+      ? 'existing'
+      : 'new'
+  const flagDiscovery = declared.flag ? 'declared' : 'inferred'
 
   return {
-    verdict: errors.length ? 'fail' : 'pass',
-    requiresAi: errors.length === 0,
-    reasons: errors.length
-      ? errors
-      : ['Deterministic flag and evidence checks passed.']
+    verdict: 'pass',
+    requiresAi: true,
+    reasons: [
+      `Flag \`${flag}\` was ${flagDiscovery}, is ${flagOrigin}, and defaults OFF in code.`
+    ],
+    flag,
+    flagOrigin,
+    flagDiscovery
   }
-}
-
-function evidencePath(value: string): string | null {
-  const filePath = /^([^#]+?\.(?:ts|tsx|vue))(?::|#|$)/.exec(value)?.[1]
-  return filePath && !filePath.startsWith('/') && !filePath.includes('..')
-    ? filePath
-    : null
-}
-
-function isTestPath(value: string): boolean {
-  const filePath = evidencePath(value)
-  return Boolean(
-    filePath &&
-    (/\.(?:test|spec)\.tsx?$/.test(filePath) ||
-      filePath.startsWith('browser_tests/'))
-  )
 }
 
 function gh(args: string[], input?: string): string {
@@ -304,16 +262,6 @@ function repoFile(repo: string, ref: string, filePath: string): string {
     'Accept: application/vnd.github.raw+json',
     `repos/${repo}/contents/${encoded}?ref=${encodeURIComponent(ref)}`
   ])
-}
-
-function maybeRepoFile(repo: string, ref: string, value: string) {
-  const filePath = evidencePath(value)
-  if (!filePath) return undefined
-  try {
-    return repoFile(repo, ref, filePath)
-  } catch {
-    return undefined
-  }
 }
 
 export function riskFromLabels(labels: string[]): RiskTier | null | 'conflict' {
@@ -414,30 +362,33 @@ function main() {
     repoFile(repo, pull.base.sha, '.github/risk.json')
   ) as RiskMap
   const runtimePaths = runtimePathsFor(files, riskMap)
-  const fields = parsePolicyFields(pull.body ?? '').fields
-  const needsEvidence =
+  const needsReview =
     (risk === 'high' || risk === 'xhigh') &&
     runtimePaths.length > 0 &&
     !labels.includes('flag-exempt')
-  const registrySource = needsEvidence
+  const registrySource = needsReview
     ? repoFile(repo, pull.head.sha, 'src/composables/useFeatureFlags.ts')
     : undefined
-  const evidenceSource =
-    needsEvidence && fields
-      ? maybeRepoFile(repo, pull.head.sha, fields.defaultOffEvidence)
-      : undefined
-  const testSource =
-    needsEvidence && fields
-      ? maybeRepoFile(repo, pull.head.sha, fields.offTest)
-      : undefined
+  const baseRegistrySource = needsReview
+    ? repoFile(repo, pull.base.sha, 'src/composables/useFeatureFlags.ts')
+    : undefined
+  const runtimePathSet = new Set(runtimePaths)
+  const patches = files
+    .filter(
+      (file) =>
+        runtimePathSet.has(file.filename) ||
+        (file.previous_filename && runtimePathSet.has(file.previous_filename))
+    )
+    .map(({ patch }) => patch)
+    .filter((patch): patch is string => patch !== undefined)
   const result = evaluatePolicy({
     body: pull.body ?? '',
     labels,
     risk,
     runtimePaths,
     registrySource,
-    evidenceSource,
-    testPathExists: fields ? testSource !== undefined : false
+    baseRegistrySource,
+    patches
   })
   if (disputed === 'conflict') {
     result.verdict = 'inconclusive'

--- a/scripts/cicd/feature-flag-policy.ts
+++ b/scripts/cicd/feature-flag-policy.ts
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+import { matchesGlob } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export type RiskTier = 'low' | 'medium' | 'high' | 'xhigh'
+
+interface RiskMap {
+  path_rules: Array<{ class: string; paths: string[] }>
+}
+
+interface PullFile {
+  filename: string
+  previous_filename?: string
+  patch?: string
+}
+
+interface PolicyFields {
+  cloudRuntimeChange: string
+  flag: string
+  flagSource: string
+  defaultOffEvidence: string
+  productionOffEvidence: string
+  offBehavior: string
+  offTest: string
+  exception: string
+  exceptionEvidence: string
+}
+
+export interface PolicyInput {
+  body: string
+  labels: string[]
+  risk: RiskTier | null
+  runtimePaths: string[]
+  registrySource?: string
+  evidenceSource?: string
+  testPathExists?: boolean
+}
+
+export interface PolicyResult {
+  verdict: 'pass' | 'fail' | 'inconclusive'
+  requiresAi: boolean
+  reasons: string[]
+}
+
+const FIELD_NAMES = [
+  'Cloud runtime change',
+  'Flag',
+  'Flag source',
+  'Default-OFF code evidence',
+  'Production-OFF evidence',
+  'Flag-OFF behavior',
+  'Flag-OFF test',
+  'Exception',
+  'Exception evidence'
+] as const
+const EXEMPT_CLASSES = new Set([
+  'risk-map',
+  'codeowners',
+  'ci',
+  'deps',
+  'build-config',
+  'website',
+  'docs',
+  'i18n-copy',
+  'storybook',
+  'tests'
+])
+const EXCEPTION_REASONS = new Set([
+  'ci',
+  'codeowners',
+  'dependency',
+  'release',
+  'backport',
+  'revert',
+  'risk-map',
+  'flag-rollout',
+  'test-only',
+  'non-cloud',
+  'contract'
+])
+const PLACEHOLDERS = new Set([
+  'key',
+  'N/A',
+  'URL',
+  'path:line',
+  'path:test',
+  'description',
+  'validation and rollback plan'
+])
+
+function clean(value: string): string {
+  return value.trim().replace(/^`|`$/g, '').trim()
+}
+
+function isFilled(value: string): boolean {
+  return value.length > 0 && !value.includes(' | ') && !PLACEHOLDERS.has(value)
+}
+
+export function parsePolicyFields(body: string): {
+  fields: PolicyFields | null
+  errors: string[]
+} {
+  const heading = /^## Feature flag\s*$/im.exec(body)
+  if (!heading)
+    return { fields: null, errors: ['Missing `## Feature flag` section.'] }
+
+  const rest = body.slice(heading.index + heading[0].length)
+  const section = rest.slice(0, /^## /m.exec(rest)?.index)
+  const entries = [...section.matchAll(/^- \*\*([^*]+)\*\*:\s*(.+?)\s*$/gm)]
+    .filter((match) =>
+      FIELD_NAMES.includes(match[1] as (typeof FIELD_NAMES)[number])
+    )
+    .map((match) => [match[1], clean(match[2])])
+  const values = new Map(entries)
+  const errors = FIELD_NAMES.filter((name) => !values.has(name)).map(
+    (name) => `Missing field: ${name}.`
+  )
+  if (values.size !== entries.length)
+    errors.push('Policy fields must be unique.')
+  if (errors.length > 0) return { fields: null, errors }
+
+  return {
+    fields: {
+      cloudRuntimeChange: values.get('Cloud runtime change')!,
+      flag: values.get('Flag')!,
+      flagSource: values.get('Flag source')!,
+      defaultOffEvidence: values.get('Default-OFF code evidence')!,
+      productionOffEvidence: values.get('Production-OFF evidence')!,
+      offBehavior: values.get('Flag-OFF behavior')!,
+      offTest: values.get('Flag-OFF test')!,
+      exception: values.get('Exception')!,
+      exceptionEvidence: values.get('Exception evidence')!
+    },
+    errors: []
+  }
+}
+
+export function runtimePathsFor(
+  files: Array<Pick<PullFile, 'filename' | 'previous_filename'>>,
+  riskMap: RiskMap
+): string[] {
+  const paths = new Set(
+    files.flatMap(({ filename, previous_filename }) =>
+      previous_filename ? [filename, previous_filename] : [filename]
+    )
+  )
+
+  return [...paths].filter((filePath) => {
+    const classes = riskMap.path_rules
+      .filter((rule) => rule.paths.some((glob) => matchesGlob(filePath, glob)))
+      .map((rule) => rule.class)
+    return !classes.some((riskClass) => EXEMPT_CLASSES.has(riskClass))
+  })
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function hasFailClosedDefault(
+  flag: string,
+  registrySource: string,
+  evidenceSource: string
+): boolean {
+  const member = new RegExp(
+    `([A-Z][A-Z0-9_]*)\\s*=\\s*['"]${escapeRegExp(flag)}['"]`
+  ).exec(registrySource)?.[1]
+  if (!member) return false
+
+  const source = `${registrySource}\n${evidenceSource}`.replace(/\s+/g, ' ')
+  const key = `ServerFeatureFlag\\.${member}`
+  const off = `(?:false|'off'|"off"|''|"")`
+  return [
+    `resolveFlag\\(\\s*${key}\\s*,[^)]{0,400},\\s*${off}\\s*\\)`,
+    `api\\.getServerFeature\\(\\s*${key}\\s*,\\s*${off}\\s*\\)`,
+    `resolveAuthGatedFlag\\(\\s*${key}\\s*,`,
+    `resolveFailClosedBooleanFlag\\(\\s*${key}\\s*\\)`
+  ].some((pattern) => new RegExp(pattern).test(source))
+}
+
+export function evaluatePolicy(input: PolicyInput): PolicyResult {
+  if (!input.risk)
+    return {
+      verdict: 'inconclusive',
+      requiresAi: false,
+      reasons: ['No current-head risk grade; a maintainer must re-run grading.']
+    }
+  if (input.risk === 'low' || input.risk === 'medium')
+    return {
+      verdict: 'pass',
+      requiresAi: false,
+      reasons: [`Risk is ${input.risk}; the policy does not apply.`]
+    }
+  if (input.runtimePaths.length === 0)
+    return {
+      verdict: 'pass',
+      requiresAi: false,
+      reasons: ['All changed paths are mechanically outside runtime scope.']
+    }
+
+  const parsed = parsePolicyFields(input.body)
+  if (!parsed.fields)
+    return { verdict: 'fail', requiresAi: false, reasons: parsed.errors }
+  const fields = parsed.fields
+
+  if (input.labels.includes('flag-exempt')) {
+    const errors: string[] = []
+    if (!EXCEPTION_REASONS.has(fields.exception))
+      errors.push('`Exception` must name an allowed reason.')
+    if (!isFilled(fields.exceptionEvidence))
+      errors.push('`Exception evidence` must include validation and rollback.')
+    return {
+      verdict: errors.length ? 'fail' : 'pass',
+      requiresAi: false,
+      reasons: errors.length
+        ? errors
+        : [`Approved flag exception: ${fields.exception}.`]
+    }
+  }
+
+  const errors: string[] = []
+  if (fields.exception !== 'none')
+    errors.push('An exception requires the `flag-exempt` label.')
+  if (fields.cloudRuntimeChange !== 'yes')
+    errors.push('In-scope paths require `Cloud runtime change: yes`.')
+  if (!isFilled(fields.flag)) errors.push('`Flag` must name the rollout key.')
+  if (!['new', 'existing'].includes(fields.flagSource))
+    errors.push('`Flag source` must be `new` or `existing`.')
+  if (!isFilled(fields.defaultOffEvidence))
+    errors.push('`Default-OFF code evidence` is required.')
+  if (!fields.productionOffEvidence.startsWith('https://'))
+    errors.push('`Production-OFF evidence` must be an HTTPS URL.')
+  if (!isFilled(fields.offBehavior))
+    errors.push('`Flag-OFF behavior` must describe the unchanged path.')
+  if (!isFilled(fields.offTest))
+    errors.push('`Flag-OFF test` must identify an automated test.')
+  else if (!isTestPath(fields.offTest))
+    errors.push('`Flag-OFF test` must reference a test file.')
+  if (
+    isFilled(fields.flag) &&
+    (!input.registrySource ||
+      !input.evidenceSource ||
+      !hasFailClosedDefault(
+        fields.flag,
+        input.registrySource,
+        input.evidenceSource
+      ))
+  )
+    errors.push('The named flag is not registered with a fail-closed default.')
+  if (input.testPathExists === false)
+    errors.push('The referenced OFF-path test does not exist.')
+
+  return {
+    verdict: errors.length ? 'fail' : 'pass',
+    requiresAi: errors.length === 0,
+    reasons: errors.length
+      ? errors
+      : ['Deterministic flag and evidence checks passed.']
+  }
+}
+
+function evidencePath(value: string): string | null {
+  const filePath = /^([^#]+?\.(?:ts|tsx|vue))(?::|#|$)/.exec(value)?.[1]
+  return filePath && !filePath.startsWith('/') && !filePath.includes('..')
+    ? filePath
+    : null
+}
+
+function isTestPath(value: string): boolean {
+  const filePath = evidencePath(value)
+  return Boolean(
+    filePath &&
+    (/\.(?:test|spec)\.tsx?$/.test(filePath) ||
+      filePath.startsWith('browser_tests/'))
+  )
+}
+
+function gh(args: string[], input?: string): string {
+  return execFileSync('gh', ['api', ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN },
+    input,
+    maxBuffer: 50 * 1024 * 1024
+  })
+}
+
+function repoFile(repo: string, ref: string, filePath: string): string {
+  const encoded = filePath.split('/').map(encodeURIComponent).join('/')
+  return gh([
+    '-H',
+    'Accept: application/vnd.github.raw+json',
+    `repos/${repo}/contents/${encoded}?ref=${encodeURIComponent(ref)}`
+  ])
+}
+
+function maybeRepoFile(repo: string, ref: string, value: string) {
+  const filePath = evidencePath(value)
+  if (!filePath) return undefined
+  try {
+    return repoFile(repo, ref, filePath)
+  } catch {
+    return undefined
+  }
+}
+
+export function riskFromLabels(labels: string[]): RiskTier | null | 'conflict' {
+  const disputes = labels
+    .map((label) => /^risk-dispute:(low|medium|high|xhigh)$/.exec(label)?.[1])
+    .filter((tier): tier is RiskTier => tier !== undefined)
+  return disputes.length > 1 ? 'conflict' : (disputes[0] ?? null)
+}
+
+function currentRisk(repo: string, sha: string, waitSeconds: number) {
+  for (let waited = 0; waited <= waitSeconds; waited += 15) {
+    const checks = JSON.parse(
+      gh([
+        `repos/${repo}/commits/${sha}/check-runs?check_name=${encodeURIComponent('PR risk (advisory)')}&filter=latest&per_page=10`
+      ])
+    ) as {
+      check_runs: Array<{ status: string; output?: { title?: string } }>
+    }
+    const title = checks.check_runs.find(({ status }) => status === 'completed')
+      ?.output?.title
+    const tier = /^Risk: R([0-3])$/.exec(title ?? '')?.[1]
+    if (tier)
+      return ['low', 'medium', 'high', 'xhigh'][Number(tier)] as RiskTier
+    if (waited < waitSeconds)
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 15_000)
+  }
+  return null
+}
+
+function publishCheck(
+  repo: string,
+  sha: string,
+  risk: RiskTier | null,
+  result: PolicyResult
+) {
+  const label =
+    result.verdict === 'pass'
+      ? 'pass'
+      : result.verdict === 'fail'
+        ? 'would block'
+        : 'inconclusive'
+  const summary = [
+    '**Shadow mode:** this check is not required by `ProtectMain`.',
+    '',
+    `**Risk:** ${risk ?? 'unknown'}`,
+    '',
+    ...result.reasons.map((reason) => `- ${reason}`)
+  ].join('\n')
+  gh(
+    ['--method', 'POST', `repos/${repo}/check-runs`, '--input', '-'],
+    JSON.stringify({
+      name: 'feature-flag-policy',
+      head_sha: sha,
+      status: 'completed',
+      conclusion: result.verdict === 'pass' ? 'success' : 'failure',
+      details_url: `${process.env.GITHUB_SERVER_URL}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+      output: { title: `Feature flag policy: ${label}`, summary }
+    })
+  )
+  if (process.env.GITHUB_STEP_SUMMARY)
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`)
+  process.stdout.write(`feature-flag-policy: ${label}\n`)
+}
+
+function main() {
+  const repo = process.env.GITHUB_REPOSITORY
+  const pr = Number(process.env.PR_NUMBER)
+  if (!process.env.GITHUB_TOKEN || !repo || !Number.isInteger(pr) || pr < 1)
+    throw new Error(
+      'GITHUB_TOKEN, GITHUB_REPOSITORY, and PR_NUMBER are required.'
+    )
+
+  const pull = JSON.parse(gh([`repos/${repo}/pulls/${pr}`])) as {
+    body: string | null
+    base: { sha: string }
+    head: { sha: string; repo: { full_name: string } | null }
+    labels: Array<{ name: string }>
+  }
+  const labels = pull.labels.map(({ name }) => name)
+  const disputed = riskFromLabels(labels)
+  const risk =
+    disputed === 'conflict'
+      ? null
+      : (disputed ??
+        currentRisk(
+          repo,
+          pull.head.sha,
+          pull.head.repo?.full_name === repo ? 720 : 0
+        ))
+  const files = JSON.parse(
+    gh([
+      '--paginate',
+      '--slurp',
+      `repos/${repo}/pulls/${pr}/files?per_page=100`
+    ])
+  ).flat() as PullFile[]
+  const riskMap = JSON.parse(
+    repoFile(repo, pull.base.sha, '.github/risk.json')
+  ) as RiskMap
+  const runtimePaths = runtimePathsFor(files, riskMap)
+  const fields = parsePolicyFields(pull.body ?? '').fields
+  const needsEvidence =
+    (risk === 'high' || risk === 'xhigh') &&
+    runtimePaths.length > 0 &&
+    !labels.includes('flag-exempt')
+  const registrySource = needsEvidence
+    ? repoFile(repo, pull.head.sha, 'src/composables/useFeatureFlags.ts')
+    : undefined
+  const evidenceSource =
+    needsEvidence && fields
+      ? maybeRepoFile(repo, pull.head.sha, fields.defaultOffEvidence)
+      : undefined
+  const testSource =
+    needsEvidence && fields
+      ? maybeRepoFile(repo, pull.head.sha, fields.offTest)
+      : undefined
+  const result = evaluatePolicy({
+    body: pull.body ?? '',
+    labels,
+    risk,
+    runtimePaths,
+    registrySource,
+    evidenceSource,
+    testPathExists: fields ? testSource !== undefined : false
+  })
+  if (disputed === 'conflict') {
+    result.verdict = 'inconclusive'
+    result.reasons = ['Multiple `risk-dispute:*` labels conflict.']
+  }
+  publishCheck(repo, pull.head.sha, risk, result)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  main()

--- a/scripts/cicd/feature-flag-policy.ts
+++ b/scripts/cicd/feature-flag-policy.ts
@@ -24,7 +24,6 @@ export interface PolicyInput {
   runtimePaths: string[]
   registrySource?: string
   baseRegistrySource?: string
-  patches?: string[]
 }
 
 export interface PolicyResult {
@@ -33,7 +32,6 @@ export interface PolicyResult {
   reasons: string[]
   flag?: string
   flagOrigin?: 'new' | 'existing'
-  flagDiscovery?: 'declared' | 'inferred'
 }
 
 const EXEMPT_CLASSES = new Set([
@@ -89,37 +87,6 @@ export function parseDeclaredFlag(body: string): {
 
   const value = values[0] ?? ''
   return { flag: isFilled(value) ? value : null, errors: [] }
-}
-
-export function inferFlags(
-  registrySource: string,
-  patches: string[]
-): string[] {
-  const registry = new Map(
-    [
-      ...registrySource.matchAll(/([A-Z][A-Z0-9_]*)\s*=\s*['"]([^'"]+)['"]/g)
-    ].map((match) => [match[1], match[2]] as const)
-  )
-  const added = patches
-    .flatMap((patch) => patch.split('\n'))
-    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
-    .join('\n')
-  const members = [
-    ...added.matchAll(/ServerFeatureFlag\.([A-Z][A-Z0-9_]*)/g)
-  ].map((match) => match[1])
-  const registered = [
-    ...added.matchAll(/([A-Z][A-Z0-9_]*)\s*=\s*['"]([^'"]+)['"]/g)
-  ]
-    .filter((match) => registry.get(match[1]) === match[2])
-    .map((match) => match[1])
-
-  return [
-    ...new Set(
-      [...members, ...registered]
-        .map((member) => registry.get(member))
-        .filter((flag): flag is string => Boolean(flag))
-    )
-  ]
 }
 
 export function runtimePathsFor(
@@ -197,19 +164,12 @@ export function evaluatePolicy(input: PolicyInput): PolicyResult {
   if (declared.errors.length)
     return { verdict: 'fail', requiresAi: false, reasons: declared.errors }
 
-  const inferred = input.registrySource
-    ? inferFlags(input.registrySource, input.patches ?? [])
-    : []
-  const flag = declared.flag ?? (inferred.length === 1 ? inferred[0] : null)
+  const flag = declared.flag
   if (!flag)
     return {
-      verdict: 'inconclusive',
-      requiresAi: true,
-      reasons: [
-        inferred.length > 1
-          ? 'Multiple flags were found; the author must set `Flag`.'
-          : 'No flag was found; the author must set `Flag` if review cannot infer it.'
-      ]
+      verdict: 'fail',
+      requiresAi: false,
+      reasons: ['The author must provide the `Flag` field.']
     }
 
   if (
@@ -232,17 +192,12 @@ export function evaluatePolicy(input: PolicyInput): PolicyResult {
     )
       ? 'existing'
       : 'new'
-  const flagDiscovery = declared.flag ? 'declared' : 'inferred'
-
   return {
     verdict: 'pass',
     requiresAi: true,
-    reasons: [
-      `Flag \`${flag}\` was ${flagDiscovery}, is ${flagOrigin}, and defaults OFF in code.`
-    ],
+    reasons: [`Flag \`${flag}\` is ${flagOrigin} and defaults OFF in code.`],
     flag,
-    flagOrigin,
-    flagDiscovery
+    flagOrigin
   }
 }
 
@@ -372,23 +327,13 @@ function main() {
   const baseRegistrySource = needsReview
     ? repoFile(repo, pull.base.sha, 'src/composables/useFeatureFlags.ts')
     : undefined
-  const runtimePathSet = new Set(runtimePaths)
-  const patches = files
-    .filter(
-      (file) =>
-        runtimePathSet.has(file.filename) ||
-        (file.previous_filename && runtimePathSet.has(file.previous_filename))
-    )
-    .map(({ patch }) => patch)
-    .filter((patch): patch is string => patch !== undefined)
   const result = evaluatePolicy({
     body: pull.body ?? '',
     labels,
     risk,
     runtimePaths,
     registrySource,
-    baseRegistrySource,
-    patches
+    baseRegistrySource
   })
   if (disputed === 'conflict') {
     result.verdict = 'inconclusive'

--- a/scripts/cicd/feature-flag-policy.ts
+++ b/scripts/cicd/feature-flag-policy.ts
@@ -83,8 +83,13 @@ const EXCEPTION_REASONS = new Set([
 ])
 const PLACEHOLDERS = new Set([
   'key',
-  'N/A',
-  'URL',
+  'n/a',
+  'na',
+  'none',
+  'not applicable',
+  'tbd',
+  'todo',
+  'url',
   'path:line',
   'path:test',
   'description',
@@ -96,7 +101,12 @@ function clean(value: string): string {
 }
 
 function isFilled(value: string): boolean {
-  return value.length > 0 && !value.includes(' | ') && !PLACEHOLDERS.has(value)
+  const normalized = value.trim().toLowerCase()
+  return (
+    normalized.length > 0 &&
+    !normalized.includes(' | ') &&
+    !PLACEHOLDERS.has(normalized)
+  )
 }
 
 export function parsePolicyFields(body: string): {


### PR DESCRIPTION
## Summary

Add the deterministic `feature-flag-policy` Check Run in non-required shadow mode.

Stack: 2/3 — [#17022](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17022) → [#17023](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17023) → [#17024](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17024). Base: `cx/feature-flag-contract`.

## Changes

- **What**: Resolve effective risk, classify Cloud runtime paths, require the author-provided `Flag`, and verify its code fallback is OFF.
- **Failure**: A missing, placeholder, duplicate, unregistered, or non-fail-closed flag fails before semantic review.
- **Breaking**: None; `feature-flag-policy` is not required by `ProtectMain`.

## Review Focus

Risk-dispute precedence, class-based runtime scope, mandatory flag validation, fail-closed defaults, and trusted base-branch execution.

## Feature flag

- **Flag**:

## Screenshots (if applicable)

N/A
