### PR TITLE
Strengthen result item typing

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -243,6 +243,7 @@ import {
   getMediaTypeFromFilename,
   isPreviewableMediaType
 } from '@/utils/formatUtil'
+import type { AugmentedResultItem } from '@/utils/resultItem'
 
 const Load3dViewerContent = defineAsyncComponent(
   () => import('@/components/load3d/Load3dViewerContent.vue')
@@ -454,13 +455,13 @@ watch(galleryActiveIndex, (index) => {
   }
 })
 
-const galleryItems = computed(() => {
+const galleryItems = computed<AugmentedResultItem[]>(() => {
   return previewableVisibleAssets.value.map((asset) => {
     const mediaType = getMediaTypeFromFilename(asset.name)
     return {
       filename: asset.name,
       subfolder: getAssetSubfolder(asset),
-      type: 'output' as const,
+      type: 'output',
       nodeId: '0',
       mediaType: mediaType === 'image' ? 'images' : mediaType,
       url: asset.preview_url || ''

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -5,7 +5,6 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { AugmentedResultItem } from '@/utils/resultItem'
-import type { SerializedNodeId } from '@/types/nodeId'
 
 import MediaLightbox from './MediaLightbox.vue'
 
@@ -36,17 +35,8 @@ const i18n = createI18n({
   }
 })
 
-type MockResultItem = Partial<AugmentedResultItem> & {
-  filename: string
-  subfolder: string
-  type: string
-  nodeId: SerializedNodeId
-  mediaType: string
+type MockResultItem = AugmentedResultItem & {
   id?: string
-  url?: string
-  isImage?: boolean
-  isVideo?: boolean
-  isAudio?: boolean
 }
 
 describe('MediaLightbox', () => {
@@ -77,9 +67,6 @@ describe('MediaLightbox', () => {
       type: 'output',
       nodeId: '123',
       mediaType: 'images',
-      isImage: true,
-      isVideo: false,
-      isAudio: false,
       url: 'image1.jpg',
       id: '1'
     },
@@ -89,9 +76,6 @@ describe('MediaLightbox', () => {
       type: 'output',
       nodeId: '456',
       mediaType: 'images',
-      isImage: true,
-      isVideo: false,
-      isAudio: false,
       url: 'image2.jpg',
       id: '2'
     },
@@ -101,9 +85,6 @@ describe('MediaLightbox', () => {
       type: 'output',
       nodeId: '789',
       mediaType: 'images',
-      isImage: true,
-      isVideo: false,
-      isAudio: false,
       url: 'image3.jpg',
       id: '3'
     }
@@ -126,7 +107,7 @@ describe('MediaLightbox', () => {
         }
       },
       props: {
-        allGalleryItems: mockGalleryItems as AugmentedResultItem[],
+        allGalleryItems: mockGalleryItems,
         activeIndex: 0,
         'onUpdate:activeIndex': onUpdateActiveIndex,
         ...props
@@ -155,7 +136,7 @@ describe('MediaLightbox', () => {
 
   it('hides navigation buttons for single item', async () => {
     renderGallery({
-      allGalleryItems: [mockGalleryItems[0]] as AugmentedResultItem[]
+      allGalleryItems: [mockGalleryItems[0]]
     })
     await nextTick()
 
@@ -171,7 +152,7 @@ describe('MediaLightbox', () => {
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */
 
     await rerender({
-      allGalleryItems: mockGalleryItems as AugmentedResultItem[],
+      allGalleryItems: mockGalleryItems,
       activeIndex: 0
     })
     await nextTick()
@@ -206,7 +187,7 @@ describe('MediaLightbox', () => {
             mediaType: 'text',
             url: '/api/view?filename=failed.txt'
           }
-        ] as AugmentedResultItem[]
+        ]
       },
       { ResultText: false }
     )
@@ -279,9 +260,6 @@ describe('MediaLightbox', () => {
       type: 'output',
       nodeId: `${n}`,
       mediaType: 'video',
-      isImage: false,
-      isVideo: true,
-      isAudio: false,
       url: `http://assets.test/v${n}.mp4`,
       id: `v${n}`
     })
@@ -290,13 +268,13 @@ describe('MediaLightbox', () => {
       const { rerender } = render(MediaLightbox, {
         global: { plugins: [i18n] },
         props: {
-          allGalleryItems: items as AugmentedResultItem[],
+          allGalleryItems: items,
           activeIndex: 0
         }
       })
       const show = async (activeIndex: number) => {
         await rerender({
-          allGalleryItems: items as AugmentedResultItem[],
+          allGalleryItems: items,
           activeIndex
         })
         await nextTick()

--- a/src/platform/assets/components/MediaLightbox.stories.ts
+++ b/src/platform/assets/components/MediaLightbox.stories.ts
@@ -4,19 +4,29 @@ import { ref } from 'vue'
 import MediaLightbox from '@/components/sidebar/tabs/queue/MediaLightbox.vue'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 
-type MockItem = Pick<AugmentedResultItem, 'filename' | 'url'>
-
-const SAMPLE_IMAGES: MockItem[] = [
+const SAMPLE_IMAGES: AugmentedResultItem[] = [
   {
     filename: 'landscape.jpg',
+    subfolder: '',
+    type: 'output',
+    nodeId: 'node-1',
+    mediaType: 'images',
     url: 'https://i.imgur.com/OB0y6MR.jpg'
   },
   {
     filename: 'portrait.jpg',
+    subfolder: '',
+    type: 'output',
+    nodeId: 'node-1',
+    mediaType: 'images',
     url: 'https://i.imgur.com/CzXTtJV.jpg'
   },
   {
     filename: 'nature.jpg',
+    subfolder: '',
+    type: 'output',
+    nodeId: 'node-1',
+    mediaType: 'images',
     url: 'https://farm9.staticflickr.com/8505/8441256181_4e98d8bff5_z_d.jpg'
   }
 ]
@@ -34,7 +44,7 @@ export const MultipleImages: Story = {
     components: { MediaLightbox },
     setup() {
       const activeIndex = ref(0)
-      const items = SAMPLE_IMAGES as AugmentedResultItem[]
+      const items = SAMPLE_IMAGES
       return { activeIndex, items }
     },
     template: `
@@ -66,7 +76,7 @@ export const SingleImage: Story = {
     components: { MediaLightbox },
     setup() {
       const activeIndex = ref(-1)
-      const items = [SAMPLE_IMAGES[0]] as AugmentedResultItem[]
+      const items = SAMPLE_IMAGES.slice(0, 1)
       return { activeIndex, items }
     },
     template: `
@@ -94,7 +104,7 @@ export const Closed: Story = {
     components: { MediaLightbox },
     setup() {
       const activeIndex = ref(-1)
-      const items = SAMPLE_IMAGES as AugmentedResultItem[]
+      const items = SAMPLE_IMAGES
       return { activeIndex, items }
     },
     template: `

--- a/src/platform/assets/composables/media/assetMappers.ts
+++ b/src/platform/assets/composables/media/assetMappers.ts
@@ -49,7 +49,7 @@ export function mapTaskOutputToAssetItem(
 
   return {
     id: taskItem.jobId,
-    name: output.filename ?? '',
+    name: output.filename,
     display_name: output.display_name,
     size: 0,
     created_at: executionTime,

--- a/src/platform/assets/utils/outputAssetUtil.test.ts
+++ b/src/platform/assets/utils/outputAssetUtil.test.ts
@@ -39,10 +39,12 @@ type OutputOverrides = Partial<{
 }>
 
 function createOutput(overrides: OutputOverrides = {}): AugmentedResultItem {
-  const merged = {
+  const merged: AugmentedResultItem = {
     filename: 'file.png',
     subfolder: 'sub',
+    type: 'output',
     nodeId: '1',
+    mediaType: 'images',
     url: 'https://example.com/file.png',
     ...overrides
   }
@@ -50,7 +52,7 @@ function createOutput(overrides: OutputOverrides = {}): AugmentedResultItem {
     ...merged,
     previewUrl: merged.url,
     display_name: merged.display_name
-  } as AugmentedResultItem
+  }
 }
 
 function createAsset(

--- a/src/renderer/extensions/linearMode/OutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistory.test.ts
@@ -281,7 +281,7 @@ describe('OutputHistory', () => {
       await nextTick()
 
       expect(screen.getByTestId('output-history-item')).toHaveTextContent(
-        output.filename ?? ''
+        output.filename
       )
     })
 

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -4,22 +4,27 @@ import type { AugmentedResultItem } from '@/utils/resultItem'
 
 const METADATA_KEYS = new Set(['animated', 'text'])
 
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+}
+
 /**
  * Validates that an unknown value is a well-formed ResultItem.
  *
  * Requires `filename` (string) since it is needed for a valid URL.
  * `subfolder` is optional here — URL building falls back to ''.
  */
-function isResultItem(item: unknown): item is ResultItem {
+function isResultItem(
+  item: unknown
+): item is ResultItem & { filename: string } {
   if (!item || typeof item !== 'object' || Array.isArray(item)) return false
 
-  const candidate = item as Record<string, unknown>
-
-  if (typeof candidate.filename !== 'string') return false
+  if (!('filename' in item) || typeof item.filename !== 'string') return false
 
   if (
-    candidate.type !== undefined &&
-    !resultItemType.safeParse(candidate.type).success
+    'type' in item &&
+    item.type !== undefined &&
+    !resultItemType.safeParse(item.type).success
   ) {
     return false
   }
@@ -33,13 +38,12 @@ export function parseNodeOutput(
 ): AugmentedResultItem[] {
   if (!nodeOutput) return []
 
-  return Object.entries(nodeOutput)
-    .filter(([key, value]) => !METADATA_KEYS.has(key) && Array.isArray(value))
-    .flatMap(([mediaType, items]) =>
-      (items as unknown[])
-        .filter(isResultItem)
-        .map((item) => ({ ...item, mediaType, nodeId }))
-    )
+  return Object.entries(nodeOutput).flatMap(([mediaType, items]) => {
+    if (METADATA_KEYS.has(mediaType) || !isUnknownArray(items)) return []
+    return items
+      .filter(isResultItem)
+      .map((item) => ({ ...item, mediaType, nodeId }))
+  })
 }
 
 export function parseTaskOutput(

--- a/src/utils/queueDisplay.test.ts
+++ b/src/utils/queueDisplay.test.ts
@@ -164,7 +164,7 @@ describe('buildJobDisplay', () => {
             nodeId: '0',
             mediaType: 'images',
             url: '/api/view?filename=preview.png&type=output&subfolder='
-          } as const
+          }
         }),
         'completed',
         createCtx()

--- a/src/utils/resultItem.ts
+++ b/src/utils/resultItem.ts
@@ -3,6 +3,7 @@ import type { SerializedNodeId } from '@/types/nodeId'
 import { getMediaTypeFromFilename } from '@/utils/formatUtil'
 
 export interface AugmentedResultItem extends ResultItem {
+  filename: string
   mediaType: string
   nodeId: SerializedNodeId
   assetId?: string
@@ -67,9 +68,9 @@ export function isTextResult(item: AugmentedResultItem): boolean {
 export function resultItemHtmlVideoType(
   item: AugmentedResultItem
 ): string | undefined {
-  if (item.filename?.endsWith('.webm')) return 'video/webm'
-  if (item.filename?.endsWith('.mp4')) return 'video/mp4'
-  if (item.filename?.endsWith('.mov')) return 'video/quicktime'
+  if (item.filename.endsWith('.webm')) return 'video/webm'
+  if (item.filename.endsWith('.mp4')) return 'video/mp4'
+  if (item.filename.endsWith('.mov')) return 'video/quicktime'
   if (isVhsFormat(item)) {
     if (item.format?.endsWith('webm')) return 'video/webm'
     if (item.format?.endsWith('mp4')) return 'video/mp4'
@@ -80,10 +81,10 @@ export function resultItemHtmlVideoType(
 export function resultItemHtmlAudioType(
   item: AugmentedResultItem
 ): string | undefined {
-  if (item.filename?.endsWith('.mp3')) return 'audio/mpeg'
-  if (item.filename?.endsWith('.wav')) return 'audio/wav'
-  if (item.filename?.endsWith('.ogg')) return 'audio/ogg'
-  if (item.filename?.endsWith('.flac')) return 'audio/flac'
+  if (item.filename.endsWith('.mp3')) return 'audio/mpeg'
+  if (item.filename.endsWith('.wav')) return 'audio/wav'
+  if (item.filename.endsWith('.ogg')) return 'audio/ogg'
+  if (item.filename.endsWith('.flac')) return 'audio/flac'
   return undefined
 }
 

--- a/src/utils/resultItemUrl.ts
+++ b/src/utils/resultItemUrl.ts
@@ -5,7 +5,7 @@ import { isImageResult } from '@/utils/resultItem'
 
 function resultItemUrlParams(item: AugmentedResultItem): URLSearchParams {
   const params = new URLSearchParams()
-  params.set('filename', item.filename ?? '')
+  params.set('filename', item.filename)
   params.set('type', item.type ?? '')
   params.set('subfolder', item.subfolder ?? '')
   if (item.format) params.set('format', item.format)


### PR DESCRIPTION
## Summary

Make the ResultItemImpl removal type-safe without assertions or casts.

## Changes

- **What**: Require parsed result filenames, narrow unknown output data safely, and use complete typed fixtures.

## Review Focus

- Result-item parsing and fixture types stacked on #17145.
