### PR TITLE
test: migrate platform mocks to import()

### DIFF
--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -7,11 +7,11 @@ const mockAuthState = vi.hoisted(() => ({
 }))
 const originalFetch = globalThis.fetch
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: true
 }))
 
-vi.mock('@/stores/authStore', () => ({
+vi.mock<unknown>(import('@/stores/authStore'), () => ({
   useAuthStore: () => ({
     getIdToken: mockGetIdToken,
     getAuthHeader: mockGetAuthHeader,
@@ -21,14 +21,14 @@ vi.mock('@/stores/authStore', () => ({
   })
 }))
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: (path: string) => `/api${path}`
   }
 }))
 
 const mockReportError = vi.fn()
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -13,17 +13,20 @@ const { mockRemint, mockTrackUnifiedAuthRetry, flagState } = vi.hoisted(() => ({
   flagState: { unifiedCloudAuthEnabled: true }
 }))
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackUnifiedAuthRetry: mockTrackUnifiedAuthRetry
   })
 }))
 
-vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
-  useWorkspaceAuthStore: () => ({ remintUnifiedOnce: mockRemint })
-}))
+vi.mock<unknown>(
+  import('@/platform/workspace/stores/workspaceAuthStore'),
+  () => ({
+    useWorkspaceAuthStore: () => ({ remintUnifiedOnce: mockRemint })
+  })
+)
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: {
       get unifiedCloudAuthEnabled() {
@@ -35,7 +38,7 @@ vi.mock('@/composables/useFeatureFlags', () => ({
 
 // The axios interceptor gates on shouldRemintCloudRequest(), which is a no-op
 // off-cloud; the unit env is not a cloud build, so force it on.
-vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
 
 describe('fetchWithUnifiedRemint', () => {
   const ok = { status: 200 } as Response

--- a/src/platform/distribution/cloudPreviewUtil.test.ts
+++ b/src/platform/distribution/cloudPreviewUtil.test.ts
@@ -4,7 +4,7 @@ import { appendCloudResParam } from './cloudPreviewUtil'
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
 
-vi.mock('./types', () => ({
+vi.mock(import('./types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }

--- a/src/platform/keybindings/keybindingService.canvas.test.ts
+++ b/src/platform/keybindings/keybindingService.canvas.test.ts
@@ -4,13 +4,13 @@ import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(() => ({
     get: vi.fn(() => [])
   }))
 }))
 
-vi.mock('@/stores/dialogStore', () => ({
+vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
   useDialogStore: vi.fn(() => ({
     dialogStack: []
   }))

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -21,20 +21,20 @@ function createTestDialogInstance(
   }
 }
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(() => ({
     get: vi.fn(() => [])
   }))
 }))
 
-vi.mock('@/stores/dialogStore', () => {
+vi.mock<unknown>(import('@/stores/dialogStore'), () => {
   const dialogStack = reactive<DialogInstance[]>([])
   return {
     useDialogStore: () => ({ dialogStack })
   }
 })
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: null
   }

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -26,20 +26,20 @@ function createTestDialogInstance(
   }
 }
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(() => ({
     get: vi.fn(() => [])
   }))
 }))
 
-vi.mock('@/stores/dialogStore', () => {
+vi.mock<unknown>(import('@/stores/dialogStore'), () => {
   const dialogStack = reactive<DialogInstance[]>([])
   return {
     useDialogStore: () => ({ dialogStack })
   }
 })
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: null
   }

--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -9,7 +9,7 @@ const settings = vi.hoisted(() => ({
   values: {} as Record<string, unknown>
 }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(() => ({
     get: vi.fn((key: string) => settings.values[key] ?? [])
   }))

--- a/src/platform/keybindings/presetService.test.ts
+++ b/src/platform/keybindings/presetService.test.ts
@@ -30,19 +30,19 @@ const mockPersistUserKeybindings = vi.hoisted(() =>
   vi.fn(async () => undefined)
 )
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: mockApi
 }))
 
-vi.mock('@/base/common/downloadUtil', () => ({
+vi.mock(import('@/base/common/downloadUtil'), () => ({
   downloadBlob: mockDownloadBlob
 }))
 
-vi.mock('@/scripts/utils', () => ({
+vi.mock(import('@/scripts/utils'), () => ({
   uploadFile: mockUploadFile
 }))
 
-vi.mock('@/services/dialogService', () => ({
+vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     confirm: mockConfirm,
     prompt: mockPrompt,
@@ -50,20 +50,20 @@ vi.mock('@/services/dialogService', () => ({
   })
 }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     set: mockSettingSet,
     get: vi.fn(() => 'default')
   })
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
+vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
   useToastStore: () => ({
     add: mockToastAdd
   })
 }))
 
-vi.mock('@/composables/useErrorHandling', () => ({
+vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: () => ({
     wrapWithErrorHandling: <T extends (...args: unknown[]) => unknown>(fn: T) =>
       fn,
@@ -74,13 +74,13 @@ vi.mock('@/composables/useErrorHandling', () => ({
   })
 }))
 
-vi.mock('@/platform/keybindings/keybindingService', () => ({
+vi.mock<unknown>(import('@/platform/keybindings/keybindingService'), () => ({
   useKeybindingService: () => ({
     persistUserKeybindings: mockPersistUserKeybindings
   })
 }))
 
-vi.mock('@/stores/dialogStore', () => ({
+vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
   useDialogStore: () => ({
     showDialog: vi.fn(),
     closeDialog: vi.fn(),
@@ -88,7 +88,7 @@ vi.mock('@/stores/dialogStore', () => ({
   })
 }))
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 

--- a/src/platform/missingMedia/components/MissingMediaCard.test.ts
+++ b/src/platform/missingMedia/components/MissingMediaCard.test.ts
@@ -8,11 +8,11 @@ import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import MissingMediaCard from './MissingMediaCard.vue'
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: {} }
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   getNodeByExecutionId: vi.fn()
 }))
 

--- a/src/platform/missingMedia/missingMediaAssetResolver.test.ts
+++ b/src/platform/missingMedia/missingMediaAssetResolver.test.ts
@@ -19,11 +19,11 @@ const { mockFetchHistoryPage } = vi.hoisted(() => ({
   mockFetchHistoryPage: vi.fn()
 }))
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({ flags: { assetsEnabled: true } })
 }))
 
-vi.mock('@/platform/assets/services/assetService', async () => {
+vi.mock(import('@/platform/assets/services/assetService'), async () => {
   const actual = await vi.importActual<typeof AssetServiceModule>(
     '@/platform/assets/services/assetService'
   )
@@ -38,7 +38,7 @@ vi.mock('@/platform/assets/services/assetService', async () => {
   }
 })
 
-vi.mock('@/platform/remote/comfyui/jobs/fetchJobs', async () => {
+vi.mock(import('@/platform/remote/comfyui/jobs/fetchJobs'), async () => {
   const actual = await vi.importActual<typeof FetchJobsModule>(
     '@/platform/remote/comfyui/jobs/fetchJobs'
   )

--- a/src/platform/missingMedia/missingMediaPipeline.test.ts
+++ b/src/platform/missingMedia/missingMediaPipeline.test.ts
@@ -22,7 +22,7 @@ const { activeWorkflow } = vi.hoisted(() => {
 
 // The real store reaches authStore -> firebase setPersistence, which has no
 // config under vitest. Mirrors missingModelPipeline.test.ts.
-vi.mock('@/stores/workspaceStore', () => ({
+vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
   useWorkspaceStore: () => ({ workflow: { activeWorkflow } })
 }))
 

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -38,7 +38,7 @@ const { mockFetchHistoryPage } = vi.hoisted(() => ({
   mockFetchHistoryPage: vi.fn()
 }))
 
-vi.mock('@/utils/graphTraversalUtil', async (importActual) => {
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), async (importActual) => {
   const actual = await importActual<typeof GraphTraversalUtil>()
   type TestNode = LGraphNode & { _testExecutionId?: string }
   type TestGraph = { _testNodes: TestNode[] }
@@ -74,11 +74,11 @@ vi.mock('@/utils/graphTraversalUtil', async (importActual) => {
   }
 })
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({ flags: { assetsEnabled: true } })
 }))
 
-vi.mock('@/platform/assets/services/assetService', async () => {
+vi.mock(import('@/platform/assets/services/assetService'), async () => {
   const actual = await vi.importActual<typeof AssetServiceModule>(
     '@/platform/assets/services/assetService'
   )
@@ -93,7 +93,7 @@ vi.mock('@/platform/assets/services/assetService', async () => {
   }
 })
 
-vi.mock('@/platform/remote/comfyui/jobs/fetchJobs', async () => {
+vi.mock(import('@/platform/remote/comfyui/jobs/fetchJobs'), async () => {
   const actual = await vi.importActual<typeof FetchJobsModule>(
     '@/platform/remote/comfyui/jobs/fetchJobs'
   )

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -6,19 +6,22 @@ import { useMissingMediaStore } from './missingMediaStore'
 import type { MissingMediaCandidate } from './types'
 
 // Mock dependencies
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => ({
-    currentGraph: null
+vi.mock<unknown>(
+  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
+  () => ({
+    useCanvasStore: () => ({
+      currentGraph: null
+    })
   })
-}))
+)
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     rootGraph: null
   }
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   getActiveGraphNodeIds: () => new Set<string>()
 }))
 

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -16,7 +16,7 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 
 const mockDownloadModel = vi.hoisted(() => vi.fn())
 
-vi.mock('@/platform/missingModel/missingModelDownload', async () => {
+vi.mock(import('@/platform/missingModel/missingModelDownload'), async () => {
   const actual = await vi.importActual<typeof MissingModelDownload>(
     '@/platform/missingModel/missingModelDownload'
   )
@@ -26,7 +26,7 @@ vi.mock('@/platform/missingModel/missingModelDownload', async () => {
   }
 })
 
-vi.mock('./MissingModelRow.vue', () => ({
+vi.mock<unknown>(import('./MissingModelRow.vue'), () => ({
   default: {
     name: 'MissingModelRow',
     template: `
@@ -52,7 +52,7 @@ vi.mock('./MissingModelRow.vue', () => ({
 }))
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -39,7 +39,7 @@ const mockUploadCallbacks = vi.hoisted(() => ({
     | undefined
 }))
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     get rootGraph() {
       return mockRootGraph.value
@@ -47,7 +47,7 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     addEventListener: vi.fn(
       (event: string, handler: (event: CustomEvent) => void) => {
@@ -60,7 +60,7 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-vi.mock('@/utils/graphTraversalUtil', async () => {
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), async () => {
   const actual = await vi.importActual<typeof GraphTraversalUtil>(
     '@/utils/graphTraversalUtil'
   )
@@ -71,7 +71,7 @@ vi.mock('@/utils/graphTraversalUtil', async () => {
   }
 })
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   },
@@ -80,31 +80,36 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-vi.mock('@/platform/assets/composables/useModelUpload', () => ({
-  useModelUpload: (
-    onUploadSuccess?: (
-      result: UploadModelSuccess
-    ) => Promise<unknown> | unknown,
-    uploadContext?: UploadModelDialogContext | UploadModelContextResolver
-  ) => {
-    mockUploadCallbacks.onUploadSuccess = onUploadSuccess
-    mockUploadContext.resolver =
-      typeof uploadContext === 'function' ? uploadContext : () => uploadContext
+vi.mock<unknown>(
+  import('@/platform/assets/composables/useModelUpload'),
+  () => ({
+    useModelUpload: (
+      onUploadSuccess?: (
+        result: UploadModelSuccess
+      ) => Promise<unknown> | unknown,
+      uploadContext?: UploadModelDialogContext | UploadModelContextResolver
+    ) => {
+      mockUploadCallbacks.onUploadSuccess = onUploadSuccess
+      mockUploadContext.resolver =
+        typeof uploadContext === 'function'
+          ? uploadContext
+          : () => uploadContext
 
-    return {
-      isUploadButtonEnabled: { value: true },
-      showUploadDialog: mockShowUploadDialog
+      return {
+        isUploadButtonEnabled: { value: true },
+        showUploadDialog: mockShowUploadDialog
+      }
     }
-  }
-}))
+  })
+)
 
-vi.mock('@/composables/useCopyToClipboard', () => ({
+vi.mock(import('@/composables/useCopyToClipboard'), () => ({
   useCopyToClipboard: () => ({
     copyToClipboard: mockCopyToClipboard
   })
 }))
 
-vi.mock('@/platform/missingModel/missingModelDownload', async () => {
+vi.mock(import('@/platform/missingModel/missingModelDownload'), async () => {
   const actual = await vi.importActual<typeof MissingModelDownload>(
     '@/platform/missingModel/missingModelDownload'
   )

--- a/src/platform/missingModel/composables/useMissingModelDownload.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   openGatedRepoPage: vi.fn<typeof MissingModelDownload.openGatedRepoPage>()
 }))
 
-vi.mock('@/platform/missingModel/missingModelDownload', () => ({
+vi.mock(import('@/platform/missingModel/missingModelDownload'), () => ({
   downloadModel: mocks.downloadModel,
   fetchModelMetadata: mocks.fetchModelMetadata,
   isTrustedHuggingFaceUrl: mocks.isTrustedHuggingFaceUrl,

--- a/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
@@ -16,31 +16,35 @@ const mockDownloadList = vi.fn(
   (): Array<{ taskId: string; status: string }> => []
 )
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     rootGraph: null
   }
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   getNodeByExecutionId: (...args: unknown[]) =>
     mockGetNodeByExecutionId(...args)
 }))
 
-vi.mock('@/utils/nodeTitleUtil', () => ({
+vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: (...args: unknown[]) =>
     mockResolveNodeDisplayName(...args)
 }))
 
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => ({})
-}))
+vi.mock<unknown>(
+  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
 
-vi.mock('@/stores/assetsStore', () => ({
+  () => ({
+    useCanvasStore: () => ({})
+  })
+)
+
+vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
   useAssetsStore: () => ({
     updateModelsForNodeType: mockUpdateModelsForNodeType,
     invalidateModelsForCategory: mockInvalidateModelsForCategory,
@@ -48,7 +52,7 @@ vi.mock('@/stores/assetsStore', () => ({
   })
 }))
 
-vi.mock('@/stores/assetDownloadStore', () => ({
+vi.mock<unknown>(import('@/stores/assetDownloadStore'), () => ({
   useAssetDownloadStore: () => ({
     get downloadList() {
       return mockDownloadList()
@@ -57,7 +61,7 @@ vi.mock('@/stores/assetDownloadStore', () => ({
   })
 }))
 
-vi.mock('@/stores/modelToNodeStore', () => ({
+vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
   useModelToNodeStore: () => ({
     getAllNodeProviders: mockGetAllNodeProviders
   })

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -18,19 +18,19 @@ const { fetchMock, mockIsDesktop, mockSidebarTabStore, mockStartDownload } =
     mockStartDownload: vi.fn()
   }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isDesktop() {
     return mockIsDesktop.value
   }
 }))
 
-vi.mock('@/stores/electronDownloadStore', () => ({
+vi.mock<unknown>(import('@/stores/electronDownloadStore'), () => ({
   useElectronDownloadStore: () => ({
     start: mockStartDownload
   })
 }))
 
-vi.mock('@/stores/workspace/sidebarTabStore', () => ({
+vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
   useSidebarTabStore: () => mockSidebarTabStore
 }))
 

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -86,32 +86,32 @@ const { mockHandles } = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
-vi.mock('@/platform/assets/services/assetService', () => ({
+vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   assetService: {
     shouldUseAssetBrowser: (nodeType: string, widgetName: string) =>
       mockHandles.assetService.shouldUseAssetBrowser(nodeType, widgetName)
   }
 }))
 
-vi.mock('@/stores/workspaceStore', () => ({
+vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
   useWorkspaceStore: () => ({
     workflow: mockHandles.workspaceWorkflow
   })
 }))
 
-vi.mock('@/stores/executionErrorStore', () => ({
+vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
   useExecutionErrorStore: () => mockHandles.executionErrorStore
 }))
 
-vi.mock('@/stores/modelToNodeStore', () => ({
+vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
   useModelToNodeStore: () => mockHandles.modelToNodeStore
 }))
 
-vi.mock('@/platform/missingModel/missingModelScan', () => ({
+vi.mock<unknown>(import('@/platform/missingModel/missingModelScan'), () => ({
   scanAllModelCandidates: (
     graph: LGraph,
     isAssetSupported: (nodeType: string, widgetName: string) => boolean,
@@ -128,21 +128,21 @@ vi.mock('@/platform/missingModel/missingModelScan', () => ({
   ) => mockHandles.verifyAssetSupportedCandidates(candidates, signal)
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
+vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
   useToastStore: () => mockHandles.toastStore
 }))
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     getFolderPaths: () => mockHandles.api.getFolderPaths()
   }
 }))
 
-vi.mock('@/platform/missingModel/missingModelDownload', () => ({
+vi.mock(import('@/platform/missingModel/missingModelDownload'), () => ({
   fetchModelMetadata: (url: string) => mockHandles.fetchModelMetadata(url)
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   isAncestorPathActive: (graph: LGraph, nodeId: string) =>
     mockHandles.isAncestorPathActive(graph, nodeId),
   isCandidateScopeActive: (graph: LGraph, candidate: MissingModelCandidate) =>

--- a/src/platform/missingModel/missingModelScan.test.ts
+++ b/src/platform/missingModel/missingModelScan.test.ts
@@ -25,7 +25,7 @@ type TestNode = Omit<LGraphNode, 'constructor'> & {
   _testExecutionId?: string
 }
 
-vi.mock('@/utils/graphTraversalUtil', () => {
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => {
   type TestNode = LGraphNode & {
     _testExecutionId?: string
     _testActiveExecutionIds?: string[]
@@ -1727,20 +1727,20 @@ const { mockUpdateModelsForNodeType, mockGetAssets } = vi.hoisted(() => ({
   mockGetAssets: vi.fn().mockReturnValue([])
 }))
 
-vi.mock('@/stores/assetsStore', () => ({
+vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
   useAssetsStore: () => ({
     updateModelsForNodeType: mockUpdateModelsForNodeType,
     getAssets: mockGetAssets
   })
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
+vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
   useToastStore: () => ({
     add: vi.fn()
   })
 }))
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   st: (_key: string, fallback: string) => fallback
 }))
 

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -12,20 +12,23 @@ const mockNodeLocatorIdToNodeExecutionId = vi.hoisted(() =>
   vi.fn((nodeLocatorId: string) => nodeLocatorId)
 )
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) => `translated:${key}`),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({
-    nodeLocatorIdToNodeExecutionId: mockNodeLocatorIdToNodeExecutionId
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  () => ({
+    useWorkflowStore: () => ({
+      nodeLocatorIdToNodeExecutionId: mockNodeLocatorIdToNodeExecutionId
+    })
   })
-}))
+)
 
 import { useMissingModelStore } from './missingModelStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'

--- a/src/platform/nodeReplacement/components/SwapNodesCard.test.ts
+++ b/src/platform/nodeReplacement/components/SwapNodesCard.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { SwapNodeGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
 
-vi.mock('./SwapNodeGroupRow.vue', () => ({
+vi.mock<unknown>(import('./SwapNodeGroupRow.vue'), () => ({
   default: {
     name: 'SwapNodeGroupRow',
     template:

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -4,35 +4,38 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 
-vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return {
-    ...actual,
-    LiteGraph: {
-      ...(actual.LiteGraph as Record<string, unknown>),
-      registered_node_types: {} as Record<string, unknown>
+vi.mock<unknown>(
+  import('@/lib/litegraph/src/litegraph'),
+  async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>()
+    return {
+      ...actual,
+      LiteGraph: {
+        ...(actual.LiteGraph as Record<string, unknown>),
+        registered_node_types: {} as Record<string, unknown>
+      }
     }
   }
-})
+)
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   collectAllNodes: vi.fn(),
   getExecutionIdByNode: vi.fn()
 }))
 
-vi.mock('@/platform/nodeReplacement/cnrIdUtil', () => ({
+vi.mock(import('@/platform/nodeReplacement/cnrIdUtil'), () => ({
   getCnrIdFromNode: vi.fn(() => undefined)
 }))
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     get: vi.fn(() => true)
   })

--- a/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
+++ b/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
 const mockShowErrorsTab = vi.hoisted(() => ({ value: false }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(() => ({
     get: vi.fn(() => mockShowErrorsTab.value)
   }))

--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -9,15 +9,15 @@ import { api } from '@/scripts/api'
 import { fetchNodeReplacements } from './nodeReplacementService'
 import { useNodeReplacementStore } from './nodeReplacementStore'
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn()
 }))
 
-vi.mock('./nodeReplacementService', () => ({
+vi.mock(import('./nodeReplacementService'), () => ({
   fetchNodeReplacements: vi.fn()
 }))
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     getServerFeature: vi.fn()
   }

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -22,19 +22,22 @@ import { widgetId } from '@/types/widgetId'
 import type { UUID } from '@/utils/uuid'
 import type { NodeReplacement } from './types'
 
-vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return {
-    ...actual,
-    LiteGraph: {
-      ...(actual.LiteGraph as Record<string, unknown>),
-      createNode: vi.fn(),
-      registered_node_types: {}
+vi.mock<unknown>(
+  import('@/lib/litegraph/src/litegraph'),
+  async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>()
+    return {
+      ...actual,
+      LiteGraph: {
+        ...(actual.LiteGraph as Record<string, unknown>),
+        createNode: vi.fn(),
+        registered_node_types: {}
+      }
     }
   }
-})
+)
 
-vi.mock('@/core/graph/nodeShell/nodeShellState', () => ({
+vi.mock(import('@/core/graph/nodeShell/nodeShellState'), () => ({
   canTransferReplacementOwnership: vi.fn(() => true),
   transferReplacementOwnership: vi.fn(
     (node: LGraphNode, replacement: LGraphNode) => {
@@ -45,29 +48,32 @@ vi.mock('@/core/graph/nodeShell/nodeShellState', () => ({
   )
 }))
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: null },
   sanitizeNodeName: (name: string) => name.replace(/[&<>"'`=]/g, '')
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   collectAllNodes: vi.fn()
 }))
 
 const { mockToastAdd } = vi.hoisted(() => ({ mockToastAdd: vi.fn() }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
+vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
   useToastStore: vi.fn(() => ({
     add: mockToastAdd
   }))
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  ComfyWorkflow: class {},
-  useWorkflowStore: vi.fn(() => workflowMocks)
-}))
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  () => ({
+    ComfyWorkflow: class {},
+    useWorkflowStore: vi.fn(() => workflowMocks)
+  })
+)
 
-vi.mock('@/i18n', () => ({
+vi.mock<unknown>(import('@/i18n'), () => ({
   st: (_key: string, fallback: string) => fallback,
   t: (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key

--- a/src/platform/onboarding/TourOverlay.test.ts
+++ b/src/platform/onboarding/TourOverlay.test.ts
@@ -11,7 +11,9 @@ import TourOverlay from './TourOverlay.vue'
 import type { CoachStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
-vi.mock('./onboardingTourStore', () => ({ useOnboardingTourStore: vi.fn() }))
+vi.mock<unknown>(import('./onboardingTourStore'), () => ({
+  useOnboardingTourStore: vi.fn()
+}))
 
 function makeTourState() {
   return {
@@ -33,7 +35,7 @@ function makeTourState() {
 }
 
 // Stubbed so the suite covers only TourOverlay's branching and intent wiring.
-vi.mock('./TourSpotlight.vue', () => ({
+vi.mock(import('./TourSpotlight.vue'), () => ({
   default: defineComponent({
     emits: ['advance', 'back', 'skip'],
     setup(_, { emit }) {

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -14,7 +14,7 @@ import { laidOut, mountNode, movingTarget } from './fixtures/coachmarkTargets'
 import { COACH_IDS, FIRST_RUN_COACH_IDS } from './onboardingTours'
 import type { SpotlightStep } from './onboardingTours'
 
-vi.mock('@primeuix/utils/zindex', () => ({
+vi.mock<unknown>(import('@primeuix/utils/zindex'), () => ({
   ZIndex: { set: vi.fn(), clear: vi.fn() }
 }))
 

--- a/src/platform/onboarding/TourSpotlight.test.ts
+++ b/src/platform/onboarding/TourSpotlight.test.ts
@@ -11,7 +11,7 @@ import { clearCoachmarks } from './coachmarkRegistry'
 import TourSpotlight from './TourSpotlight.vue'
 import type { SpotlightStep } from './onboardingTours'
 
-vi.mock('@primeuix/utils/zindex', () => ({
+vi.mock<unknown>(import('@primeuix/utils/zindex'), () => ({
   ZIndex: { set: vi.fn(), clear: vi.fn() }
 }))
 

--- a/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
@@ -12,7 +12,7 @@ import type { SpotlightStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
 const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     get: (key: string) =>
       settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
@@ -24,17 +24,17 @@ vi.mock('@/platform/settings/settingStore', () => ({
 }))
 
 const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
 }))
 
 const appModeMock = vi.hoisted(() => ({ mode: null as Ref<AppMode> | null }))
-vi.mock('@/composables/useAppMode', async () => {
+vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { ref } = await import('vue')
   appModeMock.mode = ref<AppMode>('graph')
   return { useAppMode: () => ({ mode: appModeMock.mode }) }
 })
-vi.mock('@/stores/appModeStore', () => ({
+vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
   useAppModeStore: () => ({ hasOutputs: false })
 }))
 

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -19,7 +19,7 @@ import type { CoachId, CoachStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
 const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     get: (key: string) =>
       settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
@@ -31,7 +31,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
 }))
 
 const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
 }))
 
@@ -41,12 +41,12 @@ const appModeMock = vi.hoisted(
     hasOutputs: null
   })
 )
-vi.mock('@/composables/useAppMode', async () => {
+vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { ref: r } = await import('vue')
   appModeMock.mode = r<AppMode>('graph')
   return { useAppMode: () => ({ mode: appModeMock.mode }) }
 })
-vi.mock('@/stores/appModeStore', async () => {
+vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
   const { ref: r } = await import('vue')
   appModeMock.hasOutputs = r(false)
   const hasOutputs = appModeMock.hasOutputs

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useQueuePolling } from '@/platform/remote/comfyui/useQueuePolling'
 
-vi.mock('@/stores/queueStore', () => {
+vi.mock<unknown>(import('@/stores/queueStore'), () => {
   const state = reactive({
     activeJobsCount: 0,
     isLoading: false,

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -13,7 +13,7 @@ import {
   remoteConfigState
 } from './remoteConfig'
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     fetchApi: vi.fn(),
     apiURL: vi.fn((route: string) => `/ComfyUI/api${route}`)

--- a/src/platform/secrets/api/secretsApi.test.ts
+++ b/src/platform/secrets/api/secretsApi.test.ts
@@ -4,7 +4,7 @@ import { listSecretProviders } from './secretsApi'
 
 const mockFetchApi = vi.fn()
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     fetchApi: (...args: unknown[]) => mockFetchApi(...args)
   }

--- a/src/platform/secrets/components/SecretFormDialog.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.test.ts
@@ -12,7 +12,7 @@ const mockState = vi.hoisted(() => ({
   credentialOptions: [] as SecretCredentialOption[]
 }))
 
-vi.mock('../composables/useSecretForm', () => ({
+vi.mock<unknown>(import('../composables/useSecretForm'), () => ({
   useSecretForm: () => ({
     form: { provider: '', name: '', secretValue: '' },
     errors: {},
@@ -29,55 +29,62 @@ vi.mock('../composables/useSecretForm', () => ({
   })
 }))
 
-vi.mock('primevue/inputtext', () => ({
-  default: { name: 'InputText', template: '<input />' }
-}))
-vi.mock('primevue/password', () => ({
-  default: { name: 'Password', template: '<input type="password" />' }
-}))
+vi.mock<unknown>(
+  import('primevue/inputtext'), // eslint-disable-line primevue-removal/no-imports
 
-vi.mock('@/components/ui/button/Button.vue', () => ({
+  () => ({
+    default: { name: 'InputText', template: '<input />' }
+  })
+)
+vi.mock<unknown>(
+  import('primevue/password'), // eslint-disable-line primevue-removal/no-imports
+  () => ({
+    default: { name: 'Password', template: '<input type="password" />' }
+  })
+)
+
+vi.mock<unknown>(import('@/components/ui/button/Button.vue'), () => ({
   default: { name: 'Button', template: '<button><slot /></button>' }
 }))
 
-vi.mock('@/components/ui/select/Select.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/Select.vue'), () => ({
   default: { name: 'Select', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectContent.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectContent.vue'), () => ({
   default: { name: 'SelectContent', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectItem.vue'), () => ({
   default: { name: 'SelectItem', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectTrigger.vue'), () => ({
   default: { name: 'SelectTrigger', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectValue.vue'), () => ({
   default: { name: 'SelectValue', template: '<span />' }
 }))
 
-vi.mock('@/components/ui/dialog/Dialog.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/Dialog.vue'), () => ({
   default: { name: 'Dialog', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/dialog/DialogPortal.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/DialogPortal.vue'), () => ({
   default: { name: 'DialogPortal', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/dialog/DialogOverlay.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/DialogOverlay.vue'), () => ({
   default: { name: 'DialogOverlay', template: '<div />' }
 }))
-vi.mock('@/components/ui/dialog/DialogContent.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/DialogContent.vue'), () => ({
   default: {
     name: 'DialogContent',
     template: '<div data-testid="dialog-content"><slot /></div>'
   }
 }))
-vi.mock('@/components/ui/dialog/DialogHeader.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/DialogHeader.vue'), () => ({
   default: { name: 'DialogHeader', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/dialog/DialogTitle.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/DialogTitle.vue'), () => ({
   default: { name: 'DialogTitle', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/dialog/DialogClose.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/dialog/DialogClose.vue'), () => ({
   default: { name: 'DialogClose', template: '<button />' }
 }))
 

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -7,7 +7,7 @@ import { createI18n } from 'vue-i18n'
 
 import SecretFormDialog from './SecretFormDialog.vue'
 
-vi.mock('../composables/useSecretForm', () => ({
+vi.mock<unknown>(import('../composables/useSecretForm'), () => ({
   useSecretForm: () => ({
     form: { provider: '', name: '', secretValue: '' },
     errors: {},
@@ -24,29 +24,33 @@ vi.mock('../composables/useSecretForm', () => ({
   })
 }))
 
-vi.mock('primevue/inputtext', () => ({
-  default: { name: 'InputText', template: '<input />' }
-}))
-vi.mock('primevue/password', () => ({
+vi.mock<unknown>(
+  import('primevue/inputtext'),
+
+  () => ({
+    default: { name: 'InputText', template: '<input />' }
+  })
+)
+vi.mock<unknown>(import('primevue/password'), () => ({
   default: { name: 'Password', template: '<input type="password" />' }
 }))
 
-vi.mock('@/components/ui/button/Button.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/button/Button.vue'), () => ({
   default: { name: 'Button', template: '<button><slot /></button>' }
 }))
-vi.mock('@/components/ui/select/Select.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/Select.vue'), () => ({
   default: { name: 'Select', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectContent.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectContent.vue'), () => ({
   default: { name: 'SelectContent', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectItem.vue'), () => ({
   default: { name: 'SelectItem', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectTrigger.vue'), () => ({
   default: { name: 'SelectTrigger', template: '<div><slot /></div>' }
 }))
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
+vi.mock<unknown>(import('@/components/ui/select/SelectValue.vue'), () => ({
   default: { name: 'SelectValue', template: '<span />' }
 }))
 

--- a/src/platform/secrets/components/SecretListItem.test.ts
+++ b/src/platform/secrets/components/SecretListItem.test.ts
@@ -7,7 +7,7 @@ import { createI18n } from 'vue-i18n'
 import type { SecretMetadata } from '../types'
 import SecretListItem from './SecretListItem.vue'
 
-vi.mock('../providers', () => ({
+vi.mock(import('../providers'), () => ({
   getProviderLabel: (provider: string | undefined) => {
     if (provider === 'huggingface') return 'HuggingFace'
     if (provider === 'civitai') return 'Civitai'

--- a/src/platform/secrets/components/SecretsPanel.test.ts
+++ b/src/platform/secrets/components/SecretsPanel.test.ts
@@ -22,7 +22,7 @@ const mockSecret: SecretMetadata = {
   updated_at: '2024-01-15T10:00:00Z'
 }
 
-vi.mock('@/platform/secrets/composables/useSecrets', () => ({
+vi.mock<unknown>(import('@/platform/secrets/composables/useSecrets'), () => ({
   useSecrets: () => ({
     loading: ref(false),
     secrets: ref<SecretMetadata[]>([mockSecret]),
@@ -35,17 +35,20 @@ vi.mock('@/platform/secrets/composables/useSecrets', () => ({
   })
 }))
 
-vi.mock('@/stores/dialogStore', () => ({
+vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
   useDialogStore: () => ({
     closeDialog: mockCloseDialog
   })
 }))
 
-vi.mock('@/components/dialog/confirm/confirmDialog')
+vi.mock(import('@/components/dialog/confirm/confirmDialog'))
 
-vi.mock('@/platform/secrets/components/SecretFormDialog.vue', () => ({
-  default: { name: 'SecretFormDialog', template: '<div />' }
-}))
+vi.mock<unknown>(
+  import('@/platform/secrets/components/SecretFormDialog.vue'),
+  () => ({
+    default: { name: 'SecretFormDialog', template: '<div />' }
+  })
+)
 
 const mockShowConfirmDialog = vi.mocked(showConfirmDialog)
 

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -8,14 +8,14 @@ import type {
 } from '../types'
 import { useSecretForm } from './useSecretForm'
 
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: () => ({ t: (key: string) => key })
 }))
 
 const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 
-vi.mock('../api/secretsApi', () => ({
+vi.mock<unknown>(import('../api/secretsApi'), () => ({
   createSecret: (payload: unknown) => mockCreate(payload),
   updateSecret: (id: string, payload: unknown) => mockUpdate(id, payload),
   SecretsApiError: class SecretsApiError extends Error {

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -5,11 +5,11 @@ import { useSecrets } from './useSecrets'
 
 const mockAdd = vi.fn()
 
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: () => ({ t: (key: string) => key })
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
+vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
   useToastStore: () => ({ add: mockAdd })
 }))
 
@@ -17,7 +17,7 @@ const mockListSecrets = vi.fn()
 const mockListSecretProviders = vi.fn()
 const mockDeleteSecret = vi.fn()
 
-vi.mock('../api/secretsApi', () => ({
+vi.mock<unknown>(import('../api/secretsApi'), () => ({
   listSecrets: () => mockListSecrets(),
   listSecretProviders: () => mockListSecretProviders(),
   deleteSecret: (id: string) => mockDeleteSecret(id),

--- a/src/platform/settings/components/SettingDialog.test.ts
+++ b/src/platform/settings/components/SettingDialog.test.ts
@@ -18,53 +18,62 @@ const searchMocks = vi.hoisted(() => ({
 }))
 const mockFetchBalance = vi.hoisted(() => vi.fn())
 
-vi.mock('@/platform/settings/composables/useSettingUI', () => ({
-  useSettingUI: () => ({
-    defaultCategory: {
-      value: {
-        key: 'workspace-allowlist',
-        label: 'Allowlist',
-        children: []
+vi.mock<unknown>(
+  import('@/platform/settings/composables/useSettingUI'),
+  () => ({
+    useSettingUI: () => ({
+      defaultCategory: {
+        value: {
+          key: 'workspace-allowlist',
+          label: 'Allowlist',
+          children: []
+        }
+      },
+      settingCategories: { value: [] },
+      navGroups: settingUiMocks.navGroups,
+      findCategoryByKey: (key: string) =>
+        settingUiMocks.navGroups.value
+          .flatMap(({ items }) => items)
+          .find(({ id }) => id === key) ?? null,
+      findPanelByKey: (key: string) => {
+        const item = settingUiMocks.navGroups.value
+          .flatMap(({ items }) => items)
+          .find(({ id }) => id === key)
+        return item
+          ? {
+              node: { key: item.id, label: item.label, children: [] },
+              component: { template: `<div>${key} panel</div>` }
+            }
+          : null
       }
-    },
-    settingCategories: { value: [] },
-    navGroups: settingUiMocks.navGroups,
-    findCategoryByKey: (key: string) =>
-      settingUiMocks.navGroups.value
-        .flatMap(({ items }) => items)
-        .find(({ id }) => id === key) ?? null,
-    findPanelByKey: (key: string) => {
-      const item = settingUiMocks.navGroups.value
-        .flatMap(({ items }) => items)
-        .find(({ id }) => id === key)
-      return item
-        ? {
-            node: { key: item.id, label: item.label, children: [] },
-            component: { template: `<div>${key} panel</div>` }
-          }
-        : null
-    }
+    })
   })
-}))
+)
 
-vi.mock('@/platform/settings/composables/useSettingSearch', () => ({
-  useSettingSearch: () => ({
-    searchQuery: searchMocks.searchQuery,
-    inSearch: searchMocks.inSearch,
-    searchResultsCategories: searchMocks.searchResultsCategories,
-    matchedNavItemKeys: searchMocks.matchedNavItemKeys,
-    handleSearch: vi.fn(),
-    getSearchResults: () => []
+vi.mock<unknown>(
+  import('@/platform/settings/composables/useSettingSearch'),
+  () => ({
+    useSettingSearch: () => ({
+      searchQuery: searchMocks.searchQuery,
+      inSearch: searchMocks.inSearch,
+      searchResultsCategories: searchMocks.searchResultsCategories,
+      matchedNavItemKeys: searchMocks.matchedNavItemKeys,
+      handleSearch: vi.fn(),
+      getSearchResults: () => []
+    })
   })
-}))
+)
 
-vi.mock('@/composables/billing/useBillingContext', () => ({
+vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({ fetchBalance: mockFetchBalance })
 }))
 
-vi.mock('@/platform/telemetry/searchQuery/useSearchQueryTracking', () => ({
-  useSearchQueryTracking: vi.fn()
-}))
+vi.mock(
+  import('@/platform/telemetry/searchQuery/useSearchQueryTracking'),
+  () => ({
+    useSearchQueryTracking: vi.fn()
+  })
+)
 
 beforeEach(() => {
   settingUiMocks.navGroups = ref([

--- a/src/platform/settings/components/SettingItem.test.ts
+++ b/src/platform/settings/components/SettingItem.test.ts
@@ -11,7 +11,7 @@ const flushPromises = () =>
 
 const mockGet = vi.fn()
 const mockSet = vi.fn()
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     get: mockGet,
     set: mockSet

--- a/src/platform/settings/composables/useLitegraphSettings.test.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.test.ts
@@ -13,11 +13,15 @@ const testState = vi.hoisted(
   })
 )
 
-vi.mock('@/renderer/core/canvas/canvasStore', async () => {
-  const { reactive } = await import('vue')
-  testState.canvasStore = reactive({ canvas: null })
-  return { useCanvasStore: () => testState.canvasStore }
-})
+vi.mock<unknown>(
+  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
+
+  async () => {
+    const { reactive } = await import('vue')
+    testState.canvasStore = reactive({ canvas: null })
+    return { useCanvasStore: () => testState.canvasStore }
+  }
+)
 
 import { useLitegraphSettings } from './useLitegraphSettings'
 

--- a/src/platform/settings/composables/useSettingSearch.test.ts
+++ b/src/platform/settings/composables/useSettingSearch.test.ts
@@ -20,11 +20,11 @@ interface MockSettingParams {
 }
 
 // Mock dependencies
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_: string, fallback: string) => fallback)
 }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(),
   getSettingInfo: vi.fn()
 }))

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -36,15 +36,15 @@ const env = vi.hoisted(() => {
   return { state, fakeRef }
 })
 
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: () => ({ t: (_: string, fallback: string) => fallback })
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({ isLoggedIn: env.fakeRef('isLoggedIn') })
 }))
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: {
       get partnerNodeGovernanceEnabled() {
@@ -57,11 +57,11 @@ vi.mock('@/composables/useFeatureFlags', () => ({
   })
 }))
 
-vi.mock('@/composables/useVueFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useVueFeatureFlags'), () => ({
   useVueFeatureFlags: () => ({ shouldRenderVueNodes: ref(false) })
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return env.state.isCloud
   },
@@ -70,27 +70,33 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: vi.fn(),
   getSettingInfo: vi.fn()
 }))
 
-vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
-  useWorkspaceUI: () => ({
-    workspaceRole: env.fakeRef('workspaceRole')
+vi.mock<unknown>(
+  import('@/platform/workspace/composables/useWorkspaceUI'),
+  () => ({
+    useWorkspaceUI: () => ({
+      workspaceRole: env.fakeRef('workspaceRole')
+    })
   })
-}))
+)
 
-vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
-  usePartnerNodeGovernanceStore: () => ({
-    get status() {
-      return env.state.partnerNodeGovernanceStatus
-    },
-    get providers() {
-      return env.state.partnerNodeGovernanceProviders
-    }
+vi.mock<unknown>(
+  import('@/platform/workspace/stores/partnerNodeGovernanceStore'),
+  () => ({
+    usePartnerNodeGovernanceStore: () => ({
+      get status() {
+        return env.state.partnerNodeGovernanceStatus
+      },
+      get providers() {
+        return env.state.partnerNodeGovernanceProviders
+      }
+    })
   })
-}))
+)
 
 interface MockSettingParams {
   id: string

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -9,23 +9,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const showDialog = vi.hoisted(() => vi.fn())
 const isCloudRef = vi.hoisted(() => ({ value: false }))
 
-vi.mock('@/stores/dialogStore', () => ({
+vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
   useDialogStore: () => ({ showDialog, closeDialog: vi.fn() })
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return isCloudRef.value
   }
 }))
 
-vi.mock('@/i18n', () => ({ t: (k: string) => k }))
+vi.mock(import('@/i18n'), () => ({ t: (k: string) => k }))
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackEvent: vi.fn() })
 }))
 
-vi.mock('@/composables/billing/useBillingContext', () => ({
+vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({
     canAccessSubscriptionFeatures: { value: true },
     isFreeTier: { value: false },

--- a/src/platform/settings/composables/useSettingsUrlLoader.integration.test.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.integration.test.ts
@@ -14,11 +14,14 @@ let testRouter: Router
 
 const mockShowSettings = vi.hoisted(() => vi.fn())
 
-vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
-  useSettingsDialog: () => ({
-    show: mockShowSettings
+vi.mock<unknown>(
+  import('@/platform/settings/composables/useSettingsDialog'),
+  () => ({
+    useSettingsDialog: () => ({
+      show: mockShowSettings
+    })
   })
-}))
+)
 
 function createAppLikeRouter(): Router {
   const router = createRouter({

--- a/src/platform/settings/composables/useSettingsUrlLoader.test.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.test.ts
@@ -10,7 +10,7 @@ const preservedQueryMocks = vi.hoisted(() => ({
 }))
 
 vi.mock(
-  '@/platform/navigation/preservedQueryManager',
+  import('@/platform/navigation/preservedQueryManager'),
   () => preservedQueryMocks
 )
 
@@ -19,7 +19,7 @@ const mockRouteQuery = vi.hoisted(() => ({
 }))
 const mockRouterReplace = vi.hoisted(() => vi.fn(async () => undefined))
 
-vi.mock('vue-router', () => ({
+vi.mock<unknown>(import('vue-router'), () => ({
   useRoute: () => ({
     query: mockRouteQuery.value
   }),
@@ -30,11 +30,14 @@ vi.mock('vue-router', () => ({
 
 const mockShowSettings = vi.hoisted(() => vi.fn())
 
-vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
-  useSettingsDialog: () => ({
-    show: mockShowSettings
+vi.mock<unknown>(
+  import('@/platform/settings/composables/useSettingsDialog'),
+  () => ({
+    useSettingsDialog: () => ({
+      show: mockShowSettings
+    })
   })
-}))
+)
 
 describe('useSettingsUrlLoader', () => {
   beforeEach(() => {

--- a/src/platform/settings/settingStore.test.ts
+++ b/src/platform/settings/settingStore.test.ts
@@ -13,14 +13,14 @@ const { trackSettingChanged } = vi.hoisted(() => ({
   trackSettingChanged: vi.fn()
 }))
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: vi.fn(() => ({
     trackSettingChanged
   }))
 }))
 
 // Mock the api
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     getSettings: vi.fn(),
     storeSetting: vi.fn(),
@@ -29,7 +29,7 @@ vi.mock('@/scripts/api', () => ({
 }))
 
 // Mock the app
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     ui: {
       settings: {

--- a/src/platform/support/config.test.ts
+++ b/src/platform/support/config.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const distribution = vi.hoisted(() => ({ isCloud: false, isNightly: false }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return distribution.isCloud
   },

--- a/src/platform/support/feedbackDialog.test.ts
+++ b/src/platform/support/feedbackDialog.test.ts
@@ -6,27 +6,27 @@ import { useTelemetry } from '@/platform/telemetry'
 import { FEEDBACK_TYPEFORM_ID } from './config'
 import { openFeedbackDialog } from './feedbackDialog'
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/surveys/openTypeformDialog', () => ({
+vi.mock(import('@/platform/surveys/openTypeformDialog'), () => ({
   openTypeformDialog: vi.fn()
 }))
 
 const trackUiButtonClicked = vi.fn()
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: vi.fn(() => ({ trackUiButtonClicked }))
 }))
 
 const userEmail = vi.hoisted((): { value: string | undefined } => ({
   value: undefined
 }))
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({ userEmail })
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: true,
   isNightly: false
 }))

--- a/src/platform/surveys/ErrorPanelSurveyCta.test.ts
+++ b/src/platform/surveys/ErrorPanelSurveyCta.test.ts
@@ -31,7 +31,7 @@ const mockSurveyConfig = vi.hoisted(() => ({
 }))
 const mockOpen = vi.hoisted(() => vi.fn())
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isNightly() {
     return mockIsNightly.value
   },
@@ -43,12 +43,12 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-vi.mock('./surveyRegistry', () => ({
+vi.mock<unknown>(import('./surveyRegistry'), () => ({
   getSurveyConfig: (id: string) =>
     id === FEATURE_ID ? mockSurveyConfig.value : undefined
 }))
 
-vi.mock('./useErrorSurveyPopoverState', () => ({
+vi.mock(import('./useErrorSurveyPopoverState'), () => ({
   useErrorSurveyPopoverState: () => ({
     isPopoverOpen: ref(false),
     hasOpenedOnce: ref(false),
@@ -57,7 +57,7 @@ vi.mock('./useErrorSurveyPopoverState', () => ({
   })
 }))
 
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: vi.fn(() => ({
     t: (key: string) => key
   }))

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -12,7 +12,7 @@ const mockIsNightly = vi.hoisted(() => ({ value: true }))
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
 const mockIsDesktop = vi.hoisted(() => ({ value: false }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isNightly() {
     return mockIsNightly.value
   },

--- a/src/platform/surveys/TypeformEmbed.test.ts
+++ b/src/platform/surveys/TypeformEmbed.test.ts
@@ -11,7 +11,7 @@ const embedState = vi.hoisted(() => ({
   isValidTypeformId: true
 }))
 
-vi.mock('./useTypeformEmbed', () => ({
+vi.mock<unknown>(import('./useTypeformEmbed'), () => ({
   useTypeformEmbed: vi.fn(() => ({
     typeformError: ref(embedState.typeformError),
     isValidTypeformId: ref(embedState.isValidTypeformId)

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -4,7 +4,7 @@ import { effectScope, nextTick, ref } from 'vue'
 
 const trackFeatureUsed = vi.hoisted(() => vi.fn())
 
-vi.mock('./useSurveyFeatureTracking', () => ({
+vi.mock<unknown>(import('./useSurveyFeatureTracking'), () => ({
   useSurveyFeatureTracking: () => ({
     trackFeatureUsed,
     useCount: ref(0)
@@ -16,7 +16,7 @@ const useFakeExecutionErrorStore = defineStore('fakeExecutionError', () => {
   return { hasAnyError }
 })
 
-vi.mock('@/stores/executionErrorStore', () => ({
+vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
   useExecutionErrorStore: () => useFakeExecutionErrorStore()
 }))
 

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -11,7 +11,7 @@ const mockDistribution = vi.hoisted(() => ({
   isDesktop: false
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isNightly() {
     return mockDistribution.isNightly
   },

--- a/src/platform/surveys/useSurveyFeatureTracking.test.ts
+++ b/src/platform/surveys/useSurveyFeatureTracking.test.ts
@@ -4,7 +4,7 @@ const getSurveyConfig = vi.hoisted(() =>
   vi.fn<(featureId: string) => { enabled: boolean } | undefined>()
 )
 
-vi.mock('./surveyRegistry', () => ({
+vi.mock<unknown>(import('./surveyRegistry'), () => ({
   getSurveyConfig
 }))
 

--- a/src/platform/telemetry/hostUserIdSync.test.ts
+++ b/src/platform/telemetry/hostUserIdSync.test.ts
@@ -11,7 +11,7 @@ const hoisted = vi.hoisted(() => ({
   authStore: null as unknown as MockAuthStore
 }))
 
-vi.mock('@/stores/authStore', async () => {
+vi.mock<unknown>(import('@/stores/authStore'), async () => {
   const { reactive } = await vi.importActual<typeof VueModule>('vue')
   hoisted.authStore = reactive<MockAuthStore>({
     isInitialized: false,

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -14,10 +14,10 @@ const hoisted = vi.hoisted(() => {
   }
 })
 
-vi.mock('@datadog/browser-rum', () => ({
+vi.mock<unknown>(import('@datadog/browser-rum'), () => ({
   datadogRum: hoisted
 }))
-vi.mock('./manualRefreshTracker', () => ({
+vi.mock(import('./manualRefreshTracker'), () => ({
   trackUserManualRefresh: vi.fn()
 }))
 

--- a/src/platform/telemetry/manualRefreshTracker.test.ts
+++ b/src/platform/telemetry/manualRefreshTracker.test.ts
@@ -5,7 +5,7 @@ const hoisted = vi.hoisted(() => ({
   getInternalContext: vi.fn()
 }))
 
-vi.mock('@datadog/browser-rum', () => ({
+vi.mock<unknown>(import('@datadog/browser-rum'), () => ({
   datadogRum: hoisted
 }))
 

--- a/src/platform/telemetry/nodeAdded/installNodeAddedTelemetry.test.ts
+++ b/src/platform/telemetry/nodeAdded/installNodeAddedTelemetry.test.ts
@@ -10,7 +10,7 @@ import { withNodeAddSource } from './nodeAddSource'
 
 const trackNodeAdded = vi.fn()
 
-vi.mock('..', () => ({
+vi.mock<unknown>(import('..'), () => ({
   useTelemetry: () => ({ trackNodeAdded })
 }))
 

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -40,12 +40,12 @@ const hoisted = vi.hoisted(() => {
   }
 })
 
-vi.mock('@customerio/cdp-analytics-browser', () => ({
+vi.mock<unknown>(import('@customerio/cdp-analytics-browser'), () => ({
   AnalyticsBrowser: { load: hoisted.load },
   InAppPlugin: hoisted.inAppPlugin
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({
     userEmail: hoisted.userEmail,
     resolvedUserInfo: hoisted.resolvedUserInfo,

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -19,7 +19,7 @@ const {
   getInternalContext: vi.fn()
 }))
 
-vi.mock('@datadog/browser-rum', () => ({
+vi.mock<unknown>(import('@datadog/browser-rum'), () => ({
   datadogRum: {
     addAction,
     addDurationVital,

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
@@ -30,15 +30,15 @@ const {
   }
 }))
 
-vi.mock('@/platform/telemetry/utils/checkoutAttribution', () => ({
+vi.mock(import('@/platform/telemetry/utils/checkoutAttribution'), () => ({
   captureCheckoutAttributionFromSearch: mockCaptureCheckoutAttributionFromSearch
 }))
 
-vi.mock('@/stores/apiKeyAuthStore', () => ({
+vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
   useApiKeyAuthStore: mockUseApiKeyAuthStore
 }))
 
-vi.mock('@/stores/authStore', () => ({
+vi.mock<unknown>(import('@/stores/authStore'), () => ({
   useAuthStore: mockUseAuthStore
 }))
 

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
@@ -8,21 +8,21 @@ const mockMixpanel = vi.hoisted(() => ({
   people: { set: vi.fn() }
 }))
 
-vi.mock('mixpanel-browser', () => ({
+vi.mock<unknown>(import('mixpanel-browser'), () => ({
   default: mockMixpanel
 }))
 
 const mockOnUserResolved = vi.hoisted(() => vi.fn())
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({ onUserResolved: mockOnUserResolved })
 }))
 
 const mockNormalizeSurveyResponses = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/utils/surveyNormalization', () => ({
+vi.mock(import('@/platform/telemetry/utils/surveyNormalization'), () => ({
   normalizeSurveyResponses: mockNormalizeSurveyResponses
 }))
 
-vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+vi.mock<unknown>(import('@/platform/remoteConfig/remoteConfig'), () => ({
   remoteConfig: { value: null }
 }))
 

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -63,30 +63,33 @@ const hoisted = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({
     onUserResolved: hoisted.mockOnUserResolved,
     onUserLogout: hoisted.mockOnUserLogout
   })
 }))
 
-vi.mock('@/platform/remoteConfig/remoteConfig', async () => {
+vi.mock<unknown>(import('@/platform/remoteConfig/remoteConfig'), async () => {
   const { ref } = await vi.importActual<typeof VueModule>('vue')
   hoisted.refs.remoteConfig = ref<RemoteConfig>({})
   return { remoteConfig: hoisted.refs.remoteConfig }
 })
 
-vi.mock('posthog-js', () => hoisted.mockPosthog)
+vi.mock<unknown>(import('posthog-js'), () => hoisted.mockPosthog)
 
-vi.mock('@/platform/telemetry/utils/getExecutionContext', () => ({
+vi.mock(import('@/platform/telemetry/utils/getExecutionContext'), () => ({
   getExecutionContext: () => hoisted.executionContext
 }))
 
-vi.mock('@/composables/billing/useBillingContext', async () => {
-  const { ref } = await vi.importActual<typeof VueModule>('vue')
-  hoisted.refs.tier = ref<string | null>(null)
-  return { useBillingContext: () => ({ tier: hoisted.refs.tier }) }
-})
+vi.mock<unknown>(
+  import('@/composables/billing/useBillingContext'),
+  async () => {
+    const { ref } = await vi.importActual<typeof VueModule>('vue')
+    hoisted.refs.tier = ref<string | null>(null)
+    return { useBillingContext: () => ({ tier: hoisted.refs.tier }) }
+  }
+)
 
 import { PostHogTelemetryProvider } from './PostHogTelemetryProvider'
 

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
@@ -25,13 +25,13 @@ const mocks = vi.hoisted(() => ({
   } satisfies ExecutionContext
 }))
 
-vi.mock('@sentry/vue', () => ({
+vi.mock(import('@sentry/vue'), () => ({
   addBreadcrumb: mocks.addBreadcrumb,
   setContext: mocks.setContext,
   setUser: mocks.setUser
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({
     onUserLogout: mocks.onUserLogout,
     resolvedUserInfo: {
@@ -44,15 +44,18 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
   })
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({
-    activeWorkflow: {
-      isModified: mocks.workflowIsModified
-    }
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  () => ({
+    useWorkflowStore: () => ({
+      activeWorkflow: {
+        isModified: mocks.workflowIsModified
+      }
+    })
   })
-}))
+)
 
-vi.mock('../../utils/getExecutionContext', () => ({
+vi.mock(import('../../utils/getExecutionContext'), () => ({
   getExecutionContext: () => mocks.executionContext
 }))
 

--- a/src/platform/telemetry/providers/cloud/SyftTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SyftTelemetryProvider.test.ts
@@ -9,11 +9,11 @@ const mockRemoteConfig = vi.hoisted(() => ({
   value: {} as { syftdata_source_id?: string }
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: mockCurrentUser.useCurrentUser
 }))
 
-vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+vi.mock<unknown>(import('@/platform/remoteConfig/remoteConfig'), () => ({
   remoteConfig: mockRemoteConfig
 }))
 

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -5,12 +5,12 @@ const isEnabled = vi.fn()
 const addError = vi.fn()
 const getInitConfiguration = vi.fn()
 
-vi.mock('@sentry/vue', () => ({
+vi.mock(import('@sentry/vue'), () => ({
   captureException: (...args: unknown[]) => captureException(...args),
   isEnabled: () => isEnabled()
 }))
 
-vi.mock('@datadog/browser-rum', () => ({
+vi.mock<unknown>(import('@datadog/browser-rum'), () => ({
   datadogRum: {
     addError: (...args: unknown[]) => addError(...args),
     getInitConfiguration: () => getInitConfiguration()

--- a/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
+++ b/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
@@ -6,7 +6,7 @@ const hoisted = vi.hoisted(() => ({
   trackSearchQuery: vi.fn()
 }))
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackSearchQuery: hoisted.trackSearchQuery })
 }))
 

--- a/src/platform/telemetry/useTelemetry.test.ts
+++ b/src/platform/telemetry/useTelemetry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useTelemetry } from '@/platform/telemetry'
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 

--- a/src/platform/telemetry/utils/getExecutionContext.test.ts
+++ b/src/platform/telemetry/utils/getExecutionContext.test.ts
@@ -13,7 +13,7 @@ const hoisted = vi.hoisted(() => ({
   mockTemplateByName: null as null | { sourceModule?: string }
 }))
 
-vi.mock('@/stores/nodeDefStore', () => ({
+vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
   useNodeDefStore: () => ({
     fromLGraphNode: (node: Pick<LGraphNode, 'type'>) => {
       const nodeDef = hoisted.mockNodeDefsByName[node.type]
@@ -24,16 +24,19 @@ vi.mock('@/stores/nodeDefStore', () => ({
   })
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({
-    get activeWorkflow() {
-      return hoisted.mockActiveWorkflow
-    }
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  () => ({
+    useWorkflowStore: () => ({
+      get activeWorkflow() {
+        return hoisted.mockActiveWorkflow
+      }
+    })
   })
-}))
+)
 
-vi.mock(
-  '@/platform/workflow/templates/repositories/workflowTemplatesStore',
+vi.mock<unknown>(
+  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
   () => ({
     useWorkflowTemplatesStore: () => ({
       get knownTemplateNames() {
@@ -55,7 +58,7 @@ function mockNode(
   }
 }
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   reduceAllNodes: vi.fn((_graph, reducer, initial) => {
     let result = initial
     for (const node of hoisted.mockNodes) {
@@ -65,7 +68,7 @@ vi.mock('@/utils/graphTraversalUtil', () => ({
   })
 }))
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: {} }
 }))
 

--- a/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
+++ b/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
@@ -8,25 +8,28 @@ const state = vi.hoisted(() => ({
   openWorkflows: [] as unknown[]
 }))
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({ get: (key: string) => state.settings[key] })
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({ openWorkflows: state.openWorkflows })
-}))
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  () => ({
+    useWorkflowStore: () => ({ openWorkflows: state.openWorkflows })
+  })
+)
 
-vi.mock('@/stores/workspace/bottomPanelStore', () => ({
+vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), () => ({
   useBottomPanelStore: () => ({
     bottomPanelVisible: state.bottomPanelVisible
   })
 }))
 
-vi.mock('@/stores/workspace/rightSidePanelStore', () => ({
+vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), () => ({
   useRightSidePanelStore: () => ({ isOpen: state.rightSidePanelOpen })
 }))
 
-vi.mock('@/stores/workspace/sidebarTabStore', () => ({
+vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
   useSidebarTabStore: () => ({
     activeSidebarTabId: state.activeSidebarTabId
   })

--- a/src/platform/updates/common/releaseService.test.ts
+++ b/src/platform/updates/common/releaseService.test.ts
@@ -8,7 +8,7 @@ const mockAxiosInstance = vi.hoisted(() => ({
   get: vi.fn()
 }))
 
-vi.mock('axios', () => ({
+vi.mock<unknown>(import('axios'), () => ({
   default: {
     create: vi.fn(() => mockAxiosInstance),
     isAxiosError: vi.fn()

--- a/src/platform/updates/common/releaseStore.test.ts
+++ b/src/platform/updates/common/releaseStore.test.ts
@@ -12,14 +12,14 @@ import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { SystemStats } from '@/types'
 
 // Mock the dependencies
-vi.mock('semver', () => ({
+vi.mock(import('semver'), () => ({
   compare: vi.fn(),
   valid: vi.fn(() => '1.0.0')
 }))
 
 const mockData = vi.hoisted(() => ({ isDesktop: true, isCloud: false }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isDesktop() {
     return mockData.isDesktop
   },
@@ -28,7 +28,7 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-vi.mock('@/platform/updates/common/releaseService', () => {
+vi.mock(import('@/platform/updates/common/releaseService'), () => {
   const getReleases = vi.fn()
   const isLoading = ref(false)
   const error = ref<string | null>(null)
@@ -41,7 +41,7 @@ vi.mock('@/platform/updates/common/releaseService', () => {
   }
 })
 
-vi.mock('@/platform/settings/settingStore', () => {
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => {
   const get = vi.fn((key: string) => {
     if (key === 'Comfy.Notification.ShowVersionUpdates') return true
     return null
@@ -73,7 +73,7 @@ const mockSystemStatsState = vi.hoisted(() => ({
     this.isInitialized = true
   }
 }))
-vi.mock('@/stores/systemStatsStore', () => {
+vi.mock<unknown>(import('@/stores/systemStatsStore'), () => {
   const refetchSystemStats = vi.fn()
   const getFormFactor = vi.fn(() => 'git-windows')
   return {
@@ -95,7 +95,7 @@ vi.mock('@/stores/systemStatsStore', () => {
     })
   }
 })
-vi.mock('@vueuse/core', () => ({
+vi.mock<unknown>(import('@vueuse/core'), () => ({
   until: vi.fn(() => Promise.resolve()),
   useStorage: vi.fn(() => ({ value: {} })),
   createSharedComposable: vi.fn((fn) => fn)
@@ -104,11 +104,14 @@ vi.mock('@vueuse/core', () => ({
 const mocks = vi.hoisted(() => ({
   tour: { activeTour: null as EntryPath | null }
 }))
-vi.mock('@/platform/onboarding/onboardingTourStore', async () => {
-  const { reactive } = await import('vue')
-  mocks.tour = reactive(mocks.tour)
-  return { useOnboardingTourStore: () => mocks.tour }
-})
+vi.mock<unknown>(
+  import('@/platform/onboarding/onboardingTourStore'),
+  async () => {
+    const { reactive } = await import('vue')
+    mocks.tour = reactive(mocks.tour)
+    return { useOnboardingTourStore: () => mocks.tour }
+  }
+)
 
 describe('useReleaseStore', () => {
   const mockRelease = {

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
@@ -6,14 +6,14 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useFrontendVersionMismatchWarning } from '@/platform/updates/common/useFrontendVersionMismatchWarning'
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
 
-vi.mock('@/config', () => ({
+vi.mock(import('@/config'), () => ({
   default: {
     app_title: 'ComfyUI',
     app_version: '1.0.0'
   }
 }))
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     ui: {
       settings: {
@@ -23,14 +23,14 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     getSettings: vi.fn(() => Promise.resolve({})),
     storeSetting: vi.fn(() => Promise.resolve(undefined))
   }
 }))
 
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: () => ({
     t: (key: string, params?: Record<string, string | number> | unknown) => {
       if (key === 'g.versionMismatchWarning')

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -4,25 +4,25 @@ import { ref } from 'vue'
 
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
 
-vi.mock('@/config', () => ({
+vi.mock<unknown>(import('@/config'), () => ({
   default: {
     app_version: '1.24.0'
   }
 }))
 
 const mockUseSystemStatsStore = vi.hoisted(() => vi.fn())
-vi.mock('@/stores/systemStatsStore', () => ({
+vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
   useSystemStatsStore: mockUseSystemStatsStore
 }))
 
 const mockUseSettingStore = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: mockUseSettingStore
 }))
 
 // Mock useStorage and until from VueUse
 const mockDismissalStorage = ref({} as Record<string, number>)
-vi.mock('@vueuse/core', () => ({
+vi.mock<unknown>(import('@vueuse/core'), () => ({
   useStorage: vi.fn(() => mockDismissalStorage),
   until: vi.fn(() => Promise.resolve())
 }))

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -29,7 +29,7 @@ const { toastErrorHandlerMock } = vi.hoisted(() => ({
   toastErrorHandlerMock: vi.fn()
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false,
   isNightly: false,
   get isDesktop() {
@@ -38,7 +38,7 @@ vi.mock('@/platform/distribution/types', () => ({
 }))
 
 // Mock dependencies
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: vi.fn(() => ({
     locale: { value: 'en' },
     t: vi.fn((key: string) => {
@@ -60,27 +60,27 @@ vi.mock('vue-i18n', () => ({
   }))
 }))
 
-vi.mock('@/utils/formatUtil', () => ({
+vi.mock(import('@/utils/formatUtil'), () => ({
   formatVersionAnchor: vi.fn((version: string) => version.replace(/\./g, ''))
 }))
 
-vi.mock('@/utils/markdownRendererUtil', () => ({
+vi.mock(import('@/utils/markdownRendererUtil'), () => ({
   renderMarkdownToHtml: vi.fn((content: string) => `<div>${content}</div>`)
 }))
 
-vi.mock('@/composables/useErrorHandling', () => ({
+vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: vi.fn(() => ({
     toastErrorHandler: toastErrorHandlerMock
   }))
 }))
 
-vi.mock('@/stores/commandStore', () => ({
+vi.mock<unknown>(import('@/stores/commandStore'), () => ({
   useCommandStore: vi.fn(() => ({
     execute: commandExecuteMock
   }))
 }))
 
-vi.mock('@/composables/useExternalLink', () => ({
+vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   useExternalLink: vi.fn(() => ({
     buildDocsUrl: vi.fn((path: string) => `https://docs.comfy.org${path}`),
     staticUrls: {},
@@ -98,7 +98,7 @@ const mockReleaseStore = {
   fetchReleases: vi.fn()
 }
 
-vi.mock('../common/releaseStore', () => ({
+vi.mock<unknown>(import('../common/releaseStore'), () => ({
   useReleaseStore: vi.fn(() => mockReleaseStore)
 }))
 

--- a/src/platform/updates/components/WhatsNewPopup.test.ts
+++ b/src/platform/updates/components/WhatsNewPopup.test.ts
@@ -18,7 +18,7 @@ const mockTranslations: Record<string, string> = {
   'whatsNewPopup.noReleaseNotes': 'No release notes available'
 }
 
-vi.mock('@/i18n', () => ({
+vi.mock<unknown>(import('@/i18n'), () => ({
   i18n: {
     global: {
       locale: {
@@ -34,7 +34,7 @@ vi.mock('@/i18n', () => ({
   d: (date: Date) => date.toLocaleDateString()
 }))
 
-vi.mock('vue-i18n', () => ({
+vi.mock<unknown>(import('vue-i18n'), () => ({
   useI18n: vi.fn(() => ({
     locale: { value: 'en' },
     t: vi.fn((key: string) => {
@@ -43,11 +43,11 @@ vi.mock('vue-i18n', () => ({
   }))
 }))
 
-vi.mock('@/utils/formatUtil', () => ({
+vi.mock(import('@/utils/formatUtil'), () => ({
   formatVersionAnchor: vi.fn((version: string) => version.replace(/\./g, ''))
 }))
 
-vi.mock('@/utils/markdownRendererUtil', () => ({
+vi.mock(import('@/utils/markdownRendererUtil'), () => ({
   renderMarkdownToHtml: vi.fn((content: string) => `<div>${content}</div>`)
 }))
 
@@ -60,7 +60,7 @@ const mockReleaseStore = {
   fetchReleases: vi.fn()
 }
 
-vi.mock('../common/releaseStore', () => ({
+vi.mock<unknown>(import('../common/releaseStore'), () => ({
   useReleaseStore: vi.fn(() => mockReleaseStore)
 }))
 


### PR DESCRIPTION
## Summary

Migrates legacy `vi.mock` calls in the remaining platform tests to the dynamic `import()` form as an independent slice of #16174.

## Changes

- **What**: Converts mocks across 79 files; legacy partial mocks use `<unknown>` to preserve the string overload's existing type contract.
- **Breaking**: None.

## Review Focus

This is a mechanical syntax migration. The lint rule and documentation are intentionally deferred until every domain slice has merged.

Verified with the full pre-commit lint/typecheck gates, `pnpm knip`, and the combined unit suite (1,506 files; 20,337 passed).