### PR TITLE
fix(settings): preserve falsy versioned setting defaults

### DIFF
--- a/src/platform/settings/settingStore.test.ts
+++ b/src/platform/settings/settingStore.test.ts
@@ -314,6 +314,24 @@ describe('useSettingStore', () => {
       expect(result).toBe('regular-default')
     })
 
+    it.for([false, 0, ''])(
+      'should return a falsy versioned default (%j)',
+      (falsy) => {
+        const setting: SettingParams = {
+          id: 'test.setting',
+          name: 'Test Setting',
+          type: 'text',
+          defaultValue: 'regular-default',
+          defaultsByInstallVersion: {
+            '1.21.3': falsy
+          }
+        }
+        store.addSetting(setting)
+
+        expect(store.getDefaultValue('test.setting')).toBe(falsy)
+      }
+    )
+
     it('should handle function-based versioned defaults', () => {
       const setting: SettingParams = {
         id: 'test.setting',

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -284,12 +284,7 @@ export const useSettingStore = defineStore('setting', () => {
 
     const versionedDefault = getVersionedDefaultValue(key, param)
 
-    if (versionedDefault) {
-      return versionedDefault
-    }
-
-    const defaultValue = param.defaultValue
-    return resolveDefaultValue(defaultValue)
+    return versionedDefault ?? resolveDefaultValue(param.defaultValue)
   }
 
   function getVersionedDefaultValue<


### PR DESCRIPTION
## What

`getDefaultValue` gated the versioned default on truthiness:

```ts
const versionedDefault = getVersionedDefaultValue(key, param)
if (versionedDefault) return versionedDefault
```

`getVersionedDefaultValue` returns `TValue | null`, using `null` as its "no match" sentinel. So a versioned default of `false`, `0`, or `''` was indistinguishable from no match and silently fell back to `param.defaultValue`. Replaced with `versionedDefault ?? resolveDefaultValue(param.defaultValue)`.

## Why

Any setting shipping a falsy `defaultsByInstallVersion` entry — the common case for a boolean flag turned off for new installs — resolves to the wrong default. The bug is invisible until such an entry is added.

Found by CodeRabbit on #16369, where it was anchored on `docs/SETTINGS.md` because that docs-only PR touched no source. The docs were accurate; the code was not. #16369 has since merged, so the fix lands separately here.

## Test plan

`src/platform/settings/settingStore.test.ts` covers `false`, `0`, and `''` versioned defaults. Verified red-then-green: against the previous truthiness check all three fail (`50 passed | 3 failed`); with the fix, `53 passed`.

Gates: `pnpm typecheck` (exit 0, control-checked against an injected type error), `eslint` 0 errors, `oxfmt --check` clean, `pnpm knip` clean.