### PR TITLE
fix: custom-node E2E S9/S3 and stale detection-proof patches

### DIFF
--- a/browser_tests/fixtures/customNode/allNodesExecutionTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesExecutionTier.ts
@@ -307,7 +307,7 @@ async function runBatch(
 ): Promise<string> {
   const batchWithInputs = batch.map((spec) => ({
     ...spec,
-    widgetInputs: packLedgerFor(AUTO_RUN_WIDGET_INPUTS, pack)[spec.key]
+    widgetInputs: packLedgerFor(AUTO_RUN_WIDGET_INPUTS, pack)[spec.key] ?? {}
   }))
   const { ids, allIds, nodeIdByKey, sinkIdByKey } = await page.evaluate(
     ([nodes, producers, spacingY]) => {

--- a/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
@@ -1,22 +1,23 @@
-diff --git a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-index e7e5549d59..4ca1314e3c 100644
---- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-@@ -316,4 +316,17 @@ export function computeProcessedWidgets({
-     isVisible: visible,
-     identity: { renderKey }
-   } of uniqueWidgets) {
-+    // DETECTION PROOF (row 2, mount v2): hide ImpactInt's value widget only
-+    // in Vue Nodes. Expected: S2 red and every other tier remains green.
-+    const detectionProofTier = (
-+      globalThis as {
-+        __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
-+      }
-+    ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
-+    if (
-+      detectionProofTier === 'S2' &&
-+      nodeData.type === 'ImpactInt' &&
-+      widget.name === 'value'
-+    )
-+      continue
-     const bareWidgetId = stripGraphPrefix(widget.nodeId ?? nodeId)
+diff --git a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+index 7353a17825..728dc02cec 100644
+--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
++++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+@@ -356,6 +356,18 @@ function processWidget(
+   const widgetState = ctx.widgetValueStore.getWidget(id)
+   if (!widgetState) return null
+ 
++  const detectionProofTier = (
++    globalThis as {
++      __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
++    }
++  ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
++  if (
++    detectionProofTier === 'S2' &&
++    ctx.nodeData.type === 'ImpactInt' &&
++    widgetState.name === 'value'
++  )
++    return null
++
+   const liveWidget = ctx.liveWidgets.get(id)
+   const type = liveWidget?.type ?? widgetState.type
+   const renderState = ctx.widgetValueStore.getWidgetRenderState(id)

--- a/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
@@ -1,14 +1,11 @@
 diff --git a/src/lib/litegraph/src/LGraphNode.ts b/src/lib/litegraph/src/LGraphNode.ts
-index a928d93992..65563d0dd2 100644
+index 3fb1eec569..d423d34829 100644
 --- a/src/lib/litegraph/src/LGraphNode.ts
 +++ b/src/lib/litegraph/src/LGraphNode.ts
-@@ -987,7 +987,20 @@ export class LGraphNode
-         let i = 0
-         for (const widget of this.widgets ?? []) {
+@@ -1191,6 +1191,17 @@ export class LGraphNode
+         let positionalIndex = 0
+         for (const widget of this.widgets) {
            if (widget.serialize === false) continue
--          if (i >= info.widgets_values.length) break
-+          // DETECTION PROOF (row 3, persistence): ImpactInt drops its last
-+          // widget value. Expected: S3 red and every other tier remains green.
 +          const detectionProofTier = (
 +            globalThis as {
 +              __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
@@ -17,10 +14,9 @@ index a928d93992..65563d0dd2 100644
 +          if (
 +            detectionProofTier === 'S3' &&
 +            this.type === 'ImpactInt' &&
-+            i >= info.widgets_values.length - 1
++            positionalIndex >= (info.widgets_values ?? []).length - 1
 +          )
 +            break
-+          if (i >= info.widgets_values.length) break
-           widget.value = info.widgets_values[i++]
-         }
-       }
+           const restored = useWidgetValueStore().getRestoredWidgetValue(
+             graphId,
+             this.id,

--- a/scripts/cicd/custom-node-proof.test.ts
+++ b/scripts/cicd/custom-node-proof.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { mutateExecutionSource, proofIdentity } from './custom-node-proof'
@@ -42,5 +46,26 @@ NODE_CLASS_MAPPINGS = {"VHS_LoadAudioUpload": LoadAudioUpload}
         mutationDigest: 'bad'
       })
     ).toThrow(/digest/)
+  })
+
+  it('source patches apply to current src/', () => {
+    const directory = join(
+      'browser_tests',
+      'tests',
+      'customNodes',
+      'detection-proof'
+    )
+    const patches = readdirSync(directory).filter((name) =>
+      name.endsWith('.patch')
+    )
+    expect(patches.length).toBeGreaterThan(0)
+    for (const entry of patches) {
+      const result = spawnSync(
+        'git',
+        ['apply', '--check', join(directory, entry)],
+        { encoding: 'utf8' }
+      )
+      expect(result.status, `${entry}: ${result.stderr}`).toBe(0)
+    }
   })
 })

--- a/src/lib/litegraph/src/widgets/NumberWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.test.ts
@@ -1,0 +1,22 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { NumberWidget } from '@/lib/litegraph/src/widgets/NumberWidget'
+
+describe('NumberWidget', () => {
+  it('formats a non-numeric restored value without throwing', () => {
+    const widget = new NumberWidget(
+      {
+        type: 'number',
+        name: 'value',
+        value: fromAny('1.5'),
+        options: {},
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    expect(() => widget._displayValue).not.toThrow()
+    expect(widget._displayValue).toBe('1.500')
+  })
+})

--- a/src/lib/litegraph/src/widgets/NumberWidget.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.ts
@@ -12,7 +12,8 @@ export class NumberWidget
 
   override get _displayValue() {
     if (this.computedDisabled) return ''
-    return this.value.toFixed(
+    const value: unknown = this.value
+    return Number(value).toFixed(
       this.options.precision !== undefined ? this.options.precision : 3
     )
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Custom Nodes E2E red on `main` tip (`ca54f4bd`, [run 33957893453](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33957893453)). `#17063` (design-system 1.1.0) is discarded — it only bumped `packages/design-system/package.json`. The real break is `#16802` plus two stale detection-proof patches.

## Characterization

| Mode | Proof | Broken today | Change | Root cause |
| --- | --- | --- | --- | --- |
| Detection-proof row-02 | `git apply --check browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch` fails on `useProcessedWidgets.ts:316` | `computeProcessedWidgets` moved to `processedWidgetRenderModel.ts` | Retarget patch to `processWidget` at `processedWidgetRenderModel.ts:356` | Stale hunk, not product |
| Detection-proof row-03 | `git apply --check …/row-03-persistence-offbyone.patch` fails on `LGraphNode.ts:987` | Line 987 is now `onDrawTitleText`; restore lives at the widgetValueStore loop | Retarget patch to `LGraphNode.ts:1191` (`positionalIndex` restore) | Stale hunk, not product |
| S9 | `allNodes.spec.ts:61` / `allNodesExecutionTier.ts:329` `Object.entries(spec.widgetInputs)` | `TypeError: Cannot convert undefined or null to object` on KJNodes, essentials, VideoHelperSuite, Custom-Scripts | `allNodesExecutionTier.ts:310` default missing ledger rows to `{}` | `#16802` deleted `?? {}`. Playwright drops `undefined` on evaluate, so `Object.entries` throws |
| S3 / connectivity console | `allNodesRoundtripTier.ts:916` `console errors during save/reload with VueNodes=false`; connectivity sweep same stack | `TypeError: this.value.toFixed is not a function` in `NumberWidget._displayValue` (`NumberWidget.ts:13`) | Coerce through `unknown` then `Number()` at draw | `#16802` deleted `Number(this.value)` because the type says `number`; configure/custom nodes still restore non-numbers |
| S3 itools preview wait | `valueDrift.ts:152` `iToolsLoadImagePlus: expected $$canvas-image-preview after reload, observed [image,upload]` | Same S3 page as `basic_data_handling` NumberWidget console errors | No extra change | Same page as the draw throw. Treat as same root unless it remains after this lands |
| Proof independence / forbid | `(2/5, 9)` `S9 expected=2 unexpected=2`; `(x/5, 0)` forbid after suite fail | S3/S9 unexpected fails poison the independence gate | Same fixes | Same root, not a separate harness bug |

Row-01 and row-15 already applied on this SHA. No product behavior change for numeric values that are already numbers.

## Changes

- **What**: Restore S9 evaluate payload default; restore NumberWidget display coercion; retarget row-02/row-03 patches; add `git apply --check` coverage and a NumberWidget non-numeric display test.
- **Breaking**: none

## Review Focus

`NumberWidget._displayValue` is a persist/extension boundary. The declared `value: number` is what `#16802` trusted; the failing suite is the counter-example. Do not delete the `Number()` conversion again without a restore-time normalizer that covers custom-node configure.

## Test Plan

- [x] `git apply --check` on all four detection-proof source patches (also `git apply` in a throwaway worktree; each changes `src/`)
- [x] `pnpm test:unit src/lib/litegraph/src/widgets/NumberWidget.test.ts scripts/cicd/custom-node-proof.test.ts` (4 passed)
- [x] `pnpm lint` / `pnpm typecheck` (Node 25)
- [x] PR CI: Lint Format green; Tests Unit green
- [ ] Nightly / dispatch Custom Nodes path below (`CI: Tests Custom Nodes` does not run on PRs)

## Verify (human, minutes)

From repo root on this branch:

```bash
git apply --check browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
git apply --check browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
pnpm test:unit src/lib/litegraph/src/widgets/NumberWidget.test.ts scripts/cicd/custom-node-proof.test.ts
```

Expected: both `git apply --check` commands exit 0; 4 unit tests pass.

Focused Custom Nodes path that reproduces S9 / detection-proof (Actions → CI: Tests Custom Nodes → Run workflow):

- `detection_proof_row=9` — S9 witness shard. Expected: suite green except the deliberate VHS execution break; independence assert passes.
- `detection_proof_row=2` and `3` — patches apply; S2/S3 witness red and every other tier on that shard stays green.
- `detection_proof_row=0` on `core:1/2` and `2/5` — S9 and S3 (including VueNodes=false console) green.

Expected: those shards/cases green; no other product behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfef5889-11cf-45ef-b30a-5a0b7527fd98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfef5889-11cf-45ef-b30a-5a0b7527fd98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

