### PR TITLE
fix: stabilize weekly ComfyUI release

### DIFF
--- a/.github/workflows/release-weekly-comfyui.yaml
+++ b/.github/workflows/release-weekly-comfyui.yaml
@@ -193,15 +193,14 @@ jobs:
         with:
           sparse-checkout: scripts/cicd
           sparse-checkout-cone-mode: false
+          path: release-scripts
 
-      # The tag checkout below replaces the workspace, and the tag predates these.
       - name: Stage release scripts
-        run: cp -r scripts/cicd "$RUNNER_TEMP/cicd"
+        run: cp -r release-scripts/scripts/cicd "$RUNNER_TEMP/cicd"
 
       - name: Wait for the release tag
         if: needs.trigger-release-if-needed.result == 'success'
         env:
-          GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
           REPO: ${{ github.repository }}
           TARGET_VERSION: ${{ needs.resolve-version.outputs.target_version }}
           TARGET_BRANCH: ${{ needs.resolve-version.outputs.target_branch }}
@@ -212,16 +211,21 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: v${{ needs.resolve-version.outputs.target_version }}
+          path: release
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          package_json_file: release/package.json
 
       - uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'release/.nvmrc'
           cache: 'pnpm'
+          cache-dependency-path: release/pnpm-lock.yaml
 
       - name: Build project
+        working-directory: release
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
@@ -243,12 +247,12 @@ jobs:
       - name: Build and publish PyPI package
         run: |
           set -euo pipefail
-          mkdir -p comfyui_frontend_package/comfyui_frontend_package/static/
-          cp -r dist/* comfyui_frontend_package/comfyui_frontend_package/static/
+          mkdir -p release/comfyui_frontend_package/comfyui_frontend_package/static/
+          cp -r release/dist/* release/comfyui_frontend_package/comfyui_frontend_package/static/
 
       - name: Build pypi package
         run: python -m build
-        working-directory: comfyui_frontend_package
+        working-directory: release/comfyui_frontend_package
         env:
           COMFYUI_FRONTEND_VERSION: ${{ needs.resolve-version.outputs.target_version }}
 
@@ -257,7 +261,7 @@ jobs:
         with:
           skip-existing: true
           password: ${{ secrets.PYPI_TOKEN }}
-          packages-dir: comfyui_frontend_package/dist
+          packages-dir: release/comfyui_frontend_package/dist
 
       - name: Wait for the version to be installable
         id: pypi-wait
@@ -384,6 +388,10 @@ jobs:
 
           # Create/update branch (reuse same branch name each release cycle)
           BRANCH="automation/comfyui-frontend-bump"
+          HEAD_BRANCH="$BRANCH"
+          if [[ "$COMFYUI_FORK" != "Comfy-Org/ComfyUI" ]]; then
+            HEAD_BRANCH="${FORK_OWNER}:${BRANCH}"
+          fi
           git checkout -B "$BRANCH"
           git add requirements.txt
 
@@ -408,7 +416,7 @@ jobs:
           # Try to create PR, ignore error if it already exists
           if ! gh pr create \
             --repo Comfy-Org/ComfyUI \
-            --head "${FORK_OWNER}:${BRANCH}" \
+            --head "$HEAD_BRANCH" \
             --base master \
             --title "Bump comfyui-frontend-package to ${{ needs.resolve-version.outputs.target_version }}" \
             --body "$PR_BODY" \
@@ -416,7 +424,7 @@ jobs:
 
             # Check if PR already exists
             set +e
-            EXISTING_PR=$(gh pr list --repo Comfy-Org/ComfyUI --head "${FORK_OWNER}:${BRANCH}" --json number --jq '.[0].number' 2>&1)
+            EXISTING_PR=$(gh pr list --repo Comfy-Org/ComfyUI --head "$HEAD_BRANCH" --json number --jq '.[0].number' 2>&1)
             PR_LIST_EXIT=$?
             set -e
 

--- a/scripts/cicd/wait-for-release-tag.sh
+++ b/scripts/cicd/wait-for-release-tag.sh
@@ -16,6 +16,7 @@ echo "Waiting up to $((timeout_seconds / 3600))h for ${TAG} on ${TARGET_BRANCH}.
 deadline=$((SECONDS + timeout_seconds))
 while ((SECONDS < deadline)); do
   remaining=$((deadline - SECONDS))
+  ((remaining > 0)) || break
   if git_error=$(timeout "${remaining}s" git ls-remote --exit-code --tags "https://github.com/${REPO}.git" "refs/tags/${TAG}" 2>&1); then
     echo "${TAG} found — the bump PR has been merged."
     exit 0

--- a/scripts/cicd/wait-for-release-tag.sh
+++ b/scripts/cicd/wait-for-release-tag.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 : "${TARGET_VERSION:?TARGET_VERSION is required}"
 : "${TARGET_BRANCH:?TARGET_BRANCH is required}"
 : "${RUN_ID:?RUN_ID is required}"
-: "${GH_TOKEN:?GH_TOKEN is required}"
 
 timeout_seconds=${TIMEOUT_SECONDS:-14400}
 poll_seconds=${POLL_SECONDS:-30}
@@ -16,13 +15,15 @@ echo "Waiting up to $((timeout_seconds / 3600))h for ${TAG} on ${TARGET_BRANCH}.
 
 deadline=$((SECONDS + timeout_seconds))
 while ((SECONDS < deadline)); do
-  if api_error=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --silent 2>&1); then
+  if git_error=$(git ls-remote --exit-code --tags "https://github.com/${REPO}.git" "refs/tags/${TAG}" 2>&1); then
     echo "${TAG} found — the bump PR has been merged."
     exit 0
-  fi
-  if [[ "$api_error" != *"HTTP 404"* ]]; then
-    echo "::error title=Unexpected error polling for release tag::${api_error}"
-    exit 1
+  else
+    status=$?
+    if ((status != 2)); then
+      echo "::error title=Unexpected error polling for release tag::${git_error}"
+      exit "$status"
+    fi
   fi
   echo "${TAG} not found yet; $((deadline - SECONDS))s of budget left."
   sleep "$poll_seconds"

--- a/scripts/cicd/wait-for-release-tag.sh
+++ b/scripts/cicd/wait-for-release-tag.sh
@@ -15,18 +15,23 @@ echo "Waiting up to $((timeout_seconds / 3600))h for ${TAG} on ${TARGET_BRANCH}.
 
 deadline=$((SECONDS + timeout_seconds))
 while ((SECONDS < deadline)); do
-  if git_error=$(git ls-remote --exit-code --tags "https://github.com/${REPO}.git" "refs/tags/${TAG}" 2>&1); then
+  remaining=$((deadline - SECONDS))
+  if git_error=$(timeout "${remaining}s" git ls-remote --exit-code --tags "https://github.com/${REPO}.git" "refs/tags/${TAG}" 2>&1); then
     echo "${TAG} found — the bump PR has been merged."
     exit 0
   else
     status=$?
-    if ((status != 2)); then
+    if ((status == 124)); then
+      break
+    elif ((status != 2)); then
       echo "::error title=Unexpected error polling for release tag::${git_error}"
       exit "$status"
     fi
   fi
-  echo "${TAG} not found yet; $((deadline - SECONDS))s of budget left."
-  sleep "$poll_seconds"
+  remaining=$((deadline - SECONDS))
+  ((remaining > 0)) || break
+  echo "${TAG} not found yet; ${remaining}s of budget left."
+  sleep "$((poll_seconds < remaining ? poll_seconds : remaining))"
 done
 
 readonly RECOVERY="gh run rerun ${RUN_ID} --failed"


### PR DESCRIPTION
## Summary

Fix the three independent failures blocking the weekly ComfyUI release workflow.

## Changes

- Isolate the release-script and release-tag checkouts so sparse checkout state cannot corrupt the tagged build.
- Poll tags with `git ls-remote` instead of exhausting the shared GitHub API quota.
- Use an unqualified head branch when creating or finding a same-repository ComfyUI PR.

## Review Focus

The tagged release now builds entirely under `release/`; all package, cache, build, and publish paths were updated accordingly.
