### PR TITLE
fix: guard node badge redraw before canvas setup

### DIFF
--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -1,17 +1,29 @@
 import { render } from '@testing-library/vue'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyExtension } from '@/types/comfy'
 import { app } from '@/scripts/app'
-
-import { useNodeBadge } from './useNodeBadge'
 
 const mocks = vi.hoisted(() => ({
   extensionInstalled: false,
   installNodeBadges: vi.fn(),
   registerExtension: vi.fn()
 }))
+
+const badgeMode = ref(false)
+const showApiPricingBadge = ref(false)
+const pricingRevision = ref(0)
+const canvasEventListeners = new Map<string, EventListener>()
+const canvas = {
+  canvas: {
+    addEventListener: vi.fn((name: string, listener: EventListener) => {
+      canvasEventListeners.set(name, listener)
+    })
+  },
+  setDirty: vi.fn()
+}
+let canvasReady = true
 
 vi.mock('@/systems/badgeSystem', () => ({
   installNodeBadges: mocks.installNodeBadges
@@ -26,51 +38,103 @@ vi.mock('@/stores/extensionStore', () => ({
   })
 }))
 vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: () => false })
+  useSettingStore: () => ({
+    get: (key: string) =>
+      key === 'Comfy.NodeBadge.ShowApiPricing'
+        ? showApiPricingBadge.value
+        : badgeMode.value
+  })
 }))
 vi.mock('@/composables/node/useNodePricing', () => ({
-  useNodePricing: () => ({ pricingRevision: { value: 0 } })
+  useNodePricing: () => ({ pricingRevision })
+}))
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    get canvas() {
+      return canvasReady ? canvas : undefined
+    }
+  })
 }))
 vi.mock('@/scripts/app', () => ({
   app: {
-    canvas: {
-      canvas: { addEventListener: vi.fn() },
-      setDirty: vi.fn()
+    get canvas() {
+      return canvasReady ? canvas : undefined
     }
   }
 }))
 
+const { useNodeBadge } = await import('./useNodeBadge')
+
+function renderComposable() {
+  return render(
+    defineComponent({
+      setup() {
+        useNodeBadge()
+        return () => null
+      }
+    })
+  )
+}
+
 describe('useNodeBadge', () => {
   beforeEach(() => {
     mocks.extensionInstalled = false
+    badgeMode.value = false
+    showApiPricingBadge.value = false
+    pricingRevision.value = 0
+    canvasEventListeners.clear()
+    canvasReady = true
   })
 
   it('keeps the extension-owned provider installed across canvas remounts', async () => {
-    const firstMount = render(
-      defineComponent({
-        setup() {
-          useNodeBadge()
-          return () => null
-        }
-      })
-    )
+    const firstMount = renderComposable()
     const extension = mocks.registerExtension.mock.calls[0][0] as ComfyExtension
     await extension.init?.(app)
 
     firstMount.unmount()
 
-    const secondMount = render(
-      defineComponent({
-        setup() {
-          useNodeBadge()
-          return () => null
-        }
-      })
-    )
+    const secondMount = renderComposable()
 
     expect(mocks.registerExtension).toHaveBeenCalledOnce()
     expect(mocks.installNodeBadges).toHaveBeenCalledOnce()
 
     secondMount.unmount()
+  })
+
+  it('allows badge settings to change before the canvas is ready', async () => {
+    canvasReady = false
+    const component = renderComposable()
+
+    badgeMode.value = true
+    await nextTick()
+
+    expect(canvas.setDirty).not.toHaveBeenCalled()
+    component.unmount()
+  })
+
+  it('allows pricing to update before the canvas is ready', async () => {
+    showApiPricingBadge.value = true
+    canvasReady = false
+    const component = renderComposable()
+
+    pricingRevision.value++
+    await nextTick()
+
+    expect(canvas.setDirty).not.toHaveBeenCalled()
+    component.unmount()
+  })
+
+  it('allows the canvas to be removed before a graph event arrives', async () => {
+    const component = renderComposable()
+    const extension = mocks.registerExtension.mock.calls[0][0] as ComfyExtension
+    await extension.init?.(app)
+    canvasReady = false
+
+    canvasEventListeners.get('litegraph:set-graph')?.(
+      new Event('litegraph:set-graph')
+    )
+
+    expect(canvas.setDirty).not.toHaveBeenCalled()
+    component.unmount()
   })
 })

--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -109,6 +109,12 @@ describe('useNodeBadge', () => {
     await nextTick()
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
+
+    canvasReady = true
+    badgeMode.value = false
+    await nextTick()
+
+    expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
     component.unmount()
   })
 

--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -127,6 +127,12 @@ describe('useNodeBadge', () => {
     await nextTick()
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
+
+    canvasReady = true
+    pricingRevision.value++
+    await nextTick()
+
+    expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
     component.unmount()
   })
 
@@ -141,6 +147,13 @@ describe('useNodeBadge', () => {
     )
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
+
+    canvasReady = true
+    canvasEventListeners.get('litegraph:set-graph')?.(
+      new Event('litegraph:set-graph')
+    )
+
+    expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
     component.unmount()
   })
 })

--- a/src/composables/node/useNodeBadge.ts
+++ b/src/composables/node/useNodeBadge.ts
@@ -2,6 +2,7 @@ import { computed, onMounted, watch } from 'vue'
 
 import { useNodePricing } from '@/composables/node/useNodePricing'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useExtensionStore } from '@/stores/extensionStore'
 import { installNodeBadges } from '@/systems/badgeSystem'
@@ -13,6 +14,7 @@ import { installNodeBadges } from '@/systems/badgeSystem'
 export const useNodeBadge = () => {
   const settingStore = useSettingStore()
   const extensionStore = useExtensionStore()
+  const canvasStore = useCanvasStore()
 
   const showApiPricingBadge = computed(() =>
     settingStore.get('Comfy.NodeBadge.ShowApiPricing')
@@ -26,7 +28,7 @@ export const useNodeBadge = () => {
       showApiPricingBadge
     ],
     () => {
-      app.canvas.setDirty(true, true)
+      canvasStore.canvas?.setDirty(true, true)
     }
   )
 
@@ -39,7 +41,7 @@ export const useNodeBadge = () => {
       () => nodePricing.pricingRevision.value,
       () => {
         if (!showApiPricingBadge.value) return
-        app.canvas.setDirty(true, true)
+        canvasStore.canvas?.setDirty(true, true)
       }
     )
 
@@ -50,7 +52,7 @@ export const useNodeBadge = () => {
         app.canvas.canvas.addEventListener<'litegraph:set-graph'>(
           'litegraph:set-graph',
           () => {
-            app.canvas.setDirty(true, true)
+            canvasStore.canvas?.setDirty(true, true)
           }
         )
       }


### PR DESCRIPTION
## Summary

Prevent node-badge watchers from crashing when they fire before the graph canvas is initialized or after it is removed.

## Changes

- **What**: Route redraws through the nullable canvas store and add focused lifecycle regression coverage for settings, pricing, and graph events.

## Review Focus

Verify that badge redraws resume normally once `canvasStore.canvas` is populated.

## Linear

[QA-24](https://linear.app/comfyorg/issue/QA-24/node-badge-redraw-crashes-before-canvas-initialization)