### PR TITLE
fix(agent): close PR 16957 review findings

### DIFF
--- a/src/lib/litegraph/src/LGraph.failedConfigure.test.ts
+++ b/src/lib/litegraph/src/LGraph.failedConfigure.test.ts
@@ -14,10 +14,16 @@ import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { GraphScope } from '@/types/graphScopeId'
-import { graphScopeOf } from '@/types/graphScopeId'
+import {
+  graphScopeOf,
+  toOwningGraphId,
+  toRootGraphId
+} from '@/types/graphScopeId'
 import type { GroupId } from '@/types/groupId'
 import type { NodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
 import type { RerouteId } from '@/types/rerouteId'
+import { toRerouteId } from '@/types/rerouteId'
 import { widgetId } from '@/types/widgetId'
 import { createTestSubgraphData } from './subgraph/__fixtures__/subgraphHelpers'
 
@@ -372,32 +378,14 @@ describe('a workflow loaded after a failed load, on the same graph', () => {
     expect(graph.id).toBe(GOOD_ID)
   })
 
-  it('clears nested-owner state before loading the next workflow', () => {
-    const nested = graphAfterFailedConfigure(failingNestedWorkflow())
-    const definition = nested.subgraphs.get(NESTED_DEFINITION_ID)
-    if (!definition) throw new Error('Expected failed subgraph definition')
-
-    const scope = graphScopeOf(definition)
-    const nodeIds = definition.nodes.map((node) => node.id)
-    const linkIds = [...useLinkStore().graphTopologies(scope)].map(
-      (link) => link.id
-    )
-    const rerouteIds = [...definition.reroutes.keys()]
-    const widgetIds = nodeIds.flatMap((id) =>
-      useWidgetValueStore().getNodeWidgetIds(BAD_ID, id)
-    )
-
-    expect(storeOwnership(scope, nodeIds, rerouteIds, [])).toEqual({
-      nodes: nodeIds,
-      links: linkIds,
-      reroutes: rerouteIds,
-      nodeLayouts: nodeIds,
-      rerouteLayouts: rerouteIds,
-      groupLayouts: [],
-      widgets: widgetIds
-    })
-
-    nested.configure(unrelatedWorkflow())
+  it('clears nested-owner state when definition configuration fails', () => {
+    const graph = graphAfterFailedConfigure(failingNestedWorkflow())
+    const scope = {
+      rootGraphId: toRootGraphId(BAD_ID),
+      owningGraphId: toOwningGraphId(NESTED_DEFINITION_ID)
+    }
+    const nodeIds = [toNodeId(2), toNodeId(3)]
+    const rerouteIds = [toRerouteId(1)]
 
     expect(storeOwnership(scope, nodeIds, rerouteIds, [])).toEqual({
       nodes: [],
@@ -408,7 +396,7 @@ describe('a workflow loaded after a failed load, on the same graph', () => {
       groupLayouts: [],
       widgets: []
     })
-    expect(nested.subgraphs.has(NESTED_DEFINITION_ID)).toBe(false)
+    expect(graph.subgraphs.has(NESTED_DEFINITION_ID)).toBe(false)
   })
 
   it('does not retain unrecognised top-level workflow keys', () => {

--- a/src/lib/litegraph/src/LGraph.failedConfigure.test.ts
+++ b/src/lib/litegraph/src/LGraph.failedConfigure.test.ts
@@ -297,7 +297,7 @@ describe('LGraph.configure that throws partway through', () => {
     expect(configuredEvents).toBe(1)
   })
 
-  it('does not publish a nested definition whose configuration fails', () => {
+  it('rolls back a nested definition whose configuration fails', () => {
     const graph = new LGraph()
     const created: string[] = []
     graph.events.addEventListener('subgraph-created', (event) => {
@@ -307,7 +307,7 @@ describe('LGraph.configure that throws partway through', () => {
     expect(() => graph.configure(failingNestedWorkflow())).toThrow()
 
     expect(created).toEqual([])
-    expect(graph.subgraphs.has(NESTED_DEFINITION_ID)).toBe(true)
+    expect(graph.subgraphs.has(NESTED_DEFINITION_ID)).toBe(false)
     expect(graph.empty).toBe(true)
   })
 })

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2065,13 +2065,24 @@ export class LGraph
   }
 
   private createNormalizedSubgraphs(data: ExportedSubgraph[]): Subgraph[] {
-    const subgraphs = data.map((definition) =>
-      this.createNormalizedSubgraph(definition)
-    )
+    const subgraphs = new Map<string, Subgraph>()
     for (const definition of topologicalSortSubgraphs(data)) {
-      const subgraph = this.subgraphs.get(definition.id)
-      if (!subgraph) continue
-      subgraph.configure(definition)
+      const subgraph = this.createNormalizedSubgraph(definition)
+      subgraphs.set(definition.id, subgraph)
+      try {
+        subgraph.configure(definition)
+      } catch (error) {
+        try {
+          this.releaseSubgraphs([subgraph])
+        } catch (rollbackError) {
+          throw new AggregateError(
+            [error, rollbackError],
+            `Subgraph definition ${definition.id} failed to configure and roll back`,
+            { cause: rollbackError }
+          )
+        }
+        throw error
+      }
       // A listener can register global constructors and node definitions for
       // this subgraph. Do not expose it until configuration has succeeded.
       this.rootGraph.events.dispatch('subgraph-created', {
@@ -2079,7 +2090,10 @@ export class LGraph
         data: definition
       })
     }
-    return subgraphs
+    return data.flatMap((definition) => {
+      const subgraph = subgraphs.get(definition.id)
+      return subgraph ? [subgraph] : []
+    })
   }
 
   private createNormalizedSubgraph(normalized: ExportedSubgraph): Subgraph {

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -493,6 +493,22 @@ const zSubgraphDefinition = zComfyWorkflow1
   })
   .passthrough()
 
+export const zProjectedSubgraphDefinition = zSubgraphDefinition
+  .omit({ definitions: true, extra: true, id: true })
+  .extend({
+    id: z.string(),
+    extra: z.unknown().optional(),
+    nodes: z
+      .array(
+        zComfyNode.extend({
+          properties: zProperties.optional(),
+          widgets_values_named: z.record(z.unknown()).optional()
+        })
+      )
+      .optional(),
+    definitions: z.object({ subgraphs: z.array(z.unknown()) }).optional()
+  })
+
 export type ModelFile = z.infer<typeof zModelFile>
 export type ComfyLinkObject = z.infer<typeof zComfyLinkObject>
 export type ComfyNode = z.infer<typeof zComfyNode>

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -953,6 +953,30 @@ describe('reconcileAgentAdapters', () => {
       expect(reportError).not.toHaveBeenCalled()
     })
 
+    it('replaces a missing-node placeholder when its definition completes', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7)]
+      })
+      const { follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      const stored = follower.doc
+        .getMap<Y.Map<unknown>>('definitions')
+        .get(definition.id)
+      if (!stored) throw new Error('Expected stored definition')
+      stored.delete('state')
+
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+      expect(graph.getNodeById(toNodeId(1))?.has_errors).toBe(true)
+
+      reconcileAgentAdapters(graph, [definition])
+
+      expect(graph.getNodeById(toNodeId(1))).toBeInstanceOf(SubgraphNode)
+      expect(graph.getNodeById(toNodeId(1))?.has_errors).toBeFalsy()
+    })
+
     it('does not treat a definition payload as an edit to an existing subgraph', () => {
       const definition = createTestSubgraphData({
         nodes: [nodePayload(7)]

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts
@@ -142,10 +142,9 @@ function tryCreateSubgraph(
     withNamedValuesRestore(() => rootGraph.createSubgraph(definition))
     return undefined
   } catch (cause) {
-    // Configuration failed before `subgraph-created` was dispatched, so no
-    // app-owned node type exists. Tear the half-built graph down through the
-    // same path node removal uses: a bare map delete would leave its graph
-    // metadata behind, and the next attempt would remint its id.
+    // Tear the half-built graph down through the same path node removal uses:
+    // a bare map delete would leave its graph metadata behind, and the next
+    // attempt would remint its id.
     const halfBuilt = rootGraph.subgraphs.get(definition.id)
     if (halfBuilt) {
       try {
@@ -230,15 +229,25 @@ function reconcile(
     scope.rootGraphId,
     scope.owningGraphId
   )
-  const orphans = graph._nodes.filter(
-    (node) => !nodeStore.ownsNode(scope, node._state)
-  )
+  const orphans = graph._nodes.filter((node) => {
+    const registeredType = LiteGraph.registered_node_types[node.type]
+    return (
+      !nodeStore.ownsNode(scope, node._state) ||
+      (registeredType !== undefined && !(node instanceof registeredType))
+    )
+  })
   const orphansById = new Map(orphans.map((node) => [node.id, node]))
 
   const materialized: NodeId[] = []
   for (const state of records) {
     const live = graph._nodes_by_id[state.id]
-    if (live && nodeStore.ownsNode(scope, live._state)) continue
+    if (
+      live &&
+      nodeStore.ownsNode(scope, live._state) &&
+      !orphansById.has(state.id)
+    ) {
+      continue
+    }
     const serialised = state.lastSerialization
     if (!serialised) continue
     if (pendingDefinitions.has(state.type)) continue
@@ -355,6 +364,7 @@ function materialize(
       context: { graphId: graph.id, nodeId: String(state.id) }
     })
   }
+  node.last_serialization = serialised
   return true
 }
 

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.test.ts
@@ -168,6 +168,28 @@ describe('readSubgraphDefinitions', () => {
     expect(projected.definitions).toEqual({ subgraphs: [inner] })
   })
 
+  it('rejects a definition with malformed nested definitions', () => {
+    const definition = createTestSubgraphData()
+    const doc = seed(definition)
+    const stored = expectYMap(
+      doc.getMap<unknown>('definitions').get(definition.id)
+    )
+    stored.set('definitions', { subgraphs: [null] })
+
+    expect(readSubgraphDefinitions(doc)).toEqual([])
+  })
+
+  it('rejects a definition with malformed interior nodes', () => {
+    const definition = createTestSubgraphData()
+    const doc = seed(definition)
+    const stored = expectYMap(
+      doc.getMap<unknown>('definitions').get(definition.id)
+    )
+    stored.set('nodes', [null])
+
+    expect(readSubgraphDefinitions(doc)).toEqual([])
+  })
+
   it('skips definition and node entries that are not records', () => {
     const definition = createTestSubgraphData({
       nodes: [interiorNode(1)]

--- a/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
+++ b/src/workbench/extensions/agent/crdt/agentSubgraphDefinitions.ts
@@ -2,6 +2,7 @@ import { OPAQUE_WIDGETS_KEY } from '@comfyorg/comfy-multi-player'
 import * as Y from 'yjs'
 
 import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
+import { zProjectedSubgraphDefinition } from '@/platform/workflow/validation/schemas/workflowSchema'
 
 /**
  * Root map the op layer mints `definitions.subgraphs` into, keyed by
@@ -82,26 +83,11 @@ function readInteriorNode(source: unknown): Record<string, unknown> | null {
 }
 
 function isExportedSubgraph(value: unknown): value is ExportedSubgraph {
-  if (typeof value !== 'object' || value === null) return false
-  const graph = value as Record<string, unknown>
-  const state = graph.state
-  if (typeof state !== 'object' || state === null) return false
-  const counters = state as Record<string, unknown>
+  const result = zProjectedSubgraphDefinition.safeParse(value)
+  if (!result.success) return false
   return (
-    typeof graph.id === 'string' &&
-    typeof graph.name === 'string' &&
-    (graph.version === 0 || graph.version === 1) &&
-    typeof graph.revision === 'number' &&
-    typeof graph.inputNode === 'object' &&
-    graph.inputNode !== null &&
-    typeof graph.outputNode === 'object' &&
-    graph.outputNode !== null &&
-    typeof counters.lastNodeId === 'number' &&
-    typeof counters.lastLinkId === 'number' &&
-    typeof counters.lastGroupId === 'number' &&
-    typeof counters.lastRerouteId === 'number' &&
-    (graph.nodes === undefined || Array.isArray(graph.nodes)) &&
-    (graph.links === undefined || Array.isArray(graph.links))
+    result.data.definitions === undefined ||
+    result.data.definitions.subgraphs.every(isExportedSubgraph)
   )
 }
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -30,14 +30,16 @@ const bridgeState = vi.hoisted(() => {
     sendHumanOps = vi.fn()
     subscribedWorkflowId: string | null = 'wf-1'
     lastSequence = 41
+    nodes = new Map<string, unknown>()
+    nodeMapError: Error | null = null
     follower = {
       updatesApplied: 0,
       doc: {
-        share: new Map<string, unknown>(),
-        getMap: () => ({
-          keys: () => new Map<string, unknown>().keys(),
-          toJSON: () => ({})
-        })
+        share: new Map<string, unknown>([['nodes', this.nodes]]),
+        getMap: () => {
+          if (this.nodeMapError) throw this.nodeMapError
+          return this.nodes
+        }
       }
     }
   }
@@ -410,6 +412,38 @@ describe('useAgentCrdtFollower', () => {
 
     expect(bridge().subscribe).toHaveBeenCalledWith('wf-1')
     expect(status().workflowId).toBe('wf-1')
+    unmount()
+  })
+
+  it('records document node additions and removals', async () => {
+    const { recordDevEvent } = await import('./devPanelLog')
+    const { unmount } = mountFollower('wf-1')
+    bridge().nodes.set('1', {})
+
+    dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 1 })
+    bridge().nodes.delete('1')
+    dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 2 })
+
+    const changes = vi
+      .mocked(recordDevEvent)
+      .mock.calls.filter(([event]) => event === 'doc_nodes_changed')
+    expect(changes).toEqual([
+      ['doc_nodes_changed', { added: ['1'], removed: [] }],
+      ['doc_nodes_changed', { added: [], removed: ['1'] }]
+    ])
+    unmount()
+  })
+
+  it('keeps processing an update when the nodes root has another type', () => {
+    const { unmount } = mountFollower('wf-1')
+    bridge().nodeMapError = new Error(
+      'Type with the name nodes has already been defined with a different constructor'
+    )
+
+    expect(() =>
+      dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 1 })
+    ).not.toThrow()
+
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -277,7 +277,11 @@ export function useAgentCrdtFollower(
   const currentDocNodeIds = (): Set<string> => {
     const doc = bridge.follower.doc
     if (!doc.share.has('nodes')) return new Set()
-    return new Set(doc.getMap('nodes').keys())
+    try {
+      return new Set(doc.getMap('nodes').keys())
+    } catch {
+      return new Set()
+    }
   }
 
   // FE-1901 (poc-2): a `doc_subscribed {ok:false}` is a SERVER refusal — e.g.


### PR DESCRIPTION
## Summary

Adds red-green proof and fixes for the validated review findings on #16957.

## Changes

- [`ca9c375`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/ca9c3757ddffe011a2c33791d72a580c62762353) and [`b3cb0da`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/b3cb0da) add regression coverage for failed subgraph rollback, malformed CRDT definitions, late definition recovery, and mismatched Yjs roots.
- [`57af8b1`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/57af8b1) fixes those failures without changing the regression tests.

## Verification

- Red proof on #16957's head: 5 intended failures, 108 passing before the cleanup-state assertion was added.
- Green proof: 174 passing across the six affected suites.
- `pnpm typecheck`, targeted ESLint, formatting, and pre-push Knip pass.

## Review Focus

This PR targets #16957's source branch. Review the first two commits as the test proof and the final commit as the fix.
