### PR TITLE
fix: classify desktop cloud notification failures correctly

### DIFF
--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/vue'
+import { useAsyncState } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -9,6 +10,9 @@ const settingState = {
 }
 
 const settingStore = {
+  get error(): unknown {
+    return undefined
+  },
   load: vi.fn<() => Promise<void>>(),
   get: vi.fn((key: string) =>
     key === 'Comfy.Desktop.CloudNotificationShown'
@@ -134,24 +138,79 @@ describe('DesktopCloudNotificationController', () => {
 
   it('reports a settings load failure without scheduling the notification', async () => {
     const error = new Error('load failed')
-    settingStore.load.mockRejectedValue(error)
+    const settingsLoad = useAsyncState(() => Promise.reject(error), undefined, {
+      immediate: false
+    })
+    settingStore.load.mockImplementation(async () => {
+      await settingsLoad.execute()
+    })
+    vi.spyOn(settingStore, 'error', 'get').mockImplementation(
+      () => settingsLoad.error.value
+    )
 
     const { unmount } = render(DesktopCloudNotificationController)
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(errorReporter).toHaveBeenCalledWith(error, {
-      errorType: 'cloud_notification_settings_load_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'cloud',
-        operation: 'load',
-        outcome: 'failed',
-        assert_mode: 'soft'
-      },
-      context: { platform: 'darwin', is_disposed: false },
-      level: 'error'
-    })
+    expect(errorReporter).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        errorType: 'cloud_notification_settings_load_failed',
+        tags: expect.objectContaining({
+          failure_kind: 'caught_unexpected',
+          feature_area: 'cloud',
+          operation: 'load',
+          outcome: 'failed',
+          assert_mode: 'soft'
+        }),
+        context: expect.objectContaining({
+          platform: 'darwin',
+          is_disposed: false
+        }),
+        level: 'error'
+      })
+    )
+    await vi.advanceTimersByTimeAsync(2000)
+
     expect(settingStore.set).not.toHaveBeenCalled()
+    expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('reports an initial save failure, resets state, and never opens the dialog', async () => {
+    const error = new Error('save failed')
+    settingStore.set.mockRejectedValueOnce(error)
+
+    const { unmount } = render(DesktopCloudNotificationController)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(errorReporter).toHaveBeenCalledExactlyOnceWith(
+      error,
+      expect.objectContaining({
+        errorType: 'cloud_notification_state_save_failed',
+        tags: expect.objectContaining({
+          failure_kind: 'caught_unexpected',
+          feature_area: 'cloud',
+          operation: 'save',
+          outcome: 'failed',
+          assert_mode: 'soft'
+        }),
+        context: expect.objectContaining({
+          platform: 'darwin',
+          is_disposed: false
+        }),
+        level: 'error'
+      })
+    )
+    expect(settingStore.set).toHaveBeenNthCalledWith(
+      1,
+      'Comfy.Desktop.CloudNotificationShown',
+      true
+    )
+    expect(settingStore.set).toHaveBeenLastCalledWith(
+      'Comfy.Desktop.CloudNotificationShown',
+      false
+    )
     expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
 
     unmount()
@@ -164,18 +223,24 @@ describe('DesktopCloudNotificationController', () => {
     const { unmount } = render(DesktopCloudNotificationController)
     await vi.advanceTimersByTimeAsync(2000)
 
-    expect(errorReporter).toHaveBeenCalledWith(error, {
-      errorType: 'cloud_notification_show_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'cloud',
-        operation: 'render',
-        outcome: 'failed',
-        assert_mode: 'soft'
-      },
-      context: { platform: 'darwin', is_disposed: false },
-      level: 'error'
-    })
+    expect(errorReporter).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        errorType: 'cloud_notification_show_failed',
+        tags: expect.objectContaining({
+          failure_kind: 'caught_unexpected',
+          feature_area: 'cloud',
+          operation: 'render',
+          outcome: 'failed',
+          assert_mode: 'soft'
+        }),
+        context: expect.objectContaining({
+          platform: 'darwin',
+          is_disposed: false
+        }),
+        level: 'error'
+      })
+    )
     expect(settingStore.set).toHaveBeenLastCalledWith(
       'Comfy.Desktop.CloudNotificationShown',
       false
@@ -184,33 +249,44 @@ describe('DesktopCloudNotificationController', () => {
     unmount()
   })
 
-  it('reports a failure to reset the notification shown state', async () => {
-    const showError = new Error('show failed')
-    const resetError = new Error('reset failed')
-    dialogService.showCloudNotification.mockRejectedValue(showError)
-    settingStore.set.mockImplementation(
-      async (_key: string, value: boolean) => {
-        if (!value) throw resetError
-        settingState.shown = value
-      }
-    )
+  it.for(['save', 'display'])(
+    'reports a reset failure after a %s failure',
+    async (failure) => {
+      const initialError = new Error('initial failure')
+      const resetError = new Error('reset failed')
+      dialogService.showCloudNotification.mockRejectedValue(initialError)
+      settingStore.set.mockImplementation(
+        async (_key: string, value: boolean) => {
+          if (!value) throw resetError
+          if (failure === 'save') throw initialError
+          settingState.shown = value
+        }
+      )
 
-    const { unmount } = render(DesktopCloudNotificationController)
-    await vi.advanceTimersByTimeAsync(2000)
+      const { unmount } = render(DesktopCloudNotificationController)
+      await vi.advanceTimersByTimeAsync(2000)
 
-    expect(errorReporter).toHaveBeenNthCalledWith(2, resetError, {
-      errorType: 'cloud_notification_state_reset_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'cloud',
-        operation: 'save',
-        outcome: 'failed',
-        assert_mode: 'soft'
-      },
-      context: { platform: 'darwin', is_disposed: false },
-      level: 'error'
-    })
+      expect(errorReporter).toHaveBeenNthCalledWith(
+        2,
+        resetError,
+        expect.objectContaining({
+          errorType: 'cloud_notification_state_reset_failed',
+          tags: expect.objectContaining({
+            failure_kind: 'caught_unexpected',
+            feature_area: 'cloud',
+            operation: 'save',
+            outcome: 'failed',
+            assert_mode: 'soft'
+          }),
+          context: expect.objectContaining({
+            platform: 'darwin',
+            is_disposed: false
+          }),
+          level: 'error'
+        })
+      )
 
-    unmount()
-  })
+      unmount()
+    }
+  )
 })

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
@@ -13,12 +13,32 @@ const dialogService = useDialogService()
 let isDisposed = false
 let cloudNotificationTimer: ReturnType<typeof setTimeout> | undefined
 
+async function resetNotificationState(platform: string) {
+  try {
+    await settingStore.set('Comfy.Desktop.CloudNotificationShown', false)
+  } catch (error) {
+    reportError(error, {
+      errorType: 'cloud_notification_state_reset_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'cloud',
+        operation: 'save',
+        outcome: 'failed',
+        assert_mode: 'soft'
+      },
+      context: { platform, is_disposed: isDisposed },
+      level: 'error'
+    })
+  }
+}
+
 async function scheduleCloudNotification() {
   const platform = electronAPI()?.getPlatform()
   if (!isDesktop || platform !== 'darwin') return
 
   try {
     await settingStore.load()
+    if (settingStore.error !== undefined) throw settingStore.error
   } catch (error) {
     reportError(error, {
       errorType: 'cloud_notification_settings_load_failed',
@@ -43,7 +63,26 @@ async function scheduleCloudNotification() {
 
     try {
       await settingStore.set('Comfy.Desktop.CloudNotificationShown', true)
-      if (isDisposed) return
+    } catch (error) {
+      reportError(error, {
+        errorType: 'cloud_notification_state_save_failed',
+        tags: {
+          failure_kind: 'caught_unexpected',
+          feature_area: 'cloud',
+          operation: 'save',
+          outcome: 'failed',
+          assert_mode: 'soft'
+        },
+        context: { platform, is_disposed: isDisposed },
+        level: 'error'
+      })
+      await resetNotificationState(platform)
+      return
+    }
+
+    if (isDisposed) return
+
+    try {
       await dialogService.showCloudNotification()
     } catch (error) {
       reportError(error, {
@@ -58,22 +97,7 @@ async function scheduleCloudNotification() {
         context: { platform, is_disposed: isDisposed },
         level: 'error'
       })
-      await settingStore
-        .set('Comfy.Desktop.CloudNotificationShown', false)
-        .catch((resetError) => {
-          reportError(resetError, {
-            errorType: 'cloud_notification_state_reset_failed',
-            tags: {
-              failure_kind: 'caught_unexpected',
-              feature_area: 'cloud',
-              operation: 'save',
-              outcome: 'failed',
-              assert_mode: 'soft'
-            },
-            context: { platform, is_disposed: isDisposed },
-            level: 'error'
-          })
-        })
+      await resetNotificationState(platform)
     }
   }, 2000)
 }


### PR DESCRIPTION
## Summary

Fix desktop cloud notification error handling identified in #16997; stacked on that PR while it remains open.

## Changes

- Inspect the exposed settings error after load resolves and abort scheduling on failure, using the existing VueUse contract. The missing abort predates #16997.
- Report initial shown-state write failures as `cloud_notification_state_save_failed` with operation `save`; preserve display/reset reporting and attempt reset after either failure.
- Exercise real `useAsyncState` failure behavior, prove failed loads/saves cannot show the dialog, and use partial nested telemetry assertions.

## Review Focus

Eight focused tests pass; the two regression cases fail against the parent implementation. Changed-file lint/format, full typecheck, and Knip passed through repository hooks. Existing parent CI supplies broad regression evidence; follow-up CI has not been awaited.

Fixes the findings recorded in https://github.com/Comfy-Org/ComfyUI_frontend/pull/16997#pullrequestreview-5135639019 and the save-classification concern in https://github.com/Comfy-Org/ComfyUI_frontend/pull/16997#discussion_r3935972745.
