### PR TITLE
fix(FE-1923): resolve 3D asset subfolder and persist Save3DAdvanced thumbnails

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -231,8 +231,8 @@ import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataS
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { getAssetDisplayName } from '@/platform/assets/utils/assetMetadataUtils'
 import {
-  getAssetSubfolder,
-  getAssetUrl
+  getAssetFileUrl,
+  getAssetSubfolder
 } from '@/platform/assets/utils/assetUrlUtil'
 import type { MediaKind } from '@/platform/assets/schemas/mediaAssetSchema'
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
@@ -572,7 +572,7 @@ const handleZoomClick = (asset: AssetItem) => {
       title: getAssetDisplayName(asset),
       component: Load3dViewerContent,
       props: {
-        modelUrl: asset.preview_url || getAssetUrl(asset)
+        modelUrl: getAssetFileUrl(asset)
       },
       dialogComponentProps: {
         renderer: 'reka',

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -1653,6 +1653,53 @@ describe('useLoad3d', () => {
       )
     })
 
+    it('falls back to the last loaded model file when the node has no model widget', async () => {
+      const { isAssetPreviewSupported, persistThumbnail } =
+        await import('@/platform/assets/utils/assetPreviewUtil')
+      vi.mocked(isAssetPreviewSupported).mockReturnValue(true)
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue([
+        '3d',
+        'ComfyUI_00110.glb'
+      ] as unknown as ReturnType<typeof Load3dUtils.splitFilePath>)
+      mockNode.widgets = [
+        { name: 'viewport_state', value: {} } as unknown as IWidget
+      ]
+      mockNode.properties['Last Time Model File'] = '3d/ComfyUI_00110.glb'
+
+      const { handler } = await getModelReadyHandler()
+      handler()
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(Load3dUtils.splitFilePath).toHaveBeenCalledWith(
+        '3d/ComfyUI_00110.glb'
+      )
+      expect(persistThumbnail).toHaveBeenCalledWith(
+        'ComfyUI_00110.glb',
+        expect.any(Blob)
+      )
+    })
+
+    it('falls back to the last loaded model file when the model widget value is empty', async () => {
+      const { isAssetPreviewSupported, persistThumbnail } =
+        await import('@/platform/assets/utils/assetPreviewUtil')
+      vi.mocked(isAssetPreviewSupported).mockReturnValue(true)
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue([
+        '3d',
+        'ComfyUI_00110.glb'
+      ] as unknown as ReturnType<typeof Load3dUtils.splitFilePath>)
+      mockNode.widgets = [{ name: 'image', value: '' } as unknown as IWidget]
+      mockNode.properties['Last Time Model File'] = '3d/ComfyUI_00110.glb'
+
+      const { handler } = await getModelReadyHandler()
+      handler()
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(persistThumbnail).toHaveBeenCalledWith(
+        'ComfyUI_00110.glb',
+        expect.any(Blob)
+      )
+    })
+
     it('skips persistence when the model widget has no value', async () => {
       const { isAssetPreviewSupported, persistThumbnail } =
         await import('@/platform/assets/utils/assetPreviewUtil')

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -967,7 +967,11 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       const modelWidget = node?.widgets?.find(
         (w) => w.name === 'model_file' || w.name === 'image'
       )
-      const value = modelWidget?.value
+      const widgetValue = modelWidget?.value
+      const value =
+        typeof widgetValue === 'string' && widgetValue.trim()
+          ? widgetValue
+          : node?.properties['Last Time Model File']
       if (typeof value !== 'string' || !value) return
 
       const filename = value.trim().replace(/\s*\[output\]$/, '')

--- a/src/platform/assets/composables/media/assetMappers.test.ts
+++ b/src/platform/assets/composables/media/assetMappers.test.ts
@@ -93,4 +93,28 @@ describe('unflattenOutputAssets', () => {
       'output'
     ])
   })
+
+  it('keeps the representative asset id apart from same-named outputs', () => {
+    const asset = {
+      job_id: 'job-id',
+      name: 'ComfyUI_00001.glb',
+      size: 1,
+      tags: ['output'],
+      updated_at: '2026-01-01T00:00:00Z'
+    }
+    const assets = [
+      { ...asset, id: 'earlier-id', created_at: '2026-01-01T00:00:00Z' },
+      { ...asset, id: 'later-id', created_at: '2026-01-01T00:00:01Z' }
+    ] satisfies AssetItem[]
+
+    const [grouped] = unflattenOutputAssets(assets)
+    const metadata = getOutputAssetMetadata(grouped.user_metadata)
+
+    expect(grouped.id).toBe('job-id')
+    expect(metadata?.assetId).toBe('later-id')
+    expect(metadata?.allOutputs?.map((output) => output.assetId)).toEqual([
+      'earlier-id',
+      'later-id'
+    ])
+  })
 })

--- a/src/platform/assets/composables/media/assetMappers.ts
+++ b/src/platform/assets/composables/media/assetMappers.ts
@@ -126,6 +126,7 @@ export function unflattenOutputAssets(
         jobId: job_id,
         subfolder: '',
         ...representative.user_metadata,
+        assetId: representative.id,
         outputCount: ordered.length,
         allOutputs: ordered.map(flatAssetToResultItem)
       }

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -580,7 +580,7 @@ describe('useMediaAssetActions', () => {
       unmount()
     })
 
-    it('keeps single explicit assets on the direct download path in cloud', () => {
+    it('downloads a single explicit asset by asset id in cloud', () => {
       mockIsCloud.value = true
       mockGetOutputAssetMetadata.mockReturnValue({
         jobId: 'job1',
@@ -600,7 +600,7 @@ describe('useMediaAssetActions', () => {
 
       expect(mockDownloadFile).toHaveBeenCalledOnce()
       expect(mockDownloadFile).toHaveBeenCalledWith(
-        'https://example.com/single-output.png',
+        'http://localhost:8188/api/assets/single-output/content',
         'single-output.png'
       )
       expect(mockCreateAssetExport).not.toHaveBeenCalled()

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -24,7 +24,7 @@ import {
   getAssetStoredFilename
 } from '../utils/assetMetadataUtils'
 import { getAssetType } from '../utils/assetTypeUtil'
-import { getAssetUrl } from '../utils/assetUrlUtil'
+import { getAssetFileUrl } from '../utils/assetUrlUtil'
 import { clearDeletedAssetWidgetValues } from '../utils/clearDeletedAssetWidgetValues'
 import { clearNodePreviewCacheForValues } from '../utils/clearNodePreviewCacheForValues'
 import { markDeletedAssetsAsMissingMedia } from '../utils/markDeletedAssetsAsMissingMedia'
@@ -144,8 +144,7 @@ export function useMediaAssetActions() {
 
   function downloadSingleAsset(asset: AssetItem) {
     const filename = getAssetDisplayName(asset)
-    const downloadUrl = asset.preview_url || getAssetUrl(asset)
-    downloadFile(downloadUrl, filename)
+    downloadFile(getAssetFileUrl(asset), filename)
   }
 
   async function expandAssetForDownload(

--- a/src/platform/assets/schemas/assetMetadataSchema.ts
+++ b/src/platform/assets/schemas/assetMetadataSchema.ts
@@ -14,6 +14,7 @@ export interface OutputAssetMetadata extends Record<string, unknown> {
   workflow?: ComfyWorkflowJSON
   outputCount?: number
   allOutputs?: AugmentedResultItem[]
+  assetId?: string
 }
 
 /**

--- a/src/platform/assets/utils/assetUrlUtil.test.ts
+++ b/src/platform/assets/utils/assetUrlUtil.test.ts
@@ -99,23 +99,24 @@ describe('getAssetFileUrl', () => {
       )
     })
 
-    it('uses the own output asset id of a card grouped per job', () => {
+    it('uses the own asset id kept by a card grouped per job', () => {
       const asset = createAsset({
         id: 'job-1',
         name: 'ComfyUI_00110.glb',
         user_metadata: {
           jobId: 'job-1',
           subfolder: '',
+          assetId: 'asset-model-later',
           outputCount: 2,
           allOutputs: [
-            { assetId: 'asset-image', filename: 'ComfyUI_00109.png' },
-            { assetId: 'asset-model', filename: 'ComfyUI_00110.glb' }
+            { assetId: 'asset-model-earlier', filename: 'ComfyUI_00110.glb' },
+            { assetId: 'asset-model-later', filename: 'ComfyUI_00110.glb' }
           ] as AugmentedResultItem[]
         }
       })
 
       expect(getAssetFileUrl(asset)).toBe(
-        'http://localhost:8188/api/assets/asset-model/content'
+        'http://localhost:8188/api/assets/asset-model-later/content'
       )
     })
 

--- a/src/platform/assets/utils/assetUrlUtil.test.ts
+++ b/src/platform/assets/utils/assetUrlUtil.test.ts
@@ -6,7 +6,7 @@ import {
   getAssetSubfolder,
   getAssetUrl
 } from '@/platform/assets/utils/assetUrlUtil'
-import type { ResultItemImpl } from '@/stores/queueStore'
+import type { AugmentedResultItem } from '@/utils/resultItem'
 
 const mockApiURL = vi.hoisted(() =>
   vi.fn((path: string) => `http://localhost:8188/api${path}`)
@@ -17,7 +17,7 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: { apiURL: mockApiURL }
 }))
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({ flags: mockFlags })
 }))
 
@@ -110,7 +110,7 @@ describe('getAssetFileUrl', () => {
           allOutputs: [
             { assetId: 'asset-image', filename: 'ComfyUI_00109.png' },
             { assetId: 'asset-model', filename: 'ComfyUI_00110.glb' }
-          ] as ResultItemImpl[]
+          ] as AugmentedResultItem[]
         }
       })
 

--- a/src/platform/assets/utils/assetUrlUtil.test.ts
+++ b/src/platform/assets/utils/assetUrlUtil.test.ts
@@ -1,17 +1,24 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
+  getAssetFileUrl,
   getAssetSubfolder,
   getAssetUrl
 } from '@/platform/assets/utils/assetUrlUtil'
+import type { ResultItemImpl } from '@/stores/queueStore'
 
 const mockApiURL = vi.hoisted(() =>
   vi.fn((path: string) => `http://localhost:8188/api${path}`)
 )
+const mockFlags = vi.hoisted(() => ({ assetsEnabled: false }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: { apiURL: mockApiURL }
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFlags })
 }))
 
 function createAsset(overrides: Partial<AssetItem> = {}): AssetItem {
@@ -71,5 +78,86 @@ describe('getAssetUrl', () => {
 
   it('omits the subfolder param for an asset at the type root', () => {
     expect(getAssetUrl(createAsset())).not.toContain('subfolder')
+  })
+})
+
+describe('getAssetFileUrl', () => {
+  describe('with the assets API enabled', () => {
+    beforeEach(() => {
+      mockFlags.assetsEnabled = true
+    })
+
+    it('addresses the file by asset id without any path inference', () => {
+      const asset = createAsset({
+        id: '9a7111df-ccba-4be6-8057-c673755d097c',
+        name: 'ComfyUI_00110.glb',
+        display_name: '3d/ComfyUI_00110.glb'
+      })
+
+      expect(getAssetFileUrl(asset)).toBe(
+        'http://localhost:8188/api/assets/9a7111df-ccba-4be6-8057-c673755d097c/content'
+      )
+    })
+
+    it('uses the own output asset id of a card grouped per job', () => {
+      const asset = createAsset({
+        id: 'job-1',
+        name: 'ComfyUI_00110.glb',
+        user_metadata: {
+          jobId: 'job-1',
+          subfolder: '',
+          outputCount: 2,
+          allOutputs: [
+            { assetId: 'asset-image', filename: 'ComfyUI_00109.png' },
+            { assetId: 'asset-model', filename: 'ComfyUI_00110.glb' }
+          ] as ResultItemImpl[]
+        }
+      })
+
+      expect(getAssetFileUrl(asset)).toBe(
+        'http://localhost:8188/api/assets/asset-model/content'
+      )
+    })
+
+    it('does not use a preview url that points at a thumbnail', () => {
+      const asset = createAsset({
+        id: 'asset-model',
+        name: 'mesh.glb',
+        preview_id: 'asset-thumb',
+        preview_url: '/api/view?type=output&filename=thumb.png'
+      })
+
+      expect(getAssetFileUrl(asset)).toBe(
+        'http://localhost:8188/api/assets/asset-model/content'
+      )
+    })
+  })
+
+  describe('with history-backed assets', () => {
+    beforeEach(() => {
+      mockFlags.assetsEnabled = false
+    })
+
+    it('uses preview_url, which already points at the file', () => {
+      const asset = createAsset({
+        preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid'
+      })
+
+      expect(getAssetFileUrl(asset)).toBe(
+        '/api/view?filename=clip.webm&type=output&subfolder=vid'
+      )
+    })
+
+    it('builds a /view url from the metadata subfolder when preview_url is absent', () => {
+      const asset = createAsset({
+        name: 'mesh.glb',
+        user_metadata: { subfolder: '3d' }
+      })
+
+      const { searchParams } = new URL(getAssetFileUrl(asset))
+      expect(searchParams.get('filename')).toBe('mesh.glb')
+      expect(searchParams.get('type')).toBe('output')
+      expect(searchParams.get('subfolder')).toBe('3d')
+    })
   })
 })

--- a/src/platform/assets/utils/assetUrlUtil.ts
+++ b/src/platform/assets/utils/assetUrlUtil.ts
@@ -2,7 +2,9 @@
  * Utilities for constructing asset URLs
  */
 
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { api } from '@/scripts/api'
+import { getOutputAssetMetadata } from '../schemas/assetMetadataSchema'
 import type { AssetItem } from '../schemas/assetSchema'
 import { getAssetType } from './assetTypeUtil'
 
@@ -50,4 +52,33 @@ export function getAssetSubfolder(asset: AssetItem): string {
 
   const { subfolder } = asset.user_metadata ?? {}
   return typeof subfolder === 'string' ? subfolder : ''
+}
+
+/**
+ * Id of the assets-API asset holding this item's own file.
+ *
+ * A card grouped per job carries the job id as its `id`; its own file is the
+ * `allOutputs` entry with the same filename, which keeps the real asset id.
+ */
+function getAssetContentId(asset: AssetItem): string {
+  const outputs = getOutputAssetMetadata(asset.user_metadata)?.allOutputs
+  const ownOutput = outputs?.find(
+    (output) => output.filename === asset.name && output.assetId
+  )
+  return ownOutput?.assetId ?? asset.id
+}
+
+/**
+ * URL of the asset's own file, for downloading or loading it whole.
+ *
+ * With the assets API enabled the file is served by id, so no path inference
+ * is needed and a preview that is only a thumbnail is never mistaken for the
+ * file. Otherwise the item came from the history API, whose `preview_url`
+ * already points at the file, with a `/view` URL as fallback.
+ */
+export function getAssetFileUrl(asset: AssetItem): string {
+  if (useFeatureFlags().flags.assetsEnabled) {
+    return api.apiURL(`/assets/${getAssetContentId(asset)}/content`)
+  }
+  return asset.preview_url || getAssetUrl(asset)
 }

--- a/src/platform/assets/utils/assetUrlUtil.ts
+++ b/src/platform/assets/utils/assetUrlUtil.ts
@@ -55,17 +55,11 @@ export function getAssetSubfolder(asset: AssetItem): string {
 }
 
 /**
- * Id of the assets-API asset holding this item's own file.
- *
- * A card grouped per job carries the job id as its `id`; its own file is the
- * `allOutputs` entry with the same filename, which keeps the real asset id.
+ * Id of the assets-API asset holding this item's own file. A card grouped per
+ * job carries the job id as its `id` and keeps its own asset id in metadata.
  */
 function getAssetContentId(asset: AssetItem): string {
-  const outputs = getOutputAssetMetadata(asset.user_metadata)?.allOutputs
-  const ownOutput = outputs?.find(
-    (output) => output.filename === asset.name && output.assetId
-  )
-  return ownOutput?.assetId ?? asset.id
+  return getOutputAssetMetadata(asset.user_metadata)?.assetId || asset.id
 }
 
 /**

--- a/src/platform/assets/utils/outputAssetUtil.test.ts
+++ b/src/platform/assets/utils/outputAssetUtil.test.ts
@@ -190,6 +190,25 @@ describe('resolveOutputAssetItems', () => {
     expect(results[0].id).toBe('asset-a')
   })
 
+  it('synthesizes an item id when the output carries an empty asset id', async () => {
+    const output = createOutput({
+      filename: 'a.png',
+      nodeId: '1',
+      assetId: ''
+    })
+    const metadata: OutputAssetMetadata = {
+      jobId: 'job-1',
+      nodeId: '1',
+      subfolder: 'sub',
+      outputCount: 1,
+      allOutputs: [output]
+    }
+
+    const results = await resolveOutputAssetItems(metadata)
+
+    expect(results[0].id).toBe(`job-1-${getOutputKey(output)}`)
+  })
+
   it('maps outputs and excludes a composite output key', async () => {
     const outputA = createOutput({
       filename: 'a.png',

--- a/src/platform/assets/utils/outputAssetUtil.test.ts
+++ b/src/platform/assets/utils/outputAssetUtil.test.ts
@@ -36,6 +36,7 @@ type OutputOverrides = Partial<{
   nodeId: SerializedNodeId
   url: string
   display_name: string
+  assetId: string
 }>
 
 function createOutput(overrides: OutputOverrides = {}): AugmentedResultItem {
@@ -167,6 +168,26 @@ describe('getTotalAssetOutputCount', () => {
 describe('resolveOutputAssetItems', () => {
   beforeEach(() => {
     mocks.isCloud = false
+  })
+
+  it('keeps the asset id an output already carries as the item id', async () => {
+    const output = createOutput({
+      filename: 'a.png',
+      nodeId: '1',
+      assetId: 'asset-a'
+    })
+    const metadata: OutputAssetMetadata = {
+      jobId: 'job-1',
+      nodeId: '1',
+      subfolder: 'sub',
+      outputCount: 1,
+      allOutputs: [output]
+    }
+
+    const results = await resolveOutputAssetItems(metadata)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].id).toBe('asset-a')
   })
 
   it('maps outputs and excludes a composite output key', async () => {

--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -71,7 +71,7 @@ function mapOutputsToAssetItems({
     seenOutputKeys.add(outputKey)
 
     items.push({
-      id: output.assetId ?? `${jobId}-${outputKey}`,
+      id: output.assetId || `${jobId}-${outputKey}`,
       name: output.filename,
       display_name: output.display_name,
       size: 0,

--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -71,7 +71,7 @@ function mapOutputsToAssetItems({
     seenOutputKeys.add(outputKey)
 
     items.push({
-      id: `${jobId}-${outputKey}`,
+      id: output.assetId ?? `${jobId}-${outputKey}`,
       name: output.filename,
       display_name: output.display_name,
       size: 0,


### PR DESCRIPTION
3D models in the media assets panel could not be downloaded or opened, and outputs of the Save3DAdvanced node family never got a thumbnail.

Non-previewable assets (glb etc.) come back from the assets API without preview_url and without user_metadata.subfolder, so the /view URL built for them lacked subfolder=3d and the server returned 404. With the assets API enabled the file is now served by GET /api/assets/{id}/content, so the download, the 3D viewer dialog and the 3D card source resolve through one getAssetFileUrl instead of inferring a path. History-backed items keep using preview_url with the /view fallback. A card grouped per job carries the job id, so the resolver takes the asset id from its own allOutputs entry.

Save3DAdvanced, SaveGaussianSplat and SavePointCloud have no model_file or image widget, so the modelReady thumbnail capture returned early and persistThumbnail never ran. Fall back to node.properties 'Last Time Model File' whenever the widget holds no non-blank string.