### PR TITLE
fix: preserve legacy numeric widget rendering

### DIFF
--- a/src/lib/litegraph/src/utils/widget.test.ts
+++ b/src/lib/litegraph/src/utils/widget.test.ts
@@ -7,6 +7,7 @@ import {
   getWidgetStep,
   resolveNodeRootGraphId
 } from '@/lib/litegraph/src/litegraph'
+import { formatNumericWidgetValue } from '@/lib/litegraph/src/utils/widget'
 
 describe('getWidgetStep', () => {
   test('should return step2 when available', () => {
@@ -45,6 +46,15 @@ describe('getWidgetStep', () => {
     }
 
     expect(getWidgetStep(optionsWithZeroStep)).toBe(1)
+  })
+})
+
+describe('formatNumericWidgetValue', () => {
+  test.each<[string, unknown]>([
+    ['symbol', Symbol('legacy')],
+    ['object without primitive conversion', Object.create(null)]
+  ])('formats %s coercion failures as NaN', (_label, value) => {
+    expect(formatNumericWidgetValue(value)).toBe('NaN')
   })
 })
 

--- a/src/lib/litegraph/src/utils/widget.ts
+++ b/src/lib/litegraph/src/utils/widget.ts
@@ -18,6 +18,26 @@ export function getWidgetStep(options: IWidgetOptions): number {
   return options.step2 || (options.step || 10) * 0.1
 }
 
+/**
+ * Formats a numeric widget value for legacy canvas rendering.
+ *
+ * Persisted workflows and extension-provided widgets can contain values that do
+ * not match the current numeric widget type. Keep coercion at this runtime
+ * boundary so an invalid value cannot throw and stop the canvas render loop.
+ */
+export function formatNumericWidgetValue(
+  value: unknown,
+  precision = 3
+): string {
+  let numericValue: number
+  try {
+    numericValue = Number(value)
+  } catch {
+    numericValue = Number.NaN
+  }
+  return numericValue.toFixed(precision)
+}
+
 export function evaluateInput(input: string): number | undefined {
   const result = evaluateMathExpression(input)
   if (result !== undefined) {

--- a/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
@@ -1,6 +1,7 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { IGradientSliderWidget } from '@/lib/litegraph/src/types/widgets'
+import { formatNumericWidgetValue } from '@/lib/litegraph/src/utils/widget'
 
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -38,7 +39,10 @@ export class GradientSliderWidget
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = this.value.toFixed(this.options.precision ?? 3)
+      const fixedValue = formatNumericWidgetValue(
+        this.value,
+        this.options.precision ?? 3
+      )
       ctx.fillText(
         `${this.label || this.name}  ${fixedValue}`,
         width * 0.5,

--- a/src/lib/litegraph/src/widgets/KnobWidget.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.ts
@@ -1,7 +1,10 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { IKnobWidget } from '@/lib/litegraph/src/types/widgets'
-import { getWidgetStep } from '@/lib/litegraph/src/utils/widget'
+import {
+  formatNumericWidgetValue,
+  getWidgetStep
+} from '@/lib/litegraph/src/utils/widget'
 
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -169,7 +172,10 @@ export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = this.value.toFixed(this.options.precision ?? 3)
+      const fixedValue = formatNumericWidgetValue(
+        this.value,
+        this.options.precision ?? 3
+      )
       ctx.fillText(
         `${this.label || this.name}\n${fixedValue}`,
         width * 0.5,

--- a/src/lib/litegraph/src/widgets/NumberWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { NumberWidget } from '@/lib/litegraph/src/widgets/NumberWidget'
+
+function createWidget(): { node: LGraphNode; widget: NumberWidget } {
+  const node = new LGraphNode('TestNode')
+  const widget = new NumberWidget(
+    {
+      type: 'number',
+      name: 'test',
+      value: 1,
+      options: { precision: 3 },
+      y: 0
+    },
+    node
+  )
+  node.addCustomWidget(widget)
+  return { node, widget }
+}
+
+function persistedNode(value: TWidgetValue): ISerialisedNode {
+  return {
+    id: 1,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    widgets_values: [value]
+  }
+}
+
+describe('NumberWidget', () => {
+  describe('_displayValue', () => {
+    it.each<[TWidgetValue, string]>([
+      ['both', 'NaN'],
+      [true, '1.000'],
+      ['', '0.000']
+    ])(
+      'coerces persisted non-number value %j before formatting without mutating it',
+      (value, expected) => {
+        const { node, widget } = createWidget()
+        node.configure(persistedNode(value))
+
+        expect(widget._displayValue).toBe(expected)
+        expect(widget.value).toBe(value)
+      }
+    )
+
+    it('preserves numeric formatting', () => {
+      const { widget } = createWidget()
+
+      expect(widget._displayValue).toBe('1.000')
+      expect(widget.value).toBe(1)
+    })
+  })
+})

--- a/src/lib/litegraph/src/widgets/NumberWidget.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.ts
@@ -1,5 +1,9 @@
 import type { INumericWidget } from '@/lib/litegraph/src/types/widgets'
-import { evaluateInput, getWidgetStep } from '@/lib/litegraph/src/utils/widget'
+import {
+  evaluateInput,
+  formatNumericWidgetValue,
+  getWidgetStep
+} from '@/lib/litegraph/src/utils/widget'
 
 import { BaseSteppedWidget } from './BaseSteppedWidget'
 import type { WidgetEventOptions } from './BaseWidget'
@@ -12,7 +16,8 @@ export class NumberWidget
 
   override get _displayValue() {
     if (this.computedDisabled) return ''
-    return this.value.toFixed(
+    return formatNumericWidgetValue(
+      this.value,
       this.options.precision !== undefined ? this.options.precision : 3
     )
   }

--- a/src/lib/litegraph/src/widgets/SliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.ts
@@ -1,6 +1,7 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { ISliderWidget } from '@/lib/litegraph/src/types/widgets'
+import { formatNumericWidgetValue } from '@/lib/litegraph/src/utils/widget'
 
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -59,7 +60,10 @@ export class SliderWidget
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = this.value.toFixed(this.options.precision ?? 3)
+      const fixedValue = formatNumericWidgetValue(
+        this.value,
+        this.options.precision ?? 3
+      )
       ctx.fillText(
         `${this.label || this.name}  ${fixedValue}`,
         width * 0.5,


### PR DESCRIPTION
## Summary

Restore runtime numeric coercion at the legacy canvas-widget rendering boundary.

`#16802` changed numeric widget display formatting from `Number(this.value).toFixed(...)` to `this.value.toFixed(...)` because the static widget types declare numeric values. Persisted workflows and extension/custom-node state can still violate that type at runtime. In a reproduced legacy workflow, a `NumberWidget` restored the string `"both"` and boolean `true` from stale positional widget values; `NumberWidget._displayValue` then threw `TypeError: this.value.toFixed is not a function`. Because the exception escapes the main canvas draw path, the canvas render loop stops while unrelated application state remains alive.

## Changes

- add `formatNumericWidgetValue(value: unknown, precision)` as the explicit persisted/extension compatibility boundary
- guard `Number(value)` so values such as `Symbol` or objects without primitive conversion fall back to `NaN` instead of throwing during rendering
- use the helper in all four canvas numeric widgets whose `Number(...)` coercion was removed by #16802:
  - `NumberWidget`
  - `SliderWidget`
  - `GradientSliderWidget`
  - `KnobWidget`
- add focused `NumberWidget` coverage that restores malformed, boolean, empty-string, and normal numeric values through the real `LGraphNode.configure()` persisted-workflow path before rendering
- assert display formatting does not mutate the restored widget value
- add utility coverage for coercion failures (`Symbol` and an object without primitive conversion)

The helper preserves the pre-#16802 rendering tolerance without weakening the live widget types or suppressing `no-unnecessary-type-conversion`. It only affects display formatting; it does not mutate or silently repair persisted widget state.

## Regression behavior

Before #16802, malformed legacy values were coerced for display (`Number("both") -> NaN`, `Number(true) -> 1`) and did not abort rendering. After #16802, direct `.toFixed()` on those values throws and can freeze the main canvas.

This restores the previous rendering tolerance while leaving the underlying workflow/custom-node migration problem visible to the owning node.

## Regression coverage

The regression is synchronous and isolated to LiteGraph widget restoration plus numeric display formatting. The unit test uses the real `LGraphNode.configure()` persisted-workflow restoration path and then reads the concrete `NumberWidget` display value, which directly covers the failing boundary without depending on an external custom node or a browser workflow fixture. A browser E2E test would duplicate that same path while adding custom-node/workflow-fixture coupling, so no `browser_tests/` case is added here.

PR title: `fix: preserve legacy numeric widget rendering`

Commit subject: `fix: preserve legacy numeric widget rendering`

## Validation

- based on current `main@96f4a09a570d1bca4cd10c8407ed8e5c20a23875`
- PR head is exactly one commit ahead of the current base
- regression coverage includes the reproduced `"both"` and `true` values, an empty-string/null-like case, normal numeric formatting, state preservation, and coercion failures that previously could still throw
- fork PR workflows require maintainer approval before hosted jobs can execute; until approved, executable CI remains pending