### PR TITLE
test(agent): re-enable the keyboard-activation a11y e2e

### DIFF
--- a/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
+++ b/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
@@ -65,7 +65,7 @@ test.describe(
         .toBe('false')
     })
 
-    test.fixme('supports keyboard activation and returns one complementary landmark', async ({
+    test('supports keyboard activation and returns one complementary landmark', async ({
       page
     }) => {
       await bootAgentApp(page, true)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Re-enables the Agent panel keyboard-accessibility e2e test, which was muted five days ago to unblock CI and left muted after the bug it caught was fixed 29 minutes later.

## Changes

- **What**: `test.fixme(` → `test(` on `browser_tests/tests/agent/agentPanelLifecycle.spec.ts:68`. Byte-exact inverse of the disabling commit in #16907. No assertion touched.

## Review Focus

The mute was collateral from two PRs racing on 2026-09-03:

| Time | PR | Event |
|---|---|---|
| 17:25 | #16217 | Test added, green |
| ~19:20 | #16903 + #16904 | Both render `id="agent-panel-title"` → **duplicate DOM id** |
| 19:48 | #16907 | Test muted (`toHaveCount(1)` was correctly failing) |
| 20:17 | #16912 | Duplicate id removed — the actual fix, but the mute stayed |

So the test did its job: it caught a real a11y regression (a duplicate DOM id that left the `role="complementary"` landmark's `aria-labelledby` ambiguous). #16912 is an ancestor of this branch, so the cause is gone. On `main` the id now has exactly two renderers — `PanelHeader.vue:36` (success path) and the `errorComponent` in `DockedAgentPanel.vue:48` — which are mutually exclusive.

Verified by running it, not just reading it. Against a `pnpm dev:cloud` server on the `cloud` project: **10/10 green** on `--repeat-each=10`, and the full spec goes from 4 passed / 1 skipped to 5 passed. Measured DOM state at the moment of assertion:

```json
{
  "agentPanelTitleIds": 1,
  "complementaryLandmarks": 1,
  "landmarkRole": "complementary",
  "landmarkLabelledBy": "agent-panel-title",
  "accessibleName": "Comfy Agent"
}
```

Two notes for the reviewer:

- Lines 85-91 gate for the first time here — they never executed in CI, because line 84 failed on the duplicate id before reaching them. Treat the `playwright-tests (cloud)` run as the receipt rather than my local runs.
- The one spec test that fails locally, `preserves the stored preference while the flag is off`, fails identically on unmodified `main`. It is a dev-server artifact: `agentPanel.ts:92` forces `enabled = true` when `import.meta.env.MODE === 'development'`, so "flag off" is not reproducible outside a built bundle. Unrelated to this change.

Possible follow-ups, deliberately not done here: a component-level guard asserting exactly one `#agent-panel-title` (cheaper than a single unsharded `@cloud` e2e as the only net for that class of bug — branches doing this already exist), and focus-restoration assertions if this test is meant to be the panel's full keyboard-a11y guard.

## Screenshots

Panel opened via `Enter` on the trigger, header title rendering.


## Screenshots

![Agent panel opened via Enter key, showing the Comfy Agent panel header title](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/404163042a76889f799a6c1b4c74ffbfc8f892772020572a01f8c5b07156ac0a/pr-images/1788813929923-28c36468-4861-429c-82a4-12e63b211277.png)