### PR TITLE
test: characterize materializer NodeState replacement and geometry replay

### DIFF
--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -375,6 +375,27 @@ describe('reconcileAgentAdapters', () => {
       ).toBe(7)
     })
 
+    it('keeps canonical layout geometry when configuring a materialized node', () => {
+      const graph = new LGraph()
+      const scope = seedAgentAddedNode(graph, 1)
+      layoutStore.applyOperation({
+        type: 'moveNode',
+        graphId: scope.rootGraphId,
+        nodeId: toNodeId(1),
+        position: { x: 400, y: 500 },
+        source: LayoutSource.AgentRemote,
+        timestamp: Date.now()
+      })
+
+      reconcileAgentAdapters(graph)
+
+      expect({
+        live: [...graph.getNodeById(toNodeId(1))!.pos],
+        stored: layoutStore.getNodeLayout(scope.rootGraphId, toNodeId(1))
+          ?.position
+      }).toEqual({ live: [400, 500], stored: { x: 400, y: 500 } })
+    })
+
     it('is idempotent once the node is live', () => {
       const graph = new LGraph()
       const scope = seedAgentAddedNode(graph, 1)
@@ -423,6 +444,51 @@ describe('reconcileAgentAdapters', () => {
       expect(reconcileAgentAdapters(graph)).toEqual([])
       expect(graph._nodes).toHaveLength(1)
       expect(graph.getNodeById(toNodeId(1))).toBe(live)
+    })
+
+    it('adopts canonical node and widget state across materialization and reconcile', () => {
+      const graph = new LGraph()
+      const scope = graphScopeOf(graph)
+      const mutations = remoteMutations(scope)
+      mutations.addNode(
+        { ...nodePayload(1, 'widget-node'), widgets_values: { value: 7 } },
+        REMOTE
+      )
+      const addedNodeState = useNodeDataStore().getNode(
+        scope.rootGraphId,
+        toNodeId(1)
+      )
+      reconcileAgentAdapters(graph)
+      const live = graph.getNodeById(toNodeId(1))!
+      const materializedNodeState = live._state
+
+      mutations.batch({ ...REMOTE, opId: 'reconcile-value' }, (batch) =>
+        batch.reconcileNode({
+          ...nodePayload(1, 'widget-node'),
+          widgets_values: { value: 9 }
+        })
+      )
+      reconcileAgentAdapters(graph)
+
+      expect({
+        adoptedAddedNodeState: materializedNodeState === addedNodeState,
+        keptMaterializedNodeState: live._state === materializedNodeState,
+        liveWidget: live.widgets?.[0].value,
+        storedWidget: useWidgetValueStore().getWidget(
+          widgetId(scope.rootGraphId, toNodeId(1), 'value')
+        )?.value
+      }).toEqual({
+        adoptedAddedNodeState: true,
+        keptMaterializedNodeState: true,
+        liveWidget: 9,
+        storedWidget: 9
+      })
+      live.widgets![0].value = 10
+      expect(
+        useWidgetValueStore().getWidget(
+          widgetId(scope.rootGraphId, toNodeId(1), 'value')
+        )?.value
+      ).toBe(10)
     })
 
     it('replaces a node whose record was re-created under the same id', () => {
@@ -944,6 +1010,29 @@ describe('reconcileAgentAdapters', () => {
       expect(graph.subgraphs.get(definition.id)).toBe(subgraph)
       expect(graph.getNodeById(toNodeId(1))).toBe(instance)
       expect(reportError).not.toHaveBeenCalled()
+    })
+
+    it('retires each node lifetime once on document reset', () => {
+      const definition = createTestSubgraphData({
+        nodes: [nodePayload(7)] as never
+      })
+      const { adapter, follower } = seedDocument(graph, {
+        nodes: [nodePayload(1, definition.id)],
+        links: [],
+        definitions: { subgraphs: [definition] }
+      })
+      reconcileAgentAdapters(graph, readSubgraphDefinitions(follower.doc))
+      const instance = graph.getNodeById(toNodeId(1))!
+      const interior = graph.subgraphs.get(definition.id)!.nodes[0]
+      const instanceRemoved = vi.spyOn(instance, 'onRemoved')
+      const interiorRemoved = vi.fn()
+      interior.onRemoved = interiorRemoved
+
+      adapter.clearForReset('workflow', REMOTE)
+      reconcileAgentAdapters(graph)
+
+      expect(instanceRemoved).toHaveBeenCalledOnce()
+      expect(interiorRemoved).toHaveBeenCalledOnce()
     })
 
     it('does not treat a definition payload as an edit to an existing subgraph', () => {

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -375,7 +375,7 @@ describe('reconcileAgentAdapters', () => {
       ).toBe(7)
     })
 
-    it('keeps canonical layout geometry when configuring a materialized node', () => {
+    it.fails('keeps canonical layout geometry when configuring a materialized node', () => {
       const graph = new LGraph()
       const scope = seedAgentAddedNode(graph, 1)
       layoutStore.applyOperation({
@@ -446,7 +446,7 @@ describe('reconcileAgentAdapters', () => {
       expect(graph.getNodeById(toNodeId(1))).toBe(live)
     })
 
-    it('adopts canonical node and widget state across materialization and reconcile', () => {
+    it.fails('adopts canonical node and widget state across materialization and reconcile', () => {
       const graph = new LGraph()
       const scope = graphScopeOf(graph)
       const mutations = remoteMutations(scope)


### PR DESCRIPTION
## Summary

Add two `it.fails` known failures that document current main behavior: initial materialization replaces the canonical `NodeState` and leaves the live widget proxy at `7` when reconcile moves the store to `9`, while full `configure()` replays `[0,0]` over an adopted `[400,500]` layout. The normal reset test remains a live exactly-once guard for the ordering introduced by #16973.

## Changes

- **What**: Characterize canonical state and widget proxy ownership at `src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts:449-501`.
- **What**: Characterize geometry replay at `src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts:378-396`.
- **What**: Guard reset retirement at `src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts:1015-1036`.

## Review Focus

The FE-2056 fix must change both `it.fails` cases back to `it`. Vitest fails an `it.fails` test when its assertions start passing. The exercised path deletes the canonical record at `src/workbench/extensions/agent/crdt/agentNodeMaterializer.ts:320-328`, calls `LGraph.add()` at `:329-335`, then runs full `configure()` at `:337-346`.

Related: FE-2056 https://linear.app/comfyorg/issue/FE-2056
