### PR TITLE
feat: report CMP event sink failures

### DIFF
--- a/src/platform/telemetry/cmpEventSink.test.ts
+++ b/src/platform/telemetry/cmpEventSink.test.ts
@@ -1,0 +1,52 @@
+import type { CmpEvent } from '@comfyorg/comfy-multi-player'
+
+import { reportError } from './reportError'
+import { cmpEventSink } from './cmpEventSink'
+
+vi.mock('./reportError', () => ({ reportError: vi.fn() }))
+
+const event: CmpEvent = {
+  schema_version: 1,
+  type: 'op_rejected',
+  source: 'applyOps',
+  code: 'unknown_widget',
+  message: 'widget write rejected',
+  error_name: 'OpRejectedError',
+  op_id: '0123456789abcdef0123456789abcdef',
+  batch_index: 2
+}
+
+describe('cmpEventSink', () => {
+  it('maps a cmp event to the generic error reporter', () => {
+    expect(cmpEventSink(event)).toBeUndefined()
+
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: event.message }),
+      {
+        errorType: 'cmp_event',
+        tags: {
+          cmp_event_schema_version: 1,
+          cmp_event_type: 'op_rejected',
+          cmp_event_source: 'applyOps',
+          cmp_event_code: 'unknown_widget',
+          cmp_event_error_name: 'OpRejectedError'
+        },
+        context: {
+          op_id: event.op_id,
+          batch_index: 2
+        }
+      }
+    )
+  })
+
+  it('bounds diagnostic messages and accepts additive event names', () => {
+    cmpEventSink({ ...event, type: 'future_event', message: 'x'.repeat(2_000) })
+
+    expect(reportError).toHaveBeenLastCalledWith(
+      expect.objectContaining({ message: 'x'.repeat(1_024) }),
+      expect.objectContaining({
+        tags: expect.objectContaining({ cmp_event_type: 'future_event' })
+      })
+    )
+  })
+})

--- a/src/platform/telemetry/cmpEventSink.test.ts
+++ b/src/platform/telemetry/cmpEventSink.test.ts
@@ -21,7 +21,10 @@ describe('cmpEventSink', () => {
     expect(cmpEventSink(event)).toBeUndefined()
 
     expect(reportError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: event.message }),
+      expect.objectContaining({
+        name: 'OpRejectedError',
+        message: event.message
+      }),
       {
         errorType: 'cmp_event',
         tags: {
@@ -35,6 +38,34 @@ describe('cmpEventSink', () => {
           op_id: event.op_id,
           batch_index: 2
         }
+      }
+    )
+  })
+
+  it('omits absent optional fields for a minimal event', () => {
+    cmpEventSink({
+      schema_version: 1,
+      type: 'clock_anomaly',
+      source: 'clock',
+      code: 'skew',
+      message: 'clock skew detected'
+    })
+
+    expect(reportError).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        name: 'CmpEvent',
+        message: 'clock skew detected'
+      }),
+      {
+        errorType: 'cmp_event',
+        tags: {
+          cmp_event_schema_version: 1,
+          cmp_event_type: 'clock_anomaly',
+          cmp_event_source: 'clock',
+          cmp_event_code: 'skew',
+          cmp_event_error_name: undefined
+        },
+        context: {}
       }
     )
   })

--- a/src/platform/telemetry/cmpEventSink.ts
+++ b/src/platform/telemetry/cmpEventSink.ts
@@ -1,0 +1,23 @@
+import type { CmpEventSink } from '@comfyorg/comfy-multi-player'
+
+import { reportError } from './reportError'
+
+const MAX_MESSAGE_LENGTH = 1_024
+
+export const cmpEventSink: CmpEventSink = (event) => {
+  reportError(new Error(event.message.slice(0, MAX_MESSAGE_LENGTH)), {
+    errorType: 'cmp_event',
+    tags: {
+      cmp_event_schema_version: event.schema_version,
+      cmp_event_type: event.type,
+      cmp_event_source: event.source,
+      cmp_event_code: event.code,
+      cmp_event_error_name: event.error_name
+    },
+    context: {
+      op_id: event.op_id,
+      batch_index: event.batch_index
+    }
+  })
+  return undefined
+}

--- a/src/platform/telemetry/cmpEventSink.ts
+++ b/src/platform/telemetry/cmpEventSink.ts
@@ -1,11 +1,25 @@
-import type { CmpEventSink } from '@comfyorg/comfy-multi-player'
+import type { CmpEvent, CmpEventSink } from '@comfyorg/comfy-multi-player'
 
 import { reportError } from './reportError'
 
 const MAX_MESSAGE_LENGTH = 1_024
+const DEFAULT_ERROR_NAME = 'CmpEvent'
+
+const toError = (event: CmpEvent): Error => {
+  const error = new Error(event.message.slice(0, MAX_MESSAGE_LENGTH))
+  error.name = event.error_name ?? DEFAULT_ERROR_NAME
+  return error
+}
+
+const definedContextOf = (event: CmpEvent): Record<string, unknown> => {
+  const context: Record<string, unknown> = {}
+  if (event.op_id !== undefined) context.op_id = event.op_id
+  if (event.batch_index !== undefined) context.batch_index = event.batch_index
+  return context
+}
 
 export const cmpEventSink: CmpEventSink = (event) => {
-  reportError(new Error(event.message.slice(0, MAX_MESSAGE_LENGTH)), {
+  reportError(toError(event), {
     errorType: 'cmp_event',
     tags: {
       cmp_event_schema_version: event.schema_version,
@@ -14,10 +28,7 @@ export const cmpEventSink: CmpEventSink = (event) => {
       cmp_event_code: event.code,
       cmp_event_error_name: event.error_name
     },
-    context: {
-      op_id: event.op_id,
-      batch_index: event.batch_index
-    }
+    context: definedContextOf(event)
   })
   return undefined
 }


### PR DESCRIPTION
## Summary

Restores the frontend-owned adapter that maps caller-owned CMP diagnostics into the shared error reporter.

## Changes

- **What**: Bounds messages at 1,024 characters, preserves stable event fields as tags, and keeps operation identifiers in non-indexed context, with focused tests.
- **Dependencies**: Uses the current `@comfyorg/comfy-multi-player` 0.2.1 contract; no dependency or lockfile changes.

## Review Focus

Current main has no production browser-owned `applyOps` call. The adapter therefore remains unattached rather than violating the read-only follower boundary or reporting deliberate dev-panel simulations. Open #16644 changes package ownership but preserves the exported event contract.