### PR TITLE
fix(billing): keep a clickable billing portal link when the payment popup is blocked

### DIFF
--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -57,6 +57,16 @@
       </p>
     </div>
 
+    <div
+      v-if="outstandingPaymentPortalUrl && checkoutStep === 'pricing'"
+      class="flex flex-wrap items-center justify-center gap-3 rounded-2xl border border-warning-background bg-warning-background/20 p-4 text-sm text-text-secondary"
+    >
+      <span>{{ $t('subscription.preview.paymentPopupBlocked') }}</span>
+      <Button size="sm" @click="openOutstandingPaymentPortal">
+        {{ $t('subscription.manageBilling') }}
+      </Button>
+    </div>
+
     <!-- Pricing Table Step. v-show (not v-if) keeps it mounted so the plan,
          billing cycle, and credit-stop selection survive a round trip to the
          confirm step and back. -->
@@ -248,7 +258,9 @@ const {
   handleTeamSubscriptionPayment,
   applyPromotionCode,
   invalidateQuote,
-  handleResubscribe
+  handleResubscribe,
+  outstandingPaymentPortalUrl,
+  openOutstandingPaymentPortal
 } = useSubscriptionCheckout(emit, reason, { embeddedCheckoutEnabled })
 
 const savedMethodsForConfirm = computed(() =>

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -967,6 +967,46 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('leaves a clickable portal link when the popup is blocked', async () => {
+      mockOpen.mockReturnValueOnce(null)
+      const checkout = await submitRejectedPreview(
+        'SUBSCRIPTION_PAYMENT_REQUIRED'
+      )
+
+      expect(checkout.outstandingPaymentPortalUrl.value).toBe(
+        'https://billing.stripe.com/portal'
+      )
+
+      mockOpen.mockClear()
+      checkout.openOutstandingPaymentPortal()
+
+      expect(mockOpen).toHaveBeenCalledWith(
+        'https://billing.stripe.com/portal',
+        '_blank'
+      )
+      expect(checkout.outstandingPaymentPortalUrl.value).toBeNull()
+    })
+
+    it('keeps the portal link when the user click is also blocked', async () => {
+      mockOpen.mockReturnValue(null)
+      const checkout = await submitRejectedPreview(
+        'SUBSCRIPTION_PAYMENT_REQUIRED'
+      )
+      checkout.openOutstandingPaymentPortal()
+
+      expect(checkout.outstandingPaymentPortalUrl.value).toBe(
+        'https://billing.stripe.com/portal'
+      )
+    })
+
+    it('offers no portal link when the popup opened', async () => {
+      const checkout = await submitRejectedPreview(
+        'SUBSCRIPTION_PAYMENT_REQUIRED'
+      )
+
+      expect(checkout.outstandingPaymentPortalUrl.value).toBeNull()
+    })
+
     it('keeps the original error path for non-payment transition failures', async () => {
       await submitRejectedPreview(
         'TRANSITION_NOT_ALLOWED',
@@ -3368,6 +3408,23 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.checkoutStep.value).toBe('pricing')
       expect(checkout.previewData.value).toBeNull()
       expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('leaves a portal link when a legacy-rail subscribe is blocked', async () => {
+      mockShouldUseWorkspaceBilling.value = false
+      mockOpen.mockReturnValueOnce(null)
+      mockSubscribe.mockRejectedValueOnce(
+        errorWithCode('OUTSTANDING_PAYMENT_REQUIRED', 'outstanding payment')
+      )
+      const checkout = await setupWithApprovedPreview()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+
+      await checkout.handleConfirmTransition()
+
+      expect(checkout.outstandingPaymentPortalUrl.value).toBe(
+        'https://billing.stripe.com/portal'
+      )
     })
 
     it('recovers payment failure while refreshing an expired quote', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -171,6 +171,7 @@ export function useSubscriptionCheckout(
   // rejects an unconfirmed change, keep the consent screen in reactivation
   // mode until the user backs out or completes the change.
   const reactivationRequired = ref(false)
+  const outstandingPaymentPortalUrl = ref<string | null>(null)
   const selectedBillingCycle = ref<BillingCycle>('yearly')
   const activeCheckoutOperationId = ref<string | null>(null)
   const activeCheckoutOperation = computed(() => {
@@ -468,6 +469,14 @@ export function useSubscriptionCheckout(
     )
   }
 
+  function openOutstandingPaymentPortal() {
+    const url = outstandingPaymentPortalUrl.value
+    if (!url) return
+    if (!window.open(url, '_blank')) return
+    outstandingPaymentPortalUrl.value = null
+    refreshStatusOnFocus = true
+  }
+
   async function recoverOutstandingPayment(
     error: unknown,
     isCurrent: () => boolean = () => true
@@ -501,6 +510,8 @@ export function useSubscriptionCheckout(
       }
       const paymentWindow = window.open(portalUrl.href, '_blank')
       if (!paymentWindow) {
+        // Unlike the sibling redirect paths, a refused popup here is terminal.
+        outstandingPaymentPortalUrl.value = portalUrl.href
         toast.add({
           severity: 'warn',
           summary: t('g.warning'),
@@ -508,6 +519,7 @@ export function useSubscriptionCheckout(
         })
         return 'blocked'
       }
+      outstandingPaymentPortalUrl.value = null
       refreshStatusOnFocus = true
       return 'opened'
     } catch (portalError) {
@@ -1567,6 +1579,8 @@ export function useSubscriptionCheckout(
     handleTeamSubscriptionPayment,
     applyPromotionCode,
     invalidateQuote,
-    handleResubscribe
+    handleResubscribe,
+    outstandingPaymentPortalUrl,
+    openOutstandingPaymentPortal
   }
 }


### PR DESCRIPTION
When subscribe or plan-change is rejected for an outstanding balance
(`OUTSTANDING_PAYMENT_REQUIRED`), recovery opens the Stripe billing portal with
`window.open(url, '_blank')`. If the popup is refused, it shows a transient toast,
discards the portal URL and returns `blocked`; every caller then returns early. The
customer is wedged — they cannot use the past-due plan and cannot buy or change one —
and the only route out has vanished with the toast.

The sibling redirect in `handleSubscribeResponse` is blocked just as often but survives
it: the URL is handed to `startOperation(..., initialActionUrl)`, so the operation store
keeps it. Recovery is the only path where a blocked popup is terminal.

Keep the popup, retain the URL when it is refused, and render a notice with a button in
the checkout dialog. That click is a fresh user activation, so it opens.

```
before  popup refused -> toast -> return 'blocked' -> caller returns -> URL discarded
after   popup refused -> toast + notice retained -> user clicks -> portal opens
```

No new copy or component: reuses `subscription.preview.paymentPopupBlocked` and
`subscription.manageBilling` (already this action's label in three places) and the
warning-notice styling from `SubscriptionPanelContentWorkspace.vue`. Only the Unified
dialog is touched — `useSubscriptionDialog.ts:124` routes only legacy per-member team
subscribers to the Workspace dialog, so a legacy-rail personal workspace lands here.

Verified by reproduction: stubbing the 422 and driving the composable shows the old path
reaching the toast with nothing retained. Three new tests are mutation-checked — deleting
the single assignment fails all three, restoring passes. 136 pass under `--coverage`;
99 files / 1878 tests pass across `platform/workspace`, `platform/cloud/subscription`
and `composables/billing`. `oxlint` and `pnpm typecheck` clean.

Reviewer notes:
- The notice renders only on the pricing step. Every recovery caller resets there today,
  but a future change leaving the dialog on `preview` would hide it.
- A portal session URL is not valid indefinitely; a click after a long idle may land on
  an expired session. Judged better than no affordance.
- Not visually verified — no browser in the working environment. Worth a screenshot.
- Not fixed, pre-existing: `isCurrent` defaults to `() => true` and callers at 721, 989
  and 1431 pass no guard, so a slow response from an abandoned attempt can still write
  state. Fixing it needs per-call-site request IDs (the `teamPreviewRequestId` pattern) at
  three sites — orthogonal to this and a riskier diff. This change slightly widens the
  window, since a stale response can now leave a notice rather than only a toast.
