### PR TITLE
fix: fetch history for lockfile conflict repair

### DIFF
--- a/.github/workflows/ci-lockfile-repair.yaml
+++ b/.github/workflows/ci-lockfile-repair.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Detect lockfile-only conflict

--- a/.github/workflows/pr-lockfile-conflict-repair.yaml
+++ b/.github/workflows/pr-lockfile-conflict-repair.yaml
@@ -80,6 +80,7 @@ jobs:
         with:
           repository: ${{ matrix.pull.headRepo }}
           ref: ${{ matrix.pull.headSha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Reproduce lockfile-only conflict
@@ -206,6 +207,7 @@ jobs:
         with:
           repository: ${{ matrix.pull.headRepo }}
           ref: ${{ matrix.pull.headSha }}
+          fetch-depth: 0
           token: ${{ secrets.PR_GH_TOKEN }}
 
       - name: Apply repaired lockfile

--- a/.github/workflows/pr-lockfile-repair.yaml
+++ b/.github/workflows/pr-lockfile-repair.yaml
@@ -86,6 +86,7 @@ jobs:
         with:
           repository: ${{ steps.pr.outputs.head-repository }}
           ref: ${{ steps.pr.outputs.head-sha }}
+          fetch-depth: 0
           token: ${{ secrets.PR_GH_TOKEN }}
 
       - name: Apply repaired lockfile


### PR DESCRIPTION
## Summary

Fetch complete PR history before lockfile repair workflows attempt to merge the base SHA, preventing shallow clones from being misclassified as unrelated histories.

## Changes

- **What**: Set `fetch-depth: 0` on all producer and privileged consumer checkouts that reproduce the lockfile-only merge conflict.

## Review Focus

PR #17138's repair run logged `fatal: refusing to merge unrelated histories`, selected repair mode, and pushed nothing. Confirm complete history is available at each merge step without changing the existing artifact and privilege boundaries.