### PR TITLE
test(agent): derive the recorded conversation schema from the production union

### DIFF
--- a/browser_tests/fixtures/agentConversationFixture.ts
+++ b/browser_tests/fixtures/agentConversationFixture.ts
@@ -9,14 +9,12 @@ import type {
   AgentMessages,
   AgentWsEvent
 } from '@/workbench/extensions/agent/schemas/agentApiSchema'
+import type { ServerDocWireFrame } from '@/workbench/extensions/agent/crdt/docFrameClient'
+import { DOC_PROTOCOL_VERSION } from '@/workbench/extensions/agent/crdt/docFrameClient'
 import { parseAgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
 import { agentTest, bootAgentApp } from '@e2e/fixtures/agentPanelFixture'
-import type { DocFrame } from '@e2e/fixtures/agentConversationHostDoc'
-import {
-  DOC_PROTOCOL_VERSION,
-  HostDoc
-} from '@e2e/fixtures/agentConversationHostDoc'
+import { HostDoc } from '@e2e/fixtures/agentConversationHostDoc'
 import type {
   AgentConversation,
   AgentConversationTurn,
@@ -227,10 +225,7 @@ class AgentConversationHarness {
     const bodies = this.nodeBodies()
     const byType = new Map(bodies.map((body) => [body.type, body]))
     const byId = new Map(bodies.map((body) => [String(body.id), body]))
-    const catalog = this.conversation.workflow.catalog.types as Record<
-      string,
-      { widget_order: string[] }
-    >
+    const catalog = this.conversation.workflow.catalog.types
     const links = Object.values(graph.links) as Array<
       [unknown, unknown, number, unknown, number, string]
     >
@@ -442,7 +437,7 @@ class AgentConversationHarness {
     return parsed.data
   }
 
-  private send(frame: AgentWsEvent | DocFrame): void {
+  private send(frame: AgentWsEvent | ServerDocWireFrame): void {
     if (!this.socket) throw new Error('the app has not opened /ws yet')
     this.socket.send(JSON.stringify(frame))
   }

--- a/browser_tests/fixtures/agentConversationHostDoc.ts
+++ b/browser_tests/fixtures/agentConversationHostDoc.ts
@@ -7,16 +7,12 @@ import type {
 } from '@comfyorg/comfy-multi-player'
 import * as Y from 'yjs'
 
+import type { ServerDocWireFrame } from '@/workbench/extensions/agent/crdt/docFrameClient'
+import { DOC_PROTOCOL_VERSION } from '@/workbench/extensions/agent/crdt/docFrameClient'
 import type { GraphOperation } from '@/workbench/extensions/agent/crdt/graphOperations'
 import { mintWireOps } from '@/workbench/extensions/agent/crdt/opEnvelope'
 
 const HOST_ACTOR = 'agent:comfy'
-export const DOC_PROTOCOL_VERSION = 1
-
-export interface DocFrame {
-  type: 'doc_subscribed' | 'doc_update' | 'doc_ops_result'
-  data: Record<string, unknown>
-}
 
 function toBase64(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString('base64')
@@ -43,7 +39,7 @@ export class HostDoc {
     return readGraph(this.doc)
   }
 
-  subscribed(): DocFrame {
+  subscribed(): ServerDocWireFrame {
     return {
       type: 'doc_subscribed',
       data: {
@@ -55,7 +51,7 @@ export class HostDoc {
     }
   }
 
-  catchUp(stateVectorB64: string): DocFrame {
+  catchUp(stateVectorB64: string): ServerDocWireFrame {
     const update = Y.encodeStateAsUpdate(this.doc, fromBase64(stateVectorB64))
     return this.updateFrame(update, HOST_ACTOR, [])
   }
@@ -72,7 +68,7 @@ export class HostDoc {
     return ops.map((op) => op.op_id)
   }
 
-  apply(operations: GraphOperation[]): DocFrame {
+  apply(operations: GraphOperation[]): ServerDocWireFrame {
     const before = Y.encodeStateVector(this.doc)
     const ops = mintWireOps(operations, {
       actor: HOST_ACTOR,
@@ -96,7 +92,7 @@ export class HostDoc {
     update: Uint8Array,
     actor: string,
     opIds: string[]
-  ): DocFrame {
+  ): ServerDocWireFrame {
     return {
       type: 'doc_update',
       data: {

--- a/browser_tests/fixtures/data/agent/README.md
+++ b/browser_tests/fixtures/data/agent/README.md
@@ -10,7 +10,10 @@ recorder combines two records per turn:
 
 Do not write `graph_ops` by hand or relabel a synthesized response. The fixture
 schema rejects `response_side: recorded` without a cloud thread ID, a per-turn
-message ID and an export timestamp.
+message ID and an export timestamp. Recorded events are the production socket
+union (`zAgentWsEvent` in `agentApiSchema.ts`) minus the thread and message ids
+the replay mints, so when production changes shape the fix is a new recording
+or a production-side change, never a looser fixture schema.
 
 ## Playbook
 

--- a/browser_tests/fixtures/data/agent/agentConversation.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversation.test.ts
@@ -104,9 +104,9 @@ describe('committed recordings', () => {
     const files = readdirSync(dir).filter((file) => file.endsWith('.json'))
     expect(files.length).toBeGreaterThan(0)
     for (const file of files) {
-      const conversation = zAgentConversation.parse(
-        JSON.parse(readFileSync(join(dir, file), 'utf8'))
-      )
+      const raw = JSON.parse(readFileSync(join(dir, file), 'utf8'))
+      const conversation = zAgentConversation.parse(raw)
+      expect(conversation.workflow, file).toEqual(raw.workflow)
       const frames = conversation.turns
         .flatMap((turn) => turn.response)
         .filter((entry) => entry.kind === 'event')

--- a/browser_tests/fixtures/data/agent/agentConversation.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
 import {
   zAgentConversation,
   zRecordedWsEvent
@@ -87,5 +90,27 @@ describe('zRecordedWsEvent', () => {
     expect(() =>
       zRecordedWsEvent.parse({ type: 'agent_done', data: {} })
     ).toThrow()
+  })
+})
+
+describe('committed recordings', () => {
+  // import.meta.url is not a file URL under vitest, so the loaders are bypassed.
+  const dir = join(
+    process.cwd(),
+    'browser_tests/fixtures/data/agent/conversations'
+  )
+
+  it('every recording parses against the production event union', () => {
+    const files = readdirSync(dir).filter((file) => file.endsWith('.json'))
+    expect(files.length).toBeGreaterThan(0)
+    for (const file of files) {
+      const conversation = zAgentConversation.parse(
+        JSON.parse(readFileSync(join(dir, file), 'utf8'))
+      )
+      const frames = conversation.turns
+        .flatMap((turn) => turn.response)
+        .filter((entry) => entry.kind === 'event')
+      expect(frames.length, file).toBeGreaterThan(0)
+    }
   })
 })

--- a/browser_tests/fixtures/data/agent/agentConversation.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { zAgentConversation } from '@e2e/fixtures/data/agent/agentConversation'
+import {
+  zAgentConversation,
+  zRecordedWsEvent
+} from '@e2e/fixtures/data/agent/agentConversation'
+import { zAgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
 const recorded = {
   schema_version: 'agent-conversation.v2',
@@ -25,7 +29,9 @@ const recorded = {
     {
       message_id: 'message-1',
       request: { content: 'Add a node' },
-      response: [{ kind: 'event', event: { type: 'agent_done', data: {} } }]
+      response: [
+        { kind: 'event', event: { type: 'agent_message_done', data: {} } }
+      ]
     }
   ]
 }
@@ -47,5 +53,39 @@ describe('zAgentConversation', () => {
     expect(() => zAgentConversation.parse({ ...recorded, source })).toThrow(
       'recorded responses require backend capture provenance'
     )
+  })
+})
+
+describe('zRecordedWsEvent', () => {
+  const discriminators = (
+    union: typeof zAgentWsEvent | typeof zRecordedWsEvent
+  ) => union.options.map((option) => option.shape.type.value)
+
+  it('mirrors every production event type', () => {
+    expect(discriminators(zRecordedWsEvent)).toEqual(
+      discriminators(zAgentWsEvent)
+    )
+  })
+
+  it('validates the production fields without the ids the replay mints', () => {
+    const frame = {
+      type: 'agent_tool_call',
+      data: {
+        tool_call_id: 'toolu_1',
+        tool_name: 'apply_ops',
+        status: 'success',
+        duration_ms: 12
+      }
+    }
+    expect(zRecordedWsEvent.parse(frame)).toEqual(frame)
+    expect(() =>
+      zRecordedWsEvent.parse({
+        ...frame,
+        data: { ...frame.data, status: 'done' }
+      })
+    ).toThrow()
+    expect(() =>
+      zRecordedWsEvent.parse({ type: 'agent_done', data: {} })
+    ).toThrow()
   })
 })

--- a/browser_tests/fixtures/data/agent/agentConversation.ts
+++ b/browser_tests/fixtures/data/agent/agentConversation.ts
@@ -5,16 +5,40 @@ import { FROZEN_OPS } from '@comfyorg/comfy-multi-player'
 import { z } from 'zod'
 
 import type { GraphOperation } from '@/workbench/extensions/agent/crdt/graphOperations'
+import { zAgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-export const zRecordedWsEvent = z.object({
-  type: z.string(),
-  data: z.record(z.string(), z.unknown()),
-  at_ms: z.number().int().nonnegative().optional()
-})
+// Offset from the turn's first frame, so replays can reproduce real gaps.
+const zAtMs = z.number().int().nonnegative().optional()
+
+// A recording keeps every production field except the two ids the replay
+// mints per run (agentConversationFixture stampTurn).
+const mintedIds: { thread_id: true; message_id: true } = {
+  thread_id: true,
+  message_id: true
+}
+const [thinking, toolCall, messageDelta, messageDone, activeTab] =
+  zAgentWsEvent.options
+
+export const zRecordedWsEvent = z.discriminatedUnion('type', [
+  thinking.extend({ data: thinking.shape.data.omit(mintedIds), at_ms: zAtMs }),
+  toolCall.extend({ data: toolCall.shape.data.omit(mintedIds), at_ms: zAtMs }),
+  messageDelta.extend({
+    data: messageDelta.shape.data.omit(mintedIds),
+    at_ms: zAtMs
+  }),
+  messageDone.extend({
+    data: messageDone.shape.data.omit(mintedIds),
+    at_ms: zAtMs
+  }),
+  activeTab.extend({
+    data: activeTab.shape.data.omit(mintedIds),
+    at_ms: zAtMs
+  })
+])
 export type RecordedWsEvent = z.infer<typeof zRecordedWsEvent>
 
 // The applier validates op payloads at replay time; only the vocabulary is pinned here.
@@ -72,9 +96,6 @@ export const zAgentConversationWorkflow = z.object({
 export const zAgentConversationRequest = z.object({
   content: z.string().min(1)
 })
-
-// Offset from the turn's first frame, so replays can reproduce real gaps.
-const zAtMs = z.number().int().nonnegative().optional()
 
 const zResponseEntry = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('event'), event: zRecordedWsEvent, at_ms: zAtMs }),

--- a/browser_tests/fixtures/data/agent/agentConversation.ts
+++ b/browser_tests/fixtures/data/agent/agentConversation.ts
@@ -11,33 +11,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-// Offset from the turn's first frame, so replays can reproduce real gaps.
-const zAtMs = z.number().int().nonnegative().optional()
-
 // A recording keeps every production field except the two ids the replay
 // mints per run (agentConversationFixture stampTurn).
-const mintedIds: { thread_id: true; message_id: true } = {
+export const mintedIds: { thread_id: true; message_id: true } = {
   thread_id: true,
   message_id: true
 }
+// Every member gets the same transform, so the slot order only names them.
 const [thinking, toolCall, messageDelta, messageDone, activeTab] =
   zAgentWsEvent.options
 
 export const zRecordedWsEvent = z.discriminatedUnion('type', [
-  thinking.extend({ data: thinking.shape.data.omit(mintedIds), at_ms: zAtMs }),
-  toolCall.extend({ data: toolCall.shape.data.omit(mintedIds), at_ms: zAtMs }),
-  messageDelta.extend({
-    data: messageDelta.shape.data.omit(mintedIds),
-    at_ms: zAtMs
-  }),
-  messageDone.extend({
-    data: messageDone.shape.data.omit(mintedIds),
-    at_ms: zAtMs
-  }),
-  activeTab.extend({
-    data: activeTab.shape.data.omit(mintedIds),
-    at_ms: zAtMs
-  })
+  thinking.extend({ data: thinking.shape.data.omit(mintedIds) }),
+  toolCall.extend({ data: toolCall.shape.data.omit(mintedIds) }),
+  messageDelta.extend({ data: messageDelta.shape.data.omit(mintedIds) }),
+  messageDone.extend({ data: messageDone.shape.data.omit(mintedIds) }),
+  activeTab.extend({ data: activeTab.shape.data.omit(mintedIds) })
 ])
 export type RecordedWsEvent = z.infer<typeof zRecordedWsEvent>
 
@@ -49,8 +38,8 @@ const zGraphOperation = z.custom<GraphOperation>(
     (FROZEN_OPS as readonly string[]).includes(value.op)
 )
 
-// The package types these loosely and passes unknown keys through, so the
-// schema validates the guaranteed fields and keeps the rest.
+// WorkflowJSON and WorkflowNode declare an index signature, so the schema
+// validates the guaranteed fields and keeps the rest.
 const zWorkflowJson = z
   .object({
     nodes: z.array(
@@ -77,14 +66,15 @@ const zWidgetCatalogEntry = z
       )
       .optional()
   })
-  .passthrough()
+  .strict()
 
+// WidgetCatalog and WidgetCatalogEntry declare no index signature.
 const zWidgetCatalog = z
   .object({
     comment: z.string().optional(),
     types: z.record(z.string(), zWidgetCatalogEntry)
   })
-  .passthrough()
+  .strict()
 
 export const zAgentConversationWorkflow = z.object({
   id: z.string().uuid(),
@@ -96,6 +86,9 @@ export const zAgentConversationWorkflow = z.object({
 export const zAgentConversationRequest = z.object({
   content: z.string().min(1)
 })
+
+// Offset from the turn's first frame, so replays can reproduce real gaps.
+const zAtMs = z.number().int().nonnegative().optional()
 
 const zResponseEntry = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('event'), event: zRecordedWsEvent, at_ms: zAtMs }),

--- a/browser_tests/fixtures/data/agent/agentConversation.ts
+++ b/browser_tests/fixtures/data/agent/agentConversation.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import { FROZEN_OPS } from '@comfyorg/comfy-multi-player'
-import type { WidgetCatalog, WorkflowJSON } from '@comfyorg/comfy-multi-player'
 import { z } from 'zod'
 
 import type { GraphOperation } from '@/workbench/extensions/agent/crdt/graphOperations'
@@ -26,14 +25,42 @@ const zGraphOperation = z.custom<GraphOperation>(
     (FROZEN_OPS as readonly string[]).includes(value.op)
 )
 
-const zWorkflowJson = z.custom<WorkflowJSON>(
-  (value) =>
-    isRecord(value) && Array.isArray(value.nodes) && Array.isArray(value.links)
-)
+// The package types these loosely and passes unknown keys through, so the
+// schema validates the guaranteed fields and keeps the rest.
+const zWorkflowJson = z
+  .object({
+    nodes: z.array(
+      z
+        .object({ id: z.union([z.string(), z.number()]), type: z.string() })
+        .passthrough()
+    ),
+    links: z.array(z.unknown())
+  })
+  .passthrough()
 
-const zWidgetCatalog = z.custom<WidgetCatalog>(
-  (value) => isRecord(value) && isRecord(value.types)
-)
+const zWidgetCatalogEntry = z
+  .object({
+    widget_order: z.array(z.string()),
+    autogrow_templates: z
+      .record(
+        z.string(),
+        z
+          .object({
+            prefix: z.string().optional(),
+            names: z.array(z.string()).optional()
+          })
+          .passthrough()
+      )
+      .optional()
+  })
+  .passthrough()
+
+const zWidgetCatalog = z
+  .object({
+    comment: z.string().optional(),
+    types: z.record(z.string(), zWidgetCatalogEntry)
+  })
+  .passthrough()
 
 export const zAgentConversationWorkflow = z.object({
   id: z.string().uuid(),

--- a/scripts/agentConversationAssemble.ts
+++ b/scripts/agentConversationAssemble.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 
 import type { zAgentConversationRequest } from '../browser_tests/fixtures/data/agent/agentConversation'
 import {
+  mintedIds,
   zAgentConversation,
   zAgentConversationWorkflow
 } from '../browser_tests/fixtures/data/agent/agentConversation'
@@ -375,8 +376,7 @@ function buildResponse(
         ? undefined
         : frame.at_ms - firstAt
     const data = { ...frame.data }
-    delete data.thread_id
-    delete data.message_id
+    for (const key of Object.keys(mintedIds)) delete data[key]
 
     if (frame.type === 'agent_tool_call') {
       const { status, tool_call_id: toolCallId } = frame.data
@@ -493,28 +493,32 @@ function buildConversation(options: {
   const { workflow } = input.seed.json
   const note = `RECORDED from Comfy-Org/cloud services/agent running ${STACK} at ${raw.base} (frames: ${raw.frame_source}); NOT a production capture. cloud commit ${provenance.cloudSha}; model ${provenance.model}; thread ${threadId}; messages ${turns.map((turn) => turn.message_id).join(', ')}; workflow ${workflowId} (seeded by throwaway turn ${options.seedMessageId}; turn 1 opens on a fresh workflow and switches to it first because the replay subscribes only on an agent_active_tab frame); agent_tool_calls parent rows ${list(rows.flatMap((set) => set.parents.map((row) => row.id)))}; rows ${rows.map((set) => basename(set.path)).join(', ')}; raw capture sha256 ${input.rawSha256}`
 
-  return zAgentConversation.parse({
-    schema_version: 'agent-conversation.v2',
-    source: {
-      repo: 'Comfy-Org/ComfyUI_frontend',
-      suite: 'agent',
-      case_id: raw.case_id,
-      response_side: 'recorded',
-      note,
-      capture: {
-        backend: 'Comfy-Org/cloud',
-        thread_id: threadId,
-        exported_at: provenance.exportedAt
-      }
+  return parseOrRefuse(
+    zAgentConversation,
+    {
+      schema_version: 'agent-conversation.v2',
+      source: {
+        repo: 'Comfy-Org/ComfyUI_frontend',
+        suite: 'agent',
+        case_id: raw.case_id,
+        response_side: 'recorded',
+        note,
+        capture: {
+          backend: 'Comfy-Org/cloud',
+          thread_id: threadId,
+          exported_at: provenance.exportedAt
+        }
+      },
+      workflow: {
+        id: workflowId,
+        name: workflow.name,
+        catalog: workflow.catalog,
+        seed: workflow.seed
+      },
+      turns
     },
-    workflow: {
-      id: workflowId,
-      name: workflow.name,
-      catalog: workflow.catalog,
-      seed: workflow.seed
-    },
-    turns
-  })
+    'assembled conversation'
+  )
 }
 
 interface TurnReceipt {

--- a/scripts/agentConversationAssemble.ts
+++ b/scripts/agentConversationAssemble.ts
@@ -5,10 +5,7 @@ import { basename } from 'node:path'
 import { FROZEN_OPS } from '@comfyorg/comfy-multi-player'
 import { z } from 'zod'
 
-import type {
-  zAgentConversationRequest,
-  zRecordedWsEvent
-} from '../browser_tests/fixtures/data/agent/agentConversation'
+import type { zAgentConversationRequest } from '../browser_tests/fixtures/data/agent/agentConversation'
 import {
   zAgentConversation,
   zAgentConversationWorkflow
@@ -79,7 +76,13 @@ const zOpsCarrier = z.object({
     .passthrough()
 })
 
-export type RecordedFrame = z.infer<typeof zRecordedWsEvent>
+// Every socket frame the recorder saw, agent event or not; zAgentConversation
+// narrows the kept ones to the production event union.
+export interface RecordedFrame {
+  type: string
+  data: Record<string, unknown>
+  at_ms?: number
+}
 type GraphOps = Array<Record<string, unknown>>
 
 // What the assembler hands to zAgentConversation, which narrows the op payloads.

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -1,6 +1,6 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 
-const DOC_PROTOCOL_VERSION = 1
+export const DOC_PROTOCOL_VERSION = 1
 const MAX_AWARENESS_STATE_BYTES = 8 * 1024
 
 export interface DocOp {
@@ -66,6 +66,12 @@ export type ServerDocFrame =
   | { type: 'doc_ops_result'; data: DocOpsResult }
   | { type: 'doc_reset'; data: DocReset }
   | { type: 'awareness'; data: DocAwareness }
+
+/** A frame as it travels the wire, before {@link parseServerDocFrame} reads it. */
+export interface ServerDocWireFrame {
+  type: ServerDocFrame['type']
+  data: WireData
+}
 
 export interface DocFrameTransport {
   /**


### PR DESCRIPTION
## Summary

Derives the recorded conversation fixture schema from the production event union instead of restating it, so a protocol change fails the fixture tests instead of passing silently.

## Changes

- **What**: `zRecordedWsEvent` is built from `zAgentWsEvent.options`, each member keeping every production field except the two ids the replay mints per run. Workflow and widget catalog payloads validate their real shapes; the catalog schemas are strict because the package declares no index signature there. `DOC_PROTOCOL_VERSION` and `ServerDocWireFrame` are exported from `docFrameClient.ts` so the fake host and the client share one wire contract. The assembler strips the minted ids through the same exported mask and refuses an assembled conversation with a named message. A corpus test parses every committed recording against the union and round-trips each workflow.
- **Breaking**: none.

## Review Focus

The corpus test is the load bearing one: every recording parses against the production union and its workflow deep-equals the JSON, so a schema that drops node fields fails here rather than at replay time. The `mirrors every production event type` case fails when a production event type is added without a fixture counterpart. The assembler keeps an open frame type for the raw socket stream on purpose: that stream carries `__raw__` and `draft_version` frames the fixture schema must never accept. The replay assertion rework from the same review lands on this PR as follow-on commits.