### PR TITLE
feat(website): update MiniMax license Q&A copy and add pricing-parity answer

### DIFF
--- a/apps/website/e2e/minimax-license.spec.ts
+++ b/apps/website/e2e/minimax-license.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 import { getRoutes } from '../src/config/routes'
+import { minimaxLicensePage } from '../src/data/minimaxLicense'
+import type { Locale } from '../src/i18n/translations'
 import { t } from '../src/i18n/translations'
+import { faqAnswerPlainText, parseFaqAnswer } from '../src/utils/faqAnswer'
 import { test } from './fixtures/blockExternalMedia'
 
 const PATH = '/minimax/license'
@@ -14,6 +18,32 @@ const HERO_VIDEO_PATTERN = /minimax-license\/hero\.mp4/
 const STEPS_HEADING = t('minimaxLicense.steps.heading')
 const FAQ_HEADING = t('minimaxLicense.faq.heading')
 const CLOSING_HEADING = t('minimaxLicense.cta.heading')
+
+function faqAnswer(id: string, locale: Locale) {
+  const item = minimaxLicensePage.faq?.items.find((entry) => entry.id === id)
+  if (!item) throw new Error(`no FAQ item with id "${id}"`)
+  const answer = item.answer[locale] || item.answer.en
+  return {
+    question: item.question[locale] || item.question.en,
+    plainText: faqAnswerPlainText(answer),
+    emphasised: parseFaqAnswer(answer)
+      .filter((part) => part.type === 'strong')
+      .map((part) => part.value)
+  }
+}
+
+// The Q&A section is client:visible, so a click can land before it hydrates.
+async function openFaq(page: Page, question: string): Promise<Locator> {
+  const trigger = page.getByRole('button', { name: question })
+  await trigger.scrollIntoViewIfNeeded()
+  await expect(async () => {
+    await trigger.click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true', {
+      timeout: 1000
+    })
+  }).toPass()
+  return page.getByRole('region', { name: question })
+}
 
 test.describe('MiniMax license page @smoke', () => {
   test.beforeEach(async ({ page }) => {
@@ -65,6 +95,32 @@ test.describe('MiniMax license page @smoke', () => {
     await expect(closing).toHaveAttribute('href', CONTACT_HREF)
   })
 
+  test('renders an emphasised Q&A phrase as bold, not as markup', async ({
+    page
+  }) => {
+    const { question, plainText, emphasised } = faqAnswer(
+      'pricing-parity',
+      'en'
+    )
+    expect(emphasised).toHaveLength(1)
+
+    const answer = await openFaq(page, question)
+
+    await expect(answer.locator('strong')).toHaveText(emphasised[0])
+    await expect(answer).toHaveText(plainText)
+  })
+
+  test('links the licence route out of the Q&A answer', async ({ page }) => {
+    const { question } = faqAnswer('who-needs-a-license', 'en')
+
+    const answer = await openFaq(page, question)
+
+    await expect(answer.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://platform.minimax.io/h3-license'
+    )
+  })
+
   test('footer links back to this page', async ({ page }) => {
     const footerLink = page
       .locator('footer')
@@ -93,5 +149,21 @@ test.describe('MiniMax license page — zh-CN', () => {
     })
     await steps.scrollIntoViewIfNeeded()
     await expect(steps).toBeVisible()
+  })
+
+  test('renders an emphasised Q&A phrase as bold, not as markup', async ({
+    page
+  }) => {
+    await page.goto(ZH_PATH)
+    const { question, plainText, emphasised } = faqAnswer(
+      'pricing-parity',
+      'zh-CN'
+    )
+    expect(emphasised).toHaveLength(1)
+
+    const answer = await openFaq(page, question)
+
+    await expect(answer.locator('strong')).toHaveText(emphasised[0])
+    await expect(answer).toHaveText(plainText)
   })
 })

--- a/apps/website/e2e/minimax-license.spec.ts
+++ b/apps/website/e2e/minimax-license.spec.ts
@@ -7,6 +7,7 @@ import type { Locale } from '../src/i18n/translations'
 import { t } from '../src/i18n/translations'
 import { faqAnswerPlainText, parseFaqAnswer } from '../src/utils/faqAnswer'
 import { test } from './fixtures/blockExternalMedia'
+import { waitForIsland } from './fixtures/islands'
 
 const PATH = '/minimax/license'
 const ZH_PATH = '/zh-CN/minimax/license'
@@ -32,16 +33,11 @@ function faqAnswer(id: string, locale: Locale) {
   }
 }
 
-// The Q&A section is client:visible, so a click can land before it hydrates.
 async function openFaq(page: Page, question: string): Promise<Locator> {
   const trigger = page.getByRole('button', { name: question })
-  await trigger.scrollIntoViewIfNeeded()
-  await expect(async () => {
-    await trigger.click()
-    await expect(trigger).toHaveAttribute('aria-expanded', 'true', {
-      timeout: 1000
-    })
-  }).toPass()
+  await waitForIsland(page, trigger)
+  await trigger.click()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true')
   return page.getByRole('region', { name: question })
 }
 
@@ -106,6 +102,7 @@ test.describe('MiniMax license page @smoke', () => {
 
     const answer = await openFaq(page, question)
 
+    await expect(answer.locator('strong')).toBeVisible()
     await expect(answer.locator('strong')).toHaveText(emphasised[0])
     await expect(answer).toHaveText(plainText)
   })
@@ -163,6 +160,7 @@ test.describe('MiniMax license page — zh-CN', () => {
 
     const answer = await openFaq(page, question)
 
+    await expect(answer.locator('strong')).toBeVisible()
     await expect(answer.locator('strong')).toHaveText(emphasised[0])
     await expect(answer).toHaveText(plainText)
   })

--- a/apps/website/e2e/minimax-license.spec.ts
+++ b/apps/website/e2e/minimax-license.spec.ts
@@ -19,6 +19,7 @@ const HERO_VIDEO_PATTERN = /minimax-license\/hero\.mp4/
 const STEPS_HEADING = t('minimaxLicense.steps.heading')
 const FAQ_HEADING = t('minimaxLicense.faq.heading')
 const CLOSING_HEADING = t('minimaxLicense.cta.heading')
+const HAN = /\p{Script=Han}/u
 
 function faqAnswer(id: string, locale: Locale) {
   const item = minimaxLicensePage.faq?.items.find((entry) => entry.id === id)
@@ -157,6 +158,11 @@ test.describe('MiniMax license page — zh-CN', () => {
       'zh-CN'
     )
     expect(emphasised).toHaveLength(1)
+    // faqAnswer() falls back to English, which would otherwise make an English
+    // string dropped into the zh-CN slot this test's own expectation.
+    expect(question).toMatch(HAN)
+    expect(plainText).toMatch(HAN)
+    expect(emphasised[0]).toMatch(HAN)
 
     const answer = await openFaq(page, question)
 

--- a/apps/website/src/components/blocks/FAQSplit01.test.ts
+++ b/apps/website/src/components/blocks/FAQSplit01.test.ts
@@ -62,4 +62,24 @@ describe('FAQSplit01', () => {
     ).toBeDefined()
     expect(panelWith(faqs[1].answer).hasAttribute('hidden')).toBe(true)
   })
+
+  it('renders a bold phrase in an answer as emphasis', () => {
+    render(FAQSplit01, {
+      props: {
+        heading: 'FAQ',
+        faqs: [
+          {
+            id: 'parity',
+            question: 'Is it more expensive here?',
+            answer: 'No. **We match their price**, always.'
+          }
+        ]
+      }
+    })
+
+    expect(screen.getByText('We match their price').tagName).toBe('STRONG')
+    expect(panelWith('We match their price').textContent).toBe(
+      'No. We match their price, always.'
+    )
+  })
 })

--- a/apps/website/src/components/blocks/FAQSplit01.vue
+++ b/apps/website/src/components/blocks/FAQSplit01.vue
@@ -68,6 +68,11 @@ const parsedFaqs = computed(() =>
                   class="text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 rounded-sm underline underline-offset-2 transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
                   >{{ part.label ?? part.value }}</a
                 >
+                <strong
+                  v-else-if="part.type === 'strong'"
+                  class="font-semibold text-primary-comfy-canvas"
+                  >{{ part.value }}</strong
+                >
                 <template v-else>{{ part.value }}</template>
               </template>
             </p>

--- a/apps/website/src/data/minimaxLicense.ts
+++ b/apps/website/src/data/minimaxLicense.ts
@@ -19,6 +19,8 @@ const CONTACT_HREF = 'https://comfy.org/contact'
 const MINIMAX_H3_HREF = 'https://comfy.org/minimax-h3'
 const MINIMAX_H3_DESIGN_HREF =
   'https://design.minimax.io/tools/minimax-h3-comfyui'
+const MINIMAX_H3_COMMUNITY_LICENSE_HREF =
+  'https://platform.minimax.io/h3-license'
 
 // Rows and figures come from the tier table supplied for this page
 // (2026-09-02); the pricing numbers live only here, so a deal change means
@@ -222,9 +224,8 @@ export const minimaxLicensePage: ModelLaunchPage = {
           'zh-CN': '谁需要 MiniMax H3 商业许可？'
         },
         answer: {
-          en: 'Anyone running MiniMax models locally for commercial work: business use, client work, or products you ship. Open weights let anyone download the models and start creating; the license is what makes commercial use of your local outputs legal.',
-          'zh-CN':
-            '任何在本地运行 MiniMax 模型进行商业创作的人：商业用途、客户项目，或你要发布的产品。开源权重让任何人都能下载模型开始创作；许可让你本地产出的商业使用合法合规。'
+          en: `The H3 Community License generally permits commercial use, provided your commercial products and services generate no more than $20 million in yearly revenue and you comply with its other terms. Businesses above that threshold must obtain separate written authorization from MiniMax.\n\nYou need to explicitly acquire a MiniMax H3 community license if you want to use MiniMax H3 in the United States, European Union, United Kingdom, or South Korea, which are excluded from the H3 Community License. You can acquire them here: ${MINIMAX_H3_COMMUNITY_LICENSE_HREF}`,
+          'zh-CN': `H3 社区许可通常允许商业使用，前提是你的商业产品和服务年收入不超过 2000 万美元，并且你遵守其他条款。超过该门槛的企业必须另行获得 MiniMax 的书面授权。\n\n如果你想在美国、欧盟、英国或韩国使用 MiniMax H3，则需要明确获取 MiniMax H3 社区许可，这些地区不在 H3 社区许可的覆盖范围内。你可以在此获取：${MINIMAX_H3_COMMUNITY_LICENSE_HREF}`
         }
       },
       {
@@ -261,6 +262,18 @@ export const minimaxLicensePage: ModelLaunchPage = {
           en: 'Professional is a fixed-price monthly license for studios and teams shipping client work, with up to 10 licensed users on distilled open-weight model versions. Enterprise is an annual agreement with custom volume pricing, no user cap, and every model version, undistilled weights included. Request a license and we will help you pick.',
           'zh-CN':
             '专业版是面向交付客户项目的工作室和团队的固定价格月度许可，最多 10 个授权用户，使用蒸馏开源权重模型版本。企业版是年度协议，提供定制批量定价，不限用户数，涵盖包括未蒸馏权重在内的所有模型版本。申请许可，我们会帮你选择。'
+        }
+      },
+      {
+        id: 'pricing-parity',
+        question: {
+          en: 'Is the Commercial License more expensive through Comfy?',
+          'zh-CN': '通过 Comfy 购买商业许可会更贵吗？'
+        },
+        answer: {
+          en: 'No. **MiniMax requires pricing parity across its Commercial License resellers**, so purchasing the license through Comfy does not come with a reseller markup or a higher license price compared with other authorized channels.',
+          'zh-CN':
+            '不会。**MiniMax 要求其商业许可经销商之间保持价格一致**，因此通过 Comfy 购买许可不会产生经销商加价，价格也不会高于其他授权渠道。'
         }
       },
       {

--- a/apps/website/src/data/minimaxLicense.ts
+++ b/apps/website/src/data/minimaxLicense.ts
@@ -223,8 +223,8 @@ export const minimaxLicensePage: ModelLaunchPage = {
           'zh-CN': '谁需要 MiniMax H3 商业许可？'
         },
         answer: {
-          en: `The H3 Community License generally permits commercial use, provided your commercial products and services generate no more than $20 million in yearly revenue and you comply with its other terms. Businesses above that threshold must obtain separate written authorization from MiniMax.\n\nYou need to explicitly acquire a MiniMax H3 community license if you want to use MiniMax H3 in the United States, European Union, United Kingdom, or South Korea, which are excluded from the H3 Community License. You can acquire them here: ${MINIMAX_H3_LICENSE_REQUEST_HREF}`,
-          'zh-CN': `H3 社区许可通常允许商业使用，前提是你的商业产品和服务年收入不超过 2000 万美元，并且你遵守其他条款。超过该门槛的企业必须另行获得 MiniMax 的书面授权。\n\n如果你想在美国、欧盟、英国或韩国使用 MiniMax H3，则需要明确获取 MiniMax H3 社区许可，这些地区不在 H3 社区许可的覆盖范围内。你可以在此获取：${MINIMAX_H3_LICENSE_REQUEST_HREF}`
+          en: `The H3 Community License generally permits commercial use, provided your commercial products and services generate no more than $20 million in yearly revenue and you comply with its other terms. Businesses above that threshold must obtain separate written authorization from MiniMax.\n\nYou need to explicitly acquire a MiniMax H3 commercial license if you want to use MiniMax H3 in the United States, European Union, United Kingdom, or South Korea, which are excluded from the H3 Community License. You can acquire them here: ${MINIMAX_H3_LICENSE_REQUEST_HREF}`,
+          'zh-CN': `H3 社区许可通常允许商业使用，前提是你的商业产品和服务年收入不超过 2000 万美元，并且你遵守其他条款。超过该门槛的企业必须另行获得 MiniMax 的书面授权。\n\n如果你想在美国、欧盟、英国或韩国使用 MiniMax H3，则需要明确获取 MiniMax H3 商业许可，这些地区不在 H3 社区许可的覆盖范围内。你可以在此获取：${MINIMAX_H3_LICENSE_REQUEST_HREF}`
         }
       },
       {

--- a/apps/website/src/data/minimaxLicense.ts
+++ b/apps/website/src/data/minimaxLicense.ts
@@ -19,8 +19,7 @@ const CONTACT_HREF = 'https://comfy.org/contact'
 const MINIMAX_H3_HREF = 'https://comfy.org/minimax-h3'
 const MINIMAX_H3_DESIGN_HREF =
   'https://design.minimax.io/tools/minimax-h3-comfyui'
-const MINIMAX_H3_COMMUNITY_LICENSE_HREF =
-  'https://platform.minimax.io/h3-license'
+const MINIMAX_H3_LICENSE_REQUEST_HREF = 'https://platform.minimax.io/h3-license'
 
 // Rows and figures come from the tier table supplied for this page
 // (2026-09-02); the pricing numbers live only here, so a deal change means
@@ -224,8 +223,8 @@ export const minimaxLicensePage: ModelLaunchPage = {
           'zh-CN': '谁需要 MiniMax H3 商业许可？'
         },
         answer: {
-          en: `The H3 Community License generally permits commercial use, provided your commercial products and services generate no more than $20 million in yearly revenue and you comply with its other terms. Businesses above that threshold must obtain separate written authorization from MiniMax.\n\nYou need to explicitly acquire a MiniMax H3 community license if you want to use MiniMax H3 in the United States, European Union, United Kingdom, or South Korea, which are excluded from the H3 Community License. You can acquire them here: ${MINIMAX_H3_COMMUNITY_LICENSE_HREF}`,
-          'zh-CN': `H3 社区许可通常允许商业使用，前提是你的商业产品和服务年收入不超过 2000 万美元，并且你遵守其他条款。超过该门槛的企业必须另行获得 MiniMax 的书面授权。\n\n如果你想在美国、欧盟、英国或韩国使用 MiniMax H3，则需要明确获取 MiniMax H3 社区许可，这些地区不在 H3 社区许可的覆盖范围内。你可以在此获取：${MINIMAX_H3_COMMUNITY_LICENSE_HREF}`
+          en: `The H3 Community License generally permits commercial use, provided your commercial products and services generate no more than $20 million in yearly revenue and you comply with its other terms. Businesses above that threshold must obtain separate written authorization from MiniMax.\n\nYou need to explicitly acquire a MiniMax H3 community license if you want to use MiniMax H3 in the United States, European Union, United Kingdom, or South Korea, which are excluded from the H3 Community License. You can acquire them here: ${MINIMAX_H3_LICENSE_REQUEST_HREF}`,
+          'zh-CN': `H3 社区许可通常允许商业使用，前提是你的商业产品和服务年收入不超过 2000 万美元，并且你遵守其他条款。超过该门槛的企业必须另行获得 MiniMax 的书面授权。\n\n如果你想在美国、欧盟、英国或韩国使用 MiniMax H3，则需要明确获取 MiniMax H3 社区许可，这些地区不在 H3 社区许可的覆盖范围内。你可以在此获取：${MINIMAX_H3_LICENSE_REQUEST_HREF}`
         }
       },
       {

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
@@ -35,7 +35,7 @@ describe('ModelLaunchStepsSection', () => {
     render(ModelLaunchStepsSection, {
       props: {
         steps: {
-          ...steps(2),
+          ...steps(1),
           items: [
             {
               id: 'parity',
@@ -51,6 +51,6 @@ describe('ModelLaunchStepsSection', () => {
     })
 
     expect(screen.getByText('at parity').tagName).toBe('STRONG')
-    expect(screen.queryByText(/\*\*/)).toBeNull()
+    expect(screen.queryAllByText(/\*\*/)).toEqual([])
   })
 })

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
@@ -30,4 +30,27 @@ describe('ModelLaunchStepsSection', () => {
 
     expect(screen.getByRole('list').className).toContain('md:grid-cols-3')
   })
+
+  it('renders a bold phrase in a step description as emphasis', () => {
+    render(ModelLaunchStepsSection, {
+      props: {
+        steps: {
+          ...steps(2),
+          items: [
+            {
+              id: 'parity',
+              title: { en: 'Parity', 'zh-CN': '价格一致' },
+              description: {
+                en: 'Priced **at parity** everywhere.',
+                'zh-CN': '各处**价格一致**。'
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    expect(screen.getByText('at parity').tagName).toBe('STRONG')
+    expect(screen.queryByText(/\*\*/)).toBeNull()
+  })
 })

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
@@ -31,26 +31,33 @@ describe('ModelLaunchStepsSection', () => {
     expect(screen.getByRole('list').className).toContain('md:grid-cols-3')
   })
 
-  it('renders a bold phrase in a step description as emphasis', () => {
-    render(ModelLaunchStepsSection, {
-      props: {
-        steps: {
-          ...steps(1),
-          items: [
-            {
-              id: 'parity',
-              title: { en: 'Parity', 'zh-CN': '价格一致' },
-              description: {
-                en: 'Priced **at parity** everywhere.',
-                'zh-CN': '各处**价格一致**。'
+  it.for([
+    { locale: 'en', emphasised: 'at parity' },
+    { locale: 'zh-CN', emphasised: '价格一致' }
+  ] as const)(
+    'renders a bold phrase in a $locale step description as emphasis',
+    ({ locale, emphasised }) => {
+      render(ModelLaunchStepsSection, {
+        props: {
+          locale,
+          steps: {
+            ...steps(1),
+            items: [
+              {
+                id: 'parity',
+                title: { en: 'Parity', 'zh-CN': '定价' },
+                description: {
+                  en: 'Priced **at parity** everywhere.',
+                  'zh-CN': '各处**价格一致**。'
+                }
               }
-            }
-          ]
+            ]
+          }
         }
-      }
-    })
+      })
 
-    expect(screen.getByText('at parity').tagName).toBe('STRONG')
-    expect(screen.queryAllByText(/\*\*/)).toEqual([])
-  })
+      expect(screen.getByText(emphasised).tagName).toBe('STRONG')
+      expect(screen.queryAllByText(/\*\*/)).toEqual([])
+    }
+  )
 })

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
@@ -69,6 +69,11 @@ const descriptionParts = (step: ModelLaunchSteps['items'][number]) =>
               class="text-primary-comfy-yellow underline underline-offset-2 transition-opacity hover:opacity-70"
               >{{ part.label ?? part.value }}</a
             >
+            <strong
+              v-else-if="part.type === 'strong'"
+              class="font-semibold text-primary-warm-white"
+              >{{ part.value }}</strong
+            >
             <template v-else>{{ part.value }}</template>
           </template>
         </p>

--- a/apps/website/src/utils/faqAnswer.test.ts
+++ b/apps/website/src/utils/faqAnswer.test.ts
@@ -70,19 +70,43 @@ describe('parseFaqAnswer', () => {
     ])
   })
 
-  it('leaves an unclosed bold marker as plain text', () => {
+  it('drops an unclosed bold marker rather than showing it', () => {
     expect(parseFaqAnswer('No. **We match their price')).toEqual([
-      { type: 'text', value: 'No. **We match their price' }
+      { type: 'text', value: 'No. We match their price' }
     ])
   })
 
-  it('drops the delimiters of a bold span wrapping a link', () => {
+  it('keeps the link and drops the emphasis when bold wraps a link', () => {
     expect(
       parseFaqAnswer('Use **[docs](https://docs.comfy.org/a)** now')
     ).toEqual([
       { type: 'text', value: 'Use ' },
       { type: 'link', value: 'https://docs.comfy.org/a', label: 'docs' },
       { type: 'text', value: ' now' }
+    ])
+  })
+
+  it('keeps the link and drops the emphasis when bold sits inside a label', () => {
+    expect(
+      parseFaqAnswer('Read [**the docs**](https://docs.comfy.org/a) now')
+    ).toEqual([
+      { type: 'text', value: 'Read ' },
+      { type: 'link', value: 'https://docs.comfy.org/a', label: 'the docs' },
+      { type: 'text', value: ' now' }
+    ])
+  })
+
+  it('keeps a bare URL clickable when bold wraps it', () => {
+    expect(parseFaqAnswer('**See https://x.com/a**')).toEqual([
+      { type: 'text', value: 'See ' },
+      { type: 'link', value: 'https://x.com/a' }
+    ])
+  })
+
+  it('emits no duplicated text when bold straddles a link boundary', () => {
+    expect(parseFaqAnswer('[docs **bold](https://x.com/a) tail**')).toEqual([
+      { type: 'link', value: 'https://x.com/a', label: 'docs bold' },
+      { type: 'text', value: ' tail' }
     ])
   })
 
@@ -133,9 +157,12 @@ describe('faqAnswerPlainText', () => {
     )
   })
 
-  it('emits no markdown when bold wraps a link', () => {
+  it('emits no markdown when bold and a link overlap', () => {
     expect(
       faqAnswerPlainText('Use **[docs](https://docs.comfy.org/a)** now')
     ).toBe('Use docs now')
+    expect(
+      faqAnswerPlainText('Read [**the docs**](https://docs.comfy.org/a) now')
+    ).toBe('Read the docs now')
   })
 })

--- a/apps/website/src/utils/faqAnswer.test.ts
+++ b/apps/website/src/utils/faqAnswer.test.ts
@@ -110,6 +110,12 @@ describe('parseFaqAnswer', () => {
     ])
   })
 
+  it('does not pair bold markers across a paragraph break', () => {
+    expect(parseFaqAnswer('One **stray.\n\nTwo** stray.')).toEqual([
+      { type: 'text', value: 'One stray.\n\nTwo stray.' }
+    ])
+  })
+
   it('leaves unfinished link markup as plain text', () => {
     expect(parseFaqAnswer('See [the docs](')).toEqual([
       { type: 'text', value: 'See [the docs](' }

--- a/apps/website/src/utils/faqAnswer.test.ts
+++ b/apps/website/src/utils/faqAnswer.test.ts
@@ -76,6 +76,16 @@ describe('parseFaqAnswer', () => {
     ])
   })
 
+  it('drops the delimiters of a bold span wrapping a link', () => {
+    expect(
+      parseFaqAnswer('Use **[docs](https://docs.comfy.org/a)** now')
+    ).toEqual([
+      { type: 'text', value: 'Use ' },
+      { type: 'link', value: 'https://docs.comfy.org/a', label: 'docs' },
+      { type: 'text', value: ' now' }
+    ])
+  })
+
   it('leaves unfinished link markup as plain text', () => {
     expect(parseFaqAnswer('See [the docs](')).toEqual([
       { type: 'text', value: 'See [the docs](' }
@@ -121,5 +131,11 @@ describe('faqAnswerPlainText', () => {
     expect(faqAnswerPlainText('No. **We match their price**, always.')).toBe(
       'No. We match their price, always.'
     )
+  })
+
+  it('emits no markdown when bold wraps a link', () => {
+    expect(
+      faqAnswerPlainText('Use **[docs](https://docs.comfy.org/a)** now')
+    ).toBe('Use docs now')
   })
 })

--- a/apps/website/src/utils/faqAnswer.test.ts
+++ b/apps/website/src/utils/faqAnswer.test.ts
@@ -52,6 +52,30 @@ describe('parseFaqAnswer', () => {
     expect(parseFaqAnswer('')).toEqual([])
   })
 
+  it('emphasises a bold phrase without its markers', () => {
+    expect(parseFaqAnswer('No. **We match their price**, always.')).toEqual([
+      { type: 'text', value: 'No. ' },
+      { type: 'strong', value: 'We match their price' },
+      { type: 'text', value: ', always.' }
+    ])
+  })
+
+  it('keeps a bold phrase and a link in the same answer', () => {
+    expect(
+      parseFaqAnswer('**Acquire it** at https://platform.minimax.io/h3-license')
+    ).toEqual([
+      { type: 'strong', value: 'Acquire it' },
+      { type: 'text', value: ' at ' },
+      { type: 'link', value: 'https://platform.minimax.io/h3-license' }
+    ])
+  })
+
+  it('leaves an unclosed bold marker as plain text', () => {
+    expect(parseFaqAnswer('No. **We match their price')).toEqual([
+      { type: 'text', value: 'No. **We match their price' }
+    ])
+  })
+
   it('leaves unfinished link markup as plain text', () => {
     expect(parseFaqAnswer('See [the docs](')).toEqual([
       { type: 'text', value: 'See [the docs](' }
@@ -90,6 +114,12 @@ describe('faqAnswerPlainText', () => {
   it('leaves a bare URL in place', () => {
     expect(faqAnswerPlainText('See https://docs.comfy.org/a')).toBe(
       'See https://docs.comfy.org/a'
+    )
+  })
+
+  it('drops bold markers so structured data carries no markup', () => {
+    expect(faqAnswerPlainText('No. **We match their price**, always.')).toBe(
+      'No. We match their price, always.'
     )
   })
 })

--- a/apps/website/src/utils/faqAnswer.test.ts
+++ b/apps/website/src/utils/faqAnswer.test.ts
@@ -110,6 +110,40 @@ describe('parseFaqAnswer', () => {
     ])
   })
 
+  it('emphasises the intended phrase when a stray marker precedes it', () => {
+    expect(parseFaqAnswer('Star ** alone and **real bold** after')).toEqual([
+      { type: 'text', value: 'Star  alone and ' },
+      { type: 'strong', value: 'real bold' },
+      { type: 'text', value: ' after' }
+    ])
+  })
+
+  it('does not pair markers that trail word characters', () => {
+    expect(parseFaqAnswer('Tiers cost $10**, $20**')).toEqual([
+      { type: 'text', value: 'Tiers cost $10, $20' }
+    ])
+  })
+
+  it('does not treat spaced asterisks as emphasis', () => {
+    expect(parseFaqAnswer('2 ** 8 = 256')).toEqual([
+      { type: 'text', value: '2  8 = 256' }
+    ])
+  })
+
+  it('emphasises a phrase abutting CJK punctuation', () => {
+    expect(parseFaqAnswer('各处**价格一致**。')).toEqual([
+      { type: 'text', value: '各处' },
+      { type: 'strong', value: '价格一致' },
+      { type: 'text', value: '。' }
+    ])
+  })
+
+  it('falls back to the url when a label is only delimiters', () => {
+    expect(parseFaqAnswer('[**](https://x.com/a)')).toEqual([
+      { type: 'link', value: 'https://x.com/a' }
+    ])
+  })
+
   it('does not pair bold markers across a paragraph break', () => {
     expect(parseFaqAnswer('One **stray.\n\nTwo** stray.')).toEqual([
       { type: 'text', value: 'One stray.\n\nTwo stray.' }

--- a/apps/website/src/utils/faqAnswer.ts
+++ b/apps/website/src/utils/faqAnswer.ts
@@ -12,7 +12,7 @@ interface MarkupSpan {
 
 const MARKDOWN_LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
 const BARE_URL = /https?:\/\/[\w\-./?=&#%~:@+,;]+/g
-const BOLD = /\*\*([^*]+)\*\*/g
+const BOLD = /\*\*([^*\n]+)\*\*/g
 const BOLD_DELIMITER = '**'
 
 const withoutBoldDelimiters = (text: string) =>

--- a/apps/website/src/utils/faqAnswer.ts
+++ b/apps/website/src/utils/faqAnswer.ts
@@ -1,59 +1,63 @@
 export interface FaqAnswerPart {
-  type: 'text' | 'link'
+  type: 'text' | 'link' | 'strong'
   value: string
   label?: string
 }
 
-interface LinkMatch {
+interface MarkupSpan {
   start: number
   end: number
-  url: string
-  label?: string
+  part: FaqAnswerPart
 }
 
 const MARKDOWN_LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
 const BARE_URL = /https?:\/\/[\w\-./?=&#%~:@+,;]+/g
+const BOLD = /\*\*([^*]+)\*\*/g
 
 // FAQ answers are plain strings so they stay translatable in one place. A link
 // can be written as `[label](url)`, which reads better as anchor text, or as a
-// bare URL, which keeps existing answers working.
+// bare URL, which keeps existing answers working. `**phrase**` emphasises a
+// phrase. Markup is claimed in that order, and a span overlapping one already
+// claimed stays literal text, so nothing nests.
 export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
-  const links: LinkMatch[] = []
+  const spans: MarkupSpan[] = []
+  const overlapsClaimed = (start: number, end: number) =>
+    spans.some((span) => start < span.end && end > span.start)
 
   for (const match of answer.matchAll(MARKDOWN_LINK)) {
-    const start = match.index ?? 0
-    links.push({
+    const start = match.index
+    spans.push({
       start,
       end: start + match[0].length,
-      url: match[2],
-      label: match[1]
+      part: { type: 'link', value: match[2], label: match[1] }
     })
+  }
+
+  for (const match of answer.matchAll(BOLD)) {
+    const start = match.index
+    const end = start + match[0].length
+    if (overlapsClaimed(start, end)) continue
+    spans.push({ start, end, part: { type: 'strong', value: match[1] } })
   }
 
   for (const match of answer.matchAll(BARE_URL)) {
-    const start = match.index ?? 0
+    const start = match.index
     const url = match[0].replace(/[.,;:]+$/, '')
-    const insideMarkdownLink = links.some(
-      (link) => start >= link.start && start < link.end
-    )
-    if (insideMarkdownLink) continue
-    links.push({ start, end: start + url.length, url })
+    const end = start + url.length
+    if (overlapsClaimed(start, end)) continue
+    spans.push({ start, end, part: { type: 'link', value: url } })
   }
 
-  links.sort((a, b) => a.start - b.start)
+  spans.sort((a, b) => a.start - b.start)
 
   const parts: FaqAnswerPart[] = []
   let lastIndex = 0
-  for (const link of links) {
-    if (link.start > lastIndex) {
-      parts.push({ type: 'text', value: answer.slice(lastIndex, link.start) })
+  for (const span of spans) {
+    if (span.start > lastIndex) {
+      parts.push({ type: 'text', value: answer.slice(lastIndex, span.start) })
     }
-    parts.push({
-      type: 'link',
-      value: link.url,
-      ...(link.label ? { label: link.label } : {})
-    })
-    lastIndex = link.end
+    parts.push(span.part)
+    lastIndex = span.end
   }
   if (lastIndex < answer.length) {
     parts.push({ type: 'text', value: answer.slice(lastIndex) })

--- a/apps/website/src/utils/faqAnswer.ts
+++ b/apps/website/src/utils/faqAnswer.ts
@@ -7,18 +7,25 @@ export interface FaqAnswerPart {
 interface MarkupSpan {
   start: number
   end: number
-  part: FaqAnswerPart
+  part?: FaqAnswerPart
 }
 
 const MARKDOWN_LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
 const BARE_URL = /https?:\/\/[\w\-./?=&#%~:@+,;]+/g
 const BOLD = /\*\*([^*]+)\*\*/g
+const BOLD_DELIMITER = '**'
+
+const discardedDelimiter = (start: number): MarkupSpan => ({
+  start,
+  end: start + BOLD_DELIMITER.length
+})
 
 // FAQ answers are plain strings so they stay translatable in one place. A link
 // can be written as `[label](url)`, which reads better as anchor text, or as a
 // bare URL, which keeps existing answers working. `**phrase**` emphasises a
-// phrase. Markup is claimed in that order, and a span overlapping one already
-// claimed stays literal text, so nothing nests.
+// phrase. Markup is claimed in that order; nothing nests, so a bold span
+// wrapping a link loses its emphasis rather than its delimiters leaking into
+// the page or the structured data.
 export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
   const spans: MarkupSpan[] = []
   const overlapsClaimed = (start: number, end: number) =>
@@ -36,7 +43,13 @@ export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
   for (const match of answer.matchAll(BOLD)) {
     const start = match.index
     const end = start + match[0].length
-    if (overlapsClaimed(start, end)) continue
+    if (overlapsClaimed(start, end)) {
+      spans.push(
+        discardedDelimiter(start),
+        discardedDelimiter(end - BOLD_DELIMITER.length)
+      )
+      continue
+    }
     spans.push({ start, end, part: { type: 'strong', value: match[1] } })
   }
 
@@ -56,7 +69,7 @@ export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
     if (span.start > lastIndex) {
       parts.push({ type: 'text', value: answer.slice(lastIndex, span.start) })
     }
-    parts.push(span.part)
+    if (span.part) parts.push(span.part)
     lastIndex = span.end
   }
   if (lastIndex < answer.length) {

--- a/apps/website/src/utils/faqAnswer.ts
+++ b/apps/website/src/utils/faqAnswer.ts
@@ -7,7 +7,7 @@ export interface FaqAnswerPart {
 interface MarkupSpan {
   start: number
   end: number
-  part?: FaqAnswerPart
+  part: FaqAnswerPart
 }
 
 const MARKDOWN_LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
@@ -15,17 +15,16 @@ const BARE_URL = /https?:\/\/[\w\-./?=&#%~:@+,;]+/g
 const BOLD = /\*\*([^*]+)\*\*/g
 const BOLD_DELIMITER = '**'
 
-const discardedDelimiter = (start: number): MarkupSpan => ({
-  start,
-  end: start + BOLD_DELIMITER.length
-})
+const withoutBoldDelimiters = (text: string) =>
+  text.replaceAll(BOLD_DELIMITER, '')
 
 // FAQ answers are plain strings so they stay translatable in one place. A link
 // can be written as `[label](url)`, which reads better as anchor text, or as a
 // bare URL, which keeps existing answers working. `**phrase**` emphasises a
-// phrase. Markup is claimed in that order; nothing nests, so a bold span
-// wrapping a link loses its emphasis rather than its delimiters leaking into
-// the page or the structured data.
+// phrase. Both link forms are claimed before emphasis and nothing nests, so a
+// bold span overlapping a link keeps the link and loses its emphasis. Either
+// way the delimiters are stripped, so no `**` reaches the page or the
+// structured data.
 export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
   const spans: MarkupSpan[] = []
   const overlapsClaimed = (start: number, end: number) =>
@@ -36,21 +35,12 @@ export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
     spans.push({
       start,
       end: start + match[0].length,
-      part: { type: 'link', value: match[2], label: match[1] }
+      part: {
+        type: 'link',
+        value: match[2],
+        label: withoutBoldDelimiters(match[1])
+      }
     })
-  }
-
-  for (const match of answer.matchAll(BOLD)) {
-    const start = match.index
-    const end = start + match[0].length
-    if (overlapsClaimed(start, end)) {
-      spans.push(
-        discardedDelimiter(start),
-        discardedDelimiter(end - BOLD_DELIMITER.length)
-      )
-      continue
-    }
-    spans.push({ start, end, part: { type: 'strong', value: match[1] } })
   }
 
   for (const match of answer.matchAll(BARE_URL)) {
@@ -61,20 +51,28 @@ export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
     spans.push({ start, end, part: { type: 'link', value: url } })
   }
 
+  for (const match of answer.matchAll(BOLD)) {
+    const start = match.index
+    const end = start + match[0].length
+    if (overlapsClaimed(start, end)) continue
+    spans.push({ start, end, part: { type: 'strong', value: match[1] } })
+  }
+
   spans.sort((a, b) => a.start - b.start)
 
   const parts: FaqAnswerPart[] = []
+  const pushText = (value: string) => {
+    const text = withoutBoldDelimiters(value)
+    if (text) parts.push({ type: 'text', value: text })
+  }
+
   let lastIndex = 0
   for (const span of spans) {
-    if (span.start > lastIndex) {
-      parts.push({ type: 'text', value: answer.slice(lastIndex, span.start) })
-    }
-    if (span.part) parts.push(span.part)
+    if (span.start > lastIndex) pushText(answer.slice(lastIndex, span.start))
+    parts.push(span.part)
     lastIndex = span.end
   }
-  if (lastIndex < answer.length) {
-    parts.push({ type: 'text', value: answer.slice(lastIndex) })
-  }
+  pushText(answer.slice(lastIndex))
   return parts
 }
 

--- a/apps/website/src/utils/faqAnswer.ts
+++ b/apps/website/src/utils/faqAnswer.ts
@@ -12,7 +12,11 @@ interface MarkupSpan {
 
 const MARKDOWN_LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
 const BARE_URL = /https?:\/\/[\w\-./?=&#%~:@+,;]+/g
-const BOLD = /\*\*([^*\n]+)\*\*/g
+// Group 1 is the character preceding `**` — captured, not looked behind, so the
+// pattern still parses on Safari < 16.4. Opening away from a word character and
+// refusing whitespace just inside the delimiters stops a stray `**` pairing with
+// a later one and emphasising everything between (e.g. `$10**, $20**`).
+const BOLD = /(^|[^\w])\*\*(?![\s*])([^*\n]*[^\s*])\*\*/g
 const BOLD_DELIMITER = '**'
 
 const withoutBoldDelimiters = (text: string) =>
@@ -38,7 +42,7 @@ export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
       part: {
         type: 'link',
         value: match[2],
-        label: withoutBoldDelimiters(match[1])
+        label: withoutBoldDelimiters(match[1]) || undefined
       }
     })
   }
@@ -52,10 +56,10 @@ export function parseFaqAnswer(answer: string): FaqAnswerPart[] {
   }
 
   for (const match of answer.matchAll(BOLD)) {
-    const start = match.index
-    const end = start + match[0].length
+    const start = match.index + match[1].length
+    const end = start + match[0].length - match[1].length
     if (overlapsClaimed(start, end)) continue
-    spans.push({ start, end, part: { type: 'strong', value: match[1] } })
+    spans.push({ start, end, part: { type: 'strong', value: match[2] } })
   }
 
   spans.sort((a, b) => a.start - b.start)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Updates the Q&A on [comfy.org/minimax/license](https://comfy.org/minimax/license) with copy supplied by GTM in #gtm.

## Changes

**1. Replaced the answer to "Who needs a MiniMax H3 commercial license?"** — now covers the H3 Community License $20M revenue threshold and the four excluded territories, ending with a link to `platform.minimax.io/h3-license`.

**2. Added a new Q&A on pricing parity**, placed after the Professional/Enterprise tier question:

> **Is the Commercial License more expensive through Comfy?**
> No. **MiniMax requires pricing parity across its Commercial License resellers**, so purchasing the license through Comfy does not come with a reseller markup or a higher license price compared with other authorized channels.

**3. Added `**phrase**` emphasis support to FAQ answers.** `parseFaqAnswer` previously understood links only, so the bolded clause needed a new `strong` part type. Both link forms are claimed before emphasis and nothing nests, so a bold span overlapping a link keeps the link and loses its emphasis; delimiters are stripped either way, so no `**` can reach the page or the `FAQPage` structured data. Rendered in both parser consumers (`FAQSplit01`, `ModelLaunchStepsSection`).

Both answers are localised (`en` + `zh-CN`). This is the first FAQ answer anywhere to use a paragraph break — it renders via the pre-existing `whitespace-pre-line` on the answer paragraph.

## Copy correction confirmed with GTM

The draft supplied in Slack said users in the US/EU/UK/South Korea must acquire a *"community license"* — for the territories that same sentence describes as **excluded** from the Community License, so the answer contradicted itself and never answered its own question. @U08HX6GS2GL and @U045ZEVQA1K confirmed in thread this should read **"commercial license"**, and that correction is applied in both locales.

The later reference to what the *Community* License excludes is deliberately unchanged, so the sentence now reads: acquire a **commercial** license for the territories excluded from the **Community** License.

## Remaining copy notes for GTM (non-blocking)

1. **"pricing parity across its Commercial License resellers"** and *"other authorized channels"* read as though other resellers exist, while this page's hero says **"only official reseller"**. These can coexist if "other channels" means MiniMax selling direct (which this same answer now links to) — worth a conscious call either way, since the parity line is a factual claim about a partner's contract terms.
2. `"You can acquire **them** here"` refers back to a singular licence (en only; the zh-CN string is unaffected). This wording also lands verbatim in the structured data.
3. The link's visible anchor text is the raw URL, whereas other links on the page use a label. Left as supplied rather than rewriting your sentence — happy to switch it to a labelled link if you prefer.
4. Worth confirming the licence facts themselves ($20M threshold, the four excluded territories, "separate written authorization") against the licence text, since they now appear on a public page and in structured data.

## Verification

- `pnpm test:unit` (website) — 1025 pass; `pnpm typecheck:website` — 0 errors; oxlint/eslint/oxfmt clean on changed files; `astro build` — 724 pages, exit 0
- Screenshots below are from the **production build** served via `astro preview`, both locales
- Asserted in the built output: corrected wording present in visible text *and* `FAQPage` JSON-LD, old wording absent, the Community-License exclusion reference intact, bold still renders, no raw `**` anywhere visible
- New tests cover bold parsing, bold+link coexistence, bold nested in a link label, bold straddling a link boundary, unclosed markers, pairing across a paragraph break, and marker stripping for structured data

Pre-existing and untouched: `cloudNodes.test.ts` has 9 oxlint `no-unnecessary-type-assertion` errors on `main`. Known limitation: the markdown twin (`llms.txt`) collapses the new answer's paragraph break to a space — text is complete, only the break is lost.


## Screenshots

![English /minimax/license Q&A with both answers expanded: the corrected 'acquire a MiniMax H3 commercial license' sentence, the auto-linked MiniMax URL, and the new pricing-parity answer with its bolded clause](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1f9c621222ddd0676203c37dbb3512015d29097bcd5589cca1b2402b9411ee45/pr-images/1788898739123-81216777-cb48-47af-8207-c082811b1ab1.png)

![Simplified Chinese /zh-CN/minimax/license Q&A showing the same two answers localised, with 商业许可 in the corrected sentence and the bolded parity clause rendering correctly in CJK](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1f9c621222ddd0676203c37dbb3512015d29097bcd5589cca1b2402b9411ee45/pr-images/1788898739523-0c858306-1288-4a02-8c9b-6e23825311ee.png)