### PR TITLE
fix(billing): offer payment recovery when the poll reports a parked checkout

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3095,6 +3095,8 @@
     },
     "preview": {
       "completeVerification": "Complete verification",
+      "completePayment": "Complete your payment",
+      "parkedCheckoutDetail": "Your earlier checkout is still waiting for a payment method. Complete your payment to activate this plan.",
       "confirmPayment": "Confirm your payment",
       "confirmPlanChange": "Confirm your plan change",
       "startingToday": "Starts today",

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -845,6 +845,7 @@ type BillingErrorCode =
   | 'member_removal_failed'
   | 'missing_checkout_response'
   | 'missing_payment_method_url'
+  | 'parked_checkout_recovery_offered'
   | 'payment_popup_blocked'
   | 'reactivation_not_confirmed'
   | 'reactivation_amount_changed'

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -845,7 +845,6 @@ type BillingErrorCode =
   | 'member_removal_failed'
   | 'missing_checkout_response'
   | 'missing_payment_method_url'
-  | 'parked_checkout_recovery_offered'
   | 'payment_popup_blocked'
   | 'reactivation_not_confirmed'
   | 'reactivation_amount_changed'

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -128,6 +128,9 @@ export type BillingAuthenticationState = NonNullable<
 export type BillingDeclineReason = NonNullable<
   BillingOpStatusResponse['decline_reason']
 >
+export type BillingOperationPhase = NonNullable<
+  BillingOpStatusResponse['phase']
+>
 
 interface GetBillingEventsParams {
   page?: number

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -364,16 +364,24 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
   })
 
-  it('hides the capture-mode payment action during parked-checkout recovery', () => {
+  it('hides the capture-mode payment surface during parked-checkout recovery', () => {
     render(SubscriptionAddPaymentPreviewWorkspace, {
       props: {
         tierKey: 'creator',
         parkedCheckoutRecovery: true,
-        usePaymentElement: true
+        usePaymentElement: true,
+        // A ready quote, so the selector is absent because recovery hides it
+        // rather than because there is nothing to price.
+        previewData: {
+          ...previewFixture('MONTHLY', 50_000),
+          quote_id: 'quote_parked',
+          quote_version: 1
+        }
       },
       global: globalOptions
     })
 
+    expect(screen.queryByTestId('payment-selector')).toBeNull()
     expect(
       screen.queryByRole('button', {
         name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -364,6 +364,32 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
   })
 
+  it.each([
+    ['capture-mode', { usePaymentElement: true }],
+    [
+      'saved-method',
+      { savedMethods: [{ id: 'pm_1', brand: 'visa', last4: '4242' }] }
+    ]
+  ])(
+    'hides the %s payment action during parked-checkout recovery',
+    (_variant, extraProps) => {
+      render(SubscriptionAddPaymentPreviewWorkspace, {
+        props: {
+          tierKey: 'creator',
+          parkedCheckoutRecovery: true,
+          ...extraProps
+        },
+        global: globalOptions
+      })
+
+      expect(
+        screen.queryByRole('button', {
+          name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
+        })
+      ).toBeNull()
+    }
+  )
+
   it('hides the standard subscribe action during parked-checkout recovery', () => {
     render(SubscriptionAddPaymentPreviewWorkspace, {
       props: { tierKey: 'creator', parkedCheckoutRecovery: true },
@@ -377,6 +403,32 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
       })
     ).toBeNull()
   })
+
+  it.each([
+    ['capture mode', { usePaymentElement: true }],
+    [
+      'saved methods',
+      { savedMethods: [{ id: 'pm_1', brand: 'visa', last4: '4242' }] }
+    ]
+  ])(
+    'hides the %s payment action during parked-checkout recovery',
+    (_label, extraProps) => {
+      render(SubscriptionAddPaymentPreviewWorkspace, {
+        props: {
+          tierKey: 'creator',
+          parkedCheckoutRecovery: true,
+          ...extraProps
+        },
+        global: globalOptions
+      })
+
+      expect(
+        screen.queryByRole('button', {
+          name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
+        })
+      ).toBeNull()
+    }
+  )
 
   it('retries the subscribe from the parked-checkout prompt', async () => {
     const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -364,6 +364,20 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
   })
 
+  it('hides the standard subscribe action during parked-checkout recovery', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', parkedCheckoutRecovery: true },
+      global: globalOptions
+    })
+
+    // Both emit addCreditCard; rendering them together offers the same action twice.
+    expect(
+      screen.queryByRole('button', {
+        name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
+      })
+    ).toBeNull()
+  })
+
   it('retries the subscribe from the parked-checkout prompt', async () => {
     const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
       props: { tierKey: 'creator', parkedCheckoutRecovery: true },

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -364,6 +364,23 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
   })
 
+  it('retries the subscribe from the parked-checkout prompt', async () => {
+    const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', parkedCheckoutRecovery: true },
+      global: globalOptions
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'subscription.preview.parkedCheckoutDetail'
+    )
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.completePayment'
+      })
+    )
+    expect(emitted().addCreditCard).toBeTruthy()
+  })
+
   it('reports failed verification without offering to resume it', () => {
     render(SubscriptionAddPaymentPreviewWorkspace, {
       props: {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -364,31 +364,47 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
   })
 
-  it.each([
-    ['capture-mode', { usePaymentElement: true }],
-    [
-      'saved-method',
-      { savedMethods: [{ id: 'pm_1', brand: 'visa', last4: '4242' }] }
-    ]
-  ])(
-    'hides the %s payment action during parked-checkout recovery',
-    (_variant, extraProps) => {
-      render(SubscriptionAddPaymentPreviewWorkspace, {
-        props: {
-          tierKey: 'creator',
-          parkedCheckoutRecovery: true,
-          ...extraProps
-        },
-        global: globalOptions
-      })
+  it('hides the capture-mode payment action during parked-checkout recovery', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        parkedCheckoutRecovery: true,
+        usePaymentElement: true
+      },
+      global: globalOptions
+    })
 
-      expect(
-        screen.queryByRole('button', {
-          name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
-        })
-      ).toBeNull()
-    }
-  )
+    expect(
+      screen.queryByRole('button', {
+        name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
+      })
+    ).toBeNull()
+  })
+
+  it('hides the saved-method payment action during parked-checkout recovery', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        parkedCheckoutRecovery: true,
+        savedMethods: [
+          {
+            type: 'card',
+            id: 'pm_1',
+            brand: 'visa',
+            last4: '4242',
+            is_default: true
+          }
+        ]
+      },
+      global: globalOptions
+    })
+
+    expect(
+      screen.queryByRole('button', {
+        name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
+      })
+    ).toBeNull()
+  })
 
   it('hides the standard subscribe action during parked-checkout recovery', () => {
     render(SubscriptionAddPaymentPreviewWorkspace, {
@@ -403,32 +419,6 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
       })
     ).toBeNull()
   })
-
-  it.each([
-    ['capture mode', { usePaymentElement: true }],
-    [
-      'saved methods',
-      { savedMethods: [{ id: 'pm_1', brand: 'visa', last4: '4242' }] }
-    ]
-  ])(
-    'hides the %s payment action during parked-checkout recovery',
-    (_label, extraProps) => {
-      render(SubscriptionAddPaymentPreviewWorkspace, {
-        props: {
-          tierKey: 'creator',
-          parkedCheckoutRecovery: true,
-          ...extraProps
-        },
-        global: globalOptions
-      })
-
-      expect(
-        screen.queryByRole('button', {
-          name: /subscription\.preview\.(subscribeToPlan|payAndSubscribe)/
-        })
-      ).toBeNull()
-    }
-  )
 
   it('retries the subscribe from the parked-checkout prompt', async () => {
     const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -322,7 +322,9 @@
       </Button>
 
       <Button
-        v-if="!usePaymentElement && !savedMethods?.length && !parkedCheckoutRecovery"
+        v-if="
+          !usePaymentElement && !savedMethods?.length && !parkedCheckoutRecovery
+        "
         variant="tertiary"
         size="lg"
         class="w-full rounded-lg"

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -281,7 +281,7 @@
       </Button>
 
       <UnifiedStripePaymentSelector
-        v-if="captureMode && quoteReady"
+        v-if="captureMode && quoteReady && !parkedCheckoutRecovery"
         :key="`${previewData?.quote_id}:${previewData?.quote_version}`"
         :amount-cents="amountDueCents"
         :currency="previewData?.currency ?? ''"

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -249,6 +249,25 @@
         }}
       </div>
 
+      <div v-if="parkedCheckoutRecovery" class="flex flex-col gap-2">
+        <div
+          role="alert"
+          class="rounded-lg border border-interface-stroke bg-secondary-background p-4 text-sm text-base-foreground"
+        >
+          {{ $t('subscription.preview.parkedCheckoutDetail') }}
+        </div>
+        <Button
+          variant="inverted"
+          size="lg"
+          class="w-full rounded-lg"
+          :loading="isLoading"
+          :disabled="interactionLocked"
+          @click="$emit('addCreditCard')"
+        >
+          {{ $t('subscription.preview.completePayment') }}
+        </Button>
+      </div>
+
       <Button
         v-if="actionUrl && authenticationState !== 'failed_retryable'"
         variant="inverted"
@@ -364,6 +383,9 @@ interface Props {
   authenticationState?: BillingAuthenticationState | null
   authenticationError?: string | null
   reconciliationOperationId?: string | null
+  /** Subscribe landed on a checkout already waiting for a card; only another
+   *  subscribe can re-issue its payment link. */
+  parkedCheckoutRecovery?: boolean
   usePaymentElement?: boolean
   /** Saved payment methods; when present the capture form is skipped and the
    *  confirm renders as a narrow summary. One method shows a Change
@@ -386,6 +408,7 @@ const {
   authenticationState = null,
   authenticationError = null,
   reconciliationOperationId = null,
+  parkedCheckoutRecovery = false,
   usePaymentElement = false,
   savedMethods = null,
   quoteIsCurrent = false,

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -294,7 +294,7 @@
       />
 
       <Button
-        v-if="captureMode && !quoteReady"
+        v-if="captureMode && !quoteReady && !parkedCheckoutRecovery"
         variant="inverted"
         size="lg"
         class="w-full rounded-lg"
@@ -308,7 +308,7 @@
       </Button>
 
       <Button
-        v-if="savedMethods?.length"
+        v-if="savedMethods?.length && !parkedCheckoutRecovery"
         variant="inverted"
         size="lg"
         class="w-full rounded-lg"
@@ -322,7 +322,7 @@
       </Button>
 
       <Button
-        v-if="!usePaymentElement && !savedMethods?.length"
+        v-if="!usePaymentElement && !savedMethods?.length && !parkedCheckoutRecovery"
         variant="tertiary"
         size="lg"
         class="w-full rounded-lg"

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -261,7 +261,9 @@
           size="lg"
           class="w-full rounded-lg"
           :loading="isLoading"
-          :disabled="interactionLocked"
+          :disabled="
+            interactionLocked || !quoteIsUsable || verificationRecoveryActive
+          "
           @click="$emit('addCreditCard')"
         >
           {{ $t('subscription.preview.completePayment') }}

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -101,6 +101,7 @@
         :authentication-state
         :authentication-error
         :reconciliation-operation-id
+        :parked-checkout-recovery
         :use-payment-element="stripePaymentElementEnabled"
         :saved-methods="savedMethodsForConfirm"
         :selected-saved-method-id="selectedSavedPaymentMethodId"
@@ -126,6 +127,7 @@
         :authentication-state
         :authentication-error
         :reconciliation-operation-id
+        :parked-checkout-recovery
         :use-payment-element="stripePaymentElementEnabled"
         :saved-methods="savedMethodsForConfirm"
         :selected-saved-method-id="selectedSavedPaymentMethodId"
@@ -234,6 +236,7 @@ const {
   authenticationState,
   authenticationError,
   reconciliationOperationId,
+  parkedCheckoutRecovery,
   isPolling,
   isTeamCheckout,
   previewVariant,

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -78,6 +78,7 @@
       :authentication-state
       :authentication-error
       :reconciliation-operation-id
+      :parked-checkout-recovery
       :quote-is-current
       :is-applying-promotion-code
       @add-credit-card="handleAddCreditCard"
@@ -164,6 +165,7 @@ const {
   authenticationState,
   authenticationError,
   reconciliationOperationId,
+  parkedCheckoutRecovery,
   isPolling,
   handleSubscribeClick,
   handleBackToPricing,

--- a/src/platform/workspace/composables/billingOperationTestUtils.ts
+++ b/src/platform/workspace/composables/billingOperationTestUtils.ts
@@ -21,6 +21,7 @@ export function billingOperation(
     authenticationRequiredSeen: false,
     workspaceId: 'workspace-1',
     autoHandleRequiresAction: false,
+    phase: null,
     dismissed: false,
     ...overrides
   }

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3124,7 +3124,7 @@ describe('useSubscriptionCheckout', () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockBillingStatus.value = 'awaiting_payment_method'
+      mockKnownOperations.value = new Map([['op-parked', {}]])
       mockSubscribe.mockResolvedValueOnce({
         status: 'pending_payment',
         billing_op_id: 'op-parked'
@@ -3141,7 +3141,7 @@ describe('useSubscriptionCheckout', () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockBillingStatus.value = 'awaiting_payment_method'
+      mockKnownOperations.value = new Map([['op-parked-no-url', {}]])
       mockSubscribe.mockResolvedValueOnce({
         status: 'needs_payment_method',
         billing_op_id: 'op-parked-no-url'
@@ -3158,7 +3158,6 @@ describe('useSubscriptionCheckout', () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockBillingStatus.value = 'paid'
       mockSubscribe.mockResolvedValueOnce({
         status: 'pending_payment',
         billing_op_id: 'op-live'
@@ -3178,7 +3177,7 @@ describe('useSubscriptionCheckout', () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockBillingStatus.value = 'awaiting_payment_method'
+      mockKnownOperations.value = new Map([['op-parked', {}]])
       mockSubscribe.mockResolvedValueOnce({
         status: 'pending_payment',
         billing_op_id: 'op-parked'
@@ -3202,6 +3201,74 @@ describe('useSubscriptionCheckout', () => {
         expect.any(Object),
         'https://stripe.com/pay'
       )
+    })
+
+    it('polls a replayed operation when this attempt supplied a saved card', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      checkout.selectedSavedPaymentMethodId.value = 'pm_saved'
+      // Same shape as a parked replay, but this attempt carries payment
+      // authority, so the operation is charged and must be polled.
+      mockKnownOperations.value = new Map([['op-parked', {}]])
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-parked',
+        'subscription',
+        expect.any(Object)
+      )
+    })
+
+    it('polls rather than prompting on a plan change, which cannot render the prompt', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      // Change previews never receive the recovery prop, so setting the flag
+      // there would strand the user on a dead confirm step.
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'upgrade',
+        requires_reactivation_confirmation: false
+      } as PreviewSubscribeResponse
+      mockKnownOperations.value = new Map([['op-parked', {}]])
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-parked',
+        'subscription',
+        expect.any(Object)
+      )
+    })
+
+    it('clears the payment recovery prompt when returning to pricing', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockKnownOperations.value = new Map([['op-parked', {}]])
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+
+      await checkout.handleAddCreditCard()
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+
+      checkout.handleBackToPricing()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
     })
 
     it('advances to success once the async payment operation succeeds', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1633,31 +1633,6 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.checkoutStep.value).toBe('pricing')
     })
 
-    it('offers payment recovery on a parked team-new checkout', async () => {
-      const checkout = await setup()
-      await checkout.handleSubscribeTeamClick({
-        stop: {
-          id: 'team_700',
-          usd: 700,
-          credits: 147_700,
-          discountedUsd: 665
-        },
-        billingCycle: 'monthly',
-        isChange: false
-      })
-      checkout.quoteIsCurrent.value = true
-      mockKnownOperations.value = new Map([['op-team-parked', {}]])
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'pending_payment',
-        billing_op_id: 'op-team-parked'
-      })
-
-      await checkout.handleTeamSubscribe()
-
-      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
-      expect(mockStartOperation).not.toHaveBeenCalled()
-    })
-
     it('previews a fresh team subscribe for exact billing terms', async () => {
       const checkout = await setup()
 
@@ -3145,38 +3120,72 @@ describe('useSubscriptionCheckout', () => {
       openSpy.mockRestore()
     })
 
-    it('offers payment recovery instead of polling a parked checkout', async () => {
+    it('offers payment recovery once the poll reports the checkout parked', async () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockKnownOperations.value = new Map([['op-parked', {}]])
       mockSubscribe.mockResolvedValueOnce({
         status: 'pending_payment',
         billing_op_id: 'op-parked'
       })
-
-      await checkout.handleAddCreditCard()
-
-      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
-      expect(mockStartOperation).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
-    })
-
-    it('offers payment recovery when a parked checkout returns no payment URL', async () => {
-      const checkout = await setupWithApprovedPreview()
-      checkout.selectedTierKey.value = 'standard'
-      checkout.selectedBillingCycle.value = 'yearly'
-      mockKnownOperations.value = new Map([['op-parked-no-url', {}]])
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'needs_payment_method',
-        billing_op_id: 'op-parked-no-url'
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: 'awaiting_payment_method'
       })
 
       await checkout.handleAddCreditCard()
 
       expect(checkout.parkedCheckoutRecovery.value).toBe(true)
-      expect(mockStartOperation).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      // Adopted rather than skipped: the operation is still polled, so it
+      // resolves on its own if the customer finishes checkout elsewhere.
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-parked',
+        'subscription',
+        expect.any(Object)
+      )
+    })
+
+    it('keeps polling an operation parked on an invoice instead of prompting', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-3ds'
+      })
+      // Also blocked on the customer, but it needs authentication rather than a
+      // card — actionUrl drives that, and offering this prompt would misdirect.
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: 'awaiting_invoice_payment'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
+    })
+
+    it('keeps polling when the server reports no phase at all', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-unknown-phase'
+      })
+      // Absent is no claim, never an implied in_progress — but it is equally
+      // not a licence to stop polling and prompt.
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: null
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
     })
 
     it('keeps polling a pending payment that is not parked', async () => {
@@ -3196,104 +3205,6 @@ describe('useSubscriptionCheckout', () => {
         'subscription',
         expect.any(Object)
       )
-    })
-
-    it('clears the payment recovery prompt on the next attempt', async () => {
-      const checkout = await setupWithApprovedPreview()
-      checkout.selectedTierKey.value = 'standard'
-      checkout.selectedBillingCycle.value = 'yearly'
-      mockKnownOperations.value = new Map([['op-parked', {}]])
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'pending_payment',
-        billing_op_id: 'op-parked'
-      })
-
-      await checkout.handleAddCreditCard()
-      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
-
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'needs_payment_method',
-        billing_op_id: 'op-parked',
-        payment_method_url: 'https://stripe.com/pay'
-      })
-
-      await checkout.handleAddCreditCard()
-
-      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
-      expect(mockStartOperation).toHaveBeenCalledWith(
-        'op-parked',
-        'subscription',
-        expect.any(Object),
-        'https://stripe.com/pay'
-      )
-    })
-
-    it('polls a replayed operation when this attempt supplied a saved card', async () => {
-      const checkout = await setupWithApprovedPreview()
-      checkout.selectedTierKey.value = 'standard'
-      checkout.selectedBillingCycle.value = 'yearly'
-      checkout.selectedSavedPaymentMethodId.value = 'pm_saved'
-      // Same shape as a parked replay, but this attempt carries payment
-      // authority, so the operation is charged and must be polled.
-      mockKnownOperations.value = new Map([['op-parked', {}]])
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'pending_payment',
-        billing_op_id: 'op-parked'
-      })
-
-      await checkout.handleAddCreditCard()
-
-      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
-      expect(mockStartOperation).toHaveBeenCalledWith(
-        'op-parked',
-        'subscription',
-        expect.any(Object)
-      )
-    })
-
-    it('polls rather than prompting on a plan change, which cannot render the prompt', async () => {
-      const checkout = await setupWithApprovedPreview()
-      checkout.selectedTierKey.value = 'standard'
-      checkout.selectedBillingCycle.value = 'yearly'
-      // Change previews never receive the recovery prop, so setting the flag
-      // there would strand the user on a dead confirm step.
-      checkout.previewData.value = {
-        allowed: true,
-        transition_type: 'upgrade',
-        requires_reactivation_confirmation: false
-      } as PreviewSubscribeResponse
-      mockKnownOperations.value = new Map([['op-parked', {}]])
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'pending_payment',
-        billing_op_id: 'op-parked'
-      })
-
-      await checkout.handleAddCreditCard()
-
-      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
-      expect(mockStartOperation).toHaveBeenCalledWith(
-        'op-parked',
-        'subscription',
-        expect.any(Object)
-      )
-    })
-
-    it('clears the payment recovery prompt when returning to pricing', async () => {
-      const checkout = await setupWithApprovedPreview()
-      checkout.selectedTierKey.value = 'standard'
-      checkout.selectedBillingCycle.value = 'yearly'
-      mockKnownOperations.value = new Map([['op-parked', {}]])
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'pending_payment',
-        billing_op_id: 'op-parked'
-      })
-
-      await checkout.handleAddCreditCard()
-      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
-
-      checkout.handleBackToPricing()
-
-      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
     })
 
     it('advances to success once the async payment operation succeeds', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -176,7 +176,8 @@ const {
   mockPermissions,
   mockCanReactivatePlan,
   mockCapabilities,
-  mockSubscription
+  mockSubscription,
+  mockBillingStatus
 } = vi.hoisted(() => {
   return {
     mockSubscribe: vi.fn(),
@@ -214,7 +215,8 @@ const {
         canDowngradeToPersonal: true
       }
     },
-    mockSubscription: { value: null as { isCancelled: boolean } | null }
+    mockSubscription: { value: null as { isCancelled: boolean } | null },
+    mockBillingStatus: { value: null as string | null }
   }
 })
 
@@ -252,6 +254,11 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     subscription: {
       get value() {
         return mockSubscription.value
+      }
+    },
+    billingStatus: {
+      get value() {
+        return mockBillingStatus.value
       }
     }
   })
@@ -455,6 +462,7 @@ describe('useSubscriptionCheckout', () => {
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
     Object.assign(useAuthStore(), { userId: 'user-1' })
     mockIsTeamPlan.value = false
+    mockBillingStatus.value = null
     mockOpen.mockReturnValue({})
     mockGetBillingStatus.mockResolvedValue({ billing_status: 'paid' })
     mockGetPaymentPortalUrl.mockResolvedValue({
@@ -3109,6 +3117,90 @@ describe('useSubscriptionCheckout', () => {
         })
       )
       openSpy.mockRestore()
+    })
+
+    it('offers payment recovery instead of polling a parked checkout', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockBillingStatus.value = 'awaiting_payment_method'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('offers payment recovery when a parked checkout returns no payment URL', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockBillingStatus.value = 'awaiting_payment_method'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'needs_payment_method',
+        billing_op_id: 'op-parked-no-url'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('keeps polling a pending payment that is not parked', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockBillingStatus.value = 'paid'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-live'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-live',
+        'subscription',
+        expect.any(Object)
+      )
+    })
+
+    it('clears the payment recovery prompt on the next attempt', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockBillingStatus.value = 'awaiting_payment_method'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+
+      await checkout.handleAddCreditCard()
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'needs_payment_method',
+        billing_op_id: 'op-parked',
+        payment_method_url: 'https://stripe.com/pay'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(false)
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-parked',
+        'subscription',
+        expect.any(Object),
+        'https://stripe.com/pay'
+      )
     })
 
     it('advances to success once the async payment operation succeeds', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3146,6 +3146,29 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('releases the busy state so the recovery prompt can be acted on', async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: 'awaiting_payment_method'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+      // The parents fold isPolling into the preview's isLoading, which locks
+      // the prompt's own button and Back. A checkout waiting on the customer
+      // must not read as busy, even though we keep polling it.
+      expect(checkout.isPolling.value).toBe(false)
+    })
+
     it('keeps polling an operation parked on an invoice instead of prompting', async () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3169,6 +3169,48 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.isPolling.value).toBe(false)
     })
 
+    it('releases the submit-busy state on the legacy path too', async () => {
+      // The legacy dialog binds isSubscribing || isPolling as its loading input,
+      // so releasing only isPolling left the prompt's CTA and Back disabled
+      // while the poll ran. Observed mid-poll, because handleSubscription's
+      // finally clears isSubscribing once the whole attempt returns.
+      const checkout = await setup(undefined, 'personal', false)
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'new_subscription',
+        requires_reactivation_confirmation: false
+      } as PreviewSubscribeResponse
+      checkout.quoteIsCurrent.value = true
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: 'awaiting_payment_method'
+      })
+      let resolveOperation!: (operation: { status: 'pending' }) => void
+      mockStartOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOperation = resolve
+          })
+      )
+
+      const payment = checkout.handleAddCreditCard()
+      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+      expect(checkout.isSubscribing.value).toBe(false)
+      expect(checkout.isPolling.value).toBe(false)
+
+      resolveOperation({ status: 'pending' })
+      await payment
+    })
+
     it('keeps polling an operation parked on an invoice instead of prompting', async () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3276,43 +3276,6 @@ describe('useSubscriptionCheckout', () => {
       await attemptB
     })
 
-    it('releases the lock when a team-to-personal downgrade parks', async () => {
-      // The downgrade runs inside handleSubscription's lock but hands the
-      // response to the shared handler itself, so it has to forward the token
-      // or the parked operation holds a lock nobody can release.
-      const checkout = await setupWithApprovedPreview()
-      checkout.selectedTierKey.value = 'standard'
-      checkout.selectedBillingCycle.value = 'yearly'
-      mockIsTeamPlan.value = true
-      mockShowDowngradeToPersonalDialog.mockResolvedValue({
-        preview: { allowed: true } as PreviewSubscribeResponse,
-        response: { status: 'pending_payment', billing_op_id: 'op-downgrade' }
-      })
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: 'awaiting_payment_method'
-      })
-      let resolveOperation!: (operation: { status: 'pending' }) => void
-      mockStartOperation.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveOperation = resolve
-          })
-      )
-
-      const attempt = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
-
-      // The lock is free, so the recovery CTA's own click can get through.
-      mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
-      await checkout.handleAddCreditCard()
-      expect(mockShowDowngradeToPersonalDialog).toHaveBeenCalledTimes(2)
-
-      resolveOperation({ status: 'pending' })
-      await attempt
-    })
-
     it('keeps polling an operation parked on an invoice instead of prompting', async () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3224,6 +3224,58 @@ describe('useSubscriptionCheckout', () => {
       await payment
     })
 
+    it("does not let a finished attempt release a newer attempt's lock", async () => {
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: 'awaiting_payment_method'
+      })
+
+      // A adopts a parked operation and releases the lock, then stays suspended.
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-parked'
+      })
+      let resolveA!: (operation: { status: 'pending' }) => void
+      mockStartOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveA = resolve
+          })
+      )
+      const attemptA = checkout.handleAddCreditCard()
+      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+
+      // B takes the lock and is held inside subscribe().
+      let releaseB!: () => void
+      mockSubscribe.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseB = () =>
+              resolve({
+                status: 'needs_payment_method',
+                billing_op_id: 'op-b',
+                payment_method_url: 'https://stripe.com/pay'
+              })
+          })
+      )
+      const attemptB = checkout.handleAddCreditCard()
+      await vi.waitFor(() => expect(mockSubscribe).toHaveBeenCalledTimes(2))
+
+      // A finishes. Its finally must not hand B's lock to C.
+      resolveA({ status: 'pending' })
+      await attemptA
+
+      await checkout.handleAddCreditCard()
+      expect(mockSubscribe).toHaveBeenCalledTimes(2)
+
+      releaseB()
+      await attemptB
+    })
+
     it('keeps polling an operation parked on an invoice instead of prompting', async () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -10,6 +10,7 @@ import { createI18n } from 'vue-i18n'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import type {
+  BillingStatus,
   Plan,
   PreviewSubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
@@ -216,7 +217,7 @@ const {
       }
     },
     mockSubscription: { value: null as { isCancelled: boolean } | null },
-    mockBillingStatus: { value: null as string | null }
+    mockBillingStatus: { value: null as BillingStatus | null }
   }
 })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1633,6 +1633,31 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.checkoutStep.value).toBe('pricing')
     })
 
+    it('offers payment recovery on a parked team-new checkout', async () => {
+      const checkout = await setup()
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: false
+      })
+      checkout.quoteIsCurrent.value = true
+      mockKnownOperations.value = new Map([['op-team-parked', {}]])
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-team-parked'
+      })
+
+      await checkout.handleTeamSubscribe()
+
+      expect(checkout.parkedCheckoutRecovery.value).toBe(true)
+      expect(mockStartOperation).not.toHaveBeenCalled()
+    })
+
     it('previews a fresh team subscribe for exact billing terms', async () => {
       const checkout = await setup()
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3128,18 +3128,16 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-parked'
       })
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: 'awaiting_payment_method'
-      })
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({ phase: 'awaiting_payment_method' })
+      )
 
       await checkout.handleAddCreditCard()
 
       expect(checkout.parkedCheckoutRecovery.value).toBe(true)
       // Adopted rather than skipped: the operation is still polled, so it
       // resolves on its own if the customer finishes checkout elsewhere.
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-parked',
         'subscription',
         expect.any(Object)
@@ -3154,11 +3152,9 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-parked'
       })
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: 'awaiting_payment_method'
-      })
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({ phase: 'awaiting_payment_method' })
+      )
 
       await checkout.handleAddCreditCard()
 
@@ -3187,13 +3183,13 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-parked'
       })
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: 'awaiting_payment_method'
-      })
-      let resolveOperation!: (operation: { status: 'pending' }) => void
-      mockStartOperation.mockImplementationOnce(
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({ phase: 'awaiting_payment_method' })
+      )
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -3201,7 +3197,9 @@ describe('useSubscriptionCheckout', () => {
       )
 
       const payment = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      await vi.waitFor(() =>
+        expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      )
 
       expect(checkout.parkedCheckoutRecovery.value).toBe(true)
       expect(checkout.isSubscribing.value).toBe(false)
@@ -3220,7 +3218,7 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockSubscribe).toHaveBeenCalledTimes(2)
 
-      resolveOperation({ status: 'pending' })
+      resolveOperation(billingOperation({ status: 'pending' }))
       await payment
     })
 
@@ -3228,26 +3226,28 @@ describe('useSubscriptionCheckout', () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: 'awaiting_payment_method'
-      })
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({ phase: 'awaiting_payment_method' })
+      )
 
       // A adopts a parked operation and releases the lock, then stays suspended.
       mockSubscribe.mockResolvedValueOnce({
         status: 'pending_payment',
         billing_op_id: 'op-parked'
       })
-      let resolveA!: (operation: { status: 'pending' }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveA!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveA = resolve
           })
       )
       const attemptA = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      await vi.waitFor(() =>
+        expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      )
 
       // B takes the lock and is held inside subscribe().
       let releaseB!: () => void
@@ -3266,7 +3266,7 @@ describe('useSubscriptionCheckout', () => {
       await vi.waitFor(() => expect(mockSubscribe).toHaveBeenCalledTimes(2))
 
       // A finishes. Its finally must not hand B's lock to C.
-      resolveA({ status: 'pending' })
+      resolveA(billingOperation({ status: 'pending' }))
       await attemptA
 
       await checkout.handleAddCreditCard()
@@ -3286,11 +3286,9 @@ describe('useSubscriptionCheckout', () => {
       })
       // Also blocked on the customer, but it needs authentication rather than a
       // card — actionUrl drives that, and offering this prompt would misdirect.
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: 'awaiting_invoice_payment'
-      })
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({ phase: 'awaiting_invoice_payment' })
+      )
 
       await checkout.handleAddCreditCard()
 
@@ -3307,11 +3305,9 @@ describe('useSubscriptionCheckout', () => {
       })
       // Absent is no claim, never an implied in_progress — but it is equally
       // not a licence to stop polling and prompt.
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        phase: null
-      })
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({ phase: null })
+      )
 
       await checkout.handleAddCreditCard()
 
@@ -3330,7 +3326,7 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(checkout.parkedCheckoutRecovery.value).toBe(false)
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-live',
         'subscription',
         expect.any(Object)

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3276,6 +3276,43 @@ describe('useSubscriptionCheckout', () => {
       await attemptB
     })
 
+    it('releases the lock when a team-to-personal downgrade parks', async () => {
+      // The downgrade runs inside handleSubscription's lock but hands the
+      // response to the shared handler itself, so it has to forward the token
+      // or the parked operation holds a lock nobody can release.
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockIsTeamPlan.value = true
+      mockShowDowngradeToPersonalDialog.mockResolvedValue({
+        preview: { allowed: true } as PreviewSubscribeResponse,
+        response: { status: 'pending_payment', billing_op_id: 'op-downgrade' }
+      })
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        phase: 'awaiting_payment_method'
+      })
+      let resolveOperation!: (operation: { status: 'pending' }) => void
+      mockStartOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOperation = resolve
+          })
+      )
+
+      const attempt = checkout.handleAddCreditCard()
+      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+
+      // The lock is free, so the recovery CTA's own click can get through.
+      mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
+      await checkout.handleAddCreditCard()
+      expect(mockShowDowngradeToPersonalDialog).toHaveBeenCalledTimes(2)
+
+      resolveOperation({ status: 'pending' })
+      await attempt
+    })
+
     it('keeps polling an operation parked on an invoice instead of prompting', async () => {
       const checkout = await setupWithApprovedPreview()
       checkout.selectedTierKey.value = 'standard'

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3207,6 +3207,19 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.isSubscribing.value).toBe(false)
       expect(checkout.isPolling.value).toBe(false)
 
+      // Looking enabled is not enough: the prompt's button re-enters
+      // handleSubscription, so the mutation lock has to be released as well or
+      // the click is silently dropped — and a parked operation may not go
+      // terminal until the customer performs exactly this action.
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'needs_payment_method',
+        billing_op_id: 'op-parked',
+        payment_method_url: 'https://stripe.com/pay'
+      })
+      await checkout.handleAddCreditCard()
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(2)
+
       resolveOperation({ status: 'pending' })
       await payment
     })

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -135,7 +135,8 @@ export function useSubscriptionCheckout(
     fetchStatus,
     isTeamPlan,
     resubscribe,
-    subscription
+    subscription,
+    billingStatus
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
   const { canSubscribeSelfServe, canChangeSeats, canDowngradeToPersonal } =
@@ -157,6 +158,7 @@ export function useSubscriptionCheckout(
   const selectedSavedPaymentMethodId = ref<string | null>(null)
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
+  const parkedCheckoutRecovery = ref(false)
   let teamPreviewRequestId = 0
   let promotionPreviewRequestId = 0
   let checkoutMutationLocked = false
@@ -900,6 +902,7 @@ export function useSubscriptionCheckout(
     selectedTeamCheckout.value = null
     activeCheckoutOperationId.value = null
     activeCheckoutAttemptStartedAt = undefined
+    parkedCheckoutRecovery.value = false
   }
 
   function handleBackToPricing() {
@@ -1195,6 +1198,7 @@ export function useSubscriptionCheckout(
     context: SubscriptionOutcomeContext,
     shouldTrackSubscriptionSuccess = true
   ): Promise<void> {
+    parkedCheckoutRecovery.value = false
     if (!response) {
       trackSubscriptionFailure(context, undefined, 'missing_checkout_response')
       return
@@ -1238,6 +1242,16 @@ export function useSubscriptionCheckout(
         })
       }
       checkoutStep.value = 'success'
+      return
+    }
+
+    // No payment link while already parked on a card means the operation
+    // cannot advance until checkout completes, so polling it only expires.
+    if (
+      !response.payment_method_url &&
+      billingStatus.value === 'awaiting_payment_method'
+    ) {
+      parkedCheckoutRecovery.value = true
       return
     }
 
@@ -1558,6 +1572,7 @@ export function useSubscriptionCheckout(
     authenticationState,
     authenticationError,
     reconciliationOperationId,
+    parkedCheckoutRecovery,
     isPolling,
     isTeamCheckout,
     previewVariant,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -1344,7 +1344,13 @@ export function useSubscriptionCheckout(
           initialActionUrl
         )
       : billingOperationStore.startOperation(opId, 'subscription', metadata)
-    if (embeddedCheckoutEnabled) isSubscribing.value = false
+    // The submit is over once the operation is adopted: isPolling is the busy
+    // state from here, and it is already true because startOperation registers
+    // synchronously above. Holding isSubscribing past this point kept the
+    // legacy dialog's loading input true until the operation went terminal,
+    // which disabled the recovery prompt's own CTA and Back for a checkout
+    // parked on the customer. Releasing it does not stop the poll.
+    isSubscribing.value = false
     const operation = await terminalOperation
     clearPendingSubscriptionCheckoutIfTerminal(opId, operation.status)
     if (

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -636,10 +636,7 @@ export function useSubscriptionCheckout(
 
   async function showTeamToPersonalDowngrade(
     planSlug: string,
-    tierKey: CheckoutTierKey,
-    // Forwarded so a parked downgrade releases the caller's lock on adoption;
-    // handleSubscribeClick holds none and leaves this 0.
-    mutationToken = 0
+    tierKey: CheckoutTierKey
   ): Promise<boolean> {
     if (tierPlanType === 'team' || !isTeamPlan.value) return false
 
@@ -665,8 +662,7 @@ export function useSubscriptionCheckout(
         cycle: selectedBillingCycle.value,
         checkoutType: 'change'
       },
-      false,
-      mutationToken
+      false
     )
     return true
   }
@@ -965,8 +961,7 @@ export function useSubscriptionCheckout(
 
     isSubscribing.value = true
     try {
-      if (await showTeamToPersonalDowngrade(planSlug, tierKey, mutationToken))
-        return
+      if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       await fetchStatus()
       if (!confirmReactivation && requiresReactivationConfirmation()) {
         await refreshPreviewOnReactivationBlock(planSlug)

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -157,7 +157,6 @@ export function useSubscriptionCheckout(
   const selectedSavedPaymentMethodId = ref<string | null>(null)
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
-  const parkedCheckoutRecovery = ref(false)
   let teamPreviewRequestId = 0
   let promotionPreviewRequestId = 0
   let checkoutMutationLocked = false
@@ -188,6 +187,13 @@ export function useSubscriptionCheckout(
   })
   const activeCheckoutActionUrl = computed(
     () => activeCheckoutOperation.value?.actionUrl ?? null
+  )
+  // The server says whether the operation is parked; the client no longer
+  // guesses. Only awaiting_payment_method offers this recovery — an operation
+  // parked on an invoice needs authentication, which actionUrl already drives.
+  // A null phase is no claim, so the poll simply continues.
+  const parkedCheckoutRecovery = computed(
+    () => activeCheckoutOperation.value?.phase === 'awaiting_payment_method'
   )
   const authenticationState = computed(
     () => activeCheckoutOperation.value?.authenticationState ?? null
@@ -901,7 +907,6 @@ export function useSubscriptionCheckout(
     selectedTeamCheckout.value = null
     activeCheckoutOperationId.value = null
     activeCheckoutAttemptStartedAt = undefined
-    parkedCheckoutRecovery.value = false
   }
 
   function handleBackToPricing() {
@@ -963,9 +968,6 @@ export function useSubscriptionCheckout(
       if (embeddedCheckoutEnabled && quote && !quoteIsCurrent.value) {
         throw new Error(t('subscription.preview.applyQuoteBeforeContinuing'))
       }
-      // Captured before subscribe: afterwards this attempt's own operation is
-      // registered too, and the two become indistinguishable.
-      const knownOperationIds = new Set(billingOperationStore.operations.keys())
       const response = await subscribe(planSlug, {
         ...(embeddedCheckoutEnabled &&
           buildPaymentOptions(quote, confirmationToken, promotionCode)),
@@ -992,13 +994,7 @@ export function useSubscriptionCheckout(
         tier: tierKey,
         cycle: billingCycle,
         checkoutType,
-        attemptStartedAt,
-        suppliedPaymentAuthority: Boolean(
-          confirmationToken || selectedSavedPaymentMethodId.value
-        ),
-        replayedKnownOperation: response
-          ? knownOperationIds.has(response.billing_op_id)
-          : false
+        attemptStartedAt
       })
       activeCheckoutAttemptStartedAt = undefined
     } catch (error) {
@@ -1128,18 +1124,6 @@ export function useSubscriptionCheckout(
      * subscribe call), not just the poll-observation window.
      */
     attemptStartedAt?: number
-    /**
-     * Whether this attempt carried its own payment authority (a confirmation
-     * token or a saved method). Such an attempt is charged server-side, so a
-     * link-less response from it must be polled, never treated as parked.
-     */
-    suppliedPaymentAuthority?: boolean
-    /**
-     * Whether the returned billing op was already known to the client before
-     * this attempt, captured before the subscribe call. Only a replay of an
-     * operation we already had can be the parked checkout.
-     */
-    replayedKnownOperation?: boolean
   }
 
   function trackSubscriptionStarted(
@@ -1218,7 +1202,6 @@ export function useSubscriptionCheckout(
     context: SubscriptionOutcomeContext,
     shouldTrackSubscriptionSuccess = true
   ): Promise<void> {
-    parkedCheckoutRecovery.value = false
     if (!response) {
       trackSubscriptionFailure(context, undefined, 'missing_checkout_response')
       return
@@ -1262,32 +1245,6 @@ export function useSubscriptionCheckout(
         })
       }
       checkoutStep.value = 'success'
-      return
-    }
-
-    // A link-less response is only "parked" when it names an operation we
-    // already knew about. Workspace billing status cannot decide this: the
-    // delegated subscribe path returns pending_payment without a link on
-    // healthy attempts too, and it never writes billing_status, so the status
-    // stays awaiting_payment_method through the very request that resolves it.
-    // The caller snapshots known operations before subscribing, so a hit means
-    // the backend replayed the parked op rather than reserving a new one.
-    if (
-      !response.payment_method_url &&
-      context.checkoutType === 'new' &&
-      !context.suppliedPaymentAuthority &&
-      context.replayedKnownOperation
-    ) {
-      // Still record the operation: the parked checkout is the one that will
-      // settle if the customer finishes it in the Stripe tab, and without a
-      // resume record a reload leaves that op unreconciled.
-      savePendingCheckout(response.billing_op_id, context)
-      parkedCheckoutRecovery.value = true
-      trackSubscriptionFailure(
-        context,
-        undefined,
-        'parked_checkout_recovery_offered'
-      )
       return
     }
 
@@ -1449,9 +1406,6 @@ export function useSubscriptionCheckout(
       if (embeddedCheckoutEnabled && quote && !quoteIsCurrent.value) {
         throw new Error(t('subscription.preview.applyQuoteBeforeContinuing'))
       }
-      // Captured before subscribe, as in handleSubscription: afterwards this
-      // attempt's own operation is registered too.
-      const knownOperationIds = new Set(billingOperationStore.operations.keys())
       const response = await subscribe(planSlug, {
         ...(embeddedCheckoutEnabled &&
           buildPaymentOptions(quote, confirmationToken, promotionCode)),
@@ -1480,13 +1434,7 @@ export function useSubscriptionCheckout(
         tier: 'team',
         cycle: billingCycle,
         checkoutType,
-        attemptStartedAt,
-        suppliedPaymentAuthority: Boolean(
-          confirmationToken || selectedSavedPaymentMethodId.value
-        ),
-        replayedKnownOperation: response
-          ? knownOperationIds.has(response.billing_op_id)
-          : false
+        attemptStartedAt
       })
       activeCheckoutAttemptStartedAt = undefined
     } catch (error) {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -159,7 +159,8 @@ export function useSubscriptionCheckout(
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
   let teamPreviewRequestId = 0
   let promotionPreviewRequestId = 0
-  let checkoutMutationLocked = false
+  let checkoutMutationOwner = 0
+  let checkoutMutationSeq = 0
   let refreshStatusOnFocus = false
   let activeCheckoutAttemptStartedAt: number | undefined
   useEventListener(window, 'focus', () => {
@@ -226,14 +227,20 @@ export function useSubscriptionCheckout(
       operation.authenticationState !== 'requires_action'
     )
   })
-  function beginCheckoutMutation(): boolean {
-    if (checkoutMutationLocked) return false
-    checkoutMutationLocked = true
-    return true
+  // The lock is owned by one attempt at a time. An attempt that releases early
+  // (see advanceToSuccessOnOperation) still runs its own finally afterwards, by
+  // which point a newer attempt may hold the lock — releasing on a bare boolean
+  // there would hand a third attempt a lock it does not own and let two submits
+  // run concurrently. So a release only counts from the holder.
+  function beginCheckoutMutation(): number {
+    if (checkoutMutationOwner !== 0) return 0
+    checkoutMutationOwner = ++checkoutMutationSeq
+    return checkoutMutationOwner
   }
 
-  function finishCheckoutMutation() {
-    checkoutMutationLocked = false
+  function finishCheckoutMutation(token: number) {
+    if (token !== 0 && checkoutMutationOwner === token)
+      checkoutMutationOwner = 0
   }
   const selectedTeamStop = computed(
     () => selectedTeamCheckout.value?.stop ?? null
@@ -927,18 +934,19 @@ export function useSubscriptionCheckout(
     promotionCode?: string
   ) {
     if (!canSelectTierPlan()) return
-    if (!beginCheckoutMutation()) return
+    const mutationToken = beginCheckoutMutation()
+    if (!mutationToken) return
 
     const tierKey = selectedTierKey.value
     if (!tierKey) {
-      finishCheckoutMutation()
+      finishCheckoutMutation(mutationToken)
       return
     }
 
     const billingCycle = selectedBillingCycle.value
     const planSlug = getApiPlanSlug(tierKey, billingCycle)
     if (!planSlug) {
-      finishCheckoutMutation()
+      finishCheckoutMutation(mutationToken)
       return
     }
     const checkoutType =
@@ -947,7 +955,7 @@ export function useSubscriptionCheckout(
         ? 'change'
         : 'new'
     if (!canPerformCheckout(checkoutType)) {
-      finishCheckoutMutation()
+      finishCheckoutMutation(mutationToken)
       return
     }
 
@@ -993,12 +1001,17 @@ export function useSubscriptionCheckout(
           paymentIntentSource
         })
       }
-      await handleSubscribeResponse(response, {
-        tier: tierKey,
-        cycle: billingCycle,
-        checkoutType,
-        attemptStartedAt
-      })
+      await handleSubscribeResponse(
+        response,
+        {
+          tier: tierKey,
+          cycle: billingCycle,
+          checkoutType,
+          attemptStartedAt
+        },
+        true,
+        mutationToken
+      )
       activeCheckoutAttemptStartedAt = undefined
     } catch (error) {
       if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
@@ -1021,7 +1034,7 @@ export function useSubscriptionCheckout(
       showSubscribeError(error)
     } finally {
       isSubscribing.value = false
-      finishCheckoutMutation()
+      finishCheckoutMutation(mutationToken)
     }
   }
 
@@ -1067,7 +1080,8 @@ export function useSubscriptionCheckout(
     lockMutation = true
   ): Promise<boolean> {
     if (!embeddedCheckoutEnabled) return false
-    if (lockMutation && !beginCheckoutMutation()) return false
+    const mutationToken = lockMutation ? beginCheckoutMutation() : 0
+    if (lockMutation && !mutationToken) return false
     isApplyingPromotionCode.value = true
     const requestId = ++promotionPreviewRequestId
     const normalizedInput = promotionCode.trim()
@@ -1086,12 +1100,12 @@ export function useSubscriptionCheckout(
       )
       options = normalizedInput ? { promotionCode: normalizedInput } : {}
     } else {
-      if (lockMutation) finishCheckoutMutation()
+      if (lockMutation) finishCheckoutMutation(mutationToken)
       isApplyingPromotionCode.value = false
       return false
     }
     if (!planSlug) {
-      if (lockMutation) finishCheckoutMutation()
+      if (lockMutation) finishCheckoutMutation(mutationToken)
       isApplyingPromotionCode.value = false
       return false
     }
@@ -1112,7 +1126,7 @@ export function useSubscriptionCheckout(
       if (requestId === promotionPreviewRequestId) {
         isApplyingPromotionCode.value = false
       }
-      if (lockMutation) finishCheckoutMutation()
+      if (lockMutation) finishCheckoutMutation(mutationToken)
     }
   }
 
@@ -1203,7 +1217,9 @@ export function useSubscriptionCheckout(
   async function handleSubscribeResponse(
     response: SubscribeResponse | void,
     context: SubscriptionOutcomeContext,
-    shouldTrackSubscriptionSuccess = true
+    shouldTrackSubscriptionSuccess = true,
+    // 0 when the caller holds no lock; a release from a non-holder is a no-op.
+    mutationToken = 0
   ): Promise<void> {
     if (!response) {
       trackSubscriptionFailure(context, undefined, 'missing_checkout_response')
@@ -1273,7 +1289,8 @@ export function useSubscriptionCheckout(
     await advanceToSuccessOnOperation(
       response.billing_op_id,
       context,
-      initialActionUrl
+      initialActionUrl,
+      mutationToken
     )
   }
 
@@ -1322,7 +1339,8 @@ export function useSubscriptionCheckout(
   async function advanceToSuccessOnOperation(
     opId: string,
     context: SubscriptionOutcomeContext,
-    initialActionUrl?: string
+    initialActionUrl: string | undefined,
+    mutationToken: number
   ) {
     activeCheckoutOperationId.value = opId
     const metadata = {
@@ -1355,7 +1373,7 @@ export function useSubscriptionCheckout(
     // deadlocks the recovery. Releasing neither stops the poll; the outer
     // finally still runs, and finishCheckoutMutation is idempotent.
     isSubscribing.value = false
-    finishCheckoutMutation()
+    finishCheckoutMutation(mutationToken)
     const operation = await terminalOperation
     clearPendingSubscriptionCheckoutIfTerminal(opId, operation.status)
     if (
@@ -1380,7 +1398,8 @@ export function useSubscriptionCheckout(
     ) {
       return
     }
-    if (!beginCheckoutMutation()) return
+    const mutationToken = beginCheckoutMutation()
+    if (!mutationToken) return
 
     const teamCheckout = selectedTeamCheckout.value
     if (!teamCheckout.stop.id) {
@@ -1389,7 +1408,7 @@ export function useSubscriptionCheckout(
         summary: t('subscription.teamPlan.name'),
         detail: t('subscription.teamPlan.unavailable')
       })
-      finishCheckoutMutation()
+      finishCheckoutMutation(mutationToken)
       return
     }
 
@@ -1444,12 +1463,17 @@ export function useSubscriptionCheckout(
           paymentIntentSource
         })
       }
-      await handleSubscribeResponse(response, {
-        tier: 'team',
-        cycle: billingCycle,
-        checkoutType,
-        attemptStartedAt
-      })
+      await handleSubscribeResponse(
+        response,
+        {
+          tier: 'team',
+          cycle: billingCycle,
+          checkoutType,
+          attemptStartedAt
+        },
+        true,
+        mutationToken
+      )
       activeCheckoutAttemptStartedAt = undefined
     } catch (error) {
       if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
@@ -1479,7 +1503,7 @@ export function useSubscriptionCheckout(
       showSubscribeError(error)
     } finally {
       isSubscribing.value = false
-      finishCheckoutMutation()
+      finishCheckoutMutation(mutationToken)
     }
   }
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -1278,6 +1278,10 @@ export function useSubscriptionCheckout(
       !context.suppliedPaymentAuthority &&
       context.replayedKnownOperation
     ) {
+      // Still record the operation: the parked checkout is the one that will
+      // settle if the customer finishes it in the Stripe tab, and without a
+      // resume record a reload leaves that op unreconciled.
+      savePendingCheckout(response.billing_op_id, context)
       parkedCheckoutRecovery.value = true
       trackSubscriptionFailure(
         context,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -636,7 +636,10 @@ export function useSubscriptionCheckout(
 
   async function showTeamToPersonalDowngrade(
     planSlug: string,
-    tierKey: CheckoutTierKey
+    tierKey: CheckoutTierKey,
+    // Forwarded so a parked downgrade releases the caller's lock on adoption;
+    // handleSubscribeClick holds none and leaves this 0.
+    mutationToken = 0
   ): Promise<boolean> {
     if (tierPlanType === 'team' || !isTeamPlan.value) return false
 
@@ -662,7 +665,8 @@ export function useSubscriptionCheckout(
         cycle: selectedBillingCycle.value,
         checkoutType: 'change'
       },
-      false
+      false,
+      mutationToken
     )
     return true
   }
@@ -961,7 +965,8 @@ export function useSubscriptionCheckout(
 
     isSubscribing.value = true
     try {
-      if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
+      if (await showTeamToPersonalDowngrade(planSlug, tierKey, mutationToken))
+        return
       await fetchStatus()
       if (!confirmReactivation && requiresReactivationConfirmation()) {
         await refreshPreviewOnReactivationBlock(planSlug)

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -135,8 +135,7 @@ export function useSubscriptionCheckout(
     fetchStatus,
     isTeamPlan,
     resubscribe,
-    subscription,
-    billingStatus
+    subscription
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
   const { canSubscribeSelfServe, canChangeSeats, canDowngradeToPersonal } =
@@ -964,6 +963,9 @@ export function useSubscriptionCheckout(
       if (embeddedCheckoutEnabled && quote && !quoteIsCurrent.value) {
         throw new Error(t('subscription.preview.applyQuoteBeforeContinuing'))
       }
+      // Captured before subscribe: afterwards this attempt's own operation is
+      // registered too, and the two become indistinguishable.
+      const knownOperationIds = new Set(billingOperationStore.operations.keys())
       const response = await subscribe(planSlug, {
         ...(embeddedCheckoutEnabled &&
           buildPaymentOptions(quote, confirmationToken, promotionCode)),
@@ -990,7 +992,13 @@ export function useSubscriptionCheckout(
         tier: tierKey,
         cycle: billingCycle,
         checkoutType,
-        attemptStartedAt
+        attemptStartedAt,
+        suppliedPaymentAuthority: Boolean(
+          confirmationToken || selectedSavedPaymentMethodId.value
+        ),
+        replayedKnownOperation: response
+          ? knownOperationIds.has(response.billing_op_id)
+          : false
       })
       activeCheckoutAttemptStartedAt = undefined
     } catch (error) {
@@ -1120,6 +1128,18 @@ export function useSubscriptionCheckout(
      * subscribe call), not just the poll-observation window.
      */
     attemptStartedAt?: number
+    /**
+     * Whether this attempt carried its own payment authority (a confirmation
+     * token or a saved method). Such an attempt is charged server-side, so a
+     * link-less response from it must be polled, never treated as parked.
+     */
+    suppliedPaymentAuthority?: boolean
+    /**
+     * Whether the returned billing op was already known to the client before
+     * this attempt, captured before the subscribe call. Only a replay of an
+     * operation we already had can be the parked checkout.
+     */
+    replayedKnownOperation?: boolean
   }
 
   function trackSubscriptionStarted(
@@ -1157,7 +1177,7 @@ export function useSubscriptionCheckout(
   function trackSubscriptionFailure(
     context: SubscriptionOutcomeContext,
     error?: unknown,
-    errorCode?: 'missing_checkout_response'
+    errorCode?: 'missing_checkout_response' | 'parked_checkout_recovery_offered'
   ) {
     if (context.attemptStartedAt === undefined) return
 
@@ -1245,13 +1265,25 @@ export function useSubscriptionCheckout(
       return
     }
 
-    // No payment link while already parked on a card means the operation
-    // cannot advance until checkout completes, so polling it only expires.
+    // A link-less response is only "parked" when it names an operation we
+    // already knew about. Workspace billing status cannot decide this: the
+    // delegated subscribe path returns pending_payment without a link on
+    // healthy attempts too, and it never writes billing_status, so the status
+    // stays awaiting_payment_method through the very request that resolves it.
+    // The caller snapshots known operations before subscribing, so a hit means
+    // the backend replayed the parked op rather than reserving a new one.
     if (
       !response.payment_method_url &&
-      billingStatus.value === 'awaiting_payment_method'
+      context.checkoutType === 'new' &&
+      !context.suppliedPaymentAuthority &&
+      context.replayedKnownOperation
     ) {
       parkedCheckoutRecovery.value = true
+      trackSubscriptionFailure(
+        context,
+        undefined,
+        'parked_checkout_recovery_offered'
+      )
       return
     }
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -1346,11 +1346,16 @@ export function useSubscriptionCheckout(
       : billingOperationStore.startOperation(opId, 'subscription', metadata)
     // The submit is over once the operation is adopted: isPolling is the busy
     // state from here, and it is already true because startOperation registers
-    // synchronously above. Holding isSubscribing past this point kept the
-    // legacy dialog's loading input true until the operation went terminal,
-    // which disabled the recovery prompt's own CTA and Back for a checkout
-    // parked on the customer. Releasing it does not stop the poll.
+    // synchronously above. Holding either of these past this point kept the
+    // recovery prompt's own CTA and Back disabled for a checkout parked on the
+    // customer — and the lock made the CTA a no-op even once it looked live,
+    // because the click re-enters handleSubscription and fails the gate. For
+    // awaiting_payment_method the operation may not go terminal until the
+    // customer performs exactly that action, so waiting for the outer finally
+    // deadlocks the recovery. Releasing neither stops the poll; the outer
+    // finally still runs, and finishCheckoutMutation is idempotent.
     isSubscribing.value = false
+    finishCheckoutMutation()
     const operation = await terminalOperation
     clearPendingSubscriptionCheckoutIfTerminal(opId, operation.status)
     if (

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -1178,7 +1178,7 @@ export function useSubscriptionCheckout(
   function trackSubscriptionFailure(
     context: SubscriptionOutcomeContext,
     error?: unknown,
-    errorCode?: 'missing_checkout_response' | 'parked_checkout_recovery_offered'
+    errorCode?: 'missing_checkout_response'
   ) {
     if (context.attemptStartedAt === undefined) return
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -208,16 +208,19 @@ export function useSubscriptionCheckout(
   )
   // Busy from submit until the checkout presents a terminal step. A pending
   // operation only releases the confirm action while it is parked on the
-  // customer (a challenge to complete, a failed attempt to retry); the
-  // in-page challenge this tab drives keeps it busy, and a succeeded
-  // operation stays busy for the beat between settlement and the success
-  // step taking over — that beat reopened the pay button mid-checkout.
+  // customer (a challenge to complete, a failed attempt to retry, a checkout
+  // still awaiting a card); the in-page challenge this tab drives keeps it
+  // busy, and a succeeded operation stays busy for the beat between settlement
+  // and the success step taking over — that beat reopened the pay button
+  // mid-checkout. A parked checkout keeps polling either way: releasing the
+  // action is about who is being waited on, not whether we are still watching.
   const isPolling = computed(() => {
     const operation = activeCheckoutOperation.value
     if (!operation) return false
     if (operation.status === 'succeeded') return true
     if (operation.status !== 'pending') return false
     if (operation.isAuthenticating) return true
+    if (operation.phase === 'awaiting_payment_method') return false
     return (
       operation.authenticationState !== 'failed_retryable' &&
       operation.authenticationState !== 'requires_action'

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -1449,6 +1449,9 @@ export function useSubscriptionCheckout(
       if (embeddedCheckoutEnabled && quote && !quoteIsCurrent.value) {
         throw new Error(t('subscription.preview.applyQuoteBeforeContinuing'))
       }
+      // Captured before subscribe, as in handleSubscription: afterwards this
+      // attempt's own operation is registered too.
+      const knownOperationIds = new Set(billingOperationStore.operations.keys())
       const response = await subscribe(planSlug, {
         ...(embeddedCheckoutEnabled &&
           buildPaymentOptions(quote, confirmationToken, promotionCode)),
@@ -1477,7 +1480,13 @@ export function useSubscriptionCheckout(
         tier: 'team',
         cycle: billingCycle,
         checkoutType,
-        attemptStartedAt
+        attemptStartedAt,
+        suppliedPaymentAuthority: Boolean(
+          confirmationToken || selectedSavedPaymentMethodId.value
+        ),
+        replayedKnownOperation: response
+          ? knownOperationIds.has(response.billing_op_id)
+          : false
       })
       activeCheckoutAttemptStartedAt = undefined
     } catch (error) {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -125,6 +125,55 @@ describe('billingOperationStore', () => {
       expect(store.hasPendingOperations).toBe(true)
     })
 
+    // This API-to-store hop is what activates the recovery prompt. The checkout
+    // tests take an operation that already has a phase, so only these fail if
+    // the propagation is dropped.
+    async function pollPhase(
+      served?: 'awaiting_payment_method' | 'awaiting_invoice_payment'
+    ) {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-phase',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        ...(served ? { phase: served } : {})
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-phase', 'subscription')
+      await vi.waitFor(() =>
+        expect(workspaceApi.getBillingOpStatus).toHaveBeenCalledWith('op-phase')
+      )
+      return store
+    }
+
+    it('carries a parked-on-checkout phase onto the operation', async () => {
+      const store = await pollPhase('awaiting_payment_method')
+
+      await vi.waitFor(() =>
+        expect(store.getOperation('op-phase')?.phase).toBe(
+          'awaiting_payment_method'
+        )
+      )
+    })
+
+    it('carries a parked-on-invoice phase onto the operation', async () => {
+      const store = await pollPhase('awaiting_invoice_payment')
+
+      await vi.waitFor(() =>
+        expect(store.getOperation('op-phase')?.phase).toBe(
+          'awaiting_invoice_payment'
+        )
+      )
+    })
+
+    it('leaves the phase null when the server reports none', async () => {
+      const store = await pollPhase()
+
+      await vi.waitFor(() =>
+        expect(store.getOperation('op-phase')?.phase).toBeNull()
+      )
+    })
+
     it('exposes a validated recovered action before the first poll completes', () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockReturnValue(
         new Promise(() => {})

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -23,6 +23,7 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type {
   BillingAuthenticationState,
+  BillingOperationPhase,
   BillingDeclineReason
 } from '@/platform/workspace/api/workspaceApi'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
@@ -103,6 +104,12 @@ interface BillingOperation {
   checkoutType?: SubscriptionCheckoutType
   paymentIntentSource?: PaymentIntentSource
   autoHandleRequiresAction: boolean
+  // Last phase the server reported for a pending operation. awaiting_payment_method
+  // means it is parked on a hosted checkout and will not advance until the
+  // customer supplies a card, so a dialog should offer them a way back rather
+  // than keep waiting. Null while unknown — the field is optional in the
+  // contract, and absent is explicitly no claim, never an implied in_progress.
+  phase: BillingOperationPhase | null
   downgradeToPersonal?: StartOperationMetadata['downgradeToPersonal']
   // Set when the customer walked away from this operation in the UI (e.g.
   // "Start over" after a failed challenge). The operation itself is not
@@ -251,6 +258,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       checkoutType: metadata?.checkoutType,
       paymentIntentSource: metadata?.paymentIntentSource,
       autoHandleRequiresAction: metadata?.autoHandleRequiresAction ?? false,
+      phase: null,
       downgradeToPersonal: metadata?.downgradeToPersonal,
       dismissed: false
     }
@@ -347,6 +355,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
             response.decline_reason
           )
         : false
+      updateOperationPhase(opId, response.phase ?? null)
       updateOperationActionUrl(opId, validateActionUrl(response.action_url))
       if (pollingPaused) return
       scheduleNextPoll(opId)
@@ -606,6 +615,24 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     if (!hasTimedOut(operation)) return false
     handleTimeout(opId)
     return true
+  }
+
+  function updateOperationPhase(
+    opId: string,
+    phase: BillingOperationPhase | null
+  ) {
+    const operation = operations.value.get(opId)
+    if (
+      !operation ||
+      operation.status !== 'pending' ||
+      operation.phase === phase
+    ) {
+      return
+    }
+    operations.value = new Map(operations.value).set(opId, {
+      ...operation,
+      phase
+    })
   }
 
   function updateOperationActionUrl(opId: string, actionUrl: string | null) {


### PR DESCRIPTION
## Problem

If a customer starts checkout and doesn't finish adding a card, the billing operation is left parked waiting for one. Subscribing again can return a response with no payment link, and the client polls that parked operation — which cannot advance until the customer completes checkout. The poll expires after 5 minutes with a generic timeout, so from the customer's side the Subscribe button appears to do nothing.

Reported by four customers over 2026-09-05/06.

```mermaid
flowchart LR
    A["subscribe returns<br/>no payment link"] --> B["adopt and poll<br/>the operation"]
    B -->|before| C["nothing tells us it is parked<br/>5-min timeout, generic error"]
    B -->|after| D["poll reports<br/>phase = awaiting_payment_method"]
    D --> E["Complete your payment prompt,<br/>while the poll keeps running"]
```

## Change

The operation is adopted and polled exactly as before — nothing bails out. The poll now reports an authoritative `phase` (added in Comfy-Org/cloud#8646, types in #17199), and the recovery prompt is a computed over it:

```ts
const parkedCheckoutRecovery = computed(
  () => activeCheckoutOperation.value?.phase === 'awaiting_payment_method'
)
```

`SubscriptionAddPaymentPreviewWorkspace` renders a "Complete your payment" button that re-runs subscribe, because that is what re-issues the link — there is no separate endpoint. Since the operation is still being polled, it also resolves on its own if the customer finishes checkout in the Stripe tab.

An earlier revision of this PR decided this on the client, by snapshotting known operation ids before subscribing and treating a response naming one as a replay. Review rejected that — a known id proves this client saw the id, not that the server replayed a still-parked operation — and it is gone, along with `replayedKnownOperation` and `suppliedPaymentAuthority`.

## Review focus

- **Absent `phase` keeps polling.** The field is optional, and an unrecognised server-side phase reports nothing rather than `in_progress`. Treating absent as parked would strand exactly the customers this helps.
- **`awaiting_invoice_payment` deliberately does not prompt.** It is also blocked on the customer, but needs authentication, which `actionUrl` already drives — conflating the two would misdirect.
- **The busy state has to be released, or the prompt arrives disabled.** Adopting the operation is what makes it keep polling, and both dialogs fold that into the preview's loading input — so a parked checkout rendered the prompt with its own CTA and Back locked. `isPolling` now returns false for `awaiting_payment_method`, and `isSubscribing` is released for **both** checkout modes rather than only embedded, which is what the legacy dialog needs. Neither stops the poll: releasing the action is about who is being waited on, not whether we are still watching.
- **The payment selector is hidden during recovery too.** Guarding only the three buttons left `UnifiedStripePaymentSelector` rendered alongside the prompt whenever a quote was ready.
- The standard pay actions are hidden while the prompt shows; all three emit the same `addCreditCard`, so leaving them rendered offered the same action twice.

## Verification

```
pnpm exec vitest run <5 touched test files> --coverage
Test Files  5 passed (5)      Tests  292 passed (292)
```

Run with `--coverage` to match CI. Typecheck, oxlint and oxfmt clean.

Every guard here is mutation-checked rather than assumed, because two of these tests initially passed for the wrong reason: widening the phase check to `!= null` fails the invoice-parked test; dropping the hidden-action guards fails 4 component tests; restoring the `embeddedCheckoutEnabled` guard fails the legacy busy-state test. That last one has to assert mid-poll — `handleSubscription`'s `finally` clears `isSubscribing` once the attempt returns, so asserting afterwards passes either way.

## Follow-up, not here

**This ships with no telemetry on the recovery prompt.** An earlier revision emitted one, but the rework replaced the early-return branch with a computed and the emission went with it — and routing it through `trackSubscriptionFailure` was wrong anyway, since it would have recorded a healthy recovery offer as `stage: failed` / `outcome: failure`.

Measuring how often the prompt appears is still worth doing, as a dedicated non-failure event rather than a failure code. Left out here so it is modelled properly rather than bolted onto the wrong helper.


