### PR TITLE
PM-921: test(agent): characterize an uncommitted agent build turn

### DIFF
--- a/browser_tests/tests/agent/agentGraphMutation.spec.ts
+++ b/browser_tests/tests/agent/agentGraphMutation.spec.ts
@@ -88,6 +88,7 @@ test.describe(
 
       ws.send(JSON.stringify(GRAPH_SUBSCRIBED_EVENT))
       ws.send(JSON.stringify(GRAPH_UPDATE_EVENT))
+      await comfyPage.vueNodes.waitForNodes()
       await expect(
         comfyPage.vueNodes.getNodeByTitle('Agent-created node')
       ).toBeVisible()

--- a/browser_tests/tests/agent/agentGraphMutation.spec.ts
+++ b/browser_tests/tests/agent/agentGraphMutation.spec.ts
@@ -1,0 +1,78 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import type { AgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
+
+import { agentTest, bootAgentApp } from '@e2e/fixtures/agentPanelFixture'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import {
+  BUILD_VIDEO_GRAPH_TOOL_EVENT,
+  MESSAGE_DONE_EVENT,
+  TURN_ACCEPTED,
+  VIDEO_GRAPH_DONE_EVENT
+} from '@e2e/tests/agent/agentPanelMocks'
+
+const test = mergeTests(agentTest, webSocketFixture)
+
+test.describe('In-App Agent graph mutations', { tag: '@cloud' }, () => {
+  test.use({ connectWebSocketToServer: false })
+
+  test.beforeEach(async ({ page, agentFlagEnabled }) => {
+    await page.route('**/api/agent/threads/*/messages', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          ...jsonRoute(TURN_ACCEPTED),
+          status: 202
+        })
+      }
+      return route.fulfill(jsonRoute([]))
+    })
+    await bootAgentApp(page, agentFlagEnabled)
+    await page.evaluate(() => window.app!.graph.clear())
+  })
+
+  test('GM-96 keeps a completed graph-building turn in sync with the canvas', async ({
+    page,
+    getWebSocket
+  }) => {
+    expect(await page.evaluate(() => window.app!.graph.nodes.length)).toBe(0)
+
+    await page
+      .getByRole('button', { name: enMessages.agent.askComfyAgent })
+      .click()
+
+    const panel = page.locator('#agent-panel-root')
+    const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+    await composer.fill('Build a Wan 2.2 two-stage video graph')
+
+    const post = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes('/api/agent/threads/') &&
+        request.url().endsWith('/messages')
+    )
+    const ws = await getWebSocket()
+    await panel.getByRole('button', { name: 'Send' }).click()
+    expect((await post).postData()).toContain(
+      'Build a Wan 2.2 two-stage video graph'
+    )
+    await expect(composer).toHaveValue('')
+
+    for (const event of [
+      BUILD_VIDEO_GRAPH_TOOL_EVENT,
+      VIDEO_GRAPH_DONE_EVENT,
+      MESSAGE_DONE_EVENT
+    ] satisfies AgentWsEvent[]) {
+      ws.send(JSON.stringify(event))
+    }
+
+    await expect(
+      panel.getByText('The Wan 2.2 two-stage graph is ready.')
+    ).toBeVisible()
+    await expect
+      .poll(() => page.evaluate(() => window.app!.graph.nodes.length))
+      .toBeGreaterThanOrEqual(1)
+  })
+})

--- a/browser_tests/tests/agent/agentGraphMutation.spec.ts
+++ b/browser_tests/tests/agent/agentGraphMutation.spec.ts
@@ -1,3 +1,4 @@
+import type { Page, WebSocketRoute } from '@playwright/test'
 import { expect, mergeTests } from '@playwright/test'
 
 import { webSocketFixture } from '@e2e/fixtures/ws'
@@ -5,74 +6,111 @@ import { webSocketFixture } from '@e2e/fixtures/ws'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import type { AgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
-import { agentTest, bootAgentApp } from '@e2e/fixtures/agentPanelFixture'
-import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
 import {
   BUILD_VIDEO_GRAPH_TOOL_EVENT,
   MESSAGE_DONE_EVENT,
-  TURN_ACCEPTED,
-  VIDEO_GRAPH_DONE_EVENT
+  VIDEO_GRAPH_DONE_EVENT,
+  VIDEO_GRAPH_DONE_TEXT,
+  agentTest
 } from '@e2e/tests/agent/agentPanelMocks'
 
 const test = mergeTests(agentTest, webSocketFixture)
 
+const OPEN_AGENT_LABEL = enMessages.agent.askComfyAgent
+const BUILD_PROMPT = 'Build a Wan 2.2 two-stage video graph'
+
+function pushEvent(ws: WebSocketRoute, event: AgentWsEvent): void {
+  ws.send(JSON.stringify(event))
+}
+
+/**
+ * Graph-mutation QA cases (GM-*) from the 2026-09-05 in-house eval. The
+ * zero-nodes build report is GM-96 / GM-99, tracked as PM-921.
+ *
+ * `agent_tool_call` is a transcript event: it renders a tool row and never
+ * reaches the graph. Mutations travel the CRDT path instead — doc frames on the
+ * same `/ws` connection, through `docFrameClient` to `agentNodeMaterializer`.
+ * The `add_node` in a tool-call event and the `add_node` in the op vocabulary
+ * (`crdt/graphOperations.ts`) are unrelated things sharing a name, so a
+ * successful tool call is not evidence that anything was committed. These cases
+ * drive the shape the eval captured: a turn that reports a finished build while
+ * delivering no doc frames.
+ */
 test.describe('In-App Agent graph mutations', { tag: '@cloud' }, () => {
   test.use({ connectWebSocketToServer: false })
 
-  test.beforeEach(async ({ page, agentFlagEnabled }) => {
-    await page.route('**/api/agent/threads/*/messages', (route) => {
-      if (route.request().method() === 'POST') {
-        return route.fulfill({
-          ...jsonRoute(TURN_ACCEPTED),
-          status: 202
-        })
-      }
-      return route.fulfill(jsonRoute([]))
-    })
-    await bootAgentApp(page, agentFlagEnabled)
-    await page.evaluate(() => window.app!.graph.clear())
-  })
-
-  test('GM-96 keeps a completed graph-building turn in sync with the canvas', async ({
-    page,
-    getWebSocket
-  }) => {
-    expect(await page.evaluate(() => window.app!.graph.nodes.length)).toBe(0)
-
-    await page
-      .getByRole('button', { name: enMessages.agent.askComfyAgent })
-      .click()
-
+  async function runUncommittedBuildTurn(
+    page: Page,
+    ws: WebSocketRoute,
+    postedMessages: string[]
+  ) {
     const panel = page.locator('#agent-panel-root')
     const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
-    await composer.fill('Build a Wan 2.2 two-stage video graph')
 
-    const post = page.waitForRequest(
-      (request) =>
-        request.method() === 'POST' &&
-        request.url().includes('/api/agent/threads/') &&
-        request.url().endsWith('/messages')
-    )
-    const ws = await getWebSocket()
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+    await expect(panel).toBeVisible()
+
+    await composer.fill(BUILD_PROMPT)
     await panel.getByRole('button', { name: 'Send' }).click()
-    expect((await post).postData()).toContain(
-      'Build a Wan 2.2 two-stage video graph'
-    )
+    await expect.poll(() => postedMessages.length).toBeGreaterThanOrEqual(1)
+    expect(postedMessages[0]).toContain(BUILD_PROMPT)
     await expect(composer).toHaveValue('')
 
-    for (const event of [
-      BUILD_VIDEO_GRAPH_TOOL_EVENT,
-      VIDEO_GRAPH_DONE_EVENT,
-      MESSAGE_DONE_EVENT
-    ] satisfies AgentWsEvent[]) {
-      ws.send(JSON.stringify(event))
-    }
-
+    pushEvent(ws, BUILD_VIDEO_GRAPH_TOOL_EVENT)
     await expect(
-      panel.getByText('The Wan 2.2 two-stage graph is ready.')
+      panel.getByRole('button', { name: 'Ran 1 tool call for 2.1 seconds' })
     ).toBeVisible()
-    await expect
-      .poll(() => page.evaluate(() => window.app!.graph.nodes.length))
-      .toBeGreaterThanOrEqual(1)
+
+    pushEvent(ws, VIDEO_GRAPH_DONE_EVENT)
+    await expect(panel.getByText(VIDEO_GRAPH_DONE_TEXT)).toBeVisible()
+
+    // Settle the turn so the node count is not read against an in-flight apply.
+    pushEvent(ws, MESSAGE_DONE_EVENT)
+    await expect(panel.getByRole('button', { name: 'Send' })).toBeVisible()
+    await expect(panel.getByRole('button', { name: 'Stop' })).toHaveCount(0)
+
+    return panel
+  }
+
+  test('GM-96 / PM-921 leaves the canvas empty when a build turn commits no graph operations', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket
+  }) => {
+    await comfyPage.nodeOps.clearGraph()
+    expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
+
+    const ws = await getWebSocket()
+    await runUncommittedBuildTurn(comfyPage.page, ws, postedMessages)
+
+    expect(
+      await comfyPage.nodeOps.getGraphNodesCount(),
+      'a tool-call transcript event must not mutate the graph on its own'
+    ).toBe(0)
+  })
+
+  test('GM-96 / PM-921 does not present an uncommitted build as finished', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket
+  }) => {
+    test.fixme(
+      true,
+      'PM-921: the panel renders the completion copy verbatim and has no affordance for a build the agent claimed but never committed. The affordance is undesigned — see the PR Review Focus before implementing.'
+    )
+
+    await comfyPage.nodeOps.clearGraph()
+
+    const ws = await getWebSocket()
+    const panel = await runUncommittedBuildTurn(
+      comfyPage.page,
+      ws,
+      postedMessages
+    )
+
+    expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
+    await expect(
+      panel.getByTestId('agent-uncommitted-build-notice')
+    ).toBeVisible()
   })
 })

--- a/browser_tests/tests/agent/agentGraphMutation.spec.ts
+++ b/browser_tests/tests/agent/agentGraphMutation.spec.ts
@@ -1,13 +1,13 @@
-import type { Page, WebSocketRoute } from '@playwright/test'
 import { expect, mergeTests } from '@playwright/test'
 
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
-import type { AgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
 import {
   BUILD_VIDEO_GRAPH_TOOL_EVENT,
+  GRAPH_SUBSCRIBED_EVENT,
+  GRAPH_UPDATE_EVENT,
   MESSAGE_DONE_EVENT,
   VIDEO_GRAPH_DONE_EVENT,
   VIDEO_GRAPH_DONE_TEXT,
@@ -16,101 +16,81 @@ import {
 
 const test = mergeTests(agentTest, webSocketFixture)
 
-const OPEN_AGENT_LABEL = enMessages.agent.askComfyAgent
-const BUILD_PROMPT = 'Build a Wan 2.2 two-stage video graph'
+test.describe(
+  'In-App Agent graph mutations',
+  {
+    tag: ['@cloud', '@canvas', '@node']
+  },
+  () => {
+    test.use({ connectWebSocketToServer: false })
 
-function pushEvent(ws: WebSocketRoute, event: AgentWsEvent): void {
-  ws.send(JSON.stringify(event))
-}
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.nodeOps.clearGraph()
+    })
 
-/**
- * Graph-mutation QA cases (GM-*) from the 2026-09-05 in-house eval. The
- * zero-nodes build report is GM-96 / GM-99, tracked as PM-921.
- *
- * `agent_tool_call` is a transcript event: it renders a tool row and never
- * reaches the graph. Mutations travel the CRDT path instead — doc frames on the
- * same `/ws` connection, through `docFrameClient` to `agentNodeMaterializer`.
- * The `add_node` in a tool-call event and the `add_node` in the op vocabulary
- * (`crdt/graphOperations.ts`) are unrelated things sharing a name, so a
- * successful tool call is not evidence that anything was committed. These cases
- * drive the shape the eval captured: a turn that reports a finished build while
- * delivering no doc frames.
- */
-test.describe('In-App Agent graph mutations', { tag: '@cloud' }, () => {
-  test.use({ connectWebSocketToServer: false })
+    test('GM-96 / PM-921 does not present an uncommitted build as finished', async ({
+      comfyPage,
+      postedMessages,
+      getWebSocket
+    }) => {
+      const page = comfyPage.page
+      const ws = await getWebSocket()
+      const panel = page.locator('#agent-panel-root')
+      await page
+        .getByRole('button', { name: enMessages.agent.askComfyAgent })
+        .click()
+      await panel
+        .getByRole('textbox', { name: /^Describe ideas/ })
+        .fill('Build a Wan 2.2 two-stage video graph')
+      await panel.getByRole('button', { name: 'Send' }).click()
+      await expect.poll(() => postedMessages.length).toBe(1)
 
-  async function runUncommittedBuildTurn(
-    page: Page,
-    ws: WebSocketRoute,
-    postedMessages: string[]
-  ) {
-    const panel = page.locator('#agent-panel-root')
-    const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+      ws.send(JSON.stringify(BUILD_VIDEO_GRAPH_TOOL_EVENT))
+      await expect(
+        panel.getByRole('button', { name: 'Ran 1 tool call for 2.1 seconds' })
+      ).toBeVisible()
+      ws.send(JSON.stringify(VIDEO_GRAPH_DONE_EVENT))
+      ws.send(JSON.stringify(MESSAGE_DONE_EVENT))
+      await expect(panel.getByRole('button', { name: 'Send' })).toBeVisible()
 
-    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
-    await expect(panel).toBeVisible()
+      test.fail(
+        true,
+        'PM-921: the agent reports a build that was not committed'
+      )
+      await expect(panel.getByText(VIDEO_GRAPH_DONE_TEXT)).toBeHidden()
+    })
 
-    await composer.fill(BUILD_PROMPT)
-    await panel.getByRole('button', { name: 'Send' }).click()
-    await expect.poll(() => postedMessages.length).toBeGreaterThanOrEqual(1)
-    expect(postedMessages[0]).toContain(BUILD_PROMPT)
-    await expect(composer).toHaveValue('')
+    test('materializes a committed graph node on the canvas', async ({
+      comfyPage,
+      postedMessages,
+      getWebSocket
+    }) => {
+      const page = comfyPage.page
+      const ws = await getWebSocket()
+      const clientFrames: string[] = []
+      ws.onMessage((message) => clientFrames.push(message.toString()))
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
 
-    pushEvent(ws, BUILD_VIDEO_GRAPH_TOOL_EVENT)
-    await expect(
-      panel.getByRole('button', { name: 'Ran 1 tool call for 2.1 seconds' })
-    ).toBeVisible()
+      await page
+        .getByRole('button', { name: enMessages.agent.askComfyAgent })
+        .click()
+      const panel = page.locator('#agent-panel-root')
+      await panel
+        .getByRole('textbox', { name: /^Describe ideas/ })
+        .fill('Build a graph')
+      await panel.getByRole('button', { name: 'Send' }).click()
+      await expect.poll(() => postedMessages.length).toBe(1)
+      await expect
+        .poll(() =>
+          clientFrames.some((frame) => frame.includes('"type":"doc_subscribe"'))
+        )
+        .toBe(true)
 
-    pushEvent(ws, VIDEO_GRAPH_DONE_EVENT)
-    await expect(panel.getByText(VIDEO_GRAPH_DONE_TEXT)).toBeVisible()
-
-    // Settle the turn so the node count is not read against an in-flight apply.
-    pushEvent(ws, MESSAGE_DONE_EVENT)
-    await expect(panel.getByRole('button', { name: 'Send' })).toBeVisible()
-    await expect(panel.getByRole('button', { name: 'Stop' })).toHaveCount(0)
-
-    return panel
+      ws.send(JSON.stringify(GRAPH_SUBSCRIBED_EVENT))
+      ws.send(JSON.stringify(GRAPH_UPDATE_EVENT))
+      await expect(
+        comfyPage.vueNodes.getNodeByTitle('Agent-created node')
+      ).toBeVisible()
+    })
   }
-
-  test('GM-96 / PM-921 leaves the canvas empty when a build turn commits no graph operations', async ({
-    comfyPage,
-    postedMessages,
-    getWebSocket
-  }) => {
-    await comfyPage.nodeOps.clearGraph()
-    expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
-
-    const ws = await getWebSocket()
-    await runUncommittedBuildTurn(comfyPage.page, ws, postedMessages)
-
-    expect(
-      await comfyPage.nodeOps.getGraphNodesCount(),
-      'a tool-call transcript event must not mutate the graph on its own'
-    ).toBe(0)
-  })
-
-  test('GM-96 / PM-921 does not present an uncommitted build as finished', async ({
-    comfyPage,
-    postedMessages,
-    getWebSocket
-  }) => {
-    test.fixme(
-      true,
-      'PM-921: the panel renders the completion copy verbatim and has no affordance for a build the agent claimed but never committed. The affordance is undesigned — see the PR Review Focus before implementing.'
-    )
-
-    await comfyPage.nodeOps.clearGraph()
-
-    const ws = await getWebSocket()
-    const panel = await runUncommittedBuildTurn(
-      comfyPage.page,
-      ws,
-      postedMessages
-    )
-
-    expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
-    await expect(
-      panel.getByTestId('agent-uncommitted-build-notice')
-    ).toBeVisible()
-  })
-})
+)

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -1,4 +1,6 @@
+import { mint } from '@comfyorg/comfy-multi-player'
 import type { Page, Route } from '@playwright/test'
+import * as Y from 'yjs'
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 
@@ -16,6 +18,24 @@ import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
 const THREAD_ID = 'd4c016c4-3b8c-44cf-97de-1ae27e43e718'
 const TURN_ID = '3818ba00-d772-4a3f-98c1-9312725b577d'
 const WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
+
+const GRAPH_UPDATE = Y.encodeStateAsUpdate(
+  mint(
+    {
+      nodes: [
+        {
+          id: 1,
+          type: 'TestNode',
+          title: 'Agent-created node',
+          pos: [100, 100],
+          size: [240, 100]
+        }
+      ],
+      links: []
+    },
+    { types: {} }
+  )
+)
 
 const TURN_ACCEPTED: AgentTurnAccepted = {
   message_id: TURN_ID,
@@ -70,6 +90,22 @@ export const VIDEO_GRAPH_DONE_EVENT: AgentWsEvent = {
     delta: VIDEO_GRAPH_DONE_TEXT,
     message_id: TURN_ID,
     thread_id: THREAD_ID
+  }
+}
+
+export const GRAPH_SUBSCRIBED_EVENT = {
+  type: 'doc_subscribed',
+  data: { v: 1, workflow_id: WORKFLOW_ID, ok: true, seq: 0 }
+}
+
+export const GRAPH_UPDATE_EVENT = {
+  type: 'doc_update',
+  data: {
+    v: 1,
+    workflow_id: WORKFLOW_ID,
+    seq: 1,
+    update_b64: Buffer.from(GRAPH_UPDATE).toString('base64'),
+    actor: 'agent:test:build'
   }
 }
 

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -17,7 +17,7 @@ const THREAD_ID = 'd4c016c4-3b8c-44cf-97de-1ae27e43e718'
 const TURN_ID = '3818ba00-d772-4a3f-98c1-9312725b577d'
 const WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
 
-const TURN_ACCEPTED: AgentTurnAccepted = {
+export const TURN_ACCEPTED: AgentTurnAccepted = {
   message_id: TURN_ID,
   thread_id: THREAD_ID,
   workflow_id: WORKFLOW_ID
@@ -44,6 +44,28 @@ export const TOOL_CALL_EVENT: AgentWsEvent = {
     tool_name: 'set_widget',
     status: 'success',
     duration_ms: 1300,
+    message_id: TURN_ID,
+    thread_id: THREAD_ID
+  }
+}
+
+export const BUILD_VIDEO_GRAPH_TOOL_EVENT: AgentWsEvent = {
+  type: 'agent_tool_call',
+  data: {
+    tool_call_id: 'call-build-video-graph',
+    tool_name: 'add_node',
+    status: 'success',
+    duration_ms: 2100,
+    message_id: TURN_ID,
+    thread_id: THREAD_ID
+  }
+}
+
+export const VIDEO_GRAPH_DONE_EVENT: AgentWsEvent = {
+  type: 'agent_message_delta',
+  data: {
+    delta:
+      'The Wan 2.2 two-stage graph is ready. Empty Latent Video controls the 832x480 resolution, length 81, and CreateVideo runs at 16 fps.',
     message_id: TURN_ID,
     thread_id: THREAD_ID
   }

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -17,7 +17,7 @@ const THREAD_ID = 'd4c016c4-3b8c-44cf-97de-1ae27e43e718'
 const TURN_ID = '3818ba00-d772-4a3f-98c1-9312725b577d'
 const WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
 
-export const TURN_ACCEPTED: AgentTurnAccepted = {
+const TURN_ACCEPTED: AgentTurnAccepted = {
   message_id: TURN_ID,
   thread_id: THREAD_ID,
   workflow_id: WORKFLOW_ID
@@ -61,11 +61,13 @@ export const BUILD_VIDEO_GRAPH_TOOL_EVENT: AgentWsEvent = {
   }
 }
 
+export const VIDEO_GRAPH_DONE_TEXT =
+  'The Wan 2.2 two-stage graph is ready. Empty Latent Video controls the 832x480 resolution, length 81, and CreateVideo runs at 16 fps.'
+
 export const VIDEO_GRAPH_DONE_EVENT: AgentWsEvent = {
   type: 'agent_message_delta',
   data: {
-    delta:
-      'The Wan 2.2 two-stage graph is ready. Empty Latent Video controls the 832x480 resolution, length 81, and CreateVideo runs at 16 fps.',
+    delta: VIDEO_GRAPH_DONE_TEXT,
     message_id: TURN_ID,
     thread_id: THREAD_ID
   }


### PR DESCRIPTION
## Summary

Adds focused Playwright coverage for [PM-921](https://linear.app/comfyorg/issue/PM-921), where the agent reports a finished graph without committing it to the canvas.

## Changes

- **What**: Drives the failed build turn through the agent UI and marks the desired user-visible assertion with `test.fail()` until PM-921 is fixed.
- **What**: Adds a positive control that sends a real CRDT document update and verifies the committed node is visible on the canvas.
- **What**: Removes the negative zero-node assertion and speculative placeholder affordance.

## Review Focus

The expected-failure marker is placed immediately before the known failing assertion so setup and interaction regressions still fail normally. The positive control distinguishes PM-921 from a frontend that simply drops every valid graph update.

## Verification

- Focused cloud Playwright run: 2 passed (PM-921 expected failure plus positive control).
- `pnpm typecheck`
- `pnpm typecheck:browser`
- ESLint, oxlint, oxfmt, and knip hooks
