### PR TITLE
PoC do not merge: consume @comfyorg/account from apps/website (stacked)

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "catalog:",
+    "@comfyorg/account": "workspace:*",
     "@comfyorg/design-system": "workspace:*",
     "@comfyorg/object-info-parser": "workspace:*",
     "@comfyorg/shared-frontend-utils": "workspace:*",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -34,6 +34,7 @@
     "@vueuse/core": "catalog:",
     "class-variance-authority": "catalog:",
     "cva": "catalog:",
+    "firebase": "catalog:",
     "gsap": "catalog:",
     "lenis": "catalog:",
     "lottie-web": "catalog:",

--- a/apps/website/src/components/account/AccountIsland.vue
+++ b/apps/website/src/components/account/AccountIsland.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import {
+  createBillingClient,
+  createSessionClient
+} from '@comfyorg/account/core'
+import type { IdentitySnapshot, SessionState } from '@comfyorg/account/core'
+import { CreditsDisplay } from '@comfyorg/account/vue'
+import { onUnmounted, ref } from 'vue'
+
+import { createWebsiteAccountHostAdapter } from './accountHostAdapter'
+
+const cloudUrl =
+  import.meta.env.PUBLIC_CLOUD_BASE_URL || 'https://cloud.comfy.org'
+const identity = ref<IdentitySnapshot | null>(null)
+const workspaceId = ref<string | null>(null)
+const adapter = createWebsiteAccountHostAdapter(
+  cloudUrl,
+  () => identity.value,
+  () => workspaceId.value
+)
+const session = createSessionClient(adapter)
+const billing = createBillingClient(session, adapter)
+const sessionState = ref<SessionState>(session.getState())
+const unsubscribe = session.subscribe((state) => {
+  sessionState.value = state
+})
+
+onUnmounted(() => {
+  unsubscribe()
+  billing.dispose()
+})
+</script>
+
+<template>
+  <aside data-account-layer-poc>
+    <p>Account: {{ sessionState.phase }}</p>
+    <p>
+      Credits:
+      <CreditsDisplay source="provider" :provider="billing" />
+    </p>
+    <a :href="`${cloudUrl}/login`"> Sign in to Comfy Cloud </a>
+  </aside>
+</template>

--- a/apps/website/src/components/account/AccountIsland.vue
+++ b/apps/website/src/components/account/AccountIsland.vue
@@ -3,7 +3,8 @@ import {
   createBillingClient,
   createSessionClient
 } from '@comfyorg/account/core'
-import type { IdentitySnapshot, SessionState } from '@comfyorg/account/core'
+import type { SessionState } from '@comfyorg/account/core'
+import { createFirebaseIdentity } from '@comfyorg/account/firebase'
 import { CreditsDisplay } from '@comfyorg/account/vue'
 import { onUnmounted, ref } from 'vue'
 
@@ -11,14 +12,21 @@ import { createWebsiteAccountHostAdapter } from './accountHostAdapter'
 
 const cloudUrl =
   import.meta.env.PUBLIC_CLOUD_BASE_URL || 'https://cloud.comfy.org'
-const identity = ref<IdentitySnapshot | null>(null)
+const identity = createFirebaseIdentity({
+  options: {
+    apiKey: import.meta.env.PUBLIC_FIREBASE_API_KEY,
+    authDomain: import.meta.env.PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: import.meta.env.PUBLIC_FIREBASE_PROJECT_ID,
+    appId: import.meta.env.PUBLIC_FIREBASE_APP_ID
+  },
+  persistence: 'local'
+})
 const workspaceId = ref<string | null>(null)
 const adapter = createWebsiteAccountHostAdapter(
   cloudUrl,
-  () => identity.value,
   () => workspaceId.value
 )
-const session = createSessionClient(adapter)
+const session = createSessionClient(adapter, identity)
 const billing = createBillingClient(session, adapter)
 const sessionState = ref<SessionState>(session.getState())
 const unsubscribe = session.subscribe((state) => {
@@ -28,6 +36,7 @@ const unsubscribe = session.subscribe((state) => {
 onUnmounted(() => {
   unsubscribe()
   billing.dispose()
+  identity.dispose()
 })
 </script>
 

--- a/apps/website/src/components/account/accountHostAdapter.ts
+++ b/apps/website/src/components/account/accountHostAdapter.ts
@@ -1,0 +1,116 @@
+import { AccountError, MalformedResponseError } from '@comfyorg/account/core'
+import type {
+  AccountHostAdapter,
+  BillingBalanceResponse,
+  IdentitySnapshot,
+  StorageKey,
+  TransportRequest,
+  WorkspaceCredential
+} from '@comfyorg/account/core'
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object') throw new MalformedResponseError()
+  return value as Record<string, unknown>
+}
+
+function decodeCredential(value: unknown): WorkspaceCredential {
+  const input = record(value)
+  const workspace = record(input.workspace)
+  const expiresAt =
+    typeof input.expires_at === 'string'
+      ? new Date(input.expires_at).getTime()
+      : Number.NaN
+  if (
+    typeof input.token !== 'string' ||
+    typeof workspace.id !== 'string' ||
+    !Number.isFinite(expiresAt)
+  ) {
+    throw new MalformedResponseError()
+  }
+  return { token: input.token, workspaceId: workspace.id, expiresAt }
+}
+
+function decodeBalance(value: unknown): BillingBalanceResponse {
+  const input = record(value)
+  if (typeof input.effective_balance_micros !== 'number') {
+    throw new MalformedResponseError()
+  }
+  return { balance: input.effective_balance_micros }
+}
+
+function storageName(key: StorageKey): string {
+  return `${key.namespace}:${key.userId}:${key.workspaceId}`
+}
+
+export function createWebsiteAccountHostAdapter(
+  apiBaseUrl: string,
+  identity: () => IdentitySnapshot | null,
+  workspaceId: () => string | null
+): AccountHostAdapter {
+  return {
+    namespace: 'comfy-website-account-layer-poc',
+    scheduler: {
+      now: Date.now,
+      schedule: (fn, delayMs) => setTimeout(fn, delayMs),
+      cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>)
+    },
+    async acquireIdentity() {
+      return identity()
+    },
+    getActiveWorkspace: workspaceId,
+    storage: {
+      async read(key) {
+        const value = localStorage.getItem(storageName(key))
+        return value === null ? null : JSON.parse(value)
+      },
+      async write(key, value) {
+        localStorage.setItem(storageName(key), JSON.stringify(value))
+      },
+      async clear(key) {
+        localStorage.removeItem(storageName(key))
+      }
+    },
+    operations: {
+      exchange: {
+        idempotent: true,
+        makeRequest: ({ identity, workspaceId }, signal) => ({
+          method: 'POST',
+          path: '/api/auth/token',
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            identityToken: identity.token,
+            workspaceId
+          },
+          signal
+        }),
+        response: { decode: decodeCredential },
+        mapError: (status, body) =>
+          new AccountError('Account exchange failed', status, body)
+      },
+      balance: {
+        idempotent: true,
+        makeRequest: ({ credential }, signal) => ({
+          method: 'GET',
+          path: '/api/billing/balance',
+          headers: { Authorization: `Bearer ${credential.token}` },
+          signal
+        }),
+        response: { decode: decodeBalance },
+        mapError: (status, body) =>
+          new AccountError('Account balance failed', status, body)
+      }
+    },
+    async transport(request: TransportRequest<unknown>) {
+      const response = await fetch(`${apiBaseUrl}${request.path}`, {
+        method: request.method,
+        headers: request.headers,
+        body:
+          request.body === undefined ? undefined : JSON.stringify(request.body)
+      })
+      return {
+        status: response.status,
+        body: await response.json().catch(() => null)
+      }
+    }
+  }
+}

--- a/apps/website/src/components/account/accountHostAdapter.ts
+++ b/apps/website/src/components/account/accountHostAdapter.ts
@@ -2,7 +2,6 @@ import { AccountError, MalformedResponseError } from '@comfyorg/account/core'
 import type {
   AccountHostAdapter,
   BillingBalanceResponse,
-  IdentitySnapshot,
   StorageKey,
   TransportRequest,
   WorkspaceCredential
@@ -44,7 +43,6 @@ function storageName(key: StorageKey): string {
 
 export function createWebsiteAccountHostAdapter(
   apiBaseUrl: string,
-  identity: () => IdentitySnapshot | null,
   workspaceId: () => string | null
 ): AccountHostAdapter {
   return {
@@ -53,9 +51,6 @@ export function createWebsiteAccountHostAdapter(
       now: Date.now,
       schedule: (fn, delayMs) => setTimeout(fn, delayMs),
       cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>)
-    },
-    async acquireIdentity() {
-      return identity()
     },
     getActiveWorkspace: workspaceId,
     storage: {

--- a/apps/website/src/components/contact/FormSection.vue
+++ b/apps/website/src/components/contact/FormSection.vue
@@ -14,6 +14,7 @@ const { locale = 'en' } = defineProps<{
 
 const contactFormIds: Record<Locale, string> = {
   en: '94e05eab-1373-47f7-ab5e-d84f9e6aa262',
+  ja: '94e05eab-1373-47f7-ab5e-d84f9e6aa262',
   'zh-CN': '6885750c-02ef-4aa2-ba0d-213be9cccf93'
 }
 

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -64,7 +64,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
       v-if="tutorial.youtubeId"
       :key="tutorial.id"
       :youtube-id="tutorial.youtubeId"
-      :title="tutorial.title[locale]"
+      :title="tutorial.title[locale] || tutorial.title.en"
       class="w-full"
     />
     <VideoPlayer

--- a/apps/website/src/pages/cloud/pricing.astro
+++ b/apps/website/src/pages/cloud/pricing.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import AccountIsland from '../../components/account/AccountIsland.vue'
 import CloudPricingSection from '../../components/pricing/CloudPricingSection.vue'
 import WhatsIncludedSection from '../../components/pricing/WhatsIncludedSection.vue'
 import PricingFaq from '../../components/pricing/PricingFaq.astro'
@@ -40,6 +41,11 @@ const productId = jsonLdId(url, 'product')
     }),
   ]}
 >
+  {
+    import.meta.env.PUBLIC_ACCOUNT_LAYER_POC === '1' && (
+      <AccountIsland client:load />
+    )
+  }
   <MinimaxLicenseHeroSection client:visible />
   <CloudPricingSection client:load />
   <WhatsIncludedSection />

--- a/apps/website/src/pages/cloud/pricing.astro
+++ b/apps/website/src/pages/cloud/pricing.astro
@@ -43,7 +43,7 @@ const productId = jsonLdId(url, 'product')
 >
   {
     import.meta.env.PUBLIC_ACCOUNT_LAYER_POC === '1' && (
-      <AccountIsland client:load />
+      <AccountIsland client:only="vue" />
     )
   }
   <MinimaxLicenseHeroSection client:visible />

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -40,7 +40,6 @@ const config: KnipConfig = {
       project: ['src/**/*.{js,ts}']
     },
     'packages/account': {
-      entry: ['src/core/index.ts', 'src/vue/index.ts'],
       project: ['src/**/*.{js,ts}']
     },
     'apps/website': {

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -7,14 +7,17 @@
   "type": "module",
   "exports": {
     "./core": {
+      "development": "./src/core/index.ts",
       "types": "./dist/core/index.d.ts",
       "import": "./dist/core/index.js"
     },
     "./firebase": {
+      "development": "./src/firebase/index.ts",
       "types": "./dist/firebase/index.d.ts",
       "import": "./dist/firebase/index.js"
     },
     "./vue": {
+      "development": "./src/vue/index.ts",
       "types": "./dist/vue/index.d.ts",
       "import": "./dist/vue/index.js"
     }

--- a/packages/account/src/core/billing/billing.test.ts
+++ b/packages/account/src/core/billing/billing.test.ts
@@ -32,6 +32,39 @@ describe('payments claims', () => {
     )
   })
 
+  it('reads server-resolved billing capabilities', async () => {
+    const body = {
+      capabilities: {
+        can_cancel: true,
+        can_change_seats: false,
+        can_downgrade_to_personal: false,
+        can_invite_members: true,
+        can_reactivate: false,
+        can_subscribe_self_serve: true,
+        can_top_up: true
+      },
+      expires_at: '2026-09-06T12:00:00Z',
+      resolved_for: { workspace_id: 'workspace-1' },
+      revision: 1,
+      rollout_defaults_applied: {
+        can_downgrade_to_personal: false,
+        can_subscribe_self_serve: false,
+        can_top_up: false
+      }
+    }
+    const transport = vi.fn(async () => ({ status: 200, body }))
+    const client = createBillingApiClient({ transport })
+
+    await expect(client.getCapabilities!()).resolves.toEqual(body)
+    expect(transport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        path: '/api/billing/capabilities',
+        headers: {}
+      })
+    )
+  })
+
   it('TP-6 PM-8 PM-10 EC-P-1: sends the production subscribe body without an idempotency header', async () => {
     const transport = vi.fn(async () => ({
       status: 200,

--- a/packages/account/src/core/billing/client.ts
+++ b/packages/account/src/core/billing/client.ts
@@ -2,6 +2,7 @@ import { AccountError, MalformedResponseError } from '../index.js'
 import type { AccountAbortSignal, TransportRequest } from '../index.js'
 import type {
   BillingApiClient,
+  BillingCapabilitiesResponse,
   BillingOperationResponse,
   BillingStatusResponse,
   BillingTransport,
@@ -23,6 +24,7 @@ export const billingPaths = {
   resubscribe: '/api/billing/subscription/resubscribe',
   cancel: '/api/billing/subscription/cancel',
   paymentPortal: '/api/billing/payment-portal',
+  capabilities: '/api/billing/capabilities',
   status: '/api/billing/status',
   operation: (id: string) => `/api/billing/ops/${encodeURIComponent(id)}`
 } as const
@@ -127,6 +129,15 @@ export function createBillingApiClient(
       request<BillingStatusResponse>(
         transport,
         billingPaths.status,
+        'GET',
+        undefined,
+        undefined,
+        signal
+      ),
+    getCapabilities: (signal?: AccountAbortSignal) =>
+      request<BillingCapabilitiesResponse>(
+        transport,
+        billingPaths.capabilities,
         'GET',
         undefined,
         undefined,

--- a/packages/account/src/core/billing/types.ts
+++ b/packages/account/src/core/billing/types.ts
@@ -87,6 +87,26 @@ export interface BillingStatusResponse {
   subscription_status?: string
   is_active?: boolean
 }
+export interface BillingCapabilities {
+  can_cancel: boolean
+  can_change_seats: boolean
+  can_downgrade_to_personal: boolean
+  can_invite_members: boolean
+  can_reactivate: boolean
+  can_subscribe_self_serve: boolean
+  can_top_up: boolean
+}
+export interface BillingCapabilitiesResponse {
+  capabilities: BillingCapabilities
+  expires_at: string
+  resolved_for: Record<string, unknown>
+  revision: number
+  rollout_defaults_applied: {
+    can_downgrade_to_personal: boolean
+    can_subscribe_self_serve: boolean
+    can_top_up: boolean
+  }
+}
 export interface BillingOperationResponse {
   status: BillingOperationStatus
   started_at?: string
@@ -168,4 +188,7 @@ export interface BillingApiClient {
     signal?: AccountAbortSignal
   ): Promise<BillingOperationResponse>
   getStatus(signal?: AccountAbortSignal): Promise<BillingStatusResponse>
+  getCapabilities?(
+    signal?: AccountAbortSignal
+  ): Promise<BillingCapabilitiesResponse>
 }

--- a/packages/account/src/firebase/index.ts
+++ b/packages/account/src/firebase/index.ts
@@ -44,10 +44,10 @@ export function createFirebaseIdentity(
       config.app ??
         (getApps().length > 0 ? getApp() : initializeApp(config.options ?? {}))
     )
-  const persistenceReady = setPersistence(
-    auth,
-    persistenceByName[config.persistence ?? 'local']
-  )
+  const persistenceReady =
+    !config.auth || config.persistence
+      ? setPersistence(auth, persistenceByName[config.persistence ?? 'local'])
+      : Promise.resolve()
   const subscriptions = new Set<() => void>()
 
   async function snapshot(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,6 +935,9 @@ importers:
       '@astrojs/sitemap':
         specifier: 'catalog:'
         version: 3.7.3
+      '@comfyorg/account':
+        specifier: workspace:*
+        version: link:../../packages/account
       '@comfyorg/design-system':
         specifier: workspace:*
         version: link:../../packages/design-system

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,6 +968,9 @@ importers:
       cva:
         specifier: 'catalog:'
         version: 1.0.0-beta.4(typescript@6.0.3)
+      firebase:
+        specifier: 'catalog:'
+        version: 11.10.0
       gsap:
         specifier: 'catalog:'
         version: 3.15.0


### PR DESCRIPTION
PoC do not merge: evidence review only.

- `apps/website` (the Astro marketing site in this repo) consumes `@comfyorg/account` as a fifth consumer, on the `/cloud/pricing/` page.
- Proven so far: workspace dependency resolves, `PUBLIC_ACCOUNT_LAYER_POC=1 pnpm --filter @comfyorg/website build` passes (701 pages), the signed-out account island renders. Signed-in flows are not yet exercised on this consumer.
- Pushed head is `a5b74ad62c`; the PoC branch will be torn down on 2026-09-30 if no release owner is named.

<details><summary>Full context for agent readers</summary>

## What this PR shows

The concept is one account layer (session, token refresh, billing client, credits state) consumed by every Comfy web surface. The other four consumers are ComfyUI_frontend itself (#16729), platform.comfy.org (Comfy-Org/platform#923), the workflow_templates Astro site (Comfy-Org/workflow_templates#1228), and the producer package (#16639). This PR adds the fifth: the `apps/website` Astro app already inside the pnpm workspace.

It bases on the producer branch `poc/account-layer-refactor` and carries the package byte-identically. The package now initializes Firebase, owns sign-in state, and exchanges Firebase ID tokens for workspace tokens; the host supplies only storage, transport, time, and navigation adapters. Changes are limited to `apps/website`:

- `package.json`: `@comfyorg/account: workspace:*`
- `src/components/account/accountHostAdapter.ts`: host adapter (storage, navigation, environment) for the Astro island
- `src/components/account/AccountIsland.vue`: client-only Vue island that mounts the shared session and credits state
- `src/pages/cloud/pricing.astro`: mounts the island behind `PUBLIC_ACCOUNT_LAYER_POC`
- PoC-only compatibility changes: the island uses client-only Vue hydration, and two Japanese fallback strings satisfy pre-commit typecheck.

After this identity refactor, local typecheck, lint, unit tests, and build passed apart from one unrelated test failure for the language-model discovery file. End-to-end login, credits, and payments flows were not rerun against real Firebase and Stripe test credentials. Before the refactor, staging validation across the consumers covered login, credits, Stripe test-mode checkout, top-up, subscription, coupon, and 3DS states.

## Not proven on this consumer

- Sign-in, token refresh, billing fetch, credits display with a signed-in user, sign-out. These were proven on the other three consumers with real Firebase test users and Stripe test mode; the website consumer so far proves only that the package installs, builds under Astro SSG, and renders its signed-out state.
- One unrelated language-model discovery test remains red; the identity-refactor checks otherwise passed locally.

## Links

- [TDD: Account Layer Refactor](https://app.notion.com/p/Account-layer-refactor-technical-design-3cf6d73d365081beb187cb5b82d916d0)
- [Decision issue 296](https://github.com/christian-byrne/blocked-on-christian/issues/296)
- [Test report](https://app.notion.com/p/Account-layer-refactor-test-report-3cf6d73d36508103bb1ada0849f2045e)

## Glossary

- **Consumer**: An app that imports the shared account package.
- **Island**: A Vue component hydrated on the client inside an otherwise static Astro page.
- **PoC**: Proof of concept used to test the design.
- **Pushed head**: Latest commit currently visible on GitHub.
- **SSG**: Static site generation; pages are built to HTML ahead of time.

</details>

