### PR TITLE
feat(website): add the footer language switcher

### DIFF
--- a/apps/website/e2e/locale-navigation.spec.ts
+++ b/apps/website/e2e/locale-navigation.spec.ts
@@ -1,0 +1,141 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/blockExternalMedia'
+
+/**
+ * Crossing locales must be a real page load.
+ *
+ * ClientRouter swaps the document without re-evaluating any module, and in
+ * production the browser loads only its own page's dictionary — an English
+ * reader never downloads Chinese. A client-side swap into another locale
+ * therefore left the incoming islands asking for a dictionary that was never
+ * fetched, and `t()` threw rather than render text the server did not. The page
+ * rendered broken and came right on refresh, which is a full load.
+ *
+ * Not only the language switcher: `localizeHref` returns an unprefixed path for
+ * a route a locale does not publish, so an ordinary footer link out of the
+ * Chinese tree crosses locales too. Both paths are covered here.
+ *
+ * Only a browser can catch this. The build is identical either way — the
+ * failure is in what the client does after the swap.
+ */
+async function errorsWhile(
+  page: Page,
+  act: () => Promise<void>
+): Promise<string[]> {
+  const errors: string[] = []
+  page.on('pageerror', (error) => errors.push(error.message))
+  page.on('console', (message) => {
+    // A preview server is http://localhost and the CDN is https://media.comfy.org,
+    // so external media and Vercel Analytics always complain. Neither says
+    // anything about whether the page hydrated, which is what this is for —
+    // that failure arrives as an uncaught exception on `pageerror`.
+    const text = message.text()
+    const environmental =
+      text.includes('Failed to load resource') ||
+      text.includes('Unsafe attempt to load URL') ||
+      text.includes('media.comfy.org') ||
+      text.includes('/_vercel/')
+    if (message.type() === 'error' && !environmental) errors.push(text)
+  })
+  await act()
+  await page.waitForLoadState('domcontentloaded')
+
+  // `domcontentloaded` is far too early: an island's markup is server-rendered
+  // and visible long before any of its code runs, so returning here would let a
+  // hydration failure land after the assertion had already passed.
+  //
+  // Astro's island element removes its `ssr` attribute only once `hydrator()`
+  // has resolved (astro-island.js), which makes its absence the one honest
+  // signal that hydration finished. Only `client:load` islands are waited on —
+  // a `client:visible` island below the fold may never hydrate at all.
+  //
+  // A failing hydration leaves the attribute in place, so this times out in
+  // exactly the case the test exists to catch. That is deliberate: the thrown
+  // exception is already in `errors`, and reporting it reads far better than a
+  // wait timeout would.
+  await page
+    .waitForFunction(
+      () =>
+        document.querySelectorAll('astro-island[client="load"][ssr]').length ===
+        0,
+      undefined,
+      { timeout: 5000 }
+    )
+    .catch(() => {})
+
+  return errors
+}
+
+test('switching language from the footer renders the new locale', async ({
+  page
+}) => {
+  await page.goto('/zh-CN/cli/', { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('html')).toHaveAttribute('lang', 'zh-CN')
+
+  const errors = await errorsWhile(page, async () => {
+    await page
+      .locator('a[href="/cli/"][data-astro-reload]')
+      .locator('visible=true')
+      .first()
+      .click()
+  })
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+  expect(
+    errors,
+    `console errors after switching language: ${errors.join(' | ')}`
+  ).toEqual([])
+
+  // Hydration is proven above; this is the content it produced.
+  await expect(
+    page.getByRole('link', { name: '简体中文', exact: true })
+  ).toBeVisible()
+})
+
+test('a footer link that leaves the Chinese tree renders correctly', async ({
+  page
+}) => {
+  await page.goto('/zh-CN/cli/', { waitUntil: 'domcontentloaded' })
+
+  // /terms-of-service is English-only, so `localizeHref` leaves it unprefixed
+  // and this link crosses locales without going anywhere near the switcher.
+  const errors = await errorsWhile(page, async () => {
+    await page
+      .locator('a[href="/terms-of-service"]')
+      .locator('visible=true')
+      .first()
+      .click()
+  })
+
+  await expect(page).toHaveURL(/\/terms-of-service\/?$/)
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+  expect(
+    errors,
+    `console errors after leaving the Chinese tree: ${errors.join(' | ')}`
+  ).toEqual([])
+})
+
+test('navigating within one locale still uses the client router', async ({
+  page
+}) => {
+  await page.goto('/zh-CN/cli/', { waitUntil: 'domcontentloaded' })
+
+  const errors = await errorsWhile(page, async () => {
+    await page
+      .locator(
+        'a[href^="/zh-CN/"]:not([data-astro-reload]):not([href="/zh-CN/cli/"])'
+      )
+      .locator('visible=true')
+      .first()
+      .click()
+  })
+
+  await expect(page).toHaveURL(/\/zh-CN\//)
+  await expect(page.locator('html')).toHaveAttribute('lang', 'zh-CN')
+  expect(
+    errors,
+    `console errors within one locale: ${errors.join(' | ')}`
+  ).toEqual([])
+})

--- a/apps/website/src/components/common/LanguageSwitcher.test.ts
+++ b/apps/website/src/components/common/LanguageSwitcher.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import LanguageSwitcher from './LanguageSwitcher.vue'
+
+const clustered = [
+  { hreflang: 'en', href: 'https://comfy.org/download/' },
+  { hreflang: 'zh-CN', href: 'https://comfy.org/zh-CN/download/' },
+  { hreflang: 'ja', href: 'https://comfy.org/ja/download/' },
+  { hreflang: 'x-default', href: 'https://comfy.org/download/' }
+]
+
+describe('LanguageSwitcher', () => {
+  it('offers every language the page is published in', () => {
+    render(LanguageSwitcher, { props: { locale: 'en', alternates: clustered } })
+
+    for (const name of ['English', '简体中文', '日本語']) {
+      expect(screen.getByRole('link', { name })).toBeTruthy()
+    }
+    expect(screen.getAllByRole('link')).toHaveLength(3)
+  })
+
+  /**
+   * `x-default` is a routing hint for crawlers, not a language. Rendering it
+   * would put a fourth entry in the list that duplicates English.
+   */
+  it('never offers x-default as a language', () => {
+    render(LanguageSwitcher, { props: { locale: 'en', alternates: clustered } })
+
+    expect(screen.queryByRole('link', { name: 'x-default' })).toBeNull()
+    expect(screen.getAllByRole('link')).toHaveLength(3)
+  })
+
+  it('links each language to that language of the same page', () => {
+    render(LanguageSwitcher, { props: { locale: 'en', alternates: clustered } })
+
+    expect(
+      screen.getByRole('link', { name: '日本語' }).getAttribute('href')
+    ).toBe('/ja/download/')
+  })
+
+  it('marks the language being read', () => {
+    render(LanguageSwitcher, { props: { locale: 'ja', alternates: clustered } })
+
+    // `current` is the role query for aria-current, so this asks the
+    // accessibility tree the same question a screen reader would.
+    expect(
+      screen.getByRole('link', { name: '日本語', current: true })
+    ).toBeTruthy()
+    expect(
+      screen.queryByRole('link', { name: 'English', current: true })
+    ).toBeNull()
+  })
+
+  /**
+   * A page outside a language cluster has nowhere to switch to. That is most of
+   * the site — a held-back Japanese page, a locale-invariant legal document —
+   * so the switcher has to disappear rather than render an empty control or,
+   * worse, links to pages that are not published.
+   */
+  it('renders nothing for a page that is not published in another language', () => {
+    render(LanguageSwitcher, { props: { locale: 'en', alternates: [] } })
+
+    expect(screen.queryByRole('navigation')).toBeNull()
+  })
+
+  it('renders nothing when the only alternate is the page itself', () => {
+    render(LanguageSwitcher, {
+      props: {
+        locale: 'en',
+        alternates: [
+          { hreflang: 'en', href: 'https://comfy.org/cli/' },
+          { hreflang: 'x-default', href: 'https://comfy.org/cli/' }
+        ]
+      }
+    })
+
+    expect(screen.queryByRole('navigation')).toBeNull()
+  })
+
+  /**
+   * A language change must be a real navigation, not a client-side swap.
+   *
+   * ClientRouter swaps the DOM without re-evaluating modules, and in production
+   * the browser deliberately loads only its own page's dictionary — an English
+   * reader never downloads Chinese. Crossing locales client-side therefore left
+   * the new page's islands asking for a dictionary that was never fetched, and
+   * `t()` threw rather than render text the server had not. The page looked
+   * broken until a refresh, which is a full load and fetches the right one.
+   *
+   * `data-astro-reload` opts these links out of client-side routing.
+   */
+  it('forces a full page load, so the new locale dictionary is fetched', () => {
+    render(LanguageSwitcher, { props: { locale: 'en', alternates: clustered } })
+
+    for (const name of ['English', '简体中文', '日本語']) {
+      expect(
+        screen.getByRole('link', { name }).hasAttribute('data-astro-reload'),
+        `${name} must force a full navigation`
+      ).toBe(true)
+    }
+  })
+})

--- a/apps/website/src/components/common/LanguageSwitcher.vue
+++ b/apps/website/src/components/common/LanguageSwitcher.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
+import { LOCALES, isLocale } from '../../config/locales'
+import type { Locale } from '../../config/locales'
+import { t } from '../../i18n/translations'
+import type { Alternate } from '../../utils/hreflangRoutes'
+
+/**
+ * Switching language on the page you are reading, as plain links.
+ *
+ * Built from the page's own hreflang alternates rather than from a list of its
+ * own, so the switcher offers exactly what the site advertises to crawlers. The
+ * two cannot drift apart, and the switcher widens on its own as more routes are
+ * published — which is the whole shape of this feature: one predicate, read by
+ * every surface.
+ *
+ * Links, never a toggle. A language is a different URL, so it has to be
+ * navigable, shareable, and followable by a crawler.
+ *
+ * `data-astro-reload` because a language change is a document change, not a
+ * client-side swap. ClientRouter would swap the DOM without re-evaluating any
+ * module, and in production the browser loads only its own page dictionary — an
+ * English reader never downloads Chinese. Crossing locales that way left the
+ * new page asking for a dictionary that was never fetched, so `t()` threw and
+ * the page looked broken until a refresh.
+ */
+const { locale, alternates } = defineProps<{
+  locale: Locale
+  alternates: readonly Alternate[]
+}>()
+
+const languages = alternates
+  .filter((alternate) => isLocale(alternate.hreflang))
+  .map((alternate) => ({
+    code: alternate.hreflang as Locale,
+    // Relative, so the link works on any origin — preview deploys included.
+    href: new URL(alternate.href).pathname,
+    label: LOCALES[alternate.hreflang as Locale].nativeName
+  }))
+
+// One entry means the page exists in one language, so there is nothing to
+// switch to and a control would be a dead end.
+const hasChoice = languages.length > 1
+</script>
+
+<template>
+  <nav v-if="hasChoice" :aria-label="t('footer.language', locale)">
+    <ul class="flex items-center gap-4">
+      <li v-for="language in languages" :key="language.code">
+        <a
+          :href="language.href"
+          :hreflang="language.code"
+          data-astro-reload
+          :lang="language.code"
+          :aria-current="language.code === locale ? 'true' : undefined"
+          :class="
+            cn(
+              'text-sm',
+              language.code === locale
+                ? 'underline underline-offset-4'
+                : 'hover:underline hover:underline-offset-4'
+            )
+          "
+        >
+          {{ language.label }}
+        </a>
+      </li>
+    </ul>
+  </nav>
+</template>

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -5,10 +5,15 @@ import { externalLinks, getRoutes } from '../../config/routes'
 import { useFrameScrub } from '../../composables/useFrameScrub'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
+import type { Alternate } from '../../utils/hreflangRoutes'
 import FooterLinkColumn from './FooterLinkColumn.vue'
+import LanguageSwitcher from './LanguageSwitcher.vue'
 import type { FooterLink } from './FooterLinkColumn.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale = 'en', alternates = [] } = defineProps<{
+  locale?: Locale
+  alternates?: readonly Alternate[]
+}>()
 const routes = getRoutes(locale)
 
 const footerRef = ref<HTMLElement>()
@@ -217,7 +222,10 @@ const contactColumn: { title: string; links: FooterLink[] } = {
         </div>
 
         <!-- Bottom bar -->
-        <div class="flex justify-center gap-6 lg:justify-end">
+        <div
+          class="flex flex-wrap items-center justify-center gap-6 lg:justify-end"
+        >
+          <LanguageSwitcher :locale="locale" :alternates="alternates" />
           <p class="text-sm">{{ t('footer.location', locale) }}</p>
           <p class="text-sm">&copy; {{ new Date().getFullYear() }} Comfy Org</p>
         </div>

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -268,7 +268,7 @@ const structuredData = shouldNoindex
       <slot />
     </main>
     <SiteFooter locale={locale}
-        client:load />
+        alternates={alternates} client:load />
 
     <Analytics />
     {/*


### PR DESCRIPTION
## Summary

Let visitors switch between the published language versions of a page from the footer. Pass the current hreflang alternatives into the switcher and cover navigation across language dictionaries.

Part 8/8 of native stack #17294, continuing #17129. Original implementation by Mobeen Abdullah, preserved with co-author attribution; reconciled against main at 16f4d3a2be.

## Changes

- **What**: Footer switcher, alternate-language props, and navigation E2E coverage using the current external-network isolation fixture. The required cross-language reload/history guard lives with dictionary loading in layer 2.

## Review Focus

The switcher implementation is unchanged by this restack; only its ancestry changes.

Switch only to published alternatives; preserve within-language navigation and browser history. Review the carried hydration-timeout feedback before approval.

Validation: 56 focused tests; all 1,452 final website unit tests; release build; 7 browser tests for language navigation and canonical redirects; hreflang, localized-content, JSON-LD, translation and llms.txt checks; lint and root/website type checks.

Review feedback carried from #17129 for this layer; splitting does not resolve or approve it:

- [apps/website/e2e/locale-navigation.spec.ts](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17129#discussion_r3957933531)
