### PR TITLE
fix: defer badge redraws until canvas initialization

### DIFF
--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -1,8 +1,10 @@
 import { render } from '@testing-library/vue'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyExtension } from '@/types/comfy'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 
 import { useNodeBadge } from './useNodeBadge'
@@ -25,16 +27,14 @@ vi.mock('@/stores/extensionStore', () => ({
     }
   })
 }))
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: () => false })
-}))
 vi.mock('@/composables/node/useNodePricing', () => ({
   useNodePricing: () => ({ pricingRevision: { value: 0 } })
 }))
 vi.mock('@/scripts/app', () => ({
   app: {
+    ui: { settings: { dispatchChange: vi.fn() } },
     canvas: {
-      canvas: { addEventListener: vi.fn() },
+      canvas: document.createElement('canvas'),
       setDirty: vi.fn()
     }
   }
@@ -43,6 +43,51 @@ vi.mock('@/scripts/app', () => ({
 describe('useNodeBadge', () => {
   beforeEach(() => {
     mocks.extensionInstalled = false
+  })
+
+  it('defers badge redraws until the canvas is ready and stops on unmount', async () => {
+    const settings = useSettingStore()
+    const canvasStore = useCanvasStore()
+    const canvas = app.canvas
+    const view = render(
+      defineComponent({
+        setup() {
+          useNodeBadge()
+          return () => null
+        }
+      })
+    )
+
+    try {
+      Reflect.set(app, 'canvas', undefined)
+      settings.addSetting({
+        id: 'Comfy.NodeBadge.ShowApiPricing',
+        name: 'Show API pricing',
+        type: 'boolean',
+        defaultValue: true
+      })
+      await expect(nextTick()).resolves.toBeUndefined()
+      expect(canvas.setDirty).not.toHaveBeenCalled()
+
+      app.canvas = canvas
+      canvasStore.canvas = canvas
+      await nextTick()
+      expect(canvas.setDirty).toHaveBeenCalledExactlyOnceWith(true, true)
+
+      settings.settingValues['Comfy.NodeBadge.ShowApiPricing'] = false
+      await nextTick()
+      expect(canvas.setDirty).toHaveBeenCalledTimes(2)
+
+      view.unmount()
+      settings.settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
+      await nextTick()
+      expect(canvas.setDirty).toHaveBeenCalledTimes(2)
+    } finally {
+      view.unmount()
+      app.canvas = canvas
+      canvasStore.canvas = null
+      canvasStore.$dispose()
+    }
   })
 
   it('keeps the extension-owned provider installed across canvas remounts', async () => {

--- a/src/composables/node/useNodeBadge.ts
+++ b/src/composables/node/useNodeBadge.ts
@@ -2,6 +2,7 @@ import { computed, onMounted, watch } from 'vue'
 
 import { useNodePricing } from '@/composables/node/useNodePricing'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useExtensionStore } from '@/stores/extensionStore'
 import { installNodeBadges } from '@/systems/badgeSystem'
@@ -12,6 +13,7 @@ import { installNodeBadges } from '@/systems/badgeSystem'
  */
 export const useNodeBadge = () => {
   const settingStore = useSettingStore()
+  const canvasStore = useCanvasStore()
   const extensionStore = useExtensionStore()
 
   const showApiPricingBadge = computed(() =>
@@ -20,13 +22,14 @@ export const useNodeBadge = () => {
 
   watch(
     [
+      () => canvasStore.canvas,
       () => settingStore.get('Comfy.NodeBadge.NodeSourceBadgeMode'),
       () => settingStore.get('Comfy.NodeBadge.NodeIdBadgeMode'),
       () => settingStore.get('Comfy.NodeBadge.NodeLifeCycleBadgeMode'),
       showApiPricingBadge
     ],
     () => {
-      app.canvas.setDirty(true, true)
+      canvasStore.canvas?.setDirty(true, true)
     }
   )
 


### PR DESCRIPTION

<img width="753" height="110" alt="스크린샷 2026-09-07 오후 2 34 29" src="https://github.com/user-attachments/assets/0583b39a-b68d-4ec2-a1c7-8e6db910d9fa" />


## ELI5

Keep double-click node search working on the development server by waiting until the canvas exists before requesting a badge redraw. Production already continues past this startup error, but still logs it to the console.

## Motivation

The guard removal in [#16802: chore: enable remaining no-unnecessary rules](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16802) exposed a startup ordering gap: core badge settings register before the canvas exists. In development, the resulting `setDirty` exception interrupts Vue's watcher queue, leaving pointer settings uninitialized and preventing double-click node search. In the production build tested locally, Vue logs the error (which can appear through the `installHook` console wrapper), skips the failed callback and continues initialization, so the selector still opens. The production path is not error-free.

## Summary

- Use the existing nullable canvas store for the badge-settings redraw watcher and redraw when the canvas becomes available.
- Preserve the type-based lint rules: this uses an existing `LGraphCanvas | null` reference rather than suppressing the rule or weakening the global app type.
- Add one regression test using real settings and canvas stores: pre-canvas settings registration, redraw on readiness, subsequent settings changes and teardown.
- Leave pricing callbacks, badge-provider registration, graph mutations and public APIs unchanged.

## Provenance

- **Authored by:** interactive session
- **Verified:** `pnpm test:unit src/composables/node/useNodeBadge.test.ts --maxWorkers=1 -t 'defers badge redraws'` failed on unchanged production code with the expected `setDirty` TypeError. After the fix, `pnpm test:unit src/composables/node/useNodeBadge.test.ts --maxWorkers=1` passed both tests; the regression test was unchanged between the final red and green runs.
- **Verified:** `pnpm typecheck`, `pnpm knip`, targeted ESLint/oxlint, formatting and `git diff --check` passed. Commit and push hooks passed without bypasses. Manual development-server verification opened the selector with a real double-click without the badge startup error.
- **Deviations:** Red/green proof was local, not two CI commits. The full lint and unit suites were not run locally to keep resource usage bounded.

## Review Focus

The change only affects transient redraw scheduling. Settings updates must remain harmless before canvas initialization and continue redrawing afterward, without retaining watchers after unmount.

## Test plan

- Start the development server and double-click an empty canvas area; confirm node search opens without the startup `setDirty` error.
- Change badge display settings after startup and confirm the canvas updates.
