### PR TITLE
fix(agent): put drag-in-assets before the clickable mention-nodes placeholder segment

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5176,7 +5176,7 @@
     "gotIt": "Got it",
     "greeting": "Hello {name},",
     "greetingQuestion": "What do you want to make?",
-    "placeholder": "Describe ideas, {'@'} to reference,\nmention nodes from graph or drag in assets",
+    "placeholder": "Describe ideas, {'@'} to reference workflows, drag in media asset and files, or\nmention nodes",
     "suggestedPrompts": [
       "Generate a yellow duck with a hockey mask",
       "List my saved workflows",

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -54,15 +54,20 @@ describe('Composer', () => {
   it('T-21 / PM-678 / FE-1325 hints at ideas, canvas references, and dragged assets', () => {
     mount()
 
-    expect(screen.getByText('Describe ideas, @ to reference,')).toBeVisible()
+    const text = screen.getByText(
+      'Describe ideas, @ to reference workflows, drag in media asset and files, or'
+    )
+    expect(text).toBeVisible()
     const addNodes = screen.getByRole('button', {
-      name: 'mention nodes from graph,'
+      name: 'mention nodes'
     })
     expect(addNodes).toBeVisible()
     expect(addNodes).toContainHTML(
       '<span class="icon-[lucide--mouse-pointer-click] size-[14px] shrink-0"></span>'
     )
-    expect(screen.getByText('or drag in assets')).toBeVisible()
+    expect(
+      text.compareDocumentPosition(addNodes) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   it('hides the empty-composer hint once typing begins', async () => {
@@ -72,16 +77,14 @@ describe('Composer', () => {
     await userEvent.type(box, 'hello')
 
     expect((box as HTMLTextAreaElement).value).toBe('hello')
-    expect(
-      screen.queryByRole('button', { name: 'mention nodes from graph,' })
-    ).toBeNull()
+    expect(screen.queryByRole('button', { name: 'mention nodes' })).toBeNull()
   })
 
   it('enters graph selection mode from the empty-composer hint', async () => {
     const getMentionNodes = vi.fn(() => [])
     const { emitted } = mount({ getMentionNodes })
     const hintButton = screen.getByRole('button', {
-      name: 'mention nodes from graph,'
+      name: 'mention nodes'
     })
 
     await userEvent.tab()

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -270,13 +270,8 @@ watch(mentionActive, async () => {
 const { t } = useI18n()
 
 const placeholderHint = computed(() => {
-  const [firstLine = '', secondLine = ''] = t('agent.placeholder').split('\n')
-  const addNodes = t('agent.addNodesFromGraph').toLocaleLowerCase()
-  return {
-    firstLine,
-    addNodes,
-    dragAssets: secondLine.slice(addNodes.length).trim()
-  }
+  const [text = '', mentionNodes = ''] = t('agent.placeholder').split('\n')
+  return { text, mentionNodes }
 })
 
 const composer = useComposer({
@@ -477,20 +472,19 @@ defineExpose({
           v-if="!composer.draft.value"
           class="text-agent-fg-muted pointer-events-none absolute inset-x-[12px] top-[8px] z-10 font-inter text-[14px]/[20px] font-normal"
         >
-          <span>{{ placeholderHint.firstLine }}</span>
+          <span>{{ placeholderHint.text }} </span>
           <button
             type="button"
-            class="text-agent-fg-muted hover:text-agent-fg focus-visible:text-agent-fg focus-visible:outline-agent-fg pointer-events-auto mr-[4px] ml-[-5px] inline-flex h-[20px] shrink-0 cursor-pointer items-center gap-[4px] rounded-[8px] px-[4px] align-top text-[14px]/[20px] transition-colors focus-visible:outline-1"
+            class="text-agent-fg-muted hover:text-agent-fg focus-visible:text-agent-fg focus-visible:outline-agent-fg pointer-events-auto -ml-1 inline-flex h-[20px] shrink-0 cursor-pointer items-center gap-[4px] rounded-[8px] px-[4px] align-top text-[14px]/[20px] transition-colors focus-visible:outline-1"
             @click="emit('selectNodes')"
           >
             <span
               class="icon-[lucide--mouse-pointer-click] size-[14px] shrink-0"
             />
-            <span class="underline decoration-dashed underline-offset-2"
-              >{{ placeholderHint.addNodes }},</span
-            >
+            <span class="underline decoration-dashed underline-offset-2">{{
+              placeholderHint.mentionNodes
+            }}</span>
           </button>
-          <span>{{ placeholderHint.dragAssets }}</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Reorders the agent composer placeholder so "drag in media asset and files" comes before the clickable "mention nodes" segment, which now sits at the end of the sentence. Fixes the misclick reported in [PM-855](https://linear.app/comfyorg/issue/PM-855) (fast clicks on the empty composer landed on the clickable segment and entered node-selection mode) and completes the placeholder half of [PM-952](https://linear.app/comfyorg/issue/PM-952) tracked as [PM-991](https://linear.app/comfyorg/issue/PM-991).

## Changes

- **What**: `agent.placeholder` now reads "Describe ideas, @ to reference workflows, drag in media asset and files, or mention nodes". The string is two `\n` segments: plain text, then the button label. `placeholderHint` returns them directly and no longer slices `agent.addNodesFromGraph` off the second line. In the template the plain span comes first and the existing `selectNodes` button is the last child; the hard-coded trailing comma is gone and the button margin is `-ml-1` so the gap reads as one space inline and the icon aligns to the text edge on wrap.
- English locale only; other locales are regenerated by the i18n workflow.

## Review Focus

- The plain span keeps a trailing space on purpose. Vue condenses whitespace between elements, and without it "or" and the button run together.
- `Composer.test.ts`: literal placeholder and button-name assertions updated, plus one document-order assertion that the button follows the text. The `selectNodes` emit test is unchanged. 46/46 pass locally.
- No change to `agent.addNodesFromGraph`, the node-selection banner title, or the "+" menu (those landed in #17149).
