### PR TITLE
feat: skill packs authoring UI behind the agent-skill-packs flag

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1679,7 +1679,8 @@
     "Other": "Other",
     "Secrets": "Secrets",
     "Node Library": "Node Library",
-    "PointCloud": "Point Cloud"
+    "PointCloud": "Point Cloud",
+    "SkillPacks": "Skill Packs"
   },
   "serverConfigItems": {
     "listen": {
@@ -5259,5 +5260,42 @@
     "runModeTriggerAutoLimitTooltip": "Ask when credit limit is reached",
     "showMore": "Show more",
     "showLess": "Show less"
+  },
+  "skillPacks": {
+    "title": "Agent Skill Packs",
+    "panelDescription": "Write down a preference once and the agent loads it when the trigger line matches. Packs are private to you.",
+    "yourPacks": "Your Packs",
+    "addPack": "Add Skill Pack",
+    "editPack": "Edit Skill Pack",
+    "publish": "Publish",
+    "noPacks": "No skill packs yet. Add one to teach the agent a preference you keep repeating.",
+    "name": "Name",
+    "namePlaceholder": "e.g., my-render-defaults",
+    "nameHint": "Letters, digits, '.', '_' and '-'. This is the name the agent loads the pack by.",
+    "triggerLine": "Trigger line",
+    "triggerLinePlaceholder": "Load me when the user asks about upscaling",
+    "triggerLineHint": "One line saying when to load this pack. It rides in every prompt whether the pack is used or not, so keep it short.",
+    "body": "Instructions",
+    "bodyPlaceholder": "The instructions the agent follows once this pack is loaded.",
+    "bodySize": "{bytes} of {max} bytes",
+    "packSize": "{bytes} bytes",
+    "atLimitTitle": "You are at your limit",
+    "atLimitHint": "Remove a pack to make room for this one.",
+    "deleteConfirmTitle": "Delete Skill Pack",
+    "deleteConfirmMessage": "Are you sure you want to delete \"{name}\"? This action cannot be undone.",
+    "errors": {
+      "nameRequired": "Name is required",
+      "nameTooLong": "Name must be {max} characters or less",
+      "nameCharset": "Name may only use letters, digits, '.', '_' and '-', and must include at least one character that is not a dot",
+      "nameReserved": "\"{name}\" is a built-in pack name and cannot be used",
+      "descriptionRequired": "Trigger line is required",
+      "descriptionSingleLine": "Trigger line must be a single line with no control characters",
+      "descriptionTooLong": "Trigger line must be {max} characters or less",
+      "bodyRequired": "Instructions are required",
+      "bodyTooLarge": "Instructions must be {max} bytes or less",
+      "tooManyPacks": "You already have the maximum of {max} skill packs. Remove one to add another.",
+      "totalTooLarge": "Your packs would total {over} bytes over the {max} byte limit. Remove a pack to make room.",
+      "totalAtLimit": "Your packs have reached the {max} byte total limit. Remove a pack to add another."
+    }
   }
 }

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -14,6 +14,7 @@ import type { SettingTreeNode } from '@/platform/settings/settingStore'
 import type { SettingPanelType, SettingParams } from '@/platform/settings/types'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useSkillPacksStore } from '@/platform/skills/stores/skillPacksStore'
 import type { NavGroupData } from '@/types/navTypes'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 import { buildTree } from '@/utils/treeUtil'
@@ -32,6 +33,7 @@ const CATEGORY_ICONS: Record<string, string> = {
   Other: 'icon-[lucide--ellipsis]',
   PlanCredits: 'icon-[lucide--receipt-text]',
   secrets: 'icon-[lucide--key-round]',
+  'skill-packs': 'icon-[lucide--book-open-text]',
   'server-config': 'icon-[lucide--server]',
   user: 'icon-[lucide--user]',
   workspace: 'icon-[lucide--building-2]',
@@ -58,6 +60,7 @@ export function useSettingUI(
   const { shouldRenderVueNodes } = useVueFeatureFlags()
   const { workspaceRole } = useWorkspaceUI()
   const governanceStore = usePartnerNodeGovernanceStore()
+  const skillPacksStore = useSkillPacksStore()
 
   const settingRoot = computed<SettingTreeNode>(() => {
     const root = buildTree(
@@ -217,6 +220,22 @@ export function useSettingUI(
     () => flags.userSecretsEnabled && isLoggedIn.value
   )
 
+  const skillPacksPanel: SettingPanelItem = {
+    node: {
+      key: 'skill-packs',
+      label: 'SkillPacks',
+      children: []
+    },
+    component: defineAsyncComponent(
+      () => import('@/platform/skills/components/SkillPacksPanel.vue')
+    )
+  }
+
+  // Both cohort flags plus a runtime check that the routes have not 404'd.
+  const shouldShowSkillPacksPanel = computed(
+    () => skillPacksStore.enabled && isLoggedIn.value
+  )
+
   const keybindingPanel: SettingPanelItem = {
     node: {
       key: 'keybinding',
@@ -258,7 +277,8 @@ export function useSettingUI(
     keybindingPanel,
     extensionPanel,
     ...(isDesktop ? [serverConfigPanel] : []),
-    ...(shouldShowSecretsPanel.value ? [secretsPanel] : [])
+    ...(shouldShowSecretsPanel.value ? [secretsPanel] : []),
+    ...(shouldShowSkillPacksPanel.value ? [skillPacksPanel] : [])
   ])
 
   /**
@@ -313,6 +333,9 @@ export function useSettingUI(
         ...coreSettingCategories.value.slice(0, 1).map(translateCategory),
         ...(shouldShowSecretsPanel.value
           ? [translateCategory(secretsPanel.node)]
+          : []),
+        ...(shouldShowSkillPacksPanel.value
+          ? [translateCategory(skillPacksPanel.node)]
           : []),
         ...coreSettingCategories.value.slice(1).map(translateCategory),
         translateCategory(keybindingPanel.node),
@@ -373,6 +396,7 @@ export function useSettingUI(
 
   onMounted(() => {
     activeCategory.value = defaultCategory.value
+    void skillPacksStore.startFlagGate()
   })
 
   return {

--- a/src/platform/skills/api/skillsApi.ts
+++ b/src/platform/skills/api/skillsApi.ts
@@ -1,0 +1,82 @@
+import {
+  zAgentSkill,
+  zAgentSkillListResponse
+} from '@comfyorg/ingest-types/zod'
+
+import { parseErrorResponse } from '@/platform/remote/comfyui/errors'
+import { api } from '@/scripts/api'
+
+import type { SkillPack, SkillPackPublishRequest } from '../types'
+
+/**
+ * A failed skill-pack request. `status` is the whole error contract: 400 means
+ * the user can edit this request into a valid one, 409 means a per-user budget
+ * is full and another pack has to go, and 404 means the cohort gate is off so
+ * the surface should disappear.
+ */
+export class SkillPacksApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message)
+    this.name = 'SkillPacksApiError'
+  }
+}
+
+/**
+ * The agent service answers with `{ "error": "..." }` while ingest answers with
+ * the canonical `ErrorResponse`. Both shapes reach these routes — a 404 is
+ * ingest-raised when the gate is off and agent-raised when the pack is missing
+ * — so read the agent shape first and fall back to the canonical parse.
+ */
+async function toApiError(response: Response): Promise<SkillPacksApiError> {
+  const clone = response.clone()
+  try {
+    const body: unknown = await clone.json()
+    if (
+      typeof body === 'object' &&
+      body !== null &&
+      typeof (body as { error?: unknown }).error === 'string'
+    ) {
+      return new SkillPacksApiError(
+        (body as { error: string }).error,
+        response.status
+      )
+    }
+  } catch {
+    // Fall through to the canonical ErrorResponse parse below.
+  }
+  const errorData = await parseErrorResponse(response)
+  return new SkillPacksApiError(errorData.message, response.status)
+}
+
+export async function listSkillPacks(): Promise<SkillPack[]> {
+  const response = await api.fetchApi('/agent/skills')
+  if (!response.ok) throw await toApiError(response)
+  return zAgentSkillListResponse.parse(await response.json()).skills
+}
+
+/**
+ * Create or replace. Publishing a name the caller already holds is an update,
+ * not a second pack, so this is the only write the editor needs.
+ */
+export async function publishSkillPack(
+  payload: SkillPackPublishRequest
+): Promise<SkillPack> {
+  const response = await api.fetchApi('/agent/skills', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+  if (!response.ok) throw await toApiError(response)
+  return zAgentSkill.parse(await response.json())
+}
+
+export async function deleteSkillPack(name: string): Promise<void> {
+  const response = await api.fetchApi(
+    `/agent/skills/${encodeURIComponent(name)}`,
+    { method: 'DELETE' }
+  )
+  if (!response.ok) throw await toApiError(response)
+}

--- a/src/platform/skills/components/SkillPackFormDialog.vue
+++ b/src/platform/skills/components/SkillPackFormDialog.vue
@@ -1,0 +1,156 @@
+<template>
+  <Dialog v-model:open="visible">
+    <DialogPortal>
+      <DialogOverlay v-reka-z-index data-reka-nested-dialog-overlay />
+      <DialogContent v-reka-z-index size="md" :aria-labelledby="titleId">
+        <DialogHeader>
+          <DialogTitle :id="titleId">
+            {{ pack ? $t('skillPacks.editPack') : $t('skillPacks.addPack') }}
+          </DialogTitle>
+          <DialogClose />
+        </DialogHeader>
+        <form
+          class="flex flex-col gap-4 px-4 py-2"
+          @submit.prevent="handleSubmit"
+        >
+          <div class="flex flex-col gap-1">
+            <label for="skill-pack-name" class="text-sm font-medium">
+              {{ $t('skillPacks.name') }}
+            </label>
+            <Input
+              id="skill-pack-name"
+              v-model="form.name"
+              :placeholder="$t('skillPacks.namePlaceholder')"
+              :disabled="pack !== undefined"
+            />
+            <small v-if="errors.name" class="text-destructive">
+              {{ errors.name }}
+            </small>
+            <small v-else class="text-muted">
+              {{ $t('skillPacks.nameHint') }}
+            </small>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label for="skill-pack-description" class="text-sm font-medium">
+              {{ $t('skillPacks.triggerLine') }}
+            </label>
+            <Input
+              id="skill-pack-description"
+              v-model="form.description"
+              :placeholder="$t('skillPacks.triggerLinePlaceholder')"
+            />
+            <small v-if="errors.description" class="text-destructive">
+              {{ errors.description }}
+            </small>
+            <small v-else class="text-muted">
+              {{ $t('skillPacks.triggerLineHint') }}
+            </small>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label for="skill-pack-body" class="text-sm font-medium">
+              {{ $t('skillPacks.body') }}
+            </label>
+            <Textarea
+              id="skill-pack-body"
+              v-model="form.body"
+              class="min-h-48 font-mono"
+              :placeholder="$t('skillPacks.bodyPlaceholder')"
+            />
+            <small v-if="errors.body" class="text-destructive">
+              {{ errors.body }}
+            </small>
+            <small v-else class="text-muted">{{ bodySizeLabel }}</small>
+          </div>
+
+          <div
+            v-if="budgetError"
+            data-testid="skill-pack-budget-error"
+            class="border-destructive flex flex-col gap-1 rounded-lg border p-3"
+          >
+            <span class="text-destructive text-sm font-medium">
+              {{ $t('skillPacks.atLimitTitle') }}
+            </span>
+            <span class="text-sm text-muted">{{ budgetError }}</span>
+            <span class="text-sm text-muted">
+              {{ $t('skillPacks.atLimitHint') }}
+            </span>
+          </div>
+
+          <span
+            v-else-if="fieldError"
+            data-testid="skill-pack-field-error"
+            class="text-destructive text-sm"
+          >
+            {{ fieldError }}
+          </span>
+
+          <div class="flex justify-end gap-2 py-2">
+            <Button variant="secondary" type="button" @click="visible = false">
+              {{ $t('g.cancel') }}
+            </Button>
+            <Button type="submit" :loading="loading">
+              {{ $t('skillPacks.publish') }}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </DialogPortal>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { vRekaZIndex } from '@/components/dialog/vRekaZIndex'
+import Button from '@/components/ui/button/Button.vue'
+import Dialog from '@/components/ui/dialog/Dialog.vue'
+import DialogClose from '@/components/ui/dialog/DialogClose.vue'
+import DialogContent from '@/components/ui/dialog/DialogContent.vue'
+import DialogHeader from '@/components/ui/dialog/DialogHeader.vue'
+import DialogOverlay from '@/components/ui/dialog/DialogOverlay.vue'
+import DialogPortal from '@/components/ui/dialog/DialogPortal.vue'
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
+import Input from '@/components/ui/input/Input.vue'
+import Textarea from '@/components/ui/textarea/Textarea.vue'
+
+import { useSkillPackForm } from '../composables/useSkillPackForm'
+import type { SkillPack } from '../types'
+import { MAX_PACK_BODY_BYTES } from '../types'
+
+const { pack } = defineProps<{
+  pack?: SkillPack
+}>()
+
+const visible = defineModel<boolean>('visible', { default: false })
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const { t } = useI18n()
+const titleId = useId()
+
+const {
+  form,
+  errors,
+  loading,
+  fieldError,
+  budgetError,
+  bodyBytes,
+  handleSubmit
+} = useSkillPackForm({
+  pack: () => pack,
+  visible,
+  onSaved: () => emit('saved')
+})
+
+const bodySizeLabel = computed(() =>
+  t('skillPacks.bodySize', {
+    bytes: bodyBytes.value,
+    max: MAX_PACK_BODY_BYTES
+  })
+)
+</script>

--- a/src/platform/skills/components/SkillPackListItem.vue
+++ b/src/platform/skills/components/SkillPackListItem.vue
@@ -1,0 +1,74 @@
+<template>
+  <div
+    class="bg-base-raised-surface flex items-start justify-between gap-4 rounded-lg border border-border-default p-4"
+  >
+    <div class="flex min-w-0 flex-col gap-1">
+      <span class="truncate font-medium text-base-foreground">
+        {{ pack.name }}
+      </span>
+      <span class="line-clamp-2 text-sm text-muted">
+        {{ pack.description }}
+      </span>
+      <span class="text-xs text-muted">{{ sizeLabel }}</span>
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      <i
+        v-if="loading"
+        class="icon-[lucide--loader-circle] size-4 animate-spin text-muted"
+      />
+      <template v-else>
+        <Button
+          variant="muted-textonly"
+          size="icon-sm"
+          :aria-label="editLabel"
+          :disabled="disabled"
+          @click="emit('edit')"
+        >
+          <i class="icon-[lucide--square-pen] size-4" />
+        </Button>
+        <Button
+          variant="muted-textonly"
+          size="icon-sm"
+          :aria-label="deleteLabel"
+          :disabled="disabled"
+          @click="emit('delete')"
+        >
+          <i class="icon-[lucide--trash-2] size-4" />
+        </Button>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+
+import type { SkillPack } from '../types'
+import { packByteSize } from '../types'
+
+const {
+  pack,
+  loading = false,
+  disabled = false
+} = defineProps<{
+  pack: SkillPack
+  loading?: boolean
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  edit: []
+  delete: []
+}>()
+
+const { t } = useI18n()
+
+const sizeLabel = computed(() =>
+  t('skillPacks.packSize', { bytes: packByteSize(pack) })
+)
+const editLabel = computed(() => t('g.edit'))
+const deleteLabel = computed(() => t('g.delete'))
+</script>

--- a/src/platform/skills/components/SkillPacksPanel.test.ts
+++ b/src/platform/skills/components/SkillPacksPanel.test.ts
@@ -1,0 +1,166 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
+import SkillPacksPanel from '@/platform/skills/components/SkillPacksPanel.vue'
+import type { SkillPack } from '@/platform/skills/types'
+
+const DIALOG_HANDLE = { key: 'confirm-delete-skill-pack' }
+const mockDeleteSkillPack = vi.fn().mockResolvedValue(undefined)
+const mockFetchSkillPacks = vi.fn().mockResolvedValue(undefined)
+const mockCloseDialog = vi.fn()
+
+const mockPack: SkillPack = {
+  id: 'pack-1',
+  name: 'my-render-defaults',
+  description: 'load me when upscaling',
+  body: 'always upscale with 4x-UltraSharp',
+  body_hash: 'abc',
+  created_at: '2026-08-22T00:00:00Z',
+  updated_at: '2026-08-22T00:00:00Z'
+}
+
+const atPackLimit = ref(false)
+const atByteLimit = ref(false)
+
+vi.mock('@/platform/skills/composables/useSkillPacks', () => ({
+  useSkillPacks: () => ({
+    packs: ref<SkillPack[]>([mockPack]),
+    loading: ref(false),
+    atPackLimit,
+    atByteLimit,
+    operatingPackName: ref(null),
+    fetchSkillPacks: mockFetchSkillPacks,
+    deleteSkillPack: mockDeleteSkillPack
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ closeDialog: mockCloseDialog })
+}))
+
+vi.mock('@/components/dialog/confirm/confirmDialog')
+
+vi.mock('@/platform/skills/components/SkillPackFormDialog.vue', () => ({
+  default: { name: 'SkillPackFormDialog', template: '<div />' }
+}))
+
+const mockShowConfirmDialog = vi.mocked(showConfirmDialog)
+
+interface CapturedConfirmOptions {
+  headerProps: { title: string }
+  props: { promptText: string }
+  footerProps: {
+    confirmText: string
+    confirmVariant: string
+    onCancel: () => void
+    onConfirm: () => Promise<void>
+  }
+}
+
+function capturedOptions(): CapturedConfirmOptions {
+  return mockShowConfirmDialog.mock
+    .calls[0][0] as unknown as CapturedConfirmOptions
+}
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    en: {
+      g: { delete: 'Delete' },
+      skillPacks: {
+        title: 'Agent Skill Packs',
+        panelDescription: 'Teach the agent a preference',
+        yourPacks: 'Your Packs',
+        addPack: 'Add Skill Pack',
+        noPacks: 'No skill packs yet',
+        deleteConfirmTitle: 'Delete Skill Pack',
+        deleteConfirmMessage: 'Delete {name}?',
+        errors: {
+          tooManyPacks: 'too-many-packs',
+          totalAtLimit: 'total-at-limit'
+        }
+      }
+    }
+  }
+})
+
+function renderPanel() {
+  return render(SkillPacksPanel, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Button: {
+          template:
+            '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+          props: ['disabled']
+        },
+        SkillPackListItem: {
+          template:
+            '<button data-testid="delete-trigger" @click="$emit(\'delete\')">delete</button>',
+          props: ['pack', 'loading', 'disabled'],
+          emits: ['edit', 'delete']
+        }
+      }
+    }
+  })
+}
+
+describe('SkillPacksPanel', () => {
+  beforeEach(() => {
+    atPackLimit.value = false
+    atByteLimit.value = false
+    mockShowConfirmDialog.mockReturnValue(
+      DIALOG_HANDLE as ReturnType<typeof showConfirmDialog>
+    )
+  })
+
+  it('routes delete confirmation through showConfirmDialog with destructive variant', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByTestId('delete-trigger'))
+
+    const opts = capturedOptions()
+    expect(opts.props.promptText).toBe('Delete my-render-defaults?')
+    expect(opts.footerProps.confirmVariant).toBe('destructive')
+  })
+
+  it('onConfirm closes the dialog with the helper handle and deletes the pack', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    await user.click(screen.getByTestId('delete-trigger'))
+
+    await capturedOptions().footerProps.onConfirm()
+
+    expect(mockCloseDialog).toHaveBeenCalledExactlyOnceWith(DIALOG_HANDLE)
+    expect(mockDeleteSkillPack).toHaveBeenCalledWith(mockPack)
+  })
+
+  it('blocks adding a pack and explains which limit is full when at the count budget', async () => {
+    atPackLimit.value = true
+    renderPanel()
+
+    expect(screen.getByTestId('skill-packs-at-limit')).toHaveTextContent(
+      'too-many-packs'
+    )
+    expect(
+      screen.getByRole('button', { name: /Add Skill Pack/ })
+    ).toBeDisabled()
+  })
+
+  it('explains the total-bytes budget when only that one is full', async () => {
+    atByteLimit.value = true
+    renderPanel()
+
+    expect(screen.getByTestId('skill-packs-at-limit')).toHaveTextContent(
+      'total-at-limit'
+    )
+  })
+})

--- a/src/platform/skills/components/SkillPacksPanel.vue
+++ b/src/platform/skills/components/SkillPacksPanel.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="flex h-full flex-col">
+    <div>
+      <h2 class="text-2xl font-bold">{{ $t('skillPacks.title') }}</h2>
+      <p class="mt-1 text-sm text-muted">
+        {{ $t('skillPacks.panelDescription') }}
+      </p>
+    </div>
+
+    <div class="my-4 border-t border-border-default" />
+
+    <div class="my-4 flex items-center justify-between">
+      <h3 class="my-0 text-lg font-semibold">
+        {{ $t('skillPacks.yourPacks') }}
+      </h3>
+      <Button :disabled="atPackLimit || atByteLimit" @click="openCreateDialog">
+        <i class="mr-1 icon-[lucide--plus] size-4" />
+        {{ $t('skillPacks.addPack') }}
+      </Button>
+    </div>
+
+    <p
+      v-if="atPackLimit || atByteLimit"
+      data-testid="skill-packs-at-limit"
+      class="mb-4 text-sm text-muted"
+    >
+      {{ atLimitMessage }}
+    </p>
+
+    <div v-if="loading" class="flex items-center justify-center py-8">
+      <i class="icon-[lucide--loader-circle] size-8 animate-spin text-muted" />
+    </div>
+
+    <div
+      v-else-if="packs.length === 0"
+      class="py-4 text-center text-sm text-muted"
+    >
+      {{ $t('skillPacks.noPacks') }}
+    </div>
+
+    <div v-else class="flex flex-col gap-3">
+      <SkillPackListItem
+        v-for="pack in packs"
+        :key="pack.id"
+        :pack="pack"
+        :loading="operatingPackName === pack.name"
+        :disabled="operatingPackName !== null"
+        @edit="openEditDialog(pack)"
+        @delete="confirmDelete(pack)"
+      />
+    </div>
+
+    <SkillPackFormDialog
+      v-model:visible="createDialogVisible"
+      @saved="fetchSkillPacks"
+    />
+
+    <SkillPackFormDialog
+      v-model:visible="editDialogVisible"
+      :pack="selectedPack"
+      @saved="fetchSkillPacks"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
+import Button from '@/components/ui/button/Button.vue'
+import { useDialogStore } from '@/stores/dialogStore'
+
+import { useSkillPacks } from '../composables/useSkillPacks'
+import type { SkillPack } from '../types'
+import { MAX_PACK_COUNT, MAX_TOTAL_BYTES } from '../types'
+import SkillPackFormDialog from './SkillPackFormDialog.vue'
+import SkillPackListItem from './SkillPackListItem.vue'
+
+const { t } = useI18n()
+const dialogStore = useDialogStore()
+
+const {
+  packs,
+  loading,
+  atPackLimit,
+  atByteLimit,
+  operatingPackName,
+  fetchSkillPacks,
+  deleteSkillPack
+} = useSkillPacks()
+
+const createDialogVisible = ref(false)
+const editDialogVisible = ref(false)
+const selectedPack = ref<SkillPack | undefined>()
+
+const atLimitMessage = computed(() =>
+  atPackLimit.value
+    ? t('skillPacks.errors.tooManyPacks', { max: MAX_PACK_COUNT })
+    : t('skillPacks.errors.totalAtLimit', { max: MAX_TOTAL_BYTES })
+)
+
+function openCreateDialog() {
+  createDialogVisible.value = true
+}
+
+/**
+ * The list response carries the full `body` on every row, so the editor opens
+ * straight from it — there is no fetch-one endpoint and none is needed.
+ */
+function openEditDialog(pack: SkillPack) {
+  selectedPack.value = pack
+  editDialogVisible.value = true
+}
+
+function confirmDelete(pack: SkillPack) {
+  const dialog = showConfirmDialog({
+    headerProps: { title: t('skillPacks.deleteConfirmTitle') },
+    props: {
+      promptText: t('skillPacks.deleteConfirmMessage', { name: pack.name })
+    },
+    footerProps: {
+      confirmText: t('g.delete'),
+      confirmVariant: 'destructive',
+      onCancel: () => dialogStore.closeDialog(dialog),
+      onConfirm: async () => {
+        dialogStore.closeDialog(dialog)
+        await deleteSkillPack(pack)
+      }
+    }
+  })
+}
+
+void fetchSkillPacks()
+</script>

--- a/src/platform/skills/composables/useSkillPackForm.test.ts
+++ b/src/platform/skills/composables/useSkillPackForm.test.ts
@@ -1,0 +1,253 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/vue'
+import { defineComponent, nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import { publishSkillPack, SkillPacksApiError } from '../api/skillsApi'
+import { useSkillPacksStore } from '../stores/skillPacksStore'
+import type { SkillPack } from '../types'
+import { useSkillPackForm } from './useSkillPackForm'
+
+vi.mock('../api/skillsApi', () => ({
+  publishSkillPack: vi.fn(),
+  listSkillPacks: vi.fn(),
+  SkillPacksApiError: class SkillPacksApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number
+    ) {
+      super(message)
+    }
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    en: {
+      skillPacks: {
+        errors: {
+          nameRequired: 'name-required',
+          nameTooLong: 'name-too-long',
+          nameCharset: 'name-charset',
+          nameReserved: 'name-reserved',
+          descriptionRequired: 'description-required',
+          descriptionSingleLine: 'description-single-line',
+          descriptionTooLong: 'description-too-long',
+          bodyRequired: 'body-required',
+          bodyTooLarge: 'body-too-large',
+          tooManyPacks: 'too-many-packs',
+          totalTooLarge: 'total-too-large'
+        }
+      }
+    }
+  }
+})
+
+function makePack(overrides: Partial<SkillPack> = {}): SkillPack {
+  return {
+    id: 'pack-1',
+    name: 'my-pack',
+    description: 'load me when upscaling',
+    body: 'always upscale with 4x-UltraSharp',
+    body_hash: 'abc',
+    created_at: '2026-08-22T00:00:00Z',
+    updated_at: '2026-08-22T00:00:00Z',
+    ...overrides
+  }
+}
+
+/**
+ * `useSkillPackForm` reads i18n and the store, so it has to run inside a
+ * component. The harness exposes the composable's return value directly.
+ */
+function mountForm(pack?: SkillPack) {
+  const visible = ref(true)
+  const onSaved = vi.fn()
+  let api!: ReturnType<typeof useSkillPackForm>
+  render(
+    defineComponent({
+      setup() {
+        api = useSkillPackForm({ pack: () => pack, visible, onSaved })
+        return () => null
+      }
+    }),
+    { global: { plugins: [i18n] } }
+  )
+  return { ...api, onSaved, visible }
+}
+
+describe('useSkillPackForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(publishSkillPack).mockReset()
+  })
+
+  it('seeds the editor from the pack it was given, with no second fetch', () => {
+    const pack = makePack()
+    const { form } = mountForm(pack)
+
+    expect(form.name).toBe(pack.name)
+    expect(form.description).toBe(pack.description)
+    expect(form.body).toBe(pack.body)
+  })
+
+  it.for([
+    ['..', 'name-charset'],
+    ['bad name', 'name-charset'],
+    ['a'.repeat(65), 'name-too-long'],
+    ['building', 'name-reserved']
+  ])('rejects the name %s before sending a request', async ([name, error]) => {
+    const { form, errors, handleSubmit } = mountForm()
+    form.name = name
+    form.description = 'load me'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(errors.name).toBe(error)
+    expect(publishSkillPack).not.toHaveBeenCalled()
+  })
+
+  it('rejects a multi-line trigger description before sending a request', async () => {
+    const { form, errors, handleSubmit } = mountForm()
+    form.name = 'my-pack'
+    form.description = 'line one\nline two'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(errors.description).toBe('description-single-line')
+    expect(publishSkillPack).not.toHaveBeenCalled()
+  })
+
+  it('counts the description in code points, not UTF-16 units', async () => {
+    const { form, errors, handleSubmit } = mountForm()
+    form.name = 'my-pack'
+    // 700 astral code points is 1400 UTF-16 units but under the 1024 cap.
+    form.description = '😀'.repeat(700)
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(errors.description).toBe('')
+    expect(publishSkillPack).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a body over the per-pack byte cap before sending a request', async () => {
+    const { form, errors, handleSubmit } = mountForm()
+    form.name = 'my-pack'
+    form.description = 'load me'
+    form.body = 'a'.repeat(10 * 1024 + 1)
+
+    await handleSubmit()
+
+    expect(errors.body).toBe('body-too-large')
+    expect(publishSkillPack).not.toHaveBeenCalled()
+  })
+
+  it('reports the pack-count budget as a limit state, not a field error', async () => {
+    const store = useSkillPacksStore()
+    store.packs = Array.from({ length: 5 }, (_, index) =>
+      makePack({ id: `pack-${index}`, name: `pack-${index}` })
+    )
+    const { form, errors, budgetError, handleSubmit } = mountForm()
+    form.name = 'a-sixth-pack'
+    form.description = 'load me'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(budgetError.value).toBe('too-many-packs')
+    expect(errors.name).toBe('')
+    expect(publishSkillPack).not.toHaveBeenCalled()
+  })
+
+  it('does not count the pack it replaces against the budgets', async () => {
+    const store = useSkillPacksStore()
+    store.packs = Array.from({ length: 5 }, (_, index) =>
+      makePack({ id: `pack-${index}`, name: `pack-${index}` })
+    )
+    vi.mocked(publishSkillPack).mockResolvedValue(makePack({ name: 'pack-0' }))
+    const { form, budgetError, handleSubmit } = mountForm(
+      makePack({ name: 'pack-0' })
+    )
+    form.body = 'replacement text'
+
+    await handleSubmit()
+
+    expect(budgetError.value).toBeNull()
+    expect(publishSkillPack).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces a 409 as the limit state, carrying the server message verbatim', async () => {
+    vi.mocked(publishSkillPack).mockRejectedValue(
+      new SkillPacksApiError('total size 25601 exceeds 25600 by 1', 409)
+    )
+    const { form, fieldError, budgetError, handleSubmit } = mountForm()
+    form.name = 'my-pack'
+    form.description = 'load me'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(budgetError.value).toBe('total size 25601 exceeds 25600 by 1')
+    expect(fieldError.value).toBeNull()
+  })
+
+  it('surfaces a 400 as an editable field error, distinct from the limit state', async () => {
+    vi.mocked(publishSkillPack).mockRejectedValue(
+      new SkillPacksApiError('always:true is not accepted for user packs', 400)
+    )
+    const { form, fieldError, budgetError, handleSubmit } = mountForm()
+    form.name = 'my-pack'
+    form.description = 'load me'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(fieldError.value).toBe('always:true is not accepted for user packs')
+    expect(budgetError.value).toBeNull()
+  })
+
+  it('treats a 404 as the gate closing and hides the surface', async () => {
+    vi.mocked(publishSkillPack).mockRejectedValue(
+      new SkillPacksApiError('not found', 404)
+    )
+    const store = useSkillPacksStore()
+    const { form, visible, handleSubmit } = mountForm()
+    form.name = 'my-pack'
+    form.description = 'load me'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+    await nextTick()
+
+    expect(store.routesAvailable).toBe(false)
+    expect(visible.value).toBe(false)
+  })
+
+  it('publishes the trimmed name and stores the returned pack', async () => {
+    const saved = makePack({ name: 'my-pack' })
+    vi.mocked(publishSkillPack).mockResolvedValue(saved)
+    const store = useSkillPacksStore()
+    const { form, onSaved, handleSubmit } = mountForm()
+    form.name = '  my-pack  '
+    form.description = 'load me'
+    form.body = 'do the thing'
+
+    await handleSubmit()
+
+    expect(publishSkillPack).toHaveBeenCalledWith({
+      name: 'my-pack',
+      description: 'load me',
+      body: 'do the thing'
+    })
+    expect(store.packs).toEqual([saved])
+    expect(onSaved).toHaveBeenCalledOnce()
+  })
+})

--- a/src/platform/skills/composables/useSkillPackForm.ts
+++ b/src/platform/skills/composables/useSkillPackForm.ts
@@ -1,0 +1,229 @@
+import { whenever } from '@vueuse/core'
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, reactive, ref, toValue } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { publishSkillPack, SkillPacksApiError } from '../api/skillsApi'
+import { useSkillPacksStore } from '../stores/skillPacksStore'
+import type { SkillPack } from '../types'
+import {
+  CONTROL_CHARACTERS,
+  codePointLength,
+  MAX_DESCRIPTION_CODE_POINTS,
+  MAX_NAME_LENGTH,
+  MAX_PACK_BODY_BYTES,
+  MAX_PACK_COUNT,
+  MAX_TOTAL_BYTES,
+  PACK_NAME_PATTERN,
+  RESERVED_PACK_NAMES,
+  packByteSize,
+  utf8ByteLength
+} from '../types'
+
+interface SkillPackFormState {
+  name: string
+  description: string
+  body: string
+}
+
+interface SkillPackFormErrors {
+  name: string
+  description: string
+  body: string
+}
+
+interface UseSkillPackFormOptions {
+  /** The pack being edited; absent for a new one. */
+  pack?: MaybeRefOrGetter<SkillPack | undefined>
+  visible: { value: boolean }
+  onSaved: () => void
+}
+
+function isReservedName(name: string): boolean {
+  return RESERVED_PACK_NAMES.some((reserved) => reserved === name)
+}
+
+export function useSkillPackForm(options: UseSkillPackFormOptions) {
+  const { t } = useI18n()
+  const { pack: packRef, visible, onSaved } = options
+  const store = useSkillPacksStore()
+
+  const loading = ref(false)
+  /** A 400: the request can be edited into a valid one. */
+  const fieldError = ref<string | null>(null)
+  /**
+   * A 409: nothing about this pack can be edited to make it fit, another pack
+   * has to go. The server message names the limit and the overage, so it is
+   * surfaced verbatim rather than restated in invented copy.
+   */
+  const budgetError = ref<string | null>(null)
+
+  const form = reactive<SkillPackFormState>({
+    name: '',
+    description: '',
+    body: ''
+  })
+
+  const errors = reactive<SkillPackFormErrors>({
+    name: '',
+    description: '',
+    body: ''
+  })
+
+  const isReplacing = computed(() =>
+    store.packs.some((existing) => existing.name === form.name.trim())
+  )
+
+  const bodyBytes = computed(() => utf8ByteLength(form.body))
+  const descriptionCodePoints = computed(() =>
+    codePointLength(form.description)
+  )
+
+  /**
+   * The user's total after this publish lands: the pack it replaces (if any)
+   * stops counting, because publishing a held name is an update.
+   */
+  const projectedTotalBytes = computed(() => {
+    const name = form.name.trim()
+    const others = store.packs.filter((existing) => existing.name !== name)
+    return (
+      others.reduce((sum, existing) => sum + packByteSize(existing), 0) +
+      packByteSize({ description: form.description, body: form.body })
+    )
+  })
+
+  const projectedPackCount = computed(
+    () => store.packs.length + (isReplacing.value ? 0 : 1)
+  )
+
+  function resetForm() {
+    const pack = toValue(packRef)
+    form.name = pack?.name ?? ''
+    form.description = pack?.description ?? ''
+    form.body = pack?.body ?? ''
+    errors.name = ''
+    errors.description = ''
+    errors.body = ''
+    fieldError.value = null
+    budgetError.value = null
+  }
+
+  resetForm()
+  whenever(() => visible.value, resetForm)
+
+  function validateName(): boolean {
+    const name = form.name.trim()
+    if (!name) {
+      errors.name = t('skillPacks.errors.nameRequired')
+      return false
+    }
+    if (!PACK_NAME_PATTERN.test(name)) {
+      errors.name = t('skillPacks.errors.nameCharset')
+      return false
+    }
+    if (name.length > MAX_NAME_LENGTH) {
+      errors.name = t('skillPacks.errors.nameTooLong', {
+        max: MAX_NAME_LENGTH
+      })
+      return false
+    }
+    if (isReservedName(name)) {
+      errors.name = t('skillPacks.errors.nameReserved', { name })
+      return false
+    }
+    return true
+  }
+
+  function validateDescription(): boolean {
+    if (!form.description.trim()) {
+      errors.description = t('skillPacks.errors.descriptionRequired')
+      return false
+    }
+    if (CONTROL_CHARACTERS.test(form.description)) {
+      errors.description = t('skillPacks.errors.descriptionSingleLine')
+      return false
+    }
+    if (descriptionCodePoints.value > MAX_DESCRIPTION_CODE_POINTS) {
+      errors.description = t('skillPacks.errors.descriptionTooLong', {
+        max: MAX_DESCRIPTION_CODE_POINTS
+      })
+      return false
+    }
+    return true
+  }
+
+  function validateBody(): boolean {
+    if (!form.body.trim()) {
+      errors.body = t('skillPacks.errors.bodyRequired')
+      return false
+    }
+    if (bodyBytes.value > MAX_PACK_BODY_BYTES) {
+      errors.body = t('skillPacks.errors.bodyTooLarge', {
+        max: MAX_PACK_BODY_BYTES
+      })
+      return false
+    }
+    return true
+  }
+
+  function validate(): boolean {
+    errors.name = ''
+    errors.description = ''
+    errors.body = ''
+    fieldError.value = null
+    budgetError.value = null
+
+    if (!validateName() || !validateDescription() || !validateBody()) {
+      return false
+    }
+    if (projectedPackCount.value > MAX_PACK_COUNT) {
+      budgetError.value = t('skillPacks.errors.tooManyPacks', {
+        max: MAX_PACK_COUNT
+      })
+      return false
+    }
+    if (projectedTotalBytes.value > MAX_TOTAL_BYTES) {
+      budgetError.value = t('skillPacks.errors.totalTooLarge', {
+        max: MAX_TOTAL_BYTES,
+        over: projectedTotalBytes.value - MAX_TOTAL_BYTES
+      })
+      return false
+    }
+    return true
+  }
+
+  async function handleSubmit() {
+    if (!validate()) return
+
+    loading.value = true
+    try {
+      const saved = await publishSkillPack({
+        name: form.name.trim(),
+        description: form.description,
+        body: form.body
+      })
+      store.upsertPack(saved)
+      onSaved()
+      visible.value = false
+    } catch (error) {
+      if (!(error instanceof SkillPacksApiError)) throw error
+      if (error.status === 409) budgetError.value = error.message
+      else if (error.status === 404) {
+        store.markUnavailable()
+        visible.value = false
+      } else fieldError.value = error.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    form,
+    errors,
+    loading,
+    fieldError,
+    budgetError,
+    bodyBytes,
+    handleSubmit
+  }
+}

--- a/src/platform/skills/composables/useSkillPacks.ts
+++ b/src/platform/skills/composables/useSkillPacks.ts
@@ -1,0 +1,78 @@
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { useToastStore } from '@/platform/updates/common/toastStore'
+
+import {
+  deleteSkillPack as deleteSkillPackApi,
+  SkillPacksApiError
+} from '../api/skillsApi'
+import { useSkillPacksStore } from '../stores/skillPacksStore'
+import type { SkillPack } from '../types'
+import { MAX_PACK_COUNT, MAX_TOTAL_BYTES } from '../types'
+
+export function useSkillPacks() {
+  const { t } = useI18n()
+  const toastStore = useToastStore()
+  const store = useSkillPacksStore()
+  const { packs, loading, totalBytes } = storeToRefs(store)
+
+  const operatingPackName = ref<string | null>(null)
+
+  const atPackLimit = computed(() => packs.value.length >= MAX_PACK_COUNT)
+  const atByteLimit = computed(() => totalBytes.value >= MAX_TOTAL_BYTES)
+
+  function reportUnexpected(error: unknown, context: string) {
+    console.error(context, error)
+    toastStore.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail:
+        error instanceof SkillPacksApiError
+          ? error.message
+          : t('g.unknownError')
+    })
+  }
+
+  async function fetchSkillPacks() {
+    try {
+      await store.fetchPacks()
+    } catch (error) {
+      reportUnexpected(error, 'Unexpected error fetching skill packs:')
+    }
+  }
+
+  /**
+   * A 404 here is ambiguous by contract — the pack is already gone, or the
+   * cohort gate is off — so drop the row either way and let the follow-up list
+   * request settle which it was.
+   */
+  async function deleteSkillPack(pack: SkillPack) {
+    operatingPackName.value = pack.name
+    try {
+      await deleteSkillPackApi(pack.name)
+      store.removePack(pack.name)
+    } catch (error) {
+      if (error instanceof SkillPacksApiError && error.status === 404) {
+        store.removePack(pack.name)
+        await fetchSkillPacks()
+        return
+      }
+      reportUnexpected(error, 'Unexpected error deleting skill pack:')
+    } finally {
+      operatingPackName.value = null
+    }
+  }
+
+  return {
+    packs,
+    loading,
+    totalBytes,
+    atPackLimit,
+    atByteLimit,
+    operatingPackName,
+    fetchSkillPacks,
+    deleteSkillPack
+  }
+}

--- a/src/platform/skills/stores/skillPacksStore.test.ts
+++ b/src/platform/skills/stores/skillPacksStore.test.ts
@@ -1,0 +1,92 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { listSkillPacks, SkillPacksApiError } from '../api/skillsApi'
+import type { SkillPack } from '../types'
+import { useSkillPacksStore } from './skillPacksStore'
+
+vi.mock('../api/skillsApi', () => ({
+  listSkillPacks: vi.fn(),
+  SkillPacksApiError: class SkillPacksApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number
+    ) {
+      super(message)
+    }
+  }
+}))
+
+function makePack(overrides: Partial<SkillPack> = {}): SkillPack {
+  return {
+    id: 'pack-1',
+    name: 'my-pack',
+    description: 'load me',
+    body: 'do the thing',
+    body_hash: 'abc',
+    created_at: '2026-08-22T00:00:00Z',
+    updated_at: '2026-08-22T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('skillPacksStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(listSkillPacks).mockReset()
+  })
+
+  it('stays disabled until the cohort flags resolve on', () => {
+    const store = useSkillPacksStore()
+
+    expect(store.enabled).toBe(false)
+
+    store.flagsEnabled = true
+    expect(store.enabled).toBe(true)
+  })
+
+  it('disables the surface when the routes answer 404 at runtime', async () => {
+    vi.mocked(listSkillPacks).mockRejectedValue(
+      new SkillPacksApiError('not found', 404)
+    )
+    const store = useSkillPacksStore()
+    store.flagsEnabled = true
+
+    await store.fetchPacks()
+
+    expect(store.routesAvailable).toBe(false)
+    expect(store.enabled).toBe(false)
+    expect(store.packs).toEqual([])
+  })
+
+  it('rethrows a non-404 failure rather than hiding the surface', async () => {
+    vi.mocked(listSkillPacks).mockRejectedValue(
+      new SkillPacksApiError('boom', 500)
+    )
+    const store = useSkillPacksStore()
+    store.flagsEnabled = true
+
+    await expect(store.fetchPacks()).rejects.toThrow('boom')
+    expect(store.routesAvailable).toBe(true)
+  })
+
+  it('replaces a pack of the same name instead of adding a second one', () => {
+    const store = useSkillPacksStore()
+    store.packs = [makePack({ name: 'a' }), makePack({ id: 'p2', name: 'b' })]
+
+    store.upsertPack(makePack({ id: 'p3', name: 'a', body: 'new text' }))
+
+    expect(store.packs.map((pack) => pack.name)).toEqual(['a', 'b'])
+    expect(store.packs[0].body).toBe('new text')
+  })
+
+  it('totals description plus body across the packs', () => {
+    const store = useSkillPacksStore()
+    store.packs = [
+      makePack({ name: 'a', description: 'ab', body: 'cde' }),
+      makePack({ id: 'p2', name: 'b', description: 'f', body: 'gh' })
+    ]
+
+    expect(store.totalBytes).toBe(8)
+  })
+})

--- a/src/platform/skills/stores/skillPacksStore.ts
+++ b/src/platform/skills/stores/skillPacksStore.ts
@@ -1,0 +1,114 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import { reportError } from '@/platform/telemetry/reportError'
+
+import { listSkillPacks, SkillPacksApiError } from '../api/skillsApi'
+import type { SkillPack } from '../types'
+import { packByteSize } from '../types'
+
+/** The parent gate fronting the whole `/api/agent` surface. */
+const AGENT_EXPERIENCE_FLAG = 'agent-in-app-experience'
+/** The cohort gate fronting the skill-pack CRUD routes specifically. */
+const SKILL_PACKS_FLAG = 'agent-skill-packs'
+
+/**
+ * Shared skill-pack state. It is a store rather than plain composable state
+ * because the settings navigation and the panel have to agree on whether the
+ * surface exists at all: a 404 the panel's own list request discovers has to
+ * remove the nav entry too.
+ */
+export const useSkillPacksStore = defineStore('skillPacks', () => {
+  const packs = ref<SkillPack[]>([])
+  const loading = ref(false)
+  /** Both cohort flags, read from PostHog. Both default off and fail closed. */
+  const flagsEnabled = ref(false)
+  /**
+   * Flipped false by a 404 from the routes, which is how both gates answer when
+   * off — so the flag read at load is never the only signal.
+   */
+  const routesAvailable = ref(true)
+
+  const enabled = computed(() => flagsEnabled.value && routesAvailable.value)
+
+  const totalBytes = computed(() =>
+    packs.value.reduce((sum, pack) => sum + packByteSize(pack), 0)
+  )
+
+  let flagGateStarted = false
+
+  /**
+   * Subscribes to both cohort flags. PostHog is imported lazily so a build with
+   * no PostHog project token never pays for it, matching how the agent panel's
+   * own gate is wired.
+   */
+  async function startFlagGate(): Promise<void> {
+    if (flagGateStarted) return
+    flagGateStarted = true
+    try {
+      const { default: posthog } = await import('posthog-js')
+      const sync = () => {
+        const wasEnabled = flagsEnabled.value
+        flagsEnabled.value =
+          posthog.isFeatureEnabled(AGENT_EXPERIENCE_FLAG) === true &&
+          posthog.isFeatureEnabled(SKILL_PACKS_FLAG) === true
+        // The flags can disagree with the deployed backend, so probe the routes
+        // once rather than advertising a surface that answers 404.
+        if (!wasEnabled && flagsEnabled.value) void fetchPacks().catch(() => {})
+      }
+      posthog.onFeatureFlags((_flags, _variants, context) => {
+        // A pre-init errorsLoading is an error report, not a flag delivery.
+        if (context?.errorsLoading) return
+        sync()
+      })
+      sync()
+    } catch (error) {
+      reportError(error, { errorType: 'agent_skill_packs_flag_gate_failure' })
+    }
+  }
+
+  async function fetchPacks(): Promise<void> {
+    loading.value = true
+    try {
+      packs.value = await listSkillPacks()
+      routesAvailable.value = true
+    } catch (error) {
+      if (error instanceof SkillPacksApiError && error.status === 404) {
+        markUnavailable()
+        return
+      }
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /** Replaces the pack of the same name, mirroring the create-or-replace route. */
+  function upsertPack(pack: SkillPack): void {
+    const rest = packs.value.filter((existing) => existing.name !== pack.name)
+    packs.value = [...rest, pack].sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  function removePack(name: string): void {
+    packs.value = packs.value.filter((pack) => pack.name !== name)
+  }
+
+  function markUnavailable(): void {
+    routesAvailable.value = false
+    packs.value = []
+  }
+
+  return {
+    packs,
+    loading,
+    enabled,
+    flagsEnabled,
+    routesAvailable,
+    totalBytes,
+    startFlagGate,
+    fetchPacks,
+    upsertPack,
+    removePack,
+    markUnavailable
+  }
+})

--- a/src/platform/skills/types.ts
+++ b/src/platform/skills/types.ts
@@ -1,0 +1,75 @@
+import type {
+  AgentSkill,
+  AgentSkillPublishRequest
+} from '@comfyorg/ingest-types'
+
+/**
+ * One of the caller's own skill packs, as returned by `GET /api/agent/skills`.
+ * The list response carries the full `body` on every row, so opening a pack for
+ * editing needs no second fetch — there is no fetch-one endpoint.
+ */
+export type SkillPack = AgentSkill
+
+/** The create-or-replace payload for `POST /api/agent/skills`. */
+export type SkillPackPublishRequest = AgentSkillPublishRequest
+
+/**
+ * Client-side budgets, checked before submit so the user does not discover them
+ * by rejection. The server enforces them too, and its rejection message names
+ * the limit and the overage — which is what the 409 state surfaces verbatim
+ * rather than restating in invented copy.
+ */
+export const MAX_PACK_BODY_BYTES = 10 * 1024
+export const MAX_PACK_COUNT = 5
+export const MAX_TOTAL_BYTES = 25 * 1024
+
+/** `maxLength` from the spec, counted in code points as JSON Schema defines it. */
+export const MAX_DESCRIPTION_CODE_POINTS = 1024
+export const MAX_NAME_LENGTH = 64
+
+/**
+ * Pack names: letters, digits, `.`, `_` and `-`, with at least one character
+ * that is not a dot. The all-dot exclusion is deliberate — `.` and `..` are
+ * path segments a normalizing client rewrites, so such a pack could be created
+ * but never deleted.
+ */
+export const PACK_NAME_PATTERN = /^[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*$/
+
+/**
+ * Built-in always-on packs, whose names the server refuses. The built-in
+ * on-demand packs (`batch-generation`, `comfy-director`) are deliberately
+ * shadowable, so they are not listed here.
+ */
+export const RESERVED_PACK_NAMES = [
+  'building',
+  'comfy-cloud',
+  'canvas-tabs'
+] as const
+
+/**
+ * Control characters, CR and LF included, are refused in the description: it is
+ * a single-line trigger description that rides in every prompt.
+ */
+// eslint-disable-next-line no-control-regex
+export const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/
+
+/** UTF-8 byte length, which is what every byte budget above is counted in. */
+export function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length
+}
+
+/** Code-point count, which is how the spec counts `description`. */
+export function codePointLength(value: string): number {
+  // Code points are exactly the unit the spec counts in, so the decomposition
+  // this rule warns about is the intended behaviour here.
+  // oxlint-disable-next-line no-misused-spread
+  return [...value].length
+}
+
+/** Description + body, the unit the per-user total-bytes budget is counted in. */
+export function packByteSize(pack: {
+  description: string
+  body: string
+}): number {
+  return utf8ByteLength(pack.description) + utf8ByteLength(pack.body)
+}


### PR DESCRIPTION
## ELI-5

You can already teach the agent a preference by hand-crafting HTTP requests against `/api/agent/skills`. This adds the screen for it: a Settings section where you write a pack once, edit it, and delete it. Nobody sees it until the `agent-skill-packs` flag is flipped on.

## Description

Adds `src/platform/skills/`, mirroring the existing user-scoped CRUD settings surface in `src/platform/secrets/` (api module + composables + panel/dialog/list-item, mounted as a settings section through `useSettingUI.ts`).

- `api/skillsApi.ts` — the three operations (`POST` create-or-replace, `GET` list, `DELETE`) through the generated `@comfyorg/ingest-types` bindings (`zAgentSkill`, `zAgentSkillListResponse`). `SkillPacksApiError` carries the status, because the status **is** the error contract here.
- `stores/skillPacksStore.ts` — shared state, because the settings navigation and the panel have to agree on whether the surface exists at all. Holds both cohort flags (read from PostHog) and a `routesAvailable` flag that a runtime 404 clears.
- `composables/useSkillPacks.ts` — list/delete plus toasts. `composables/useSkillPackForm.ts` — client-side validation and the 400-vs-409 split.
- `components/SkillPacksPanel.vue`, `SkillPackFormDialog.vue`, `SkillPackListItem.vue`. Built without PrimeVue (the secrets panel's `TabPanel`/`Divider`/`ProgressSpinner` are grandfathered; new imports are banned), so a plain wrapper, a border-based divider and an iconify spinner.

### The error contract drives different copy

A **400** means the user can edit this request into a valid one — it renders as an inline field error carrying the server's message. A **409** means no edit to *this* pack can make it fit — it renders as a distinct bordered "you are at your limit / remove a pack to make room" block, and surfaces the server's message verbatim, since that message is what names the limit and the overage. A **404** means a cohort gate is off, so the surface disappears rather than showing an error.

### Client-side validation, before any request is sent

Name charset (`^[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*$`, so `.` and `..` are refused) and the 64-character cap; description non-empty, single-line (control characters including CR/LF refused) and within 1024 **code points**; body non-empty and within 10 KiB. Plus the two per-user budgets: 5 packs and 25 KiB of description+body across them, both projected forward so that replacing a pack you already hold does not count the old copy twice.

### Round-trip

The list response carries the full `body` on every row deliberately — there is no fetch-one endpoint — so `openEditDialog` seeds the editor straight from the list row and issues no second request.

### Gating

Both `agent-in-app-experience` and `agent-skill-packs` must resolve true in PostHog (both default off, both fail closed), **and** the routes must not have answered 404. When the flags first resolve on, the store probes the routes once, so a build whose flags disagree with the deployed backend never advertises a nav entry that 404s.

## Judgment calls

- **Client-side reserved-name check is exact-match, not case-insensitive.** Rejecting `Building` client-side when the server may accept it would be the UI denying a capability the product offers, so the check mirrors the three documented always-on names exactly and leaves anything else to the server's 400.
- **The name field is disabled when editing.** Publishing is create-or-replace keyed on name, so allowing a rename in the edit dialog would silently create a second pack and orphan the first.
- **The gate lives in a Pinia store rather than a plain composable.** `platform/` cannot import from `workbench/` under the layer rules, so the store reads both PostHog flags directly instead of reusing the agent panel's `createPostHogFlagSource`; the two flag-name string constants are the only duplication.
- **No `always` field in the form.** The API accepts `always` only so an `always: true` pasted out of a `SKILL.md` frontmatter is refused with an explanation. The form never sends it, and a server 400 about it surfaces like any other field error.

## Residual

- **The last acceptance criterion is unexercised.** "On agent.comfy.org, publish a pack from this UI and confirm the next agent turn can `load_skill` it" is a post-merge manual step against a deployed test environment; this branch was built and verified locally with no access to that environment, so nothing here confirms the publish → `load_skill` loop end to end. Whoever lands this should run it. Everything up to the HTTP boundary is covered by unit tests; nothing verifies the deployed backend actually accepts these payloads.
- **The API contract was read from the generated types in this repo, not from the service.** `packages/ingest-types` on `main` carries `AgentSkill`, `AgentSkillPublishRequest`, `AgentSkillListResponse` and the request/response bindings for all three operations, and the per-status semantics (which 404 is gate-off vs. no-such-pack, which body shape each raises) come from those generated doc comments. The upstream `services/ingest/openapi.yaml` and `server.go` live in another repo and were not read.
- **The three byte budgets are hard-coded client-side.** The spec says the exact limits are deployment configuration and are only named in the server's rejection message. 10 KiB / 5 packs / 25 KiB are taken from the ticket. If a deployment configures them differently the client pre-check drifts from the server, in which case the 409 path still renders correctly but the pre-check either blocks early or lets a request through to be rejected. A follow-up could read the limits off a config endpoint if one is added.
- **`DELETE` 404 is treated as "already gone".** The contract makes that status ambiguous between no-such-pack and gate-off, and the two differ only by body shape. Rather than shape-sniff, the row is dropped and a list refresh settles which it was — a gate-off then removes the whole surface on the next request. This is correct but means one extra request on that path.
- **No E2E coverage.** The surface is flag-gated off by default, so a Playwright spec would need a feature-flag fixture plus API mocks for three routes; that was left out of this PR to keep it reviewable. Unit coverage is 23 tests across the store, the form composable and the panel.
- **Design is the plain secrets-panel idiom, by decision, not by omission.** The ticket names richer editing and placement changes as a later design pass.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `vitest run src/platform/skills`: 23 passed, 0 failed; `vitest run src/platform/settings`: 148 passed across both paths, 0 failed; `pnpm typecheck`: clean; `pnpm lint` (stylelint + oxlint --type-aware + eslint): clean; `pnpm exec knip`: clean; pre-commit lint-staged (oxfmt + lint + typecheck) passed on the staged set.
- **Deviations:** the final acceptance criterion (manual publish → `load_skill` on agent.comfy.org) was not exercised — see `## Residual`.
