### PR TITLE
fix: allow EXR image uploads

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -164,6 +164,21 @@ describe('WidgetSelectDropdown', () => {
     expect(screen.getByText('img_001.png')).toBeDefined()
   })
 
+  it('allows EXR files for image uploads', () => {
+    const widget = createMockWidget<string | undefined>({
+      value: undefined,
+      name: 'test_image',
+      type: 'combo',
+      options: { values: [] }
+    })
+    renderComponent(widget, undefined)
+
+    expect(screen.getByLabelText('g.upload')).toHaveAttribute(
+      'accept',
+      'image/*,.exr'
+    )
+  })
+
   it('renders in cloud asset mode', () => {
     mockAssetsData.items = [
       fromPartial({

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -137,7 +137,7 @@ const acceptTypes = computed(() => {
   // that can handle a wide range of formats
   switch (props.assetKind) {
     case 'image':
-      return 'image/*'
+      return 'image/*,.exr'
     case 'video':
       return 'video/*'
     case 'audio':


### PR DESCRIPTION
## Summary

Allow OpenEXR files to be selected from image upload file pickers.

## Changes

- **What**: Add `.exr` alongside `image/*` in the image upload accept filter and cover it with a component test.

## Review Focus

Confirm `.exr` is visible in the Load Image file picker while existing image MIME types remain accepted.

## Screenshot

<img width="372" height="441" alt="{BBAF8C06-E3DC-4FD9-8A99-D2E9A507AC02}" src="https://github.com/user-attachments/assets/36ad8d65-b8f7-4e84-b845-2c5b8f109321" />
