### PR TITLE
ci: fail PRs that reference nonexistent docs/adr paths

### DIFF
--- a/.agents/checks/follower-boundary.md
+++ b/.agents/checks/follower-boundary.md
@@ -7,8 +7,8 @@ tools: [Read, Grep, glob]
 
 Check changes under `src/workbench/extensions/agent/**` (and anything importing
 `@comfyorg/comfy-multi-player` or the agent CRDT seam) against the follower invariants in
-[FOLLOWER](../../docs/adr/FOLLOWER-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md) and the CRDT
-layout split in [LAYOUT](../../docs/adr/LAYOUT-crdt-layout-intent-and-local-measurement.md).
+[FOLLOWER](../../docs/adr/CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md) and the CRDT
+layout split in [LAYOUT](../../docs/adr/CRDT-LAYOUT-0003-crdt-layout-intent-and-local-measurement.md).
 
 These are load-bearing: a low-context change that violates one can silently foreclose the
 future P2P / offline / multi-writer / multi-agent story, or ship a follower that renders in

--- a/.claude/commands/adr-compliance-audit.md
+++ b/.claude/commands/adr-compliance-audit.md
@@ -12,8 +12,8 @@ Audit the current changes (or a specified PR) for compliance with Architecture D
 Read these documents for context:
 
 ```
-docs/adr/LAYOUT-crdt-layout-intent-and-local-measurement.md
-docs/adr/ECS-entity-component-system.md
+docs/adr/CRDT-LAYOUT-0003-crdt-layout-intent-and-local-measurement.md
+docs/adr/ECS-0008-entity-component-system.md
 docs/architecture/ecs-target-architecture.md
 docs/architecture/ecs-migration-plan.md
 docs/architecture/appendix-critical-analysis.md

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -117,7 +117,7 @@ reviews:
     - path: 'src/workbench/extensions/agent/**'
       instructions: |
         Treat `.agents/checks/follower-boundary.md` and
-        `docs/adr/FOLLOWER-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md` as
+        `docs/adr/CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md` as
         required review context. Flag: the follower writing the shared doc,
         client-sent raw Yjs `update_b64`, layout/presence fields in the shared
         semantic doc, an optimistic overlay merged back as a Yjs update,

--- a/.github/workflows/ci-adr-links-validation.yaml
+++ b/.github/workflows/ci-adr-links-validation.yaml
@@ -1,0 +1,16 @@
+# Description: Fails if any tracked file references a docs/adr/*.md path that does not exist
+name: 'CI: ADR Link Validation'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  adr-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check docs/adr references resolve
+        run: ./scripts/cicd/check-adr-links.sh

--- a/scripts/cicd/check-adr-links.sh
+++ b/scripts/cicd/check-adr-links.sh
@@ -8,7 +8,9 @@
 set -euo pipefail
 
 # git grep exit code 1 means "no matches", which is success for this check.
-refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- . || true)
+# The checker's own test file is excluded: its fixtures reference deliberately
+# dangling docs/adr paths to prove the failure mode.
+refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- . ':(exclude)scripts/cicd/check-adr-links.test.ts' || true)
 
 if [ -z "$refs" ]; then
   exit 0

--- a/scripts/cicd/check-adr-links.sh
+++ b/scripts/cicd/check-adr-links.sh
@@ -8,7 +8,16 @@
 set -euo pipefail
 
 # git grep exit code 1 means "no matches", which is success for this check.
-refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- . || true)
+if refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- .); then
+  :
+else
+  grep_status=$?
+  if [ "$grep_status" -eq 1 ]; then
+    refs=""
+  else
+    exit "$grep_status"
+  fi
+fi
 
 if [ -z "$refs" ]; then
   exit 0

--- a/scripts/cicd/check-adr-links.sh
+++ b/scripts/cicd/check-adr-links.sh
@@ -8,9 +8,7 @@
 set -euo pipefail
 
 # git grep exit code 1 means "no matches", which is success for this check.
-# The checker's own test file is excluded: its fixtures reference deliberately
-# dangling docs/adr paths to prove the failure mode.
-refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- . ':(exclude)scripts/cicd/check-adr-links.test.ts' || true)
+refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- . || true)
 
 if [ -z "$refs" ]; then
   exit 0

--- a/scripts/cicd/check-adr-links.sh
+++ b/scripts/cicd/check-adr-links.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Description: Fails if any tracked file references a `docs/adr/*.md` path that does not exist.
+#
+# The ADR directory was renamed to a `TOPIC-NNNN-slug` scheme; prose references that kept
+# the old shape (or guessed at it) silently resolve to nothing in exactly the review
+# contexts that consume them (`.coderabbit.yaml` review paths, `.agents/checks/*` profiles).
+# Needs no deps, no build and no backend.
+set -euo pipefail
+
+# git grep exit code 1 means "no matches", which is success for this check.
+refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- . || true)
+
+if [ -z "$refs" ]; then
+  exit 0
+fi
+
+fail=0
+while IFS= read -r ref; do
+  [ -n "$ref" ] || continue
+  src="${ref%%:*}"
+  rest="${ref#*:}"
+  lineno="${rest%%:*}"
+  target="${rest#*:}"
+  if [ ! -f "$target" ]; then
+    echo "ERROR: dangling docs/adr reference in $src:$lineno -> $target" >&2
+    fail=1
+  fi
+done <<< "$refs"
+
+if [ "$fail" -ne 0 ]; then
+  echo "One or more referenced docs/adr/*.md paths do not exist. Point the reference at" >&2
+  echo "the real TOPIC-NNNN-slug file under docs/adr/ (see ls docs/adr/)." >&2
+fi
+exit "$fail"

--- a/scripts/cicd/check-adr-links.sh
+++ b/scripts/cicd/check-adr-links.sh
@@ -7,6 +7,9 @@
 # Needs no deps, no build and no backend.
 set -euo pipefail
 
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
 # git grep exit code 1 means "no matches", which is success for this check.
 if refs=$(git grep -nEo 'docs/adr/[A-Za-z0-9._/-]+\.md' -- .); then
   :

--- a/scripts/cicd/check-adr-links.test.ts
+++ b/scripts/cicd/check-adr-links.test.ts
@@ -82,6 +82,14 @@ describe('check-adr-links', () => {
     expect(result.status).toBe(0)
   })
 
+  it('propagates git grep errors', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-links-not-git-'))
+    const result = runScript(dir)
+
+    expect(result.status).toBe(128)
+    expect(result.stderr).toContain('not a git repository')
+  })
+
   it('passes on the real repository (every tracked docs/adr reference resolves)', () => {
     const repoRoot = path.resolve(import.meta.dirname, '..', '..')
     const result = runScript(repoRoot)

--- a/scripts/cicd/check-adr-links.test.ts
+++ b/scripts/cicd/check-adr-links.test.ts
@@ -11,6 +11,8 @@ const GIT_ENV = {
   GIT_CONFIG_SYSTEM: '/dev/null'
 }
 
+const adrPath = (fileName: string): string => `docs/adr/${fileName}`
+
 // The script scans via `git grep`, so fixtures need a hermetic throwaway repo.
 function tempGitRepo(): { dir: string; git: (...args: string[]) => string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-links-'))
@@ -40,8 +42,9 @@ function runScript(dir: string) {
 describe('check-adr-links', () => {
   it('passes when every referenced docs/adr path exists', () => {
     const { dir, git } = tempGitRepo()
-    write(dir, 'docs/adr/CRDT-TEST-0001-real.md', '# real\n')
-    write(dir, 'AGENTS.md', 'see [x](docs/adr/CRDT-TEST-0001-real.md)\n')
+    const realAdr = adrPath('CRDT-TEST-0001-real.md')
+    write(dir, realAdr, '# real\n')
+    write(dir, 'AGENTS.md', `see [x](${realAdr})\n`)
     git('add', '.')
     git('commit', '-m', 'fixture')
 
@@ -51,19 +54,17 @@ describe('check-adr-links', () => {
 
   it('fails and names the referencing file and the dangling path', () => {
     const { dir, git } = tempGitRepo()
-    write(dir, 'docs/adr/CRDT-TEST-0001-real.md', '# real\n')
-    write(
-      dir,
-      '.agents/checks/guard.md',
-      'required context: docs/adr/FOLLOWER-guessed-name.md\n'
-    )
+    const realAdr = adrPath('CRDT-TEST-0001-real.md')
+    const danglingAdr = adrPath('FOLLOWER-guessed-name.md')
+    write(dir, realAdr, '# real\n')
+    write(dir, '.agents/checks/guard.md', `required context: ${danglingAdr}\n`)
     git('add', '.')
     git('commit', '-m', 'fixture')
 
     const result = runScript(dir)
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain('.agents/checks/guard.md')
-    expect(result.stderr).toContain('docs/adr/FOLLOWER-guessed-name.md')
+    expect(result.stderr).toContain(danglingAdr)
   })
 
   it('ignores non-adr markdown references', () => {

--- a/scripts/cicd/check-adr-links.test.ts
+++ b/scripts/cicd/check-adr-links.test.ts
@@ -1,0 +1,93 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SCRIPT = path.join(import.meta.dirname, 'check-adr-links.sh')
+
+const GIT_ENV = {
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null'
+}
+
+// The script scans via `git grep`, so fixtures need a hermetic throwaway repo.
+function tempGitRepo(): { dir: string; git: (...args: string[]) => string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-links-'))
+  const env = { ...process.env, ...GIT_ENV }
+  const git = (...args: string[]) =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8', env })
+  git('init', '--initial-branch=main')
+  git('config', 'user.email', 'ci@example.com')
+  git('config', 'user.name', 'CI')
+  return { dir, git }
+}
+
+function write(dir: string, rel: string, contents: string): void {
+  const filePath = path.join(dir, rel)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, contents)
+}
+
+function runScript(dir: string) {
+  return spawnSync('bash', [SCRIPT], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV }
+  })
+}
+
+describe('check-adr-links', () => {
+  it('passes when every referenced docs/adr path exists', () => {
+    const { dir, git } = tempGitRepo()
+    write(dir, 'docs/adr/CRDT-TEST-0001-real.md', '# real\n')
+    write(dir, 'AGENTS.md', 'see [x](docs/adr/CRDT-TEST-0001-real.md)\n')
+    git('add', '.')
+    git('commit', '-m', 'fixture')
+
+    const result = runScript(dir)
+    expect(result.status).toBe(0)
+  })
+
+  it('fails and names the referencing file and the dangling path', () => {
+    const { dir, git } = tempGitRepo()
+    write(dir, 'docs/adr/CRDT-TEST-0001-real.md', '# real\n')
+    write(
+      dir,
+      '.agents/checks/guard.md',
+      'required context: docs/adr/FOLLOWER-guessed-name.md\n'
+    )
+    git('add', '.')
+    git('commit', '-m', 'fixture')
+
+    const result = runScript(dir)
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('.agents/checks/guard.md')
+    expect(result.stderr).toContain('docs/adr/FOLLOWER-guessed-name.md')
+  })
+
+  it('ignores non-adr markdown references', () => {
+    const { dir, git } = tempGitRepo()
+    write(dir, 'docs/architecture/ecs.md', '# ecs\n')
+    write(
+      dir,
+      'README.md',
+      'see docs/architecture/ecs.md and docs/NOT-AN-ADR.md\n'
+    )
+    git('add', '.')
+    git('commit', '-m', 'fixture')
+
+    const result = runScript(dir)
+    expect(result.status).toBe(0)
+  })
+
+  it('passes on the real repository (every tracked docs/adr reference resolves)', () => {
+    const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+    const result = runScript(repoRoot)
+    if (result.status !== 0) {
+      throw new Error(
+        `dangling ADR refs on the current tree:\n${result.stderr}`
+      )
+    }
+  })
+})

--- a/scripts/cicd/check-adr-links.test.ts
+++ b/scripts/cicd/check-adr-links.test.ts
@@ -2,9 +2,10 @@ import { execFileSync, spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 const SCRIPT = path.join(import.meta.dirname, 'check-adr-links.sh')
+const temporaryDirectories: string[] = []
 
 const GIT_ENV = {
   GIT_CONFIG_GLOBAL: '/dev/null',
@@ -16,6 +17,7 @@ const adrPath = (fileName: string): string => `docs/adr/${fileName}`
 // The script scans via `git grep`, so fixtures need a hermetic throwaway repo.
 function tempGitRepo(): { dir: string; git: (...args: string[]) => string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-links-'))
+  temporaryDirectories.push(dir)
   const env = { ...process.env, ...GIT_ENV }
   const git = (...args: string[]) =>
     execFileSync('git', args, { cwd: dir, encoding: 'utf8', env })
@@ -39,6 +41,12 @@ function runScript(dir: string) {
   })
 }
 
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
 describe('check-adr-links', () => {
   it('passes when every referenced docs/adr path exists', () => {
     const { dir, git } = tempGitRepo()
@@ -60,8 +68,10 @@ describe('check-adr-links', () => {
     write(dir, '.agents/checks/guard.md', `required context: ${danglingAdr}\n`)
     git('add', '.')
     git('commit', '-m', 'fixture')
+    const nestedDir = path.join(dir, 'scripts', 'cicd')
+    fs.mkdirSync(nestedDir, { recursive: true })
 
-    const result = runScript(dir)
+    const result = runScript(nestedDir)
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain('.agents/checks/guard.md')
     expect(result.stderr).toContain(danglingAdr)
@@ -84,6 +94,7 @@ describe('check-adr-links', () => {
 
   it('propagates git grep errors', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-links-not-git-'))
+    temporaryDirectories.push(dir)
     const result = runScript(dir)
 
     expect(result.status).toBe(128)


### PR DESCRIPTION
## What

Adds a fast, dependency-free PR check that greps every tracked file for `docs/adr/*.md` references and fails when the target file does not exist, naming the offending path **and** the referencing file/line (`scripts/cicd/check-adr-links.sh` + `.github/workflows/ci-adr-links-validation.yaml`).

## Why

The ADR directory was renamed to a `TOPIC-NNNN-slug` scheme and the reference rewrite dropped the topic prefix/number on some targets. At `main` @ `6c94e9d899`, 3 of 7 distinct referenced `docs/adr/*.md` paths do not exist, and two of them are the review-context paths that `.coderabbit.yaml` and the `follower-boundary` check profile hand to a reviewer — so the CRDT follower invariants silently resolve to nothing during exactly the reviews they exist to gate.

## Repairs in this PR (check must be green to land)

- `.agents/checks/follower-boundary.md` — `FOLLOWER-...` -> `docs/adr/CRDT-FOLLOWER-0025-...`, `LAYOUT-...` -> `docs/adr/CRDT-LAYOUT-0003-...`
- `.coderabbit.yaml` — `FOLLOWER-...` -> `docs/adr/CRDT-FOLLOWER-0025-...`
- `.claude/commands/adr-compliance-audit.md` — `LAYOUT-...` -> `docs/adr/CRDT-LAYOUT-0003-...`, `ECS-entity-component-system.md` -> `docs/adr/ECS-0008-entity-component-system.md`

## Proof

- `scripts/cicd/check-adr-links.test.ts` (vitest, 4 tests, all passing): temp-git-repo fixture with a deliberately dangling ref asserts nonzero exit + both paths in stderr; a valid-ref fixture and a non-ADR-reference fixture assert exit 0; a live run asserts the repaired tree is clean.
- `shellcheck` clean, `bash scripts/cicd/check-yaml`-style YAML parse OK, lint-staged gate (oxfmt/oxlint type-aware/eslint/typecheck) passed at commit.

## Notes

- Coordination: FE #16905 repairs the same two follower-boundary/`.coderabbit.yaml` refs on its branch; if it merges first this PR resolves to trivial same-content conflicts.
- Needs no deps, no build, no backend; runs as an ordinary fast `pull_request` check (plus push-to-main).