### PR TITLE
docs: align command guidance with layout scope

### DIFF
--- a/.agents/checks/adr-compliance.md
+++ b/.agents/checks/adr-compliance.md
@@ -13,13 +13,12 @@ These are the primary architectural guardrails. Every entity/litegraph change mu
 
 ### Command Pattern (ADR-LAYOUT)
 
-All entity state mutations MUST be expressible as **serializable, idempotent, deterministic commands**. This is required for CRDT sync, undo/redo, cross-environment portability, and gateway backends.
+Durable entity-geometry mutations MUST flow through explicit, serializable `LayoutOperation` objects rather than direct property access. This requirement covers persistent node, group, and reroute geometry. It does not make commands mandatory for every entity mutation: non-layout stores currently expose direct actions, and graph operations still coordinate imperative class callbacks.
 
 Flag:
 
-- **Direct spatial mutation** — `node.pos = ...`, `node.size = ...`, `group.pos = ...` outside of a store or command. All spatial data flows through `layoutStore` commands.
-- **Imperative fire-and-forget mutation** — Any new API that mutates entity state as a side effect rather than producing a serializable command object. Systems should produce command batches, not execute mutations directly.
-- **Void-returning mutation APIs** — New entity mutation functions that return `void` instead of a result type (`{ status: 'applied' | 'rejected' | 'no-op' }`). Commands need error/rejection semantics.
+- **Direct durable spatial mutation** — `node.pos = ...`, `node.size = ...`, `group.pos = ...` outside of `layoutStore` operations.
+- **Bypassing layout operations** — New APIs that mutate persistent node, group, or reroute geometry without applying a `LayoutOperation`.
 - **Auto-incrementing IDs in new entity code** — New entity creation using auto-increment counters without acknowledging the CRDT collision problem. Concurrent environments need globally unique, stable identifiers.
 
 ### ECS Architecture (ADR-ECS)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ When working from a TDD or design doc, record its tradeoffs, alternatives consid
 
 ### Entity Architecture Constraints (ADR-CRDT-LAYOUT-0003 + ADR-ECS-0008)
 
-1. **Command pattern for all mutations**: Every entity state change must be a serializable, idempotent, deterministic command — replayable, undoable, and transmittable over CRDT. No imperative fire-and-forget mutation APIs. Systems produce command batches, not direct side effects.
+1. **Command pattern for durable layout mutations**: Persistent node, group, and reroute geometry changes must flow through serializable `LayoutOperation` objects rather than direct property access. Transient renderer measurements remain outside that command stream. Do not generalize layout command coverage to all ECS mutations; non-layout stores currently expose direct actions, and graph operations still coordinate imperative class callbacks.
 2. **Dedicated stores over instance state**: Entity data lives in dedicated Pinia stores keyed by each concern's established ID type. Most entity IDs are branded numbers; node IDs may be numbers or strings, graph IDs are UUID strings, and scoped concerns may use composite string keys such as `WidgetId` (`graphId:nodeId:name`, see `src/types/widgetId.ts`). Prefer a focused store to a single unified registry. Do not add new instance properties/methods to entity classes for data that belongs in a store. Do not use OOP inheritance for entity modeling.
 3. **No god-object growth**: Do not add methods to `LGraphNode`, `LGraphCanvas`, `LGraph`, or `Subgraph`. Extract to systems, stores, or composables.
 4. **Plain data components**: ECS components are plain data objects — no methods, no back-references to parent entities. Behavior belongs in systems (pure functions).


### PR DESCRIPTION
## ELI5

Two rulebooks currently disagree: the architecture docs and implementation apply command objects to durable layout geometry, while the review instructions require them for every entity change. This aligns the review instructions with the narrower, implemented boundary so valid non-layout store actions are not flagged.

## Motivation

The accepted layout and ECS guidance scopes current command-based mutation to persistent node, group, and reroute geometry, while explicitly allowing non-layout stores to expose direct actions. The root agent instructions and automated ADR checker still enforce an earlier universal rule and reject void-returning mutation APIs, even though `layoutStore.applyOperation()` itself returns `void`. That mismatch can produce false-positive architecture findings and push unrelated ECS changes toward infrastructure that is not part of the current migration phase. Synchronizing the enforcement text keeps reviews consistent without changing runtime behavior or architectural direction.

## Provenance

- **Authored by:** interactive session
- **Verified:** `pnpm exec oxfmt --check AGENTS.md .agents/checks/adr-compliance.md` passed; `git diff --check origin/main...HEAD` passed; the pre-push `knip --cache` hook completed successfully

## Reviewer context

- **Type:** hygiene, aligning repository review instructions with accepted architecture boundaries
- **Slots into:** ECS migration and CRDT-backed layout guidance
- **Not in scope:** changing ADRs, changing runtime behavior, or extending command infrastructure beyond layout

## Summary

- Scope the root command-pattern rule to persistent node, group, and reroute geometry handled through `LayoutOperation`.
- Preserve the boundary that transient renderer measurements remain outside the command stream.
- Stop the ADR checker from treating every non-layout direct action or `void`-returning mutation API as a command-pattern violation.
- Keep checks for direct durable geometry mutation and APIs that bypass layout operations.

## Changes

- **What:** Updated `AGENTS.md` and `.agents/checks/adr-compliance.md` only.

## Review Focus

Should we update these enforcement instructions to match the command scope already documented by the accepted ADRs and current implementation? If the broader all-entity rule is still intended as a current requirement, this PR should not merge.

## Test plan

- [x] Format-check both changed Markdown files.
- [x] Check the diff for whitespace errors.
- [x] Run the repository pre-push checks.
