### PR TITLE
fix: report stable native Datadog error types

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -16,8 +16,9 @@
   })
   ```
 
-  `errorType` is a stable slug. It lands as the `error_type` Sentry tag and the
-  `error_type` RUM context field, so one query works against either console.
+  `errorType` is a stable slug. It lands as native RUM `error.type` and the
+  `error_type` Sentry tag. The legacy `error_type` RUM context field is retained
+  for existing queries; prefer `@error.type` for new Datadog queries.
   Pick a slug that names the failure, not the symptom, and reuse the existing
   one if the failure already has a name.
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -12,15 +12,33 @@
 
   ```typescript
   reportError(error, {
-    errorType: 'workspace_auth_gate_initialization_failure'
+    errorType: 'failure_initializing_workspace_auth_gate'
   })
   ```
 
   `errorType` is a stable slug. It lands as native RUM `error.type` and the
   `error_type` Sentry tag. The legacy `error_type` RUM context field is retained
   for existing queries; prefer `@error.type` for new Datadog queries.
-  Pick a slug that names the failure, not the symptom, and reuse the existing
-  one if the failure already has a name.
+
+### Error Type Naming
+
+- Name error types from generic to specific in lowercase `snake_case`:
+  `<category>_<operation>_<subject>[_detail]`. Put the category first, then
+  the operation as a present participle, then the affected subject so related
+  failures sort together.
+- Examples: `error_loading_resource`, `error_loading_asset`,
+  `error_rendering_foo`, `error_rendering_bar`, and
+  `failure_initializing_workspace_auth_gate`. Here `workspace_auth_gate`
+  names the `WorkspaceAuthGate` component and stays together as one subject.
+- Search existing `errorType` values before adding one. Reuse the same slug
+  for the same failure mode across call sites. Keep vocabulary consistent
+  within a family; do not introduce synonyms such as `error_loading_asset`
+  and `failure_loading_asset` for the same failure.
+- Keep filenames, timestamps, IDs, URLs, and other instance-specific values
+  in the error message or context, never in the type.
+- Treat existing emitted types as telemetry contracts. Rename them only with
+  a migration of affected queries and alerts that accounts for old and new
+  releases reporting different names.
 
 ## Security
 

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -49,11 +49,44 @@ describe('reportError', () => {
       })
     )
     expect(addError).toHaveBeenCalledWith(
-      error,
+      expect.objectContaining({
+        name: 'workspace_auth_gate_initialization_failure',
+        message: error.message
+      }),
       expect.objectContaining({
         error_type: 'workspace_auth_gate_initialization_failure'
       })
     )
+  })
+
+  it('names a Datadog copy without changing the original error', async () => {
+    const { reportError } = await loadReportError()
+    const cause = new Error('Connection closed')
+    const error = Object.freeze(
+      Object.assign(
+        new TypeError('Failed to fetch /assets/app-123.js', { cause }),
+        {
+          dd_fingerprint: 'asset_load',
+          dd_context: { asset: '/assets/app-123.js' }
+        }
+      )
+    )
+
+    reportError(error, { errorType: 'resource_load_error' })
+
+    const [datadogError] = addError.mock.calls[0]
+    expect(datadogError).toBeInstanceOf(Error)
+    expect(datadogError).not.toBe(error)
+    expect(datadogError).toMatchObject({
+      name: 'resource_load_error',
+      message: error.message,
+      stack: error.stack,
+      cause,
+      dd_fingerprint: error.dd_fingerprint,
+      dd_context: error.dd_context
+    })
+    expect(captureException.mock.calls[0][0]).toBe(error)
+    expect(error.name).toBe('TypeError')
   })
 
   it('still reports to Datadog when Sentry is inert', async () => {
@@ -78,7 +111,10 @@ describe('reportError', () => {
     flushErrorReports()
 
     expect(addError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'early' }),
+      expect.objectContaining({
+        name: 'resource_load_error',
+        message: 'early'
+      }),
       expect.objectContaining({ error_type: 'resource_load_error' })
     )
   })
@@ -118,7 +154,10 @@ describe('reportError', () => {
     reportError('just a string', { errorType: 'bootstrap_auth_wait_timeout' })
 
     expect(addError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'just a string' }),
+      expect.objectContaining({
+        name: 'bootstrap_auth_wait_timeout',
+        message: 'just a string'
+      }),
       expect.anything()
     )
   })

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -8,8 +8,8 @@ import { toError } from '@/utils/errorUtil'
 export interface ReportErrorOptions {
   /**
    * Stable machine-readable slug for this failure mode. Lands as the
-   * `error_type` Sentry tag and the `error_type` RUM context field, so the
-   * same query works against either console.
+   * native RUM `error.type`, the `error_type` Sentry tag, and the legacy
+   * `error_type` RUM context field.
    */
   errorType: string
   tags?: Record<string, string | number | boolean | undefined>
@@ -55,7 +55,12 @@ function dispatch(error: Error, options: ReportErrorOptions): boolean {
     })
   }
   if (datadogLive) {
-    datadogRum.addError(error, {
+    const datadogError = Object.assign(
+      new Error(error.message, { cause: error.cause }),
+      error,
+      { name: errorType, stack: error.stack }
+    )
+    datadogRum.addError(datadogError, {
       ...context,
       ...tags,
       error_type: errorType,


### PR DESCRIPTION
## Summary

Set the Datadog error copy's `name` from `reportError()`'s stable `errorType`, so custom errors can be grouped by native `@error.type` instead of `@context.error_type`.

## Changes

- Preserve the message, stack, cause, custom metadata, and original Sentry exception; retain legacy RUM context for existing dashboards.
- Cover direct, buffered, string, and frozen errors; update instrumentation guidance.
- Require generic-to-specific error slugs (`<category>_<operation>_<subject>[_detail]`), consistent vocabulary, and reuse of existing failure names. Example: `failure_initializing_workspace_auth_gate`. Existing emitted slugs require a coordinated query/alert migration before renaming.

## Review Focus

Native error types change for new custom reports, which can create new Error Tracking issue groups. Dashboard companion: https://github.com/Comfy-Org/comfy-infra/pull/1106. Switch that dashboard to native types after the frontend change reaches both stable and canary.

Validation: 22 focused tests, typecheck, lint (existing warnings), knip, formatting, and commit hooks passed. A check using Datadog SDK 6.33.0 confirmed different filenames/timestamps emit the same native error type. The naming-rule follow-up changes documentation only; formatting and commit/push hooks passed. No UI changes.

Created by Codex