### PR TITLE
fix: recover malformed numeric widget interactions

### DIFF
--- a/src/lib/litegraph/src/widgets/KnobWidget.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.ts
@@ -231,8 +231,10 @@ export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
         : step
 
     const deltaValue = adjustment * step_with_shift_modifier
+    const currentValue = coerceNumericWidgetValue(this.value)
     const newValue = clamp(
-      this.value + deltaValue,
+      (Number.isNaN(currentValue) ? this.options.min : currentValue) +
+        deltaValue,
       this.options.min,
       this.options.max
     )

--- a/src/lib/litegraph/src/widgets/NumericWidgetRendering.test.ts
+++ b/src/lib/litegraph/src/widgets/NumericWidgetRendering.test.ts
@@ -2,10 +2,49 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type {
+  IBaseWidget,
+  TWidgetValue
+} from '@/lib/litegraph/src/types/widgets'
 import { GradientSliderWidget } from '@/lib/litegraph/src/widgets/GradientSliderWidget'
 import { KnobWidget } from '@/lib/litegraph/src/widgets/KnobWidget'
 import { SliderWidget } from '@/lib/litegraph/src/widgets/SliderWidget'
-import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
+import {
+  createMockCanvas,
+  createMockCanvasPointerEvent,
+  createMockCanvasRenderingContext2D
+} from '@/utils/__tests__/litegraphTestUtils'
+
+function createKnob(node: LGraphNode) {
+  return new KnobWidget(
+    {
+      type: 'knob',
+      name: 'test',
+      value: 1,
+      options: { min: 0, max: 10, step2: 1 },
+      y: 0
+    },
+    node
+  )
+}
+
+function restoreWidgetValue(
+  node: LGraphNode,
+  widget: IBaseWidget,
+  value: TWidgetValue
+) {
+  node.addCustomWidget(widget)
+  node.configure({
+    id: 1,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    widgets_values: [value]
+  } satisfies ISerialisedNode)
+}
 
 const cases = [
   {
@@ -38,37 +77,21 @@ const cases = [
   },
   {
     name: 'knob',
-    create: (node: LGraphNode) =>
-      new KnobWidget(
-        {
-          type: 'knob',
-          name: 'test',
-          value: 1,
-          options: { min: 0, max: 10, step2: 1 },
-          y: 0
-        },
-        node
-      )
+    create: createKnob
   }
 ]
 
+const valueCases: [TWidgetValue, string][] = [
+  [Object.create(null), 'NaN'],
+  [null, '0.000']
+]
+
 describe('numeric widget rendering', () => {
-  it.for(cases)(
-    '$name tolerates values that cannot be coerced',
-    ({ create }) => {
+  it.for(cases)('$name tolerates malformed values', ({ create }) => {
+    for (const [value, expected] of valueCases) {
       const node = new LGraphNode('TestNode')
       const widget = create(node)
-      node.addCustomWidget(widget)
-      node.configure({
-        id: 1,
-        type: 'TestNode',
-        pos: [0, 0],
-        size: [200, 100],
-        flags: {},
-        order: 0,
-        mode: 0,
-        widgets_values: [Object.create(null)]
-      } satisfies ISerialisedNode)
+      restoreWidgetValue(node, widget, value)
 
       const gradient = { addColorStop: vi.fn() }
       const ctx = createMockCanvasRenderingContext2D({
@@ -78,10 +101,29 @@ describe('numeric widget rendering', () => {
 
       expect(() => widget.drawWidget(ctx, { width: 200 })).not.toThrow()
       expect(ctx.fillText).toHaveBeenCalledWith(
-        expect.stringContaining('NaN'),
+        expect.stringContaining(expected),
         expect.any(Number),
         expect.any(Number)
       )
     }
-  )
+  })
+
+  it('recovers from a malformed knob value when dragged', () => {
+    const node = new LGraphNode('TestNode')
+    const widget = createKnob(node)
+    restoreWidgetValue(node, widget, Object.create(null))
+
+    expect(() =>
+      widget.onDrag({
+        e: createMockCanvasPointerEvent(0, 0, {
+          movementX: 16,
+          movementY: 0,
+          shiftKey: false
+        }),
+        node,
+        canvas: createMockCanvas()
+      })
+    ).not.toThrow()
+    expect(widget.value).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary

Follow up #17099 by covering successful null coercion and recovering malformed knob values when users drag the widget.

## Changes

- **What**: Add `null` rendering coverage for slider, gradient slider, and knob widgets. Coerce malformed knob state before drag arithmetic and fall back to the configured minimum when conversion produces `NaN`.

## Review Focus

This PR is stacked on #17099 so that its merge-queue entry remains untouched. The drag fallback converts the first valid movement from the configured minimum and preserves the existing clamp behavior.

## Screenshots (if applicable)

Not applicable. Valid numeric rendering is unchanged.