### PR TITLE
test: characterize missing projection-commit fence in the CRDT follower

### DIFF
--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -143,7 +143,7 @@ describe('graphMutations', () => {
     error.mockRestore()
   })
 
-  it('rolls back store writes when a batch commit throws', () => {
+  it.fails('rolls back store writes when a batch commit throws', () => {
     createLayout.mockImplementationOnce(() => {
       throw new Error('layout commit failed')
     })

--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -143,6 +143,20 @@ describe('graphMutations', () => {
     error.mockRestore()
   })
 
+  it('rolls back store writes when a batch commit throws', () => {
+    createLayout.mockImplementationOnce(() => {
+      throw new Error('layout commit failed')
+    })
+
+    expect(() =>
+      mutations().batch(context, (batch) => {
+        batch.addNode(node(1))
+        batch.addNode(node(2))
+      })
+    ).toThrow('layout commit failed')
+    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+  })
+
   it('rejects a sibling-owned node collision before committing earlier writes', () => {
     const siblingScope = {
       rootGraphId: scope.rootGraphId,

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -114,7 +114,7 @@ function wire() {
 }
 
 describe('follower commit boundary', () => {
-  it('does not publish a frame rejected by ECS projection', () => {
+  it.fails('does not publish a frame rejected by ECS projection', () => {
     const { transport, bridge } = wire()
     const mutations: GraphMutations = {
       batch: vi.fn(() => false),
@@ -145,7 +145,7 @@ describe('follower commit boundary', () => {
     }).toEqual({ sequence: 0, stateVector: initialVector })
   })
 
-  it('does not integrate Yjs structs when a truncated update throws', () => {
+  it.fails('does not integrate Yjs structs when a truncated update throws', () => {
     const host = new Y.Doc()
     host.transact(() => {
       host.getMap('nodes').set('1', { type: 'Source' })

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -23,8 +23,12 @@ import { SCHEMA_VERSION, mint, nodesMap } from '@comfyorg/comfy-multi-player'
 import { describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
 
+import type { GraphMutations } from '@/core/graph/graphMutations'
+
 import type { DocFrameTransport, DocOp, DocUpdate } from './docFrameClient'
 import { DocFrameClient, encodeBase64 } from './docFrameClient'
+import { EcsFollowerAdapter } from './ecsFollowerAdapter'
+import { FollowerDoc } from './followerDoc'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
 import { FollowerSchemaError, assertReadableSchema } from './schemaGuard'
 
@@ -108,6 +112,60 @@ function wire() {
   })
   return { transport, client, bridge, projected, schemaErrors }
 }
+
+describe('follower commit boundary', () => {
+  it('does not publish a frame rejected by ECS projection', () => {
+    const { transport, bridge } = wire()
+    const mutations: GraphMutations = {
+      batch: vi.fn(() => false),
+      addNode: vi.fn(() => false),
+      setWidget: vi.fn(() => false),
+      connect: vi.fn(() => false),
+      deleteNode: vi.fn(() => false),
+      clearSemanticGraph: vi.fn(() => false)
+    }
+    const adapter = new EcsFollowerAdapter(mutations)
+    const projectionResults: boolean[] = []
+    adapter.bind(WORKFLOW_ID, bridge.follower)
+    bridge.addEventListener('doc_update', (event) => {
+      if (event instanceof CustomEvent) {
+        projectionResults.push(adapter.applyFrame(event.detail as DocUpdate))
+      }
+    })
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    const initialVector = encodeBase64(bridge.follower.stateVector())
+
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+
+    expect(projectionResults).toEqual([false])
+    expect({
+      sequence: bridge.lastSequence,
+      stateVector: encodeBase64(bridge.follower.stateVector())
+    }).toEqual({ sequence: 0, stateVector: initialVector })
+  })
+
+  it('does not integrate Yjs structs when a truncated update throws', () => {
+    const host = new Y.Doc()
+    host.transact(() => {
+      host.getMap('nodes').set('1', { type: 'Source' })
+      host.getMap('nodes').set('2', { type: 'Sink' })
+      host.getMap('nodes').delete('2')
+    })
+    const follower = new FollowerDoc()
+    const initialVector = encodeBase64(follower.stateVector())
+    const update = Y.encodeStateAsUpdate(host)
+
+    expect(() => follower.applyRemoteUpdate(update.slice(0, -1))).toThrow(
+      'Unexpected end of array'
+    )
+    expect({
+      nodeIds: [...nodesMap(follower.doc).keys()],
+      stateVector: encodeBase64(follower.stateVector()),
+      updatesApplied: follower.updatesApplied
+    }).toEqual({ nodeIds: [], stateVector: initialVector, updatesApplied: 0 })
+  })
+})
 
 describe('FE-SUBSCRIBE-1 — a subscribe raced against socket startup recovers', () => {
   it('retries the subscribe when the socket becomes usable, and then follows', () => {


### PR DESCRIPTION
## Summary

Adds three `it.fails` known failures that document the missing projection-commit fence and current `main` behavior in the CRDT follower.

## Changes

- **What**:
  - `src/workbench/extensions/agent/crdt/followerSubscription.test.ts:117-146`: rejected ECS projection still publishes sequence 1 and a non-empty state vector; current ordering is `layoutFollowerBridge.ts:278-301`, with vector derivation in `followerDoc.ts:9-20` and projection in `ecsFollowerAdapter.ts:218-310`.
  - `src/workbench/extensions/agent/crdt/followerSubscription.test.ts:148-167`: a truncated update applied through real Yjs throws after integrating node 1 and advancing the state vector.
  - `src/core/graph/graphMutations.test.ts:146-158`: a layout commit throw leaves the earlier node-store write; sequential commit occurs at `graphMutations.ts:621-768` without rollback at `graphMutations.ts:771-808`.

## Review Focus

Confirm these known failures define the required all-or-nothing boundary across Yjs integration, ECS projection, sequence publication, and state-vector publication. The FE-2055 fix PR must change them back to `it`; Vitest fails an `it.fails` test once its assertions start passing.

Related: FE-2055 https://linear.app/comfyorg/issue/FE-2055
