### PR TITLE
fix: show payment recovery for personal workspaces

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -376,6 +376,19 @@ describe('BillingStatusBanner', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows payment recovery to personal workspace owners', async () => {
+    paymentFailedState()
+    state.isTeamPlan = false
+    state.workspaceType = 'personal'
+    renderBanner()
+
+    expect(screen.getByRole('status')).toHaveTextContent('Payment failed')
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment' })
+    )
+    expect(state.manageSubscription).toHaveBeenCalledTimes(1)
+  })
+
   it('does not expose payment controls to members', () => {
     paymentFailedState()
     state.canManageSubscription = false

--- a/src/platform/workspace/composables/deriveBillingBanner.test.ts
+++ b/src/platform/workspace/composables/deriveBillingBanner.test.ts
@@ -41,8 +41,14 @@ describe('deriveBillingBanner', () => {
     expect(derive({})).toBeNull()
   })
 
-  it('shows no banner outside a team plan', () => {
+  it('keeps team billing-control notices out of personal plans', () => {
     expect(derive({ isTeamPlan: false, hasFunds: false })).toBeNull()
+  })
+
+  it('shows payment failed to personal workspace owners', () => {
+    expect(derive({ ...paymentFailed, isTeamPlan: false })).toBe(
+      'paymentFailed'
+    )
   })
 
   it('hides existing notices when billing control is rolled back', () => {

--- a/src/platform/workspace/composables/useBillingBanner.ts
+++ b/src/platform/workspace/composables/useBillingBanner.ts
@@ -35,17 +35,16 @@ export interface BillingBannerInputs {
 export function deriveBillingBanner(
   inputs: BillingBannerInputs
 ): BillingBannerKind | null {
-  if (!inputs.isTeamPlan || !inputs.isLoaded) {
-    return null
-  }
+  if (!inputs.isLoaded) return null
 
   if (inputs.v1PaymentRecovery) {
-    if (inputs.billingStatus === 'paused') return 'paused'
+    if (inputs.isTeamPlan && inputs.billingStatus === 'paused') return 'paused'
     if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
       return 'paymentFailed'
     }
   }
 
+  if (!inputs.isTeamPlan) return null
   if (!inputs.canAccessSubscriptionFeatures) return null
   if (!inputs.billingControlEnabled) return null
 


### PR DESCRIPTION
## Summary

Show the existing payment-failed recovery banner to personal workspace owners instead of limiting it to team plans.

## Changes

- **What**: Evaluate flagged payment-failure recovery before the team-plan-only billing notices, while keeping paused and billing-control banners team-scoped.
- **Tests**: Cover personal banner derivation and the Update payment action in the rendered Settings banner.

## Review Focus

Confirm personal `payment_failed` owners see recovery without exposing team-only paused or billing-control notices.

Linear: FE-2051

## Screenshots (if applicable)

Not included; this reuses the existing payment-failed banner.