### PR TITLE
test: isolate browser tests from external networks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -175,6 +175,31 @@
     },
     {
       "files": ["browser_tests/**/*.ts"],
+      "excludeFiles": ["browser_tests/fixtures/networkIsolationFixture.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@playwright/test",
+                "importNames": ["test"],
+                "message": "Use a fixture based on networkIsolationFixture instead of raw Playwright test."
+              }
+            ]
+          }
+        ],
+        "no-restricted-properties": [
+          "error",
+          {
+            "property": "continue",
+            "message": "Use route.fallback() so requests pass through the network policy."
+          }
+        ]
+      }
+    },
+    {
+      "files": ["browser_tests/**/*.ts"],
       "jsPlugins": ["eslint-plugin-playwright"],
       "rules": {
         "typescript/no-explicit-any": "error",

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -124,6 +124,42 @@ await comfyPage.setup({ mockReleases: false })
 
 See `tests/releaseNotifications.spec.ts` for release-specific tests.
 
+### Network isolation
+
+The shared fixtures allow HTTP and real WebSockets only to the configured
+frontend/backend origins: `PLAYWRIGHT_TEST_URL`, `PLAYWRIGHT_SETUP_API_URL`,
+`DEV_SERVER_COMFYUI_URL`, and Playwright's `baseURL`. Service workers are blocked.
+Other browser requests must have a local `route.fulfill()` or intentional
+`route.abort()` mock. An unmocked request is blocked and fails its owning test,
+even if the app catches the network error. Popup mocks belong on `context`,
+not `page`, so they cover the first navigation.
+
+Use `route.fallback()` for unmatched requests. `route.continue()` bypasses
+other handlers. Keep auth mocks in the existing auth helpers; shared mocks
+only replace third-party scripts, model metadata lookups, and carousel media.
+Use scoped `test.use({ userAgent })` rather than `browser.newContext()` so
+custom user agents retain the fixture's isolation.
+
+Both `request` and `context.request` reject external URLs and disable automatic
+redirect following. Node networking, new standalone request/browser contexts,
+`route.fetch()`, and browser redirects can bypass fixture routing. For a full
+test-process network boundary, run the frontend, backend, and tests together
+in a Docker container with networking disabled:
+
+```bash
+pnpm install --frozen-lockfile
+VITE_USE_LEGACY_DEFAULT_GRAPH=true pnpm build
+docker pull ghcr.io/comfy-org/comfyui-ci-container:0.0.22
+scripts/test-browser-offline.sh --project=chromium errorDialog.spec.ts
+```
+
+Complete downloads and builds first. The offline runner never pulls an image
+or invokes the package manager. It requires a Linux-compatible `node_modules`
+and a cached CI image. `COMFYUI_TEST_IMAGE` selects a source-built image;
+`PLAYWRIGHT_OFFLINE_DIST` selects another built distribution, such as a cloud
+build for `--project=cloud` or `--project=mobile-safari`. Remote backend runs
+still use the regular test commands, not the offline runner.
+
 ## Recording Tests (For Non-Developers)
 
 If you're a QA tester or non-developer, use the interactive recorder:

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -135,7 +135,9 @@ even if the app catches the network error. Popup mocks belong on `context`,
 not `page`, so they cover the first navigation.
 
 Use `route.fallback()` for unmatched requests. `route.continue()` bypasses
-other handlers. Keep auth mocks in the existing auth helpers; shared mocks
+other handlers. Oxlint bans raw Playwright `test` imports and `continue()`
+outside `networkIsolationFixture.ts`. Extend that fixture for custom test roots.
+Keep auth mocks in the existing auth helpers; shared mocks
 only replace third-party scripts, model metadata lookups, and carousel media.
 Use scoped `test.use({ userAgent })` rather than `browser.newContext()` so
 custom user agents retain the fixture's isolation.
@@ -159,6 +161,13 @@ and a cached CI image. `COMFYUI_TEST_IMAGE` selects a source-built image;
 `PLAYWRIGHT_OFFLINE_DIST` selects another built distribution, such as a cloud
 build for `--project=cloud` or `--project=mobile-safari`. Remote backend runs
 still use the regular test commands, not the offline runner.
+
+The container runs as root so the bundled backend can write to `/ComfyUI`.
+Generated reports are root-owned on the host. Before running tests outside the
+container, restore ownership of each generated output directory with
+`sudo chown -R "$(id -u):$(id -g)" test-results`, substituting
+`playwright-report`, `blob-report`, `coverage`, or your `--output` directory
+when used.
 
 ## Recording Tests (For Non-Developers)
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -1,9 +1,9 @@
 import type { APIRequestContext, Locator, Page } from '@playwright/test'
-import { test as base } from '@playwright/test'
 import { config as dotenvConfig } from 'dotenv'
 import MCR from 'monocart-coverage-reports'
 
 import { COVERAGE_OUTPUT_DIR } from '@e2e/coverageConfig'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import {
   ENTRY_PATHS,
   TOUR_SEEN_SETTING
@@ -349,7 +349,7 @@ export class ComfyPage {
             body: JSON.stringify([])
           })
         } else {
-          await route.continue()
+          await route.fallback()
         }
       })
     }

--- a/browser_tests/fixtures/UserSelectPage.ts
+++ b/browser_tests/fixtures/UserSelectPage.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
-import { test as base } from '@playwright/test'
+
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 class UserSelectPage {
   public readonly selectionUrl: string

--- a/browser_tests/fixtures/apiKeyAuthFixture.ts
+++ b/browser_tests/fixtures/apiKeyAuthFixture.ts
@@ -1,12 +1,13 @@
 import type { Route } from '@playwright/test'
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 import type {
   BillingBalanceResponse,
   BillingEventsResponse,
   BillingPlansResponse,
   BillingStatusResponse,
-  CurrentWorkspaceResponse
+  CurrentWorkspaceResponse,
+  ListMembersResponse
 } from '@comfyorg/ingest-types'
 import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
 import type { operations } from '@/types/comfyRegistryTypes'
@@ -89,6 +90,15 @@ export const apiKeyAuthFixture = base.extend<{
       'Comfy.userId': userId
     })
 
+    await page.route('https://{api,stagingapi}.comfy.org/releases**', (route) =>
+      route.fulfill({ json: [] })
+    )
+    await page.route('**/api/workspace/members{,?*}', (route) =>
+      fulfillForApiKey(route, {
+        members: [],
+        pagination: { offset: 0, limit: 50, total: 0, has_more: false }
+      } satisfies ListMembersResponse)
+    )
     await page.route('**/customers', (route) => {
       if (route.request().method() !== 'POST') return route.fallback()
       return route.fulfill({

--- a/browser_tests/fixtures/assetApiFixture.ts
+++ b/browser_tests/fixtures/assetApiFixture.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import type { Page, Route } from '@playwright/test'
 
 import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'

--- a/browser_tests/fixtures/cloudAppFixture.ts
+++ b/browser_tests/fixtures/cloudAppFixture.ts
@@ -1,5 +1,7 @@
-import { expect as baseExpect, test as base } from '@playwright/test'
+import { expect as baseExpect } from '@playwright/test'
 import type { Page } from '@playwright/test'
+
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 const CLOUD_APP_BOOT_TIMEOUT = 45_000
 

--- a/browser_tests/fixtures/helpers/AssetsHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetsHelper.ts
@@ -317,7 +317,7 @@ export class AssetsHelper {
     this.deleteHistoryRouteHandler = async (route: Route) => {
       const request = route.request()
       if (request.method() !== 'POST') {
-        await route.continue()
+        await route.fallback()
         return
       }
 

--- a/browser_tests/fixtures/helpers/CloudAuthHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudAuthHelper.ts
@@ -132,7 +132,7 @@ export class CloudAuthHelper {
    * Intercept Firebase Auth REST API endpoints so the SDK can
    * "refresh" the mock user's token without real credentials.
    */
-  private async mockFirebaseEndpoints(): Promise<void> {
+  async mockFirebaseEndpoints(email = CLOUD_SELF_EMAIL): Promise<void> {
     await this.page.route('**/securetoken.googleapis.com/**', (route) =>
       route.fulfill({
         status: 200,
@@ -158,7 +158,7 @@ export class CloudAuthHelper {
           users: [
             {
               localId: 'test-user-e2e',
-              email: CLOUD_SELF_EMAIL,
+              email,
               displayName: 'E2E Test User',
               emailVerified: true,
               validSince: '0',

--- a/browser_tests/fixtures/helpers/HelpCenterHelper.ts
+++ b/browser_tests/fixtures/helpers/HelpCenterHelper.ts
@@ -74,7 +74,7 @@ class HelpCenterHelper {
           body: JSON.stringify(releases)
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
   }
@@ -116,7 +116,11 @@ class HelpCenterHelper {
    * opened by help center actions don't navigate to the real sites.
    */
   async stubExternalPages(): Promise<void> {
-    for (const pattern of ['https://comfy.org/**', 'https://github.com/**']) {
+    for (const pattern of [
+      'https://comfy.org/**',
+      'https://github.com/**',
+      'https://discord.com/invite/comfyorg'
+    ]) {
       await this.page.context().route(pattern, (route: Route) =>
         route.fulfill({
           status: 200,

--- a/browser_tests/fixtures/helpers/LogsTerminalHelper.ts
+++ b/browser_tests/fixtures/helpers/LogsTerminalHelper.ts
@@ -1,6 +1,7 @@
-import { test as base, expect } from '@playwright/test'
+import { expect } from '@playwright/test'
 import type { Page, Route, WebSocketRoute } from '@playwright/test'
 
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import type { LogsRawResponse } from '@/schemas/apiSchema'
 
 const RAW_LOGS_URL = '**/internal/logs/raw**'

--- a/browser_tests/fixtures/helpers/PublishApiHelper.ts
+++ b/browser_tests/fixtures/helpers/PublishApiHelper.ts
@@ -54,7 +54,7 @@ class PublishApiHelper {
   async mockProfile(profile: HubProfile | null): Promise<void> {
     await this.addRoute('**/hub/profiles/me', async (route) => {
       if (route.request().method() !== 'GET') {
-        await route.continue()
+        await route.fallback()
         return
       }
       if (profile === null) {
@@ -87,7 +87,7 @@ class PublishApiHelper {
   ): Promise<void> {
     await this.addRoute('**/userdata/*/publish', async (route) => {
       if (route.request().method() !== 'GET') {
-        await route.continue()
+        await route.fallback()
         return
       }
       if (status === 'unpublished') {
@@ -119,7 +119,7 @@ class PublishApiHelper {
     await this.removeRoutes('**/hub/workflows')
     await this.addRoute('**/hub/workflows', async (route) => {
       if (route.request().method() !== 'POST') {
-        await route.continue()
+        await route.fallback()
         return
       }
       await route.fulfill({
@@ -137,7 +137,7 @@ class PublishApiHelper {
     await this.removeRoutes('**/hub/workflows')
     await this.addRoute('**/hub/workflows', async (route) => {
       if (route.request().method() !== 'POST') {
-        await route.continue()
+        await route.fallback()
         return
       }
       await route.fulfill({

--- a/browser_tests/fixtures/helpers/SubgraphBreadcrumbHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphBreadcrumbHelper.ts
@@ -1,6 +1,7 @@
-import { test as base, expect } from '@playwright/test'
+import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import { SubgraphBreadcrumbPanel } from '@e2e/fixtures/components/SubgraphBreadcrumbPanel'
 
 class SubgraphBreadcrumbHelper {

--- a/browser_tests/fixtures/helpers/WorkflowHelper.ts
+++ b/browser_tests/fixtures/helpers/WorkflowHelper.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 
-import { expect, test } from '@playwright/test'
+import { expect } from '@playwright/test'
+import { networkIsolationFixture as test } from '@e2e/fixtures/networkIsolationFixture'
 
 import type { AppMode } from '@/utils/appMode'
 import type {

--- a/browser_tests/fixtures/jobsRouteFixture.ts
+++ b/browser_tests/fixtures/jobsRouteFixture.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import type { Page } from '@playwright/test'
 import type { z } from 'zod'
 import {

--- a/browser_tests/fixtures/localAuthFixture.ts
+++ b/browser_tests/fixtures/localAuthFixture.ts
@@ -1,7 +1,11 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 import type { operations } from '@/types/comfyRegistryTypes'
 import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  EMPTY_BILLING_BALANCE,
+  EMPTY_BILLING_PLANS
+} from '@e2e/fixtures/data/cloudWorkspace'
 import {
   createSubscriptionHelper,
   withUnsubscribed
@@ -37,6 +41,15 @@ export const localAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
 
     await comfyPage.cloudAuth.mockAuth()
     await mockWorkspace(page, workspace('personal', 'owner'), [])
+    await page.route('https://{api,stagingapi}.comfy.org/releases**', (route) =>
+      route.fulfill({ json: [] })
+    )
+    await page.route('**/api/billing/balance', (route) =>
+      route.fulfill({ json: EMPTY_BILLING_BALANCE })
+    )
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill({ json: EMPTY_BILLING_PLANS })
+    )
     await page.route('**/customers', (route) =>
       route.fulfill({
         status: 201,

--- a/browser_tests/fixtures/networkIsolationFixture.ts
+++ b/browser_tests/fixtures/networkIsolationFixture.ts
@@ -125,7 +125,6 @@ export const networkIsolationFixture = base.extend<{
     )
 
     await use(context)
-    await context.close()
     restore()
   }
 })

--- a/browser_tests/fixtures/networkIsolationFixture.ts
+++ b/browser_tests/fixtures/networkIsolationFixture.ts
@@ -104,6 +104,9 @@ export const networkIsolationFixture = base.extend<{
     await context.route('https://apis.google.com/js/api.js**', (route) =>
       route.fulfill({ status: 503, body: '' })
     )
+    await context.route('https://cloud.comfy.org/cdn-cgi/trace', (route) =>
+      route.fulfill({ contentType: 'text/plain', body: 'loc=US\n' })
+    )
     for (const slide of HERO_SLIDES) {
       await context.route(slide.poster, (route) =>
         route.fulfill({ path: assetPath('image32x32.webp') })

--- a/browser_tests/fixtures/networkIsolationFixture.ts
+++ b/browser_tests/fixtures/networkIsolationFixture.ts
@@ -1,0 +1,128 @@
+import type { APIRequestContext } from '@playwright/test'
+import { expect, test as base } from '@playwright/test'
+import { config as dotenvConfig } from 'dotenv'
+
+import { HERO_SLIDES } from '@/platform/cloud/onboarding/constants/heroSlides'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+
+dotenvConfig()
+
+function guardApiRequests(
+  request: APIRequestContext,
+  origins: Set<string>,
+  unexpected: Set<string>,
+  baseURL?: string
+) {
+  const fetch = request.fetch.bind(request)
+  request.fetch = async (urlOrRequest, options) => {
+    const url = new URL(
+      typeof urlOrRequest === 'string' ? urlOrRequest : urlOrRequest.url(),
+      baseURL
+    )
+    if (!origins.has(url.origin)) {
+      const message = `API ${url.origin}${url.pathname}`
+      unexpected.add(message)
+      throw new Error(`Unexpected external request: ${message}`)
+    }
+    return fetch(urlOrRequest, { ...options, maxRedirects: 0 })
+  }
+  return () => {
+    request.fetch = fetch
+  }
+}
+
+export const networkIsolationFixture = base.extend<{
+  networkPolicy: { origins: Set<string>; unexpected: Set<string> }
+}>({
+  serviceWorkers: 'block',
+  networkPolicy: [
+    async ({ baseURL }, use) => {
+      const frontend =
+        process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+      const origins = new Set(
+        [
+          frontend,
+          baseURL,
+          process.env.PLAYWRIGHT_SETUP_API_URL,
+          process.env.DEV_SERVER_COMFYUI_URL
+        ].flatMap((url) => (url ? [new URL(url).origin] : []))
+      )
+      const unexpected = new Set<string>()
+      await use({ origins, unexpected })
+      expect(
+        [...unexpected],
+        'Unexpected external requests. Add a local mock.'
+      ).toEqual([])
+    },
+    { auto: true }
+  ],
+  request: async (
+    { request, baseURL, networkPolicy: { origins, unexpected } },
+    use
+  ) => {
+    const restore = guardApiRequests(request, origins, unexpected, baseURL)
+    await use(request)
+    restore()
+  },
+  context: async (
+    { context, baseURL, networkPolicy: { origins, unexpected } },
+    use
+  ) => {
+    const restore = guardApiRequests(
+      context.request,
+      origins,
+      unexpected,
+      baseURL
+    )
+    await context.route('**/*', async (route) => {
+      const url = new URL(route.request().url())
+      if (origins.has(url.origin)) {
+        await route.continue()
+        return
+      }
+      unexpected.add(`${route.request().method()} ${url.origin}${url.pathname}`)
+      await route.abort('blockedbyclient')
+    })
+    await context.routeWebSocket(
+      (url) => !origins.has(url.origin.replace(/^ws/, 'http')),
+      async (socket) => {
+        const url = new URL(socket.url())
+        unexpected.add(`WebSocket ${url.origin}${url.pathname}`)
+        await socket.close()
+      }
+    )
+    await context.route('https://huggingface.co/**/resolve/**', (route) =>
+      route.request().method() === 'HEAD'
+        ? route.fulfill({ status: 200, body: '' })
+        : route.fallback()
+    )
+    await context.route(
+      'https://utt.impactcdn.com/A6951770-3747-434a-9ac7-4e582e67d91f1.js',
+      (route) =>
+        route.fulfill({ contentType: 'application/javascript', body: '' })
+    )
+    await context.route('https://apis.google.com/js/api.js**', (route) =>
+      route.fulfill({ status: 503, body: '' })
+    )
+    for (const slide of HERO_SLIDES) {
+      await context.route(slide.poster, (route) =>
+        route.fulfill({ path: assetPath('image32x32.webp') })
+      )
+      await context.route(slide.src, (route) =>
+        route.fulfill({ path: assetPath('video/video-preview-portrait.webm') })
+      )
+    }
+    await context.route(
+      'https://{api,stagingapi}.comfy.org/comfy-nodes/*/node',
+      (route) => route.fulfill({ status: 404, body: '' })
+    )
+    await context.route(
+      'https://{api,stagingapi}.comfy.org/nodes{,?*}',
+      (route) => route.fulfill({ status: 404, body: '' })
+    )
+
+    await use(context)
+    await context.close()
+    restore()
+  }
+})

--- a/browser_tests/fixtures/sharedWorkflowImportFixture.ts
+++ b/browser_tests/fixtures/sharedWorkflowImportFixture.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import type { Page } from '@playwright/test'
 import type {
   Asset,

--- a/browser_tests/fixtures/templateApiFixture.ts
+++ b/browser_tests/fixtures/templateApiFixture.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 import type { TemplateHelper } from '@e2e/fixtures/helpers/TemplateHelper'
 import { createTemplateHelper } from '@e2e/fixtures/helpers/TemplateHelper'

--- a/browser_tests/fixtures/tourFixture.ts
+++ b/browser_tests/fixtures/tourFixture.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 import { OnboardingCoachmarks } from '@e2e/fixtures/components/Tour'
 

--- a/browser_tests/fixtures/utils/cloudSecretsMocks.ts
+++ b/browser_tests/fixtures/utils/cloudSecretsMocks.ts
@@ -67,7 +67,7 @@ export async function mockSecretsBackend(
     // Anchor to the start of the pathname so only genuine `/api/secrets…` API
     // routes are handled; everything else falls through to the real Vite server.
     if (!/^\/api\/secrets(\/|$)/.test(pathname)) {
-      return route.continue()
+      return route.fallback()
     }
 
     // GET /secrets/providers — the entitlement-gated provider allowlist.

--- a/browser_tests/fixtures/workspaceRailAuthFixture.ts
+++ b/browser_tests/fixtures/workspaceRailAuthFixture.ts
@@ -1,7 +1,9 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
+import type { ListSavedPaymentMethodsResponse } from '@comfyorg/ingest-types'
 import type { operations } from '@/types/comfyRegistryTypes'
 import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { EMPTY_BILLING_PLANS } from '@e2e/fixtures/data/cloudWorkspace'
 import {
   createSubscriptionHelper,
   withUnsubscribed
@@ -43,6 +45,15 @@ export const workspaceRailAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
 
     await comfyPage.cloudAuth.mockAuth()
     await mockWorkspace(page, workspace('personal', 'owner'), [])
+    await page.route('https://{api,stagingapi}.comfy.org/releases**', (route) =>
+      route.fulfill({ json: [] })
+    )
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill({ json: EMPTY_BILLING_PLANS })
+    )
+    await page.route('**/api/billing/payment-methods', (route) =>
+      route.fulfill({ json: [] satisfies ListSavedPaymentMethodsResponse })
+    )
     await page.route('**/customers', (route) =>
       route.fulfill({
         status: 201,

--- a/browser_tests/fixtures/workspaceSwitcherFixture.ts
+++ b/browser_tests/fixtures/workspaceSwitcherFixture.ts
@@ -1,3 +1,5 @@
+import type { ListMembersResponse } from '@comfyorg/ingest-types'
+
 import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
@@ -34,6 +36,15 @@ export const workspaceSwitcherTest = comfyPageFixture.extend<{
     )
 
     await mockWorkspaceList(page, WORKSPACE_SWITCHER_WORKSPACES)
+
+    await page.route('**/api/workspace/members**', (route) =>
+      route.fulfill({
+        json: {
+          members: [],
+          pagination: { offset: 0, limit: 50, total: 0, has_more: false }
+        } satisfies ListMembersResponse
+      })
+    )
 
     await page.route('**/api/auth/token', async (route) => {
       const requestBody = route.request().postDataJSON() as {

--- a/browser_tests/fixtures/ws.ts
+++ b/browser_tests/fixtures/ws.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 import type { WebSocketRoute } from '@playwright/test'
 
 function createWebSocketRouteHandler(

--- a/browser_tests/tests/backgroundImageUpload.spec.ts
+++ b/browser_tests/tests/backgroundImageUpload.spec.ts
@@ -1,8 +1,12 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { assetPath } from '@e2e/fixtures/utils/paths'
 
-test.beforeEach(async ({ comfyPage }) => {
+test.beforeEach(async ({ page, comfyPage }) => {
+  await page.route('https://example.com/*.png', (route) =>
+    route.fulfill({ path: assetPath('image32x32.webp') })
+  )
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
 })
 

--- a/browser_tests/tests/cloudLoginIosWebview.spec.ts
+++ b/browser_tests/tests/cloudLoginIosWebview.spec.ts
@@ -18,12 +18,12 @@ async function injectWkWebViewBridge(page: Page) {
 }
 
 test.describe('Cloud login on iOS (FE-1357)', { tag: '@mobile-ios' }, () => {
-  test('offers Google without an in-app-browser notice in Chrome', async ({
-    browser
-  }) => {
-    const context = await browser.newContext({ userAgent: CHROME_IOS_UA })
-    try {
-      const page = await context.newPage()
+  test.describe('Chrome', () => {
+    test.use({ userAgent: CHROME_IOS_UA })
+
+    test('offers Google without an in-app-browser notice in Chrome', async ({
+      page
+    }) => {
       await injectWkWebViewBridge(page)
 
       await page.goto(APP_URL)
@@ -33,9 +33,7 @@ test.describe('Cloud login on iOS (FE-1357)', { tag: '@mobile-ios' }, () => {
       await expect(
         page.getByTestId('google-sso-in-app-browser-notice')
       ).toBeHidden()
-    } finally {
-      await context.close()
-    }
+    })
   })
 
   test('offers Google without an in-app-browser notice in Safari', async ({
@@ -52,14 +50,15 @@ test.describe('Cloud login on iOS (FE-1357)', { tag: '@mobile-ios' }, () => {
     ).toBeHidden()
   })
 
-  test('offers Google with a notice in an embedded WKWebView', async ({
-    browser
-  }) => {
-    const wkWebViewUa =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
-    const context = await browser.newContext({ userAgent: wkWebViewUa })
-    try {
-      const page = await context.newPage()
+  test.describe('WKWebView', () => {
+    test.use({
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+    })
+
+    test('offers Google with a notice in an embedded WKWebView', async ({
+      page
+    }) => {
       await injectWkWebViewBridge(page)
 
       await page.goto(APP_URL)
@@ -69,8 +68,6 @@ test.describe('Cloud login on iOS (FE-1357)', { tag: '@mobile-ios' }, () => {
       await expect(
         page.getByTestId('google-sso-in-app-browser-notice')
       ).toBeVisible()
-    } finally {
-      await context.close()
-    }
+    })
   })
 })

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -7,6 +7,7 @@ import { ApiSignin } from '@e2e/fixtures/components/ApiSignin'
 import { CloudNotification } from '@e2e/fixtures/components/CloudNotification'
 import { UpdatePassword } from '@e2e/fixtures/components/UpdatePassword'
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
@@ -157,6 +158,24 @@ test.describe('Signin dialog', () => {
   })
 
   test('Sign-in dialog resolves true on login', async ({ comfyPage }) => {
+    await comfyPage.cloudAuth.mockFirebaseEndpoints('test@example.com')
+    await mockWorkspace(comfyPage.page, workspace('personal', 'owner'), [])
+    await comfyPage.page.route(
+      '**/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?*',
+      (route) =>
+        route.fulfill({
+          json: {
+            kind: 'identitytoolkit#VerifyPasswordResponse',
+            localId: 'test-user-e2e',
+            email: 'test@example.com',
+            displayName: 'E2E Test User',
+            idToken: 'mock-firebase-id-token',
+            registered: true,
+            refreshToken: 'mock-refresh-token',
+            expiresIn: '3600'
+          }
+        })
+    )
     await comfyPage.page.route('**/customers', (route) =>
       route.fulfill({
         status: 201,
@@ -229,6 +248,11 @@ test.describe('Cloud notification dialog', () => {
   test('Should display cloud notification and navigate to comfy.org on Explore', async ({
     comfyPage
   }) => {
+    await comfyPage.page
+      .context()
+      .route('https://comfy.org/cloud/**', (route) =>
+        route.fulfill({ contentType: 'text/html', body: '<!doctype html>' })
+      )
     const dialog = new CloudNotification(comfyPage.page)
     await dialog.open()
 

--- a/browser_tests/tests/dialog.spec.ts
+++ b/browser_tests/tests/dialog.spec.ts
@@ -7,6 +7,7 @@ import { ApiSignin } from '@e2e/fixtures/components/ApiSignin'
 import { CloudNotification } from '@e2e/fixtures/components/CloudNotification'
 import { UpdatePassword } from '@e2e/fixtures/components/UpdatePassword'
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
+import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
 import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
 
 test.beforeEach(async ({ comfyPage }) => {
@@ -160,6 +161,7 @@ test.describe('Signin dialog', () => {
   test('Sign-in dialog resolves true on login', async ({ comfyPage }) => {
     await comfyPage.cloudAuth.mockFirebaseEndpoints('test@example.com')
     await mockWorkspace(comfyPage.page, workspace('personal', 'owner'), [])
+    await mockBilling(comfyPage.page)
     await comfyPage.page.route(
       '**/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?*',
       (route) =>
@@ -190,9 +192,17 @@ test.describe('Signin dialog', () => {
     await dialog.passwordInput.fill('TestPassword123!')
     await expect(dialog.root).toBeVisible()
 
+    const billingResponses = Promise.all(
+      ['status', 'balance', 'plans'].map((endpoint) =>
+        comfyPage.page.waitForResponse(`**/api/billing/${endpoint}`)
+      )
+    )
     await dialog.signInButton.click()
     await expect(dialog.root).toBeHidden()
     expect(await dialogResult).toBe(true)
+    for (const response of await billingResponses) {
+      expect(response.ok()).toBe(true)
+    }
   })
 
   test('Sign-in dialog resolves false when closed without sign-in', async ({

--- a/browser_tests/tests/dialogs/managerDialog.spec.ts
+++ b/browser_tests/tests/dialogs/managerDialog.spec.ts
@@ -2,7 +2,10 @@ import { expect } from '@playwright/test'
 
 import type { AlgoliaNodePack } from '@/types/algoliaTypes'
 import type { components as ManagerComponents } from '@/workbench/extensions/manager/types/generatedManagerTypes'
-import type { components as RegistryComponents } from '@comfyorg/registry-types'
+import type {
+  components as RegistryComponents,
+  operations as RegistryOperations
+} from '@comfyorg/registry-types'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
@@ -231,6 +234,26 @@ test.describe('ManagerDialog', { tag: '@ui' }, () => {
       async (route) => {
         await route.fulfill({ json: registryListResponse })
       }
+    )
+
+    await comfyPage.page.route(
+      'https://api.comfy.org/bulk/nodes/versions',
+      (route) =>
+        route.fulfill({
+          json: {
+            node_versions: []
+          } satisfies RegistryComponents['schemas']['BulkNodeVersionsResponse']
+        })
+    )
+    await comfyPage.page.route(
+      'https://api.comfy.org/nodes/test-pack-a/versions/1.0.0/comfy-nodes**',
+      (route) =>
+        route.fulfill({
+          json: {
+            comfy_nodes: [],
+            totalNumberOfPages: 0
+          } satisfies RegistryOperations['ListComfyNodes']['responses'][200]['content']['application/json']
+        })
     )
 
     await comfyPage.page.route(

--- a/browser_tests/tests/dialogs/queueClearHistory.spec.ts
+++ b/browser_tests/tests/dialogs/queueClearHistory.spec.ts
@@ -55,7 +55,7 @@ test.describe('Queue Clear History Dialog', { tag: '@ui' }, () => {
       if (route.request().method() === 'POST') {
         clearCalled = true
       }
-      return route.continue()
+      return route.fallback()
     })
 
     await dialog.getByRole('button', { name: 'Cancel' }).click()
@@ -78,7 +78,7 @@ test.describe('Queue Clear History Dialog', { tag: '@ui' }, () => {
       if (route.request().method() === 'POST') {
         clearCalled = true
       }
-      return route.continue()
+      return route.fallback()
     })
 
     await dialog.getByLabel('Close').click()

--- a/browser_tests/tests/errorDialog.spec.ts
+++ b/browser_tests/tests/errorDialog.spec.ts
@@ -35,7 +35,13 @@ async function waitForPopupNavigation(page: Page, action: () => Promise<void>) {
 }
 
 test.describe('Error dialog', () => {
-  test.beforeEach(async ({ comfyPage }) => {
+  test.beforeEach(async ({ context, comfyPage }) => {
+    await context.route('https://github.com/**/issues**', (route) =>
+      route.fulfill({ contentType: 'text/html', body: '<!doctype html>' })
+    )
+    await context.route('https://support.comfy.org/**', (route) =>
+      route.fulfill({ contentType: 'text/html', body: '<!doctype html>' })
+    )
     await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
   })
 

--- a/browser_tests/tests/imageCompare.spec.ts
+++ b/browser_tests/tests/imageCompare.spec.ts
@@ -9,7 +9,8 @@ import { toNodeId } from '@/types/nodeId'
 const IMAGE_COMPARE_NODE_ID = toNodeId(1)
 
 test.describe('Image Compare', { tag: ['@widget', '@vue-nodes'] }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
+  test.beforeEach(async ({ page, comfyPage }) => {
+    await page.route('http://127.0.0.1:1/broken*.png', (route) => route.abort())
     await comfyPage.workflow.loadWorkflow('widgets/image_compare_widget')
   })
 

--- a/browser_tests/tests/infrastructure/networkIsolation.spec.ts
+++ b/browser_tests/tests/infrastructure/networkIsolation.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { apiKeyAuthFixture } from '@e2e/fixtures/apiKeyAuthFixture'
+import { cloudAppFixture } from '@e2e/fixtures/cloudAppFixture'
+import { localAuthFixture } from '@e2e/fixtures/localAuthFixture'
+import { templateApiFixture } from '@e2e/fixtures/templateApiFixture'
+import { workspaceRailAuthFixture } from '@e2e/fixtures/workspaceRailAuthFixture'
 
 test.describe('Network isolation', { tag: '@smoke' }, () => {
   test.beforeEach(async ({ page }) => {
@@ -143,3 +148,33 @@ test.describe('Network isolation', { tag: '@smoke' }, () => {
     )
   })
 })
+
+for (const [name, fixture] of [
+  ['cloudAppFixture', cloudAppFixture],
+  ['localAuthFixture', localAuthFixture],
+  ['templateApiFixture', templateApiFixture],
+  ['workspaceRailAuthFixture', workspaceRailAuthFixture],
+  ['apiKeyAuthFixture', apiKeyAuthFixture]
+] as const) {
+  fixture(
+    `${name} reports external requests at teardown`,
+    { tag: '@smoke' },
+    async ({ page }) => {
+      const frontend =
+        process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+      await page.goto(`${frontend}/api/users`)
+      expect(
+        await page.evaluate(() =>
+          fetch('https://network-test.invalid/data').then(
+            () => 'loaded',
+            () => 'blocked'
+          )
+        )
+      ).toBe('blocked')
+      fixture.fail(
+        true,
+        'The fixture must report the blocked request at teardown'
+      )
+    }
+  )
+}

--- a/browser_tests/tests/infrastructure/networkIsolation.spec.ts
+++ b/browser_tests/tests/infrastructure/networkIsolation.spec.ts
@@ -1,0 +1,145 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+test.describe('Network isolation', { tag: '@smoke' }, () => {
+  test.beforeEach(async ({ page }) => {
+    const frontend = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+    await page.goto(`${frontend}/api/users`)
+  })
+
+  test('retains page mock precedence and intercepts the first popup request', async ({
+    page,
+    context
+  }) => {
+    await context.route('https://network-test.invalid/**', (route) =>
+      route.fulfill({ contentType: 'text/html', body: 'context mock' })
+    )
+    await page.route('https://network-test.invalid/**', (route) =>
+      route.fulfill({ body: 'page mock' })
+    )
+    expect(
+      await page.evaluate(() =>
+        fetch('https://network-test.invalid/data').then((response) =>
+          response.text()
+        )
+      )
+    ).toBe('page mock')
+
+    const popupPromise = context.waitForEvent('page')
+    await page.evaluate(() => window.open('https://network-test.invalid/popup'))
+    const popup = await popupPromise
+    await expect(popup.locator('body')).toHaveText('context mock')
+    await expect(popup).toHaveURL('https://network-test.invalid/popup')
+  })
+
+  test('keeps real backend WebSocket messages', async ({ page }) => {
+    const backend =
+      process.env.PLAYWRIGHT_SETUP_API_URL ||
+      process.env.PLAYWRIGHT_TEST_URL ||
+      'http://localhost:8188'
+    const url = new URL('ws', `${backend}/`)
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    const message = await page.evaluate(
+      (url) =>
+        new Promise<string>((resolve, reject) => {
+          const socket = new WebSocket(url)
+          socket.onmessage = (event) => {
+            resolve(event.data)
+            socket.close()
+          }
+          socket.onerror = () => reject(new Error('Backend WebSocket failed'))
+        }),
+      url.toString()
+    )
+    expect(JSON.parse(message)).toMatchObject({ type: 'status' })
+  })
+
+  test('blocks service worker registration', async ({ page, context }) => {
+    await page.route('**/network-test-sw.js', (route) =>
+      route.fulfill({ contentType: 'application/javascript', body: '' })
+    )
+    await expect(
+      page.evaluate(() =>
+        navigator.serviceWorker.register('/network-test-sw.js')
+      )
+    ).resolves.toBeUndefined()
+    expect(context.serviceWorkers()).toHaveLength(0)
+  })
+
+  test('fails the owning test even when an external fetch error is caught', async ({
+    page
+  }) => {
+    expect(
+      await page.evaluate(() =>
+        fetch('https://network-test.invalid/data').then(
+          () => 'loaded',
+          () => 'blocked'
+        )
+      )
+    ).toBe('blocked')
+    test.fail(
+      true,
+      'The network fixture must report the blocked request at teardown'
+    )
+  })
+
+  test('fails the owning test for an external WebSocket', async ({ page }) => {
+    await expect(
+      page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            const socket = new WebSocket('wss://network-test.invalid/socket')
+            socket.onclose = () => resolve()
+          })
+      )
+    ).resolves.toBeUndefined()
+    test.fail(
+      true,
+      'The network fixture must report the blocked WebSocket at teardown'
+    )
+  })
+
+  test('fails the owning test for an unmocked popup', async ({
+    page,
+    context
+  }) => {
+    const failedRequest = context.waitForEvent('requestfailed', {
+      predicate: (request) =>
+        request.url() === 'https://network-test.invalid/popup'
+    })
+    await page.evaluate(() => window.open('https://network-test.invalid/popup'))
+    expect((await failedRequest).failure()?.errorText).toContain(
+      'ERR_BLOCKED_BY_CLIENT'
+    )
+    test.fail(
+      true,
+      'The network fixture must report the blocked popup at teardown'
+    )
+  })
+
+  test('guards every API verb, including context.request', async ({
+    request,
+    context
+  }) => {
+    for (const method of [
+      'get',
+      'post',
+      'put',
+      'patch',
+      'delete',
+      'head',
+      'fetch'
+    ] as const) {
+      for (const api of [request, context.request]) {
+        await expect(
+          api[method]('https://network-test.invalid/api')
+        ).rejects.toThrow('Unexpected external request')
+      }
+    }
+    test.fail(
+      true,
+      'The network fixture must report caught API errors at teardown'
+    )
+  })
+})

--- a/browser_tests/tests/linearMode.spec.ts
+++ b/browser_tests/tests/linearMode.spec.ts
@@ -58,6 +58,9 @@ test.describe('Linear Mode', { tag: '@ui' }, () => {
     const userId = await comfyPage.setupUser(username)
     comfyPage.userIds[parallelIndex] = userId
 
+    await page.route('https://{api,stagingapi}.comfy.org/releases**', (route) =>
+      route.fulfill({ json: [] })
+    )
     await page.goto(`${comfyPage.url}/api/users`)
     await page.evaluate((id) => {
       localStorage.clear()

--- a/browser_tests/tests/linearMode.spec.ts
+++ b/browser_tests/tests/linearMode.spec.ts
@@ -80,7 +80,7 @@ test.describe('Linear Mode', { tag: '@ui' }, () => {
     await page.route('**/templates/default.json', async (route) => {
       notifyWorkflowRequested()
       await requestUnblocked
-      return route.continue()
+      return route.fallback()
     })
 
     await comfyPage.goto({ url: `${comfyPage.url}/?template=default` })

--- a/browser_tests/tests/loadWorkflowInMedia.spec.ts
+++ b/browser_tests/tests/loadWorkflowInMedia.spec.ts
@@ -1,8 +1,14 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { assetPath } from '@e2e/fixtures/utils/paths'
 
-test.beforeEach(async ({ comfyPage }) => {
+test.beforeEach(async ({ page, comfyPage }) => {
+  await page.route(
+    'https://comfyanonymous.github.io/ComfyUI_examples/hidream/hidream_dev_example.png',
+    (route) =>
+      route.fulfill({ path: assetPath('workflowInMedia/workflow_itxt.png') })
+  )
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
 })
 
@@ -60,7 +66,9 @@ test.describe(
       test(`Load workflow from URL ${url} (drop from different browser tabs)`, async ({
         comfyPage
       }) => {
+        await comfyPage.nodeOps.clearGraph()
         const initialNodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+        expect(initialNodeCount).toBe(0)
 
         await comfyPage.dragDrop.dragAndDropURL(url)
 
@@ -71,6 +79,7 @@ test.describe(
             timeout: 15000
           })
           .toBeGreaterThan(initialNodeCount)
+        expect(await comfyPage.nodeOps.getGraphNodesCount()).toBe(1)
       })
     })
 

--- a/browser_tests/tests/nodeHelp.spec.ts
+++ b/browser_tests/tests/nodeHelp.spec.ts
@@ -5,6 +5,16 @@ import {
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+
+test.beforeEach(async ({ page }) => {
+  await page.route('https://example.com/image.png', (route) =>
+    route.fulfill({ path: assetPath('image32x32.webp') })
+  )
+  await page.route('https://example.com/video.webm', (route) =>
+    route.fulfill({ path: assetPath('video/video-preview-wide.webm') })
+  )
+})
 
 // TODO: there might be a better solution for this
 // Helper function to pan canvas and select node

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -357,7 +357,7 @@ async function delayNextUpload(
       })
       return
     }
-    await route.continue()
+    await route.fallback()
   }
 
   await comfyPage.page.route('**/upload/image', uploadRouteHandler)

--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -40,7 +40,7 @@ test.describe('Release Notifications', () => {
           ])
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 
@@ -121,7 +121,7 @@ test.describe('Release Notifications', () => {
           body: JSON.stringify({ error: 'Server error' })
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 
@@ -169,7 +169,7 @@ test.describe('Release Notifications', () => {
           body: JSON.stringify([createMockRelease({ attention: 'high' })])
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 
@@ -222,7 +222,7 @@ test.describe('Release Notifications', () => {
           body: JSON.stringify([])
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 
@@ -255,7 +255,7 @@ test.describe('Release Notifications', () => {
           body: JSON.stringify([createMockRelease()])
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 
@@ -304,7 +304,7 @@ test.describe('Release Notifications', () => {
           ])
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 
@@ -365,7 +365,7 @@ test.describe('Release Notifications', () => {
           body: JSON.stringify([])
         })
       } else {
-        await route.continue()
+        await route.fallback()
       }
     })
 

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -195,10 +195,6 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
       }
     )
 
-    await comfyPage.page.route('**/templates/index.json', (route) =>
-      route.continue()
-    )
-
     await comfyPage.settings.setSetting('Comfy.Locale', locale)
 
     const localeRequestPromise = comfyPage.page.waitForRequest(

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -18,6 +18,14 @@ async function checkTemplateFileExists(
 }
 
 test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.route(
+      'https://comfyanonymous.github.io/ComfyUI_examples/',
+      (route) =>
+        route.fulfill({ contentType: 'text/html', body: '<!doctype html>' })
+    )
+  })
+
   test('should have a JSON workflow file for each template', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/templates/partnerNodesEducationCard.spec.ts
+++ b/browser_tests/tests/templates/partnerNodesEducationCard.spec.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { mockPaidTemplate } from '@e2e/fixtures/helpers/TemplateHelper'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { assetPath } from '@e2e/fixtures/utils/paths'
 
 const PAID_TEMPLATE = 'paid-template'
 const PARTNER_WORKFLOW = 'browser_tests/assets/partner_api_node.json'
@@ -12,6 +13,11 @@ test.describe('Partner nodes education card (local)', () => {
     comfyPage
   }) => {
     const page = comfyPage.page
+    await page.route(
+      'https://media.comfy.org/website/partner-nodes/*.webm',
+      (route) =>
+        route.fulfill({ path: assetPath('video/video-preview-wide.webm') })
+    )
     const templates = await mockPaidTemplate(
       page,
       PAID_TEMPLATE,

--- a/browser_tests/tests/vueNodes/widgets/imageCrop.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/imageCrop.spec.ts
@@ -840,7 +840,7 @@ test.describe('Image Crop', { tag: ['@widget', '@vue-nodes'] }, () => {
             await route.abort('failed')
             return
           }
-          await route.continue()
+          await route.fallback()
         })
         try {
           failExamplePng = true
@@ -1207,13 +1207,13 @@ test.describe('Image Crop', { tag: ['@widget', '@vue-nodes'] }, () => {
         await comfyPage.page.route('**/api/view**', async (route) => {
           const url = route.request().url()
           if (!url.includes('example.png')) {
-            await route.continue()
+            await route.fallback()
             return
           }
           await new Promise<void>((resolve) => {
             setTimeout(resolve, 500)
           })
-          await route.continue()
+          await route.fallback()
         })
 
         try {

--- a/browser_tests/tests/workspaceAuthRefresh.spec.ts
+++ b/browser_tests/tests/workspaceAuthRefresh.spec.ts
@@ -164,18 +164,17 @@ test.describe('Workspace auth refresh', { tag: '@cloud' }, () => {
       .toBeGreaterThanOrEqual(2)
 
     // A 403 ACCESS_DENIED response must clear the workspace session entirely.
-    await expect
-      .poll(
-        () =>
-          page.evaluate(() => sessionStorage.getItem('Comfy.Workspace.Token')),
-        { timeout: 5000 }
-      )
-      .toBeNull()
-
-    expect(
-      await page.evaluate(() =>
-        sessionStorage.getItem('Comfy.Workspace.Current')
-      )
-    ).toBeNull()
+    await expect(async () => {
+      expect(
+        await page.evaluate(() =>
+          sessionStorage.getItem('Comfy.Workspace.Token')
+        )
+      ).toBeNull()
+      expect(
+        await page.evaluate(() =>
+          sessionStorage.getItem('Comfy.Workspace.Current')
+        )
+      ).toBeNull()
+    }).toPass({ timeout: 5000 })
   })
 })

--- a/scripts/test-browser-offline.sh
+++ b/scripts/test-browser-offline.sh
@@ -2,13 +2,19 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
-dist="$(realpath "${PLAYWRIGHT_OFFLINE_DIST:-$repo_root/dist}")"
+dist="$(realpath -m "${PLAYWRIGHT_OFFLINE_DIST:-$repo_root/dist}")"
 image="${COMFYUI_TEST_IMAGE:-ghcr.io/comfy-org/comfyui-ci-container:0.0.22}"
 
-test -f "$dist/index.html"
-test -d "$repo_root/node_modules"
+test -f "$dist/index.html" || {
+  echo "No build at $dist. Run pnpm build or set PLAYWRIGHT_OFFLINE_DIST." >&2
+  exit 1
+}
+test -d "$repo_root/node_modules" || {
+  echo "No node_modules. Run pnpm install --frozen-lockfile on Linux." >&2
+  exit 1
+}
 
-exec docker run --rm --pull never --network none --ipc host --user 0:0 \
+exec docker run --rm --pull never --network none --shm-size=2g --user 0:0 \
   --mount "type=bind,src=$repo_root,dst=$repo_root" \
   --mount "type=bind,src=$dist,dst=/frontend,readonly" \
   --mount "type=bind,src=$repo_root/tools/devtools,dst=/ComfyUI/custom_nodes/ComfyUI_devtools,readonly" \
@@ -23,5 +29,5 @@ exec docker run --rm --pull never --network none --ipc host --user 0:0 \
       cat /tmp/comfyui.log
       exit 1
     }
-    node node_modules/@playwright/test/cli.js test --retries=0 "$@"
+    node node_modules/@playwright/test/cli.js test "$@" --retries=0
   ' bash "$@"

--- a/scripts/test-browser-offline.sh
+++ b/scripts/test-browser-offline.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+dist="$(realpath "${PLAYWRIGHT_OFFLINE_DIST:-$repo_root/dist}")"
+image="${COMFYUI_TEST_IMAGE:-ghcr.io/comfy-org/comfyui-ci-container:0.0.22}"
+
+test -f "$dist/index.html"
+test -d "$repo_root/node_modules"
+
+exec docker run --rm --pull never --network none --ipc host --user 0:0 \
+  --mount "type=bind,src=$repo_root,dst=$repo_root" \
+  --mount "type=bind,src=$dist,dst=/frontend,readonly" \
+  --mount "type=bind,src=$repo_root/tools/devtools,dst=/ComfyUI/custom_nodes/ComfyUI_devtools,readonly" \
+  --workdir "$repo_root" \
+  --env CI=true \
+  --env PLAYWRIGHT_TEST_URL=http://127.0.0.1:8188 \
+  --env PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:8188 \
+  "$image" bash -euc '
+    python3 /ComfyUI/main.py --cpu --multi-user --front-end-root /frontend \
+      >/tmp/comfyui.log 2>&1 &
+    wait-for-it --service 127.0.0.1:8188 -t 120 || {
+      cat /tmp/comfyui.log
+      exit 1
+    }
+    node node_modules/@playwright/test/cli.js test --retries=0 "$@"
+  ' bash "$@"

--- a/scripts/test-browser-offline.sh
+++ b/scripts/test-browser-offline.sh
@@ -14,8 +14,8 @@ exec docker run --rm --pull never --network none --ipc host --user 0:0 \
   --mount "type=bind,src=$repo_root/tools/devtools,dst=/ComfyUI/custom_nodes/ComfyUI_devtools,readonly" \
   --workdir "$repo_root" \
   --env CI=true \
-  --env PLAYWRIGHT_TEST_URL=http://127.0.0.1:8188 \
-  --env PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:8188 \
+  --env PLAYWRIGHT_TEST_URL=http://localhost:8188 \
+  --env PLAYWRIGHT_SETUP_API_URL=http://localhost:8188 \
   "$image" bash -euc '
     python3 /ComfyUI/main.py --cpu --multi-user --front-end-root /frontend \
       >/tmp/comfyui.log 2>&1 &

--- a/tools/oxlint-plugins/browserNetworkIsolation.test.ts
+++ b/tools/oxlint-plugins/browserNetworkIsolation.test.ts
@@ -1,0 +1,64 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+const reportSchema = z.object({
+  diagnostics: z.array(z.object({ code: z.string() }))
+})
+
+function isolationRules(filename: string) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.resolve('node_modules/oxlint/bin/oxlint'),
+      '--config',
+      path.resolve('.oxlintrc.json'),
+      '--format=json',
+      filename
+    ],
+    { encoding: 'utf8' }
+  )
+  expect(result.error).toBeUndefined()
+  const { diagnostics } = reportSchema.parse(JSON.parse(result.stdout))
+  return diagnostics
+    .map(({ code }) => code)
+    .filter((code) => /no-restricted-(imports|properties)/.test(code))
+}
+
+describe('browser network isolation lint rules', () => {
+  it.for([
+    [
+      "import { test as base } from '@playwright/test'",
+      'no-restricted-imports'
+    ],
+    ["import * as playwright from '@playwright/test'", 'no-restricted-imports'],
+    ["export { test } from '@playwright/test'", 'no-restricted-imports'],
+    ['route.continue()', 'no-restricted-properties'],
+    ["handler['continue']()", 'no-restricted-properties'],
+    ["import { expect } from '@playwright/test'", null],
+    [
+      "import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'",
+      null
+    ],
+    ['route.fallback()', null]
+  ] as const)('%s', ([source, rule]) => {
+    const directory = mkdtempSync(
+      path.resolve('browser_tests/fixtures/__network_policy_')
+    )
+    try {
+      const filename = path.join(directory, 'fixture.ts')
+      writeFileSync(filename, source)
+      expect(isolationRules(filename)).toEqual(rule ? [`eslint(${rule})`] : [])
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('allows the policy boundary to import Playwright and continue requests', () => {
+    expect(
+      isolationRules('browser_tests/fixtures/networkIsolationFixture.ts')
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Stop browser tests from depending on external networks while keeping configured backend HTTP and WebSocket connections real.

## Changes

- Add context-level default-deny routing, service-worker blocking, and guarded Playwright API requests. Unexpected requests fail the owning test; existing local mocks retain precedence.
- Serve popups, workflow-image URL drops, remote assets, geo lookup, Firebase sign-in, registry responses, releases, and workspace members locally at their fixture/test owners. Use scoped iOS user-agent options instead of standalone contexts.
- Add seven policy probes and a Docker `--network none` runner. Complete dependencies and builds before testing. Use localhost to match checked-in workflow URLs.
- Preserve assertion conditions and baselines. No application changes or increased retries/timeouts. Workspace-session assertions wait across the reload exposed by faster local mocks, within their original timeout.

## Review Focus

Fixture routing is not an OS network boundary. Raw Node requests, standalone contexts, `route.fetch()`, and browser redirects can bypass it. The offline runner isolates the complete test process; configured remote backends still use the regular runner.

Verified with prebuilt local/cloud distributions and the source-built `comfyui-ci-container-local:0.0.22` image, with networking disabled and retries set to zero:

- Full Chromium, all 16 shards with two workers each: **1,917 expected outcomes**, including four intentional policy failures; **13 existing skips, 3 failures**. No unexpected external requests remain.
- All three failures also reproduce on the [exact pre-PR commit](https://github.com/Comfy-Org/ComfyUI_frontend/commit/fc793a4e0e131ab588262d80168355f5da30df15) in the same environment: `outputHistory.spec.ts:141` cancellation timeout and both positive version-warning cases in `versionMismatchWarnings.spec.ts`. The cancellation control failed in repetition five; both warning failures reproduced in one run.
- Full cloud and mobile-Safari projects: **172 passed, 2 existing skips**.
- Real backend WebSocket status received. Raw Node egress probe returned `ENETUNREACH` inside the offline container.
- `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint`, targeted ESLint/oxlint/formatting, and `pnpm knip` passed. Lint retains 193 existing warnings.

Reproduce Chromium with `COMFYUI_TEST_IMAGE=comfyui-ci-container-local:0.0.22 PLAYWRIGHT_OFFLINE_DIST=/tmp/comfy-dist-local scripts/test-browser-offline.sh --project=chromium --workers=2 --shard=N/16` for N=1–16.

The source-built image may differ from the published CI image. Custom-node/performance projects and real remote backends were not run. No overall speedup has been established.
