### PR TITLE
prototype(workshop): the top-up journey after Stripe — reference, not for merge

### DIFF
--- a/apps/website/src/components/common/HeaderMain/HeaderAccount.test.ts
+++ b/apps/website/src/components/common/HeaderMain/HeaderAccount.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 
 import { useMockSession } from '../../../composables/useMockSession'
+import { usePrototypeTweaks } from '../../../composables/usePrototypeTweaks'
 import HeaderAccount from './HeaderAccount.vue'
 
 function mountAccount(kind: 'existing' | 'new') {
@@ -72,5 +73,52 @@ describe('HeaderAccount', () => {
     await user.click(screen.getByTestId('header-account'))
     await user.click(await screen.findByTestId('account-sign-out'))
     expect(await screen.findByTestId('header-sign-in')).toBeTruthy()
+  })
+})
+
+describe('HeaderAccount — who can buy, and by which rail', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('gives a member no purchase route at all', async () => {
+    const user = userEvent.setup()
+    const api = mountAccount('existing')
+    api.setRole('member')
+    await nextTick()
+
+    await user.click(screen.getByTestId('header-account'))
+    // The header pill still carries the balance — the member workspace is the
+    // empty one — so repeating it in the menu under an action they cannot take
+    // is the thing being removed.
+    expect(screen.queryByTestId('account-plan')).toBeNull()
+    expect(screen.getByTestId('header-credits').textContent).toContain('0')
+  })
+
+  it('links out to platform on the MVP rail instead of opening the dialog', async () => {
+    const user = userEvent.setup()
+    let tweaks!: ReturnType<typeof usePrototypeTweaks>
+    render(
+      defineComponent({
+        setup() {
+          useMockSession().signIn('existing')
+          tweaks = usePrototypeTweaks()
+          tweaks.topUpRail.value = 'platform'
+          return () => h(HeaderAccount)
+        }
+      })
+    )
+    await nextTick()
+
+    await user.click(screen.getByTestId('header-account'))
+    // as-child merges the row into the anchor, so the row *is* the link.
+    const row = await screen.findByTestId('account-plan')
+    expect(row.tagName).toBe('A')
+    expect(row.getAttribute('href')).toBe(
+      'https://platform.comfy.org/billing?workspace=Ada%27s+Studio'
+    )
+    expect(row.getAttribute('target')).toBe('_blank')
+    expect(screen.queryByTestId('buy-credits-dialog')).toBeNull()
+    tweaks.topUpRail.value = 'in-place'
   })
 })

--- a/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { ArrowLeftRight, Check, Coins, LogOut, Settings } from '@lucide/vue'
+import {
+  ArrowLeftRight,
+  ArrowUpRight,
+  Check,
+  Coins,
+  LogOut,
+  Settings
+} from '@lucide/vue'
 import {
   DropdownMenuContent,
   DropdownMenuItem,
@@ -197,8 +204,12 @@ const avatarClass =
         >
           <a :href="topUpHref" target="_blank" rel="noopener">
             <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
-            <span class="flex-1">
-              {{ t('nav.creditsLabelPlatform', locale) }}
+            <span class="flex flex-1 items-center gap-1.5">
+              {{ t('nav.creditsLabel', locale) }}
+              <ArrowUpRight
+                class="size-3.5 text-primary-warm-gray"
+                aria-hidden="true"
+              />
             </span>
             <span
               :class="

--- a/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
@@ -204,7 +204,7 @@ const avatarClass =
         >
           <a :href="topUpHref" target="_blank" rel="noopener">
             <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
-            <span class="flex flex-1 items-center gap-1.5">
+            <span class="flex flex-1 items-center gap-3">
               {{ t('nav.creditsLabel', locale) }}
               <ExternalLink
                 class="size-5 text-primary-warm-gray"
@@ -260,7 +260,7 @@ const avatarClass =
               class="size-5 text-primary-warm-gray"
               aria-hidden="true"
             />
-            <span class="flex flex-1 items-center gap-1.5">
+            <span class="flex flex-1 items-center gap-3">
               {{ t('nav.workspaceSettings', locale) }}
               <ExternalLink
                 class="size-5 text-primary-warm-gray"

--- a/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
@@ -207,7 +207,7 @@ const avatarClass =
             <span class="flex flex-1 items-center gap-1.5">
               {{ t('nav.creditsLabel', locale) }}
               <ExternalLink
-                class="size-3.5 text-primary-warm-gray"
+                class="size-5 text-primary-warm-gray"
                 aria-hidden="true"
               />
             </span>
@@ -263,7 +263,7 @@ const avatarClass =
             <span class="flex flex-1 items-center gap-1.5">
               {{ t('nav.workspaceSettings', locale) }}
               <ExternalLink
-                class="size-3.5 text-primary-warm-gray"
+                class="size-5 text-primary-warm-gray"
                 aria-hidden="true"
               />
             </span>

--- a/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import {
   ArrowLeftRight,
-  ArrowUpRight,
   Check,
   Coins,
+  ExternalLink,
   LogOut,
   Settings
 } from '@lucide/vue'
@@ -206,7 +206,7 @@ const avatarClass =
             <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
             <span class="flex flex-1 items-center gap-1.5">
               {{ t('nav.creditsLabel', locale) }}
-              <ArrowUpRight
+              <ExternalLink
                 class="size-3.5 text-primary-warm-gray"
                 aria-hidden="true"
               />
@@ -260,7 +260,13 @@ const avatarClass =
               class="size-5 text-primary-warm-gray"
               aria-hidden="true"
             />
-            {{ t('nav.workspaceSettings', locale) }}
+            <span class="flex flex-1 items-center gap-1.5">
+              {{ t('nav.workspaceSettings', locale) }}
+              <ExternalLink
+                class="size-3.5 text-primary-warm-gray"
+                aria-hidden="true"
+              />
+            </span>
           </a>
         </DropdownMenuItem>
 

--- a/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderAccount.vue
@@ -17,8 +17,10 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 import Button from '@/components/ui/button/Button.vue'
 import { WORKSPACES, useMockSession } from '../../../composables/useMockSession'
+import { usePrototypeTweaks } from '../../../composables/usePrototypeTweaks'
 import { useSignInHref } from '../../../composables/useSignInHref'
 import { externalLinks } from '../../../config/routes'
+import { platformTopUpHref } from '../../../lib/workshop/buy-credits'
 import type { Locale } from '../../../i18n/translations'
 import { t } from '../../../i18n/translations'
 import BuyCreditsDialog from '../../workshop/BuyCreditsDialog.vue'
@@ -26,12 +28,19 @@ import BuyCreditsDialog from '../../workshop/BuyCreditsDialog.vue'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const { session, signOut, switchWorkspace } = useMockSession()
+const { topUpRail } = usePrototypeTweaks()
 const signInHref = useSignInHref(locale)
 
 const account = computed(() =>
   session.value.status === 'signedIn' ? session.value.account : undefined
 )
 const hasCredits = computed(() => (account.value?.credits ?? 0) > 0)
+// Buying is owner-only server-side, so a member gets no purchase route here.
+// Not a balance-only row either: the header pill already carries the number,
+// and repeating it under a dead action is worse than leaving it out. See
+// DES-1015.
+const canTopUp = computed(() => account.value?.role !== 'member')
+const topUpHref = computed(() => platformTopUpHref(account.value?.workspace))
 const formattedCredits = computed(() =>
   new Intl.NumberFormat(locale).format(account.value?.credits ?? 0)
 )
@@ -181,6 +190,33 @@ const avatarClass =
         </DropdownMenuSub>
 
         <DropdownMenuItem
+          v-if="canTopUp && topUpRail === 'platform'"
+          as-child
+          :class="itemClass"
+          data-testid="account-plan"
+        >
+          <a :href="topUpHref" target="_blank" rel="noopener">
+            <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
+            <span class="flex-1">
+              {{ t('nav.creditsLabelPlatform', locale) }}
+            </span>
+            <span
+              :class="
+                cn(
+                  'text-base font-bold tabular-nums',
+                  hasCredits
+                    ? 'text-primary-warm-white'
+                    : 'text-primary-comfy-yellow'
+                )
+              "
+            >
+              {{ formattedCredits }}
+            </span>
+          </a>
+        </DropdownMenuItem>
+
+        <DropdownMenuItem
+          v-else-if="canTopUp"
           :class="itemClass"
           data-testid="account-plan"
           @click="buyingCredits = true"

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -221,6 +221,17 @@ const stepperClass =
           </span>
         </div>
 
+        <!-- REMOVE BEFORE SHIPPING. Scaffolding, not a feature: it shows the
+             return address being carried so a reviewer can watch `success_url`
+             follow them between models. It cannot survive the real flow — a
+             live Checkout URL is created server-side and opaque
+             (`/c/pay/cs_live_…`), so there is nothing legible to print — and
+             showing a payment URL on a page that takes money teaches people to
+             trust pasted Stripe links, which is the shape of a phishing
+             attempt. It is a <p>, not an <a>: it is not a fallback for a
+             blocked popup. That case needs a same-tab retry instead, and does
+             not exist yet. Deleting this also means dropping the `success_url`
+             assertion in ModelDetail.test.ts. -->
         <p
           class="bg-transparency-white-t4 overflow-x-auto rounded-2xl px-4 py-3 font-mono text-xs whitespace-nowrap text-primary-warm-gray"
           data-testid="buy-credits-url"

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -1,15 +1,35 @@
 <script setup lang="ts">
-import { Check, ExternalLink, Lock } from '@lucide/vue'
-import { computed, ref, watch } from 'vue'
+import {
+  Check,
+  Clock,
+  Coins,
+  ExternalLink,
+  Loader2,
+  Lock,
+  Minus,
+  Plus
+} from '@lucide/vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useMockSession } from '../../composables/useMockSession'
-import { usdToCredits } from '../../config/credits'
+import { usePrototypeTweaks } from '../../composables/usePrototypeTweaks'
+import {
+  MAX_TOP_UP_USD,
+  MIN_TOP_UP_USD,
+  TOP_UP_PACKS,
+  clampTopUp,
+  usdToCredits
+} from '../../config/credits'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
-import { stripeCheckoutHref } from '../../lib/workshop/buy-credits'
+import {
+  SETTLE_DELAY_MS,
+  returnStepFor,
+  stripeCheckoutHref
+} from '../../lib/workshop/buy-credits'
 import Dialog from '../ui/dialog/Dialog.vue'
 import DialogContent from '../ui/dialog/DialogContent.vue'
 import DialogDescription from '../ui/dialog/DialogDescription.vue'
@@ -18,30 +38,77 @@ import DialogTitle from '../ui/dialog/DialogTitle.vue'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 const open = defineModel<boolean>('open', { default: false })
 
-const { addCredits } = useMockSession()
+const { session, addCredits } = useMockSession()
+const { topUpOutcome } = usePrototypeTweaks()
 
-const PACKS = [10, 25, 50] as const
 const usd = ref<number>(25)
 const credits = computed(() => usdToCredits(usd.value))
+const workspace = computed(() =>
+  session.value.status === 'signedIn' ? session.value.account.workspace : ''
+)
 
-// The real flow leaves for Stripe Checkout and comes back. The prototype plays
-// that round trip out in place, so the whole journey can be reviewed without a
-// payment account.
-type Step = 'leaving' | 'checkout' | 'back'
+// The real flow leaves for Stripe Checkout and comes back on a fresh page load.
+// The prototype plays that round trip out in place, so the whole journey can be
+// reviewed without a payment account — but the states after the hand-off are the
+// ones the live page will really have to render.
+type Step = 'leaving' | 'checkout' | 'waiting' | 'landed' | 'unresolved'
 const step = ref<Step>('leaving')
+// Canceling at Stripe is not a failure: it returns to the amount with the
+// chosen amount intact and nothing to retry.
+const canceled = ref(false)
+const previousCredits = ref(0)
 
 const returnPath = ref('/workshop/')
 const href = computed(() => stripeCheckoutHref(returnPath.value, usd.value))
+// Stands in for the billing operation id support would search on.
+const operationId = computed(
+  () => `op_${(usdToCredits(usd.value) * 7919).toString(36)}`
+)
+
+let settleTimer: ReturnType<typeof setTimeout> | undefined
+function clearSettleTimer() {
+  if (settleTimer) clearTimeout(settleTimer)
+  settleTimer = undefined
+}
+onBeforeUnmount(clearSettleTimer)
 
 watch(open, (value) => {
+  clearSettleTimer()
   if (!value) return
   returnPath.value = location.pathname + location.search
   step.value = 'leaving'
+  canceled.value = false
 })
 
+function setAmount(next: number) {
+  usd.value = clampTopUp(next)
+}
+
+function leaveForStripe() {
+  canceled.value = false
+  step.value = 'checkout'
+}
+
+function cancelAtStripe() {
+  clearSettleTimer()
+  canceled.value = true
+  step.value = 'leaving'
+}
+
+// Stripe redirects the moment the card clears; the grant follows on a webhook.
+// Coming back before the credits do is the normal case, not an edge one, so the
+// page always lands on `waiting` first and resolves from there.
 function pay() {
-  addCredits(credits.value)
-  step.value = 'back'
+  previousCredits.value =
+    session.value.status === 'signedIn' ? session.value.account.credits : 0
+  step.value = 'waiting'
+  const settled = returnStepFor(topUpOutcome.value)
+  if (settled === 'waiting') return
+  clearSettleTimer()
+  settleTimer = setTimeout(() => {
+    if (settled === 'landed') addCredits(credits.value)
+    step.value = settled
+  }, SETTLE_DELAY_MS)
 }
 
 const format = (value: number) => value.toLocaleString(locale)
@@ -52,6 +119,8 @@ const packClass = (selected: boolean) =>
       ? 'bg-primary-comfy-yellow text-primary-comfy-ink'
       : 'bg-transparency-white-t4 text-primary-comfy-canvas hover:bg-transparency-white-t8'
   )
+const stepperClass =
+  'grid size-7 place-items-center rounded-full bg-transparency-white-t8 text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t20 disabled:opacity-40'
 </script>
 
 <template>
@@ -61,7 +130,12 @@ const packClass = (selected: boolean) =>
       class="sm:max-w-xl"
       data-testid="buy-credits-dialog"
     >
-      <div v-if="step === 'leaving'" class="flex flex-col gap-6">
+      <!-- 1 · Amount — the last screen we own before the hand-off -->
+      <div
+        v-if="step === 'leaving'"
+        class="flex flex-col gap-6"
+        data-step="leaving"
+      >
         <DialogTitle class="pr-16">
           {{ t('workshop.credits.title', locale) }}
         </DialogTitle>
@@ -69,21 +143,65 @@ const packClass = (selected: boolean) =>
           {{ t('workshop.credits.body', locale) }}
         </DialogDescription>
 
-        <div class="grid grid-cols-3 gap-2" data-testid="buy-credits-packs">
+        <p
+          v-if="canceled"
+          class="bg-transparency-white-t4 rounded-2xl px-4 py-3 text-sm text-primary-comfy-canvas"
+          data-testid="buy-credits-canceled"
+        >
+          {{ t('workshop.credits.canceledNotice', locale) }}
+        </p>
+
+        <div class="grid grid-cols-4 gap-2" data-testid="buy-credits-packs">
           <button
-            v-for="pack in PACKS"
+            v-for="pack in TOP_UP_PACKS"
             :key="pack"
             type="button"
             :aria-pressed="usd === pack"
             :class="packClass(usd === pack)"
             :data-testid="`buy-credits-pack-${pack}`"
-            @click="usd = pack"
+            @click="setAmount(pack)"
           >
             <span class="text-lg font-bold">${{ pack }}</span>
             <span class="text-xs tabular-nums opacity-70">
-              {{ format(usdToCredits(pack)) }} {{ t('nav.credits', locale) }}
+              {{ format(usdToCredits(pack)) }}
             </span>
           </button>
+        </div>
+
+        <div
+          class="bg-transparency-white-t4 flex items-center justify-between gap-3 rounded-2xl px-4 py-3"
+          data-testid="buy-credits-custom"
+        >
+          <span class="text-sm text-primary-warm-gray">
+            {{ t('workshop.credits.custom', locale) }}
+          </span>
+          <span class="flex items-center gap-3">
+            <button
+              type="button"
+              :class="stepperClass"
+              :disabled="usd <= MIN_TOP_UP_USD"
+              :aria-label="t('workshop.credits.less', locale)"
+              data-testid="buy-credits-less"
+              @click="setAmount(usd - 5)"
+            >
+              <Minus class="size-3.5" aria-hidden="true" />
+            </button>
+            <span
+              class="w-28 text-right text-sm text-primary-comfy-canvas tabular-nums"
+            >
+              ${{ format(usd) }} · {{ format(credits) }}
+            </span>
+            <button
+              type="button"
+              :class="stepperClass"
+              :disabled="usd >= MAX_TOP_UP_USD"
+              :aria-label="t('workshop.credits.more', locale)"
+              data-testid="buy-credits-more"
+              @click="setAmount(usd + 5)"
+            >
+              <Plus class="size-3.5" aria-hidden="true" />
+            </button>
+          </span>
         </div>
 
         <p
@@ -98,7 +216,7 @@ const packClass = (selected: boolean) =>
             size="lg"
             class="px-5"
             data-testid="buy-credits-continue"
-            @click="step = 'checkout'"
+            @click="leaveForStripe"
           >
             {{ t('workshop.credits.continue', locale) }}
             <template #append>
@@ -117,7 +235,12 @@ const packClass = (selected: boolean) =>
         </div>
       </div>
 
-      <div v-else-if="step === 'checkout'" class="flex flex-col gap-6">
+      <!-- 2 · Stripe's page. Never renders live: the browser is on stripe.com. -->
+      <div
+        v-else-if="step === 'checkout'"
+        class="flex flex-col gap-6"
+        data-step="checkout"
+      >
         <p
           class="inline-flex w-fit items-center gap-2 rounded-full bg-transparency-white-t8 px-3 py-1.5 text-xs text-primary-warm-gray"
         >
@@ -137,7 +260,9 @@ const packClass = (selected: boolean) =>
           <dt class="text-primary-comfy-canvas">
             {{ format(credits) }} {{ t('nav.credits', locale) }}
           </dt>
-          <dd class="text-lg font-bold text-primary-warm-white">${{ usd }}</dd>
+          <dd class="text-lg font-bold text-primary-warm-white">
+            ${{ format(usd) }}
+          </dd>
         </dl>
 
         <div class="flex flex-wrap gap-3">
@@ -147,21 +272,66 @@ const packClass = (selected: boolean) =>
             data-testid="buy-credits-pay"
             @click="pay"
           >
-            {{ t('workshop.credits.pay', locale).replace('{usd}', `$${usd}`) }}
+            {{
+              t('workshop.credits.pay', locale).replace(
+                '{usd}',
+                `$${format(usd)}`
+              )
+            }}
           </Button>
           <Button
             variant="outline"
             size="lg"
             class="px-5"
-            data-testid="buy-credits-back"
-            @click="step = 'leaving'"
+            data-testid="buy-credits-cancel-stripe"
+            @click="cancelAtStripe"
           >
-            {{ t('workshop.credits.back', locale) }}
+            {{ t('workshop.credits.cancelAtStripe', locale) }}
           </Button>
         </div>
       </div>
 
-      <div v-else class="flex flex-col gap-6" data-testid="buy-credits-done">
+      <!-- 3a · Waiting. No pending signal exists on this rail, so this is also
+           what a lost grant looks like — only elapsed time tells them apart. -->
+      <div
+        v-else-if="step === 'waiting'"
+        class="flex flex-col gap-6"
+        data-step="waiting"
+      >
+        <DialogTitle class="pr-16">
+          {{ t('workshop.credits.waitingTitle', locale) }}
+        </DialogTitle>
+        <DialogDescription class="text-base text-primary-comfy-canvas/70">
+          {{ t('workshop.credits.waitingBody', locale) }}
+        </DialogDescription>
+        <p
+          class="bg-transparency-white-t4 flex items-center gap-3 rounded-2xl px-4 py-3 text-sm text-primary-comfy-canvas"
+          data-testid="buy-credits-polling"
+        >
+          <Loader2
+            class="text-primary-comfy-yellow size-4 animate-spin"
+            aria-hidden="true"
+          />
+          {{ t('workshop.credits.waitingPolling', locale) }}
+        </p>
+        <Button
+          variant="outline"
+          size="lg"
+          class="w-fit px-5"
+          data-testid="buy-credits-reopen"
+          @click="step = 'checkout'"
+        >
+          {{ t('workshop.credits.reopen', locale) }}
+        </Button>
+      </div>
+
+      <!-- 3b · The credits landed. -->
+      <div
+        v-else-if="step === 'landed'"
+        class="flex flex-col gap-6"
+        data-testid="buy-credits-done"
+        data-step="landed"
+      >
         <span
           class="bg-primary-comfy-yellow grid size-12 place-items-center rounded-2xl text-primary-comfy-ink"
           aria-hidden="true"
@@ -174,8 +344,49 @@ const packClass = (selected: boolean) =>
           }}
         </DialogTitle>
         <DialogDescription class="text-base text-primary-comfy-canvas/70">
-          {{ t('workshop.credits.doneBody', locale) }}
+          {{
+            t('workshop.credits.addedTo', locale).replace(
+              '{workspace}',
+              workspace
+            )
+          }}
         </DialogDescription>
+
+        <dl
+          class="bg-transparency-white-t4 flex flex-col gap-2 rounded-2xl px-4 py-3 text-sm"
+          data-testid="buy-credits-ledger"
+        >
+          <div class="flex items-baseline justify-between">
+            <dt class="text-primary-warm-gray">
+              {{ t('workshop.credits.previousBalance', locale) }}
+            </dt>
+            <dd class="text-primary-warm-gray tabular-nums">
+              {{ format(previousCredits) }}
+            </dd>
+          </div>
+          <div class="flex items-baseline justify-between">
+            <dt class="text-primary-warm-gray">
+              {{ t('workshop.credits.added', locale) }}
+            </dt>
+            <dd class="text-primary-warm-gray tabular-nums">
+              +{{ format(credits) }}
+            </dd>
+          </div>
+          <div
+            class="flex items-baseline justify-between border-t border-transparency-white-t8 pt-2"
+          >
+            <dt class="text-primary-comfy-canvas">
+              {{ t('workshop.credits.newBalance', locale) }}
+            </dt>
+            <dd
+              class="flex items-center gap-1.5 font-bold text-primary-warm-white tabular-nums"
+            >
+              <Coins class="size-4" aria-hidden="true" />
+              {{ format(previousCredits + credits) }}
+            </dd>
+          </div>
+        </dl>
+
         <Button
           size="lg"
           class="w-fit px-5"
@@ -184,6 +395,57 @@ const packClass = (selected: boolean) =>
         >
           {{ t('workshop.credits.resume', locale) }}
         </Button>
+      </div>
+
+      <!-- 3c · Paid, but nothing arrived. Deliberately promises no self-healing:
+           this rail has no reconciler (IR-126/128), unlike the in-app one. -->
+      <div
+        v-else
+        class="flex flex-col gap-6"
+        data-testid="buy-credits-held"
+        data-step="unresolved"
+      >
+        <span
+          class="grid size-12 place-items-center rounded-2xl bg-transparency-white-t8 text-primary-warm-white"
+          aria-hidden="true"
+        >
+          <Clock class="size-6" />
+        </span>
+        <DialogTitle class="pr-16">
+          {{ t('workshop.credits.heldTitle', locale) }}
+        </DialogTitle>
+        <DialogDescription class="text-base text-primary-comfy-canvas/70">
+          {{ t('workshop.credits.heldBody', locale) }}
+        </DialogDescription>
+
+        <div
+          class="bg-transparency-white-t4 flex flex-col gap-1 rounded-2xl px-4 py-3"
+        >
+          <span class="text-xs text-primary-warm-gray">
+            {{ t('workshop.credits.heldSupport', locale) }}
+          </span>
+          <span
+            class="font-mono text-sm text-primary-warm-white"
+            data-testid="buy-credits-op-id"
+          >
+            {{ operationId }}
+          </span>
+        </div>
+
+        <div class="flex flex-wrap gap-3">
+          <Button size="lg" class="px-5" data-testid="buy-credits-support">
+            {{ t('workshop.credits.contactSupport', locale) }}
+          </Button>
+          <Button
+            variant="outline"
+            size="lg"
+            class="px-5"
+            data-testid="buy-credits-held-close"
+            @click="open = false"
+          >
+            {{ t('workshop.credits.close', locale) }}
+          </Button>
+        </div>
       </div>
     </DialogContent>
   </Dialog>

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -39,7 +39,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 const open = defineModel<boolean>('open', { default: false })
 
 const { session, addCredits } = useMockSession()
-const { topUpOutcome } = usePrototypeTweaks()
+const { topUpOutcome, buyStep } = usePrototypeTweaks()
 
 const usd = ref<number>(25)
 const credits = computed(() => usdToCredits(usd.value))
@@ -72,12 +72,29 @@ function clearSettleTimer() {
 }
 onBeforeUnmount(clearSettleTimer)
 
+const RETURN_STEPS = ['waiting', 'landed', 'unresolved'] as const
+function isReturnStep(value: string): value is (typeof RETURN_STEPS)[number] {
+  return (RETURN_STEPS as readonly string[]).includes(value)
+}
+
 watch(open, (value) => {
   clearSettleTimer()
   if (!value) return
   returnPath.value = location.pathname + location.search
-  step.value = 'leaving'
-  canceled.value = false
+  // A review link can open any part of the flow. The states after the hand-off
+  // are three clicks deep otherwise, and they are the ones worth looking at.
+  const entry = buyStep.value
+  // Consumed once: after the link has opened its step, the dialog behaves
+  // normally, so closing and reopening does not jump back and grant again.
+  if (entry !== 'closed') buyStep.value = 'closed'
+  canceled.value = entry === 'canceled'
+  step.value = isReturnStep(entry) ? entry : 'leaving'
+  if (step.value === 'landed') {
+    previousCredits.value =
+      session.value.status === 'signedIn' ? session.value.account.credits : 0
+    // Land the grant too, so the ledger and the header agree.
+    addCredits(credits.value)
+  }
 })
 
 function setAmount(next: number) {

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -47,15 +47,16 @@ const workspace = computed(() =>
   session.value.status === 'signedIn' ? session.value.account.workspace : ''
 )
 
-// The real flow leaves for Stripe Checkout and comes back on a fresh page load.
-// The prototype plays that round trip out in place, so the whole journey can be
-// reviewed without a payment account — but the states after the hand-off are the
-// ones the live page will really have to render.
+// Continue is a real link, so the tab opens on the visitor's own click and a
+// popup blocker never sees a programmatic open to swallow. That removes the
+// blocked case rather than handling it, and it means cancelling happens at
+// Stripe, in the other tab: this page just keeps waiting until they come back
+// or dismiss it. There is no "you cancelled" state to return to.
+//
+// The prototype plays Stripe's own page out in place, so the journey can be
+// reviewed without a payment account.
 type Step = 'leaving' | 'checkout' | 'waiting' | 'landed' | 'unresolved'
 const step = ref<Step>('leaving')
-// Canceling at Stripe is not a failure: it returns to the amount with the
-// chosen amount intact and nothing to retry.
-const canceled = ref(false)
 const previousCredits = ref(0)
 
 const returnPath = ref('/workshop/')
@@ -87,7 +88,6 @@ watch(open, (value) => {
   // Consumed once: after the link has opened its step, the dialog behaves
   // normally, so closing and reopening does not jump back and grant again.
   if (entry !== 'closed') buyStep.value = 'closed'
-  canceled.value = entry === 'canceled'
   step.value = isReturnStep(entry) ? entry : 'leaving'
   if (step.value === 'landed') {
     previousCredits.value =
@@ -101,15 +101,11 @@ function setAmount(next: number) {
   usd.value = clampTopUp(next)
 }
 
+// The anchor opens Stripe; this only moves the page behind it on. In the
+// prototype the navigation is prevented so Stripe's page can be played out in
+// place — shipping means dropping the `.prevent` and letting the link work.
 function leaveForStripe() {
-  canceled.value = false
-  step.value = 'checkout'
-}
-
-function cancelAtStripe() {
-  clearSettleTimer()
-  canceled.value = true
-  step.value = 'leaving'
+  step.value = 'waiting'
 }
 
 // Stripe redirects the moment the card clears; the grant follows on a webhook.
@@ -159,14 +155,6 @@ const stepperClass =
         <DialogDescription class="text-base text-primary-comfy-canvas/70">
           {{ t('workshop.credits.body', locale) }}
         </DialogDescription>
-
-        <p
-          v-if="canceled"
-          class="bg-transparency-white-t4 rounded-2xl px-4 py-3 text-sm text-primary-comfy-canvas"
-          data-testid="buy-credits-canceled"
-        >
-          {{ t('workshop.credits.canceledNotice', locale) }}
-        </p>
 
         <div class="grid grid-cols-4 gap-2" data-testid="buy-credits-packs">
           <button
@@ -243,8 +231,11 @@ const stepperClass =
           <Button
             size="lg"
             class="px-5"
+            :href="href"
+            target="_blank"
+            rel="noopener noreferrer"
             data-testid="buy-credits-continue"
-            @click="leaveForStripe"
+            @click.prevent="leaveForStripe"
           >
             {{ t('workshop.credits.continue', locale) }}
             <template #append>
@@ -311,10 +302,10 @@ const stepperClass =
             variant="outline"
             size="lg"
             class="px-5"
-            data-testid="buy-credits-cancel-stripe"
-            @click="cancelAtStripe"
+            data-testid="buy-credits-back"
+            @click="step = 'waiting'"
           >
-            {{ t('workshop.credits.cancelAtStripe', locale) }}
+            {{ t('workshop.credits.back', locale) }}
           </Button>
         </div>
       </div>
@@ -342,14 +333,35 @@ const stepperClass =
           />
           {{ t('workshop.credits.waitingPolling', locale) }}
         </p>
+        <p
+          class="flex flex-wrap items-center gap-2 text-sm text-primary-warm-gray"
+        >
+          {{ t('workshop.credits.reopenPrompt', locale) }}
+          <!-- The tab is already open in the real flow; this brings it back if
+               they closed it. Not a fallback — there is no blocked case. -->
+          <a
+            :href="href"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-primary-comfy-yellow underline-offset-4 hover:underline"
+            data-testid="buy-credits-reopen"
+            @click.prevent="step = 'checkout'"
+          >
+            {{ t('workshop.credits.reopen', locale) }}
+          </a>
+        </p>
+
         <Button
           variant="outline"
           size="lg"
           class="w-fit px-5"
-          data-testid="buy-credits-reopen"
-          @click="step = 'checkout'"
+          data-testid="buy-credits-dismiss"
+          @click="open = false"
         >
-          {{ t('workshop.credits.reopen', locale) }}
+          <!-- Not "Cancel": dismissing this does not cancel anything. The
+               checkout is open in the other tab and will complete or not on its
+               own; this only puts the page back. -->
+          {{ t('workshop.credits.close', locale) }}
         </Button>
       </div>
 

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -191,24 +191,6 @@ const stepperClass =
           </span>
         </div>
 
-        <!-- REMOVE BEFORE SHIPPING. Scaffolding, not a feature: it shows the
-             return address being carried so a reviewer can watch `success_url`
-             follow them between models. It cannot survive the real flow — a
-             live Checkout URL is created server-side and opaque
-             (`/c/pay/cs_live_…`), so there is nothing legible to print — and
-             showing a payment URL on a page that takes money teaches people to
-             trust pasted Stripe links, which is the shape of a phishing
-             attempt. It is a <p>, not an <a>: it is not a fallback for a
-             blocked popup. That case needs a same-tab retry instead, and does
-             not exist yet. Deleting this also means dropping the `success_url`
-             assertion in ModelDetail.test.ts. -->
-        <p
-          class="bg-transparency-white-t4 overflow-x-auto rounded-2xl px-4 py-3 font-mono text-xs whitespace-nowrap text-primary-warm-gray"
-          data-testid="buy-credits-url"
-        >
-          {{ href }}
-        </p>
-
         <div class="flex flex-wrap gap-3">
           <Button
             size="lg"

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -9,12 +9,13 @@ import {
   Minus,
   Plus
 } from '@lucide/vue'
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useMockSession } from '../../composables/useMockSession'
+import { usePendingTopUp } from '../../composables/usePendingTopUp'
 import { usePrototypeTweaks } from '../../composables/usePrototypeTweaks'
 import {
   MAX_TOP_UP_USD,
@@ -25,11 +26,7 @@ import {
 } from '../../config/credits'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
-import {
-  SETTLE_DELAY_MS,
-  returnStepFor,
-  stripeCheckoutHref
-} from '../../lib/workshop/buy-credits'
+import { stripeCheckoutHref } from '../../lib/workshop/buy-credits'
 import Dialog from '../ui/dialog/Dialog.vue'
 import DialogContent from '../ui/dialog/DialogContent.vue'
 import DialogDescription from '../ui/dialog/DialogDescription.vue'
@@ -38,8 +35,9 @@ import DialogTitle from '../ui/dialog/DialogTitle.vue'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 const open = defineModel<boolean>('open', { default: false })
 
-const { session, addCredits } = useMockSession()
+const { session } = useMockSession()
 const { topUpOutcome, buyStep } = usePrototypeTweaks()
+const { pending, outcome, begin, settle, place, clear } = usePendingTopUp()
 
 const usd = ref<number>(25)
 const credits = computed(() => usdToCredits(usd.value))
@@ -48,16 +46,18 @@ const workspace = computed(() =>
 )
 
 // Continue is a real link, so the tab opens on the visitor's own click and a
-// popup blocker never sees a programmatic open to swallow. That removes the
-// blocked case rather than handling it, and it means cancelling happens at
-// Stripe, in the other tab: this page just keeps waiting until they come back
-// or dismiss it. There is no "you cancelled" state to return to.
+// popup blocker never sees a programmatic open to swallow. Cancelling then
+// happens at Stripe, in the other tab: this page just keeps waiting until they
+// come back or dismiss it.
 //
-// The prototype plays Stripe's own page out in place, so the journey can be
-// reviewed without a payment account.
+// The purchase itself lives in usePendingTopUp, above this component, so
+// dismissing the card never abandons money that is already in flight.
 type Step = 'leaving' | 'checkout' | 'waiting' | 'landed' | 'unresolved'
-const step = ref<Step>('leaving')
-const previousCredits = ref(0)
+const standIn = ref(false)
+const step = computed<Step>(() =>
+  standIn.value ? 'checkout' : pending.value ? outcome.value : 'leaving'
+)
+const previousCredits = computed(() => pending.value?.previousCredits ?? 0)
 
 const returnPath = ref('/workshop/')
 const href = computed(() => stripeCheckoutHref(returnPath.value, usd.value))
@@ -66,35 +66,22 @@ const operationId = computed(
   () => `op_${(usdToCredits(usd.value) * 7919).toString(36)}`
 )
 
-let settleTimer: ReturnType<typeof setTimeout> | undefined
-function clearSettleTimer() {
-  if (settleTimer) clearTimeout(settleTimer)
-  settleTimer = undefined
-}
-onBeforeUnmount(clearSettleTimer)
-
 const RETURN_STEPS = ['waiting', 'landed', 'unresolved'] as const
 function isReturnStep(value: string): value is (typeof RETURN_STEPS)[number] {
   return (RETURN_STEPS as readonly string[]).includes(value)
 }
 
 watch(open, (value) => {
-  clearSettleTimer()
   if (!value) return
   returnPath.value = location.pathname + location.search
+  standIn.value = false
   // A review link can open any part of the flow. The states after the hand-off
   // are three clicks deep otherwise, and they are the ones worth looking at.
   const entry = buyStep.value
-  // Consumed once: after the link has opened its step, the dialog behaves
-  // normally, so closing and reopening does not jump back and grant again.
+  // Consumed once, so closing and reopening behaves normally afterwards.
   if (entry !== 'closed') buyStep.value = 'closed'
-  step.value = isReturnStep(entry) ? entry : 'leaving'
-  if (step.value === 'landed') {
-    previousCredits.value =
-      session.value.status === 'signedIn' ? session.value.account.credits : 0
-    // Land the grant too, so the ledger and the header agree.
-    addCredits(credits.value)
-  }
+  if (isReturnStep(entry)) place(entry, credits.value)
+  else if (entry === 'amount') clear()
 })
 
 function setAmount(next: number) {
@@ -105,23 +92,18 @@ function setAmount(next: number) {
 // prototype the navigation is prevented so Stripe's page can be played out in
 // place — shipping means dropping the `.prevent` and letting the link work.
 function leaveForStripe() {
-  step.value = 'waiting'
+  begin(credits.value)
 }
 
-// Stripe redirects the moment the card clears; the grant follows on a webhook.
-// Coming back before the credits do is the normal case, not an edge one, so the
-// page always lands on `waiting` first and resolves from there.
 function pay() {
-  previousCredits.value =
-    session.value.status === 'signedIn' ? session.value.account.credits : 0
-  step.value = 'waiting'
-  const settled = returnStepFor(topUpOutcome.value)
-  if (settled === 'waiting') return
-  clearSettleTimer()
-  settleTimer = setTimeout(() => {
-    if (settled === 'landed') addCredits(credits.value)
-    step.value = settled
-  }, SETTLE_DELAY_MS)
+  standIn.value = false
+  settle(topUpOutcome.value)
+}
+
+// Concluding the purchase: the money has resolved either way, so stop tracking.
+function finish() {
+  clear()
+  open.value = false
 }
 
 const format = (value: number) => value.toLocaleString(locale)
@@ -303,7 +285,7 @@ const stepperClass =
             size="lg"
             class="px-5"
             data-testid="buy-credits-back"
-            @click="step = 'waiting'"
+            @click="standIn = false"
           >
             {{ t('workshop.credits.back', locale) }}
           </Button>
@@ -345,24 +327,18 @@ const stepperClass =
             rel="noopener noreferrer"
             class="text-primary-comfy-yellow underline-offset-4 hover:underline"
             data-testid="buy-credits-reopen"
-            @click.prevent="step = 'checkout'"
+            @click.prevent="standIn = true"
           >
             {{ t('workshop.credits.reopen', locale) }}
           </a>
         </p>
 
-        <Button
-          variant="outline"
-          size="lg"
-          class="w-fit px-5"
-          data-testid="buy-credits-dismiss"
-          @click="open = false"
-        >
-          <!-- Not "Cancel": dismissing this does not cancel anything. The
-               checkout is open in the other tab and will complete or not on its
-               own; this only puts the page back. -->
-          {{ t('workshop.credits.close', locale) }}
-        </Button>
+        <!-- No button: there is no decision to make here. The X closes the card,
+             and closing changes nothing — the checkout is open in the other tab
+             and resolves on its own, with the page still watching. -->
+        <p class="text-sm text-primary-warm-gray">
+          {{ t('workshop.credits.closingIsSafe', locale) }}
+        </p>
       </div>
 
       <!-- 3b · The credits landed. -->
@@ -431,7 +407,7 @@ const stepperClass =
           size="lg"
           class="w-fit px-5"
           data-testid="buy-credits-resume"
-          @click="open = false"
+          @click="finish"
         >
           {{ t('workshop.credits.resume', locale) }}
         </Button>
@@ -481,7 +457,7 @@ const stepperClass =
             size="lg"
             class="px-5"
             data-testid="buy-credits-held-close"
-            @click="open = false"
+            @click="finish"
           >
             {{ t('workshop.credits.close', locale) }}
           </Button>

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -191,7 +191,16 @@ const stepperClass =
           </span>
         </div>
 
-        <div class="flex flex-wrap gap-3">
+        <div class="flex flex-wrap items-center justify-end gap-3">
+          <Button
+            variant="outline"
+            size="lg"
+            class="px-5"
+            data-testid="buy-credits-cancel"
+            @click="open = false"
+          >
+            {{ t('workshop.credits.cancel', locale) }}
+          </Button>
           <Button
             size="lg"
             class="px-5"
@@ -205,15 +214,6 @@ const stepperClass =
             <template #append>
               <ExternalLink class="size-4" aria-hidden="true" />
             </template>
-          </Button>
-          <Button
-            variant="outline"
-            size="lg"
-            class="px-5"
-            data-testid="buy-credits-cancel"
-            @click="open = false"
-          >
-            {{ t('workshop.credits.cancel', locale) }}
           </Button>
         </div>
       </div>
@@ -248,7 +248,16 @@ const stepperClass =
           </dd>
         </dl>
 
-        <div class="flex flex-wrap gap-3">
+        <div class="flex flex-wrap items-center justify-end gap-3">
+          <Button
+            variant="outline"
+            size="lg"
+            class="px-5"
+            data-testid="buy-credits-back"
+            @click="standIn = false"
+          >
+            {{ t('workshop.credits.back', locale) }}
+          </Button>
           <Button
             size="lg"
             class="px-5"
@@ -261,15 +270,6 @@ const stepperClass =
                 `$${format(usd)}`
               )
             }}
-          </Button>
-          <Button
-            variant="outline"
-            size="lg"
-            class="px-5"
-            data-testid="buy-credits-back"
-            @click="standIn = false"
-          >
-            {{ t('workshop.credits.back', locale) }}
           </Button>
         </div>
       </div>
@@ -387,7 +387,7 @@ const stepperClass =
 
         <Button
           size="lg"
-          class="w-fit px-5"
+          class="ml-auto w-fit px-5"
           data-testid="buy-credits-resume"
           @click="finish"
         >
@@ -430,10 +430,7 @@ const stepperClass =
           </span>
         </div>
 
-        <div class="flex flex-wrap gap-3">
-          <Button size="lg" class="px-5" data-testid="buy-credits-support">
-            {{ t('workshop.credits.contactSupport', locale) }}
-          </Button>
+        <div class="flex flex-wrap items-center justify-end gap-3">
           <Button
             variant="outline"
             size="lg"
@@ -442,6 +439,9 @@ const stepperClass =
             @click="finish"
           >
             {{ t('workshop.credits.close', locale) }}
+          </Button>
+          <Button size="lg" class="px-5" data-testid="buy-credits-support">
+            {{ t('workshop.credits.contactSupport', locale) }}
           </Button>
         </div>
       </div>

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -122,13 +122,13 @@ const stepperClass =
   <Dialog v-model:open="open">
     <DialogContent
       :close-label="t('workshop.credits.close', locale)"
-      class="sm:max-w-xl"
+      class="flex min-h-[min(85vh,41rem)] flex-col sm:min-h-136 sm:max-w-xl"
       data-testid="buy-credits-dialog"
     >
       <!-- 1 · Amount — the last screen we own before the hand-off -->
       <div
         v-if="step === 'leaving'"
-        class="flex flex-col gap-6"
+        class="flex flex-1 flex-col gap-6"
         data-step="leaving"
       >
         <DialogTitle class="pr-16">
@@ -191,7 +191,7 @@ const stepperClass =
           </span>
         </div>
 
-        <div class="flex flex-wrap items-center justify-end gap-3">
+        <div class="mt-auto flex flex-wrap items-center justify-end gap-3">
           <Button
             variant="outline"
             size="lg"
@@ -221,7 +221,7 @@ const stepperClass =
       <!-- 2 · Stripe's page. Never renders live: the browser is on stripe.com. -->
       <div
         v-else-if="step === 'checkout'"
-        class="flex flex-col gap-6"
+        class="flex flex-1 flex-col gap-6"
         data-step="checkout"
       >
         <p
@@ -248,7 +248,7 @@ const stepperClass =
           </dd>
         </dl>
 
-        <div class="flex flex-wrap items-center justify-end gap-3">
+        <div class="mt-auto flex flex-wrap items-center justify-end gap-3">
           <Button
             variant="outline"
             size="lg"
@@ -278,7 +278,7 @@ const stepperClass =
            what a lost grant looks like — only elapsed time tells them apart. -->
       <div
         v-else-if="step === 'waiting'"
-        class="flex flex-col gap-6"
+        class="flex flex-1 flex-col gap-6"
         data-step="waiting"
       >
         <DialogTitle class="pr-16">
@@ -326,7 +326,7 @@ const stepperClass =
       <!-- 3b · The credits landed. -->
       <div
         v-else-if="step === 'landed'"
-        class="flex flex-col gap-6"
+        class="flex flex-1 flex-col gap-6"
         data-testid="buy-credits-done"
         data-step="landed"
       >
@@ -387,7 +387,7 @@ const stepperClass =
 
         <Button
           size="lg"
-          class="ml-auto w-fit px-5"
+          class="mt-auto ml-auto w-fit px-5"
           data-testid="buy-credits-resume"
           @click="finish"
         >
@@ -399,7 +399,7 @@ const stepperClass =
            this rail has no reconciler (IR-126/128), unlike the in-app one. -->
       <div
         v-else
-        class="flex flex-col gap-6"
+        class="flex flex-1 flex-col gap-6"
         data-testid="buy-credits-held"
         data-step="unresolved"
       >
@@ -430,7 +430,7 @@ const stepperClass =
           </span>
         </div>
 
-        <div class="flex flex-wrap items-center justify-end gap-3">
+        <div class="mt-auto flex flex-wrap items-center justify-end gap-3">
           <Button
             variant="outline"
             size="lg"

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -9,7 +9,7 @@ import {
   Minus,
   Plus
 } from '@lucide/vue'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -100,8 +100,65 @@ function pay() {
   settle(topUpOutcome.value)
 }
 
+// The landed card closes itself after a beat. It is the one state with nothing
+// left to decide — the credits are in and the gate behind has already flipped to
+// Run — so making someone dismiss it is a step that buys nothing.
+//
+// Two guards, because it is still a receipt. The countdown runs only while the
+// tab is actually being looked at, so someone who wandered off does not return
+// to a confirmation that already went. And any interaction cancels it for good,
+// so nobody loses the ledger halfway through reading it.
+//
+// Deliberately not applied to waiting or unresolved: those are unfinished, and a
+// card that closes itself says the opposite.
+const AUTO_CLOSE_MS = 5_000
+let autoCloseTimer: ReturnType<typeof setTimeout> | undefined
+let autoCloseCancelled = false
+
+function stopAutoClose() {
+  if (autoCloseTimer) clearTimeout(autoCloseTimer)
+  autoCloseTimer = undefined
+}
+
+function cancelAutoClose() {
+  autoCloseCancelled = true
+  stopAutoClose()
+}
+
+function scheduleAutoClose() {
+  stopAutoClose()
+  if (autoCloseCancelled) return
+  if (typeof document !== 'undefined' && document.hidden) return
+  autoCloseTimer = setTimeout(() => finish(), AUTO_CLOSE_MS)
+}
+
+function onVisibilityChange() {
+  if (step.value !== 'landed') return
+  if (document.hidden) stopAutoClose()
+  else scheduleAutoClose()
+}
+
+watch(step, (value) => {
+  if (value !== 'landed') {
+    stopAutoClose()
+    return
+  }
+  autoCloseCancelled = false
+  scheduleAutoClose()
+})
+
+onMounted(() => {
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+
+onBeforeUnmount(() => {
+  stopAutoClose()
+  document.removeEventListener('visibilitychange', onVisibilityChange)
+})
+
 // Concluding the purchase: the money has resolved either way, so stop tracking.
 function finish() {
+  stopAutoClose()
   clear()
   open.value = false
 }
@@ -124,6 +181,8 @@ const stepperClass =
       :close-label="t('workshop.credits.close', locale)"
       class="flex min-h-[min(85vh,41rem)] flex-col sm:min-h-136 sm:max-w-xl"
       data-testid="buy-credits-dialog"
+      @pointerdown="cancelAutoClose"
+      @keydown="cancelAutoClose"
     >
       <!-- 1 · Amount — the last screen we own before the hand-off -->
       <div

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -379,20 +379,20 @@ const stepperClass =
         data-testid="buy-credits-done"
         data-step="landed"
       >
-        <div class="flex items-center gap-3 pr-16">
-          <span
-            class="border-primary-comfy-yellow text-primary-comfy-yellow grid size-8 shrink-0 place-items-center rounded-full border-2"
-            aria-hidden="true"
-          >
-            <Check class="size-4" :stroke-width="3" />
-          </span>
-          <DialogTitle>
-            {{
-              t('workshop.credits.done', locale).replace('{n}', format(credits))
-            }}
-          </DialogTitle>
-        </div>
-        <DialogDescription class="text-base text-primary-comfy-canvas/70">
+        <span
+          class="border-primary-comfy-yellow text-primary-comfy-yellow -mb-2 grid size-16 shrink-0 place-items-center self-center rounded-full border-2"
+          aria-hidden="true"
+        >
+          <Check class="size-7" :stroke-width="2.5" />
+        </span>
+        <DialogTitle class="px-8 text-center">
+          {{
+            t('workshop.credits.done', locale).replace('{n}', format(credits))
+          }}
+        </DialogTitle>
+        <DialogDescription
+          class="px-8 text-center text-base text-primary-comfy-canvas/70"
+        >
           {{
             t('workshop.credits.addedTo', locale).replace(
               '{workspace}',
@@ -454,25 +454,24 @@ const stepperClass =
         data-testid="buy-credits-held"
         data-step="unresolved"
       >
-        <div class="flex items-center gap-3 pr-16">
-          <!-- Not yellow: "Payment received" is a reassuring headline on the
-               outcome that is not fine, and the mark is what says so before the
-               body does. Not secondary-mauve either, which /payment/failed uses
-               — it is #4d3762 on a #211927 surface, about 1.6:1, so it barely
-               renders. Orange is the palette's "needs attention" that is
-               legible on ink, the same problem --color-destructive-light exists
-               to solve. -->
-          <span
-            class="border-primary-comfy-orange text-primary-comfy-orange grid size-8 shrink-0 place-items-center rounded-full border-2"
-            aria-hidden="true"
-          >
-            <Clock class="size-4" />
-          </span>
-          <DialogTitle>
-            {{ t('workshop.credits.heldTitle', locale) }}
-          </DialogTitle>
-        </div>
-        <DialogDescription class="text-base text-primary-comfy-canvas/70">
+        <!-- Not yellow: "Payment received" is a reassuring headline on the
+             outcome that is not fine, and the mark is what says so before the
+             body does. Not secondary-mauve either, which /payment/failed uses —
+             it is #4d3762 on a #211927 surface, about 1.6:1, so it barely
+             renders. Orange is the palette's "needs attention" that is legible
+             on ink, the same problem --color-destructive-light exists to solve. -->
+        <span
+          class="border-primary-comfy-orange text-primary-comfy-orange -mb-2 grid size-16 shrink-0 place-items-center self-center rounded-full border-2"
+          aria-hidden="true"
+        >
+          <Clock class="size-7" />
+        </span>
+        <DialogTitle class="px-8 text-center">
+          {{ t('workshop.credits.heldTitle', locale) }}
+        </DialogTitle>
+        <DialogDescription
+          class="px-8 text-center text-base text-primary-comfy-canvas/70"
+        >
           {{ t('workshop.credits.heldBody', locale) }}
         </DialogDescription>
 

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -456,12 +456,14 @@ const stepperClass =
       >
         <!-- Not yellow: "Payment received" is a reassuring headline on the
              outcome that is not fine, and the mark is what says so before the
-             body does. Not secondary-mauve either, which /payment/failed uses —
-             it is #4d3762 on a #211927 surface, about 1.6:1, so it barely
-             renders. Orange is the palette's "needs attention" that is legible
-             on ink, the same problem --color-destructive-light exists to solve. -->
+             body does. Not orange either — at this size it reads as a near-miss
+             of the success yellow rather than a different outcome. Not
+             secondary-mauve, which /payment/failed uses: it is #4d3762 on a
+             #211927 surface, about 1.6:1, so it barely renders. Canvas at 70% is
+             the palette's neutral, clears 3:1 here, and reads as "no verdict
+             yet" — which is exactly the state. -->
         <span
-          class="border-primary-comfy-orange text-primary-comfy-orange -mb-2 grid size-16 shrink-0 place-items-center self-center rounded-full border-2"
+          class="-mb-2 grid size-16 shrink-0 place-items-center self-center rounded-full border-2 border-primary-comfy-canvas/70 text-primary-comfy-canvas/70"
           aria-hidden="true"
         >
           <Clock class="size-7" />

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -111,23 +111,16 @@ function pay() {
 //
 // Deliberately not applied to waiting or unresolved: those are unfinished, and a
 // card that closes itself says the opposite.
-const AUTO_CLOSE_MS = 5_000
+const AUTO_CLOSE_MS = 3_600
 let autoCloseTimer: ReturnType<typeof setTimeout> | undefined
-let autoCloseCancelled = false
 
 function stopAutoClose() {
   if (autoCloseTimer) clearTimeout(autoCloseTimer)
   autoCloseTimer = undefined
 }
 
-function cancelAutoClose() {
-  autoCloseCancelled = true
-  stopAutoClose()
-}
-
 function scheduleAutoClose() {
   stopAutoClose()
-  if (autoCloseCancelled) return
   if (typeof document !== 'undefined' && document.hidden) return
   autoCloseTimer = setTimeout(() => finish(), AUTO_CLOSE_MS)
 }
@@ -143,7 +136,6 @@ watch(step, (value) => {
     stopAutoClose()
     return
   }
-  autoCloseCancelled = false
   scheduleAutoClose()
 })
 
@@ -181,8 +173,6 @@ const stepperClass =
       :close-label="t('workshop.credits.close', locale)"
       class="flex min-h-[min(85vh,41rem)] flex-col sm:min-h-136 sm:max-w-xl"
       data-testid="buy-credits-dialog"
-      @pointerdown="cancelAutoClose"
-      @keydown="cancelAutoClose"
     >
       <!-- 1 · Amount — the last screen we own before the hand-off -->
       <div
@@ -389,17 +379,19 @@ const stepperClass =
         data-testid="buy-credits-done"
         data-step="landed"
       >
-        <span
-          class="bg-primary-comfy-yellow grid size-12 place-items-center rounded-2xl text-primary-comfy-ink"
-          aria-hidden="true"
-        >
-          <Check class="size-6" :stroke-width="3" />
-        </span>
-        <DialogTitle class="pr-16">
-          {{
-            t('workshop.credits.done', locale).replace('{n}', format(credits))
-          }}
-        </DialogTitle>
+        <div class="flex items-center gap-3 pr-16">
+          <span
+            class="border-primary-comfy-yellow text-primary-comfy-yellow grid size-8 shrink-0 place-items-center rounded-full border-2"
+            aria-hidden="true"
+          >
+            <Check class="size-4" :stroke-width="3" />
+          </span>
+          <DialogTitle>
+            {{
+              t('workshop.credits.done', locale).replace('{n}', format(credits))
+            }}
+          </DialogTitle>
+        </div>
         <DialogDescription class="text-base text-primary-comfy-canvas/70">
           {{
             t('workshop.credits.addedTo', locale).replace(
@@ -462,15 +454,24 @@ const stepperClass =
         data-testid="buy-credits-held"
         data-step="unresolved"
       >
-        <span
-          class="grid size-12 place-items-center rounded-2xl bg-transparency-white-t8 text-primary-warm-white"
-          aria-hidden="true"
-        >
-          <Clock class="size-6" />
-        </span>
-        <DialogTitle class="pr-16">
-          {{ t('workshop.credits.heldTitle', locale) }}
-        </DialogTitle>
+        <div class="flex items-center gap-3 pr-16">
+          <!-- Not yellow: "Payment received" is a reassuring headline on the
+               outcome that is not fine, and the mark is what says so before the
+               body does. Not secondary-mauve either, which /payment/failed uses
+               — it is #4d3762 on a #211927 surface, about 1.6:1, so it barely
+               renders. Orange is the palette's "needs attention" that is
+               legible on ink, the same problem --color-destructive-light exists
+               to solve. -->
+          <span
+            class="border-primary-comfy-orange text-primary-comfy-orange grid size-8 shrink-0 place-items-center rounded-full border-2"
+            aria-hidden="true"
+          >
+            <Clock class="size-4" />
+          </span>
+          <DialogTitle>
+            {{ t('workshop.credits.heldTitle', locale) }}
+          </DialogTitle>
+        </div>
         <DialogDescription class="text-base text-primary-comfy-canvas/70">
           {{ t('workshop.credits.heldBody', locale) }}
         </DialogDescription>

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -9,6 +9,7 @@ import {
   EXISTING_CREDITS
 } from '../../composables/useMockSession'
 import type { WorkshopModelDetail } from '../../config/workshop'
+import { SETTLE_DELAY_MS } from '../../lib/workshop/buy-credits'
 import ModelDetail from './ModelDetail.vue'
 
 const prompt = {
@@ -180,6 +181,13 @@ describe('ModelDetail', () => {
     ).toContain('success_url=')
     await user().click(screen.getByTestId('buy-credits-continue'))
     await user().click(await screen.findByTestId('buy-credits-pay'))
+
+    // Stripe redirects the moment the card clears, but the grant follows on a
+    // webhook: the page waits before it can say anything.
+    expect(await screen.findByTestId('buy-credits-polling')).toBeTruthy()
+    vi.advanceTimersByTime(SETTLE_DELAY_MS)
+    await nextTick()
+
     expect((await screen.findByTestId('buy-credits-done')).textContent).toMatch(
       /credits added/i
     )

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -176,8 +176,9 @@ describe('ModelDetail', () => {
     // The trip to Platform is explained before it happens, it carries the page
     // back with it, and the mocked purchase returns with the credits added.
     await user().click(run)
+    // The page it carries back is on the link itself, not on any display of it.
     expect(
-      (await screen.findByTestId('buy-credits-url')).textContent
+      (await screen.findByTestId('buy-credits-continue')).getAttribute('href')
     ).toContain('success_url=')
     // Continue is a link: the tab opens on the click and this page starts
     // waiting straight away, rather than showing anything of its own.

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -179,11 +179,17 @@ describe('ModelDetail', () => {
     expect(
       (await screen.findByTestId('buy-credits-url')).textContent
     ).toContain('success_url=')
+    // Continue is a link: the tab opens on the click and this page starts
+    // waiting straight away, rather than showing anything of its own.
     await user().click(screen.getByTestId('buy-credits-continue'))
+    expect(await screen.findByTestId('buy-credits-polling')).toBeTruthy()
+
+    // Stripe's page stands in here, reachable the way a closed tab would be.
+    await user().click(screen.getByTestId('buy-credits-reopen'))
     await user().click(await screen.findByTestId('buy-credits-pay'))
 
-    // Stripe redirects the moment the card clears, but the grant follows on a
-    // webhook: the page waits before it can say anything.
+    // The redirect beats the webhook, so it waits again before it can say
+    // anything.
     expect(await screen.findByTestId('buy-credits-polling')).toBeTruthy()
     vi.advanceTimersByTime(SETTLE_DELAY_MS)
     await nextTick()

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -231,7 +231,8 @@ describe('ModelDetail', () => {
     expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
       'memberNoCredits'
     )
-    await user().click(screen.getByTestId('switch-personal'))
+    // Option A leaves one control in the run slot, so it is the run button.
+    await user().click(screen.getByTestId('run-button'))
     expect(credits(api)).toBe(EXISTING_CREDITS)
     expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
       'ready'

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -8,6 +8,7 @@ import {
   useMockSession,
   EXISTING_CREDITS
 } from '../../composables/useMockSession'
+import { usePrototypeTweaks } from '../../composables/usePrototypeTweaks'
 import type { WorkshopModelDetail } from '../../config/workshop'
 import { SETTLE_DELAY_MS } from '../../lib/workshop/buy-credits'
 import ModelDetail from './ModelDetail.vue'
@@ -283,5 +284,52 @@ describe('ModelDetail', () => {
     expect(
       (screen.getByTestId('field-prompt') as HTMLTextAreaElement).value
     ).toBe('a capybara')
+  })
+})
+
+describe('ModelDetail — the MVP top-up rail', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('turns the gate into a link out and names the workspace', async () => {
+    let tweaks!: ReturnType<typeof usePrototypeTweaks>
+    let api!: ReturnType<typeof useMockSession>
+    render(
+      defineComponent({
+        setup() {
+          api = useMockSession()
+          tweaks = usePrototypeTweaks()
+          tweaks.topUpRail.value = 'platform'
+          return () => h(ModelDetail, { model })
+        }
+      })
+    )
+    api.signIn('existing')
+    api.setCredits(0)
+    await nextTick()
+
+    const gate = screen.getByTestId('run-button')
+    expect(gate.tagName).toBe('A')
+    expect(gate.getAttribute('href')).toBe(
+      'https://platform.comfy.org/billing?workspace=Ada%27s+Studio'
+    )
+    expect(gate.getAttribute('target')).toBe('_blank')
+    // Naming the workspace is what makes a wrong-wallet top-up visible before
+    // it happens, since platform keeps its own switcher.
+    expect(screen.getByTestId('gate-note').textContent).toContain(
+      "Ada's Studio"
+    )
+    tweaks.topUpRail.value = 'in-place'
+  })
+
+  it('keeps the dialog on the in-place rail', async () => {
+    const api = await signedInDetail()
+    api.setCredits(0)
+    await nextTick()
+
+    const gate = screen.getByTestId('run-button')
+    expect(gate.tagName).toBe('BUTTON')
+    expect(gate.getAttribute('href')).toBeNull()
   })
 })

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -109,7 +109,8 @@ const { session, setCredits, switchWorkspace } = useMockSession()
 const {
   outcome: simOutcome,
   modelState: simGate,
-  showStatuses
+  showStatuses,
+  buyStep
 } = usePrototypeTweaks()
 const signInHref = useSignInHref(locale)
 
@@ -172,6 +173,9 @@ onMounted(() => {
   } catch {
     /* storage unavailable */
   }
+  // `?buy=` opens the credits flow straight onto a given step, so each state
+  // can be linked for review instead of clicked to.
+  if (buyStep.value !== 'closed') buyingCredits.value = true
 })
 watch(
   values,

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Coins, Copy, Play } from '@lucide/vue'
+import { ArrowUpRight, Coins, Copy, Play } from '@lucide/vue'
 import { useIntervalFn } from '@vueuse/core'
 import { computed, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue'
 
@@ -126,14 +126,6 @@ const workspace = computed(() =>
 // at click time, so a plain anchor is enough and no popup can be blocked.
 const topUpHref = computed(() => platformTopUpHref(workspace.value))
 
-// "Out of credits" and "Not enough credits" are different situations and the
-// gate should not blur them: one is an empty wallet, the other is a wallet that
-// cannot cover this particular run.
-const noCreditsTitleKey = computed<TranslationKey>(() =>
-  credits.value > 0
-    ? 'workshop.error.lowCreditsTitle'
-    : 'workshop.error.noCreditsTitle'
-)
 const noCreditsBody = computed(() => {
   if (topUpRail.value === 'platform')
     return t('workshop.error.noCreditsPlatform', locale).replace(
@@ -417,7 +409,7 @@ function useInCode() {
           <template v-else-if="gate === 'noCredits'">
             <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
               <p class="text-sm font-bold text-primary-warm-white">
-                {{ t(noCreditsTitleKey, locale) }}
+                {{ t('workshop.error.creditsTitle', locale) }}
               </p>
               <p class="text-xs text-primary-warm-gray">{{ noCreditsBody }}</p>
             </div>
@@ -429,10 +421,11 @@ function useInCode() {
               rel="noopener"
               size="lg"
               class="w-full px-5"
+              :append-icon="ArrowUpRight"
               data-testid="run-button"
               data-gate="noCredits"
             >
-              {{ t('workshop.run.buyCreditsPlatform', locale) }}
+              {{ t('workshop.run.buyCredits', locale) }}
             </Button>
             <Button
               v-else
@@ -454,7 +447,7 @@ function useInCode() {
           <template v-else-if="gate === 'memberNoCredits'">
             <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
               <p class="text-sm font-bold text-primary-warm-white">
-                {{ t('workshop.error.memberNoCreditsTitle', locale) }}
+                {{ t('workshop.error.creditsTitle', locale) }}
               </p>
               <p class="text-xs text-primary-warm-gray">
                 {{

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -13,6 +13,7 @@ import {
 import { useSignInHref } from '../../composables/useSignInHref'
 import { useTablist } from '../../composables/useTablist'
 import { usePrototypeTweaks } from '../../composables/usePrototypeTweaks'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import type { WorkshopModelDetail } from '../../config/workshop'
 import type {
   FieldErrors,
@@ -110,13 +111,20 @@ const {
   outcome: simOutcome,
   modelState: simGate,
   showStatuses,
-  buyStep
+  buyStep,
+  topUpRail
 } = usePrototypeTweaks()
 const signInHref = useSignInHref(locale)
 
 const credits = computed(() =>
   session.value.status === 'signedIn' ? session.value.account.credits : 0
 )
+const workspace = computed(() =>
+  session.value.status === 'signedIn' ? session.value.account.workspace : ''
+)
+// On the MVP rail the gate is a link, not a trigger: the destination is known
+// at click time, so a plain anchor is enough and no popup can be blocked.
+const topUpHref = computed(() => platformTopUpHref(workspace.value))
 const creditsPerRun = model.creditsPerRun
 const modelStatus = computed(() =>
   simGate.value === 'deprecated' || simGate.value === 'degraded'
@@ -379,6 +387,19 @@ function useInCode() {
             {{ t('workshop.run.signIn', locale) }}
           </Button>
           <Button
+            v-else-if="gate === 'noCredits' && topUpRail === 'platform'"
+            as="a"
+            :href="topUpHref"
+            target="_blank"
+            rel="noopener"
+            size="lg"
+            class="w-full px-5"
+            data-testid="run-button"
+            data-gate="noCredits"
+          >
+            {{ t('workshop.run.buyCreditsPlatform', locale) }}
+          </Button>
+          <Button
             v-else-if="gate === 'noCredits'"
             size="lg"
             class="w-full px-5"
@@ -450,11 +471,16 @@ function useInCode() {
             data-testid="gate-note"
           >
             {{
-              credits > 0
-                ? t('workshop.error.lowCredits', locale)
-                    .replace('{credits}', String(credits))
-                    .replace('{n}', String(creditsPerRun))
-                : t('workshop.error.noCredits', locale)
+              topUpRail === 'platform'
+                ? t('workshop.error.noCreditsPlatform', locale).replace(
+                    '{workspace}',
+                    workspace
+                  )
+                : credits > 0
+                  ? t('workshop.error.lowCredits', locale)
+                      .replace('{credits}', String(credits))
+                      .replace('{n}', String(creditsPerRun))
+                  : t('workshop.error.noCredits', locale)
             }}
           </p>
           <p

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -446,7 +446,7 @@ function useInCode() {
           </Button>
           <p
             v-if="gate === 'noCredits'"
-            class="text-xs text-primary-warm-gray"
+            class="mt-2 text-xs text-primary-warm-gray"
             data-testid="gate-note"
           >
             {{
@@ -459,7 +459,7 @@ function useInCode() {
           </p>
           <p
             v-else-if="gate === 'memberNoCredits'"
-            class="text-xs text-primary-warm-gray"
+            class="mt-2 text-xs text-primary-warm-gray"
             data-testid="gate-note"
           >
             {{
@@ -471,7 +471,7 @@ function useInCode() {
           </p>
           <p
             v-else-if="modelStatus === 'degraded'"
-            class="text-primary-comfy-orange text-xs"
+            class="text-primary-comfy-orange mt-2 text-xs"
             data-testid="gate-note"
           >
             {{ t('workshop.run.degraded', locale) }}

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -416,18 +416,25 @@ function useInCode() {
                explanation carries that meaning, the button carries the action.
                See DES-1015. -->
           <template v-else-if="gate === 'memberNoCredits'">
-            <p
-              class="mb-2 text-xs text-primary-warm-gray"
-              data-testid="gate-note"
-            >
-              {{
-                t('workshop.error.memberNoCredits', locale).replace(
-                  '{workspace}',
-                  workspace
-                )
-              }}
-            </p>
+            <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
+              <p class="text-sm font-bold text-primary-warm-white">
+                {{ t('workshop.error.memberNoCreditsTitle', locale) }}
+              </p>
+              <p class="text-xs text-primary-warm-gray">
+                {{
+                  t('workshop.error.memberNoCredits', locale).replace(
+                    '{workspace}',
+                    workspace
+                  )
+                }}
+              </p>
+            </div>
+            <!-- Outline, not the filled default: comfy yellow is the site's one
+                 accent, so a filled button here out-shouts the message it is
+                 meant to follow. Switching workspace is a fallback, not the
+                 headline. -->
             <Button
+              variant="outline"
               size="lg"
               class="w-full px-5"
               data-testid="run-button"

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -409,21 +409,29 @@ function useInCode() {
           >
             {{ t('workshop.run.buyCredits', locale) }}
           </Button>
+          <!-- The reason comes before the escape. This state used to stack a
+               disabled "Ask the owner for credits" button above the real one; a
+               disabled control is a sentence wearing a button, and it took
+               weight from the only thing a member can actually do here. The
+               explanation carries that meaning, the button carries the action.
+               See DES-1015. -->
           <template v-else-if="gate === 'memberNoCredits'">
+            <p
+              class="mb-2 text-xs text-primary-warm-gray"
+              data-testid="gate-note"
+            >
+              {{
+                t('workshop.error.memberNoCredits', locale).replace(
+                  '{workspace}',
+                  workspace
+                )
+              }}
+            </p>
             <Button
               size="lg"
               class="w-full px-5"
-              disabled
               data-testid="run-button"
               data-gate="memberNoCredits"
-            >
-              {{ t('workshop.run.memberNoCredits', locale) }}
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              class="w-full px-5"
-              data-testid="switch-personal"
               @click="switchWorkspace(PERSONAL_WORKSPACE)"
             >
               {{ t('workshop.run.switchPersonal', locale) }}
@@ -481,18 +489,6 @@ function useInCode() {
                       .replace('{credits}', String(credits))
                       .replace('{n}', String(creditsPerRun))
                   : t('workshop.error.noCredits', locale)
-            }}
-          </p>
-          <p
-            v-else-if="gate === 'memberNoCredits'"
-            class="mt-2 text-xs text-primary-warm-gray"
-            data-testid="gate-note"
-          >
-            {{
-              t('workshop.error.memberNoCredits', locale).replace(
-                '{workspace}',
-                session.status === 'signedIn' ? session.account.workspace : ''
-              )
             }}
           </p>
           <p

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -125,6 +125,30 @@ const workspace = computed(() =>
 // On the MVP rail the gate is a link, not a trigger: the destination is known
 // at click time, so a plain anchor is enough and no popup can be blocked.
 const topUpHref = computed(() => platformTopUpHref(workspace.value))
+
+// "Out of credits" and "Not enough credits" are different situations and the
+// gate should not blur them: one is an empty wallet, the other is a wallet that
+// cannot cover this particular run.
+const noCreditsTitleKey = computed<TranslationKey>(() =>
+  credits.value > 0
+    ? 'workshop.error.lowCreditsTitle'
+    : 'workshop.error.noCreditsTitle'
+)
+const noCreditsBody = computed(() => {
+  if (topUpRail.value === 'platform')
+    return t('workshop.error.noCreditsPlatform', locale).replace(
+      '{workspace}',
+      workspace.value
+    )
+  if (credits.value > 0)
+    return t('workshop.error.lowCredits', locale)
+      .replace('{credits}', String(credits.value))
+      .replace('{n}', String(creditsPerRun))
+  return t('workshop.error.noCredits', locale).replace(
+    '{n}',
+    String(creditsPerRun)
+  )
+})
 const creditsPerRun = model.creditsPerRun
 const modelStatus = computed(() =>
   simGate.value === 'deprecated' || simGate.value === 'degraded'
@@ -386,29 +410,41 @@ function useInCode() {
           >
             {{ t('workshop.run.signIn', locale) }}
           </Button>
-          <Button
-            v-else-if="gate === 'noCredits' && topUpRail === 'platform'"
-            as="a"
-            :href="topUpHref"
-            target="_blank"
-            rel="noopener"
-            size="lg"
-            class="w-full px-5"
-            data-testid="run-button"
-            data-gate="noCredits"
-          >
-            {{ t('workshop.run.buyCreditsPlatform', locale) }}
-          </Button>
-          <Button
-            v-else-if="gate === 'noCredits'"
-            size="lg"
-            class="w-full px-5"
-            data-testid="run-button"
-            data-gate="noCredits"
-            @click="buyingCredits = true"
-          >
-            {{ t('workshop.run.buyCredits', locale) }}
-          </Button>
+          <!-- Same shape as the member gate: a bold lead states the problem and
+               the body says what to do, then the control. The title separates an
+               empty balance from one that is merely short, so the body does not
+               have to. -->
+          <template v-else-if="gate === 'noCredits'">
+            <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
+              <p class="text-sm font-bold text-primary-warm-white">
+                {{ t(noCreditsTitleKey, locale) }}
+              </p>
+              <p class="text-xs text-primary-warm-gray">{{ noCreditsBody }}</p>
+            </div>
+            <Button
+              v-if="topUpRail === 'platform'"
+              as="a"
+              :href="topUpHref"
+              target="_blank"
+              rel="noopener"
+              size="lg"
+              class="w-full px-5"
+              data-testid="run-button"
+              data-gate="noCredits"
+            >
+              {{ t('workshop.run.buyCreditsPlatform', locale) }}
+            </Button>
+            <Button
+              v-else
+              size="lg"
+              class="w-full px-5"
+              data-testid="run-button"
+              data-gate="noCredits"
+              @click="buyingCredits = true"
+            >
+              {{ t('workshop.run.buyCredits', locale) }}
+            </Button>
+          </template>
           <!-- The reason comes before the escape. This state used to stack a
                disabled "Ask the owner for credits" button above the real one; a
                disabled control is a sentence wearing a button, and it took
@@ -481,25 +517,7 @@ function useInCode() {
             }}
           </Button>
           <p
-            v-if="gate === 'noCredits'"
-            class="mt-2 text-xs text-primary-warm-gray"
-            data-testid="gate-note"
-          >
-            {{
-              topUpRail === 'platform'
-                ? t('workshop.error.noCreditsPlatform', locale).replace(
-                    '{workspace}',
-                    workspace
-                  )
-                : credits > 0
-                  ? t('workshop.error.lowCredits', locale)
-                      .replace('{credits}', String(credits))
-                      .replace('{n}', String(creditsPerRun))
-                  : t('workshop.error.noCredits', locale)
-            }}
-          </p>
-          <p
-            v-else-if="modelStatus === 'degraded'"
+            v-if="modelStatus === 'degraded'"
             class="text-primary-comfy-orange mt-2 text-xs"
             data-testid="gate-note"
           >

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -421,11 +421,13 @@ function useInCode() {
               rel="noopener"
               size="lg"
               class="w-full px-5"
-              :append-icon="ExternalLink"
               data-testid="run-button"
               data-gate="noCredits"
             >
               {{ t('workshop.run.buyCredits', locale) }}
+              <template #append>
+                <ExternalLink class="size-5" aria-hidden="true" />
+              </template>
             </Button>
             <Button
               v-else

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowUpRight, Coins, Copy, Play } from '@lucide/vue'
+import { Coins, Copy, ExternalLink, Play } from '@lucide/vue'
 import { useIntervalFn } from '@vueuse/core'
 import { computed, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue'
 
@@ -421,7 +421,7 @@ function useInCode() {
               rel="noopener"
               size="lg"
               class="w-full px-5"
-              :append-icon="ArrowUpRight"
+              :append-icon="ExternalLink"
               data-testid="run-button"
               data-gate="noCredits"
             >

--- a/apps/website/src/components/workshop/PrototypeTweaks.vue
+++ b/apps/website/src/components/workshop/PrototypeTweaks.vue
@@ -50,7 +50,8 @@ const {
   version,
   showStatuses,
   groupVersions,
-  topUpOutcome
+  topUpOutcome,
+  buyStep
 } = usePrototypeTweaks()
 
 const SESSION_CHOICES: readonly SessionChoice[] = [
@@ -112,7 +113,8 @@ const shareState = computed<ShareState>(() => ({
   member: isMember.value,
   outcome: outcome.value,
   modelState: modelState.value,
-  topUpOutcome: topUpOutcome.value
+  topUpOutcome: topUpOutcome.value,
+  buyStep: buyStep.value
 }))
 const shareUrl = computed(
   () =>

--- a/apps/website/src/components/workshop/PrototypeTweaks.vue
+++ b/apps/website/src/components/workshop/PrototypeTweaks.vue
@@ -19,11 +19,13 @@ import {
 import type {
   ModelState,
   RunOutcome,
+  TopUpOutcome,
   Version
 } from '../../composables/usePrototypeTweaks'
 import {
   MODEL_STATES,
   RUN_OUTCOMES,
+  TOP_UP_OUTCOMES,
   VERSIONS,
   usePrototypeTweaks
 } from '../../composables/usePrototypeTweaks'
@@ -42,8 +44,14 @@ const { locale = 'en', showRunControls = false } = defineProps<{
 
 const { session, signIn, signOut, setCredits, setSubscribed, setRole } =
   useMockSession()
-const { outcome, modelState, version, showStatuses, groupVersions } =
-  usePrototypeTweaks()
+const {
+  outcome,
+  modelState,
+  version,
+  showStatuses,
+  groupVersions,
+  topUpOutcome
+} = usePrototypeTweaks()
 
 const SESSION_CHOICES: readonly SessionChoice[] = [
   'signedOut',
@@ -81,6 +89,7 @@ onMounted(() => {
     groupVersions.value = shared.groupVersions
   if (shared.outcome) outcome.value = shared.outcome
   if (shared.modelState) modelState.value = shared.modelState
+  if (shared.topUpOutcome) topUpOutcome.value = shared.topUpOutcome
   if (shared.session === 'signedOut') signOut()
   else if (shared.session) signIn(shared.session)
   if (shared.subscribed !== undefined) setSubscribed(shared.subscribed)
@@ -102,7 +111,8 @@ const shareState = computed<ShareState>(() => ({
   balance: zeroBalance.value ? 'zero' : lowBalance.value ? 'low' : 'normal',
   member: isMember.value,
   outcome: outcome.value,
-  modelState: modelState.value
+  modelState: modelState.value,
+  topUpOutcome: topUpOutcome.value
 }))
 const shareUrl = computed(
   () =>
@@ -148,6 +158,11 @@ const outcomeLabel: Record<RunOutcome, TranslationKey> = {
   provider: 'workshop.proto.outcome.provider',
   rateLimit: 'workshop.proto.outcome.rateLimit',
   timeout: 'workshop.proto.outcome.timeout'
+}
+const topUpOutcomeLabel: Record<TopUpOutcome, TranslationKey> = {
+  landed: 'workshop.proto.topUp.landed',
+  settling: 'workshop.proto.topUp.settling',
+  unresolved: 'workshop.proto.topUp.unresolved'
 }
 const modelStateLabel: Record<ModelState, TranslationKey> = {
   none: 'workshop.proto.gate.none',
@@ -374,6 +389,32 @@ const selectClass =
             >
               <span :class="knobClass(isMember)" />
             </button>
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-primary-warm-gray">
+              {{ t('workshop.proto.topUp', locale) }}
+            </span>
+            <span class="relative flex items-center">
+              <select
+                v-model="topUpOutcome"
+                data-testid="tweak-topup"
+                :class="selectClass"
+              >
+                <option
+                  v-for="option in TOP_UP_OUTCOMES"
+                  :key="option"
+                  :value="option"
+                  class="bg-primary-comfy-ink"
+                >
+                  {{ t(topUpOutcomeLabel[option], locale) }}
+                </option>
+              </select>
+              <ChevronDown
+                class="pointer-events-none absolute right-2 size-3.5 text-primary-warm-gray"
+                aria-hidden="true"
+              />
+            </span>
           </label>
 
           <template v-if="showRunControls">

--- a/apps/website/src/components/workshop/PrototypeTweaks.vue
+++ b/apps/website/src/components/workshop/PrototypeTweaks.vue
@@ -20,12 +20,14 @@ import type {
   ModelState,
   RunOutcome,
   TopUpOutcome,
+  TopUpRail,
   Version
 } from '../../composables/usePrototypeTweaks'
 import {
   MODEL_STATES,
   RUN_OUTCOMES,
   TOP_UP_OUTCOMES,
+  TOP_UP_RAILS,
   VERSIONS,
   usePrototypeTweaks
 } from '../../composables/usePrototypeTweaks'
@@ -51,7 +53,8 @@ const {
   showStatuses,
   groupVersions,
   topUpOutcome,
-  buyStep
+  buyStep,
+  topUpRail
 } = usePrototypeTweaks()
 
 const SESSION_CHOICES: readonly SessionChoice[] = [
@@ -91,6 +94,7 @@ onMounted(() => {
   if (shared.outcome) outcome.value = shared.outcome
   if (shared.modelState) modelState.value = shared.modelState
   if (shared.topUpOutcome) topUpOutcome.value = shared.topUpOutcome
+  if (shared.topUpRail) topUpRail.value = shared.topUpRail
   if (shared.session === 'signedOut') signOut()
   else if (shared.session) signIn(shared.session)
   if (shared.subscribed !== undefined) setSubscribed(shared.subscribed)
@@ -114,7 +118,8 @@ const shareState = computed<ShareState>(() => ({
   outcome: outcome.value,
   modelState: modelState.value,
   topUpOutcome: topUpOutcome.value,
-  buyStep: buyStep.value
+  buyStep: buyStep.value,
+  topUpRail: topUpRail.value
 }))
 const shareUrl = computed(
   () =>
@@ -160,6 +165,10 @@ const outcomeLabel: Record<RunOutcome, TranslationKey> = {
   provider: 'workshop.proto.outcome.provider',
   rateLimit: 'workshop.proto.outcome.rateLimit',
   timeout: 'workshop.proto.outcome.timeout'
+}
+const topUpRailLabel: Record<TopUpRail, TranslationKey> = {
+  'in-place': 'workshop.proto.rail.inPlace',
+  platform: 'workshop.proto.rail.platform'
 }
 const topUpOutcomeLabel: Record<TopUpOutcome, TranslationKey> = {
   landed: 'workshop.proto.topUp.landed',
@@ -394,6 +403,32 @@ const selectClass =
           </label>
 
           <label class="flex flex-col gap-1">
+            <span class="text-primary-warm-gray">
+              {{ t('workshop.proto.rail', locale) }}
+            </span>
+            <span class="relative flex items-center">
+              <select
+                v-model="topUpRail"
+                data-testid="tweak-rail"
+                :class="selectClass"
+              >
+                <option
+                  v-for="option in TOP_UP_RAILS"
+                  :key="option"
+                  :value="option"
+                  class="bg-primary-comfy-ink"
+                >
+                  {{ t(topUpRailLabel[option], locale) }}
+                </option>
+              </select>
+              <ChevronDown
+                class="pointer-events-none absolute right-2 size-3.5 text-primary-warm-gray"
+                aria-hidden="true"
+              />
+            </span>
+          </label>
+
+          <label v-if="topUpRail === 'in-place'" class="flex flex-col gap-1">
             <span class="text-primary-warm-gray">
               {{ t('workshop.proto.topUp', locale) }}
             </span>

--- a/apps/website/src/composables/usePendingTopUp.ts
+++ b/apps/website/src/composables/usePendingTopUp.ts
@@ -1,0 +1,68 @@
+import { ref } from 'vue'
+
+import type { ReturnStep } from '../lib/workshop/buy-credits'
+import { SETTLE_DELAY_MS, returnStepFor } from '../lib/workshop/buy-credits'
+import { useMockSession } from './useMockSession'
+import type { TopUpOutcome } from './usePrototypeTweaks'
+
+interface PendingTopUp {
+  readonly credits: number
+  readonly previousCredits: number
+}
+
+// A purchase in flight outlives the dialog. Dismissing the card cannot cancel
+// anything — the checkout is open in another tab and resolves on its own — so
+// the page keeps watching and the balance updates underneath. Owning this here
+// rather than in the dialog is what makes closing safe.
+const pending = ref<PendingTopUp | null>(null)
+const outcome = ref<ReturnStep>('waiting')
+let timer: ReturnType<typeof setTimeout> | undefined
+
+function clearTimer() {
+  if (timer) clearTimeout(timer)
+  timer = undefined
+}
+
+export function usePendingTopUp() {
+  const { session, addCredits } = useMockSession()
+
+  const currentCredits = () =>
+    session.value.status === 'signedIn' ? session.value.account.credits : 0
+
+  // They have left for Stripe. Nothing has been paid yet and nothing is
+  // scheduled: the page simply starts waiting.
+  function begin(credits: number) {
+    clearTimer()
+    pending.value = { credits, previousCredits: currentCredits() }
+    outcome.value = 'waiting'
+  }
+
+  // Stripe took the card. The grant follows on a webhook, so the page keeps
+  // waiting until it lands — or, when it never does, until the timeout.
+  function settle(resolveTo: TopUpOutcome) {
+    const target = returnStepFor(resolveTo)
+    if (!pending.value || target === 'waiting') return
+    clearTimer()
+    timer = setTimeout(() => {
+      if (target === 'landed' && pending.value)
+        addCredits(pending.value.credits)
+      outcome.value = target
+    }, SETTLE_DELAY_MS)
+  }
+
+  // Only for review links, which drop straight onto a resolved state.
+  function place(step: ReturnStep, credits: number) {
+    clearTimer()
+    pending.value = { credits, previousCredits: currentCredits() }
+    outcome.value = step
+    if (step === 'landed') addCredits(credits)
+  }
+
+  function clear() {
+    clearTimer()
+    pending.value = null
+    outcome.value = 'waiting'
+  }
+
+  return { pending, outcome, begin, settle, place, clear }
+}

--- a/apps/website/src/composables/usePrototypeTweaks.ts
+++ b/apps/website/src/composables/usePrototypeTweaks.ts
@@ -26,6 +26,19 @@ export type ModelState = (typeof MODEL_STATES)[number]
 export const TOP_UP_OUTCOMES = ['landed', 'settling', 'unresolved'] as const
 export type TopUpOutcome = (typeof TOP_UP_OUTCOMES)[number]
 
+// Which part of the buy-credits flow a link opens on. The states after the
+// hand-off are the point of the flow and cost three clicks to reach, so they
+// are addressable directly for review.
+export const BUY_STEPS = [
+  'closed',
+  'amount',
+  'waiting',
+  'landed',
+  'unresolved',
+  'canceled'
+] as const
+export type BuyStep = (typeof BUY_STEPS)[number]
+
 // One control for the whole prototype: V1 is the flat models catalog (11 Sep),
 // V1.1 opens that same catalog as browseable rows per use case, V1.2 moves the
 // categories into a rail beside the grid, and V2 is the screen where workflows,
@@ -44,11 +57,19 @@ const showStatuses = ref(false)
 // releases of a family behind the newest is an unsettled variant.
 const groupVersions = ref(false)
 const topUpOutcome = ref<TopUpOutcome>('landed')
+const buyStep = ref<BuyStep>('closed')
 let hydrated = false
 
 function isVersion(value: unknown): value is Version {
   return (
     typeof value === 'string' && (VERSIONS as readonly string[]).includes(value)
+  )
+}
+
+function isBuyStep(value: unknown): value is BuyStep {
+  return (
+    typeof value === 'string' &&
+    (BUY_STEPS as readonly string[]).includes(value)
   )
 }
 
@@ -71,6 +92,12 @@ export function usePrototypeTweaks() {
     } catch {
       /* storage unavailable */
     }
+    // Read straight from the query rather than through the share codec, which
+    // imports this module. Hydrating here rather than in the tweaks panel keeps
+    // it independent of which island mounts first, and means the dialog can
+    // consume it without the panel putting it back.
+    const entry = new URLSearchParams(location.search).get('buy')
+    if (isBuyStep(entry)) buyStep.value = entry
   })
   return {
     outcome,
@@ -78,6 +105,7 @@ export function usePrototypeTweaks() {
     version,
     showStatuses,
     groupVersions,
-    topUpOutcome
+    topUpOutcome,
+    buyStep
   }
 }

--- a/apps/website/src/composables/usePrototypeTweaks.ts
+++ b/apps/website/src/composables/usePrototypeTweaks.ts
@@ -20,6 +20,12 @@ export const MODEL_STATES = [
 ] as const
 export type ModelState = (typeof MODEL_STATES)[number]
 
+// What the visitor finds when Stripe sends them back. On this rail completion
+// arrives by webhook, so "settling" and "never arrives" are indistinguishable to
+// the page — the difference is only how long it has been.
+export const TOP_UP_OUTCOMES = ['landed', 'settling', 'unresolved'] as const
+export type TopUpOutcome = (typeof TOP_UP_OUTCOMES)[number]
+
 // One control for the whole prototype: V1 is the flat models catalog (11 Sep),
 // V1.1 opens that same catalog as browseable rows per use case, V1.2 moves the
 // categories into a rail beside the grid, and V2 is the screen where workflows,
@@ -37,6 +43,7 @@ const showStatuses = ref(false)
 // The catalogue lists one card per model, as the TDD describes. Grouping the
 // releases of a family behind the newest is an unsettled variant.
 const groupVersions = ref(false)
+const topUpOutcome = ref<TopUpOutcome>('landed')
 let hydrated = false
 
 function isVersion(value: unknown): value is Version {
@@ -70,6 +77,7 @@ export function usePrototypeTweaks() {
     modelState,
     version,
     showStatuses,
-    groupVersions
+    groupVersions,
+    topUpOutcome
   }
 }

--- a/apps/website/src/composables/usePrototypeTweaks.ts
+++ b/apps/website/src/composables/usePrototypeTweaks.ts
@@ -34,8 +34,7 @@ export const BUY_STEPS = [
   'amount',
   'waiting',
   'landed',
-  'unresolved',
-  'canceled'
+  'unresolved'
 ] as const
 export type BuyStep = (typeof BUY_STEPS)[number]
 

--- a/apps/website/src/composables/usePrototypeTweaks.ts
+++ b/apps/website/src/composables/usePrototypeTweaks.ts
@@ -38,6 +38,14 @@ export const BUY_STEPS = [
 ] as const
 export type BuyStep = (typeof BUY_STEPS)[number]
 
+// Which rail the buy actions use. 'in-place' is the designed flow (DES-1013):
+// our dialog, then hosted checkout, then the outcome states. 'platform' is the
+// MVP that ships first (DES-1015): every buy action is a plain link out to
+// platform.comfy.org, and this page's only job on return is to re-read the
+// balance. The two share a gate and nothing else.
+export const TOP_UP_RAILS = ['in-place', 'platform'] as const
+export type TopUpRail = (typeof TOP_UP_RAILS)[number]
+
 // One control for the whole prototype: V1 is the flat models catalog (11 Sep),
 // V1.1 opens that same catalog as browseable rows per use case, V1.2 moves the
 // categories into a rail beside the grid, and V2 is the screen where workflows,
@@ -57,11 +65,19 @@ const showStatuses = ref(false)
 const groupVersions = ref(false)
 const topUpOutcome = ref<TopUpOutcome>('landed')
 const buyStep = ref<BuyStep>('closed')
+const topUpRail = ref<TopUpRail>('in-place')
 let hydrated = false
 
 function isVersion(value: unknown): value is Version {
   return (
     typeof value === 'string' && (VERSIONS as readonly string[]).includes(value)
+  )
+}
+
+function isTopUpRail(value: unknown): value is TopUpRail {
+  return (
+    typeof value === 'string' &&
+    (TOP_UP_RAILS as readonly string[]).includes(value)
   )
 }
 
@@ -95,8 +111,11 @@ export function usePrototypeTweaks() {
     // imports this module. Hydrating here rather than in the tweaks panel keeps
     // it independent of which island mounts first, and means the dialog can
     // consume it without the panel putting it back.
-    const entry = new URLSearchParams(location.search).get('buy')
+    const query = new URLSearchParams(location.search)
+    const entry = query.get('buy')
     if (isBuyStep(entry)) buyStep.value = entry
+    const rail = query.get('rail')
+    if (isTopUpRail(rail)) topUpRail.value = rail
   })
   return {
     outcome,
@@ -105,6 +124,7 @@ export function usePrototypeTweaks() {
     showStatuses,
     groupVersions,
     topUpOutcome,
-    buyStep
+    buyStep,
+    topUpRail
   }
 }

--- a/apps/website/src/config/credits.ts
+++ b/apps/website/src/config/credits.ts
@@ -4,3 +4,14 @@ const CREDITS_PER_USD = 211
 export function usdToCredits(usd: number): number {
   return Math.round(usd * CREDITS_PER_USD)
 }
+
+// The same packs and bounds ComfyUI's top-up dialog and platform.comfy.org use,
+// so someone who has bought credits there meets the same numbers here.
+export const TOP_UP_PACKS = [10, 25, 50, 100] as const
+export const MIN_TOP_UP_USD = 5
+export const MAX_TOP_UP_USD = 10_000
+
+export function clampTopUp(usd: number): number {
+  if (!Number.isFinite(usd)) return MIN_TOP_UP_USD
+  return Math.min(MAX_TOP_UP_USD, Math.max(MIN_TOP_UP_USD, Math.round(usd)))
+}

--- a/apps/website/src/config/workshop-share.test.ts
+++ b/apps/website/src/config/workshop-share.test.ts
@@ -63,4 +63,24 @@ describe('share links for the prototype controls', () => {
       decodeShareSearch(encodeShareSearch(SHARE_DEFAULTS, '?version=v2'))
     ).toEqual({})
   })
+
+  it('carries the return state and the step a review link opens on', () => {
+    const search = encodeShareSearch({
+      ...SHARE_DEFAULTS,
+      topUpOutcome: 'unresolved',
+      buyStep: 'landed'
+    })
+
+    expect(search).toContain('topup=unresolved')
+    expect(search).toContain('buy=landed')
+    expect(decodeShareSearch(search)).toMatchObject({
+      topUpOutcome: 'unresolved',
+      buyStep: 'landed'
+    })
+  })
+
+  it('leaves both out when they are at their defaults', () => {
+    expect(encodeShareSearch(SHARE_DEFAULTS)).not.toContain('topup=')
+    expect(encodeShareSearch(SHARE_DEFAULTS)).not.toContain('buy=')
+  })
 })

--- a/apps/website/src/config/workshop-share.test.ts
+++ b/apps/website/src/config/workshop-share.test.ts
@@ -83,4 +83,16 @@ describe('share links for the prototype controls', () => {
     expect(encodeShareSearch(SHARE_DEFAULTS)).not.toContain('topup=')
     expect(encodeShareSearch(SHARE_DEFAULTS)).not.toContain('buy=')
   })
+
+  it('carries which top-up rail the link should open on', () => {
+    const search = encodeShareSearch({
+      ...SHARE_DEFAULTS,
+      topUpRail: 'platform'
+    })
+
+    expect(search).toContain('rail=platform')
+    expect(decodeShareSearch(search)).toMatchObject({ topUpRail: 'platform' })
+    // The designed flow is the default, so only the MVP shows up in a link.
+    expect(encodeShareSearch(SHARE_DEFAULTS)).not.toContain('rail=')
+  })
 })

--- a/apps/website/src/config/workshop-share.ts
+++ b/apps/website/src/config/workshop-share.ts
@@ -2,11 +2,13 @@ import type { AccountKind } from '../composables/useMockSession'
 import type {
   ModelState,
   RunOutcome,
+  TopUpOutcome,
   Version
 } from '../composables/usePrototypeTweaks'
 import {
   MODEL_STATES,
   RUN_OUTCOMES,
+  TOP_UP_OUTCOMES,
   VERSIONS
 } from '../composables/usePrototypeTweaks'
 
@@ -24,6 +26,7 @@ export interface ShareState {
   readonly member: boolean
   readonly outcome: RunOutcome
   readonly modelState: ModelState
+  readonly topUpOutcome: TopUpOutcome
 }
 
 export const SHARE_DEFAULTS: ShareState = {
@@ -35,7 +38,8 @@ export const SHARE_DEFAULTS: ShareState = {
   balance: 'normal',
   member: false,
   outcome: 'success',
-  modelState: 'none'
+  modelState: 'none',
+  topUpOutcome: 'landed'
 }
 
 const SESSION_CHOICES: readonly SessionChoice[] = [
@@ -54,7 +58,8 @@ const KEYS = {
   balance: 'balance',
   member: 'member',
   outcome: 'outcome',
-  modelState: 'state'
+  modelState: 'state',
+  topUpOutcome: 'topup'
 } as const
 
 const flag = (value: boolean) => (value ? '1' : '0')
@@ -101,7 +106,8 @@ export function decodeShareSearch(search: string): Partial<ShareState> {
     balance: pick(BALANCE_CHOICES, params.get(KEYS.balance)),
     member: pickFlag(params.get(KEYS.member)),
     outcome: pick(RUN_OUTCOMES, params.get(KEYS.outcome)),
-    modelState: pick(MODEL_STATES, params.get(KEYS.modelState))
+    modelState: pick(MODEL_STATES, params.get(KEYS.modelState)),
+    topUpOutcome: pick(TOP_UP_OUTCOMES, params.get(KEYS.topUpOutcome))
   }
   return Object.fromEntries(
     Object.entries(decoded).filter(([, value]) => value !== undefined)

--- a/apps/website/src/config/workshop-share.ts
+++ b/apps/website/src/config/workshop-share.ts
@@ -1,11 +1,13 @@
 import type { AccountKind } from '../composables/useMockSession'
 import type {
+  BuyStep,
   ModelState,
   RunOutcome,
   TopUpOutcome,
   Version
 } from '../composables/usePrototypeTweaks'
 import {
+  BUY_STEPS,
   MODEL_STATES,
   RUN_OUTCOMES,
   TOP_UP_OUTCOMES,
@@ -27,6 +29,7 @@ export interface ShareState {
   readonly outcome: RunOutcome
   readonly modelState: ModelState
   readonly topUpOutcome: TopUpOutcome
+  readonly buyStep: BuyStep
 }
 
 export const SHARE_DEFAULTS: ShareState = {
@@ -39,7 +42,8 @@ export const SHARE_DEFAULTS: ShareState = {
   member: false,
   outcome: 'success',
   modelState: 'none',
-  topUpOutcome: 'landed'
+  topUpOutcome: 'landed',
+  buyStep: 'closed'
 }
 
 const SESSION_CHOICES: readonly SessionChoice[] = [
@@ -59,7 +63,8 @@ const KEYS = {
   member: 'member',
   outcome: 'outcome',
   modelState: 'state',
-  topUpOutcome: 'topup'
+  topUpOutcome: 'topup',
+  buyStep: 'buy'
 } as const
 
 const flag = (value: boolean) => (value ? '1' : '0')
@@ -107,7 +112,8 @@ export function decodeShareSearch(search: string): Partial<ShareState> {
     member: pickFlag(params.get(KEYS.member)),
     outcome: pick(RUN_OUTCOMES, params.get(KEYS.outcome)),
     modelState: pick(MODEL_STATES, params.get(KEYS.modelState)),
-    topUpOutcome: pick(TOP_UP_OUTCOMES, params.get(KEYS.topUpOutcome))
+    topUpOutcome: pick(TOP_UP_OUTCOMES, params.get(KEYS.topUpOutcome)),
+    buyStep: pick(BUY_STEPS, params.get(KEYS.buyStep))
   }
   return Object.fromEntries(
     Object.entries(decoded).filter(([, value]) => value !== undefined)

--- a/apps/website/src/config/workshop-share.ts
+++ b/apps/website/src/config/workshop-share.ts
@@ -4,6 +4,7 @@ import type {
   ModelState,
   RunOutcome,
   TopUpOutcome,
+  TopUpRail,
   Version
 } from '../composables/usePrototypeTweaks'
 import {
@@ -11,6 +12,7 @@ import {
   MODEL_STATES,
   RUN_OUTCOMES,
   TOP_UP_OUTCOMES,
+  TOP_UP_RAILS,
   VERSIONS
 } from '../composables/usePrototypeTweaks'
 
@@ -30,6 +32,7 @@ export interface ShareState {
   readonly modelState: ModelState
   readonly topUpOutcome: TopUpOutcome
   readonly buyStep: BuyStep
+  readonly topUpRail: TopUpRail
 }
 
 export const SHARE_DEFAULTS: ShareState = {
@@ -43,7 +46,8 @@ export const SHARE_DEFAULTS: ShareState = {
   outcome: 'success',
   modelState: 'none',
   topUpOutcome: 'landed',
-  buyStep: 'closed'
+  buyStep: 'closed',
+  topUpRail: 'in-place'
 }
 
 const SESSION_CHOICES: readonly SessionChoice[] = [
@@ -64,7 +68,8 @@ const KEYS = {
   outcome: 'outcome',
   modelState: 'state',
   topUpOutcome: 'topup',
-  buyStep: 'buy'
+  buyStep: 'buy',
+  topUpRail: 'rail'
 } as const
 
 const flag = (value: boolean) => (value ? '1' : '0')
@@ -113,7 +118,8 @@ export function decodeShareSearch(search: string): Partial<ShareState> {
     outcome: pick(RUN_OUTCOMES, params.get(KEYS.outcome)),
     modelState: pick(MODEL_STATES, params.get(KEYS.modelState)),
     topUpOutcome: pick(TOP_UP_OUTCOMES, params.get(KEYS.topUpOutcome)),
-    buyStep: pick(BUY_STEPS, params.get(KEYS.buyStep))
+    buyStep: pick(BUY_STEPS, params.get(KEYS.buyStep)),
+    topUpRail: pick(TOP_UP_RAILS, params.get(KEYS.topUpRail))
   }
   return Object.fromEntries(
     Object.entries(decoded).filter(([, value]) => value !== undefined)

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8666,13 +8666,81 @@ Enterprise`
     en: '{n} credits added',
     'zh-CN': '已添加 {n} 积分'
   },
-  'workshop.credits.doneBody': {
-    en: 'You are back on the model page, with your inputs exactly as you left them.',
-    'zh-CN': '你已回到模型页面，输入内容与离开时完全一致。'
-  },
   'workshop.credits.resume': {
     en: 'Back to the model',
     'zh-CN': '返回模型'
+  },
+  'workshop.credits.custom': {
+    en: 'Custom · $5 – $10,000',
+    'zh-CN': '自定义 · $5 – $10,000'
+  },
+  'workshop.credits.less': { en: 'Less', 'zh-CN': '减少' },
+  'workshop.credits.more': { en: 'More', 'zh-CN': '增加' },
+  'workshop.credits.cancelAtStripe': {
+    en: 'Cancel payment',
+    'zh-CN': '取消付款'
+  },
+  'workshop.credits.canceledNotice': {
+    en: 'Payment canceled: nothing was charged.',
+    'zh-CN': '付款已取消：未产生任何扣款。'
+  },
+  'workshop.credits.waitingTitle': {
+    en: 'Waiting for your payment',
+    'zh-CN': '正在等待付款'
+  },
+  'workshop.credits.waitingBody': {
+    en: 'Complete the purchase in the new tab. This updates automatically.',
+    'zh-CN': '请在新标签页中完成购买，此处会自动更新。'
+  },
+  'workshop.credits.waitingPolling': {
+    en: 'Checking for credits…',
+    'zh-CN': '正在查询积分…'
+  },
+  'workshop.credits.reopen': {
+    en: 'Reopen Stripe',
+    'zh-CN': '重新打开 Stripe'
+  },
+  'workshop.credits.addedTo': {
+    en: 'Added to {workspace}. Your inputs are as you left them.',
+    'zh-CN': '已添加到 {workspace}。你的输入保持原样。'
+  },
+  'workshop.credits.previousBalance': {
+    en: 'Previous balance',
+    'zh-CN': '原有余额'
+  },
+  'workshop.credits.added': { en: 'Added', 'zh-CN': '新增' },
+  'workshop.credits.newBalance': { en: 'New balance', 'zh-CN': '当前余额' },
+  'workshop.credits.heldTitle': {
+    en: 'Payment received',
+    'zh-CN': '已收到付款'
+  },
+  'workshop.credits.heldBody': {
+    en: 'Your payment went through, but the credits have not arrived yet. You will not be charged again.',
+    'zh-CN': '付款已成功，但积分尚未到账。不会重复扣款。'
+  },
+  'workshop.credits.heldSupport': {
+    en: 'If they do not appear, give support this ID',
+    'zh-CN': '若积分仍未到账，请将此 ID 提供给客服'
+  },
+  'workshop.credits.contactSupport': {
+    en: 'Contact support',
+    'zh-CN': '联系客服'
+  },
+  'workshop.proto.topUp': {
+    en: 'Return from Stripe',
+    'zh-CN': '从 Stripe 返回后'
+  },
+  'workshop.proto.topUp.landed': {
+    en: 'Credits land',
+    'zh-CN': '积分到账'
+  },
+  'workshop.proto.topUp.settling': {
+    en: 'Still settling (holds)',
+    'zh-CN': '仍在结算（保持等待）'
+  },
+  'workshop.proto.topUp.unresolved': {
+    en: 'Never arrives (receipt)',
+    'zh-CN': '始终未到账（凭据）'
   },
   'workshop.credits.close': { en: 'Close', 'zh-CN': '关闭' },
   'workshop.media.label': {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8692,6 +8692,10 @@ Enterprise`
     en: 'Reopen Stripe',
     'zh-CN': '重新打开 Stripe'
   },
+  'workshop.credits.closingIsSafe': {
+    en: 'Closing this won’t affect your payment.',
+    'zh-CN': '关闭此窗口不会影响你的付款。'
+  },
   'workshop.credits.reopenPrompt': {
     en: 'Closed it by mistake?',
     'zh-CN': '不小心关闭了？'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8676,20 +8676,12 @@ Enterprise`
   },
   'workshop.credits.less': { en: 'Less', 'zh-CN': '减少' },
   'workshop.credits.more': { en: 'More', 'zh-CN': '增加' },
-  'workshop.credits.cancelAtStripe': {
-    en: 'Cancel payment',
-    'zh-CN': '取消付款'
-  },
-  'workshop.credits.canceledNotice': {
-    en: 'Payment canceled: nothing was charged.',
-    'zh-CN': '付款已取消：未产生任何扣款。'
-  },
   'workshop.credits.waitingTitle': {
     en: 'Waiting for your payment',
     'zh-CN': '正在等待付款'
   },
   'workshop.credits.waitingBody': {
-    en: 'Complete the purchase in the new tab. This updates automatically.',
+    en: 'Complete the purchase in the tab that just opened. This page updates on its own.',
     'zh-CN': '请在新标签页中完成购买，此处会自动更新。'
   },
   'workshop.credits.waitingPolling': {
@@ -8699,6 +8691,10 @@ Enterprise`
   'workshop.credits.reopen': {
     en: 'Reopen Stripe',
     'zh-CN': '重新打开 Stripe'
+  },
+  'workshop.credits.reopenPrompt': {
+    en: 'Closed it by mistake?',
+    'zh-CN': '不小心关闭了？'
   },
   'workshop.credits.addedTo': {
     en: 'Added to {workspace}. Your inputs are as you left them.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8371,7 +8371,6 @@ Enterprise`
   'nav.noCredits': { en: 'No credits', 'zh-CN': '无积分' },
   'nav.buyCredits': { en: 'Buy credits', 'zh-CN': '购买积分' },
   'nav.creditsLabel': { en: 'Credits', 'zh-CN': '积分' },
-  'nav.creditsLabelPlatform': { en: 'Add credits ↗', 'zh-CN': '添加积分 ↗' },
   'nav.workspaces': { en: 'Workspaces', 'zh-CN': '工作区' },
   'nav.planAndCredits': { en: 'Plan & credits', 'zh-CN': '套餐与积分' },
   'nav.workspaceSettings': {
@@ -8826,10 +8825,6 @@ Enterprise`
     en: 'Add credits',
     'zh-CN': '添加积分'
   },
-  'workshop.run.buyCreditsPlatform': {
-    en: 'Add credits ↗',
-    'zh-CN': '添加积分 ↗'
-  },
   'workshop.run.run': { en: 'Run', 'zh-CN': '运行' },
   'workshop.run.cancel': { en: 'Cancel', 'zh-CN': '取消' },
   'workshop.run.running': { en: 'Generating…', 'zh-CN': '生成中…' },
@@ -8893,11 +8888,7 @@ Enterprise`
     en: 'Your workspace policy blocks this provider.',
     'zh-CN': '你的工作区策略禁止了该提供方。'
   },
-  'workshop.error.noCreditsTitle': {
-    en: 'Out of credits',
-    'zh-CN': '积分已用完'
-  },
-  'workshop.error.lowCreditsTitle': {
+  'workshop.error.creditsTitle': {
     en: 'Not enough credits',
     'zh-CN': '积分不足'
   },
@@ -8927,10 +8918,6 @@ Enterprise`
     en: 'You have {credits} credits and this run needs {n}. Your inputs stay here while you buy.',
     'zh-CN':
       '你有 {credits} 积分，本次运行需要 {n}。购买时你的输入会保留在这里。'
-  },
-  'workshop.error.memberNoCreditsTitle': {
-    en: 'Out of credits',
-    'zh-CN': '积分已用完'
   },
   'workshop.error.memberNoCredits': {
     en: '{workspace} has used all its credits. Ask the workspace owner to add more, or run this on your personal workspace.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8893,14 +8893,22 @@ Enterprise`
     en: 'Your workspace policy blocks this provider.',
     'zh-CN': '你的工作区策略禁止了该提供方。'
   },
+  'workshop.error.noCreditsTitle': {
+    en: 'Out of credits',
+    'zh-CN': '积分已用完'
+  },
+  'workshop.error.lowCreditsTitle': {
+    en: 'Not enough credits',
+    'zh-CN': '积分不足'
+  },
   'workshop.error.noCreditsPlatform': {
-    en: 'Not enough credits for this run. Add credits to {workspace} on your Comfy account. Your inputs stay here.',
+    en: 'Add credits to {workspace} on your Comfy account. Your inputs stay here.',
     'zh-CN':
-      '本次运行积分不足。请在你的 Comfy 账户中为 {workspace} 添加积分。你的输入会保留在这里。'
+      '请在你的 Comfy 账户中为 {workspace} 添加积分。你的输入会保留在这里。'
   },
   'workshop.error.noCredits': {
-    en: 'Not enough credits. Payment happens on Stripe.',
-    'zh-CN': '积分不足。支付在 Stripe 完成。'
+    en: 'This run needs {n} credits. Your inputs stay here while you buy.',
+    'zh-CN': '本次运行需要 {n} 积分。购买时你的输入会保留在这里。'
   },
   'workshop.error.unavailable': {
     en: 'This model is temporarily unavailable.',
@@ -8916,9 +8924,9 @@ Enterprise`
     'zh-CN': '提供方响应超时。未扣费。'
   },
   'workshop.error.lowCredits': {
-    en: 'You have {credits} credits and this run needs {n}. Buy credits to continue; your inputs stay here.',
+    en: 'You have {credits} credits and this run needs {n}. Your inputs stay here while you buy.',
     'zh-CN':
-      '你有 {credits} 积分，本次运行需要 {n}。购买积分后继续，你的输入会保留。'
+      '你有 {credits} 积分，本次运行需要 {n}。购买时你的输入会保留在这里。'
   },
   'workshop.error.memberNoCreditsTitle': {
     en: 'Out of credits',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8920,10 +8920,14 @@ Enterprise`
     'zh-CN':
       '你有 {credits} 积分，本次运行需要 {n}。购买积分后继续，你的输入会保留。'
   },
+  'workshop.error.memberNoCreditsTitle': {
+    en: 'Out of credits',
+    'zh-CN': '积分已用完'
+  },
   'workshop.error.memberNoCredits': {
-    en: '{workspace} has no credits left. Only the workspace owner can buy more; you can run this on your personal workspace instead.',
+    en: '{workspace} has used all its credits. Ask the workspace owner to add more, or run this on your personal workspace.',
     'zh-CN':
-      '{workspace} 的积分已用完。只有工作区所有者可以购买；你可以改用个人工作区运行。'
+      '{workspace} 的积分已全部用完。请联系工作区所有者添加积分，或改用个人工作区运行。'
   },
   'workshop.run.switchPersonal': {
     en: 'Switch to personal workspace',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8639,19 +8639,19 @@ Enterprise`
     'zh-CN': '浏览全部模型'
   },
   'workshop.credits.title': {
-    en: 'Payment happens on Stripe',
+    en: 'Add credits',
     'zh-CN': '支付在 Stripe 完成'
   },
   'workshop.credits.body': {
-    en: 'Pick a top-up here and finish the purchase on Stripe Checkout. We send the page you are on as the return address, so you land back here with your inputs as you left them:',
+    en: 'Pick a bundle, or choose a custom amount.',
     'zh-CN':
       '在此选择充值额度，然后在 Stripe Checkout 完成支付。我们会带上当前页面作为返回地址，付款后你会回到这里，输入内容保持原样：'
   },
   'workshop.credits.continue': {
-    en: 'Continue to Stripe',
+    en: 'Continue',
     'zh-CN': '前往 Stripe'
   },
-  'workshop.credits.cancel': { en: 'Stay here', 'zh-CN': '留在此页' },
+  'workshop.credits.cancel': { en: 'Cancel', 'zh-CN': '留在此页' },
   'workshop.credits.checkout': {
     en: 'Checkout',
     'zh-CN': '结账'
@@ -8667,7 +8667,7 @@ Enterprise`
     'zh-CN': '已添加 {n} 积分'
   },
   'workshop.credits.resume': {
-    en: 'Back to the model',
+    en: 'Done',
     'zh-CN': '返回模型'
   },
   'workshop.credits.custom': {
@@ -8697,7 +8697,7 @@ Enterprise`
     'zh-CN': '关闭此窗口不会影响你的付款。'
   },
   'workshop.credits.reopenPrompt': {
-    en: 'Closed it by mistake?',
+    en: 'Lost the tab?',
     'zh-CN': '不小心关闭了？'
   },
   'workshop.credits.addedTo': {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8925,10 +8925,6 @@ Enterprise`
     'zh-CN':
       '{workspace} 的积分已用完。只有工作区所有者可以购买；你可以改用个人工作区运行。'
   },
-  'workshop.run.memberNoCredits': {
-    en: 'Ask the owner for credits',
-    'zh-CN': '请所有者购买积分'
-  },
   'workshop.run.switchPersonal': {
     en: 'Switch to personal workspace',
     'zh-CN': '切换到个人工作区'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8371,6 +8371,7 @@ Enterprise`
   'nav.noCredits': { en: 'No credits', 'zh-CN': '无积分' },
   'nav.buyCredits': { en: 'Buy credits', 'zh-CN': '购买积分' },
   'nav.creditsLabel': { en: 'Credits', 'zh-CN': '积分' },
+  'nav.creditsLabelPlatform': { en: 'Add credits ↗', 'zh-CN': '添加积分 ↗' },
   'nav.workspaces': { en: 'Workspaces', 'zh-CN': '工作区' },
   'nav.planAndCredits': { en: 'Plan & credits', 'zh-CN': '套餐与积分' },
   'nav.workspaceSettings': {
@@ -8726,6 +8727,15 @@ Enterprise`
     en: 'Contact support',
     'zh-CN': '联系客服'
   },
+  'workshop.proto.rail': { en: 'Top-up rail', 'zh-CN': '充值通道' },
+  'workshop.proto.rail.inPlace': {
+    en: 'In place · DES-1013',
+    'zh-CN': '站内完成 · DES-1013'
+  },
+  'workshop.proto.rail.platform': {
+    en: 'Platform · DES-1015 MVP',
+    'zh-CN': '跳转 Platform · DES-1015 MVP'
+  },
   'workshop.proto.topUp': {
     en: 'Return from Stripe',
     'zh-CN': '从 Stripe 返回后'
@@ -8816,6 +8826,10 @@ Enterprise`
     en: 'Add credits',
     'zh-CN': '添加积分'
   },
+  'workshop.run.buyCreditsPlatform': {
+    en: 'Add credits ↗',
+    'zh-CN': '添加积分 ↗'
+  },
   'workshop.run.run': { en: 'Run', 'zh-CN': '运行' },
   'workshop.run.cancel': { en: 'Cancel', 'zh-CN': '取消' },
   'workshop.run.running': { en: 'Generating…', 'zh-CN': '生成中…' },
@@ -8878,6 +8892,11 @@ Enterprise`
   'workshop.error.policy': {
     en: 'Your workspace policy blocks this provider.',
     'zh-CN': '你的工作区策略禁止了该提供方。'
+  },
+  'workshop.error.noCreditsPlatform': {
+    en: 'Not enough credits for this run. Add credits to {workspace} on your Comfy account. Your inputs stay here.',
+    'zh-CN':
+      '本次运行积分不足。请在你的 Comfy 账户中为 {workspace} 添加积分。你的输入会保留在这里。'
   },
   'workshop.error.noCredits': {
     en: 'Not enough credits. Payment happens on Stripe.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8893,13 +8893,12 @@ Enterprise`
     'zh-CN': '积分不足'
   },
   'workshop.error.noCreditsPlatform': {
-    en: 'Add credits to {workspace} on your Comfy account. Your inputs stay here.',
-    'zh-CN':
-      '请在你的 Comfy 账户中为 {workspace} 添加积分。你的输入会保留在这里。'
+    en: 'Add credits to {workspace} on platform.comfy.org',
+    'zh-CN': '在 platform.comfy.org 上为 {workspace} 添加积分'
   },
   'workshop.error.noCredits': {
-    en: 'This run needs {n} credits. Your inputs stay here while you buy.',
-    'zh-CN': '本次运行需要 {n} 积分。购买时你的输入会保留在这里。'
+    en: 'This run needs {n} credits.',
+    'zh-CN': '本次运行需要 {n} 积分。'
   },
   'workshop.error.unavailable': {
     en: 'This model is temporarily unavailable.',
@@ -8915,9 +8914,8 @@ Enterprise`
     'zh-CN': '提供方响应超时。未扣费。'
   },
   'workshop.error.lowCredits': {
-    en: 'You have {credits} credits and this run needs {n}. Your inputs stay here while you buy.',
-    'zh-CN':
-      '你有 {credits} 积分，本次运行需要 {n}。购买时你的输入会保留在这里。'
+    en: 'You have {credits} credits and this run needs {n}.',
+    'zh-CN': '你有 {credits} 积分，本次运行需要 {n}。'
   },
   'workshop.error.memberNoCredits': {
     en: '{workspace} has used all its credits. Ask the workspace owner to add more, or run this on your personal workspace.',

--- a/apps/website/src/lib/workshop/buy-credits.test.ts
+++ b/apps/website/src/lib/workshop/buy-credits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { stripeCheckoutHref } from './buy-credits'
+import { returnStepFor, stripeCheckoutHref } from './buy-credits'
 
 describe('stripeCheckoutHref', () => {
   it('sends the page as the return address', () => {
@@ -17,5 +17,19 @@ describe('stripeCheckoutHref', () => {
     const url = new URL(stripeCheckoutHref('//evil.example/steal', 10))
 
     expect(url.searchParams.get('success_url')).toBeNull()
+  })
+})
+
+describe('returnStepFor', () => {
+  it('settles on the credits when the grant lands', () => {
+    expect(returnStepFor('landed')).toBe('landed')
+  })
+
+  it('holds on waiting while the webhook is still in flight', () => {
+    expect(returnStepFor('settling')).toBe('waiting')
+  })
+
+  it('falls through to the receipt when the grant never arrives', () => {
+    expect(returnStepFor('unresolved')).toBe('unresolved')
   })
 })

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -1,3 +1,5 @@
+import type { TopUpOutcome } from '../../composables/usePrototypeTweaks'
+
 // The MVP buys credits on a Stripe Checkout page: the amount is picked here and
 // the purchase finishes on Stripe, which returns the visitor to the page they
 // left. Only same-site paths go into the return address.
@@ -9,4 +11,21 @@ export function stripeCheckoutHref(returnPath: string, usd: number): string {
   if (returnPath.startsWith('/') && !returnPath.startsWith('//'))
     url.searchParams.set('success_url', returnPath)
   return url.toString()
+}
+
+// How long the prototype holds `waiting` before resolving. The real wait is a
+// webhook we do not control; this only has to be long enough to read.
+export const SETTLE_DELAY_MS = 1200
+
+// Where the page settles once Stripe sends the visitor back.
+export type ReturnStep = 'waiting' | 'landed' | 'unresolved'
+
+// Completion on this rail arrives by webhook and there is no pending signal, so
+// "still settling" and "the grant was lost" are the same reading: payment done,
+// balance unchanged. Only elapsed time separates them, which is why the
+// prototype lets you hold the page in `waiting` indefinitely.
+export function returnStepFor(outcome: TopUpOutcome): ReturnStep {
+  if (outcome === 'landed') return 'landed'
+  if (outcome === 'unresolved') return 'unresolved'
+  return 'waiting'
 }

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -13,6 +13,22 @@ export function stripeCheckoutHref(returnPath: string, usd: number): string {
   return url.toString()
 }
 
+// The MVP rail (DES-1015) does not buy anything here — every action is a link
+// to platform's billing page, which the visitor never returns from directly.
+//
+// The workspace has to travel with them: comfy.org and platform keep separate
+// switchers, so without it someone can top up the wallet that is not the empty
+// one. The parameter name and the identifier are both unconfirmed on platform's
+// side — the mock only has display names — so this is the shape, not the
+// contract. See DES-1015.
+const PLATFORM_ORIGIN = 'https://platform.comfy.org'
+
+export function platformTopUpHref(workspace?: string): string {
+  const url = new URL('/billing', PLATFORM_ORIGIN)
+  if (workspace) url.searchParams.set('workspace', workspace)
+  return url.toString()
+}
+
 // How long the prototype holds `waiting` before resolving. The real wait is a
 // webhook we do not control; this only has to be long enough to read.
 export const SETTLE_DELAY_MS = 1200


### PR DESCRIPTION
Stacked on `workshop` (#16556). Prototype work — it extends Mar's mock, it does not build against the real endpoint, which is [mid-consolidation](https://github.com/Comfy-Org/cloud/pull/5968).

## What a visitor can do now

Buy credits from a model page and land somewhere sensible whatever happens at Stripe. Before, paying always ended on "credits added", which only models the case where the money beat the visitor back. On this rail it usually does not: Stripe redirects the moment the card clears and the grant follows on a webhook, so returning before your credits do is the normal path.

**Continue to Stripe is a real link, not a button.** A button would call `window.open`, which a popup blocker can swallow silently. A link opens the tab on the visitor's own click, which blockers permit — so the blocked case stops existing rather than needing a fallback. It costs nothing: Continue was already a click. Recorded as a general rule in the billing wiki: [anchor-first payment hand-off](https://github.com/Comfy-Org/team-billing-wiki/blob/main/wiki/decisions/anchor-first-payment-handoff.md).

Two things follow from that, both simplifications:

- **Cancelling never comes back to us.** It happens at Stripe, in the other tab; this page keeps waiting until they return or dismiss it. The "payment canceled" screen and the `cancel_url` behind it are both gone.
- **The page behind never unloads**, so typed inputs survive with no persistence work — including uploaded images, which the form save skips and a same-tab redirect would have lost.

## The three states after the hand-off

| State | What they see |
| -- | -- |
| **Waiting** | "Complete the purchase in the tab that just opened. This page updates on its own." Plus *Closed it by mistake? Reopen Stripe* |
| **Landed** | A previous / added / new ledger, and the workspace named |
| **Unresolved** | "Payment received" plus the operation id support would search on |

**A purchase in flight outlives the dialog.** The settle timer used to live in the dialog and be cleared on close, so dismissing abandoned it. That is the wrong owner — the money is already with Stripe and nothing here can call it back, so closing must be safe. It now lives in `usePendingTopUp`, above the component. Close the card mid-flight and the credits still land: the balance updates and the run gate flips from Add credits to Run on its own. That gate flip is the payoff — the thing they were trying to do becoming possible, where they were already looking — so nothing re-opens the dialog at them.

**Waiting has no button.** There is no decision to make: the X closes it, and a button at the foot of a card implies a choice that does not exist. A line says so instead, because "can I close this?" is the question the state raises. It does not say "Cancel" anywhere — dismissing cancels nothing.

**The workspace is named on the landed state** because a checkout session is bound to a customer when it is created, but the return page renders whichever workspace is *active*. Someone who switched workspaces in another tab would otherwise read a balance that is not the one that just changed.

**The receipt promises no self-healing**, unlike its in-app counterpart (FE-1992), whose copy says the workspace "usually catches up on its own". That is true on the workspace rail, which has a reconciler. This one does not — IR-126/128 recorded customers charged with nothing for up to eleven days — so it leads with the support handle instead of a promise we cannot keep.

**Waiting and unresolved are deliberately the same reading.** There is no pending signal here, so a grant still settling and a grant that was lost both look like "payment done, balance unchanged". Only elapsed time separates them, which is why the prototype can hold the page in waiting indefinitely — that is a real state, not a spinner.

## Layout

**One height across the whole flow.** The dialog is centred, so every change of height moved both edges: 72px of travel on desktop between the amount and waiting steps, 270px on mobile — title, close button and primary CTA all sliding under the pointer mid-flow. It now holds the height of its tallest step, with content pinned to the top and actions anchored to the bottom. Because the height no longer changes, the centring no longer moves anything, so the kit's positioning is untouched. The floor is capped at the same 85vh the kit uses as its ceiling, so it can never force a scroll that would not have happened anyway.

**Buttons follow the app's convention.** The website kit has no `DialogFooter`, and this is the only dialog on comfy.org with action buttons — so rather than invent a convention, it follows `src/components/ui/dialog/DialogFooter.vue`: right-aligned, primary last. Anyone arriving from the app's billing dialogs already has that muscle memory, and billing is where the two surfaces meet.

## Reviewing it

`?buy=` opens the flow directly on any step:

- `?session=existing&balance=zero&buy=amount`
- `?session=existing&balance=zero&buy=waiting`
- `?session=existing&balance=zero&buy=landed`
- `?session=existing&balance=zero&buy=unresolved`

The tweaks panel gains a **Return from Stripe** control — *Credits land* / *Still settling (holds)* / *Never arrives (receipt)* — deciding what paying through the flow resolves to, shared by link like the others.

The amount picker gains the **$100** pack and the **$5–$10,000** custom range that ComfyUI's dialog and platform.comfy.org already share, so the three surfaces quote the same numbers.

Designs and screenshots of every state: [Comfy.org Billing](https://www.figma.com/design/cULtZN6S9CT5BUaR15qzJ7/Comfy.org-Billing?node-id=4016-2).

## Verification

| Check | Result |
| -- | -- |
| `pnpm test:unit` (website) | 179 files, 1170 tests, all passing |
| `pnpm typecheck` (website) | 0 errors |
| `format`, `stylelint`, `oxlint`, `eslint`, `knip` | pass (lint-staged and pre-push run them) |
| Browser | Every state walked at `localhost:4337`: Continue renders as `<a target="_blank" rel="noopener noreferrer">`; paying then dismissing mid-flight still lands the credits, flips the gate and updates the balance; dialog height, top edge and primary-button position measured identical across all five states. |

Note: `VideoMaskScene.test.ts` fails intermittently on this branch **and on a clean `workshop`** — roughly one run in three. `fakeTimers: { shouldAdvanceTime: true }` makes it sensitive to machine load. Pre-existing, unrelated.

## Not in scope

Everything needing the real contract: a server-supplied `checkout_url` (and validating it before navigating, as platform#943 does), and whether the session-creation endpoint will accept a comfy.org return address.

The prototype prevents the link's navigation so Stripe's page can be played out in place — shipping means dropping that `.prevent`.

A ticking balance on arrival was attempted and reverted: it stopped the header updating at all. Worth another go separately — the static value rendered correctly and only reactivity broke, which is a narrower problem than it looked.