### PR TITLE
fix: preserve website e2e timeout diagnostics

### DIFF
--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:
@@ -66,7 +66,10 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: website-playwright-report
-          path: apps/website/playwright-report/
+          path: |
+            apps/website/playwright-report/
+            apps/website/results.json
+            apps/website/test-results/
           retention-days: 30
 
       - name: Deploy report to Cloudflare

--- a/apps/website/playwright.config.ts
+++ b/apps/website/playwright.config.ts
@@ -24,8 +24,9 @@ export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
+  globalTimeout: process.env.CI ? 20 * 60_000 : 0,
   reporter: process.env.CI
-    ? [['html'], ['json', { outputFile: 'results.json' }]]
+    ? [['list'], ['html'], ['json', { outputFile: 'results.json' }]]
     : 'html',
   expect: {
     toHaveScreenshot: { maxDiffPixels: 100 }


### PR DESCRIPTION
## Summary

Let website E2E tests report failures before GitHub cancels the job. All 11 canceled runs in a sample of 47 merge-group runs hit the 15-minute limit, including [the reported run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34163234449/job/101869175351).

## Changes

- Set a 30-minute job limit and 20-minute CI Playwright deadline.
- Add the list reporter and upload JSON results and retry traces.

## Review Focus

Timeout diagnostics only; the test fixes are in #17141. Failures still fail the required check. Manual cancellations skip uploads.

A probe verified the deadline exits nonzero and produces HTML, JSON errors, and a retry trace. Lint, both typechecks, Knip, and formatting passed. All 412 tests were discovered; the full suite was not run locally for this PR.

<details>
<summary>Inter license in #17141</summary>

This PR adds no fonts. #17141 includes an unchanged Google Fonts Inter file with its copyright notice and OFL 1.1 license. [OFL permits bundling with other software licenses](https://openfontlicense.org/ofl-faq/); Inter remains under OFL, not GPL, and cannot be sold by itself.

</details>
