### PR TITLE
fix: address desktop notification review feedback

### DIFF
--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -4,8 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
 
-import { UnauthorizedError } from '@/scripts/api'
-
 import DesktopCloudNotificationController from './DesktopCloudNotificationController.vue'
 
 let settingStore: ReturnType<typeof useSettingStore>
@@ -54,7 +52,8 @@ describe('DesktopCloudNotificationController', () => {
     vi.mocked(settingStore.load).mockResolvedValue(undefined)
     vi.mocked(settingStore.set).mockImplementation(
       async (_key: string, value: boolean) => {
-        settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = value
+        settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] =
+          value
       }
     )
     dialogService.showCloudNotification.mockResolvedValue(undefined)
@@ -110,7 +109,9 @@ describe('DesktopCloudNotificationController', () => {
       'Comfy.Desktop.CloudNotificationShown',
       true
     )
-    expect(vi.mocked(settingStore.set).mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      vi.mocked(settingStore.set).mock.invocationCallOrder[0]
+    ).toBeLessThan(
       dialogService.showCloudNotification.mock.invocationCallOrder[0]
     )
 
@@ -130,7 +131,9 @@ describe('DesktopCloudNotificationController', () => {
     const { unmount } = render(DesktopCloudNotificationController)
     await vi.advanceTimersByTimeAsync(2000)
 
-    expect(settingStore.settingValues['Comfy.Desktop.CloudNotificationShown']).toBe(true)
+    expect(
+      settingStore.settingValues['Comfy.Desktop.CloudNotificationShown']
+    ).toBe(true)
     unmount()
     saveSettings.resolve()
     await vi.advanceTimersByTimeAsync(0)
@@ -139,53 +142,21 @@ describe('DesktopCloudNotificationController', () => {
       'Comfy.Desktop.CloudNotificationShown',
       false
     )
-    expect(settingStore.settingValues['Comfy.Desktop.CloudNotificationShown']).toBe(false)
+    expect(
+      settingStore.settingValues['Comfy.Desktop.CloudNotificationShown']
+    ).toBe(false)
     expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
   })
 
-  it.for([new Error('load failed'), new UnauthorizedError('session expired')])(
-    'aborts without reporting a stored settings error: %s',
-    async (error) => {
-      vi.spyOn(settingStore, 'error', 'get').mockReturnValue(error)
-
-      const { unmount } = render(DesktopCloudNotificationController)
-      await vi.advanceTimersByTimeAsync(2000)
-
-      expect(errorReporter).not.toHaveBeenCalled()
-      expect(settingStore.set).not.toHaveBeenCalled()
-      expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
-
-      unmount()
-    }
-  )
-
-  it('reports a rejected settings load without scheduling the notification', async () => {
-    const error = new Error('load rejected')
-    vi.mocked(settingStore.load).mockRejectedValue(error)
+  it('aborts without reporting a stored settings error', async () => {
+    vi.spyOn(settingStore, 'error', 'get').mockReturnValue(
+      new Error('load failed')
+    )
 
     const { unmount } = render(DesktopCloudNotificationController)
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(errorReporter).toHaveBeenCalledWith(
-      error,
-      expect.objectContaining({
-        errorType: 'cloud_notification_settings_load_failed',
-        tags: expect.objectContaining({
-          failure_kind: 'caught_unexpected',
-          feature_area: 'cloud',
-          operation: 'load',
-          outcome: 'failed',
-          assert_mode: 'soft'
-        }),
-        context: expect.objectContaining({
-          platform: 'darwin',
-          is_disposed: false
-        }),
-        level: 'error'
-      })
-    )
     await vi.advanceTimersByTimeAsync(2000)
 
+    expect(errorReporter).not.toHaveBeenCalled()
     expect(settingStore.set).not.toHaveBeenCalled()
     expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
 
@@ -276,7 +247,8 @@ describe('DesktopCloudNotificationController', () => {
         async (_key: string, value: boolean) => {
           if (!value) throw resetError
           if (failure === 'save') throw initialError
-          settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = value
+          settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] =
+            value
         }
       )
 

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -1,9 +1,10 @@
 import type * as DistributionModule from '@/platform/distribution/types'
 import { render } from '@testing-library/vue'
-import { useAsyncState } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
+
+import { UnauthorizedError } from '@/scripts/api'
 
 import DesktopCloudNotificationController from './DesktopCloudNotificationController.vue'
 
@@ -48,15 +49,12 @@ function createDeferred() {
 describe('DesktopCloudNotificationController', () => {
   beforeEach(() => {
     settingStore = useSettingStore()
-    useSettingStore().settingValues['Comfy.Desktop.CloudNotificationShown'] =
-      false
+    settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = false
     electron.getPlatform.mockReturnValue('darwin')
     vi.mocked(settingStore.load).mockResolvedValue(undefined)
     vi.mocked(settingStore.set).mockImplementation(
       async (_key: string, value: boolean) => {
-        useSettingStore().settingValues[
-          'Comfy.Desktop.CloudNotificationShown'
-        ] = value
+        settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = value
       }
     )
     dialogService.showCloudNotification.mockResolvedValue(undefined)
@@ -69,8 +67,7 @@ describe('DesktopCloudNotificationController', () => {
     const { unmount } = render(DesktopCloudNotificationController)
     await nextTick()
 
-    useSettingStore().settingValues['Comfy.Desktop.CloudNotificationShown'] =
-      true
+    settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = true
     loadSettings.resolve()
 
     await vi.advanceTimersByTimeAsync(0)
@@ -113,9 +110,7 @@ describe('DesktopCloudNotificationController', () => {
       'Comfy.Desktop.CloudNotificationShown',
       true
     )
-    expect(
-      vi.mocked(settingStore.set).mock.invocationCallOrder[0]
-    ).toBeLessThan(
+    expect(vi.mocked(settingStore.set).mock.invocationCallOrder[0]).toBeLessThan(
       dialogService.showCloudNotification.mock.invocationCallOrder[0]
     )
 
@@ -125,17 +120,48 @@ describe('DesktopCloudNotificationController', () => {
     unmount()
   })
 
-  it('reports a settings load failure without scheduling the notification', async () => {
-    const error = new Error('load failed')
-    const settingsLoad = useAsyncState(() => Promise.reject(error), undefined, {
-      immediate: false
+  it('resets the shown state when unmounted before the initial save completes', async () => {
+    const saveSettings = createDeferred()
+    vi.mocked(settingStore.set).mockImplementationOnce(async (_key, value) => {
+      settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = value
+      await saveSettings.promise
     })
-    vi.mocked(settingStore.load).mockImplementation(async () => {
-      await settingsLoad.execute()
-    })
-    vi.spyOn(settingStore, 'error', 'get').mockImplementation(
-      () => settingsLoad.error.value
+
+    const { unmount } = render(DesktopCloudNotificationController)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(settingStore.settingValues['Comfy.Desktop.CloudNotificationShown']).toBe(true)
+    unmount()
+    saveSettings.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(settingStore.set).toHaveBeenLastCalledWith(
+      'Comfy.Desktop.CloudNotificationShown',
+      false
     )
+    expect(settingStore.settingValues['Comfy.Desktop.CloudNotificationShown']).toBe(false)
+    expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
+  })
+
+  it.for([new Error('load failed'), new UnauthorizedError('session expired')])(
+    'aborts without reporting a stored settings error: %s',
+    async (error) => {
+      vi.spyOn(settingStore, 'error', 'get').mockReturnValue(error)
+
+      const { unmount } = render(DesktopCloudNotificationController)
+      await vi.advanceTimersByTimeAsync(2000)
+
+      expect(errorReporter).not.toHaveBeenCalled()
+      expect(settingStore.set).not.toHaveBeenCalled()
+      expect(dialogService.showCloudNotification).not.toHaveBeenCalled()
+
+      unmount()
+    }
+  )
+
+  it('reports a rejected settings load without scheduling the notification', async () => {
+    const error = new Error('load rejected')
+    vi.mocked(settingStore.load).mockRejectedValue(error)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await vi.advanceTimersByTimeAsync(0)
@@ -243,20 +269,30 @@ describe('DesktopCloudNotificationController', () => {
     async (failure) => {
       const initialError = new Error('initial failure')
       const resetError = new Error('reset failed')
-      dialogService.showCloudNotification.mockRejectedValue(initialError)
+      if (failure === 'display') {
+        dialogService.showCloudNotification.mockRejectedValue(initialError)
+      }
       vi.mocked(settingStore.set).mockImplementation(
         async (_key: string, value: boolean) => {
           if (!value) throw resetError
           if (failure === 'save') throw initialError
-          useSettingStore().settingValues[
-            'Comfy.Desktop.CloudNotificationShown'
-          ] = value
+          settingStore.settingValues['Comfy.Desktop.CloudNotificationShown'] = value
         }
       )
 
       const { unmount } = render(DesktopCloudNotificationController)
       await vi.advanceTimersByTimeAsync(2000)
 
+      expect(errorReporter).toHaveBeenNthCalledWith(
+        1,
+        initialError,
+        expect.objectContaining({
+          errorType:
+            failure === 'save'
+              ? 'cloud_notification_state_save_failed'
+              : 'cloud_notification_show_failed'
+        })
+      )
       expect(errorReporter).toHaveBeenNthCalledWith(
         2,
         resetError,

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
@@ -14,8 +14,11 @@ let isDisposed = false
 let cloudNotificationTimer: ReturnType<typeof setTimeout> | undefined
 
 function reportNotificationFailure(
-  errorType: string,
-  operation: 'load' | 'save' | 'render',
+  errorType:
+    | 'cloud_notification_state_save_failed'
+    | 'cloud_notification_show_failed'
+    | 'cloud_notification_state_reset_failed',
+  operation: 'save' | 'render',
   cause: unknown,
   platform: string
 ) {
@@ -50,18 +53,7 @@ async function scheduleCloudNotification() {
   const platform = electronAPI()?.getPlatform()
   if (!isDesktop || platform !== 'darwin') return
 
-  try {
-    await settingStore.load()
-  } catch (error) {
-    reportNotificationFailure(
-      'cloud_notification_settings_load_failed',
-      'load',
-      error,
-      platform
-    )
-    return
-  }
-
+  await settingStore.load()
   if (settingStore.error !== undefined) return
   if (isDisposed) return
   if (settingStore.get('Comfy.Desktop.CloudNotificationShown')) return

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.vue
@@ -13,22 +13,36 @@ const dialogService = useDialogService()
 let isDisposed = false
 let cloudNotificationTimer: ReturnType<typeof setTimeout> | undefined
 
+function reportNotificationFailure(
+  errorType: string,
+  operation: 'load' | 'save' | 'render',
+  cause: unknown,
+  platform: string
+) {
+  reportError(cause, {
+    errorType,
+    tags: {
+      failure_kind: 'caught_unexpected',
+      feature_area: 'cloud',
+      operation,
+      outcome: 'failed',
+      assert_mode: 'soft'
+    },
+    context: { platform, is_disposed: isDisposed },
+    level: 'error'
+  })
+}
+
 async function resetNotificationState(platform: string) {
   try {
     await settingStore.set('Comfy.Desktop.CloudNotificationShown', false)
   } catch (error) {
-    reportError(error, {
-      errorType: 'cloud_notification_state_reset_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'cloud',
-        operation: 'save',
-        outcome: 'failed',
-        assert_mode: 'soft'
-      },
-      context: { platform, is_disposed: isDisposed },
-      level: 'error'
-    })
+    reportNotificationFailure(
+      'cloud_notification_state_reset_failed',
+      'save',
+      error,
+      platform
+    )
   }
 }
 
@@ -38,23 +52,17 @@ async function scheduleCloudNotification() {
 
   try {
     await settingStore.load()
-    if (settingStore.error !== undefined) throw settingStore.error
   } catch (error) {
-    reportError(error, {
-      errorType: 'cloud_notification_settings_load_failed',
-      tags: {
-        failure_kind: 'caught_unexpected',
-        feature_area: 'cloud',
-        operation: 'load',
-        outcome: 'failed',
-        assert_mode: 'soft'
-      },
-      context: { platform, is_disposed: isDisposed },
-      level: 'error'
-    })
+    reportNotificationFailure(
+      'cloud_notification_settings_load_failed',
+      'load',
+      error,
+      platform
+    )
     return
   }
 
+  if (settingStore.error !== undefined) return
   if (isDisposed) return
   if (settingStore.get('Comfy.Desktop.CloudNotificationShown')) return
 
@@ -64,39 +72,30 @@ async function scheduleCloudNotification() {
     try {
       await settingStore.set('Comfy.Desktop.CloudNotificationShown', true)
     } catch (error) {
-      reportError(error, {
-        errorType: 'cloud_notification_state_save_failed',
-        tags: {
-          failure_kind: 'caught_unexpected',
-          feature_area: 'cloud',
-          operation: 'save',
-          outcome: 'failed',
-          assert_mode: 'soft'
-        },
-        context: { platform, is_disposed: isDisposed },
-        level: 'error'
-      })
+      reportNotificationFailure(
+        'cloud_notification_state_save_failed',
+        'save',
+        error,
+        platform
+      )
       await resetNotificationState(platform)
       return
     }
 
-    if (isDisposed) return
+    if (isDisposed) {
+      await resetNotificationState(platform)
+      return
+    }
 
     try {
       await dialogService.showCloudNotification()
     } catch (error) {
-      reportError(error, {
-        errorType: 'cloud_notification_show_failed',
-        tags: {
-          failure_kind: 'caught_unexpected',
-          feature_area: 'cloud',
-          operation: 'render',
-          outcome: 'failed',
-          assert_mode: 'soft'
-        },
-        context: { platform, is_disposed: isDisposed },
-        level: 'error'
-      })
+      reportNotificationFailure(
+        'cloud_notification_show_failed',
+        'render',
+        error,
+        platform
+      )
       await resetNotificationState(platform)
     }
   }, 2000)


### PR DESCRIPTION
## Summary

Stop re-reporting stored settings-load errors and restore notification eligibility when unmount interrupts the initial save. Stacked on #17135; merge that PR first.

## Changes

- Await settings loading and abort on the exposed store error without another component-level report.
- Share notification telemetry fields in a local helper with explicit failure types.
- Reset the shown flag if the component unmounts during the initial save.
- Mock the exposed store error directly and distinguish save/display failures in reset tests; remove the unused load catch and mock-only rejection case.

## Review Focus

59 focused tests pass. The stored-error and disposal regressions fail against the parent implementation. Full lint, typecheck, formatting, and Knip validated locally.

Fixes the review findings on #17135, including the pending-save disposal race, and the follow-up cleanup findings on this PR.
