### PR TITLE
test: consolidate measured unit-test speedups

### DIFF
--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -100,6 +100,7 @@ function globalOptions() {
 
 describe('SignUpForm', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     mockLoadingRef.value = false
     mockTurnstileEnabled.value = false
     mockTurnstileToken.value = ''

--- a/src/components/searchbox/v2/NodeSearchContent.test.ts
+++ b/src/components/searchbox/v2/NodeSearchContent.test.ts
@@ -22,6 +22,7 @@ const MOBILE_VIEWPORT = { width: 360, height: 800 }
 
 describe('NodeSearchContent', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     setupTestPinia()
     setViewport(DESKTOP_VIEWPORT)
     const settings = useSettingStore()

--- a/src/composables/node/useNodePricing.test.ts
+++ b/src/composables/node/useNodePricing.test.ts
@@ -125,6 +125,10 @@ function createMockNode(
   })
 }
 
+function drainMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -138,10 +142,10 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"usd","usd":0.05}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
 
     it('should evaluate static text result', async () => {
@@ -151,10 +155,9 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"text","text":"Free"}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe('Free')
+      await vi.waitFor(() => expect(getNodeDisplayPrice(node)).toBe('Free'), {
+        interval: 1
+      })
     })
   })
 
@@ -169,10 +172,10 @@ describe('useNodePricing', () => {
         [{ name: 'count', value: 5 }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
 
     it('caches per signature so base and override reads both settle', async () => {
@@ -188,10 +191,13 @@ describe('useNodePricing', () => {
 
       getNodeDisplayPrice(node)
       getNodeDisplayPrice(node, overrides)
-      await vi.waitFor(() => {
-        expect(getNodeDisplayPrice(node)).toBe('inner')
-        expect(getNodeDisplayPrice(node, overrides)).toBe('outer')
-      })
+      await vi.waitFor(
+        () => {
+          expect(getNodeDisplayPrice(node)).toBe('inner')
+          expect(getNodeDisplayPrice(node, overrides)).toBe('outer')
+        },
+        { interval: 1 }
+      )
       expect(getNodeDisplayPrice(node)).toBe('inner')
     })
 
@@ -205,10 +211,10 @@ describe('useNodePricing', () => {
         [{ name: 'rate', value: 0.05 }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.5))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.5)),
+        { interval: 1 }
+      )
     })
 
     it('should handle COMBO widget with numeric value', async () => {
@@ -221,10 +227,10 @@ describe('useNodePricing', () => {
         [{ name: 'duration', value: 5 }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.35))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.35)),
+        { interval: 1 }
+      )
     })
 
     it('should handle COMBO widget with string value', async () => {
@@ -238,10 +244,10 @@ describe('useNodePricing', () => {
         [{ name: 'mode', value: 'Pro' }] // Should be lowercased to "pro"
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
 
     it('should handle BOOLEAN widget', async () => {
@@ -254,10 +260,10 @@ describe('useNodePricing', () => {
         [{ name: 'premium', value: true }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
 
     it('should handle STRING widget (lowercased)', async () => {
@@ -271,10 +277,10 @@ describe('useNodePricing', () => {
         [{ name: 'model', value: 'ProModel' }] // Should be lowercased to "promodel"
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
   })
 
@@ -293,10 +299,10 @@ describe('useNodePricing', () => {
         [{ name: 'resolution', value: '1080p' }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
 
     it('should handle multiple widgets', async () => {
@@ -319,10 +325,10 @@ describe('useNodePricing', () => {
         ]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(1.0))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(1.0)),
+        { interval: 1 }
+      )
     })
 
     it('should handle conditional pricing based on widget values', async () => {
@@ -346,10 +352,10 @@ describe('useNodePricing', () => {
         ]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.56))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.56)),
+        { interval: 1 }
+      )
     })
   })
 
@@ -361,10 +367,13 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"range_usd","min_usd":0.05,"max_usd":0.10}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toMatch(/\d+\.?\d*-\d+\.?\d* credits\/Run/)
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toMatch(
+            /\d+\.?\d*-\d+\.?\d* credits\/Run/
+          ),
+        { interval: 1 }
+      )
     })
 
     it('should format list_usd result', async () => {
@@ -374,10 +383,13 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"list_usd","usd":[0.05, 0.10, 0.15]}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toMatch(/\d+\.?\d*\/\d+\.?\d*\/\d+\.?\d* credits\/Run/)
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toMatch(
+            /\d+\.?\d*\/\d+\.?\d*\/\d+\.?\d* credits\/Run/
+          ),
+        { interval: 1 }
+      )
     })
 
     it('should respect custom suffix in format options', async () => {
@@ -387,10 +399,11 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"usd","usd":0.07,"format":{"suffix":"/second"}}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.07, '/second'))
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.07, '/second')),
+        { interval: 1 }
+      )
     })
 
     it('should add approximate prefix when specified', async () => {
@@ -400,10 +413,13 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"usd","usd":0.05,"format":{"approximate":true}}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toMatch(/^~\d+\.?\d* credits\/Run$/)
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toMatch(
+            /^~\d+\.?\d* credits\/Run$/
+          ),
+        { interval: 1 }
+      )
     })
 
     it('should add note suffix when specified', async () => {
@@ -413,10 +429,13 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"usd","usd":0.05,"format":{"note":"(estimated)"}}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toMatch(/credits\/Run \(estimated\)$/)
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toMatch(
+            /credits\/Run \(estimated\)$/
+          ),
+        { interval: 1 }
+      )
     })
 
     it('should combine approximate prefix and note suffix', async () => {
@@ -428,10 +447,13 @@ describe('useNodePricing', () => {
         )
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toMatch(/^~\d+\.?\d* credits\/image \(beta\)$/)
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toMatch(
+            /^~\d+\.?\d* credits\/image \(beta\)$/
+          ),
+        { interval: 1 }
+      )
     })
 
     it('should use custom separator for list_usd', async () => {
@@ -443,10 +465,13 @@ describe('useNodePricing', () => {
         )
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toMatch(/\d+\.?\d* or \d+\.?\d* credits\/Run/)
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(node)).toMatch(
+            /\d+\.?\d* or \d+\.?\d* credits\/Run/
+          ),
+        { interval: 1 }
+      )
     })
   })
 
@@ -464,10 +489,10 @@ describe('useNodePricing', () => {
         [{ name: 'image', connected: true }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
 
     it('should handle disconnected input check', async () => {
@@ -483,10 +508,10 @@ describe('useNodePricing', () => {
         [{ name: 'image', connected: false }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
   })
 
@@ -524,10 +549,10 @@ describe('useNodePricing', () => {
         [{ name: 'count', value: null }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
 
     it('should handle missing widget gracefully', async () => {
@@ -541,10 +566,10 @@ describe('useNodePricing', () => {
         []
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
 
     it('should handle undefined widget value gracefully', async () => {
@@ -558,10 +583,10 @@ describe('useNodePricing', () => {
         [{ name: 'count', value: undefined }]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
   })
 
@@ -575,9 +600,10 @@ describe('useNodePricing', () => {
 
       const before = pricingRevision.value
       getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-
-      expect(pricingRevision.value).toBeGreaterThan(before)
+      await vi.waitFor(
+        () => expect(pricingRevision.value).toBeGreaterThan(before),
+        { interval: 1 }
+      )
     })
 
     it('bumps the per-node revision ref after async evaluation resolves in VueNodes mode', async () => {
@@ -595,11 +621,13 @@ describe('useNodePricing', () => {
         const tickBefore = pricingRevision.value
 
         getNodeDisplayPrice(node)
-        await new Promise((r) => setTimeout(r, 50))
-
-        // VueNodes path bumps per-node ref and the global tick.
-        expect(getNodeRevisionRef(nodeId).value).toBeGreaterThan(revBefore)
-        expect(pricingRevision.value).toBeGreaterThan(tickBefore)
+        await vi.waitFor(
+          () => {
+            expect(getNodeRevisionRef(nodeId).value).toBeGreaterThan(revBefore)
+            expect(pricingRevision.value).toBeGreaterThan(tickBefore)
+          },
+          { interval: 1 }
+        )
       } finally {
         LiteGraph.vueNodesMode = false
       }
@@ -613,14 +641,22 @@ describe('useNodePricing', () => {
       )
 
       // First call schedules eval; second call (after resolution) is a cache hit.
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
+      const revisionBeforeEvaluation = pricingRevision.value
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(
+            revisionBeforeEvaluation
+          ),
+        { interval: 1 }
+      )
       const first = getNodeDisplayPrice(node)
+      expect(first).toBe(creditsLabel(0.05))
 
       const tickAfterFirst = pricingRevision.value
       const second = getNodeDisplayPrice(node)
       // Cache-hit path must not schedule a new evaluation, so no further tick.
-      await new Promise((r) => setTimeout(r, 20))
+      await drainMicrotasks()
 
       expect(second).toBe(first)
       expect(pricingRevision.value).toBe(tickAfterFirst)
@@ -629,7 +665,7 @@ describe('useNodePricing', () => {
 
   describe('failed evaluation caching', () => {
     it('recovers the price badge when a failed string value is corrected to its numeric equivalent', async () => {
-      const { getNodeDisplayPrice } = useNodePricing()
+      const { getNodeDisplayPrice, pricingRevision } = useNodePricing()
       const rule = priceBadge('{"type":"usd","usd": widgets.steps * 0.01}', [
         { name: 'steps', type: 'COMBO' }
       ])
@@ -644,12 +680,18 @@ describe('useNodePricing', () => {
         [{ name: 'steps', value: '10' }]
       )
 
-      getNodeDisplayPrice(numericNode)
-      await new Promise((r) => setTimeout(r, 50))
-      expect(getNodeDisplayPrice(numericNode)).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(numericNode)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
 
+      const revisionBeforeFailure = pricingRevision.value
       expect(getNodeDisplayPrice(correctedNode)).toBe('')
-      await new Promise((r) => setTimeout(r, 50))
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(revisionBeforeFailure),
+        { interval: 1 }
+      )
       expect(getNodeDisplayPrice(correctedNode)).toBe('')
 
       const stepsWidget = correctedNode.widgets?.find(
@@ -659,8 +701,11 @@ describe('useNodePricing', () => {
       stepsWidget.value = 10
 
       expect(getNodeDisplayPrice(correctedNode)).toBe('')
-      await new Promise((r) => setTimeout(r, 50))
-      expect(getNodeDisplayPrice(correctedNode)).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () =>
+          expect(getNodeDisplayPrice(correctedNode)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
 
     it('does not retry a failed price badge evaluation for an unchanged value', async () => {
@@ -675,12 +720,15 @@ describe('useNodePricing', () => {
 
       const revisionBeforeFailure = pricingRevision.value
       expect(getNodeDisplayPrice(node)).toBe('')
-      await new Promise((r) => setTimeout(r, 50))
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(revisionBeforeFailure),
+        { interval: 1 }
+      )
       const revisionAfterFailure = pricingRevision.value
-      expect(revisionAfterFailure).toBeGreaterThan(revisionBeforeFailure)
 
       expect(getNodeDisplayPrice(node)).toBe('')
-      await new Promise((r) => setTimeout(r, 20))
+      await drainMicrotasks()
       expect(pricingRevision.value).toBe(revisionAfterFailure)
     })
   })
@@ -720,7 +768,7 @@ describe('useNodePricing', () => {
   })
 
   describe('error handling', () => {
-    it('should return empty string for invalid JSONata expression', async () => {
+    it('should return empty string for invalid JSONata expression', () => {
       const { getNodeDisplayPrice } = useNodePricing()
       const node = createMockNodeWithPriceBadge(
         'TestInvalidExprNode',
@@ -728,39 +776,48 @@ describe('useNodePricing', () => {
         priceBadge('{"type":"usd","usd": (widgets.count * 0.01')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
       // Should not crash, just return empty
-      expect(price).toBe('')
+      expect(getNodeDisplayPrice(node)).toBe('')
     })
 
     it('should return empty string for expression that throws at runtime', async () => {
-      const { getNodeDisplayPrice } = useNodePricing()
+      const { getNodeDisplayPrice, pricingRevision } = useNodePricing()
       const node = createMockNodeWithPriceBadge(
         'TestRuntimeErrorNode',
         // Expression that will fail at runtime (calling function on undefined)
         priceBadge('$lookup(undefined, "key")')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe('')
+      const revisionBeforeEvaluation = pricingRevision.value
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(
+            revisionBeforeEvaluation
+          ),
+        { interval: 1 }
+      )
+      expect(getNodeDisplayPrice(node)).toBe('')
     })
 
     it('should return empty string for invalid PricingResult type', async () => {
-      const { getNodeDisplayPrice } = useNodePricing()
+      const { getNodeDisplayPrice, pricingRevision } = useNodePricing()
       const node = createMockNodeWithPriceBadge(
         'TestInvalidResultTypeNode',
         // Returns object with invalid type field
         priceBadge('{"type":"invalid_type","value":123}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe('')
+      const revisionBeforeEvaluation = pricingRevision.value
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(
+            revisionBeforeEvaluation
+          ),
+        { interval: 1 }
+      )
+      expect(getNodeDisplayPrice(node)).toBe('')
     })
 
     it('should handle legacy format without type field', async () => {
@@ -771,38 +828,50 @@ describe('useNodePricing', () => {
         priceBadge('{"usd":0.05}')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
       // Legacy format {usd: number} is supported
-      expect(price).toBe(creditsLabel(0.05))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.05)),
+        { interval: 1 }
+      )
     })
 
     it('should return empty string for non-object result', async () => {
-      const { getNodeDisplayPrice } = useNodePricing()
+      const { getNodeDisplayPrice, pricingRevision } = useNodePricing()
       const node = createMockNodeWithPriceBadge(
         'TestNonObjectNode',
         // Returns a plain number instead of PricingResult object
         priceBadge('0.05')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe('')
+      const revisionBeforeEvaluation = pricingRevision.value
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(
+            revisionBeforeEvaluation
+          ),
+        { interval: 1 }
+      )
+      expect(getNodeDisplayPrice(node)).toBe('')
     })
 
     it('should return empty string for null result', async () => {
-      const { getNodeDisplayPrice } = useNodePricing()
+      const { getNodeDisplayPrice, pricingRevision } = useNodePricing()
       const node = createMockNodeWithPriceBadge(
         'TestNullResultNode',
         priceBadge('null')
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
-      expect(price).toBe('')
+      const revisionBeforeEvaluation = pricingRevision.value
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await vi.waitFor(
+        () =>
+          expect(pricingRevision.value).toBeGreaterThan(
+            revisionBeforeEvaluation
+          ),
+        { interval: 1 }
+      )
+      expect(getNodeDisplayPrice(node)).toBe('')
     })
   })
 
@@ -834,11 +903,11 @@ describe('useNodePricing', () => {
         ]
       )
 
-      getNodeDisplayPrice(node)
-      await new Promise((r) => setTimeout(r, 50))
-      const price = getNodeDisplayPrice(node)
       // 2 connected inputs in 'videos' group * 0.05 = 0.10
-      expect(price).toBe(creditsLabel(0.1))
+      await vi.waitFor(
+        () => expect(getNodeDisplayPrice(node)).toBe(creditsLabel(0.1)),
+        { interval: 1 }
+      )
     })
   })
 
@@ -909,10 +978,10 @@ describe('useNodePricing', () => {
           priceBadge('{"type":"usd","usd":0.05}')
         )
 
-        getNodeDisplayPrice(node)
-        await new Promise((r) => setTimeout(r, 50))
-        const price = getNodeDisplayPrice(node)
-        expect(price).toBe('10.6 credits/Run')
+        await vi.waitFor(
+          () => expect(getNodeDisplayPrice(node)).toBe('10.6 credits/Run'),
+          { interval: 1 }
+        )
       })
 
       it('should not display decimal in badge for whole credits', async () => {
@@ -923,10 +992,10 @@ describe('useNodePricing', () => {
           priceBadge('{"type":"usd","usd":1.00}')
         )
 
-        getNodeDisplayPrice(node)
-        await new Promise((r) => setTimeout(r, 50))
-        const price = getNodeDisplayPrice(node)
-        expect(price).toBe('211 credits/Run')
+        await vi.waitFor(
+          () => expect(getNodeDisplayPrice(node)).toBe('211 credits/Run'),
+          { interval: 1 }
+        )
       })
 
       it('should handle range with mixed decimal display', async () => {
@@ -938,10 +1007,10 @@ describe('useNodePricing', () => {
           priceBadge('{"type":"range_usd","min_usd":0.05,"max_usd":1.00}')
         )
 
-        getNodeDisplayPrice(node)
-        await new Promise((r) => setTimeout(r, 50))
-        const price = getNodeDisplayPrice(node)
-        expect(price).toBe('10.6-211 credits/Run')
+        await vi.waitFor(
+          () => expect(getNodeDisplayPrice(node)).toBe('10.6-211 credits/Run'),
+          { interval: 1 }
+        )
       })
     })
   })

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import MediaAssetFilterButton from '@/platform/assets/components/MediaAssetFilterButton.vue'
@@ -80,6 +80,10 @@ const dateLabels = [
 ]
 
 describe('MediaAssetFilterMenu', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
   it('focuses the filter search when the menu opens', async () => {
     const { user } = renderMenu()
     await openMenu(user)

--- a/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
+++ b/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
@@ -55,6 +55,7 @@ const submitButton = () =>
   screen.getByRole('button', { name: LOGIN_COPY.loginButton })
 
 beforeEach(() => {
+  vi.useRealTimers()
   loading.value = false
 })
 

--- a/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
+++ b/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EffectScope, Ref } from 'vue'
 import { effectScope, ref } from 'vue'
 
@@ -11,9 +11,6 @@ vi.mock('@/platform/telemetry', () => ({
 }))
 
 import { useSearchQueryTracking } from './useSearchQueryTracking'
-
-const DEBOUNCE_FLUSH_MS = 600
-const flush = () => new Promise((r) => setTimeout(r, DEBOUNCE_FLUSH_MS))
 
 describe('useSearchQueryTracking', () => {
   const scopes: EffectScope[] = []
@@ -30,6 +27,10 @@ describe('useSearchQueryTracking', () => {
     return scope
   }
 
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
   afterEach(() => {
     scopes.forEach((s) => s.stop())
     scopes.length = 0
@@ -40,7 +41,7 @@ describe('useSearchQueryTracking', () => {
     const results = ref<string[]>(['a', 'b', 'c'])
     track(query, results)
     query.value = '  hello  '
-    await flush()
+    await vi.advanceTimersByTimeAsync(500)
     expect(hoisted.trackSearchQuery).toHaveBeenCalledExactlyOnceWith({
       surface: 'node_sidebar',
       query: 'hello',
@@ -55,7 +56,7 @@ describe('useSearchQueryTracking', () => {
     const results = ref<string[]>([])
     track(query, results)
     query.value = 'nothingmatches'
-    await flush()
+    await vi.advanceTimersByTimeAsync(500)
     expect(hoisted.trackSearchQuery).toHaveBeenCalledExactlyOnceWith({
       surface: 'node_sidebar',
       query: 'nothingmatches',
@@ -70,7 +71,7 @@ describe('useSearchQueryTracking', () => {
     const results = ref<string[]>(['a', 'b'])
     track(query, results)
     query.value = '   '
-    await flush()
+    await vi.advanceTimersByTimeAsync(500)
     expect(hoisted.trackSearchQuery).not.toHaveBeenCalled()
   })
 
@@ -80,7 +81,7 @@ describe('useSearchQueryTracking', () => {
     const scope = track(query, results)
     query.value = 'hello'
     scope.stop()
-    await flush()
+    await vi.advanceTimersByTimeAsync(500)
     expect(hoisted.trackSearchQuery).not.toHaveBeenCalled()
   })
 
@@ -90,7 +91,7 @@ describe('useSearchQueryTracking', () => {
     track(query, results)
     const long = 'x'.repeat(250)
     query.value = long
-    await flush()
+    await vi.advanceTimersByTimeAsync(500)
     expect(hoisted.trackSearchQuery).toHaveBeenCalledExactlyOnceWith({
       surface: 'node_sidebar',
       query: 'x'.repeat(100),

--- a/src/platform/workspace/components/InviteMembersForm.test.ts
+++ b/src/platform/workspace/components/InviteMembersForm.test.ts
@@ -95,6 +95,7 @@ function submitButton() {
 
 describe('InviteMembersForm', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     mockPendingInvites.value = []
     mockFetchPendingInvites.mockResolvedValue([...mockPendingInvites.value])
     mockFetchStatus.mockResolvedValue(undefined)

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
@@ -102,6 +102,7 @@ function inviteButton() {
 
 describe('InviteMemberDialogContent', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     mockFetchPendingInvites.mockResolvedValue([])
     mockFetchStatus.mockResolvedValue(undefined)
     mockMaxSeats.value = 73

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -130,6 +130,7 @@ function setOwnedWorkspaces() {
 
 describe('TeamWorkspacesDialogContent', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
     workspaceStore = useTeamWorkspaceStore(pinia)
     workspaceStore.workspaces = []

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -132,6 +132,7 @@ async function openBulkMenu(user: ReturnType<typeof userEvent.setup>) {
 
 describe('PartnerNodeAccessPanel', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     mockGovernedWorkspaceId.value = 'workspace-one'
     mockStatus.value = 'configured'
     mockWorkspaceRole.value = 'owner'

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -613,7 +613,6 @@ describe('useMinimap', () => {
       const minimap = await createAndInitializeMinimap()
 
       await minimap.init()
-      await new Promise((resolve) => setTimeout(resolve, 100))
 
       expect(mockContext2D.clearRect).not.toHaveBeenCalled()
 
@@ -636,8 +635,6 @@ describe('useMinimap', () => {
 
       // The renderer has a fast path for empty graphs, force it to execute
       minimap.renderMinimap()
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
 
       expect(minimap.initialized.value).toBe(true)
 
@@ -938,57 +935,6 @@ describe('useMinimap', () => {
       await nextTick()
 
       expect(minimap.viewportStyles.value).toBeDefined()
-    })
-  })
-
-  describe('graph change handling', () => {
-    it('should handle node addition', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      const newNode = {
-        id: 'node3',
-        pos: [300, 200],
-        size: [100, 100],
-        renderingSize: [100, 100],
-        constructor: { color: '#666' },
-        outputs: []
-      }
-
-      moduleMockGraph._nodes.push(newNode)
-      if (moduleMockGraph.onNodeAdded) {
-        moduleMockGraph.onNodeAdded(newNode)
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 600))
-    })
-
-    it('should handle node removal', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      const removedNode = moduleMockGraph._nodes[0]
-      moduleMockGraph._nodes.splice(0, 1)
-
-      if (moduleMockGraph.onNodeRemoved) {
-        moduleMockGraph.onNodeRemoved(removedNode)
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 600))
-    })
-
-    it('should handle connection changes', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      if (moduleMockGraph.onConnectionChange) {
-        moduleMockGraph.onConnectionChange(moduleMockGraph._nodes[0])
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 600))
     })
   })
 

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -107,6 +107,23 @@ describe('useMinimapGraph', () => {
     expect(onGraphChangedMock).toHaveBeenCalled()
   })
 
+  it('notifies on connection change after running the original callback', () => {
+    const originalOnConnectionChange = vi.fn()
+    mockGraph.onConnectionChange = originalOnConnectionChange
+
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+
+    graphManager.setupEventListeners()
+    mockGraph.onConnectionChange(mockGraph._nodes[0])
+
+    expect(originalOnConnectionChange).toHaveBeenCalledWith(mockGraph._nodes[0])
+    expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
+    expect(originalOnConnectionChange.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(onGraphChangedMock).mock.invocationCallOrder[0]
+    )
+  })
+
   it('should prevent duplicate event listener setup', () => {
     const graphRef = ref(mockGraph) as Ref<LGraph | null>
     const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -30,6 +30,10 @@ const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
 describe('WidgetSelectDefault', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
   const createWidget = (
     values: unknown,
     options: Record<string, unknown> = {}

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@/i18n'
 import type { HistoryGroups } from '../../stores/agent/agentChatHistoryStore'
@@ -68,6 +68,7 @@ async function openRename(
 
 describe('ChatHistoryScreen', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     i18n.global.locale.value = 'en'
   })
 

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -47,6 +47,7 @@ function mount(props: ComponentProps<typeof Composer> = {}) {
 
 describe('Composer', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     setActivePinia(createPinia())
   })
 

--- a/src/workbench/extensions/agent/components/agent/composer/WorkflowSelectorChip.test.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/WorkflowSelectorChip.test.ts
@@ -2,7 +2,7 @@ import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { ComponentProps } from 'vue-component-type-helpers'
@@ -41,6 +41,7 @@ const tabs = [
 let pinia: Pinia
 
 beforeEach(() => {
+  vi.useRealTimers()
   pinia = createPinia()
   setActivePinia(pinia)
 })

--- a/tools/oxlint-plugins/comfyIngestTypes.test.ts
+++ b/tools/oxlint-plugins/comfyIngestTypes.test.ts
@@ -217,7 +217,7 @@ describe('comfy/no-duplicate-ingest-type', () => {
     writeFileSync(path.join(vueProbeDir, 'Probe.vue'), vueProbe)
     writeFileSync(path.join(browserTestProbeDir, 'probe.ts'), browserTestProbe)
 
-    findings = lint(['src', 'browser_tests'])
+    findings = lint([tsProbeDir, vueProbeDir, browserTestProbeDir])
   })
 
   afterAll(() => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -8,6 +8,7 @@ import DOMPurify from 'dompurify'
 import { clearRegisteredLiteGraphTypes } from '@/lib/litegraph/src/litegraphInstance'
 
 beforeEach(() => {
+  vi.stubGlobal('__VUE_DEVTOOLS_GLOBAL_HOOK__', { emit: vi.fn() })
   setActivePinia(createTestingPinia({ stubActions: false }))
 })
 


### PR DESCRIPTION
## Summary

Consolidate the measured unit-test speedups into one test-only PR. Production code and the global fake-timer default are unchanged.

## Changes

- Use real timers in 12 interaction suites, retaining Composer's fake-timer insertion contract. Provide a test-only devtools hook so Vue's first-render discovery timer cannot contaminate that assertion.
- Run the Oxlint integration test against its six fixtures in their original directories, using the repository config and all 17 existing assertions.
- Replace search/pricing sleeps with explicit debounce advancement and observable completion. Remove minimap waits and three assertion-free cases; add a connection-callback chaining assertion. Consolidates #16993, #16999, and #16995 without closing them.

Same-orb sequential measurements, retries disabled:

| Metric | Before | After |
|---|---:|---:|
| 17-file process wall, median of 3 runs | 17.26 s | 12.99 s, 24.7% lower |
| 17-file cumulative test/hook time | 69.52 s | 20.22 s, 70.9% lower |
| Full-suite process wall, median of 2 runs | 168.435 s | 168.350 s, effectively unchanged |

Full-suite import/transform work still dominates. These results do not demonstrate an end-to-end suite wall-time improvement.

## Review Focus

- Two full runs passed: 1,497 files, 20,199 passing tests, two expected failures, seven skipped. Net test count decreases by two due to the minimap changes.
- All 445 focused tests passed in three normal runs and shuffled seeds 17021, 2903, and 4127. The existing isolated Composer timer assertion fails on the base, passes with the hook, and still fails after a temporary delayed-focus mutation.
- Typecheck, full lint, targeted ESLint/format, knip, and diff checks pass. Full lint retains existing warnings.
- Async diagnostics are not clean: baseline reports 56 promises; after reports 55 promises plus two pending UI timeouts, with stacks pointing to Reka TagsInput's 1 ms focus and SearchInput's 300 ms debounce. Real timers expose these pending tasks. No recurring store timer was identified, and the Vue discovery timeout is absent. Production cleanup changes are not included here.
