### PR TITLE
fix: address widget visibility review follow-ups

### DIFF
--- a/browser_tests/tests/painter.spec.ts
+++ b/browser_tests/tests/painter.spec.ts
@@ -50,6 +50,9 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
       })
       await comfyPage.actionbar.propertiesButton.click()
       const parameters = comfyPage.menu.propertiesPanel.root
+      await expect(comfyPage.menu.propertiesPanel.panelTitle).toContainText(
+        'Painter'
+      )
       for (const widgetName of HIDDEN_PAINTER_WIDGET_NAMES) {
         await expect(
           parameters.getByLabel(widgetName, { exact: true })

--- a/src/components/builder/AppBuilder.test.ts
+++ b/src/components/builder/AppBuilder.test.ts
@@ -40,39 +40,50 @@ vi.mock('@/scripts/app', () => ({
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
 
 describe('AppBuilder', () => {
-  it('does not select panel-hidden widgets as app inputs', async () => {
-    const canvasElement = document.createElement('canvas')
-    canvasElement.getContext = vi
-      .fn()
-      .mockReturnValue(createMockCanvasRenderingContext2D())
-    const graph = new LGraph()
-    const canvas = new LGraphCanvas(canvasElement, graph, { skip_render: true })
-    const node = new LGraphNode('Source', 'Source')
-    const widget = node.addWidget('text', 'hidden', '', () => {})
-    graph.add(node)
-    if (!widget.visibility)
-      throw new Error('Missing concrete widget visibility')
-    widget.visibility.surfaces.panel = 'never'
-    vi.spyOn(graph, 'getNodeOnPos').mockReturnValue(node)
-    vi.spyOn(node, 'getWidgetOnPos').mockReturnValue(widget)
-    vi.spyOn(canvas, 'adjustMouseEvent').mockImplementation(() => {})
-    useCanvasStore().canvas = canvas
+  it.for([
+    ['shown', true],
+    ['never', false]
+  ] as const)(
+    'selects a widget with panel visibility %s: %s',
+    async ([panelVisibility, selectable]) => {
+      const canvasElement = document.createElement('canvas')
+      canvasElement.getContext = vi
+        .fn()
+        .mockReturnValue(createMockCanvasRenderingContext2D())
+      const graph = new LGraph()
+      const canvas = new LGraphCanvas(canvasElement, graph, {
+        skip_render: true
+      })
+      const node = new LGraphNode('Source', 'Source')
+      const widget = node.addWidget('text', 'input', '', () => {})
+      graph.add(node)
+      if (!widget.visibility)
+        throw new Error('Missing concrete widget visibility')
+      widget.visibility.surfaces.panel = panelVisibility
+      vi.spyOn(graph, 'getNodeOnPos').mockReturnValue(node)
+      vi.spyOn(node, 'getWidgetOnPos').mockReturnValue(widget)
+      vi.spyOn(canvas, 'adjustMouseEvent').mockImplementation(() => {})
+      useCanvasStore().canvas = canvas
+      useAppModeStore().selectedInputs = []
 
-    render(AppBuilder, {
-      global: {
-        plugins: [i18n],
-        stubs: {
-          AppModeWidgetList: true,
-          DraggableList: true,
-          IoItem: true,
-          PropertiesAccordionItem: true,
-          TransformPane: true
+      render(AppBuilder, {
+        global: {
+          plugins: [i18n],
+          stubs: {
+            AppModeWidgetList: true,
+            DraggableList: true,
+            IoItem: true,
+            PropertiesAccordionItem: true,
+            TransformPane: true
+          }
         }
-      }
-    })
+      })
 
-    await userEvent.click(screen.getByTestId('builder-selection-overlay'))
+      await userEvent.click(screen.getByTestId('builder-selection-overlay'))
 
-    expect(useAppModeStore().selectedInputs).toEqual([])
-  })
+      expect(useAppModeStore().selectedInputs).toEqual(
+        selectable ? [[widget.widgetId, widget.name, undefined]] : []
+      )
+    }
+  )
 })

--- a/src/components/builder/AppBuilder.test.ts
+++ b/src/components/builder/AppBuilder.test.ts
@@ -64,7 +64,6 @@ describe('AppBuilder', () => {
       vi.spyOn(node, 'getWidgetOnPos').mockReturnValue(widget)
       vi.spyOn(canvas, 'adjustMouseEvent').mockImplementation(() => {})
       useCanvasStore().canvas = canvas
-      useAppModeStore().selectedInputs = []
 
       render(AppBuilder, {
         global: {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -487,7 +487,7 @@ export class LGraph
    * Ref-backed so the id reassignment on every workflow load ({@link configure})
    * propagates to reactive consumers keyed by root graph id.
    */
-  protected readonly _id = shallowRef<UUID>(zeroUuid)
+  private readonly _id = shallowRef<UUID>(zeroUuid)
   get id(): UUID {
     return toRaw(this)._id.value
   }
@@ -3372,35 +3372,26 @@ export class Subgraph
     // No-op: subgraphs share the root graph's state.
   }
 
-  constructor(
-    rootGraph: LGraph | null | undefined,
-    data: ExportedSubgraph,
-    keepId = false
-  ) {
+  constructor(rootGraph: LGraph | null | undefined, data: ExportedSubgraph) {
     if (!rootGraph) throw new Error('Root graph is required')
 
     super()
 
     this._rootGraph = rootGraph
     const cloned = structuredClone(data)
-    const idIsOccupied = useGraphMetadataStore().has(rootGraph.id, cloned.id)
-    if (keepId && idIsOccupied) {
-      this._id.value = cloned.id
-    } else if (idIsOccupied) {
+    if (useGraphMetadataStore().has(rootGraph.id, cloned.id)) {
       cloned.id = createUuidv4()
     }
     this._configureBase(cloned)
     this._configureSubgraph(cloned)
   }
 
-  /** Clones the subgraph with a new ID and an independent store scope. */
+  /** Clones and registers the subgraph under a new ID. */
   // fallow-ignore-next-line unused-class-member
   clone(): Subgraph {
     const exported = this.asSerialisable()
     exported.id = createUuidv4()
-    const subgraph = new Subgraph(this.rootGraph, exported)
-    subgraph.configure(structuredClone(exported))
-    return subgraph
+    return this.rootGraph.createSubgraph(structuredClone(exported))
   }
 
   getIoNodeOnPos(

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -487,7 +487,7 @@ export class LGraph
    * Ref-backed so the id reassignment on every workflow load ({@link configure})
    * propagates to reactive consumers keyed by root graph id.
    */
-  private readonly _id = shallowRef<UUID>(zeroUuid)
+  protected readonly _id = shallowRef<UUID>(zeroUuid)
   get id(): UUID {
     return toRaw(this)._id.value
   }
@@ -3372,18 +3372,36 @@ export class Subgraph
     // No-op: subgraphs share the root graph's state.
   }
 
-  constructor(rootGraph: LGraph | null | undefined, data: ExportedSubgraph) {
+  constructor(
+    rootGraph: LGraph | null | undefined,
+    data: ExportedSubgraph,
+    keepId = false
+  ) {
     if (!rootGraph) throw new Error('Root graph is required')
 
     super()
 
     this._rootGraph = rootGraph
     const cloned = structuredClone(data)
-    if (useGraphMetadataStore().has(rootGraph.id, cloned.id)) {
+    const idIsOccupied = useGraphMetadataStore().has(rootGraph.id, cloned.id)
+    if (keepId && idIsOccupied) {
+      this._id.value = cloned.id
+    } else if (idIsOccupied) {
       cloned.id = createUuidv4()
     }
     this._configureBase(cloned)
     this._configureSubgraph(cloned)
+  }
+
+  /**
+   * Clones the subgraph, creating an identical copy with a new ID.
+   * @returns A new subgraph with the same configuration, but a new ID.
+   */
+  // fallow-ignore-next-line unused-class-member
+  clone(keepId: boolean = false): Subgraph {
+    const exported = this.asSerialisable()
+    if (!keepId) exported.id = createUuidv4()
+    return new Subgraph(this.rootGraph, exported, keepId)
   }
 
   getIoNodeOnPos(

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -3394,14 +3394,17 @@ export class Subgraph
   }
 
   /**
-   * Clones the subgraph, creating an identical copy with a new ID.
-   * @returns A new subgraph with the same configuration, but a new ID.
+   * Clones the subgraph, creating an identical copy. Generates a new ID by
+   * default; `clone(true)` preserves the existing ID.
+   * @returns A new subgraph with the same configuration.
    */
   // fallow-ignore-next-line unused-class-member
   clone(keepId: boolean = false): Subgraph {
     const exported = this.asSerialisable()
     if (!keepId) exported.id = createUuidv4()
-    return new Subgraph(this.rootGraph, exported, keepId)
+    const subgraph = new Subgraph(this.rootGraph, exported, keepId)
+    subgraph.configure(exported)
+    return subgraph
   }
 
   getIoNodeOnPos(

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -3395,7 +3395,7 @@ export class Subgraph
 
   /**
    * Clones the subgraph, creating an identical copy. Generates a new ID by
-   * default; `clone(true)` preserves the existing ID.
+   * default; `clone(true)` preserves the existing ID for replacement flows.
    * @returns A new subgraph with the same configuration.
    */
   // fallow-ignore-next-line unused-class-member
@@ -3403,7 +3403,7 @@ export class Subgraph
     const exported = this.asSerialisable()
     if (!keepId) exported.id = createUuidv4()
     const subgraph = new Subgraph(this.rootGraph, exported, keepId)
-    subgraph.configure(exported)
+    subgraph.configure(structuredClone(exported))
     return subgraph
   }
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -3393,16 +3393,12 @@ export class Subgraph
     this._configureSubgraph(cloned)
   }
 
-  /**
-   * Clones the subgraph, creating an identical copy. Generates a new ID by
-   * default; `clone(true)` preserves the existing ID for replacement flows.
-   * @returns A new subgraph with the same configuration.
-   */
+  /** Clones the subgraph with a new ID and an independent store scope. */
   // fallow-ignore-next-line unused-class-member
-  clone(keepId: boolean = false): Subgraph {
+  clone(): Subgraph {
     const exported = this.asSerialisable()
-    if (!keepId) exported.id = createUuidv4()
-    const subgraph = new Subgraph(this.rootGraph, exported, keepId)
+    exported.id = createUuidv4()
+    const subgraph = new Subgraph(this.rootGraph, exported)
     subgraph.configure(structuredClone(exported))
     return subgraph
   }

--- a/src/lib/litegraph/src/subgraph/Subgraph.test.ts
+++ b/src/lib/litegraph/src/subgraph/Subgraph.test.ts
@@ -13,12 +13,7 @@ import {
   SUBGRAPH_OUTPUT_ID
 } from '@/lib/litegraph/src/constants'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
-import {
-  createUuidv4,
-  LGraphNode,
-  LiteGraph,
-  Subgraph
-} from '@/lib/litegraph/src/litegraph'
+import { createUuidv4, Subgraph } from '@/lib/litegraph/src/litegraph'
 import { subgraphTest } from './__fixtures__/subgraphFixtures'
 import {
   assertSubgraphStructure,
@@ -27,11 +22,8 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
-class CloneTestNode extends LGraphNode {}
-
 beforeEach(() => {
   resetSubgraphFixtureState()
-  LiteGraph.registerNodeType('clone-test', CloneTestNode)
 })
 
 describe('Subgraph Construction', () => {
@@ -75,22 +67,31 @@ describe('Subgraph Construction', () => {
     expect(subgraph.name).toBe(customName)
   })
 
-  it('clones with a new ID unless preserving it is requested', () => {
-    const subgraph = createTestSubgraph({ name: 'Clone source' })
-    subgraph.add(new CloneTestNode('Clone content'))
+  it('clones into an independent store scope', () => {
+    const subgraph = createTestSubgraph({
+      name: 'Clone source',
+      nodeCount: 1,
+      inputs: [{ name: 'source input', type: 'number' }]
+    })
+    const sourceBeforeClone = subgraph.asSerialisable()
 
     const clone = subgraph.clone()
-    const preservedIdClone = subgraph.clone(true)
+    for (const node of clone.nodes) node.title = 'Changed clone node'
+    clone.addInput('clone input', 'string')
 
     expect(clone).not.toBe(subgraph)
     expect(clone.id).not.toBe(subgraph.id)
     expect(clone.name).toBe(subgraph.name)
-    expect(clone.nodes.map(({ title }) => title)).toEqual(['Clone content'])
-    expect(preservedIdClone.id).toBe(subgraph.id)
-    expect(preservedIdClone.nodes.map(({ title }) => title)).toEqual([
-      'Clone content'
+    expect(clone.nodes.map(({ title }) => title)).toEqual([
+      'Changed clone node'
     ])
-    expect(subgraph.nodes.map(({ title }) => title)).toEqual(['Clone content'])
+    expect(clone.asSerialisable().inputs?.map(({ name }) => name)).toEqual([
+      'source input',
+      'clone input'
+    ])
+    expect(subgraph.nodes).toHaveLength(1)
+    expect(subgraph.nodes.map(({ title }) => title)).toEqual(['Test Node 0'])
+    expect(subgraph.asSerialisable()).toEqual(sourceBeforeClone)
   })
 })
 

--- a/src/lib/litegraph/src/subgraph/Subgraph.test.ts
+++ b/src/lib/litegraph/src/subgraph/Subgraph.test.ts
@@ -73,7 +73,8 @@ describe('Subgraph Construction', () => {
       nodeCount: 1,
       inputs: [{ name: 'source input', type: 'number' }]
     })
-    const sourceBeforeClone = subgraph.asSerialisable()
+    subgraph.rootGraph.subgraphs.set(subgraph.id, subgraph)
+    const sourceBeforeClone = structuredClone(subgraph.asSerialisable())
 
     const clone = subgraph.clone()
     for (const node of clone.nodes) node.title = 'Changed clone node'
@@ -81,7 +82,13 @@ describe('Subgraph Construction', () => {
 
     expect(clone).not.toBe(subgraph)
     expect(clone.id).not.toBe(subgraph.id)
+    expect(subgraph.rootGraph.subgraphs.get(clone.id)).toBe(clone)
     expect(clone.name).toBe(subgraph.name)
+    expect(clone.nodes.map(({ id }) => id)).not.toEqual(
+      subgraph.nodes.map(({ id }) => id)
+    )
+    expect(clone.nodes.map(({ type }) => type)).toEqual(['Fixture/TestNode'])
+    expect(clone.nodes.every(({ has_errors }) => !has_errors)).toBe(true)
     expect(clone.nodes.map(({ title }) => title)).toEqual([
       'Changed clone node'
     ])
@@ -91,7 +98,13 @@ describe('Subgraph Construction', () => {
     ])
     expect(subgraph.nodes).toHaveLength(1)
     expect(subgraph.nodes.map(({ title }) => title)).toEqual(['Test Node 0'])
-    expect(subgraph.asSerialisable()).toEqual(sourceBeforeClone)
+
+    subgraph.rootGraph.releaseSubgraphs([clone])
+    expect(subgraph.rootGraph.subgraphs.has(clone.id)).toBe(false)
+    expect(subgraph.asSerialisable()).toEqual({
+      ...sourceBeforeClone,
+      state: subgraph.state
+    })
   })
 })
 

--- a/src/lib/litegraph/src/subgraph/Subgraph.test.ts
+++ b/src/lib/litegraph/src/subgraph/Subgraph.test.ts
@@ -13,7 +13,12 @@ import {
   SUBGRAPH_OUTPUT_ID
 } from '@/lib/litegraph/src/constants'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
-import { createUuidv4, Subgraph } from '@/lib/litegraph/src/litegraph'
+import {
+  createUuidv4,
+  LGraphNode,
+  LiteGraph,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
 import { subgraphTest } from './__fixtures__/subgraphFixtures'
 import {
   assertSubgraphStructure,
@@ -22,8 +27,11 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
+class CloneTestNode extends LGraphNode {}
+
 beforeEach(() => {
   resetSubgraphFixtureState()
+  LiteGraph.registerNodeType('clone-test', CloneTestNode)
 })
 
 describe('Subgraph Construction', () => {
@@ -69,6 +77,7 @@ describe('Subgraph Construction', () => {
 
   it('clones with a new ID unless preserving it is requested', () => {
     const subgraph = createTestSubgraph({ name: 'Clone source' })
+    subgraph.add(new CloneTestNode('Clone content'))
 
     const clone = subgraph.clone()
     const preservedIdClone = subgraph.clone(true)
@@ -76,7 +85,11 @@ describe('Subgraph Construction', () => {
     expect(clone).not.toBe(subgraph)
     expect(clone.id).not.toBe(subgraph.id)
     expect(clone.name).toBe(subgraph.name)
+    expect(clone.nodes.map(({ title }) => title)).toEqual(['Clone content'])
     expect(preservedIdClone.id).toBe(subgraph.id)
+    expect(preservedIdClone.nodes.map(({ title }) => title)).toEqual([
+      'Clone content'
+    ])
   })
 })
 

--- a/src/lib/litegraph/src/subgraph/Subgraph.test.ts
+++ b/src/lib/litegraph/src/subgraph/Subgraph.test.ts
@@ -66,6 +66,18 @@ describe('Subgraph Construction', () => {
     expect(subgraph.id).toBe(customId)
     expect(subgraph.name).toBe(customName)
   })
+
+  it('clones with a new ID unless preserving it is requested', () => {
+    const subgraph = createTestSubgraph({ name: 'Clone source' })
+
+    const clone = subgraph.clone()
+    const preservedIdClone = subgraph.clone(true)
+
+    expect(clone).not.toBe(subgraph)
+    expect(clone.id).not.toBe(subgraph.id)
+    expect(clone.name).toBe(subgraph.name)
+    expect(preservedIdClone.id).toBe(subgraph.id)
+  })
 })
 
 describe('Subgraph Input/Output Management', () => {

--- a/src/lib/litegraph/src/subgraph/Subgraph.test.ts
+++ b/src/lib/litegraph/src/subgraph/Subgraph.test.ts
@@ -90,6 +90,7 @@ describe('Subgraph Construction', () => {
     expect(preservedIdClone.nodes.map(({ title }) => title)).toEqual([
       'Clone content'
     ])
+    expect(subgraph.nodes.map(({ title }) => title)).toEqual(['Clone content'])
   })
 })
 

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -50,7 +50,7 @@ class FixtureStringConcatenateNode extends LGraphNode {
 
 class FixtureTestNode extends LGraphNode {
   constructor(title = 'Test Node') {
-    super(title)
+    super(title, FIXTURE_TEST_NODE_TYPE)
     this.addInput('in', '*')
     this.addOutput('out', '*')
   }
@@ -287,7 +287,7 @@ export function createTestSubgraph(
 
   // Add test nodes if requested
   if (options.nodeCount) {
-    LiteGraph.registerNodeType(FIXTURE_TEST_NODE_TYPE, FixtureTestNode)
+    LiteGraph.registered_node_types[FIXTURE_TEST_NODE_TYPE] ??= FixtureTestNode
     for (let i = 0; i < options.nodeCount; i++) {
       subgraph.add(new FixtureTestNode(`Test Node ${i}`))
     }

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -31,6 +31,7 @@ import {
 import { subgraphComplexPromotion1 } from './subgraphComplexPromotion1'
 
 const FIXTURE_STRING_CONCAT_TYPE = 'Fixture/StringConcatenate'
+const FIXTURE_TEST_NODE_TYPE = 'Fixture/TestNode'
 const FIXTURE_UUID_PREFIX = '00000000-0000-4000-8000-'
 
 let fixtureUuidSequence = 1
@@ -44,6 +45,14 @@ class FixtureStringConcatenateNode extends LGraphNode {
     this.addWidget('text', 'string_a', '', () => {})
     this.addWidget('text', 'string_b', '', () => {})
     this.addWidget('text', 'delimiter', '', () => {})
+  }
+}
+
+class FixtureTestNode extends LGraphNode {
+  constructor(title = 'Test Node') {
+    super(title)
+    this.addInput('in', '*')
+    this.addOutput('out', '*')
   }
 }
 
@@ -61,6 +70,9 @@ function nextFixtureUuid(): UUID {
 export function resetSubgraphFixtureState(): void {
   fixtureUuidSequence = 1
   cleanupComplexPromotionFixtureNodeType()
+  if (FIXTURE_TEST_NODE_TYPE in LiteGraph.registered_node_types) {
+    LiteGraph.unregisterNodeType(FIXTURE_TEST_NODE_TYPE)
+  }
 }
 
 export function enableSubgraphNodeCreation(rootGraph: LGraph): () => void {
@@ -275,11 +287,9 @@ export function createTestSubgraph(
 
   // Add test nodes if requested
   if (options.nodeCount) {
+    LiteGraph.registerNodeType(FIXTURE_TEST_NODE_TYPE, FixtureTestNode)
     for (let i = 0; i < options.nodeCount; i++) {
-      const node = new LGraphNode(`Test Node ${i}`)
-      node.addInput('in', '*')
-      node.addOutput('out', '*')
-      subgraph.add(node)
+      subgraph.add(new FixtureTestNode(`Test Node ${i}`))
     }
   }
 

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -86,7 +86,6 @@ describe('BaseWidget store integration', () => {
 
     widget.drawSuppressedRowLabel(ctx, { width: 200 })
 
-    expect(ctx.fillText).toHaveBeenCalledWith('Input label', 35, 14)
     expect(vi.mocked(ctx.fillText).mock.calls.map(([text]) => text)).toEqual([
       'Input label'
     ])

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -20,6 +20,7 @@ import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 import { isWidgetHidden } from '@/types/widgetVisibility'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 function createTestWidget(
   node: LGraphNode,
@@ -74,6 +75,21 @@ describe('BaseWidget store integration', () => {
     node = new LGraphNode('TestNode')
     node.id = toNodeId(1)
     graph.add(node)
+  })
+
+  it('draws only the label for a connection-suppressed row', () => {
+    const widget = createTestWidget(node, {
+      label: 'Input label',
+      value: 73
+    })
+    const ctx = createMockCanvasRenderingContext2D()
+
+    widget.drawSuppressedRowLabel(ctx, { width: 200 })
+
+    expect(ctx.fillText).toHaveBeenCalledWith('Input label', 35, 14)
+    expect(vi.mocked(ctx.fillText).mock.calls.map(([text]) => text)).toEqual([
+      'Input label'
+    ])
   })
 
   it('preserves name in keys, spread copies, and JSON', () => {

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -608,8 +608,16 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     ctx: CanvasRenderingContext2D,
     { width }: DrawWidgetOptions
   ): void {
-    ctx.textAlign = 'left'
-    this.drawTruncatingText({ ctx, width })
+    const { margin } = BaseWidget
+    const x = margin * 2 + 5
+    const area = new Rectangle(
+      x,
+      this.y,
+      width - x - 2 * margin,
+      this.height * 0.7
+    )
+    ctx.fillStyle = this.secondary_text_color
+    drawTextInArea({ ctx, text: this.displayName, area, align: 'left' })
   }
 
   /**

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -160,7 +160,7 @@ function buildSlotMetadata(
       ? linkStore.getInputSlotLink(scope, nodeId, index)
       : undefined
     const widgetName = getSlotWidgetName(input, link !== undefined)
-    if (!widgetName) continue
+    if (!widgetName || metadata.has(widgetName)) continue
     metadata.set(widgetName, createSlotMetadata(input, index, link, graphRef))
   }
   return metadata

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -168,6 +168,58 @@ describe('widget slot ownership', () => {
 
     expect(processedWidget.slotMetadata).toBeUndefined()
   })
+
+  it('uses the first same-named widget input slot', () => {
+    const nodeId = toNodeId(1)
+    const { graph, node } = createGraphWithNode([], nodeId)
+    const widget = node.addWidget('text', 'value', '', () => {})
+    node.inputs = [
+      {
+        name: 'value',
+        type: 'STRING',
+        widget: { name: 'value' },
+        boundingRect: [0, 0, 0, 0]
+      },
+      {
+        name: 'value',
+        type: 'STRING',
+        widget: { name: 'value' },
+        boundingRect: [0, 0, 0, 0]
+      }
+    ]
+    useLinkStore().registerLink(
+      {
+        rootGraphId: toRootGraphId(GRAPH_ID),
+        owningGraphId: toOwningGraphId(GRAPH_ID)
+      },
+      {
+        id: toLinkId(1),
+        graphId: toOwningGraphId(GRAPH_ID),
+        originNodeId: toNodeId(2),
+        originSlot: 0,
+        targetNodeId: nodeId,
+        targetSlot: 1,
+        type: 'STRING'
+      }
+    )
+    const id = widget.widgetId
+    if (!id) throw new Error('Missing widget ID')
+
+    const [processedWidget] = computeProcessedWidgets({
+      nodeData: node._state,
+      widgetIds: [id],
+      graphId: GRAPH_ID,
+      showAdvanced: false,
+      isGraphReady: true,
+      rootGraph: graph,
+      ui: noopUi
+    })
+
+    expect(processedWidget.slotMetadata).toMatchObject({
+      index: 0,
+      linked: false
+    })
+  })
 })
 
 describe('widget visibility', () => {


### PR DESCRIPTION
## Summary

Addresses the final widget visibility review follow-ups from #16326 and FE-1948.

## Changes

- **Suppressed rows**: Draw only the widget label, without its value.
- **Duplicate slots**: Preserve the first same-named widget input's metadata.
- **Painter coverage**: Anchor hidden-widget assertions to the selected Painter panel.
- **App Builder coverage**: Verify shown widgets are selectable and panel-hidden widgets are not.
- **Subgraph API**: Restore `Subgraph.clone()` as a root-registered definition with normalized entity IDs, and remove the unsafe historical `clone(true)` keep-ID mode.

## Review Focus

Widget-to-input resolution for duplicate input names, plus clone normalization and root lifecycle registration.
