### PR TITLE
fix(website): unify locale routing and hreflang metadata

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -4,13 +4,11 @@ import sitemap from '@astrojs/sitemap'
 import vue from '@astrojs/vue'
 import tailwindcss from '@tailwindcss/vite'
 import { isExcludedFromSitemap } from './src/config/indexing'
+import { DEFAULT_LOCALE, LOCALE_CODES } from './src/config/locales'
 import { redirects } from './src/config/redirects'
 import { markdownTwins } from './src/integrations/markdown-twins'
 import { workshopReleaseGate } from './src/integrations/workshop-release-gate'
 import { sitemapAlternates } from './src/lib/hreflang'
-
-const LOCALES = ['en', 'zh-CN', 'ja'] as const
-const DEFAULT_LOCALE = 'en'
 
 export default defineConfig({
   site: 'https://comfy.org',
@@ -46,7 +44,7 @@ export default defineConfig({
     }
   },
   i18n: {
-    locales: [...LOCALES],
+    locales: [...LOCALE_CODES],
     defaultLocale: DEFAULT_LOCALE,
     routing: {
       prefixDefaultLocale: false

--- a/apps/website/scripts/check-hreflang.ts
+++ b/apps/website/scripts/check-hreflang.ts
@@ -82,14 +82,30 @@ function sitemapAlternates(): Map<string, Alternate[]> | null {
 }
 
 const files = htmlFiles(DIST)
-const pages = new Map<string, Alternate[]>(
-  files.map((file) => [
-    routeOf(file),
-    alternatesIn(readFileSync(file, 'utf-8'))
-  ])
-)
+const pages = new Map<string, Alternate[]>()
+/**
+ * Routes whose page names ITSELF as the canonical.
+ *
+ * Since the i18n fallback landed, a /ja/ page existing no longer means Japanese
+ * is published there: the fallback builds one for every route. A page pointing
+ * at the English original is declaring itself not the original. Reading that
+ * from the built HTML keeps the audit independent of the emitter — it compares
+ * two statements the site makes rather than trusting the config that made them.
+ */
+const selfCanonical = new Set<string>()
+
+for (const file of files) {
+  const route = routeOf(file)
+  const html = readFileSync(file, 'utf-8')
+  pages.set(route, alternatesIn(html))
+
+  const canonical = /<link rel="canonical" href="([^"]+)"/.exec(html)?.[1]
+  if (canonical && new URL(canonical).pathname === route) {
+    selfCanonical.add(route)
+  }
+}
 const sitemap = sitemapAlternates()
-const errors = auditBuiltSite({ pages, sitemap, origin: ORIGIN })
+const errors = auditBuiltSite({ pages, sitemap, selfCanonical, origin: ORIGIN })
 
 const withCluster = [...pages.values()].filter((list) => list.length > 0).length
 // The repo's lint config allows console.warn and console.error only, and this

--- a/apps/website/src/config/indexing.ts
+++ b/apps/website/src/config/indexing.ts
@@ -1,14 +1,11 @@
+import { LOCALE_CODES, localePrefix } from './locales'
 import { models } from './models'
 import { isWorkshopInBuild, isWorkshopRoute } from './workshop-release'
 
-const LOCALES = ['en', 'zh-CN'] as const
-const DEFAULT_LOCALE = 'en'
 const PAYMENT_STATUSES = ['success', 'failed'] as const
 const PLACEHOLDER_PATHNAMES = ['/case-studies', '/videos', '/demos'] as const
 
-const LOCALE_PREFIXES = LOCALES.map((locale) =>
-  locale === DEFAULT_LOCALE ? '' : `/${locale}`
-)
+const LOCALE_PREFIXES = LOCALE_CODES.map(localePrefix)
 
 const NOINDEX_PATHNAMES = new Set([
   ...LOCALE_PREFIXES.flatMap((prefix) =>

--- a/apps/website/src/config/locales.test.ts
+++ b/apps/website/src/config/locales.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_LOCALE,
+  LOCALE_CODES,
+  LOCALES,
+  isPageIndexable,
+  localeHasRoute,
+  localePrefix
+} from './locales'
+
+describe('LOCALES', () => {
+  it('is the one list every locale-aware site derives from', () => {
+    expect(LOCALE_CODES).toEqual(['en', 'zh-CN', 'ja'])
+    expect(DEFAULT_LOCALE).toBe('en')
+  })
+
+  it('gives the default locale an empty prefix and every other a real one', () => {
+    expect(localePrefix('en')).toBe('')
+    expect(localePrefix('zh-CN')).toBe('/zh-CN')
+    // Short form for ja while Chinese keeps the legacy /zh-CN. Deliberate: the
+    // Chinese URLs rank and a migration would risk that for no SEO gain.
+    expect(localePrefix('ja')).toBe('/ja')
+  })
+
+  /**
+   * The guard. `LocaleConfig` requires every field, so adding a member to
+   * `LOCALES` without filling all of them is a compile error. This asserts the
+   * same thing at runtime for the fields whose emptiness a type cannot catch.
+   */
+  it('carries complete metadata for every locale', () => {
+    for (const code of LOCALE_CODES) {
+      const locale = LOCALES[code]
+      expect(locale.code, code).toBe(code)
+      expect(locale.name, code).toBeTruthy()
+      expect(locale.nativeName, code).toBeTruthy()
+      expect(locale.hreflang, code).toBeTruthy()
+      expect(['ltr', 'rtl'], code).toContain(locale.dir)
+      // Open Graph wants language_TERRITORY, not the BCP 47 tag.
+      expect(locale.ogLocale, code).toMatch(/^[a-z]{2}_[A-Z]{2}$/)
+    }
+  })
+})
+
+describe('isPageIndexable', () => {
+  /**
+   * The single predicate every surface reads: the page's hreflang tags, the
+   * sitemap, the canonical and the build assert. They cannot disagree because
+   * there is only one answer, and it is knowable before a page renders.
+   */
+  it('always allows English, which is the source', () => {
+    expect(isPageIndexable('en', '/')).toBe(true)
+    expect(isPageIndexable('en', '/anything')).toBe(true)
+  })
+
+  it('allows a localized page the locale actually serves', () => {
+    expect(isPageIndexable('zh-CN', '/cli')).toBe(true)
+    expect(isPageIndexable('ja', '/')).toBe(true)
+  })
+
+  /**
+   * Indexability can never exceed existence. Advertising a page that was never
+   * built is the 404-in-a-cluster defect Phase 0 fixed.
+   */
+  it('never allows a page the locale does not serve', () => {
+    expect(isPageIndexable('ja', '/cli')).toBe(false)
+    expect(isPageIndexable('ja', '/pricing')).toBe(false)
+  })
+})
+
+describe('localeHasRoute', () => {
+  it('is true for every route in the default locale', () => {
+    expect(localeHasRoute('en', '/')).toBe(true)
+    expect(localeHasRoute('en', '/cli')).toBe(true)
+    expect(localeHasRoute('en', '/anything-at-all')).toBe(true)
+  })
+
+  it('is true for zh-CN, which has a twin for nearly every route', () => {
+    expect(localeHasRoute('zh-CN', '/')).toBe(true)
+    expect(localeHasRoute('zh-CN', '/cli')).toBe(true)
+  })
+
+  /**
+   * Japanese is a partial locale: one page today. Callers use this so a link or
+   * an hreflang alternate is only offered where the page really exists, rather
+   * than pointing at a 404.
+   */
+  it('is true only for the Japanese routes that exist', () => {
+    expect(localeHasRoute('ja', '/')).toBe(true)
+    expect(localeHasRoute('ja', '/cli')).toBe(false)
+    expect(localeHasRoute('ja', '/pricing')).toBe(false)
+  })
+})

--- a/apps/website/src/config/locales.ts
+++ b/apps/website/src/config/locales.ts
@@ -77,15 +77,10 @@ export type Locale = keyof typeof LOCALES
 /** Declaration order, which is also the order clusters and switchers list. */
 export const LOCALE_CODES = Object.keys(LOCALES) as Locale[]
 
-/** Non-default locales, i.e. the ones that carry a URL prefix. */
-export const LOCALIZED_CODES = LOCALE_CODES.filter(
-  (code) => code !== DEFAULT_LOCALE
-)
-
 /** Every URL prefix that identifies a locale, default excluded. */
-export const LOCALE_PREFIXES = LOCALIZED_CODES.map(
-  (code) => LOCALES[code].prefix
-)
+export const LOCALE_PREFIXES = LOCALE_CODES.filter(
+  (code) => code !== DEFAULT_LOCALE
+).map((code) => LOCALES[code].prefix)
 
 export function localePrefix(locale: Locale): string {
   return LOCALES[locale].prefix

--- a/apps/website/src/config/locales.ts
+++ b/apps/website/src/config/locales.ts
@@ -1,0 +1,167 @@
+/**
+ * The single source of truth for the locales this site serves.
+ *
+ * Before this file the answer to "what locales exist?" was written down in six
+ * places that did not agree, and adding Japanese missed two of them: the
+ * indexing policy never learned about `ja`, and the hreflang builder read `/ja/`
+ * as an English route. Everything locale-shaped now derives from `LOCALES`.
+ *
+ * Kept free of imports so `astro.config.ts` can read it at build time and so it
+ * can never form an import cycle with `routes.ts` or `hreflang.ts`, both of
+ * which depend on it.
+ */
+
+export interface LocaleConfig {
+  /** BCP 47 tag. Also the key this locale is stored under. */
+  code: string
+  /**
+   * URL prefix, empty for the default locale.
+   *
+   * Japanese uses the short `/ja` while Chinese keeps the legacy `/zh-CN`. The
+   * asymmetry is historical rather than designed, and is preserved on purpose:
+   * the Chinese URLs rank, and a migration would risk that for no SEO gain.
+   * See `context/decision-zh-hreflang-value.md`.
+   */
+  prefix: string
+  /** The value published in `hreflang` and `<html lang>`. */
+  hreflang: string
+  /** Open Graph wants `language_TERRITORY`, not the BCP 47 tag. */
+  ogLocale: string
+  /** English name, for internal listings. */
+  name: string
+  /** Endonym, for the language switcher. */
+  nativeName: string
+  /** Writing direction. Arabic (CRE-584) will be the first `rtl`. */
+  dir: 'ltr' | 'rtl'
+}
+
+export const DEFAULT_LOCALE = 'en'
+
+/**
+ * Adding a locale here is a compile error until every field is supplied, and
+ * `locales.test.ts` plus the dependent sites' own tests fail until each of them
+ * widens too. That is the guard whose absence let `ja` ship half-wired.
+ */
+export const LOCALES = {
+  en: {
+    code: 'en',
+    prefix: '',
+    hreflang: 'en',
+    ogLocale: 'en_US',
+    name: 'English',
+    nativeName: 'English',
+    dir: 'ltr'
+  },
+  'zh-CN': {
+    code: 'zh-CN',
+    prefix: '/zh-CN',
+    hreflang: 'zh-CN',
+    ogLocale: 'zh_CN',
+    name: 'Chinese (Simplified)',
+    nativeName: '简体中文',
+    dir: 'ltr'
+  },
+  ja: {
+    code: 'ja',
+    prefix: '/ja',
+    hreflang: 'ja',
+    ogLocale: 'ja_JP',
+    name: 'Japanese',
+    nativeName: '日本語',
+    dir: 'ltr'
+  }
+} as const satisfies Record<string, LocaleConfig>
+
+export type Locale = keyof typeof LOCALES
+
+/** Declaration order, which is also the order clusters and switchers list. */
+export const LOCALE_CODES = Object.keys(LOCALES) as Locale[]
+
+/** Non-default locales, i.e. the ones that carry a URL prefix. */
+export const LOCALIZED_CODES = LOCALE_CODES.filter(
+  (code) => code !== DEFAULT_LOCALE
+)
+
+/** Every URL prefix that identifies a locale, default excluded. */
+export const LOCALE_PREFIXES = LOCALIZED_CODES.map(
+  (code) => LOCALES[code].prefix
+)
+
+export function localePrefix(locale: Locale): string {
+  return LOCALES[locale].prefix
+}
+
+export function isLocale(value: string | undefined): value is Locale {
+  // Own keys only. `in` also finds inherited names, so `isLocale('toString')`
+  // was true and narrowed to Locale, after which every lookup keyed on it —
+  // prefix, hreflang, og locale — came back undefined instead of falling to
+  // DEFAULT_LOCALE.
+  return value !== undefined && Object.hasOwn(LOCALES, value)
+}
+
+/**
+ * Routes a partially-translated locale actually publishes.
+ *
+ * Chinese is absent because it is fully translated, so it gets a blanket yes and
+ * `LOCALE_INVARIANT_PATHS` carves out the exceptions.
+ *
+ * P3 changed what this set means. It used to record which Japanese pages
+ * existed, because only one did; Astro's fallback now builds all 560, so the
+ * question is which of them we publish. It is the only lever, gating indexing,
+ * the sitemap, and whether any link on the site points there.
+ *
+ * Paths carry no trailing slash, matching `baseRoutes` and `englishPath`.
+ */
+export const PARTIAL_LOCALE_ROUTES: Partial<
+  Record<Locale, ReadonlySet<string>>
+> = {
+  ja: new Set(['/'])
+}
+
+/**
+ * Whether `route` (an English path) is served in `locale`.
+ *
+ * Consumed by the hreflang builder, so a cluster never names a page that does
+ * not exist, and by `localizeHref`, so a link never points at one either. Those
+ * two used to disagree, which is how `/ja/` came to advertise `/zh-CN/ja/`.
+ */
+export function localeHasRoute(locale: Locale, route: string): boolean {
+  if (locale === DEFAULT_LOCALE) return true
+  const served = PARTIAL_LOCALE_ROUTES[locale]
+  return served === undefined || served.has(route)
+}
+
+/**
+ * Which localized pages may be indexed.
+ *
+ * Deliberately an explicit list rather than something computed from how much of
+ * a page is translated. Completeness is only known after a page renders, but its
+ * hreflang tags are written before that, so a computed gate would let the tags
+ * and the sitemap disagree, which is the defect Phase 0 fixed. An allowlist is
+ * known up front, so every surface reads the same answer.
+ *
+ * It also matches how the hub works: a locale goes live in its own small,
+ * reviewed change rather than by a heuristic deciding on someone's behalf.
+ *
+ * `pnpm i18n:report` says which namespaces are complete enough to add here.
+ */
+const INDEXABLE_PAGES: Record<
+  Exclude<Locale, typeof DEFAULT_LOCALE>,
+  'all' | ReadonlySet<string>
+> = {
+  // Complete and human-approved, so every page it serves is fair game.
+  'zh-CN': 'all',
+  // Japanese is gated by `PARTIAL_LOCALE_ROUTES` above, so 'all' means every
+  // route it publishes rather than every route there is. Its home page stays
+  // indexed while P4 fills it, rather than changing live behaviour twice in one
+  // release.
+  ja: 'all'
+}
+
+/** Whether `route` may be indexed in `locale`. English is always indexable. */
+export function isPageIndexable(locale: Locale, route: string): boolean {
+  if (locale === DEFAULT_LOCALE) return true
+  if (!localeHasRoute(locale, route)) return false
+  const allowed = INDEXABLE_PAGES[locale]
+  return allowed === 'all' || allowed.has(route)
+}

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -25,9 +25,59 @@ describe('localizeHref', () => {
     )
   })
 
-  it('only localizes the Japanese homepage', () => {
+  it('never prefixes a page NESTED under a locale-invariant route', () => {
+    // The two answers to "is this path locale-invariant?" disagreed:
+    // `isLocaleInvariantPath` matched prefixes while this matched only whole
+    // paths, so a per-model page under the catalogue slipped through and
+    // /zh-CN/models linked to /zh-CN/p/supported-models/grok-imagine, which has
+    // never existed. Every individual model page has this shape.
+    expect(localizeHref('/p/supported-models', 'zh-CN')).toBe(
+      '/p/supported-models'
+    )
+    expect(localizeHref('/p/supported-models/grok-imagine', 'zh-CN')).toBe(
+      '/p/supported-models/grok-imagine'
+    )
+    expect(localizeHref('/pixal3d-trellis2/anything', 'ja')).toBe(
+      '/pixal3d-trellis2/anything'
+    )
+  })
+
+  /**
+   * A query or fragment is not part of the route. Checking it as one sent a
+   * link into a section of a published page back to the English tree.
+   */
+  it('keeps a query or fragment while localizing the path', () => {
+    expect(localizeHref('/cloud#pricing', 'zh-CN')).toBe('/zh-CN/cloud#pricing')
+    expect(localizeHref('/cloud?ref=nav', 'zh-CN')).toBe('/zh-CN/cloud?ref=nav')
+    expect(localizeHref('/about#team', 'ja')).toBe('/about#team')
+  })
+
+  it('still refuses to localize a held-back route that carries one', () => {
+    expect(localizeHref('/cli#install', 'ja')).toBe('/cli#install')
+  })
+
+  it('still refuses to localize an invariant route that carries one', () => {
+    expect(localizeHref('/terms-of-service#scope', 'zh-CN')).toBe(
+      '/terms-of-service#scope'
+    )
+  })
+
+  /**
+   * Japanese publishes tier 1 and holds the long tail back. A held-back route
+   * is left unprefixed so nothing on the site links to a page that is not
+   * published, which is the same predicate the hreflang emitter reads.
+   *
+   * This asserted "only the home page" until P4 filled Japanese and tier 1 went
+   * live. The routes are named from both sides on purpose: a one-sided check
+   * passes just as well when the allowlist is empty as when it is right.
+   */
+  it('localizes a published Japanese route and leaves a held-back one alone', () => {
     expect(localizeHref('/', 'ja')).toBe('/ja/')
     expect(localizeHref('/cloud', 'ja')).toBe('/cloud')
+    expect(localizeHref('/about', 'ja')).toBe('/about')
+
+    expect(localizeHref('/cli', 'ja')).toBe('/cli')
+    expect(localizeHref('/careers', 'ja')).toBe('/careers')
   })
 })
 

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -1,4 +1,5 @@
-import type { Locale } from '../i18n/translations'
+import { DEFAULT_LOCALE, localeHasRoute, localePrefix } from './locales'
+import type { Locale } from './locales'
 
 const baseRoutes = {
   home: '/',
@@ -101,6 +102,7 @@ const LOCALE_INVARIANT_ROUTE_KEYS = new Set<keyof Routes>([
 // workshop: the catalog is English-only. It is also build-gated until launch,
 // but enabled previews must not advertise a localized page that does not exist.
 const LOCALE_INVARIANT_EXTRA_PATHS = [
+  '/workshop',
   '/pixal3d-trellis2',
   '/platform/serverless-animation',
   '/workshop'
@@ -122,15 +124,37 @@ export function isLocaleInvariantPath(pathname: string): boolean {
   )
 }
 
-export function localizeHref(href: string, locale: Locale = 'en'): string {
-  if (locale === 'en' || !href.startsWith('/')) return href
-  if (LOCALE_INVARIANT_PATHS.has(href)) return href
-  if (locale === 'ja') return href === '/' ? '/ja/' : href
-  return `/${locale}${href}`
+export function localizeHref(
+  href: string,
+  locale: Locale = DEFAULT_LOCALE
+): string {
+  if (locale === DEFAULT_LOCALE || !href.startsWith('/')) return href
+  // A query or fragment is not part of the route. `/customers#hero-video` was
+  // compared against a route list holding `/customers`, missed, and returned
+  // unprefixed — so a link into a section of a published page would leave the
+  // locale. The suffix is set aside for the checks and put back afterwards.
+  const suffixAt = href.search(/[?#]/)
+  if (suffixAt !== -1) {
+    return `${localizeHref(href.slice(0, suffixAt), locale)}${href.slice(suffixAt)}`
+  }
+  // The same predicate the hreflang emitter uses. It matched whole paths here
+  // and prefixes there, so a page nested under an invariant route was localized
+  // by one and not the other: /zh-CN/models linked to
+  // /zh-CN/p/supported-models/grok-imagine, which has never existed.
+  if (isLocaleInvariantPath(href)) return href
+  // Only localize a path the locale actually serves. This replaces a hardcoded
+  // `locale === 'ja'` branch that sent every Japanese link except the home page
+  // to the English page. Deleting that outright would have been worse than the
+  // bug: the links would resolve to /ja/<path> URLs that do not exist until P3
+  // generates the shells. `localeHasRoute` is the same predicate the hreflang
+  // builder uses, so links and clusters cannot disagree, and both start working
+  // on their own as P3 adds pages.
+  if (!localeHasRoute(locale, href)) return href
+  return `${localePrefix(locale)}${href === '/' ? '/' : href}`
 }
 
-export function getRoutes(locale: Locale = 'en'): Routes {
-  if (locale === 'en') return baseRoutes
+export function getRoutes(locale: Locale = DEFAULT_LOCALE): Routes {
+  if (locale === DEFAULT_LOCALE) return baseRoutes
   return Object.fromEntries(
     Object.entries(baseRoutes).map(([key, path]) => [
       key,

--- a/apps/website/src/lib/hreflang.test.ts
+++ b/apps/website/src/lib/hreflang.test.ts
@@ -5,8 +5,11 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import { isNoindexPathname } from '../config/indexing'
+import { PARTIAL_LOCALE_ROUTES } from '../config/locales'
+import { isLocaleInvariantPath } from '../config/routes'
 import { redirects } from '../config/redirects'
-import { routeOf, ZH_PREFIX } from '../utils/hreflangRoutes'
+import { routeOf } from '../utils/hreflangRoutes'
+import type { Alternate } from './hreflang'
 import {
   hreflangAlternates,
   ogLocale,
@@ -31,15 +34,45 @@ describe('hreflangAlternates', () => {
     )
   })
 
-  it('handles the home page in both locales', () => {
+  it('handles the home page in every locale that has one', () => {
+    // The home page is the one route with all three locales, so it is the only
+    // place the full cluster shape can be asserted today.
     const home = hreflangAlternates('/', ORIGIN)
-    expect(home.map((a) => a.href)).toEqual([
-      'https://comfy.org/',
-      'https://comfy.org/zh-CN/',
-      'https://comfy.org/'
+    expect(home).toEqual([
+      { hreflang: 'en', href: 'https://comfy.org/' },
+      { hreflang: 'zh-CN', href: 'https://comfy.org/zh-CN/' },
+      { hreflang: 'ja', href: 'https://comfy.org/ja/' },
+      { hreflang: 'x-default', href: 'https://comfy.org/' }
     ])
     expect(hreflangAlternates('/zh-CN/', ORIGIN)).toEqual(home)
     expect(hreflangAlternates('/zh-CN', ORIGIN)).toEqual(home)
+  })
+
+  // BE-11285. Previously `/ja/` was read as the English route `/ja`, so it was
+  // labelled `en` and its cluster pointed at `/zh-CN/ja/`, which 404s.
+  it('labels the Japanese home page ja and clusters it with the others', () => {
+    expect(hreflangAlternates('/ja/', ORIGIN)).toEqual(
+      hreflangAlternates('/', ORIGIN)
+    )
+    expect(hreflangAlternates('/ja', ORIGIN)).toEqual(
+      hreflangAlternates('/', ORIGIN)
+    )
+  })
+
+  it('never treats a locale prefix as part of the English path', () => {
+    const hrefs = hreflangAlternates('/ja/', ORIGIN).map((a) => a.href)
+    expect(hrefs).not.toContain('https://comfy.org/zh-CN/ja/')
+    expect(hrefs).not.toContain('https://comfy.org/ja/ja/')
+  })
+
+  // Japanese has exactly one page. A blanket rule like Chinese's would
+  // advertise a Japanese URL for every route on the site.
+  it('offers no ja alternate for routes that have no Japanese page', () => {
+    for (const pathname of ['/cli/', '/zh-CN/cli/', '/mcp/']) {
+      expect(
+        hreflangAlternates(pathname, ORIGIN).map((a) => a.hreflang)
+      ).toEqual(['en', 'zh-CN', 'x-default'])
+    }
   })
 
   it('covers dynamic routes that exist in both locales', () => {
@@ -73,12 +106,13 @@ describe('sitemapAlternates', () => {
     ])
   })
 
-  it('emits nothing for Japanese, from either locale prefix', () => {
-    // /ja/ has no twin rule yet, so a cluster here would advertise
-    // /zh-CN/ja/, which 404s. The prefixed form must be suppressed too, or a
-    // locale-prefixed request slips past a check that only reads the raw path.
-    expect(hreflangAlternates('/ja/', ORIGIN)).toEqual([])
-    expect(hreflangAlternates('/zh-CN/ja/', ORIGIN)).toEqual([])
+  it('gives the Japanese home page a cluster with no 404 in it', () => {
+    expect(sitemapAlternates('https://comfy.org/ja/')).toEqual([
+      { url: 'https://comfy.org/', lang: 'en' },
+      { url: 'https://comfy.org/zh-CN/', lang: 'zh-CN' },
+      { url: 'https://comfy.org/ja/', lang: 'ja' },
+      { url: 'https://comfy.org/', lang: 'x-default' }
+    ])
   })
 
   it('leaves English-only entries without links', () => {
@@ -101,18 +135,65 @@ describe('og locale', () => {
     expect(ogLocaleAlternate('zh-CN', clustered)).toBe('en_US')
     expect(ogLocaleAlternate('en', [])).toBeNull()
   })
+
+  it('pairs a Japanese page with English, not with Chinese', () => {
+    // OG takes one alternate. Testing for `zh-CN` rather than `en` sent every
+    // localized page to zh_CN, so a Japanese page named a language it has
+    // nothing to do with.
+    const clustered = hreflangAlternates('/ja/', ORIGIN)
+    expect(ogLocaleAlternate('ja', clustered)).toBe('en_US')
+  })
 })
 
 /**
- * `isLocaleInvariantPath` is a hand-maintained list, and the page tree is the
- * thing it is meant to describe. Reading the tree back catches the entry nobody
- * added: an English page whose Chinese twin does not exist still advertises one,
- * which is a cluster pointing at a 404.
+ * The partial-locale allowlist is hand-maintained, and the page tree is the
+ * thing it is meant to describe.
  *
- * Static routes only. A dynamic route's two `getStaticPaths` are free to produce
- * different slug sets, which the file tree cannot see.
+ * What that means changed in P3. The tree used to hold one file per locale, so
+ * the check was "does the twin exist". Every localized page is now served from
+ * the English one through the i18n fallback, so a localized URL exists exactly
+ * when its English page does, and the rot moved with it: the allowlist is now
+ * the only thing deciding which localized URLs are linked, indexed and listed
+ * in the sitemap, so a wrong entry there is what advertises a URL that 404s.
+ *
+ * The four tests this replaced all read the tree for locale-named files, and
+ * three of them could not fail once those files were gone: two iterated a set
+ * that is now always empty, and one filtered the English routes by whether they
+ * were absent from the English routes.
+ *
+ * Static routes only. A dynamic route's `getStaticPaths` can produce any slug
+ * set, which the file tree cannot see.
  */
-describe('the emitter agrees with the page tree', () => {
+describe('ogLocaleAlternate', () => {
+  const alt = (...codes: Alternate['hreflang'][]): Alternate[] =>
+    codes.map((hreflang) => ({ hreflang, href: 'https://comfy.org/x/' }))
+
+  it('names the Chinese twin when the page has one', () => {
+    expect(ogLocaleAlternate('en', alt('en', 'zh-CN', 'x-default'))).toBe(
+      'zh_CN'
+    )
+  })
+
+  /**
+   * An English-only route still carries `en` and `x-default`, so a non-empty
+   * cluster was never evidence that a Chinese page exists.
+   */
+  it('names nothing when the target locale is not published', () => {
+    expect(ogLocaleAlternate('en', alt('en', 'x-default'))).toBeNull()
+  })
+
+  it('names nothing for a page outside any cluster', () => {
+    expect(ogLocaleAlternate('en', [])).toBeNull()
+  })
+
+  it('points a localized page back at English', () => {
+    expect(ogLocaleAlternate('zh-CN', alt('en', 'zh-CN', 'x-default'))).toBe(
+      'en_US'
+    )
+  })
+})
+
+describe('the allowlist agrees with the page tree', () => {
   const pagesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'pages')
 
   const astroFiles = (dir: string): string[] =>
@@ -122,43 +203,88 @@ describe('the emitter agrees with the page tree', () => {
       return entry.name.endsWith('.astro') ? [full] : []
     })
 
-  const english = new Set<string>()
-  const chinese = new Set<string>()
-  for (const file of astroFiles(pagesDir)) {
-    const rel = relative(pagesDir, file).split(sep).join('/')
-    if (rel.includes('[')) continue
-    const route = routeOf(`/src/pages/${rel}`)
-    if (route.startsWith(`${ZH_PREFIX}/`)) {
-      chinese.add(route.slice(ZH_PREFIX.length) || '/')
-    } else {
-      english.add(route)
-    }
-  }
+  /** `routeOf` trails a slash and the allowlist does not, so one side gives. */
+  const withoutTrailingSlash = (route: string) => route.replace(/(.)\/$/, '$1')
 
-  const redirected = new Set(
-    Object.keys(redirects).map((source) => source.replace(/\/$/, ''))
+  const english = new Set(
+    astroFiles(pagesDir)
+      .map((file) => relative(pagesDir, file).split(sep).join('/'))
+      .filter((rel) => !rel.includes('['))
+      .map((rel) => withoutTrailingSlash(routeOf(`/src/pages/${rel}`)))
   )
 
-  /** What `BaseLayout` ends up emitting for a route that was actually built. */
-  const clusters = (pathname: string): boolean =>
-    !redirected.has(pathname.replace(/\/$/, '')) &&
-    !isNoindexPathname(pathname) &&
-    hreflangAlternates(pathname, ORIGIN).length > 0
+  const published = Object.entries(PARTIAL_LOCALE_ROUTES).flatMap(
+    ([locale, routes]) => [...routes].map((route) => ({ locale, route }))
+  )
 
-  it('never advertises a zh-CN page that does not exist', () => {
-    const lying = [...english].filter(
-      (route) => clusters(route) && !chinese.has(route)
-    )
+  it('reads a page tree and an allowlist to check', () => {
+    expect(english.size).toBeGreaterThan(50)
+    expect(published.length).toBeGreaterThan(0)
+  })
+
+  it('backs every published route with an English page', () => {
+    const unbacked = published
+      .filter(({ route }) => !english.has(route))
+      .map(({ locale, route }) => `${locale}: ${route}`)
+
     expect(
-      lying,
-      'add a zh-CN page or mark the route locale-invariant'
+      unbacked,
+      'no page exists to serve this locale from, so the URL 404s'
     ).toEqual([])
   })
 
-  it('never advertises an English page that does not exist', () => {
-    const lying = [...chinese].filter(
-      (route) => clusters(`${ZH_PREFIX}${route}`) && !english.has(route)
-    )
-    expect(lying, 'the English twin was moved or removed').toEqual([])
+  /**
+   * An entry for a route that is never localized does nothing at all: the
+   * redirect wins, the noindex wins, or `localizeHref` refuses to prefix it. The
+   * legal documents are all one of the three — the contracts are locale-invariant
+   * and the policies are noindexed — so this is also what keeps them out of a
+   * localized tree if someone widens the allowlist by hand.
+   */
+  it('never publishes a route that cannot be localized anyway', () => {
+    const redirected = new Set(Object.keys(redirects).map(withoutTrailingSlash))
+    const inert = published
+      .filter(
+        ({ route }) =>
+          redirected.has(route) ||
+          isNoindexPathname(route) ||
+          isLocaleInvariantPath(route)
+      )
+      .map(({ locale, route }) => `${locale}: ${route}`)
+
+    expect(
+      inert,
+      'the entry does nothing: the route is redirected, held out of the index, or never localized'
+    ).toEqual([])
+  })
+})
+
+describe('a page whose own locale is held back', () => {
+  /**
+   * Astro's i18n fallback builds /ja/<route> for every route, but only / is on
+   * the Japanese allowlist. Those pages canonical to English, which is right.
+   * They were also emitting the English cluster, which is not: nothing in that
+   * cluster lists them back, so the site advertised a one-way relationship, and
+   * the pages appeared to claim membership of a group they are held out of.
+   *
+   * A page that is not published in its own locale belongs in no cluster.
+   */
+  it('emits no alternates for a Japanese page that is not indexable', () => {
+    // The English pathname is deliberate: that is what Astro reports during a
+    // rewritten fallback render. Only the locale argument reveals it is ja.
+    expect(hreflangAlternates('/pricing/', ORIGIN, 'ja')).toEqual([])
+  })
+
+  it('still emits them for the Japanese page that IS indexable', () => {
+    expect(
+      hreflangAlternates('/ja/', ORIGIN, 'ja').map((a) => a.hreflang)
+    ).toContain('ja')
+  })
+
+  it('leaves Chinese alone, since every Chinese page is published', () => {
+    expect(
+      hreflangAlternates('/zh-CN/pricing/', ORIGIN, 'zh-CN').map(
+        (a) => a.hreflang
+      )
+    ).toEqual(['en', 'zh-CN', 'x-default'])
   })
 })

--- a/apps/website/src/lib/hreflang.ts
+++ b/apps/website/src/lib/hreflang.ts
@@ -1,9 +1,17 @@
+import {
+  DEFAULT_LOCALE,
+  LOCALE_CODES,
+  LOCALE_PREFIXES,
+  LOCALES,
+  isPageIndexable,
+  localePrefix,
+  isLocale
+} from '../config/locales'
+import type { Locale } from '../config/locales'
 import { isLocaleInvariantPath } from '../config/routes'
 
-const LOCALE_PREFIX = '/zh-CN'
-
 export interface Alternate {
-  hreflang: 'en' | 'zh-CN' | 'x-default'
+  hreflang: Locale | 'x-default'
   href: string
 }
 
@@ -16,44 +24,63 @@ function withSlash(pathname: string): string {
   return pathname === '/' ? '/' : `${pathname}/`
 }
 
-/** The English path a page belongs to, whichever locale rendered it. */
+/**
+ * The English path a page belongs to, whichever locale rendered it.
+ *
+ * Every locale prefix is stripped, not just Chinese. Reading `/ja/` as the
+ * English route `/ja` is what labelled the Japanese home page `en` and pointed
+ * its cluster at `/zh-CN/ja/`, which 404s.
+ */
 function englishPath(pathname: string): string {
   const path = trimSlash(pathname)
-  if (path === LOCALE_PREFIX) return '/'
-  return path.startsWith(`${LOCALE_PREFIX}/`)
-    ? path.slice(LOCALE_PREFIX.length)
-    : path
+  for (const prefix of LOCALE_PREFIXES) {
+    if (path === prefix) return '/'
+    if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length)
+  }
+  return path
 }
 
 /**
- * hreflang alternates for a page: the English page, its zh-CN twin, and
- * x-default on English. English-only routes get none, so no alternate ever
- * points at a redirect stub or a 404.
+ * hreflang alternates for a page: the English page, its zh-CN twin, its ja twin
+ * where one exists, and x-default on English. English-only routes get none, so
+ * no alternate ever points at a redirect stub or a 404.
  */
 export function hreflangAlternates(
   pathname: string,
-  origin: string
+  origin: string,
+  pageLocale: Locale = DEFAULT_LOCALE
 ): Alternate[] {
   const en = englishPath(pathname)
-  // Japanese has one page and no twin rule yet, so anything under /ja/ emits
-  // nothing rather than a cluster. Without this the homepage advertises
-  // /zh-CN/ja/, which does not exist: the same lie this function's English-only
-  // guard exists to prevent. Read off the English path so a locale-prefixed
-  // request is suppressed too. Clustering ja properly is BE-11285.
-  if (en === '/ja' || en.startsWith('/ja/')) return []
   if (en === '/404' || isLocaleInvariantPath(en)) return []
+
+  // A page whose OWN locale is held back belongs in no cluster. Astro's i18n
+  // fallback builds /ja/<route> for every route while only / is on the Japanese
+  // allowlist; those pages were emitting the English cluster, which nothing in
+  // that cluster listed back, so the site advertised a one-way relationship and
+  // the pages appeared to claim membership of a group they are held out of.
+  //
+  // The locale must be PASSED IN, not read from the path. During a rewritten
+  // fallback render Astro reports the ENGLISH pathname while
+  // `Astro.currentLocale` is the requested locale, so a path-derived answer is
+  // `en` for every fallback page and this rule would never fire. That version
+  // passed its unit test and changed nothing in the build.
+  if (!isPageIndexable(pageLocale, en)) return []
   const enHref = new URL(withSlash(en), origin).href
-  return [
-    { hreflang: 'en', href: enHref },
-    {
-      hreflang: 'zh-CN',
-      href: new URL(
-        withSlash(`${LOCALE_PREFIX}${en === '/' ? '' : en}`),
-        origin
-      ).href
-    },
-    { hreflang: 'x-default', href: enHref }
-  ]
+  const twin = (locale: Locale) =>
+    new URL(withSlash(`${localePrefix(locale)}${en === '/' ? '' : en}`), origin)
+      .href
+  // `isPageIndexable` is the single predicate: it already asks whether the
+  // locale serves this route, and additionally whether that page is allowed to
+  // be indexed. Both the page tags and the sitemap read it, so they cannot
+  // disagree about a cluster.
+  const alternates: Alternate[] = LOCALE_CODES.filter((locale) =>
+    isPageIndexable(locale, en)
+  ).map((locale) => ({
+    hreflang: LOCALES[locale].hreflang,
+    href: locale === DEFAULT_LOCALE ? enHref : twin(locale)
+  }))
+  alternates.push({ hreflang: 'x-default', href: enHref })
+  return alternates
 }
 
 /** `xhtml:link` alternates for one sitemap entry, or nothing for English-only pages. */
@@ -61,7 +88,15 @@ export function sitemapAlternates(
   url: string
 ): { url: string; lang: string }[] | undefined {
   const { pathname, origin } = new URL(url)
-  const alternates = hreflangAlternates(pathname, origin)
+  // Unlike a page render, a sitemap entry's path IS the localized one, so the
+  // locale can be read off it here.
+  const pageLocale =
+    LOCALE_CODES.find(
+      (locale) =>
+        locale !== DEFAULT_LOCALE &&
+        pathname.startsWith(`${localePrefix(locale)}/`)
+    ) ?? DEFAULT_LOCALE
+  const alternates = hreflangAlternates(pathname, origin, pageLocale)
   return alternates.length > 0
     ? alternates.map((alternate) => ({
         url: alternate.href,
@@ -70,27 +105,38 @@ export function sitemapAlternates(
     : undefined
 }
 
-/** OG wants underscored locale identifiers, not the BCP 47 tags used elsewhere. */
 /**
  * Open Graph wants `language_TERRITORY`, not the BCP 47 tag we route on.
- * A locale missing here would silently declare itself English, so new locales
- * belong in this map at the same time they get a route.
+ *
+ * Read off `LOCALES` rather than kept as a second map here. The old map could
+ * fall out of step with the locale list, and a locale missing from it silently
+ * declared itself English.
  */
-const OG_LOCALES: Record<string, string> = {
-  en: 'en_US',
-  'zh-CN': 'zh_CN',
-  ja: 'ja_JP'
-}
-
 export function ogLocale(locale: string): string {
-  return OG_LOCALES[locale] ?? OG_LOCALES.en
+  return isLocale(locale)
+    ? LOCALES[locale].ogLocale
+    : LOCALES[DEFAULT_LOCALE].ogLocale
 }
 
-/** The OG identifier for the other language, when this page has one. */
+/**
+ * The OG identifier for the other language, when this page has one.
+ *
+ * Open Graph takes a single alternate here, so a localized page names English
+ * and English names Chinese. Testing for `en` rather than `zh-CN` matters now
+ * that a third locale exists: the old form sent Japanese pages to `zh_CN`,
+ * pairing them with a language they have nothing to do with.
+ */
 export function ogLocaleAlternate(
   locale: string,
   alternates: Alternate[]
 ): string | null {
-  if (alternates.length === 0) return null
-  return locale === 'zh-CN' ? 'en_US' : 'zh_CN'
+  // The target has to be in this page's own cluster. A non-empty cluster was
+  // not enough: an English-only route still carries `en` and `x-default`, so
+  // every one of them advertised a Chinese alternate for a page that does not
+  // exist. No page does that today, but nothing stopped it.
+  const target = locale === 'en' ? 'zh-CN' : 'en'
+  if (!alternates.some((alternate) => alternate.hreflang === target)) {
+    return null
+  }
+  return target === 'zh-CN' ? 'zh_CN' : 'en_US'
 }

--- a/apps/website/src/utils/hreflangAudit.test.ts
+++ b/apps/website/src/utils/hreflangAudit.test.ts
@@ -28,7 +28,9 @@ function healthySite() {
       ['/about/', cluster('/about/')],
       ['/zh-CN/about/', cluster('/about/')],
       ['/affiliates/', []]
-    ])
+    ]),
+    // No Japanese page claims to be an original in these fixtures.
+    selfCanonical: new Set<string>()
   }
 }
 
@@ -228,5 +230,53 @@ describe('sitemapChunkNames', () => {
   it('returns nothing for an empty or unparseable index', () => {
     expect(sitemapChunkNames('')).toEqual([])
     expect(sitemapChunkNames('<sitemapindex></sitemapindex>')).toEqual([])
+  })
+})
+
+describe('a locale that is built but not ready', () => {
+  /**
+   * Astro's i18n fallback builds a page for EVERY route in a fallback locale,
+   * so /ja/ went from one page to 560. "The file exists" therefore stopped
+   * meaning "this language is published here", and the audit had been reading
+   * exactly that: it demanded every English page advertise a Japanese twin, and
+   * the check failed on 1,124 routes.
+   *
+   * The signal it reads now is the Japanese page's OWN canonical. A page that
+   * points at the English original is declaring itself not the original, which
+   * is precisely "built but not ready". That keeps the audit independent of the
+   * emitter's config — it cross-checks two things the built site says.
+   */
+  function siteWithFallbackJapanese() {
+    return {
+      origin: ORIGIN,
+      pages: new Map<string, Alternate[]>([
+        ['/about/', cluster('/about/')],
+        ['/zh-CN/about/', cluster('/about/')],
+        // Built by the fallback: canonical points home to English, and it
+        // advertises no cluster of its own.
+        ['/ja/about/', []]
+      ]),
+      sitemap: new Map<string, Alternate[]>([
+        ['/about/', cluster('/about/')],
+        ['/zh-CN/about/', cluster('/about/')]
+      ]),
+      selfCanonical: new Set<string>()
+    }
+  }
+
+  it('does not demand a cluster name a Japanese page that points at English', () => {
+    expect(auditBuiltSite(siteWithFallbackJapanese())).toEqual([])
+  })
+
+  it('still demands it once the Japanese page canonicals to itself', () => {
+    const site = siteWithFallbackJapanese()
+    site.selfCanonical = new Set(['/ja/about/'])
+
+    expect(auditBuiltSite(site)).toEqual([
+      '/about/: page expects ja -> https://comfy.org/ja/about/, but does not declare it',
+      '/zh-CN/about/: page expects ja -> https://comfy.org/ja/about/, but does not declare it',
+      '/about/: sitemap expects ja -> https://comfy.org/ja/about/, but does not declare it',
+      '/zh-CN/about/: sitemap expects ja -> https://comfy.org/ja/about/, but does not declare it'
+    ])
   })
 })

--- a/apps/website/src/utils/hreflangAudit.ts
+++ b/apps/website/src/utils/hreflangAudit.ts
@@ -7,7 +7,14 @@
  */
 import type { Alternate } from './hreflangRoutes'
 
-import { unprefixed, ZH_HREFLANG, ZH_PREFIX } from './hreflangRoutes'
+import {
+  JA_HREFLANG,
+  JA_PREFIX,
+  localizedHref,
+  unprefixed,
+  ZH_HREFLANG,
+  ZH_PREFIX
+} from './hreflangRoutes'
 
 export interface BuiltSite {
   /** Every built route, mapped to the alternates its HTML emits. */
@@ -21,6 +28,19 @@ export interface BuiltSite {
    * which is the same lie the page-side rules already refuse.
    */
   sitemap: Map<string, Alternate[]> | null
+  /**
+   * Routes whose page canonicals to ITSELF.
+   *
+   * Astro's i18n fallback builds a page for every route in a fallback locale,
+   * so a `/ja/` file existing stopped meaning Japanese is published there. A
+   * page that canonicals to the English original is declaring itself not the
+   * original; one that canonicals to itself is claiming to be the real thing
+   * and must therefore appear in its cluster.
+   *
+   * Read off the built HTML, so the audit still never inherits the emitter's
+   * opinion — it cross-checks two statements the built site makes.
+   */
+  selfCanonical: ReadonlySet<string>
   origin: string
 }
 
@@ -32,17 +52,32 @@ export interface BuiltSite {
  */
 function expectedAlternates(
   route: string,
-  origin: string
+  origin: string,
+  selfCanonical: ReadonlySet<string>
 ): Map<string, string> {
   const path = unprefixed(route)
   const english = `${origin}${path}`
-  const chinese = `${origin}${ZH_PREFIX}${path === '/' ? '/' : path}`
+  const chinese = `${origin}${localizedHref(ZH_PREFIX, path)}`
+  const japaneseRoute = localizedHref(JA_PREFIX, path)
 
-  return new Map([
+  const expected = new Map([
     ['en', english],
-    [ZH_HREFLANG, chinese],
-    ['x-default', english]
+    [ZH_HREFLANG, chinese]
   ])
+  // Japanese is a partial locale, and since the i18n fallback landed its pages
+  // exist for every route whether or not the language is published there. So
+  // the signal is the Japanese page's own canonical, not its existence: a page
+  // pointing at the English original is held back and must stay out of the
+  // cluster, while one pointing at itself is claiming to be the real thing and
+  // must be in it. Read off the BUILT site, so the audit stays independent of
+  // the emitter. A stale answer fails both ways round: claim a Japanese page
+  // that was not built and the "was not built (404)" rule fires; publish one
+  // and leave it out and the "expects ja -> ..." rule fires.
+  if (selfCanonical.has(japaneseRoute)) {
+    expected.set(JA_HREFLANG, `${origin}${japaneseRoute}`)
+  }
+  expected.set('x-default', english)
+  return expected
 }
 
 /**
@@ -57,10 +92,11 @@ function clusterErrors(
   route: string,
   alternates: Alternate[],
   origin: string,
-  source: string
+  source: string,
+  selfCanonical: ReadonlySet<string>
 ): string[] {
   const errors: string[] = []
-  const expected = expectedAlternates(route, origin)
+  const expected = expectedAlternates(route, origin, selfCanonical)
   const seen = new Set<string>()
   for (const { hreflang, href } of alternates) {
     if (seen.has(hreflang)) {
@@ -72,8 +108,9 @@ function clusterErrors(
 
     // Checking only that the expected pairs are present accepts extras beside
     // them. A locale this site does not publish still resolves and can still be
-    // reciprocal, so nothing downstream catches it: /ja/ pages that exist for
-    // some other reason would silently enter the cluster. The set is closed.
+    // reciprocal, so nothing downstream catches it. The set stays closed: `ja`
+    // is admitted above only for a route whose Japanese page was actually
+    // built, so a cluster naming `ja` on any other route is still rejected.
     if (!expected.has(hreflang)) {
       errors.push(
         `${route}: ${source} declares hreflang="${hreflang}", which is not one of ${[...expected.keys()].join(', ')}`
@@ -108,13 +145,16 @@ function clusterErrors(
 export function auditBuiltSite({
   pages,
   sitemap,
+  selfCanonical,
   origin
 }: BuiltSite): string[] {
   const errors: string[] = []
   const routeOfHref = (href: string) => href.slice(origin.length) || '/'
 
   for (const [route, alternates] of pages) {
-    errors.push(...clusterErrors(route, alternates, origin, 'page'))
+    errors.push(
+      ...clusterErrors(route, alternates, origin, 'page', selfCanonical)
+    )
 
     // Only the pages can be checked against what was actually built.
     for (const { hreflang, href } of alternates) {
@@ -164,7 +204,15 @@ export function auditBuiltSite({
       continue
     }
 
-    errors.push(...clusterErrors(route, sitemapAlternates, origin, 'sitemap'))
+    errors.push(
+      ...clusterErrors(
+        route,
+        sitemapAlternates,
+        origin,
+        'sitemap',
+        selfCanonical
+      )
+    )
 
     const langs = new Set(
       sitemapAlternates.map((alternate) => alternate.hreflang)

--- a/apps/website/src/utils/hreflangRoutes.ts
+++ b/apps/website/src/utils/hreflangRoutes.ts
@@ -8,9 +8,22 @@
  * Kept free of `import.meta.glob` so a plain Node script can import it.
  */
 
+/**
+ * Prefixes and hreflang values come from `config/locales.ts` rather than being
+ * restated here. Sharing them is deliberate and is what #15488 asked for: there
+ * must be exactly one definition of what the Chinese twin of a URL is, or the
+ * pages and the sitemap can disagree about it. What this module keeps to itself
+ * is which ROUTES cluster, which is the part that has to stay independent of
+ * the emitter.
+ */
+import { LOCALE_PREFIXES, LOCALES } from '../config/locales'
+
 /** The value the marketing site publishes for Simplified Chinese. */
-export const ZH_HREFLANG = 'zh-CN'
-export const ZH_PREFIX = '/zh-CN'
+export const ZH_HREFLANG = LOCALES['zh-CN'].hreflang
+export const ZH_PREFIX = LOCALES['zh-CN'].prefix
+
+export const JA_HREFLANG = LOCALES.ja.hreflang
+export const JA_PREFIX = LOCALES.ja.prefix
 
 /**
  * `/src/pages/cloud/pricing.astro` -> `/cloud/pricing/`, index files -> their directory.
@@ -39,10 +52,16 @@ export interface Alternate {
  * whatever page happens to own that path.
  */
 export function unprefixed(pathname: string): string {
-  const isLocalePrefixed =
-    pathname === ZH_PREFIX || pathname.startsWith(`${ZH_PREFIX}/`)
-  const path = isLocalePrefixed
-    ? pathname.slice(ZH_PREFIX.length) || '/'
-    : pathname
-  return path.endsWith('/') ? path : `${path}/`
+  for (const prefix of LOCALE_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      const path = pathname.slice(prefix.length) || '/'
+      return path.endsWith('/') ? path : `${path}/`
+    }
+  }
+  return pathname.endsWith('/') ? pathname : `${pathname}/`
+}
+
+/** The URL of `path` in a locale, given that locale's prefix. */
+export function localizedHref(prefix: string, path: string): string {
+  return `${prefix}${path === '/' ? '/' : path}`
 }


### PR DESCRIPTION
## Summary

Give routing and language metadata one locale configuration, and connect the existing Japanese homepage to its English and Chinese alternatives.

Part 1/8 of native stack #17294, continuing #17129. Original implementation by Mobeen Abdullah, preserved with co-author attribution. Reconciled with main at 16f4d3a2be.

## Changes

- **What**: Language registry, route availability, localized links, hreflang and Open Graph metadata, and the corresponding built-site audit.

## Review Focus

Japanese publication remains limited to the homepage. Canonical helpers and unpublished-page sitemap checks are in the next PR; Markdown generation is in the third.

Validation: 1,289 website unit tests; website build and hreflang audit; lint and root/website type checks.


Review feedback carried from #17205; this split does not resolve it:

- [apps/website/scripts/check-hreflang.ts](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17205#discussion_r3963333613)
- [apps/website/src/config/routes.ts](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17205#discussion_r3963333625)
- [apps/website/src/lib/hreflang.test.ts](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17205#discussion_r3963333635)
