### PR TITLE
fix(litegraph): restore numeric coercion in slider, knob and gradient slider draw

### DIFF
--- a/src/lib/litegraph/src/widgets/GradientSliderWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/GradientSliderWidget.test.ts
@@ -1,0 +1,43 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { GradientSliderWidget } from './GradientSliderWidget'
+
+function fakeCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    font: '',
+    textAlign: '',
+    textBaseline: ''
+  } as unknown as CanvasRenderingContext2D
+}
+
+describe('GradientSliderWidget', () => {
+  it('draws a non-numeric restored value without throwing', () => {
+    const widget = new GradientSliderWidget(
+      {
+        type: 'gradientslider',
+        name: 'strength',
+        value: fromAny('0.5'),
+        options: { min: 0, max: 1, step2: 0.01 },
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    const ctx = fakeCtx()
+    expect(() => widget.drawWidget(ctx, { width: 200 })).not.toThrow()
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      'strength  0.500',
+      expect.any(Number),
+      expect.any(Number)
+    )
+  })
+})

--- a/src/lib/litegraph/src/widgets/GradientSliderWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/GradientSliderWidget.test.ts
@@ -40,4 +40,24 @@ describe('GradientSliderWidget', () => {
       expect.any(Number)
     )
   })
+
+  it('draws a numeric value with the same formatting', () => {
+    const widget = new GradientSliderWidget(
+      {
+        type: 'gradientslider',
+        name: 'strength',
+        value: 0.5,
+        options: { min: 0, max: 1, step2: 0.01 },
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    const ctx = fakeCtx()
+    widget.drawWidget(ctx, { width: 200 })
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      'strength  0.500',
+      expect.any(Number),
+      expect.any(Number)
+    )
+  })
 })

--- a/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
@@ -38,7 +38,8 @@ export class GradientSliderWidget
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = this.value.toFixed(this.options.precision ?? 3)
+      const rawValue: unknown = this.value
+      const fixedValue = Number(rawValue).toFixed(this.options.precision ?? 3)
       ctx.fillText(
         `${this.label || this.name}  ${fixedValue}`,
         width * 0.5,

--- a/src/lib/litegraph/src/widgets/KnobWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.test.ts
@@ -1,0 +1,55 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { KnobWidget } from './KnobWidget'
+
+function fakeGradient() {
+  return { addColorStop: vi.fn() } as unknown as CanvasGradient
+}
+
+function fakeCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    createConicGradient: vi.fn(fakeGradient),
+    createRadialGradient: vi.fn(fakeGradient),
+    lineWidth: 1,
+    fillStyle: '',
+    strokeStyle: '',
+    font: '',
+    textAlign: '',
+    textBaseline: ''
+  } as unknown as CanvasRenderingContext2D
+}
+
+describe('KnobWidget', () => {
+  it('draws a non-numeric restored value without throwing', () => {
+    const widget = new KnobWidget(
+      {
+        type: 'knob',
+        name: 'cfg',
+        value: fromAny('0.5'),
+        options: { min: 0, max: 1, step2: 0.01 },
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    const ctx = fakeCtx()
+    expect(() => widget.drawWidget(ctx, { width: 200 })).not.toThrow()
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      'cfg\n0.500',
+      expect.any(Number),
+      expect.any(Number)
+    )
+  })
+})

--- a/src/lib/litegraph/src/widgets/KnobWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.test.ts
@@ -52,4 +52,24 @@ describe('KnobWidget', () => {
       expect.any(Number)
     )
   })
+
+  it('draws a numeric value with the same formatting', () => {
+    const widget = new KnobWidget(
+      {
+        type: 'knob',
+        name: 'cfg',
+        value: 0.5,
+        options: { min: 0, max: 1, step2: 0.01 },
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    const ctx = fakeCtx()
+    widget.drawWidget(ctx, { width: 200 })
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      'cfg\n0.500',
+      expect.any(Number),
+      expect.any(Number)
+    )
+  })
 })

--- a/src/lib/litegraph/src/widgets/KnobWidget.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.ts
@@ -169,7 +169,8 @@ export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = this.value.toFixed(this.options.precision ?? 3)
+      const rawValue: unknown = this.value
+      const fixedValue = Number(rawValue).toFixed(this.options.precision ?? 3)
       ctx.fillText(
         `${this.label || this.name}\n${fixedValue}`,
         width * 0.5,

--- a/src/lib/litegraph/src/widgets/SliderWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.test.ts
@@ -1,0 +1,43 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { SliderWidget } from './SliderWidget'
+
+function fakeCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    font: '',
+    textAlign: '',
+    textBaseline: ''
+  } as unknown as CanvasRenderingContext2D
+}
+
+describe('SliderWidget', () => {
+  it('draws a non-numeric restored value without throwing', () => {
+    const widget = new SliderWidget(
+      {
+        type: 'slider',
+        name: 'denoise',
+        value: fromAny('0.5'),
+        options: { min: 0, max: 1, step2: 0.01 },
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    const ctx = fakeCtx()
+    expect(() => widget.drawWidget(ctx, { width: 200 })).not.toThrow()
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      'denoise  0.500',
+      expect.any(Number),
+      expect.any(Number)
+    )
+  })
+})

--- a/src/lib/litegraph/src/widgets/SliderWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.test.ts
@@ -40,4 +40,24 @@ describe('SliderWidget', () => {
       expect.any(Number)
     )
   })
+
+  it('draws a numeric value with the same formatting', () => {
+    const widget = new SliderWidget(
+      {
+        type: 'slider',
+        name: 'denoise',
+        value: 0.5,
+        options: { min: 0, max: 1, step2: 0.01 },
+        y: 0
+      },
+      new LGraphNode('TestNode')
+    )
+    const ctx = fakeCtx()
+    widget.drawWidget(ctx, { width: 200 })
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      'denoise  0.500',
+      expect.any(Number),
+      expect.any(Number)
+    )
+  })
 })

--- a/src/lib/litegraph/src/widgets/SliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.ts
@@ -59,7 +59,8 @@ export class SliderWidget
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = this.value.toFixed(this.options.precision ?? 3)
+      const rawValue: unknown = this.value
+      const fixedValue = Number(rawValue).toFixed(this.options.precision ?? 3)
       ctx.fillText(
         `${this.label || this.name}  ${fixedValue}`,
         width * 0.5,


### PR DESCRIPTION
## Summary

[#16802](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16802) enabled `typescript/no-unnecessary-type-conversion` and removed the `Number(...)` coercion at **four** widget draw sites. The red-`main` repair [#17067](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17067) restores it in `NumberWidget`; this restores the other three, so the defect class is closed rather than only its one observed instance.

| Site | Removed by #16802 | Restored by |
| --- | --- | --- |
| `NumberWidget._displayValue` | `Number(this.value).toFixed(...)` | [#17067](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17067) |
| `SliderWidget.drawWidget` | `Number(this.value).toFixed(...)` | this PR |
| `KnobWidget.drawWidget` | `Number(this.value).toFixed(...)` | this PR |
| `GradientSliderWidget.drawWidget` | `Number(this.value).toFixed(...)` | this PR |

## Why the type is not the contract here

`IBaseWidget['value']` declares `number`, which is what made the coercion look redundant to the rule. At runtime these widgets are populated from serialised workflows and custom-node definitions, so a string reaches `toFixed` and throws `TypeError: this.value.toFixed is not a function`. Because this happens inside `drawWidget`, it surfaces as an *uncaught page error* on canvas render rather than a caught failure, which is how the custom-node E2E console-error collector reports it.

The `NumberWidget` instance of this is currently red on `main` ([run 33957893453](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33957893453), `ca54f4bd2e`). The three sites here are latent only because the nightly corpus exercises the number path; nothing prevents a slider or knob from being restored with a non-numeric value.

## Changes

- Restore the coercion in `SliderWidget`, `KnobWidget` and `GradientSliderWidget`, using the same `const rawValue: unknown = this.value` idiom #17067 uses so the conversion is not re-flagged as unnecessary.
- Add a regression test per widget driving `drawWidget` with a non-numeric value.

Disjoint from #17067's files, so the two do not conflict and can land in either order.

## Review Focus

Whether coercing at the draw site is the right boundary, or whether these values should instead be normalised on restore so the declared `number` type is actually honoured. This PR deliberately matches #17067 rather than diverging from an in-flight red-`main` fix; a normalise-on-restore change would supersede both and is worth doing separately.

## Evidence

Failing first, with only the tests applied and the three source files at `main`:

```
FAIL src/lib/litegraph/src/widgets/GradientSliderWidget.test.ts
FAIL src/lib/litegraph/src/widgets/KnobWidget.test.ts
FAIL src/lib/litegraph/src/widgets/SliderWidget.test.ts
  AssertionError: expected [Function] to not throw an error but
  'TypeError: this.value.toFixed is not a function' was thrown
Test Files  3 failed (3) | Tests  3 failed (3)
```

That is the same error string the nightly connectivity sweep reports.

With the fix (Node 25, `NODE_OPTIONS=--no-experimental-webstorage`):

- `vitest run src/lib/litegraph/src/widgets/` — 9 files, 80 tests passed
- `vue-tsc --noEmit` — exit 0
- `oxfmt --check`, `oxlint`, `eslint` over all six touched files — exit 0 each
- commit hooks (oxfmt, oxlint type-aware, eslint, typecheck) — passed
