### PR TITLE
fix(agent): clarify workflow chip tooltip copy

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5200,7 +5200,7 @@
     "attachmentTooLarge": "{name} is larger than {limit}",
     "attachmentUploadFailed": "{name} could not be uploaded",
     "mention": "Mention a node",
-    "changeWorkflowForChat": "Change the workflow for this chat",
+    "changeWorkflowForChat": "Change the workflow that the agent can edit",
     "chatOptions": "Chat options",
     "chooseWorkflow": "Choose a workflow",
     "chooseWorkflowForChat": "Choose a workflow for this chat",


### PR DESCRIPTION
## Summary

Copy-only change to the agent composer's workflow selector chip. The tooltip shown when a workflow is active now reads **"Change the workflow that the agent can edit"** instead of "Change the workflow for this chat", so it states what the control actually does.

- Only `agent.changeWorkflowForChat` in `src/locales/en/main.json` changes.
- The no-active-workflow placeholder (`agent.chooseWorkflowForChat`) is intentionally untouched. It is being handled separately.
- No component or test change: `WorkflowSelectorChip.vue` reads the key via `t()`, and `WorkflowSelectorChip.test.ts` compares against the `en` messages. Other locales are generated on release.

Linear: [PM-857](https://linear.app/comfyorg/issue/PM-857/quick-winclarify-workflow-card-hover-tooltip-copy)
Source: tester suggestion from the agent feedback survey.

## Test plan

- [ ] CI unit tests pass (`WorkflowSelectorChip.test.ts`)
- [ ] Hover the workflow chip above the agent prompt box with a workflow open, confirm the new tooltip text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ciLJNwyeTTDsFirUX8dSh