### PR TITLE
Fix integer color input widgets

### DIFF
--- a/browser_tests/assets/vueNodes/empty-image-integer-color.json
+++ b/browser_tests/assets/vueNodes/empty-image-integer-color.json
@@ -1,0 +1,35 @@
+{
+  "id": "c0107e57-c01047-c01047-c01047-c0101010c011",
+  "revision": 0,
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "EmptyImage",
+      "pos": [400, 300],
+      "size": [270, 130],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyImage"
+      },
+      "widgets_values": [512, 512, 1, 0]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/browser_tests/tests/vueNodes/widgets/color/colorWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/color/colorWidget.spec.ts
@@ -34,3 +34,49 @@ test.describe('Vue Color Widget defaults', { tag: '@vue-nodes' }, () => {
     await expect(colorTrigger).toBeVisible()
   })
 })
+
+test.describe(
+  'Vue integer color widget',
+  { tag: ['@vue-nodes', '@node', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow(
+        'vueNodes/empty-image-integer-color'
+      )
+    })
+
+    test('round-trips packed RGB values without alpha', async ({
+      comfyPage
+    }) => {
+      const colorWidget = comfyPage.vueNodes.getWidgetRowByLabel(
+        'Empty Image',
+        'color'
+      )
+      await expect(colorWidget).toContainText('#000000')
+
+      await colorWidget.getByRole('button').click()
+      await expect(comfyPage.page.getByLabel('Alpha')).toHaveCount(0)
+
+      const hexInput = comfyPage.page.getByLabel('Hex')
+      await hexInput.fill('#00ff00')
+      await expect(colorWidget).toContainText('#00ff00')
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (node) => node.type === 'EmptyImage'
+            )!
+            const widgetIndex = node.widgets!.findIndex(
+              (widget) => widget.name === 'color'
+            )
+            return {
+              value: node.widgets![widgetIndex].value,
+              serializedValue: node.serialize().widgets_values?.[widgetIndex]
+            }
+          })
+        )
+        .toEqual({ value: 0x00ff00, serializedValue: 0x00ff00 })
+    })
+  }
+)

--- a/packages/object-info-parser/src/__tests__/nodeDefSchema.test.ts
+++ b/packages/object-info-parser/src/__tests__/nodeDefSchema.test.ts
@@ -31,6 +31,10 @@ describe('validateNodeDef', () => {
     [{ ckpt_name: ['foo', { default: 1 }] }, ['foo', { default: 1 }]],
     [{ ckpt_name: ['foo', { bar: 1 }] }, ['foo', { bar: 1 }]],
     [{ ckpt_name: ['INT', { bar: 1 }] }, ['INT', { bar: 1 }]],
+    [
+      { ckpt_name: ['INT', { default: 0, display: 'color' }] },
+      ['INT', { default: 0, display: 'color' }]
+    ],
     [{ ckpt_name: [[1, 2, 3], { bar: 1 }] }, [[1, 2, 3], { bar: 1 }]]
   ])(
     'validateComfyNodeDef with various input spec formats',

--- a/packages/object-info-parser/src/__tests__/nodeDefSchema.test.ts
+++ b/packages/object-info-parser/src/__tests__/nodeDefSchema.test.ts
@@ -55,8 +55,9 @@ describe('validateNodeDef', () => {
     [{ ckpt_name: { 'model1.safetensors': 'foo' } }],
     [{ ckpt_name: ['*', ''] }],
     [{ ckpt_name: ['foo', { default: 1 }, { default: 2 }] }],
-    [{ ckpt_name: ['INT', { default: '124' }] }]
-  ])('validateComfyNodeDef rejects invalid input specs', (inputSpec) => {
+    [{ ckpt_name: ['INT', { default: '124' }] }],
+    [{ ckpt_name: ['FLOAT', { display: 'color' }] }]
+  ])('validateComfyNodeDef rejects invalid input specs', ([inputSpec]) => {
     it(`rejects input spec format: ${JSON.stringify(inputSpec)}`, () => {
       expect(
         validateComfyNodeDef({

--- a/packages/object-info-parser/src/schemas/nodeDefSchema.ts
+++ b/packages/object-info-parser/src/schemas/nodeDefSchema.ts
@@ -48,7 +48,9 @@ const zNumericInputOptions = zBaseInputOptions.extend({
   step: z.number().optional(),
   /** Note: Many node authors are using INT/FLOAT to pass list of INT/FLOAT. */
   default: z.union([z.number(), z.array(z.number())]).optional(),
-  display: z.enum(['slider', 'number', 'knob', 'gradientslider']).optional()
+  display: z
+    .enum(['slider', 'number', 'knob', 'gradientslider', 'color'])
+    .optional()
 })
 
 export const zIntInputOptions = zNumericInputOptions.extend({

--- a/packages/object-info-parser/src/schemas/nodeDefSchema.ts
+++ b/packages/object-info-parser/src/schemas/nodeDefSchema.ts
@@ -48,12 +48,13 @@ const zNumericInputOptions = zBaseInputOptions.extend({
   step: z.number().optional(),
   /** Note: Many node authors are using INT/FLOAT to pass list of INT/FLOAT. */
   default: z.union([z.number(), z.array(z.number())]).optional(),
-  display: z
-    .enum(['slider', 'number', 'knob', 'gradientslider', 'color'])
-    .optional()
+  display: z.enum(['slider', 'number', 'knob', 'gradientslider']).optional()
 })
 
 export const zIntInputOptions = zNumericInputOptions.extend({
+  display: z
+    .enum(['slider', 'number', 'knob', 'gradientslider', 'color'])
+    .optional(),
   /**
    * If true, a linked widget will be added to the node to select the mode
    * of `control_after_generate`.

--- a/src/components/ui/color-picker/ColorPicker.vue
+++ b/src/components/ui/color-picker/ColorPicker.vue
@@ -115,7 +115,7 @@ const contentStyle = useModalLiftedZIndex(isOpen)
                 <span>{{ baseRgb.b }}</span>
               </div>
             </template>
-            <span>{{ hsva.a }}%</span>
+            <span v-if="alpha">{{ hsva.a }}%</span>
           </div>
         </button>
       </slot>

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -252,9 +252,9 @@ export interface IFileUploadWidget extends IBaseWidget<string, 'fileupload'> {
 }
 
 /** Color picker widget for selecting colors */
-export interface IColorWidget extends IBaseWidget<string, 'color'> {
+export interface IColorWidget extends IBaseWidget<string | number, 'color'> {
   type: 'color'
-  value: string
+  value: string | number
 }
 
 /** Markdown widget for displaying formatted text */

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -5,6 +5,7 @@ import type { BoundingBox } from '@/types/boundingBoxes'
 import type { NodeId } from '@/types/nodeId'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetId } from '@/types/widgetId'
+import type { ColorFormat } from '@/utils/colorUtil'
 
 import type {
   CanvasColour,
@@ -252,7 +253,15 @@ export interface IFileUploadWidget extends IBaseWidget<string, 'fileupload'> {
 }
 
 /** Color picker widget for selecting colors */
-export interface IColorWidget extends IBaseWidget<string | number, 'color'> {
+export interface IColorWidgetOptions extends IWidgetOptions {
+  format?: ColorFormat | 'int'
+}
+
+export interface IColorWidget extends IBaseWidget<
+  string | number,
+  'color',
+  IColorWidgetOptions
+> {
   type: 'color'
   value: string | number
 }

--- a/src/lib/litegraph/src/widgets/ColorWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/ColorWidget.test.ts
@@ -88,6 +88,20 @@ describe('ColorWidget', () => {
       expect(input.value).toBe('#00ff00')
     })
 
+    it('should display integer-backed colors as hex', () => {
+      widget = new ColorWidget(
+        createMockWidgetConfig({ value: 0x45edf5 }),
+        node
+      )
+
+      widget.onClick({ e: mockEvent, node, canvas: mockCanvas })
+
+      const input = document.querySelector(
+        'input[type="color"]'
+      ) as HTMLInputElement
+      expect(input.value).toBe('#45edf5')
+    })
+
     it('should default to #000000 when widget value is empty', () => {
       widget = new ColorWidget(createMockWidgetConfig({ value: '' }), node)
 
@@ -178,6 +192,28 @@ describe('ColorWidget', () => {
       input.dispatchEvent(new Event('change'))
 
       expect(setValueSpy).toHaveBeenCalledWith('#00ff00', {
+        e: mockEvent,
+        node,
+        canvas: mockCanvas
+      })
+    })
+
+    it('should preserve integer-backed colors when the input changes', () => {
+      widget = new ColorWidget(
+        createMockWidgetConfig({ value: 0x45edf5 }),
+        node
+      )
+      const setValueSpy = vi.spyOn(widget, 'setValue')
+
+      widget.onClick({ e: mockEvent, node, canvas: mockCanvas })
+
+      const input = document.querySelector(
+        'input[type="color"]'
+      ) as HTMLInputElement
+      input.value = '#00ff00'
+      input.dispatchEvent(new Event('change'))
+
+      expect(setValueSpy).toHaveBeenCalledWith(0x00ff00, {
         e: mockEvent,
         node,
         canvas: mockCanvas

--- a/src/lib/litegraph/src/widgets/ColorWidget.ts
+++ b/src/lib/litegraph/src/widgets/ColorWidget.ts
@@ -1,4 +1,5 @@
 import type { IColorWidget } from '../types/widgets'
+import { hexToInt, intToHex } from '@/utils/colorUtil'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
 import { BaseWidget } from './BaseWidget'
 
@@ -28,6 +29,12 @@ export class ColorWidget
 {
   override type = 'color' as const
 
+  private get hexValue(): string {
+    return typeof this.value === 'number'
+      ? intToHex(this.value)
+      : this.value || '#000000'
+  }
+
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { fillStyle, strokeStyle, textAlign } = ctx
 
@@ -49,7 +56,7 @@ export class ColorWidget
     // Draw color swatch as rounded pill
     ctx.beginPath()
     ctx.roundRect(swatchX, swatchY, swatchWidth, swatchHeight, swatchRadius)
-    ctx.fillStyle = this.value || '#000000'
+    ctx.fillStyle = this.hexValue
     ctx.fill()
 
     // Draw label on the left
@@ -60,21 +67,23 @@ export class ColorWidget
     // Draw hex value to the left of swatch
     ctx.fillStyle = this.text_color
     ctx.textAlign = 'right'
-    ctx.fillText(this.value || '#000000', swatchX - 8, y + height * 0.7)
+    ctx.fillText(this.hexValue, swatchX - 8, y + height * 0.7)
 
     Object.assign(ctx, { textAlign, strokeStyle, fillStyle })
   }
 
   onClick({ e, node, canvas }: WidgetEventOptions): void {
     const input = getColorInput()
-    input.value = this.value || '#000000'
+    input.value = this.hexValue
     input.style.left = `${e.clientX}px`
     input.style.top = `${e.clientY}px`
 
     input.addEventListener(
       'change',
       () => {
-        this.setValue(input.value, { e, node, canvas })
+        const value =
+          typeof this.value === 'number' ? hexToInt(input.value) : input.value
+        this.setValue(value, { e, node, canvas })
         canvas.setDirty(true)
       },
       { once: true }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts
@@ -107,6 +107,22 @@ describe('WidgetColorPicker Value Binding', () => {
 
       expect(onUpdateModelValue).toHaveBeenCalledWith(0x00ff00)
     })
+
+    it('round-trips black as integer zero', async () => {
+      const onUpdateModelValue = vi.fn()
+      const widget = createColorWidget(0, { format: 'int' })
+      renderComponent(widget, 0, {
+        'onUpdate:modelValue': onUpdateModelValue
+      })
+
+      const input = screen.getByTestId('color-picker-input')
+      expect(input).toHaveValue('#000000')
+
+      await fireEvent.update(input, '#45edf5')
+      await fireEvent.update(input, '#000000')
+
+      expect(onUpdateModelValue).toHaveBeenCalledWith(0)
+    })
   })
 
   describe('Component Rendering', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts
@@ -19,11 +19,13 @@ const WidgetLayoutFieldStub = defineComponent({
 const ColorPickerStub = defineComponent({
   name: 'ColorPicker',
   props: {
-    modelValue: { type: String, default: '' }
+    modelValue: { type: String, default: '' },
+    alpha: { type: Boolean, default: true }
   },
   emits: ['update:modelValue'],
   template: `<input
     data-testid="color-picker-input"
+    :data-alpha="alpha"
     :value="modelValue"
     @input="$emit('update:modelValue', $event.target.value)"
   />`
@@ -31,9 +33,9 @@ const ColorPickerStub = defineComponent({
 
 describe('WidgetColorPicker Value Binding', () => {
   const createColorWidget = (
-    value: string = '#000000',
+    value: string | number = '#000000',
     options: Record<string, unknown> = {},
-    callback?: (value: string) => void
+    callback?: (value: string | number) => void
   ) =>
     createMockWidget({
       value,
@@ -44,8 +46,8 @@ describe('WidgetColorPicker Value Binding', () => {
     })
 
   const renderComponent = (
-    widget: SimplifiedWidget<string>,
-    modelValue: string,
+    widget: SimplifiedWidget<string | number>,
+    modelValue: string | number,
     extraProps: Record<string, unknown> = {}
   ) => {
     return render(WidgetColorPicker, {
@@ -88,6 +90,22 @@ describe('WidgetColorPicker Value Binding', () => {
       await fireEvent.update(input, '#ff00ff')
 
       expect(onUpdateModelValue).toHaveBeenCalledWith('#ff00ff')
+    })
+
+    it('converts integer-backed colors without changing their value type', async () => {
+      const onUpdateModelValue = vi.fn()
+      const widget = createColorWidget(0x45edf5, { format: 'int' })
+      renderComponent(widget, 0x45edf5, {
+        'onUpdate:modelValue': onUpdateModelValue
+      })
+
+      const input = screen.getByTestId('color-picker-input')
+      expect(input).toHaveValue('#45edf5')
+      expect(input).toHaveAttribute('data-alpha', 'false')
+
+      await fireEvent.update(input, '#00ff00')
+
+      expect(onUpdateModelValue).toHaveBeenCalledWith(0x00ff00)
     })
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts
@@ -92,23 +92,7 @@ describe('WidgetColorPicker Value Binding', () => {
       expect(onUpdateModelValue).toHaveBeenCalledWith('#ff00ff')
     })
 
-    it('converts integer-backed colors without changing their value type', async () => {
-      const onUpdateModelValue = vi.fn()
-      const widget = createColorWidget(0x45edf5, { format: 'int' })
-      renderComponent(widget, 0x45edf5, {
-        'onUpdate:modelValue': onUpdateModelValue
-      })
-
-      const input = screen.getByTestId('color-picker-input')
-      expect(input).toHaveValue('#45edf5')
-      expect(input).toHaveAttribute('data-alpha', 'false')
-
-      await fireEvent.update(input, '#00ff00')
-
-      expect(onUpdateModelValue).toHaveBeenCalledWith(0x00ff00)
-    })
-
-    it('round-trips black as integer zero', async () => {
+    it('round-trips integer-backed colors including zero', async () => {
       const onUpdateModelValue = vi.fn()
       const widget = createColorWidget(0, { format: 'int' })
       renderComponent(widget, 0, {
@@ -117,10 +101,12 @@ describe('WidgetColorPicker Value Binding', () => {
 
       const input = screen.getByTestId('color-picker-input')
       expect(input).toHaveValue('#000000')
+      expect(input).toHaveAttribute('data-alpha', 'false')
 
-      await fireEvent.update(input, '#45edf5')
+      await fireEvent.update(input, '#00ff00')
+      expect(onUpdateModelValue).toHaveBeenCalledWith(0x00ff00)
+
       await fireEvent.update(input, '#000000')
-
       expect(onUpdateModelValue).toHaveBeenCalledWith(0)
     })
   })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.vue
@@ -1,6 +1,10 @@
 <template>
   <WidgetLayoutField :widget="widget">
-    <ColorPicker v-model="localValue" @update:model-value="onUpdate" />
+    <ColorPicker
+      v-model="localValue"
+      :alpha="format !== 'int'"
+      @update:model-value="onUpdate"
+    />
   </WidgetLayoutField>
 </template>
 
@@ -8,7 +12,12 @@
 import { ref, watch } from 'vue'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
-import { isColorFormat, toHexFromFormat } from '@/utils/colorUtil'
+import {
+  hexToInt,
+  intToHex,
+  isColorFormat,
+  toHexFromFormat
+} from '@/utils/colorUtil'
 import type { ColorFormat } from '@/utils/colorUtil'
 
 import type { IWidgetOptions } from '@/lib/litegraph/src/types/widgets'
@@ -17,26 +26,35 @@ import ColorPicker from '@/components/ui/color-picker/ColorPicker.vue'
 
 import WidgetLayoutField from './layout/WidgetLayoutField.vue'
 
-type WidgetOptions = IWidgetOptions & { format?: ColorFormat }
+type ColorWidgetValue = string | number
+type WidgetOptions = IWidgetOptions & { format?: ColorFormat | 'int' }
 
 const { widget } = defineProps<{
-  widget: SimplifiedWidget<string, WidgetOptions>
+  widget: SimplifiedWidget<ColorWidgetValue, WidgetOptions>
 }>()
 
-const modelValue = defineModel<string>({ required: true })
+const modelValue = defineModel<ColorWidgetValue>({ required: true })
 
-const format = isColorFormat(widget.options?.format)
-  ? widget.options.format
-  : 'hex'
+const format =
+  widget.options?.format === 'int' || isColorFormat(widget.options?.format)
+    ? widget.options.format
+    : 'hex'
 
-const localValue = ref(toHexFromFormat(modelValue.value || '#000000', format))
+function toPickerValue(value: ColorWidgetValue): string {
+  if (format === 'int') {
+    return typeof value === 'number' ? intToHex(value) : '#000000'
+  }
+  return toHexFromFormat(value || '#000000', format)
+}
+
+const localValue = ref(toPickerValue(modelValue.value))
 
 watch(modelValue, (newVal) => {
-  localValue.value = toHexFromFormat(newVal || '#000000', format)
+  localValue.value = toPickerValue(newVal)
 })
 
 function onUpdate(val: string) {
   localValue.value = val
-  modelValue.value = val
+  modelValue.value = format === 'int' ? hexToInt(val) : val
 }
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.vue
@@ -18,19 +18,17 @@ import {
   isColorFormat,
   toHexFromFormat
 } from '@/utils/colorUtil'
-import type { ColorFormat } from '@/utils/colorUtil'
 
-import type { IWidgetOptions } from '@/lib/litegraph/src/types/widgets'
+import type { IColorWidgetOptions } from '@/lib/litegraph/src/types/widgets'
 
 import ColorPicker from '@/components/ui/color-picker/ColorPicker.vue'
 
 import WidgetLayoutField from './layout/WidgetLayoutField.vue'
 
 type ColorWidgetValue = string | number
-type WidgetOptions = IWidgetOptions & { format?: ColorFormat | 'int' }
 
 const { widget } = defineProps<{
-  widget: SimplifiedWidget<ColorWidgetValue, WidgetOptions>
+  widget: SimplifiedWidget<ColorWidgetValue, IColorWidgetOptions>
 }>()
 
 const modelValue = defineModel<ColorWidgetValue>({ required: true })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts
@@ -1,21 +1,45 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { INumericWidget } from '@/lib/litegraph/src/types/widgets'
-import { _for_testing } from '@/renderer/extensions/vueNodes/widgets/composables/useIntWidget'
+import {
+  _for_testing,
+  useIntWidget
+} from '@/renderer/extensions/vueNodes/widgets/composables/useIntWidget'
 
 vi.mock('@/scripts/widgets', () => ({
-  addValueControlWidgets: vi.fn()
+  addValueControlWidget: vi.fn()
 }))
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
-    settings: {}
+    get: vi.fn(() => false)
   })
 }))
 
 const { onValueChange } = _for_testing
 
 describe('useIntWidget', () => {
+  it('uses a color picker while preserving the integer value', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('EmptyImage')
+    node.serialize_widgets = true
+    graph.add(node)
+    const widget = useIntWidget()(node, {
+      type: 'INT',
+      name: 'color',
+      default: 0x45edf5,
+      min: 0,
+      max: 0xffffff,
+      display: 'color'
+    })
+
+    expect(widget.type).toBe('color')
+    expect(widget.value).toBe(0x45edf5)
+    expect(widget.options).toMatchObject({ format: 'int' })
+    expect(node.serialize().widgets_values).toEqual([0x45edf5])
+  })
+
   describe('onValueChange', () => {
     let widget: INumericWidget
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
@@ -1,7 +1,7 @@
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type {
-  INumericWidget,
-  IWidgetOptions
+  IColorWidgetOptions,
+  INumericWidget
 } from '@/lib/litegraph/src/types/widgets'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -57,7 +57,7 @@ export const useIntWidget = () => {
     const step = inputSpec.step ?? 1
     /** Assertion {@link inputSpec.default} */
     const defaultValue = (inputSpec.default as number | undefined) ?? 0
-    const options: IWidgetOptions & { format?: 'int' } = {
+    const options: IColorWidgetOptions = {
       min: inputSpec.min ?? 0,
       max: inputSpec.max ?? 2048,
       /** @deprecated Use step2 instead. The 10x value is a legacy implementation. */

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.ts
@@ -1,5 +1,8 @@
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import type { INumericWidget } from '@/lib/litegraph/src/types/widgets'
+import type {
+  INumericWidget,
+  IWidgetOptions
+} from '@/lib/litegraph/src/types/widgets'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { isIntInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -43,28 +46,33 @@ export const useIntWidget = () => {
     const sliderEnabled = !settingStore.get('Comfy.DisableSliders')
     const display_type = inputSpec.display
     const widgetType =
-      sliderEnabled && display_type == 'slider'
-        ? 'slider'
-        : display_type == 'knob'
-          ? 'knob'
-          : 'number'
+      display_type == 'color'
+        ? 'color'
+        : sliderEnabled && display_type == 'slider'
+          ? 'slider'
+          : display_type == 'knob'
+            ? 'knob'
+            : 'number'
 
     const step = inputSpec.step ?? 1
     /** Assertion {@link inputSpec.default} */
     const defaultValue = (inputSpec.default as number | undefined) ?? 0
+    const options: IWidgetOptions & { format?: 'int' } = {
+      min: inputSpec.min ?? 0,
+      max: inputSpec.max ?? 2048,
+      /** @deprecated Use step2 instead. The 10x value is a legacy implementation. */
+      step: step * 10,
+      step2: step,
+      precision: 0
+    }
+    if (display_type == 'color') options.format = 'int'
+
     const widget = node.addWidget(
       widgetType,
       inputSpec.name,
       defaultValue,
       onValueChange,
-      {
-        min: inputSpec.min ?? 0,
-        max: inputSpec.max ?? 2048,
-        /** @deprecated Use step2 instead. The 10x value is a legacy implementation. */
-        step: step * 10,
-        step2: step,
-        precision: 0
-      }
+      options
     )
 
     const controlAfterGenerate =

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -137,6 +137,13 @@ describe('colorUtil conversions', () => {
     it('converts an RGB integer to a padded hexadecimal color', () => {
       expect(intToHex(0)).toBe('#000000')
       expect(intToHex(0x45edf5)).toBe('#45edf5')
+      expect(intToHex(0xffffff)).toBe('#ffffff')
+    })
+
+    it('normalizes values to the 24-bit RGB range', () => {
+      expect(intToHex(-1)).toBe('#000000')
+      expect(intToHex(0.5)).toBe('#000001')
+      expect(intToHex(0x1000000)).toBe('#ffffff')
     })
   })
 

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -134,19 +134,18 @@ describe('colorUtil conversions', () => {
   })
 
   describe('intToHex', () => {
-    it('converts an RGB integer to a padded hexadecimal color', () => {
-      expect(intToHex(0)).toBe('#000000')
-      expect(intToHex(0x45edf5)).toBe('#45edf5')
-      expect(intToHex(0xffffff)).toBe('#ffffff')
-    })
-
-    it('normalizes values to the 24-bit RGB range', () => {
-      expect(intToHex(-1)).toBe('#000000')
-      expect(intToHex(0.5)).toBe('#000001')
-      expect(intToHex(0x1000000)).toBe('#ffffff')
-      expect(intToHex(Number.NaN)).toBe('#000000')
-      expect(intToHex(Number.POSITIVE_INFINITY)).toBe('#000000')
-      expect(intToHex(Number.NEGATIVE_INFINITY)).toBe('#000000')
+    it.for([
+      [0, '#000000'],
+      [0x45edf5, '#45edf5'],
+      [0xffffff, '#ffffff'],
+      [-1, '#000000'],
+      [0.5, '#000001'],
+      [0x1000000, '#ffffff'],
+      [Number.NaN, '#000000'],
+      [Number.POSITIVE_INFINITY, '#000000'],
+      [Number.NEGATIVE_INFINITY, '#000000']
+    ] as const)('%s → %s', ([value, expected]) => {
+      expect(intToHex(value)).toBe(expected)
     })
   })
 

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -144,6 +144,9 @@ describe('colorUtil conversions', () => {
       expect(intToHex(-1)).toBe('#000000')
       expect(intToHex(0.5)).toBe('#000001')
       expect(intToHex(0x1000000)).toBe('#ffffff')
+      expect(intToHex(Number.NaN)).toBe('#000000')
+      expect(intToHex(Number.POSITIVE_INFINITY)).toBe('#000000')
+      expect(intToHex(Number.NEGATIVE_INFINITY)).toBe('#000000')
     })
   })
 

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -8,6 +8,7 @@ import {
   hexToRgb,
   hsbToRgb,
   hsvaToHex,
+  intToHex,
   isTransparent,
   luminance,
   normalizeHex,
@@ -129,6 +130,13 @@ describe('colorUtil conversions', () => {
     it('converts 3-digit hex to packed integer', () => {
       expect(hexToInt('#fff')).toBe(0xffffff)
       expect(hexToInt('#f00')).toBe(0xff0000)
+    })
+  })
+
+  describe('intToHex', () => {
+    it('converts an RGB integer to a padded hexadecimal color', () => {
+      expect(intToHex(0)).toBe('#000000')
+      expect(intToHex(0x45edf5)).toBe('#45edf5')
     })
   })
 

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -88,7 +88,10 @@ export function hexToInt(hex: string): number {
 }
 
 export function intToHex(value: number): string {
-  return `#${value.toString(16).padStart(6, '0')}`
+  const normalized = Number.isFinite(value)
+    ? Math.max(0, Math.min(0xffffff, Math.round(value)))
+    : 0
+  return `#${normalized.toString(16).padStart(6, '0')}`
 }
 
 export function rgbToHex({ r, g, b }: RGB): string {

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -87,6 +87,10 @@ export function hexToInt(hex: string): number {
   return (r << 16) | (g << 8) | b
 }
 
+export function intToHex(value: number): string {
+  return `#${value.toString(16).padStart(6, '0')}`
+}
+
 export function rgbToHex({ r, g, b }: RGB): string {
   const toHex = (n: number) =>
     Math.max(0, Math.min(255, Math.round(n)))

--- a/src/utils/nodeDefUtil.ts
+++ b/src/utils/nodeDefUtil.ts
@@ -28,7 +28,7 @@ const IGNORE_KEYS = new Set<string>([
   'dynamicPrompts'
 ])
 
-const getRange = (options: NumericInputOptions) => {
+const getRange = (options: Pick<NumericInputOptions, 'min' | 'max'>) => {
   const min = options.min ?? -Infinity
   const max = options.max ?? Infinity
   return { min, max }


### PR DESCRIPTION
## Summary

Use the interactive color picker for integer inputs that declare `display: "color"`, such as Empty Image, while preserving their packed RGB integer value.

## Changes

- **What**: Recognize the numeric `color` display mode and round-trip picker values as RGB integers in both Vue and legacy canvas widgets.
- **Breaking**: None. Existing workflow values remain integers and the backend input type remains `INT`.
- **Dependencies**: None.

## Review Focus

Integer-backed colors intentionally disable alpha controls because their value contract is 24-bit RGB. Existing string-backed color widgets retain alpha support.

## Tests

- `pnpm test:unit src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.test.ts src/components/ui/color-picker/ColorPickerPanel.test.ts src/utils/colorUtil.test.ts src/lib/litegraph/src/widgets/ColorWidget.test.ts`
- `pnpm --filter @comfyorg/object-info-parser test`
- `pnpm --filter @comfyorg/object-info-parser typecheck`
- `pnpm lint`
- `pnpm typecheck`
- Visually verified the Empty Image picker with alpha controls hidden.
