### PR TITLE
test: avoid accidental double-click in FE-2040 selection coverage

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/canvas/selection.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/selection.spec.ts
@@ -84,7 +84,6 @@ test.describe(
     test('empty canvas click clears Ctrl+A selection and hides the toolbox', async ({
       comfyPage
     }) => {
-      await comfyPage.canvasOps.click({ x: 100, y: 100 })
       await comfyPage.keyboard.selectAll()
       await expect(comfyPage.vueNodes.selectedNodes).toHaveCount(3)
       await expect(comfyPage.selectionToolbox).toBeVisible()


### PR DESCRIPTION
## Summary

Fix the empty-canvas selection test failing in [CI](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34020834281/job/101453391229). Two clicks at the same point can register as a double-click and open node search instead of clearing selection.

## Changes

- Remove the redundant setup click; `keyboard.selectAll()` already focuses the canvas. Assertions are unchanged.

## Review Focus

Verified against the frontend artifact from the failing CI run:
- Before: 3/3 reproductions failed with three nodes still selected.
- After: 20/20 targeted repetitions passed.
- Full selection suite: 11 normal passes and the existing FE-2040/#7454 expected failure.
- Formatting, type-aware oxlint, ESLint, both typechecks, commit hooks, and pre-push knip passed.