### PR TITLE
ci: stop diagnostics upload failures from failing the custom-node suite

### DIFF
--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -422,6 +422,7 @@ jobs:
 
       - name: Upload Playwright report and raw diagnostics
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           # Shard-scoped: artifact names are unique per run, so matrix jobs


### PR DESCRIPTION
## Summary

A GitHub artifact-storage 403 currently fails custom-node jobs whose tests already passed, which would eject PRs from the merge queue once this suite gates.

## Changes

- **What**: `continue-on-error: true` on the "Upload Playwright report and raw diagnostics" step.

## Review Focus

The upload runs *after* both verdict steps (`Forbid failed, skipped, or flaky tests` / `Assert deliberate failure independence`) and carries only reports and logs, so its failure cannot mask a test failure.

The `if-no-files-found: error` guard is not the authoritative check for "did the suite run" — `scripts/cicd/custom-node-results.ts` already throws when the results JSON is missing:

```ts
if (!existsSync('custom-nodes-results.json'))
  throw new Error(`suite wrote no results JSON (${process.env.SUITE_OUTCOME ?? 'unknown'})`)
```

Observed today on runs 34252470835 (2 slices, `0 failed, 32 passed` each) and 34253652964 (`524 passed (524)`), both red solely on `Failed to FinalizeArtifact: (403) Forbidden`. This is prerequisite work for restoring the PR/merge_group triggers removed in #16577.