### PR TITLE
test: verify effective-low flag policy path

### DIFF
--- a/src/platform/cloud/featureFlagPolicyEffectiveLowFixture.test.ts
+++ b/src/platform/cloud/featureFlagPolicyEffectiveLowFixture.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { featureFlagPolicyEffectiveLowFixture } from './featureFlagPolicyEffectiveLowFixture'
+
+describe('featureFlagPolicyEffectiveLowFixture', () => {
+  it('keeps current behavior', () => {
+    expect(featureFlagPolicyEffectiveLowFixture()).toBe('current')
+  })
+})

--- a/src/platform/cloud/featureFlagPolicyEffectiveLowFixture.ts
+++ b/src/platform/cloud/featureFlagPolicyEffectiveLowFixture.ts
@@ -1,0 +1,3 @@
+export function featureFlagPolicyEffectiveLowFixture() {
+  return 'current'
+}


### PR DESCRIPTION
## Summary

Disposable fixture for #17022. Do not merge.

## Changes

- Add a normal Cloud runtime change with focused coverage.
- Leave `Flag` blank to prove the effective-low path skips the gate.

## Review Focus

Apply `risk-dispute:low`; expected effective risk is low and feature-flag policy is skipped.

## Feature flag

- **Flag**:

## Screenshots (if applicable)

N/A
