### PR TITLE
fix: repair malformed Dependabot lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
-    versioning-strategy: 'increase-if-necessary'
     schedule:
       interval: 'weekly'
     labels:

--- a/.github/workflows/ci-dependabot-lockfile-repair.yaml
+++ b/.github/workflows/ci-dependabot-lockfile-repair.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout pull request
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Install pnpm
@@ -38,26 +39,9 @@ jobs:
       - name: Repair lockfile
         run: pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
 
-      - name: Prepare repair artifact
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          mkdir dependabot-lockfile-repair
-          cp pnpm-lock.yaml dependabot-lockfile-repair/pnpm-lock.yaml
-          jq -n \
-            --arg head_ref "$HEAD_REF" \
-            --arg head_sha "$HEAD_SHA" \
-            --argjson pull_request "$PR_NUMBER" \
-            --arg repository "$REPOSITORY" \
-            '{head_ref: $head_ref, head_sha: $head_sha, pull_request: $pull_request, repository: $repository}' \
-            > dependabot-lockfile-repair/metadata.json
-
       - name: Upload repair artifact
         uses: actions/upload-artifact@v6
         with:
           name: dependabot-lockfile-repair
-          path: dependabot-lockfile-repair
+          path: pnpm-lock.yaml
           retention-days: 1

--- a/.github/workflows/ci-dependabot-lockfile-repair.yaml
+++ b/.github/workflows/ci-dependabot-lockfile-repair.yaml
@@ -1,0 +1,63 @@
+name: 'CI: Repair Dependabot Lockfile'
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  repair:
+    if: >
+      github.repository == 'Comfy-Org/ComfyUI_frontend' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Repair lockfile
+        run: pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
+
+      - name: Prepare repair artifact
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir dependabot-lockfile-repair
+          cp pnpm-lock.yaml dependabot-lockfile-repair/pnpm-lock.yaml
+          jq -n \
+            --arg head_ref "$HEAD_REF" \
+            --arg head_sha "$HEAD_SHA" \
+            --argjson pull_request "$PR_NUMBER" \
+            --arg repository "$REPOSITORY" \
+            '{head_ref: $head_ref, head_sha: $head_sha, pull_request: $pull_request, repository: $repository}' \
+            > dependabot-lockfile-repair/metadata.json
+
+      - name: Upload repair artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: dependabot-lockfile-repair
+          path: dependabot-lockfile-repair
+          retention-days: 1

--- a/.github/workflows/pr-dependabot-lockfile-repair.yaml
+++ b/.github/workflows/pr-dependabot-lockfile-repair.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -25,7 +25,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout trusted workflow revision
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve pull request
+        id: pr
+        uses: ./.github/actions/resolve-pr-from-workflow-run
+
+      - name: Validate repair target
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+        run: |
+          test "$PR_AUTHOR" = 'dependabot[bot]'
+          case "$HEAD_REF" in
+            dependabot/*) ;;
+            *) exit 1 ;;
+          esac
+
       - name: Download repair artifact
+        if: steps.pr.outputs.skip != 'true'
         uses: actions/download-artifact@v8
         with:
           name: dependabot-lockfile-repair
@@ -33,82 +55,22 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Validate repair source
-        id: source
-        uses: actions/github-script@v9
-        env:
-          ARTIFACT_DIR: ${{ runner.temp }}/dependabot-lockfile-repair
-        with:
-          script: |
-            const fs = require('node:fs')
-            const path = require('node:path')
-            const files = fs.readdirSync(process.env.ARTIFACT_DIR).sort()
-            const expectedFiles = ['metadata.json', 'pnpm-lock.yaml']
-
-            if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
-              throw new Error('Repair artifact contains unexpected files')
-            }
-            for (const file of files) {
-              if (!fs.lstatSync(path.join(process.env.ARTIFACT_DIR, file)).isFile()) {
-                throw new Error(`Repair artifact entry is not a regular file: ${file}`)
-              }
-            }
-
-            const metadata = JSON.parse(
-              fs.readFileSync(path.join(process.env.ARTIFACT_DIR, 'metadata.json'), 'utf8'),
-            )
-            const run = context.payload.workflow_run
-            const prNumber = metadata.pull_request
-
-            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
-              throw new Error('Invalid pull request number')
-            }
-            if (metadata.repository !== `${context.repo.owner}/${context.repo.repo}`) {
-              throw new Error('Artifact repository does not match this repository')
-            }
-            if (metadata.head_sha !== run.head_sha) {
-              throw new Error('Artifact SHA does not match the triggering workflow')
-            }
-
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            })
-
-            if (pullRequest.state !== 'open') {
-              throw new Error('Pull request is no longer open')
-            }
-            if (pullRequest.user.login !== 'dependabot[bot]') {
-              throw new Error('Pull request author is not Dependabot')
-            }
-            if (pullRequest.head.repo?.full_name !== metadata.repository) {
-              throw new Error('Pull request branch is not in this repository')
-            }
-            if (!pullRequest.head.ref.startsWith('dependabot/')) {
-              throw new Error('Pull request is not using a Dependabot branch')
-            }
-            if (pullRequest.head.ref !== metadata.head_ref) {
-              throw new Error('Artifact branch does not match the pull request')
-            }
-            if (pullRequest.head.sha !== metadata.head_sha) {
-              throw new Error('Pull request advanced after the repair was generated')
-            }
-
-            core.setOutput('head-ref', pullRequest.head.ref)
-            core.setOutput('head-sha', pullRequest.head.sha)
-
       - name: Checkout validated pull request revision
+        if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.source.outputs.head-sha }}
+          ref: ${{ steps.pr.outputs.head-sha }}
+          token: ${{ secrets.PR_GH_TOKEN }}
 
       - name: Apply repaired lockfile
+        if: steps.pr.outputs.skip != 'true'
         id: repair
         env:
           REPAIRED_LOCKFILE: ${{ runner.temp }}/dependabot-lockfile-repair/pnpm-lock.yaml
         run: |
           test ! -L pnpm-lock.yaml
+          test -f "$REPAIRED_LOCKFILE"
+          test ! -L "$REPAIRED_LOCKFILE"
           cp "$REPAIRED_LOCKFILE" pnpm-lock.yaml
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -120,8 +82,8 @@ jobs:
       - name: Commit and push repaired lockfile
         if: steps.repair.outputs.changed == 'true'
         env:
-          HEAD_REF: ${{ steps.source.outputs.head-ref }}
-          HEAD_SHA: ${{ steps.source.outputs.head-sha }}
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ steps.pr.outputs.head-sha }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/pr-dependabot-lockfile-repair.yaml
+++ b/.github/workflows/pr-dependabot-lockfile-repair.yaml
@@ -1,0 +1,131 @@
+name: 'PR: Apply Dependabot Lockfile Repair'
+
+on:
+  workflow_run:
+    workflows: ['CI: Repair Dependabot Lockfile']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: dependabot-lockfile-repair-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    if: >
+      github.repository == 'Comfy-Org/ComfyUI_frontend' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download repair artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: dependabot-lockfile-repair
+          path: ${{ runner.temp }}/dependabot-lockfile-repair
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate repair source
+        id: source
+        uses: actions/github-script@v9
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/dependabot-lockfile-repair
+        with:
+          script: |
+            const fs = require('node:fs')
+            const path = require('node:path')
+            const files = fs.readdirSync(process.env.ARTIFACT_DIR).sort()
+            const expectedFiles = ['metadata.json', 'pnpm-lock.yaml']
+
+            if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+              throw new Error('Repair artifact contains unexpected files')
+            }
+            for (const file of files) {
+              if (!fs.lstatSync(path.join(process.env.ARTIFACT_DIR, file)).isFile()) {
+                throw new Error(`Repair artifact entry is not a regular file: ${file}`)
+              }
+            }
+
+            const metadata = JSON.parse(
+              fs.readFileSync(path.join(process.env.ARTIFACT_DIR, 'metadata.json'), 'utf8'),
+            )
+            const run = context.payload.workflow_run
+            const prNumber = metadata.pull_request
+
+            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+              throw new Error('Invalid pull request number')
+            }
+            if (metadata.repository !== `${context.repo.owner}/${context.repo.repo}`) {
+              throw new Error('Artifact repository does not match this repository')
+            }
+            if (metadata.head_sha !== run.head_sha) {
+              throw new Error('Artifact SHA does not match the triggering workflow')
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            })
+
+            if (pullRequest.state !== 'open') {
+              throw new Error('Pull request is no longer open')
+            }
+            if (pullRequest.user.login !== 'dependabot[bot]') {
+              throw new Error('Pull request author is not Dependabot')
+            }
+            if (pullRequest.head.repo?.full_name !== metadata.repository) {
+              throw new Error('Pull request branch is not in this repository')
+            }
+            if (!pullRequest.head.ref.startsWith('dependabot/')) {
+              throw new Error('Pull request is not using a Dependabot branch')
+            }
+            if (pullRequest.head.ref !== metadata.head_ref) {
+              throw new Error('Artifact branch does not match the pull request')
+            }
+            if (pullRequest.head.sha !== metadata.head_sha) {
+              throw new Error('Pull request advanced after the repair was generated')
+            }
+
+            core.setOutput('head-ref', pullRequest.head.ref)
+            core.setOutput('head-sha', pullRequest.head.sha)
+
+      - name: Checkout validated pull request revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.source.outputs.head-sha }}
+
+      - name: Apply repaired lockfile
+        id: repair
+        env:
+          REPAIRED_LOCKFILE: ${{ runner.temp }}/dependabot-lockfile-repair/pnpm-lock.yaml
+        run: |
+          test ! -L pnpm-lock.yaml
+          cp "$REPAIRED_LOCKFILE" pnpm-lock.yaml
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test "$(git diff --name-only)" = "pnpm-lock.yaml"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push repaired lockfile
+        if: steps.repair.outputs.changed == 'true'
+        env:
+          HEAD_REF: ${{ steps.source.outputs.head-ref }}
+          HEAD_SHA: ${{ steps.source.outputs.head-sha }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add pnpm-lock.yaml
+          git commit -m 'fix: repair Dependabot lockfile'
+          git push origin "HEAD:refs/heads/$HEAD_REF" \
+            --force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA"


### PR DESCRIPTION
## Summary

Automatically regenerate malformed pnpm catalog lockfiles produced by Dependabot while preserving frozen-lockfile CI.

## Changes

- **What**: An unprivileged Dependabot-only workflow regenerates and uploads `pnpm-lock.yaml`; a trusted `workflow_run` validates the repository, author, branch, PR, and exact head SHA before committing only the repaired lockfile.
- **Dependencies**: None.

## Review Focus

The trusted workflow never executes pull-request code and rejects stale heads with an atomic `--force-with-lease`. This works around dependabot/dependabot-core#12244 and dependabot/dependabot-core#14339. It also removes the ineffective `increase-if-necessary` mitigation.