### PR TITLE
test(ingest-types): pin key-discriminated narrowing for global settings [BE-12346]

### DIFF
--- a/packages/ingest-types/test/globalSettings.test.ts
+++ b/packages/ingest-types/test/globalSettings.test.ts
@@ -90,11 +90,14 @@ describe('the shipped Zod schemas enforce the same contract', () => {
     ).toEqual({ key: CONSENT_KEY, value: true })
     expect(zGlobalSettingKey.parse(CONSENT_KEY)).toBe(CONSENT_KEY)
 
+    // `satisfies` contextually types the literal, so `value` stays `true`
+    // instead of widening to `boolean`, and the fixture breaks if the
+    // generated type drifts.
     const stored = {
       key: CONSENT_KEY,
       value: true,
       updated_at: '2026-09-08T00:00:00Z'
-    }
+    } satisfies GlobalSetting
     expect(zGlobalSetting.parse(stored)).toEqual(stored)
   })
 

--- a/packages/ingest-types/test/globalSettings.test.ts
+++ b/packages/ingest-types/test/globalSettings.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Global settings contract coverage (BE-12346).
+ *
+ * This lives outside `src/` because `openapi-ts.config.ts` sets
+ * `output.clean`: regeneration wipes that directory, and the cloud→frontend
+ * vendoring workflow commits only `packages/ingest-types/src/`.
+ *
+ * The type-level assertions are checked by `pnpm typecheck`, which the root
+ * tsconfig covers this directory for; vitest erases them.
+ */
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import type {
+  AgentConsentSettingValue,
+  GlobalSetting,
+  GlobalSettingKey,
+  GlobalSettingValue
+} from '../src/index.ts'
+import {
+  zAgentConsentSettingValue,
+  zGlobalSetting,
+  zGlobalSettingKey,
+  zGlobalSettingValue
+} from '../src/zod.gen.ts'
+
+const CONSENT_KEY = 'Comfy.AgentPanel.ConsentAccepted' as const
+
+/**
+ * `Extract` selects the sole member today and exactly the matching member once
+ * a second key joins the union, so these assertions cannot pass by accident.
+ */
+type NarrowByKey<T, K extends GlobalSettingKey> = Extract<T, { key: K }>
+
+describe('the emitted types are key-discriminated', () => {
+  it('narrows to the matching value schema', () => {
+    expectTypeOf<
+      NarrowByKey<GlobalSettingValue, typeof CONSENT_KEY>['value']
+    >().toEqualTypeOf<true>()
+    expectTypeOf<
+      NarrowByKey<GlobalSettingValue, typeof CONSENT_KEY>
+    >().toExtend<AgentConsentSettingValue>()
+    expectTypeOf<
+      NarrowByKey<GlobalSetting, typeof CONSENT_KEY>['value']
+    >().toEqualTypeOf<true>()
+    expectTypeOf<
+      NarrowByKey<GlobalSetting, typeof CONSENT_KEY>['updated_at']
+    >().toEqualTypeOf<string>()
+  })
+
+  it('lets a caller read the value with no cast or schema lookup', () => {
+    const readConsent = (setting: GlobalSetting): true => setting.value
+
+    expect(
+      readConsent({
+        key: CONSENT_KEY,
+        value: true,
+        updated_at: '2026-09-08T00:00:00Z'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a key the registry does not publish', () => {
+    // Each directive sits on the offending property, which is the line
+    // TypeScript reports the mismatch on, and fails typecheck as an unused
+    // directive if the key set ever stops being closed.
+    const unregisteredWrite: GlobalSettingValue = {
+      // @ts-expect-error 'Comfy.Unregistered' is not a registered setting key
+      key: 'Comfy.Unregistered',
+      value: true
+    }
+    // @ts-expect-error 'Comfy.Unregistered' is not a registered setting key
+    const unregisteredKey: GlobalSettingKey = 'Comfy.Unregistered'
+    const revokeByFalse: GlobalSettingValue = {
+      key: CONSENT_KEY,
+      // @ts-expect-error revocation is DELETE, so `false` is not writable
+      value: false
+    }
+
+    expect([unregisteredWrite, unregisteredKey, revokeByFalse]).toHaveLength(3)
+  })
+})
+
+describe('the shipped Zod schemas enforce the same contract', () => {
+  it('accepts the published write and read shapes', () => {
+    expect(
+      zGlobalSettingValue.parse({ key: CONSENT_KEY, value: true })
+    ).toEqual({ key: CONSENT_KEY, value: true })
+    expect(
+      zAgentConsentSettingValue.parse({ key: CONSENT_KEY, value: true })
+    ).toEqual({ key: CONSENT_KEY, value: true })
+    expect(zGlobalSettingKey.parse(CONSENT_KEY)).toBe(CONSENT_KEY)
+
+    const stored = {
+      key: CONSENT_KEY,
+      value: true,
+      updated_at: '2026-09-08T00:00:00Z'
+    }
+    expect(zGlobalSetting.parse(stored)).toEqual(stored)
+  })
+
+  it('rejects an unregistered key and a non-`true` value', () => {
+    expect(
+      zGlobalSettingValue.safeParse({ key: 'Comfy.Unregistered', value: true })
+        .success
+    ).toBe(false)
+    expect(zGlobalSettingKey.safeParse('Comfy.Unregistered').success).toBe(
+      false
+    )
+    expect(
+      zGlobalSettingValue.safeParse({ key: CONSENT_KEY, value: false }).success
+    ).toBe(false)
+    expect(
+      zGlobalSettingValue.safeParse({ key: CONSENT_KEY, value: 'true' }).success
+    ).toBe(false)
+  })
+
+  it('requires a timestamp on a stored setting', () => {
+    expect(
+      zGlobalSetting.safeParse({ key: CONSENT_KEY, value: true }).success
+    ).toBe(false)
+    expect(
+      zGlobalSetting.safeParse({
+        key: CONSENT_KEY,
+        value: true,
+        updated_at: 'not-a-timestamp'
+      }).success
+    ).toBe(false)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,8 @@
     "global.d.ts",
     "knip.config.ts",
     "lint-staged.config.ts",
+    // Type-level assertions vitest erases; they only bind if tsc sees them.
+    "packages/ingest-types/test/**/*",
     "src/**/*.vue",
     "src/**/*",
     "src/types/**/*.d.ts",


### PR DESCRIPTION
Linear: BE-12346

## What

Contract coverage for the `GlobalSettingValue` / `GlobalSetting` types and Zod schemas that #17150 just vendored in.

- **Type level** — narrowing on `key` yields `value: true` (not `boolean`) for both the write and read unions, and an unregistered key or a `false` write is inexpressible. `Extract<T, { key: K }>` is used rather than a `switch`, so the assertions select exactly the matching member once a second key joins the union instead of passing degenerately.
- **Runtime** — `zGlobalSettingValue` / `zGlobalSetting` / `zGlobalSettingKey` / `zAgentConsentSettingValue` accept the published shapes and reject an unregistered key, a non-`true` value, and a stored setting with a missing or malformed `updated_at`.

## Why the file sits outside `packages/ingest-types/src/`

`openapi-ts.config.ts` sets `output.clean`, so regeneration wipes `src/` — and `push-ingest-types-to-frontend.yml` commits only `packages/ingest-types/src/`. Hand-written coverage in there would be deleted by the next vendoring run and the deletion committed.

`tsconfig.json` gains that directory in `include` because vitest erases `expectTypeOf` and `@ts-expect-error` assertions; without a typechecker over the file they assert nothing. `pnpm typecheck` (which `pnpm build` runs in CI) now covers it.

## Verification

- `pnpm test:unit packages/ingest-types` — 6/6 pass
- `pnpm typecheck`, `pnpm knip`, `pnpm oxlint`, `eslint src`, `oxfmt --check` — clean
- Assertions confirmed non-vacuous: changing `toEqualTypeOf<true>` to `<boolean>` fails typecheck, and widening `GlobalSettingKey` to `string` produces `TS2578 Unused '@ts-expect-error' directive`.
- **localhost bundle, measured** (`DISTRIBUTION=localhost vite build`, before/after the vendored types): shipped `.js` 41,694,226 → 41,695,585 bytes (**+1,359**, +0.003%); gzipped `.js` 9,796,574 → 9,797,077 (**+503**, +0.005%). The new key literal appears in `dist/assets/api-*.js` (0 occurrences before, 4 after), so the schemas are genuinely present in the localhost build rather than tree-shaken.

No feature or component wiring — the Agent activation consent card is FE-1867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)