### PR TITLE
fix: rename agent composer add actions to mention/drag/upload

### DIFF
--- a/src/components/graph/NodeSelectionModeBanner.test.ts
+++ b/src/components/graph/NodeSelectionModeBanner.test.ts
@@ -24,7 +24,7 @@ describe('NodeSelectionModeBanner', () => {
       global: { plugins: [pinia, i18n] }
     })
 
-    expect(screen.getByText('Add nodes from graph')).toBeVisible()
+    expect(screen.getByText('Mention nodes from graph')).toBeVisible()
     expect(
       screen.getByText('Select one or many nodes to add as reference')
     ).toBeVisible()

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5176,7 +5176,7 @@
     "gotIt": "Got it",
     "greeting": "Hello {name},",
     "greetingQuestion": "What do you want to make?",
-    "placeholder": "Describe ideas, {'@'} to reference,\nadd nodes from graph or drag in assets",
+    "placeholder": "Describe ideas, {'@'} to reference,\nmention nodes from graph or drag in assets",
     "suggestedPrompts": [
       "Generate a yellow duck with a hockey mask",
       "List my saved workflows",
@@ -5185,17 +5185,17 @@
       "Build a workflow for image to video with 3 models"
     ],
     "attach": "Attach a file",
-    "attachFiles": "Attach images or files",
+    "attachFiles": "Upload images or files",
     "addToPrompt": "Add to prompt",
-    "addNodesFromGraph": "Add nodes from graph",
+    "addNodesFromGraph": "Mention nodes from graph",
     "dragAndDropAssets": "Drag and drop assets here",
     "nodeSelection": {
-      "bannerTitle": "Add nodes from graph",
+      "bannerTitle": "Mention nodes from graph",
       "bannerSubtitle": "Select one or many nodes to add as reference",
       "exit": "Exit mode",
       "selectNode": "Select node"
     },
-    "addFromAssets": "Add from assets panel",
+    "addFromAssets": "Drag in asset from asset panel",
     "assetNotAttachable": "Images, video, audio, 3D models, and text files can be attached",
     "attachmentTooLarge": "{name} is larger than {limit}",
     "attachmentUploadFailed": "{name} could not be uploaded",

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -56,7 +56,7 @@ describe('Composer', () => {
 
     expect(screen.getByText('Describe ideas, @ to reference,')).toBeVisible()
     const addNodes = screen.getByRole('button', {
-      name: 'add nodes from graph,'
+      name: 'mention nodes from graph,'
     })
     expect(addNodes).toBeVisible()
     expect(addNodes).toContainHTML(
@@ -73,7 +73,7 @@ describe('Composer', () => {
 
     expect((box as HTMLTextAreaElement).value).toBe('hello')
     expect(
-      screen.queryByRole('button', { name: 'add nodes from graph,' })
+      screen.queryByRole('button', { name: 'mention nodes from graph,' })
     ).toBeNull()
   })
 
@@ -81,7 +81,7 @@ describe('Composer', () => {
     const getMentionNodes = vi.fn(() => [])
     const { emitted } = mount({ getMentionNodes })
     const hintButton = screen.getByRole('button', {
-      name: 'add nodes from graph,'
+      name: 'mention nodes from graph,'
     })
 
     await userEvent.tab()
@@ -119,7 +119,7 @@ describe('Composer', () => {
 
     // The menu strings only compile once reka mounts the lazy menu content.
     await openAddMenu()
-    await screen.findByRole('menuitem', { name: 'Attach images or files' })
+    await screen.findByRole('menuitem', { name: 'Upload images or files' })
 
     // Unescaped syntax characters (@, |, {) in a locale message compile to an
     // error and silently fall back to the raw string.
@@ -556,7 +556,7 @@ describe('Composer', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Add to prompt' }))
     // Anchor on the entry that is always present, so the absence assertions
     // below cannot pass against a menu that never opened.
-    return screen.findByRole('menuitem', { name: 'Add nodes from graph' })
+    return screen.findByRole('menuitem', { name: 'Mention nodes from graph' })
   }
 
   it('hides the conditional entries from the add menu by default', async () => {
@@ -565,10 +565,10 @@ describe('Composer', () => {
     await openAddMenu()
 
     expect(
-      screen.queryByRole('menuitem', { name: 'Attach images or files' })
+      screen.queryByRole('menuitem', { name: 'Upload images or files' })
     ).toBeNull()
     expect(
-      screen.queryByRole('menuitem', { name: 'Add from assets panel' })
+      screen.queryByRole('menuitem', { name: 'Drag in asset from asset panel' })
     ).toBeNull()
   })
 
@@ -577,7 +577,7 @@ describe('Composer', () => {
 
     await openAddMenu()
     await userEvent.click(
-      await screen.findByRole('menuitem', { name: 'Attach images or files' })
+      await screen.findByRole('menuitem', { name: 'Upload images or files' })
     )
 
     expect(emitted().attach).toHaveLength(1)
@@ -588,7 +588,9 @@ describe('Composer', () => {
 
     await openAddMenu()
     await userEvent.click(
-      await screen.findByRole('menuitem', { name: 'Add from assets panel' })
+      await screen.findByRole('menuitem', {
+        name: 'Drag in asset from asset panel'
+      })
     )
 
     expect(emitted().openAssets).toHaveLength(1)


### PR DESCRIPTION
## Summary

Rename the agent composer's "add" actions to say what they actually do: mention nodes, drag in assets, upload files.

## Changes

- **What**: four `agent.*` strings in `src/locales/en/main.json`
  - `addNodesFromGraph`: "Add nodes from graph" -> "Mention nodes from graph"
  - `addFromAssets`: "Add from assets panel" -> "Drag in asset from asset panel"
  - `attachFiles`: "Attach images or files" -> "Upload images or files"
  - `nodeSelection.bannerTitle`: "Add nodes from graph" -> "Mention nodes from graph" (canvas banner, kept consistent with the menu item)
  - `placeholder` second line: "add nodes from graph or drag in assets" -> "mention nodes from graph or drag in assets"
- Test literals updated in `Composer.test.ts` and `NodeSelectionModeBanner.test.ts`.

## Review Focus

- `Composer.vue` `placeholderHint` slices the lowercased `agent.addNodesFromGraph` off the placeholder's second line to render the clickable hint. The placeholder edit only keeps that prefix in sync; the full placeholder rewrite is tracked separately in PM-991.
- English only. Other locales are left to the i18n workflow.

Linear: PM-990 (child of PM-952)
