### PR TITLE
fix(vue-nodes): hide local values for subgraph boundary widgets

### DIFF
--- a/browser_tests/fixtures/utils/promotedMissingModel.ts
+++ b/browser_tests/fixtures/utils/promotedMissingModel.ts
@@ -250,6 +250,12 @@ export async function expectResolvedPromotedModelSuppressesStaleInteriorErrors(
     ).toContainText(staleModelName)
     await expect(staleCombo).toBeHidden()
     await expect(
+      node.getByRole('combobox', {
+        name: PROMOTED_MODEL_WIDGET_NAME,
+        exact: true
+      })
+    ).toHaveCount(0)
+    await expect(
       node.getByRole('img', {
         name: `${PROMOTED_MODEL_WIDGET_NAME}: Linked input`,
         exact: true

--- a/browser_tests/fixtures/utils/promotedMissingModel.ts
+++ b/browser_tests/fixtures/utils/promotedMissingModel.ts
@@ -237,16 +237,24 @@ export async function expectResolvedPromotedModelSuppressesStaleInteriorErrors(
 
     const staleCombo = node.getByRole('combobox', {
       name: PROMOTED_MODEL_WIDGET_NAME,
-      exact: true
+      exact: true,
+      includeHidden: true
     })
     await expect(
       staleCombo,
-      `${step.nodeTitle} should expose the stale linked interior widget`
+      `${step.nodeTitle} should retain the disabled linked interior widget`
     ).toBeDisabled()
     await expect(
       staleCombo,
       `${step.nodeTitle} should keep the stale interior value`
     ).toContainText(staleModelName)
+    await expect(staleCombo).toBeHidden()
+    await expect(
+      node.getByRole('img', {
+        name: `${PROMOTED_MODEL_WIDGET_NAME}: Linked input`,
+        exact: true
+      })
+    ).toBeVisible()
     await expectNoMissingModelUi(comfyPage)
   }
 }

--- a/browser_tests/tests/subgraph/subgraphBoundaryWidgetPresentation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphBoundaryWidgetPresentation.spec.ts
@@ -1,0 +1,184 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import {
+  routeObjectInfoFromSetupApi,
+  setStringInputTooltip
+} from '@e2e/fixtures/utils/objectInfo'
+import { toNodeId } from '@/types/nodeId'
+
+test.describe(
+  'Subgraph boundary widget presentation',
+  { tag: ['@canvas', '@widget', '@vue-nodes', '@subgraph'] },
+  () => {
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.canvasOps.resetView()
+    })
+
+    test.describe('textarea', () => {
+      test.beforeEach(async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-with-promoted-text-widget'
+        )
+        await comfyPage.page.evaluate(
+          ({ hostId, interiorId }) => {
+            const host = window.app!.graph.getNodeById(hostId)
+            if (!host?.isSubgraphNode())
+              throw new Error('Missing subgraph host')
+            const widget = host.subgraph
+              .getNodeById(interiorId)
+              ?.widgets?.find((widget) => widget.name === 'text')
+            if (!widget) throw new Error('Missing interior text widget')
+            widget.value = 'Local draft retained behind the boundary'
+            window.app!.graph.setDirtyCanvas(true, true)
+          },
+          { hostId: toNodeId('11'), interiorId: toNodeId('10') }
+        )
+        await comfyPage.nextFrame()
+        await comfyPage.vueNodes.enterSubgraph('11')
+        await comfyPage.vueNodes.waitForNodes(2)
+      })
+
+      test('keeps the editor mounted and restores its value through disconnect, undo, and redo', async ({
+        comfyPage
+      }) => {
+        const node = comfyPage.vueNodes.getNodeLocator('10')
+        const editor = node.getByRole('textbox', { includeHidden: true })
+        const indicator = node.getByRole('img', { name: 'text: Linked input' })
+
+        await expect(editor).toBeAttached()
+        await expect(editor).toBeHidden()
+        await expect(editor).toHaveValue(
+          'Local draft retained behind the boundary'
+        )
+        await expect(indicator).toBeVisible()
+        const mountedEditor = await editor.evaluateHandle((element) => element)
+
+        const position = await comfyPage.subgraph
+          .getInputSlot('text')
+          .getPosition()
+        await comfyPage.page.mouse.click(position.x, position.y, {
+          button: 'right'
+        })
+        await comfyPage.contextMenu.clickLitegraphMenuItem('Remove Slot')
+        await comfyPage.contextMenu.waitForHidden()
+        await comfyPage.nextFrame()
+
+        await expect(editor).toBeAttached()
+        await expect(editor).toBeVisible()
+        await expect(editor).toHaveValue(
+          'Local draft retained behind the boundary'
+        )
+        expect(
+          await mountedEditor.evaluate((element) => element.isConnected)
+        ).toBe(true)
+        await mountedEditor.dispose()
+        await expect(indicator).toHaveCount(0)
+
+        await comfyPage.keyboard.undo()
+        await expect(editor).toBeAttached()
+        await expect(editor).toBeHidden()
+        await expect(editor).toHaveValue(
+          'Local draft retained behind the boundary'
+        )
+        await expect(indicator).toBeVisible()
+
+        await comfyPage.keyboard.redo()
+        await expect(editor).toBeAttached()
+        await expect(editor).toBeVisible()
+        await expect(editor).toHaveValue(
+          'Local draft retained behind the boundary'
+        )
+        await expect(indicator).toHaveCount(0)
+      })
+    })
+
+    test.describe('help tooltip', () => {
+      test.use({ initialSettings: { 'Comfy.EnableTooltips': true } })
+
+      test.beforeEach(async ({ page }) => {
+        await routeObjectInfoFromSetupApi(page, (objectInfo) =>
+          setStringInputTooltip(
+            objectInfo,
+            'CLIPTextEncode',
+            'text',
+            'Describe the image to generate.'
+          )
+        )
+      })
+
+      test.describe('boundary-linked text', () => {
+        test.beforeEach(async ({ comfyPage }) => {
+          await comfyPage.workflow.loadWorkflow(
+            'subgraphs/subgraph-with-promoted-text-widget'
+          )
+          await comfyPage.page.evaluate(
+            ({ hostId, interiorId }) => {
+              const host = window.app!.graph.getNodeById(hostId)
+              if (!host?.isSubgraphNode())
+                throw new Error('Missing subgraph host')
+              const widget = host.subgraph
+                .getNodeById(interiorId)
+                ?.widgets?.find((widget) => widget.name === 'text')
+              if (!widget) throw new Error('Missing interior text widget')
+              widget.value =
+                'A stale local value that must not appear in the tooltip'
+              window.app!.graph.setDirtyCanvas(true, true)
+            },
+            { hostId: toNodeId('11'), interiorId: toNodeId('10') }
+          )
+          await comfyPage.nextFrame()
+          await comfyPage.vueNodes.enterSubgraph('11')
+          await comfyPage.vueNodes.waitForNodes(2)
+        })
+
+        test('preserves help while omitting the hidden local value', async ({
+          comfyPage
+        }) => {
+          const node = comfyPage.vueNodes.getNodeLocator('10')
+          const editor = node.getByRole('textbox', { includeHidden: true })
+          const indicator = node.getByRole('img', {
+            name: 'text: Linked input'
+          })
+
+          await expect(editor).toBeAttached()
+          await expect(editor).toBeHidden()
+          await expect(editor).toHaveValue(
+            'A stale local value that must not appear in the tooltip'
+          )
+          await indicator.hover()
+          await expect(comfyPage.vueNodes.getVisibleWidgetTooltip()).toHaveText(
+            'Describe the image to generate.'
+          )
+        })
+      })
+    })
+
+    test.describe('ordinary Primitive link', () => {
+      test.beforeEach(async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+      })
+
+      test('keeps a linked seed value and its auxiliary control visible', async ({
+        comfyPage
+      }) => {
+        const widget = comfyPage.vueNodes.getWidgetRowByLabel(
+          'KSampler',
+          'seed'
+        )
+        const controls = comfyPage.vueNodes.getInputNumberControls(widget)
+        const node = await comfyPage.nodeOps.getNodeRefById('10')
+        const inputSlot = await node.getInput(4)
+
+        await expect.poll(() => inputSlot.getLinkCount()).toBe(1)
+        await expect(controls.input).toBeVisible()
+        await expect(controls.input).toHaveValue('67')
+        await expect(controls.valueControl).toBeVisible()
+        await expect(
+          widget.getByRole('img', { name: 'seed: Linked input' })
+        ).toHaveCount(0)
+      })
+    })
+  }
+)

--- a/browser_tests/tests/subgraph/subgraphBoundaryWidgetPresentation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphBoundaryWidgetPresentation.spec.ts
@@ -102,57 +102,44 @@ test.describe(
         await routeObjectInfoFromSetupApi(page, (objectInfo) =>
           setStringInputTooltip(
             objectInfo,
-            'CLIPTextEncode',
-            'text',
-            'Describe the image to generate.'
+            'DevToolsNodeWithStringInput',
+            'string_input',
+            'Enter a string.'
           )
         )
       })
 
-      test.describe('boundary-linked text', () => {
-        test.beforeEach(async ({ comfyPage }) => {
-          await comfyPage.workflow.loadWorkflow(
-            'subgraphs/subgraph-with-promoted-text-widget'
-          )
-          await comfyPage.page.evaluate(
-            ({ hostId, interiorId }) => {
-              const host = window.app!.graph.getNodeById(hostId)
-              if (!host?.isSubgraphNode())
-                throw new Error('Missing subgraph host')
-              const widget = host.subgraph
-                .getNodeById(interiorId)
-                ?.widgets?.find((widget) => widget.name === 'text')
-              if (!widget) throw new Error('Missing interior text widget')
-              widget.value =
-                'A stale local value that must not appear in the tooltip'
-              window.app!.graph.setDirtyCanvas(true, true)
-            },
-            { hostId: toNodeId('11'), interiorId: toNodeId('10') }
-          )
-          await comfyPage.nextFrame()
-          await comfyPage.vueNodes.enterSubgraph('11')
-          await comfyPage.vueNodes.waitForNodes(2)
-        })
+      test('preserves help while omitting a linked single-line input value', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow('inputs/string_input')
+        await fitToViewInstant(comfyPage)
+        const node = comfyPage.vueNodes.getNodeLocator('1')
+        const editor = node.getByRole('textbox', { includeHidden: true })
+        const localValue = 'A stale local value'
+        await editor.fill(localValue)
+        await editor.press('Tab')
+        await editor.hover()
+        await expect(comfyPage.vueNodes.getVisibleWidgetTooltip()).toHaveText(
+          `Enter a string.\n\n${localValue}`
+        )
 
-        test('preserves help while omitting the hidden local value', async ({
-          comfyPage
-        }) => {
-          const node = comfyPage.vueNodes.getNodeLocator('10')
-          const editor = node.getByRole('textbox', { includeHidden: true })
-          const indicator = node.getByRole('img', {
-            name: 'text: Linked input'
-          })
+        const nodeRef = await comfyPage.nodeOps.getNodeRefById('1')
+        const host = await nodeRef.convertToSubgraph()
+        await comfyPage.vueNodes.enterSubgraph(String(host.id))
+        await comfyPage.vueNodes.waitForNodes(1)
+        await comfyPage.subgraph.promoteWidget(node, 'string_input')
 
-          await expect(editor).toBeAttached()
-          await expect(editor).toBeHidden()
-          await expect(editor).toHaveValue(
-            'A stale local value that must not appear in the tooltip'
-          )
-          await indicator.hover()
-          await expect(comfyPage.vueNodes.getVisibleWidgetTooltip()).toHaveText(
-            'Describe the image to generate.'
-          )
+        const indicator = node.getByRole('img', {
+          name: 'string_input: Linked input'
         })
+        await expect(editor).toBeAttached()
+        await expect(editor).toBeHidden()
+        await expect(editor).toHaveValue(localValue)
+        await indicator.hover()
+        await expect(comfyPage.vueNodes.getVisibleWidgetTooltip()).toHaveText(
+          'Enter a string.'
+        )
       })
     })
 

--- a/browser_tests/tests/subgraph/subgraphBoundaryWidgetPresentation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphBoundaryWidgetPresentation.spec.ts
@@ -2,6 +2,7 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 import {
   routeObjectInfoFromSetupApi,
   setStringInputTooltip
@@ -152,6 +153,58 @@ test.describe(
             'Describe the image to generate.'
           )
         })
+      })
+    })
+
+    test.describe('boolean switch alignment', () => {
+      test.beforeEach(async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('widgets/boolean_widget')
+        await fitToViewInstant(comfyPage)
+        const node = await comfyPage.nodeOps.getNodeRefById('11')
+        const host = await node.convertToSubgraph()
+        await comfyPage.vueNodes.enterSubgraph(String(host.id))
+        await comfyPage.vueNodes.waitForNodes(1)
+        await comfyPage.subgraph.promoteWidget(
+          comfyPage.vueNodes.getNodeLocator('11'),
+          'boolean_input'
+        )
+        await comfyPage.nextFrame()
+      })
+
+      test('centers the linked indicator on the switch track with matching dimensions', async ({
+        comfyPage
+      }) => {
+        const node = comfyPage.vueNodes.getNodeLocator('11')
+        const control = node.getByRole('switch', { includeHidden: true })
+        const indicator = node.getByRole('img', {
+          name: 'boolean_input: Linked input'
+        })
+
+        await expect(control).toBeAttached()
+        await expect(control).toBeHidden()
+        await expect(indicator).toBeVisible()
+        await expect(async () => {
+          const track = await control.evaluate((element) => {
+            const track = element.firstElementChild
+            if (!track) throw new Error('Missing switch track')
+            const { x, y, width, height } = track.getBoundingClientRect()
+            return { x, y, width, height }
+          })
+          const marker = await indicator.boundingBox()
+          if (!marker) throw new Error('Missing linked switch indicator')
+          expect(track.width).toBeGreaterThan(0)
+          expect(track.height).toBeGreaterThan(0)
+          expect(marker.width).toBeCloseTo(track.width, 1)
+          expect(marker.height).toBeCloseTo(track.height, 1)
+          expect(marker.x + marker.width / 2).toBeCloseTo(
+            track.x + track.width / 2,
+            1
+          )
+          expect(marker.y + marker.height / 2).toBeCloseTo(
+            track.y + track.height / 2,
+            1
+          )
+        }).toPass({ timeout: 5000 })
       })
     })
 

--- a/browser_tests/tests/subgraph/subgraphNested.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphNested.spec.ts
@@ -63,7 +63,9 @@ test.describe('Nested Subgraphs', { tag: ['@subgraph'] }, () => {
         )
         await comfyExpect(innerNode).toBeVisible()
 
-        const innerTextboxes = innerNode.getByRole('textbox')
+        const innerTextboxes = innerNode.getByRole('textbox', {
+          includeHidden: true
+        })
         await comfyExpect(innerTextboxes).toHaveCount(2)
         const innerValues = await innerTextboxes.evaluateAll<
           string[],
@@ -71,6 +73,19 @@ test.describe('Nested Subgraphs', { tag: ['@subgraph'] }, () => {
         >((boxes) => boxes.map((b) => b.value))
         comfyExpect(innerValues).toContain('11111111111')
         comfyExpect(innerValues).toContain('22222222222')
+        await comfyExpect(
+          innerNode.getByRole('textbox', { name: 'text', exact: true })
+        ).toHaveValue('11111111111')
+        const linkedTextbox = innerNode.getByRole('textbox', {
+          name: 'text_1',
+          exact: true,
+          includeHidden: true
+        })
+        await comfyExpect(linkedTextbox).toHaveValue('22222222222')
+        await comfyExpect(linkedTextbox).toBeHidden()
+        await comfyExpect(
+          innerNode.getByRole('img', { name: 'text_1: Linked input' })
+        ).toBeVisible()
       })
     }
   )

--- a/browser_tests/tests/subgraph/subgraphNested.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphNested.spec.ts
@@ -84,6 +84,9 @@ test.describe('Nested Subgraphs', { tag: ['@subgraph'] }, () => {
         await comfyExpect(linkedTextbox).toHaveValue('22222222222')
         await comfyExpect(linkedTextbox).toBeHidden()
         await comfyExpect(
+          innerNode.getByRole('textbox', { name: 'text_1', exact: true })
+        ).toHaveCount(0)
+        await comfyExpect(
           innerNode.getByRole('img', { name: 'text_1: Linked input' })
         ).toBeVisible()
       })

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -162,6 +162,20 @@ test.describe(
             comfyPage.page.getByTestId('linked-widget-placeholder')
           ).toHaveCount(2)
 
+          const interiorNodes = comfyPage.vueNodes.getNodeByTitle(
+            'CLIP Text Encode (Prompt)'
+          )
+          await expect(interiorNodes).toHaveCount(2)
+          const firstInteriorNode = interiorNodes.nth(0)
+          const secondInteriorNode = interiorNodes.nth(1)
+          const sampler = comfyPage.vueNodes.getNodeByTitle('KSampler')
+          await firstInteriorNode.getByTestId('node-collapse-button').focus()
+          await comfyPage.page.keyboard.press('Tab')
+          await expect(secondInteriorNode).toBeFocused()
+          await secondInteriorNode.getByTestId('node-collapse-button').focus()
+          await comfyPage.page.keyboard.press('Tab')
+          await expect(sampler).toBeFocused()
+
           await comfyPage.subgraph.exitViaBreadcrumb()
 
           await expect(

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -154,8 +154,13 @@ test.describe(
 
           const interiorTextareas = comfyPage.page
             .locator('[data-node-id]')
-            .getByRole('textbox')
+            .getByRole('textbox', { includeHidden: true })
           await expect(interiorTextareas).toHaveCount(2)
+          await expect(interiorTextareas.nth(0)).toBeHidden()
+          await expect(interiorTextareas.nth(1)).toBeHidden()
+          await expect(
+            comfyPage.page.getByTestId('linked-widget-placeholder')
+          ).toHaveCount(2)
 
           await comfyPage.subgraph.exitViaBreadcrumb()
 

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -159,7 +159,7 @@ test.describe(
           await expect(interiorTextareas.nth(0)).toBeHidden()
           await expect(interiorTextareas.nth(1)).toBeHidden()
           await expect(
-            comfyPage.page.getByTestId('linked-widget-placeholder')
+            comfyPage.page.getByRole('img', { name: 'text: Linked input' })
           ).toHaveCount(2)
 
           const interiorNodes = comfyPage.vueNodes.getNodeByTitle(

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3470,7 +3470,7 @@
     "Set Group Nodes to Always": "Set Group Nodes to Always"
   },
   "widgets": {
-    "linkedInput": "Linked input",
+    "linkedInputFor": "{name}: Linked input",
     "boolean": {
       "true": "true",
       "false": "false"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3470,6 +3470,7 @@
     "Set Group Nodes to Always": "Set Group Nodes to Always"
   },
   "widgets": {
+    "linkedInput": "Linked input",
     "boolean": {
       "true": "true",
       "false": "false"

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -2,6 +2,7 @@ import type { TooltipOptions } from 'primevue'
 
 import { showNodeOptions } from '@/composables/graph/useMoreOptionsMenu'
 import { resolvePromotedWidgetSource } from '@/core/graph/subgraph/resolvePromotedWidgetSource'
+import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type {
@@ -18,6 +19,7 @@ import WidgetDOM from '@/renderer/extensions/vueNodes/widgets/components/WidgetD
 import WidgetLegacy from '@/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue'
 import {
   getComponent,
+  getLinkedWidgetDisplay,
   shouldRenderAsVue
 } from '@/renderer/extensions/vueNodes/widgets/registry/widgetRegistry'
 import { app } from '@/scripts/app'
@@ -367,6 +369,16 @@ function processWidget(
     resolveLiveWidgetContext(ctx.rootGraph, ctx.hostNode, liveWidget)
 
   const slotInfo = ctx.slotMetadata.get(widgetState.name)
+  const vueComponent =
+    !renderState?.isDOMWidget && typeof liveWidget?.draw === 'function'
+      ? WidgetLegacy
+      : getComponent(type) ||
+        (renderState?.isDOMWidget ? WidgetDOM : WidgetLegacy)
+  const isBoundaryLinked = slotInfo?.originNodeId === SUBGRAPH_INPUT_ID
+  const linkedDisplay =
+    isBoundaryLinked && vueComponent !== WidgetLegacy
+      ? getLinkedWidgetDisplay(type, options)
+      : undefined
   const visible = isWidgetVisible(
     options,
     ctx.showAdvanced,
@@ -403,6 +415,7 @@ function processWidget(
     controlWidget,
     label: widgetState.label,
     linkedUpstream,
+    linkedDisplay,
     nodeLocatorId: widgetNodeLocatorId(ctx, bareWidgetId, sourceExecutionId),
     options: widgetOptions,
     spec: live
@@ -414,10 +427,12 @@ function processWidget(
     isTooltipValueType(type) && String(value).length > 10
       ? String(value)
       : undefined
-  const tooltipConfig = ctx.ui.getTooltipConfig(
-    { name: widgetState.name, tooltip: renderState?.tooltip },
-    valueTooltip
-  )
+  const tooltipConfig = linkedDisplay
+    ? { disabled: true }
+    : ctx.ui.getTooltipConfig(
+        { name: widgetState.name, tooltip: renderState?.tooltip },
+        valueTooltip
+      )
   const handleContextMenu = (e: PointerEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -438,11 +453,7 @@ function processWidget(
     ),
     widgetId: id,
     renderKey: `${id}:${type}`,
-    vueComponent:
-      !renderState?.isDOMWidget && typeof liveWidget?.draw === 'function'
-        ? WidgetLegacy
-        : getComponent(type) ||
-          (renderState?.isDOMWidget ? WidgetDOM : WidgetLegacy),
+    vueComponent,
     simplified,
     visible,
     updateHandler,

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -377,7 +377,7 @@ function processWidget(
   const isBoundaryLinked = slotInfo?.originNodeId === SUBGRAPH_INPUT_ID
   const linkedDisplay =
     isBoundaryLinked && vueComponent !== WidgetLegacy
-      ? getLinkedWidgetDisplay(type, options)
+      ? getLinkedWidgetDisplay(type)
       : undefined
   const visible = isWidgetVisible(
     options,

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -424,15 +424,13 @@ function processWidget(
   }
 
   const valueTooltip =
-    isTooltipValueType(type) && String(value).length > 10
+    !linkedDisplay && isTooltipValueType(type) && String(value).length > 10
       ? String(value)
       : undefined
-  const tooltipConfig = linkedDisplay
-    ? { disabled: true }
-    : ctx.ui.getTooltipConfig(
-        { name: widgetState.name, tooltip: renderState?.tooltip },
-        valueTooltip
-      )
+  const tooltipConfig = ctx.ui.getTooltipConfig(
+    { name: widgetState.name, tooltip: renderState?.tooltip },
+    valueTooltip
+  )
   const handleContextMenu = (e: PointerEvent) => {
     e.preventDefault()
     e.stopPropagation()

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -432,10 +432,10 @@ describe('promoted subgraph widgets', () => {
   it.for([
     ['number', 'control'],
     ['number', 'control', true],
-    ['boolean', 'switch'],
-    ['customtext', 'expanding'],
+    ['boolean', 'control'],
+    ['customtext', 'multiline'],
     ['combo', 'control'],
-    ['asset', undefined],
+    ['asset', 'control'],
     ['color', undefined],
     ['gradientslider', undefined],
     ['curve', undefined]

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import {
   cleanupComplexPromotionFixtureNodeType,
+  createTestSubgraphData,
+  createTestSubgraphNode,
   resetSubgraphFixtureState,
   setupComplexPromotionFixture
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
@@ -15,6 +17,7 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { computeProcessedWidgets } from '@/renderer/extensions/vueNodes/composables/useProcessedWidgets'
 import WidgetDOM from '@/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue'
 import WidgetLegacy from '@/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue'
+import { IS_CONTROL_WIDGET } from '@/scripts/controlWidgetMarker'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useLinkStore } from '@/stores/linkStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -355,6 +358,103 @@ describe('promoted subgraph widgets', () => {
 
     expect(processHostWidget(graph, hostNode).hasError).toBe(true)
   })
+
+  it('shows a link indicator only for subgraph input connections', () => {
+    const { graph, subgraph } = setupComplexPromotionFixture()
+    const node = subgraph.getNodeById(INTERIOR_ID)
+    if (!node) throw new Error('Expected the interior node')
+
+    function processInteriorWidget(node: LGraphNode) {
+      return computeProcessedWidgets({
+        nodeData: node._state,
+        graphId: graph.id,
+        showAdvanced: false,
+        isGraphReady: true,
+        rootGraph: graph,
+        ui: noopUi
+      }).find((widget) => widget.simplified.name === 'string_a')
+    }
+
+    expect(processInteriorWidget(node)?.simplified.linkedDisplay).toBe(
+      'control'
+    )
+    expect(processInteriorWidget(node)?.tooltipConfig).toEqual({
+      disabled: true
+    })
+    node.disconnectInput(0)
+    expect(
+      processInteriorWidget(node)?.simplified.linkedDisplay
+    ).toBeUndefined()
+
+    const source = new LGraphNode('Source')
+    subgraph.add(source)
+    source.addOutput('text', 'STRING')
+    expect(source.connect(0, node, 0)).toBeTruthy()
+    expect(processInteriorWidget(node)?.slotMetadata?.linked).toBe(true)
+    expect(
+      processInteriorWidget(node)?.simplified.linkedDisplay
+    ).toBeUndefined()
+
+    node.disconnectInput(0)
+    subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+    expect(processInteriorWidget(node)?.simplified.linkedDisplay).toBe(
+      'control'
+    )
+  })
+
+  it('shows a link indicator on a nested host only when connected to its containing subgraph input', () => {
+    const { graph, subgraph } = setupComplexPromotionFixture()
+    const outer = graph.createSubgraph(createTestSubgraphData())
+    outer.addInput('text', 'STRING')
+    const host = createTestSubgraphNode(subgraph, { parentGraph: outer })
+    outer.add(host)
+
+    expect(
+      processHostWidget(graph, host).simplified.linkedDisplay
+    ).toBeUndefined()
+    outer.inputNode.slots[0].connect(host.inputs[0], host)
+    expect(processHostWidget(graph, host).simplified.linkedDisplay).toBe(
+      'control'
+    )
+  })
+
+  it.for([
+    ['number', 'control'],
+    ['number', 'control', true],
+    ['boolean', 'switch'],
+    ['customtext', 'expanding'],
+    ['combo', 'control'],
+    ['asset', undefined],
+    ['color', undefined],
+    ['gradientslider', undefined],
+    ['curve', undefined]
+  ] as const)(
+    'limits the boundary link indicator for %s widgets',
+    ([type, display, hasControl]) => {
+      const { graph, subgraph } = setupComplexPromotionFixture()
+      const node = subgraph.getNodeById(INTERIOR_ID)
+      const widget = node?.widgets?.find((widget) => widget.name === 'string_a')
+      if (!node || !widget) throw new Error('Expected the interior widget')
+      widget.type = type
+      if (hasControl) {
+        widget.linkedWidgets = [
+          createMockWidget({ value: 'randomize', [IS_CONTROL_WIDGET]: true })
+        ]
+      }
+
+      const result = computeProcessedWidgets({
+        nodeData: node._state,
+        graphId: graph.id,
+        showAdvanced: false,
+        isGraphReady: true,
+        rootGraph: graph,
+        ui: noopUi
+      }).find((widget) => widget.simplified.name === 'string_a')
+
+      expect(result).toBeDefined()
+      expect(result?.simplified.linkedDisplay).toBe(display)
+    }
+  )
 
   it('resolves the widget locator to the interior source node', () => {
     const { graph, subgraph, hostNode } = setupComplexPromotionFixture()

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -363,6 +363,9 @@ describe('promoted subgraph widgets', () => {
     const { graph, subgraph } = setupComplexPromotionFixture()
     const node = subgraph.getNodeById(INTERIOR_ID)
     if (!node) throw new Error('Expected the interior node')
+    const widget = node.widgets?.find((widget) => widget.name === 'string_a')
+    if (!widget) throw new Error('Expected the interior widget')
+    widget.value = 'Local text that should not appear while linked'
 
     function processInteriorWidget(node: LGraphNode) {
       return computeProcessedWidgets({
@@ -371,7 +374,12 @@ describe('promoted subgraph widgets', () => {
         showAdvanced: false,
         isGraphReady: true,
         rootGraph: graph,
-        ui: noopUi
+        ui: {
+          ...noopUi,
+          getTooltipConfig: (_widget, fullValue) => ({
+            value: ['Input description', fullValue].filter(Boolean).join('\n\n')
+          })
+        }
       }).find((widget) => widget.simplified.name === 'string_a')
     }
 
@@ -379,12 +387,15 @@ describe('promoted subgraph widgets', () => {
       'control'
     )
     expect(processInteriorWidget(node)?.tooltipConfig).toEqual({
-      disabled: true
+      value: 'Input description'
     })
     node.disconnectInput(0)
     expect(
       processInteriorWidget(node)?.simplified.linkedDisplay
     ).toBeUndefined()
+    expect(processInteriorWidget(node)?.tooltipConfig).toEqual({
+      value: `Input description\n\n${widget.value}`
+    })
 
     const source = new LGraphNode('Source')
     subgraph.add(source)
@@ -429,7 +440,7 @@ describe('promoted subgraph widgets', () => {
     ['gradientslider', undefined],
     ['curve', undefined]
   ] as const)(
-    'limits the boundary link indicator for %s widgets',
+    'limits the boundary link indicator for %s widgets (display: %s, auxiliary control: %s)',
     ([type, display, hasControl]) => {
       const { graph, subgraph } = setupComplexPromotionFixture()
       const node = subgraph.getNodeById(INTERIOR_ID)

--- a/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetPresentation.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetPresentation.test.ts
@@ -50,6 +50,9 @@ describe('linked widget presentation', () => {
     expect(
       screen.getByRole('img', { name: 'seed: Linked input' })
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: 'seed: Linked input' })
+    ).not.toHaveAttribute('title')
     expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', {
@@ -133,21 +136,34 @@ describe('linked widget presentation', () => {
     await user.click(input)
     expect(input).toHaveFocus()
 
+    await rerender({ widget: { ...widget, options: { read_only: true } } })
+    expect(
+      screen.getByRole('button', { name: messages.g.copyToClipboard })
+    ).toBeInTheDocument()
+
     await rerender({
       widget: {
         ...widget,
-        linkedDisplay: 'expanding',
-        options: { disabled: true }
+        linkedDisplay: 'multiline',
+        options: { read_only: true, disabled: true }
       }
     })
     expect(
       screen.getByRole('img', { name: 'Prompt: Linked input' })
     ).toBeInTheDocument()
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: messages.g.copyToClipboard })
+    ).not.toBeInTheDocument()
     expect(input).toBeInTheDocument()
     expect(input).toHaveValue('Local draft')
     expect(input).toHaveAttribute('inert')
     expect(onUpdate).not.toHaveBeenCalled()
+
+    await rerender({ widget: { ...widget, options: { read_only: true } } })
+    expect(
+      screen.getByRole('button', { name: messages.g.copyToClipboard })
+    ).toBeInTheDocument()
 
     await rerender({ widget })
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
@@ -173,7 +189,7 @@ describe('linked widget presentation', () => {
     await rerender({
       widget: {
         ...widget,
-        linkedDisplay: 'switch',
+        linkedDisplay: 'control',
         options: { disabled: true }
       }
     })
@@ -187,5 +203,43 @@ describe('linked widget presentation', () => {
     expect(screen.getByRole('switch')).toBe(control)
     expect(control.matches('[inert], [inert] *')).toBe(false)
     expect(control).toBeChecked()
+  })
+
+  it('hides labeled toggle choices and restores the selected option', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+    const widget: SimplifiedWidget<boolean> = {
+      name: 'mode',
+      type: 'boolean',
+      value: true,
+      options: { on: 'Enabled', off: 'Disabled' }
+    }
+    const { rerender } = render(WidgetToggleSwitch, {
+      global: { plugins: widgetPlugins() },
+      props: { widget, modelValue: true, 'onUpdate:modelValue': onUpdate }
+    })
+    const enabled = screen.getByRole('button', { name: 'Enabled' })
+    const disabled = screen.getByRole('button', { name: 'Disabled' })
+
+    await rerender({
+      widget: {
+        ...widget,
+        linkedDisplay: 'control',
+        options: { ...widget.options, disabled: true }
+      }
+    })
+    expect(
+      screen.getByRole('img', { name: 'mode: Linked input' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(enabled.matches('[inert], [inert] *')).toBe(true)
+    expect(disabled.matches('[inert], [inert] *')).toBe(true)
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    await rerender({ widget })
+    expect(screen.getByRole('button', { name: 'Enabled' })).toBe(enabled)
+    expect(enabled).toHaveAttribute('aria-pressed', 'true')
+    await user.click(disabled)
+    expect(onUpdate).toHaveBeenLastCalledWith(false)
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetPresentation.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetPresentation.test.ts
@@ -1,0 +1,182 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import messages from '@/locales/en/main.json'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetInputNumber from './WidgetInputNumber.vue'
+import WidgetSelectDefault from './WidgetSelectDefault.vue'
+import WidgetTextarea from './WidgetTextarea.vue'
+import WidgetToggleSwitch from './WidgetToggleSwitch.vue'
+
+vi.mock('@/composables/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copyToClipboard: vi.fn() })
+}))
+
+function widgetPlugins() {
+  return [
+    createI18n({ legacy: false, locale: 'en', messages: { en: messages } })
+  ]
+}
+
+describe('linked widget presentation', () => {
+  it('hides and restores the seed value and its auxiliary control together', async () => {
+    const updateControl = vi.fn()
+    const onUpdate = vi.fn()
+    const widget: SimplifiedWidget<number> = {
+      name: 'seed',
+      type: 'number',
+      value: 42,
+      controlWidget: { value: 'randomize', update: updateControl }
+    }
+    const { rerender } = render(WidgetInputNumber, {
+      global: { plugins: widgetPlugins() },
+      props: { widget, modelValue: 42, 'onUpdate:modelValue': onUpdate }
+    })
+    const input = await screen.findByRole('spinbutton')
+    const control = screen.getByRole('button', {
+      name: messages.widgets.valueControl.randomize
+    })
+
+    await rerender({
+      widget: {
+        ...widget,
+        linkedDisplay: 'control',
+        options: { disabled: true }
+      }
+    })
+    expect(
+      screen.getByRole('img', { name: 'seed: Linked input' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: messages.widgets.valueControl.randomize
+      })
+    ).not.toBeInTheDocument()
+    expect(input).toBeInTheDocument()
+    expect(control).toBeInTheDocument()
+    expect(input).toHaveValue('42')
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(updateControl).not.toHaveBeenCalled()
+
+    await rerender({ widget })
+    expect(screen.getByRole('spinbutton')).toBe(input)
+    expect(
+      screen.getByRole('button', {
+        name: messages.widgets.valueControl.randomize
+      })
+    ).toBe(control)
+    expect(input).toHaveValue('42')
+  })
+
+  it('hides a combo value and restores its selection on disconnect', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+    const widget: SimplifiedWidget<string | undefined> = {
+      name: 'sampler',
+      type: 'combo',
+      value: 'euler',
+      options: { values: ['euler', 'heun'] }
+    }
+    const { rerender } = render(WidgetSelectDefault, {
+      global: { plugins: widgetPlugins() },
+      props: { widget, modelValue: 'euler', 'onUpdate:modelValue': onUpdate }
+    })
+    const trigger = screen.getByRole('combobox', { name: 'sampler' })
+    await rerender({
+      widget: {
+        ...widget,
+        linkedDisplay: 'control',
+        options: { ...widget.options, disabled: true }
+      }
+    })
+    expect(
+      screen.getByRole('img', { name: 'sampler: Linked input' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(trigger).toBeInTheDocument()
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    await rerender({ widget })
+    expect(screen.getByRole('combobox', { name: 'sampler' })).toBe(trigger)
+    expect(trigger).toHaveTextContent('euler')
+    await user.click(trigger)
+    await user.click(await screen.findByRole('option', { name: 'heun' }))
+    expect(onUpdate).toHaveBeenLastCalledWith('heun')
+  })
+  it('preserves the mounted textarea editor and value through display transitions', async () => {
+    const user = userEvent.setup()
+    const widget: SimplifiedWidget<string> = {
+      name: 'prompt',
+      label: 'Prompt',
+      type: 'textarea',
+      value: 'Local draft'
+    }
+    const onUpdate = vi.fn()
+    const { rerender } = render(WidgetTextarea, {
+      global: { plugins: widgetPlugins() },
+      props: {
+        widget,
+        modelValue: widget.value,
+        'onUpdate:modelValue': onUpdate
+      }
+    })
+    const input = screen.getByRole('textbox')
+    await user.click(input)
+    expect(input).toHaveFocus()
+
+    await rerender({
+      widget: {
+        ...widget,
+        linkedDisplay: 'expanding',
+        options: { disabled: true }
+      }
+    })
+    expect(
+      screen.getByRole('img', { name: 'Prompt: Linked input' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveValue('Local draft')
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    await rerender({ widget })
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBe(input)
+    await user.clear(input)
+    await user.type(input, 'New draft')
+    expect(onUpdate).toHaveBeenLastCalledWith('New draft')
+  })
+
+  it('retains the switch state without emitting a value change when linked', async () => {
+    const widget: SimplifiedWidget<boolean> = {
+      name: 'enabled',
+      type: 'boolean',
+      value: true
+    }
+    const onUpdate = vi.fn()
+    const { rerender } = render(WidgetToggleSwitch, {
+      global: { plugins: widgetPlugins() },
+      props: { widget, modelValue: true, 'onUpdate:modelValue': onUpdate }
+    })
+    const control = screen.getByRole('switch')
+    await rerender({
+      widget: {
+        ...widget,
+        linkedDisplay: 'switch',
+        options: { disabled: true }
+      }
+    })
+    expect(
+      screen.getByRole('img', { name: 'enabled: Linked input' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    expect(onUpdate).not.toHaveBeenCalled()
+    await rerender({ widget })
+    expect(screen.getByRole('switch')).toBe(control)
+    expect(control).toBeChecked()
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetPresentation.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetPresentation.test.ts
@@ -59,11 +59,14 @@ describe('linked widget presentation', () => {
     expect(input).toBeInTheDocument()
     expect(control).toBeInTheDocument()
     expect(input).toHaveValue('42')
+    expect(input.matches('[inert], [inert] *')).toBe(true)
+    expect(control.matches('[inert], [inert] *')).toBe(true)
     expect(onUpdate).not.toHaveBeenCalled()
     expect(updateControl).not.toHaveBeenCalled()
 
     await rerender({ widget })
     expect(screen.getByRole('spinbutton')).toBe(input)
+    expect(input.matches('[inert], [inert] *')).toBe(false)
     expect(
       screen.getByRole('button', {
         name: messages.widgets.valueControl.randomize
@@ -98,10 +101,12 @@ describe('linked widget presentation', () => {
     ).toBeInTheDocument()
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     expect(trigger).toBeInTheDocument()
+    expect(trigger.matches('[inert], [inert] *')).toBe(true)
     expect(onUpdate).not.toHaveBeenCalled()
 
     await rerender({ widget })
     expect(screen.getByRole('combobox', { name: 'sampler' })).toBe(trigger)
+    expect(trigger.matches('[inert], [inert] *')).toBe(false)
     expect(trigger).toHaveTextContent('euler')
     await user.click(trigger)
     await user.click(await screen.findByRole('option', { name: 'heun' }))
@@ -141,11 +146,13 @@ describe('linked widget presentation', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
     expect(input).toBeInTheDocument()
     expect(input).toHaveValue('Local draft')
+    expect(input).toHaveAttribute('inert')
     expect(onUpdate).not.toHaveBeenCalled()
 
     await rerender({ widget })
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
     expect(screen.getByRole('textbox')).toBe(input)
+    expect(input).not.toHaveAttribute('inert')
     await user.clear(input)
     await user.type(input, 'New draft')
     expect(onUpdate).toHaveBeenLastCalledWith('New draft')
@@ -174,9 +181,11 @@ describe('linked widget presentation', () => {
       screen.getByRole('img', { name: 'enabled: Linked input' })
     ).toBeInTheDocument()
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    expect(control.matches('[inert], [inert] *')).toBe(true)
     expect(onUpdate).not.toHaveBeenCalled()
     await rerender({ widget })
     expect(screen.getByRole('switch')).toBe(control)
+    expect(control.matches('[inert], [inert] *')).toBe(false)
     expect(control).toBeChecked()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetStatus.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetStatus.vue
@@ -8,32 +8,35 @@ import type {
 import { cn } from '@comfyorg/tailwind-utils'
 
 const { display, widget } = defineProps<{
-  display: LinkedWidgetDisplay
+  display: LinkedWidgetDisplay | 'switch'
   widget: Pick<SimplifiedWidget, 'name' | 'label'>
 }>()
 
 const { t } = useI18n()
+
+const displayClasses: Record<LinkedWidgetDisplay | 'switch', string> = {
+  control: 'inset-0 justify-start rounded-md px-3',
+  multiline: 'inset-0 justify-start rounded-lg px-3',
+  switch:
+    'top-1/2 right-0.5 h-5 w-9 -translate-y-1/2 justify-center rounded-full'
+}
 </script>
 
 <template>
   <div
-    data-testid="linked-widget-placeholder"
     role="img"
-    :aria-label="`${widget.label || widget.name}: ${t('widgets.linkedInput')}`"
-    :title="t('widgets.linkedInput')"
+    :aria-label="
+      t('widgets.linkedInputFor', { name: widget.label || widget.name })
+    "
     :class="
       cn(
-        'absolute z-20 flex cursor-default items-center overflow-hidden bg-component-node-widget-background/40 select-none',
-        display === 'switch'
-          ? 'top-1/2 right-0.5 h-5 w-9 -translate-y-1/2 justify-center rounded-full'
-          : display === 'expanding'
-            ? 'inset-0 justify-start rounded-lg px-3'
-            : 'inset-0 justify-start rounded-md px-3'
+        'absolute z-20 flex cursor-default items-center overflow-hidden bg-component-node-widget-background-disabled select-none',
+        displayClasses[display]
       )
     "
   >
     <i
-      class="icon-[lucide--link] size-4 text-component-node-foreground-secondary opacity-40"
+      class="icon-[lucide--link] size-4 text-component-node-foreground-secondary"
       aria-hidden="true"
     />
   </div>

--- a/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetStatus.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetStatus.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import type {
+  LinkedWidgetDisplay,
+  SimplifiedWidget
+} from '@/types/simplifiedWidget'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { display, widget } = defineProps<{
+  display: LinkedWidgetDisplay
+  widget: Pick<SimplifiedWidget, 'name' | 'label'>
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    data-testid="linked-widget-placeholder"
+    role="img"
+    :aria-label="`${widget.label || widget.name}: ${t('widgets.linkedInput')}`"
+    :title="t('widgets.linkedInput')"
+    :class="
+      cn(
+        'absolute z-20 flex cursor-default items-center overflow-hidden bg-component-node-widget-background/40 select-none',
+        display === 'switch'
+          ? 'top-1 right-1 h-6 w-10 justify-center rounded-full'
+          : display === 'expanding'
+            ? 'inset-0 justify-start rounded-lg px-3'
+            : 'inset-0 justify-start rounded-md px-3'
+      )
+    "
+  >
+    <i
+      class="icon-[lucide--link] size-4 text-component-node-foreground-secondary opacity-40"
+      aria-hidden="true"
+    />
+  </div>
+</template>

--- a/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetStatus.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/LinkedWidgetStatus.vue
@@ -25,7 +25,7 @@ const { t } = useI18n()
       cn(
         'absolute z-20 flex cursor-default items-center overflow-hidden bg-component-node-widget-background/40 select-none',
         display === 'switch'
-          ? 'top-1 right-1 h-6 w-10 justify-center rounded-full'
+          ? 'top-1/2 right-0.5 h-5 w-9 -translate-y-1/2 justify-center rounded-full'
           : display === 'expanding'
             ? 'inset-0 justify-start rounded-lg px-3'
             : 'inset-0 justify-start rounded-md px-3'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
@@ -1,11 +1,14 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import type { InputTextProps } from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
 import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
 
 import type { IWidgetOptions } from '@/lib/litegraph/src/types/widgets'
+import messages from '@/locales/en/main.json'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 import WidgetInputText from './WidgetInputText.vue'
@@ -31,7 +34,14 @@ describe('WidgetInputText Value Binding', () => {
   ) => {
     return render(WidgetInputText, {
       global: {
-        plugins: [PrimeVue],
+        plugins: [
+          PrimeVue,
+          createI18n({
+            legacy: false,
+            locale: 'en',
+            messages: { en: messages }
+          })
+        ],
         components: { InputText, Textarea }
       },
       props: {
@@ -56,6 +66,52 @@ describe('WidgetInputText Value Binding', () => {
     }
     return input
   }
+
+  describe('linked widget presentation', () => {
+    it('preserves the mounted text editor and value through display transitions', async () => {
+      const user = userEvent.setup()
+      const widget = createInputTextWidget('Local draft')
+      const onUpdate = vi.fn()
+      const { rerender } = renderComponent(widget, 'Local draft', {
+        'onUpdate:modelValue': onUpdate
+      })
+      const input = screen.getByRole('textbox')
+      await user.click(input)
+      expect(input).toHaveFocus()
+
+      await rerender({
+        widget: {
+          ...widget,
+          linkedDisplay: 'control',
+          options: { disabled: true }
+        }
+      })
+      expect(
+        screen.getByRole('img', { name: 'test_input: Linked input' })
+      ).toBeInTheDocument()
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveValue('Local draft')
+      expect(onUpdate).not.toHaveBeenCalled()
+
+      await rerender({ widget })
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+      expect(screen.getByRole('textbox')).toBe(input)
+      await user.clear(input)
+      await user.type(input, 'New draft')
+      expect(onUpdate).toHaveBeenLastCalledWith('New draft')
+    })
+
+    it('does not replace an unlinked disabled control with a link indicator', () => {
+      renderComponent(
+        createInputTextWidget('Read me', { disabled: true }),
+        'Read me'
+      )
+      expect(screen.getByRole('textbox')).toBeDisabled()
+      expect(screen.getByRole('textbox')).toHaveValue('Read me')
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    })
+  })
 
   describe('Vue Event Emission', () => {
     it('emits Vue event when input value changes on blur', async () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
@@ -92,11 +92,13 @@ describe('WidgetInputText Value Binding', () => {
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
       expect(input).toBeInTheDocument()
       expect(input).toHaveValue('Local draft')
+      expect(input.matches('[inert], [inert] *')).toBe(true)
       expect(onUpdate).not.toHaveBeenCalled()
 
       await rerender({ widget })
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
       expect(screen.getByRole('textbox')).toBe(input)
+      expect(input.matches('[inert], [inert] *')).toBe(false)
       await user.clear(input)
       await user.type(input, 'New draft')
       expect(onUpdate).toHaveBeenLastCalledWith('New draft')

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -68,6 +68,7 @@ const isReadOnly = computed(() =>
 const layoutWidget = computed(() => ({
   name: widget.name,
   label: widget.label,
+  linkedDisplay: widget.linkedDisplay,
   borderStyle: cn(
     widget.borderStyle,
     invalid && 'border border-destructive-background'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.vue
@@ -66,9 +66,7 @@ const isReadOnly = computed(() =>
 )
 
 const layoutWidget = computed(() => ({
-  name: widget.name,
-  label: widget.label,
-  linkedDisplay: widget.linkedDisplay,
+  ...widget,
   borderStyle: cn(
     widget.borderStyle,
     invalid && 'border border-destructive-background'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -179,33 +179,66 @@ describe('WidgetSelectDropdown', () => {
     )
   })
 
-  it('renders in cloud asset mode', () => {
-    mockAssetsData.items = [
-      fromPartial({
-        id: 'asset-1',
-        name: 'model_a.safetensors',
-        preview_url: 'https://example.com/a.jpg',
-        tags: []
+  it.for(['combo', 'asset'])(
+    'preserves the cloud %s selection through boundary display transitions',
+    async (type) => {
+      mockAssetsData.items = [
+        fromPartial({
+          id: 'asset-1',
+          name: 'model_a.safetensors',
+          preview_url: 'https://example.com/a.jpg',
+          tags: []
+        })
+      ]
+      mockItemsRef.value = [{ id: 'asset-1', name: 'model_a.safetensors' }]
+      mockSelectedSetRef.value = new Set(['asset-1'])
+      const widget = createMockWidget<string | undefined>({
+        value: 'model_a.safetensors',
+        name: 'test_model',
+        type,
+        options: {
+          values: [],
+          nodeType: 'CheckpointLoaderSimple'
+        }
       })
-    ]
-    mockItemsRef.value = [{ id: 'asset-1', name: 'model_a.safetensors' }]
-    mockSelectedSetRef.value = new Set(['asset-1'])
-    const widget = createMockWidget<string | undefined>({
-      value: 'model_a.safetensors',
-      name: 'test_model',
-      type: 'combo',
-      options: {
-        values: [],
-        nodeType: 'CheckpointLoaderSimple'
-      }
-    })
-    renderComponent(widget, 'model_a.safetensors', {
-      assetKind: 'model',
-      isAssetMode: true,
-      nodeType: 'CheckpointLoaderSimple'
-    })
-    expect(screen.getByText('model_a.safetensors')).toBeDefined()
-  })
+      const { rerender, emitted } = renderComponent(
+        widget,
+        'model_a.safetensors',
+        {
+          assetKind: 'model',
+          isAssetMode: true,
+          nodeType: 'CheckpointLoaderSimple'
+        }
+      )
+      expect(screen.getByText('model_a.safetensors')).toBeDefined()
+      const trigger = screen.getByRole('button', {
+        name: 'model_a.safetensors'
+      })
+
+      await rerender({
+        widget: {
+          ...widget,
+          linkedDisplay: 'control',
+          options: { ...widget.options, disabled: true }
+        }
+      })
+      expect(screen.getByRole('img')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'model_a.safetensors' })
+      ).not.toBeInTheDocument()
+      expect(trigger).toBeInTheDocument()
+      expect(trigger.matches('[inert], [inert] *')).toBe(true)
+      expect(emitted('update:modelValue')).toBeUndefined()
+      expect(mockUpdateSelectedItems).not.toHaveBeenCalled()
+
+      await rerender({ widget })
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'model_a.safetensors' })).toBe(
+        trigger
+      )
+      expect(trigger.matches('[inert], [inert] *')).toBe(false)
+    }
+  )
 
   describe('composable wiring', () => {
     const items: FormDropdownItem[] = [

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -11,7 +11,7 @@
     <label
       v-if="!hideLayoutField"
       :for="id"
-      class="pointer-events-none absolute top-1.5 left-3 z-10 text-2xs text-muted-foreground"
+      class="pointer-events-none absolute top-1.5 left-3 z-30 text-2xs text-muted-foreground"
     >
       {{ displayName }}
     </label>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.vue
@@ -26,11 +26,14 @@
           'size-full resize-none text-(length:--comfy-textarea-font-size) leading-normal',
           !hideLayoutField && 'pt-5',
           // Avoid overflow-auto when idle to prevent per-textarea compositing layers.
-          'overflow-hidden hover:overflow-auto focus:overflow-auto'
+          'overflow-hidden hover:overflow-auto focus:overflow-auto',
+          widget.linkedDisplay && 'invisible'
         )
       "
       :placeholder
       :readonly="isReadOnly"
+      :inert="!!widget.linkedDisplay"
+      :aria-hidden="widget.linkedDisplay ? true : undefined"
       data-capture-wheel="true"
       @pointerdown.capture.stop="trackFocus"
       @pointermove.capture.stop
@@ -38,7 +41,7 @@
       @contextmenu.capture="handleContextMenu"
     />
     <Button
-      v-if="isReadOnly"
+      v-if="isReadOnly && !widget.linkedDisplay"
       variant="textonly"
       size="icon"
       class="invisible absolute top-1.5 right-1.5 z-10 group-focus-within:visible group-hover:visible hover:bg-base-foreground/10"
@@ -49,6 +52,11 @@
     >
       <i class="icon-[lucide--copy] size-4 text-component-node-foreground" />
     </Button>
+    <LinkedWidgetStatus
+      v-if="widget.linkedDisplay"
+      :display="widget.linkedDisplay"
+      :widget
+    />
   </div>
 </template>
 
@@ -68,6 +76,7 @@ import {
 } from '@/utils/widgetPropFilter'
 
 import { WidgetInputBaseClass } from './layout'
+import LinkedWidgetStatus from './LinkedWidgetStatus.vue'
 
 const { widget, placeholder = '' } = defineProps<{
   widget: SimplifiedWidget<string>

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
@@ -5,10 +5,12 @@ import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { useHideLayoutField } from '@/types/widgetTypes'
 import { cn } from '@comfyorg/tailwind-utils'
 
+import LinkedWidgetStatus from '../LinkedWidgetStatus.vue'
+
 const { widget, rootClass } = defineProps<{
   widget: Pick<
     SimplifiedWidget<string | number | undefined>,
-    'name' | 'label' | 'borderStyle'
+    'name' | 'label' | 'borderStyle' | 'linkedDisplay'
   >
   rootClass?: string
   noBorder?: boolean
@@ -47,15 +49,23 @@ const borderStyle = computed(() =>
         :class="
           cn(
             'min-w-0 cursor-default rounded-md transition-all',
-            !noBorder && borderStyle
+            !noBorder && borderStyle,
+            widget.linkedDisplay && 'invisible'
           )
         "
+        :inert="!!widget.linkedDisplay"
+        :aria-hidden="widget.linkedDisplay ? true : undefined"
         @pointerdown.stop
         @pointermove.stop
         @pointerup.stop
       >
         <slot :border-style />
       </div>
+      <LinkedWidgetStatus
+        v-if="widget.linkedDisplay"
+        :display="widget.linkedDisplay"
+        :widget
+      />
     </div>
   </div>
 </template>

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
@@ -63,8 +63,9 @@ const borderStyle = computed(() =>
       </div>
       <LinkedWidgetStatus
         v-if="widget.linkedDisplay"
-        :display="widget.linkedDisplay"
+        :display="noBorder ? 'switch' : widget.linkedDisplay"
         :widget
+        :class="widget.borderStyle"
       />
     </div>
   </div>

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -5,6 +5,7 @@ import { defineAsyncComponent } from 'vue'
 import type { Component } from 'vue'
 
 import type { IWidgetOptions } from '@/lib/litegraph/src/types/widgets'
+import type { LinkedWidgetDisplay } from '@/types/simplifiedWidget'
 
 const WidgetButton = defineAsyncComponent(
   () => import('../components/WidgetButton.vue')
@@ -317,6 +318,26 @@ const getCanonicalType = (type: string): string => aliasMap.get(type) || type
 export const getComponent = (type: string): Component | null => {
   const canonicalType = getCanonicalType(type)
   return widgets.get(canonicalType)?.component || null
+}
+
+export function getLinkedWidgetDisplay(
+  type: string,
+  options: IWidgetOptions
+): LinkedWidgetDisplay | undefined {
+  if (type === 'gradientslider' || type === 'asset') return
+
+  const component = getComponent(type)
+  if (
+    component === WidgetInputText ||
+    component === WidgetInputNumber ||
+    component === WidgetSelect
+  ) {
+    return 'control'
+  }
+  if (component === WidgetTextarea) return 'expanding'
+  if (component === WidgetToggleSwitch) {
+    return options.on == null && options.off == null ? 'switch' : 'control'
+  }
 }
 
 export const isEssential = (type: string): boolean => {

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -321,23 +321,20 @@ export const getComponent = (type: string): Component | null => {
 }
 
 export function getLinkedWidgetDisplay(
-  type: string,
-  options: IWidgetOptions
+  type: string
 ): LinkedWidgetDisplay | undefined {
-  if (type === 'gradientslider' || type === 'asset') return
+  if (type === 'gradientslider') return
 
   const component = getComponent(type)
   if (
     component === WidgetInputText ||
     component === WidgetInputNumber ||
-    component === WidgetSelect
+    component === WidgetSelect ||
+    component === WidgetToggleSwitch
   ) {
     return 'control'
   }
-  if (component === WidgetTextarea) return 'expanding'
-  if (component === WidgetToggleSwitch) {
-    return options.on == null && options.off == null ? 'switch' : 'control'
-  }
+  if (component === WidgetTextarea) return 'multiline'
 }
 
 export const isEssential = (type: string): boolean => {

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -52,6 +52,8 @@ export interface LinkedUpstreamInfo {
   outputName?: string
 }
 
+export type LinkedWidgetDisplay = 'control' | 'switch' | 'expanding'
+
 export interface SimplifiedWidget<
   T extends WidgetValue = WidgetValue,
   O extends IWidgetOptions = IWidgetOptions
@@ -96,6 +98,8 @@ export interface SimplifiedWidget<
   controlWidget?: SafeControlWidget
 
   linkedUpstream?: LinkedUpstreamInfo
+
+  linkedDisplay?: LinkedWidgetDisplay
 }
 
 export interface SimplifiedControlWidget<

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -52,7 +52,7 @@ export interface LinkedUpstreamInfo {
   outputName?: string
 }
 
-export type LinkedWidgetDisplay = 'control' | 'switch' | 'expanding'
+export type LinkedWidgetDisplay = 'control' | 'multiline'
 
 export interface SimplifiedWidget<
   T extends WidgetValue = WidgetValue,


### PR DESCRIPTION
## ELI5

Inside a subgraph, an input can receive its value from outside that subgraph. Showing the inner widget's saved local value can make it look like the value actually supplied by the parent, even though this view cannot determine that parent instance's effective value. This change shows a link indicator in place of that local value, only for the Vue-rendered widget types and boundary connections listed below.

## Motivation

This follows a scope review of linked-widget hiding. Ordinary node-to-node connections can already propagate useful values, so hiding every linked or disabled widget would be too broad. The target here is specifically a widget viewed inside a subgraph whose input is connected to that subgraph's input boundary, where the view has no instance-specific upstream value to display. General disabled-state and editor lifecycle behavior are separate concerns.

## Summary

Only the **Vue node renderer** is affected. A supported widget is hidden only when its actual incoming link originates at the **containing subgraph's input boundary** (`SUBGRAPH_INPUT_ID`). Being disabled or having promoted-widget metadata alone does not qualify. This includes a nested subgraph node's widget when it is connected to its containing subgraph's input boundary.

## Changes

Supported Vue-rendered widget types (including their existing registry aliases):

| Widget kind | Types | Hidden presentation |
| --- | --- | --- |
| Single-line text | `string`, `STRING`, `text` | Local text editor |
| Numeric input / slider | `int`, `INT`, `float`, `FLOAT`, `number`, `slider` | Local numeric control, including a seed's auxiliary value-control button |
| Boolean | `boolean`, `BOOLEAN`, `toggle` | Switch or labeled toggle control |
| Combo / Cloud model asset picker | `combo`, `COMBO`, `asset` | Local selection control in the existing Vue combo/dropdown renderer |
| Multiline text | `textarea`, `TEXTAREA`, `multiline`, `customtext` | Local text area |

- Keep labels, mounted editors, stored values and layout; visually replace the local controls with a link indicator. Hidden controls are inert and excluded from the accessibility tree.
- Preserve widget help tooltips, but omit the hidden local value from them. Disconnecting restores the existing editor and value.
- Use the existing disabled-background token and an opaque link icon. Keep the multiline label above the indicator and preserve widget-level error borders and advanced rings on the visible presentation. The accessible name is one interpolated translation, without a duplicate native tooltip.
- Derive the condition from existing owner-scoped slot/link metadata. No new topology store, parent-instance reverse lookup, value propagation or serialization changes.

## Review Focus

- **Not targeted:** ordinary Primitive/node-to-node links at the root or inside a subgraph, unlinked disabled widgets, or a host widget merely exposed on a subgraph node.
- **Not targeted:** the legacy canvas renderer/custom canvas-drawn widget fallback, the `gradientslider` type, ColorPicker, curve/3D/image editors and other specialized widget types outside the table.
- **Not targeted:** the right-side Parameters panel, which builds a separate widget model and may still show the saved local value. That behavior predates this PR; its presentation can now differ from the canvas node.
- Popup closing, modal/mask-editor lifecycle, generic keyboard/disabled guards and a shared value-editing API are not part of this PR.
- No additional feature flag: this is a narrowly scoped presentation correction within the existing Vue node renderer; the legacy renderer is unchanged.

## Provenance

- **Authored by:** interactive session
- **Verified at `3cdfa7f8dc`:** `pnpm test:unit` on eight directly related files with one worker: 129 passed. Coverage includes asset/combo projection and retained selection, labeled toggles, textarea copy-button suppression/restoration, and retained editors.
- **Verified:** `pnpm test:browser` with Chromium and one worker: five selected scenarios passed, covering disconnect/undo/redo, single-line help versus local-value tooltips, switch geometry, ordinary Primitive-linked seed controls, and keyboard navigation past multiple hidden textareas. Removing only the tooltip's `!linkedDisplay` guard made the single-line regression fail; restoring it passed.
- **Verified:** `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint`, `pnpm knip`, changed-file formatting and `git diff --check` passed. Full lint completed with existing warnings.
- **Verified manually:** light/dark previews for the nine standard-widget cases, plus a linked text indicator retaining its execution-error border and advanced ring. The error check used locally injected store state, not a backend execution.
- **Local coverage limits:** the full unit/browser suites, the existing `subgraphPromotion.spec.ts` unpromote scenarios, and a real Cloud deployment E2E were not run. Cloud asset behavior was checked at projection/component level.

Browser-test changes span three specs (`subgraphBoundaryWidgetPresentation.spec.ts`, `subgraphNested.spec.ts`, `subgraphPromotionDom.spec.ts`) and `fixtures/utils/promotedMissingModel.ts`. The changed helper is exercised by `propertiesPanel/errorsTabModeAware.spec.ts`; `errorsTabCloudMissingModels.spec.ts` imports other helpers from that file, not the changed assertion helper. This affected-file list is broader than the selected local E2E run above.

## Test plan

- [ ] In Vue nodes, enter a subgraph with a supported widget connected to an input boundary: confirm a link indicator replaces its local value while help remains available.
- [ ] Disconnect, undo and redo: confirm the existing value and corresponding presentation are restored.
- [ ] Confirm ordinary Primitive-linked values and specialized editors remain unchanged.
- [ ] In Cloud asset mode, verify a boundary-linked model picker hides its local selection and restores it after disconnect; compare the unchanged Parameters panel separately.

## Screenshots

These captures show the covered widget kinds and layout before the latest icon/background contrast and multiline-label adjustments.

<img width="1320" height="750" alt="00-all-widget-types-aligned" src="https://github.com/user-attachments/assets/e5e566c3-e604-4024-8db3-24b5a1cdfa56" />
<img width="1385" height="225" alt="01-text" src="https://github.com/user-attachments/assets/2f6ecd5a-c4b4-4e57-bddf-5a34db1156e3" />
<img width="1385" height="225" alt="02-integer" src="https://github.com/user-attachments/assets/c9410592-00c5-4deb-8593-0d3e1afb60d5" />
<img width="1385" height="225" alt="03-decimal" src="https://github.com/user-attachments/assets/820fe011-ef40-4dcf-a090-b54275e4f6bd" />
<img width="1385" height="225" alt="04-slider" src="https://github.com/user-attachments/assets/2599cd34-94ab-4c17-9035-1298f7bbfc0f" />
<img width="1385" height="225" alt="05-seed" src="https://github.com/user-attachments/assets/2c1f7afa-83fe-4712-8afb-bb8efd964a94" />
<img width="1385" height="225" alt="06-switch-aligned" src="https://github.com/user-attachments/assets/9cbf5ba6-a3bd-4850-a3e4-632a4049aefb" />
<img width="1385" height="225" alt="07-toggle" src="https://github.com/user-attachments/assets/9068d9f0-23c7-4bb0-ba60-5bd31d6778e3" />
<img width="1385" height="225" alt="08-combo" src="https://github.com/user-attachments/assets/0e7566aa-c416-495b-b9a9-de40f503857f" />
<img width="1385" height="405" alt="09-multiline" src="https://github.com/user-attachments/assets/dff9fda0-7885-44dd-a096-2d46aa2f72eb" />
