### PR TITLE
fix: custom-node E2E S9 TypeError and stale detection-proof patches

### DIFF
--- a/browser_tests/fixtures/customNode/allNodesExecutionTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesExecutionTier.ts
@@ -307,7 +307,7 @@ async function runBatch(
 ): Promise<string> {
   const batchWithInputs = batch.map((spec) => ({
     ...spec,
-    widgetInputs: packLedgerFor(AUTO_RUN_WIDGET_INPUTS, pack)[spec.key]
+    widgetInputs: packLedgerFor(AUTO_RUN_WIDGET_INPUTS, pack)[spec.key] ?? {}
   }))
   const { ids, allIds, nodeIdByKey, sinkIdByKey } = await page.evaluate(
     ([nodes, producers, spacingY]) => {

--- a/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
@@ -1,22 +1,23 @@
-diff --git a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-index e7e5549d59..4ca1314e3c 100644
---- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
-@@ -316,4 +316,17 @@ export function computeProcessedWidgets({
-     isVisible: visible,
-     identity: { renderKey }
-   } of uniqueWidgets) {
-+    // DETECTION PROOF (row 2, mount v2): hide ImpactInt's value widget only
-+    // in Vue Nodes. Expected: S2 red and every other tier remains green.
-+    const detectionProofTier = (
-+      globalThis as {
-+        __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
-+      }
-+    ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
-+    if (
-+      detectionProofTier === 'S2' &&
-+      nodeData.type === 'ImpactInt' &&
-+      widget.name === 'value'
-+    )
-+      continue
-     const bareWidgetId = stripGraphPrefix(widget.nodeId ?? nodeId)
+diff --git a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+index 7353a17825..728dc02cec 100644
+--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
++++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+@@ -356,6 +356,18 @@ function processWidget(
+   const widgetState = ctx.widgetValueStore.getWidget(id)
+   if (!widgetState) return null
+ 
++  const detectionProofTier = (
++    globalThis as {
++      __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
++    }
++  ).__COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__
++  if (
++    detectionProofTier === 'S2' &&
++    ctx.nodeData.type === 'ImpactInt' &&
++    widgetState.name === 'value'
++  )
++    return null
++
+   const liveWidget = ctx.liveWidgets.get(id)
+   const type = liveWidget?.type ?? widgetState.type
+   const renderState = ctx.widgetValueStore.getWidgetRenderState(id)

--- a/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
+++ b/browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
@@ -1,14 +1,11 @@
 diff --git a/src/lib/litegraph/src/LGraphNode.ts b/src/lib/litegraph/src/LGraphNode.ts
-index a928d93992..65563d0dd2 100644
+index 3fb1eec569..d423d34829 100644
 --- a/src/lib/litegraph/src/LGraphNode.ts
 +++ b/src/lib/litegraph/src/LGraphNode.ts
-@@ -987,7 +987,20 @@ export class LGraphNode
-         let i = 0
-         for (const widget of this.widgets ?? []) {
+@@ -1191,6 +1191,17 @@ export class LGraphNode
+         let positionalIndex = 0
+         for (const widget of this.widgets) {
            if (widget.serialize === false) continue
--          if (i >= info.widgets_values.length) break
-+          // DETECTION PROOF (row 3, persistence): ImpactInt drops its last
-+          // widget value. Expected: S3 red and every other tier remains green.
 +          const detectionProofTier = (
 +            globalThis as {
 +              __COMFY_CUSTOM_NODE_DETECTION_PROOF_TIER__?: string
@@ -17,10 +14,9 @@ index a928d93992..65563d0dd2 100644
 +          if (
 +            detectionProofTier === 'S3' &&
 +            this.type === 'ImpactInt' &&
-+            i >= info.widgets_values.length - 1
++            positionalIndex >= (info.widgets_values ?? []).length - 1
 +          )
 +            break
-+          if (i >= info.widgets_values.length) break
-           widget.value = info.widgets_values[i++]
-         }
-       }
+           const restored = useWidgetValueStore().getRestoredWidgetValue(
+             graphId,
+             this.id,

--- a/scripts/cicd/custom-node-proof.test.ts
+++ b/scripts/cicd/custom-node-proof.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { mutateExecutionSource, proofIdentity } from './custom-node-proof'
@@ -42,5 +46,26 @@ NODE_CLASS_MAPPINGS = {"VHS_LoadAudioUpload": LoadAudioUpload}
         mutationDigest: 'bad'
       })
     ).toThrow(/digest/)
+  })
+
+  it('source patches apply to current src/', () => {
+    const directory = join(
+      'browser_tests',
+      'tests',
+      'customNodes',
+      'detection-proof'
+    )
+    const patches = readdirSync(directory).filter((name) =>
+      name.endsWith('.patch')
+    )
+    expect(patches.length).toBeGreaterThan(0)
+    for (const entry of patches) {
+      const result = spawnSync(
+        'git',
+        ['apply', '--check', join(directory, entry)],
+        { encoding: 'utf8' }
+      )
+      expect(result.status, `${entry}: ${result.stderr}`).toBe(0)
+    }
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Draft — do not mark ready.** Do not enable auto-merge. Custom Nodes nightly does not run on PRs; humans must dispatch the verify path below.

Supersedes conflicting #17067 (same S9/`?? {}` + row-02/row-03 retarget, rebased onto `main` tip `fc793a4e0e`). Does not reopen #16537. NumberWidget/`toFixed` is **not** in this PR: tip already routes display through `formatNumericWidgetValue` / `coerceNumericWidgetValue`, and nightly [34210213667](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34210213667) S3 packs (including VueNodes=false) were already green.

## Summary

Restores the S9 evaluate payload default and retargets two stale detection-proof patches so Custom Nodes nightly can apply its independence proofs again.

## Characterization

| Mode | Proof | Broken on tip `fc793a4e0e` | Change | Root cause |
| --- | --- | --- | --- | --- |
| S9 | `allNodes.spec.ts:61` / `allNodesExecutionTier.ts:329` `Object.entries(spec.widgetInputs)` | `TypeError: Cannot convert undefined or null to object` on KJNodes, essentials, VideoHelperSuite / `comfyui-videohelpersuite`, Custom-Scripts ([run 34210213667](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34210213667) shards `(2/5, 0)`, `(core:1/2, 0)`, `(core:2/2, 0)`, `(2/5, 9)`) | `allNodesExecutionTier.ts:310` default missing ledger rows to `{}` | `#16802` deleted `spec.widgetInputs ?? {}`. `AUTO_RUN_WIDGET_INPUTS` only lists Impact-Pack + VHS upload widgets; other runnable nodes have no row. Playwright evaluate drops `undefined`, so `Object.entries` throws. |
| Detection-proof row-02 | `git apply --check …/row-02-mount-v2-vue-widget-dropped.patch` | Fails on `useProcessedWidgets.ts:316`; nightly `(4/5, 2)` `git apply --check … exited 1` | Retarget to `processWidget` at `processedWidgetRenderModel.ts:356` | Stale hunk after `computeProcessedWidgets` moved. Not product. |
| Detection-proof row-03 | `git apply --check …/row-03-persistence-offbyone.patch` | Fails on `LGraphNode.ts:987`; nightly `(4/5, 3)` `git apply --check … exited 1` | Retarget to `LGraphNode.ts:1191` (`positionalIndex` restore) | Stale hunk; restore now lives at the widgetValueStore loop. Not product. |
| S3 / `toFixed` | Nightly S3 on the same run | Already green (`basic_data_handling`, KJNodes, essentials, VHS, Custom-Scripts, …) | None | Tip already coerces at `NumberWidget._displayValue`. Re-applying `#17067`'s `Number(value).toFixed` hunk would conflict and change nothing. |

No product behavior change for numeric values that are already numbers, or for nodes that already have ledger rows.

## Changes

- **What**: Default missing S9 `widgetInputs` to `{}` at the payload build site; retarget row-02/row-03; add `git apply --check` coverage so the next src move fails in unit instead of nightly.
- **Breaking**: none

## Review Focus

The `?? {}` belongs at `allNodesExecutionTier.ts:310`, not at `Object.entries`. Playwright's evaluate serialization is the boundary: `undefined` never arrives in the page. Do not delete the default again because the `Record` index type looks always-defined — that is the `#16802` hole.

## Test Plan

- [x] `git apply --check` on all four detection-proof source patches (also `git apply` in a throwaway worktree; each changes `src/`)
- [x] `pnpm test:unit scripts/cicd/custom-node-proof.test.ts` — 3 passed
- [x] `pnpm lint` (Node 25) — 0 errors
- [x] `pnpm typecheck` — green
- [x] `pnpm format:check` — green
- [ ] Nightly / dispatch Custom Nodes path below (`CI: Tests Custom Nodes` does not run on PRs)

## Verify (human)

From repo root on this branch:

```bash
git apply --check browser_tests/tests/customNodes/detection-proof/row-02-mount-v2-vue-widget-dropped.patch
git apply --check browser_tests/tests/customNodes/detection-proof/row-03-persistence-offbyone.patch
pnpm test:unit scripts/cicd/custom-node-proof.test.ts
pnpm lint
pnpm typecheck
```

Expected: both `git apply --check` commands exit 0; the proof unit file is green (3 tests, including source patches apply); lint and typecheck green.

Focused Custom Nodes path (Actions → **CI: Tests Custom Nodes** → Run workflow), `branch` = `cursor/custom-nodes-e2e-s9-887e`:

- `detection_proof_row=9` — S9 witness shard. Expected: suite green except the deliberate VHS execution break; independence assert passes.
- `detection_proof_row=2` and `3` — patches apply; S2/S3 witness red and every other tier on that shard stays green.
- `detection_proof_row=0` on `core:1/2` and `2/5` — S9 (and S3, including VueNodes=false console) green.

Expected: those shards/cases green; no other product behavior change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e828094a-0949-4607-a4df-b6104b94887e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e828094a-0949-4607-a4df-b6104b94887e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

