### PR TITLE
fix: guard tooltip lookup for stale inputs

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts
@@ -97,6 +97,14 @@ describe('useNodeTooltips', () => {
     expect(consoleError).not.toHaveBeenCalled()
   })
 
+  it('returns empty tooltips for inputs absent from the live node definition', () => {
+    const { getInputSlotTooltip, getWidgetTooltip } =
+      useNodeTooltips('SAM3_Detect')
+
+    expect(getInputSlotTooltip('stale_input')).toBe('')
+    expect(getWidgetTooltip({ name: 'stale_widget' })).toBe('')
+  })
+
   it('reads output slot tooltips without i18n placeholder errors', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { getOutputSlotTooltip } = useNodeTooltips('SAM3_Detect')

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -125,7 +125,7 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
       'tooltip',
       unref(nodeType),
       slotName,
-      nodeDef.value.inputs[slotName].tooltip
+      nodeDef.value.inputs[slotName]?.tooltip
     )
   }
 
@@ -158,7 +158,7 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
       'tooltip',
       unref(nodeType),
       widget.name,
-      nodeDef.value.inputs[widget.name].tooltip
+      nodeDef.value.inputs[widget.name]?.tooltip
     )
   }
 


### PR DESCRIPTION
## Summary

Restore runtime guards removed by #16802 for input and widget tooltip lookup. Serialized workflows can reference an input absent from the live node definition; that descriptor is then `undefined`, and reading `.tooltip` aborts node rendering.

Adds regression coverage for both stale input-slot and stale widget names.

Fixes PM-873
Fixes PM-904

## Verification

- `pnpm test:unit src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts --run`
- `pnpm exec oxfmt --check src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts`
- `pnpm exec oxlint src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts`
- `pnpm typecheck`
