### PR TITLE
test: verify risk escalation flag policy path

### DIFF
--- a/src/platform/cloud/featureFlagPolicyEscalatedFixture.test.ts
+++ b/src/platform/cloud/featureFlagPolicyEscalatedFixture.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { featureFlagPolicyEscalatedFixtureBehavior } from './featureFlagPolicyEscalatedFixture'
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: { featureFlagPolicyFixtureEnabled: false }
+  })
+}))
+
+describe('featureFlagPolicyEscalatedFixtureBehavior', () => {
+  it('preserves current behavior while the flag is off', () => {
+    expect(featureFlagPolicyEscalatedFixtureBehavior()).toBe('current')
+  })
+})

--- a/src/platform/cloud/featureFlagPolicyEscalatedFixture.ts
+++ b/src/platform/cloud/featureFlagPolicyEscalatedFixture.ts
@@ -1,0 +1,11 @@
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+
+function resolveFeatureFlagPolicyEscalatedFixture(enabled: boolean) {
+  return enabled ? 'candidate' : 'current'
+}
+
+export function featureFlagPolicyEscalatedFixtureBehavior() {
+  return resolveFeatureFlagPolicyEscalatedFixture(
+    useFeatureFlags().flags.featureFlagPolicyFixtureEnabled
+  )
+}


### PR DESCRIPTION
## Summary

Disposable fixture for #17022. Do not merge.

## Changes

- Add a normal Cloud runtime behavior gated by the fixture flag.
- Exercise the OFF path in a focused test.

## Review Focus

Expected sequence: computed `risk:medium` plus `risk-dispute:high` produces effective high, so the feature-flag policy applies.

## Feature flag

- **Flag**: feature_flag_policy_fixture

## Screenshots (if applicable)

N/A
