### PR TITLE
assetDeletionEnabled only changes message

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3933,8 +3933,9 @@
     "assetsDeleted": "{n} / {total} assets were deleted",
     "jobsDeleted": "{n} / {total} jobs were deleted",
     "deleteItems": "Delete these items",
-    "deletePermanent": "They will be permanently removed.",
     "deleteHistoryOnly": "Only history will be affected, files will remain on disk",
+    "deletePermanent": "They will be permanently removed.",
+    "deleteTombstone": "They will no longer display in ComfyUI, but will remain on disk",
     "deletingImportedFilesCloudOnly": "Deleting imported files is only supported in cloud version",
     "deletionUnsupported": "Assets are enabled, but server doesn't support deletion",
     "actions": {

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -646,15 +646,6 @@ export function useMediaAssetActions() {
         })
         return uniqBy(operations, (op) => op.id)
       }
-      if (!flags.assetDeletionEnabled) {
-        toast.add({
-          detail: t('mediaAsset.deletionUnsupported'),
-          life: 5000,
-          severity: 'error',
-          summary: t('g.error')
-        })
-        return []
-      }
       return assets.flatMap((asset) => {
         const markDeletionId = asset.id
         const metadata = getOutputAssetMetadata(asset.user_metadata)
@@ -769,9 +760,11 @@ export function useMediaAssetActions() {
     const deleteConfirmed = await dialogService.confirm({
       title: t('mediaAsset.deleteItems'),
       type: 'delete',
-      message: plannedAssetCount
-        ? t('mediaAsset.deletePermanent')
-        : t('mediaAsset.deleteHistoryOnly'),
+      message: !plannedAssetCount
+        ? t('mediaAsset.deleteHistoryOnly')
+        : flags.assetDeletionEnabled
+          ? t('mediaAsset.deletePermanent')
+          : t('mediaAsset.deleteTombstone'),
       itemList: deletionPlan.flatMap(getNames)
     })
     if (!deleteConfirmed) return false


### PR DESCRIPTION
The local backend implementation has been updated such that performing a delete operation is allowed but will leave the file on disk. Accordingly, the frontend will no longer skip the actual deletion request when `!flags.assetDeletionEnabled`. Instead a modified confirmation is displayed that states the files will remain on disk.