### PR TITLE
test: enforce import-form Vitest mocks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -102,6 +102,7 @@
     "unicorn/no-empty-file": "off",
     "vitest/require-mock-type-parameters": "off",
     "vitest/hoisted-apis-on-top": "error",
+    "vitest/prefer-import-in-mock": "error",
     "typescript/no-misused-spread": "error",
     "vitest/consistent-each-for": [
       "error",

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -19,6 +19,16 @@ which is always loaded. In addition:
 ## Mocking
 
 - Use Vitest's mocking utilities (`vi.mock`, `vi.spyOn`)
+- Pass the module as a dynamic import - `vi.mock(import('@/scripts/api'), …)`,
+  not `vi.mock('@/scripts/api', …)`. Enforced by
+  `vitest/prefer-import-in-mock`. Vitest rewrites it back to the string form
+  while hoisting, so this is a typing change only: the factory is now checked
+  against the real module.
+- `vi.mock<unknown>(import('…'), …)` opts a call back out of that check. It
+  marks mocks that predate the rule and could not satisfy it - most often a
+  composable mocked by returning a subset of its return value, which
+  `Partial<Module>` cannot express. Do not copy it into new mocks; type the
+  factory instead.
 - Keep module mocks contained - no global mutable state
 - Use `vi.hoisted()` for per-test mock manipulation
 - Vitest automatically resets mocks, restores spies, and unstubs globals and

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -19,16 +19,9 @@ which is always loaded. In addition:
 ## Mocking
 
 - Use Vitest's mocking utilities (`vi.mock`, `vi.spyOn`)
-- Pass the module as a dynamic import - `vi.mock(import('@/scripts/api'), …)`,
-  not `vi.mock('@/scripts/api', …)`. Enforced by
-  `vitest/prefer-import-in-mock`. Vitest rewrites it back to the string form
-  while hoisting, so this is a typing change only: the factory is now checked
-  against the real module.
-- `vi.mock<unknown>(import('…'), …)` opts a call back out of that check. It
-  marks mocks that predate the rule and could not satisfy it - most often a
-  composable mocked by returning a subset of its return value, which
-  `Partial<Module>` cannot express. Do not copy it into new mocks; type the
-  factory instead.
+- Use `vi.mock<unknown>(import('…'), …)` only for legacy partial factories that
+  cannot satisfy the module type. Do not use it in new mocks; type the factory
+  instead.
 - Keep module mocks contained - no global mutable state
 - Use `vi.hoisted()` for per-test mock manipulation
 - Vitest automatically resets mocks, restores spies, and unstubs globals and

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -19,9 +19,8 @@ which is always loaded. In addition:
 ## Mocking
 
 - Use Vitest's mocking utilities (`vi.mock`, `vi.spyOn`)
-- Use `vi.mock<unknown>(import('…'), …)` only for legacy partial factories that
-  cannot satisfy the module type. Do not use it in new mocks; type the factory
-  instead.
+- `vi.mock<unknown>(import('…'), …)` is only for legacy partial factories that
+  cannot satisfy the module type. For new mocks, type the factory instead.
 - Keep module mocks contained - no global mutable state
 - Use `vi.hoisted()` for per-test mock manipulation
 - Vitest automatically resets mocks, restores spies, and unstubs globals and

--- a/docs/testing/store-testing.md
+++ b/docs/testing/store-testing.md
@@ -161,7 +161,7 @@ Mocking API and other dependencies:
 ```typescript
 // Example from a colocated store unit test
 // Add mock for api at the top of the file
-vi.mock('@/scripts/api', () => ({
+vi.mock(import('@/scripts/api'), () => ({
   api: {
     getUserData: vi.fn(),
     storeUserData: vi.fn(),
@@ -172,7 +172,7 @@ vi.mock('@/scripts/api', () => ({
 }))
 
 // Mock comfyApp globally for the store setup
-vi.mock('@/scripts/app', () => ({
+vi.mock(import('@/scripts/app'), () => ({
   app: {
     canvas: null // Start with canvas potentially undefined or null
   }

--- a/docs/testing/unit-testing.md
+++ b/docs/testing/unit-testing.md
@@ -24,7 +24,7 @@ import { nextTick } from 'vue'
 import { useServerLogs } from '@/composables/useServerLogs'
 
 // Mock dependencies
-vi.mock('@/scripts/api', () => ({
+vi.mock(import('@/scripts/api'), () => ({
   api: {
     subscribeLogs: vi.fn()
   }
@@ -130,7 +130,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { api } from '@/scripts/api'
 
 // Mock the api object
-vi.mock('@/scripts/api', () => ({
+vi.mock(import('@/scripts/api'), () => ({
   api: {
     subscribeLogs: vi.fn(),
     addEventListener: vi.fn(),
@@ -155,7 +155,7 @@ Mocking utility functions like debounce:
 // Mock debounce to execute immediately
 import { debounce } from 'es-toolkit/compat'
 
-vi.mock('es-toolkit/compat', () => ({
+vi.mock(import('es-toolkit/compat'), () => ({
   debounce: vi.fn((fn) => {
     // Return function that calls the input function immediately
     const mockDebounced = (...args: any[]) => fn(...args)
@@ -275,7 +275,7 @@ When mocking composables that return reactive refs, define the mock implementati
 // Example from: src/platform/updates/common/releaseStore.test.ts
 import { ref } from 'vue'
 
-vi.mock('@/path/to/composable', () => {
+vi.mock(import('@/path/to/composable'), () => {
   const doSomething = vi.fn()
   const isLoading = ref(false)
   const error = ref<string | null>(null)
@@ -321,7 +321,7 @@ beforeEach(() => {
 })
 
 // ❌ Don't auto-mock then override — reactive refs won't work correctly
-vi.mock('@/path/to/composable')
+vi.mock(import('@/path/to/composable'))
 vi.mocked(useMyComposable).mockReturnValue({ isLoading: ref(false) })
 ```
 

--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -97,14 +97,14 @@ const fetchMock = vi.fn(async () => ({ ok: true }))
 ### Module mocks with vi.mock()
 
 ```typescript
-vi.mock('@/scripts/api', () => ({
+vi.mock(import('@/scripts/api'), () => ({
   api: {
     addEventListener: vi.fn(),
     fetchData: vi.fn()
   }
 }))
 
-vi.mock('@/services/myService', () => ({
+vi.mock(import('@/services/myService'), () => ({
   myService: {
     doThing: vi.fn()
   }

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -8,15 +8,15 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 import App from './App.vue'
 
-vi.mock('firebase/auth')
-vi.mock('vuefire', () => ({ useFirebaseAuth: vi.fn() }))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
-vi.mock('@/components/dialog/GlobalDialog.vue', () => ({
+vi.mock<unknown>(import('@/components/dialog/GlobalDialog.vue'), () => ({
   default: { template: '<div />' }
 }))
-vi.mock('@/scripts/app', () => ({ app: {} }))
-vi.mock(
-  '@/workbench/extensions/manager/composables/useConflictDetection',
+vi.mock<unknown>(import('@/scripts/app'), () => ({ app: {} }))
+vi.mock<unknown>(
+  import('@/workbench/extensions/manager/composables/useConflictDetection'),
   () => ({
     useConflictDetection: () => ({
       initializeConflictDetection: vi.fn()

--- a/src/components/LiteGraphCanvasSplitterOverlay.test.ts
+++ b/src/components/LiteGraphCanvasSplitterOverlay.test.ts
@@ -12,7 +12,7 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 
-vi.mock('@/stores/authStore', () => ({
+vi.mock<unknown>(import('@/stores/authStore'), () => ({
   useAuthStore: vi.fn(() => ({ currentUser: null, loading: false }))
 }))
 

--- a/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
@@ -16,28 +16,34 @@ const showApiNodesSignInDialog = vi.hoisted(() =>
   vi.fn(() => Promise.resolve(false))
 )
 
-vi.mock('@/composables/billing/usePartnerNodesRunGate', async () => {
-  const { ref } = await import('vue')
-  gateState.gate = ref<'sign-in' | 'none'>('none')
-  gateState.partnerNodes = ref<PartnerNode[]>([])
-  return {
-    usePartnerNodesRunGate: () => ({
-      gate: gateState.gate,
-      partnerNodes: gateState.partnerNodes
-    })
+vi.mock<unknown>(
+  import('@/composables/billing/usePartnerNodesRunGate'),
+  async () => {
+    const { ref } = await import('vue')
+    gateState.gate = ref<'sign-in' | 'none'>('none')
+    gateState.partnerNodes = ref<PartnerNode[]>([])
+    return {
+      usePartnerNodesRunGate: () => ({
+        gate: gateState.gate,
+        partnerNodes: gateState.partnerNodes
+      })
+    }
   }
-})
+)
 
-vi.mock('@/services/dialogService', () => ({
+vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showApiNodesSignInDialog })
 }))
 
-vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
-  default: {
-    name: 'ComfyQueueButton',
-    template: '<button data-testid="queue-button" />'
-  }
-}))
+vi.mock<unknown>(
+  import('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue'),
+  () => ({
+    default: {
+      name: 'ComfyQueueButton',
+      template: '<button data-testid="queue-button" />'
+    }
+  })
+)
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/actionbar/PartnerNodesEducationCard.test.ts
+++ b/src/components/actionbar/PartnerNodesEducationCard.test.ts
@@ -15,20 +15,23 @@ import { usePartnerNodesEducationStore } from '@/platform/workflow/templates/sto
 
 import PartnerNodesEducationCard from './PartnerNodesEducationCard.vue'
 
-vi.mock('@/composables/node/usePartnerNodesInGraph', async () => {
-  const { computed, ref } = await import('vue')
-  const hasNodes = ref(true)
-  return {
-    usePartnerNodesInGraph: () => ({
-      hasPartnerNodes: computed(() => hasNodes.value)
-    }),
-    __setHasPartnerNodes: (value: boolean) => {
-      hasNodes.value = value
+vi.mock<unknown>(
+  import('@/composables/node/usePartnerNodesInGraph'),
+  async () => {
+    const { computed, ref } = await import('vue')
+    const hasNodes = ref(true)
+    return {
+      usePartnerNodesInGraph: () => ({
+        hasPartnerNodes: computed(() => hasNodes.value)
+      }),
+      __setHasPartnerNodes: (value: boolean) => {
+        hasNodes.value = value
+      }
     }
   }
-})
+)
 
-vi.mock('@/composables/billing/usePartnerNodesRunGate', async () => {
+vi.mock(import('@/composables/billing/usePartnerNodesRunGate'), async () => {
   const { computed, ref } = await import('vue')
   const gate = ref<'sign-in' | 'none'>('none')
   return {
@@ -45,7 +48,7 @@ vi.mock('@/composables/billing/usePartnerNodesRunGate', async () => {
 })
 
 const showApiNodesSignInDialog = vi.fn()
-vi.mock('@/services/dialogService', () => ({
+vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showApiNodesSignInDialog })
 }))
 

--- a/src/components/builder/AppBuilder.test.ts
+++ b/src/components/builder/AppBuilder.test.ts
@@ -10,7 +10,7 @@ import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphT
 
 import AppBuilder from './AppBuilder.vue'
 
-vi.mock('@/composables/useAppMode', async () => {
+vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { ref } = await import('vue')
   return {
     useAppMode: () => ({
@@ -26,7 +26,7 @@ vi.mock('@/composables/useAppMode', async () => {
   }
 })
 
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     rootGraph: {
       id: '11111111-1111-4111-8111-111111111111',

--- a/src/components/dialog/content/ApiNodesSignInContent.test.ts
+++ b/src/components/dialog/content/ApiNodesSignInContent.test.ts
@@ -11,7 +11,7 @@ const hoisted = vi.hoisted(() => ({
   nodeDefsByName: {} as Record<string, { display_name?: string }>
 }))
 
-vi.mock('@/stores/nodeDefStore', () => ({
+vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
   useNodeDefStore: () => ({ nodeDefsByName: hoisted.nodeDefsByName })
 }))
 
@@ -19,7 +19,7 @@ const buildDocsUrl = vi.hoisted(() =>
   vi.fn((path: string) => `https://docs.comfy.org${path}`)
 )
 
-vi.mock('@/composables/useExternalLink', () => ({
+vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   useExternalLink: () => ({ buildDocsUrl })
 }))
 

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -42,8 +42,8 @@ const mocks = vi.hoisted(() => ({
   }
 }))
 
-vi.mock(
-  '@/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry',
+vi.mock<unknown>(
+  import('@/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry'),
   () => ({
     useFirstRunEntry: () => ({
       gettingStartedVisible: { value: false },
@@ -55,7 +55,7 @@ vi.mock(
 )
 
 vi.mock(
-  '@/platform/workflow/persistence/composables/useWorkflowPersistenceV2',
+  import('@/platform/workflow/persistence/composables/useWorkflowPersistenceV2'),
   () => ({
     useWorkflowPersistenceV2: () => ({
       initializeWorkflow: mocks.initializeWorkflow,
@@ -67,7 +67,7 @@ vi.mock(
   })
 )
 
-vi.mock('@/scripts/app', () => {
+vi.mock<unknown>(import('@/scripts/app'), () => {
   const canvas = {
     render_canvas_border: false,
     graph: null,
@@ -87,72 +87,69 @@ vi.mock('@/scripts/app', () => {
   }
 })
 
-vi.mock('@/scripts/changeTracker', () => ({
+vi.mock<unknown>(import('@/scripts/changeTracker'), () => ({
   ChangeTracker: { init: vi.fn() }
 }))
 
-vi.mock('@/services/useNewUserService', () => ({
+vi.mock<unknown>(import('@/services/useNewUserService'), () => ({
   useNewUserService: () => ({
     initializeIfNewUser: vi.fn(),
     isNewUser: () => false
   })
 }))
 
-vi.mock('@/composables/useUrlActionLoaders', () => ({
+vi.mock(import('@/composables/useUrlActionLoaders'), () => ({
   useUrlActionLoaders: () => ({
     runUrlActionLoaders: mocks.runUrlActionLoaders
   })
 }))
 
-vi.mock('@/platform/updates/common/releaseStore', () => ({
+vi.mock<unknown>(import('@/platform/updates/common/releaseStore'), () => ({
   useReleaseStore: () => ({ initialize: vi.fn() })
 }))
 
-vi.mock('@/composables/graph/useVueNodeLifecycle', () => ({
-  useVueNodeLifecycle: () => ({
-    nodeManager: { value: null },
-    setupEmptyGraphListener: vi.fn(),
-    initializeNodeManager: vi.fn(),
-    disposeNodeManagerAndSyncs: vi.fn(),
-    cleanup: vi.fn()
-  })
-}))
-
-vi.mock('@/composables/graph/useErrorClearingHooks', () => ({
+vi.mock(import('@/composables/graph/useErrorClearingHooks'), () => ({
   installErrorClearingHooks: () => vi.fn()
 }))
 
-vi.mock('@/services/colorPaletteService', () => ({
+vi.mock<unknown>(import('@/services/colorPaletteService'), () => ({
   useColorPaletteService: () => ({ loadColorPalette: vi.fn() })
 }))
 
-vi.mock('@/renderer/core/canvas/useCanvasInteractions', () => ({
-  useCanvasInteractions: () => ({ forwardEventToCanvas: vi.fn() })
-}))
+vi.mock<unknown>(
+  import('@/renderer/core/canvas/useCanvasInteractions'),
+  () => ({
+    useCanvasInteractions: () => ({ forwardEventToCanvas: vi.fn() })
+  })
+)
 
-vi.mock('@/composables/useCanvasDrop', () => ({ useCanvasDrop: vi.fn() }))
-vi.mock('@/platform/settings/composables/useLitegraphSettings', () => ({
+vi.mock<unknown>(import('@/composables/useCanvasDrop'), () => ({
+  useCanvasDrop: vi.fn()
+}))
+vi.mock(import('@/platform/settings/composables/useLitegraphSettings'), () => ({
   useLitegraphSettings: vi.fn()
 }))
-vi.mock('@/composables/node/useNodeBadge', () => ({ useNodeBadge: vi.fn() }))
-vi.mock('@/composables/useGlobalLitegraph', () => ({
+vi.mock<unknown>(import('@/composables/node/useNodeBadge'), () => ({
+  useNodeBadge: vi.fn()
+}))
+vi.mock(import('@/composables/useGlobalLitegraph'), () => ({
   useGlobalLitegraph: vi.fn()
 }))
-vi.mock('@/composables/useContextMenuTranslation', () => ({
+vi.mock(import('@/composables/useContextMenuTranslation'), () => ({
   useContextMenuTranslation: vi.fn()
 }))
-vi.mock('@/composables/graph/useGroupContextMenu', () => ({
+vi.mock(import('@/composables/graph/useGroupContextMenu'), () => ({
   useGroupContextMenu: vi.fn()
 }))
 // Instantiating the real one pulls in the Firebase auth store.
-vi.mock('@/stores/workspaceStore', () => ({
+vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
   useWorkspaceStore: () => mocks.workspaceStore
 }))
 
-vi.mock('@/composables/useCopy', () => ({ useCopy: vi.fn() }))
-vi.mock('@/composables/usePaste', () => ({ usePaste: vi.fn() }))
+vi.mock(import('@/composables/useCopy'), () => ({ useCopy: vi.fn() }))
+vi.mock(import('@/composables/usePaste'), () => ({ usePaste: vi.fn() }))
 vi.mock(
-  '@/platform/workflow/persistence/composables/useWorkflowAutoSave',
+  import('@/platform/workflow/persistence/composables/useWorkflowAutoSave'),
   () => ({ useWorkflowAutoSave: vi.fn() })
 )
 

--- a/src/components/graph/NodeSelectionModeBanner.test.ts
+++ b/src/components/graph/NodeSelectionModeBanner.test.ts
@@ -8,9 +8,12 @@ import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
 import NodeSelectionModeBanner from './NodeSelectionModeBanner.vue'
 
-vi.mock('@/renderer/core/canvas/useCanvasInteractions', () => ({
-  useCanvasInteractions: () => ({ forwardEventToCanvas: vi.fn() })
-}))
+vi.mock<unknown>(
+  import('@/renderer/core/canvas/useCanvasInteractions'),
+  () => ({
+    useCanvasInteractions: () => ({ forwardEventToCanvas: vi.fn() })
+  })
+)
 
 describe('NodeSelectionModeBanner', () => {
   it('shows the selection instructions and exits from the CTA', async () => {

--- a/src/components/graph/agentPanelMount.test.ts
+++ b/src/components/graph/agentPanelMount.test.ts
@@ -9,7 +9,7 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import LiteGraphCanvasSplitterOverlay from '../LiteGraphCanvasSplitterOverlay.vue'
 
-vi.mock('@/composables/useAppMode', async () => {
+vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { ref } = await import('vue')
   return {
     useAppMode: () => ({
@@ -21,7 +21,7 @@ vi.mock('@/composables/useAppMode', async () => {
 
 // The overlay's workspace stores reach Firebase auth and app bootstrap in
 // their real setups; the structure under test only needs these fields.
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     get: vi.fn((key: string) =>
       key === 'Comfy.Sidebar.Location' ? 'left' : undefined
@@ -30,7 +30,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
   })
 }))
 
-vi.mock('@/stores/workspaceStore', async () => {
+vi.mock<unknown>(import('@/stores/workspaceStore'), async () => {
   const { defineStore } = await import('pinia')
   const { ref } = await import('vue')
   return {
@@ -40,7 +40,7 @@ vi.mock('@/stores/workspaceStore', async () => {
   }
 })
 
-vi.mock('@/stores/workspace/rightSidePanelStore', async () => {
+vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), async () => {
   const { defineStore } = await import('pinia')
   const { ref } = await import('vue')
   return {
@@ -50,7 +50,7 @@ vi.mock('@/stores/workspace/rightSidePanelStore', async () => {
   }
 })
 
-vi.mock('@/stores/workspace/sidebarTabStore', async () => {
+vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), async () => {
   const { defineStore } = await import('pinia')
   const { ref } = await import('vue')
   return {
@@ -61,7 +61,7 @@ vi.mock('@/stores/workspace/sidebarTabStore', async () => {
   }
 })
 
-vi.mock('@/stores/workspace/bottomPanelStore', async () => {
+vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), async () => {
   const { defineStore } = await import('pinia')
   const { ref } = await import('vue')
   return {

--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -4,13 +4,15 @@ import { generateModelThumbnail } from './modelThumbnail'
 
 const isAssetPreviewSupported = vi.hoisted(() => vi.fn(() => false))
 const persistThumbnail = vi.hoisted(() => vi.fn(async () => {}))
-vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
+vi.mock(import('@/platform/assets/utils/assetPreviewUtil'), () => ({
   isAssetPreviewSupported,
   persistThumbnail
 }))
 
 const createLoad3d = vi.hoisted(() => vi.fn())
-vi.mock('@/extensions/core/load3d/createLoad3d', () => ({ createLoad3d }))
+vi.mock(import('@/extensions/core/load3d/createLoad3d'), () => ({
+  createLoad3d
+}))
 
 function mockInstance(overrides: Record<string, unknown> = {}) {
   return {

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -8,10 +8,10 @@ import type { AugmentedResultItem } from '@/utils/resultItem'
 
 import MediaLightbox from './MediaLightbox.vue'
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({ get: () => undefined })
 }))
-vi.mock('@/stores/extensionStore', () => ({
+vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
   useExtensionStore: () => ({
     isExtensionInstalled: () => false,
     isExtensionEnabled: () => false

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -13,9 +13,13 @@ const toastService = vi.hoisted(() => ({
   removeAllGroups: vi.fn()
 }))
 
-vi.mock('primevue/usetoast', () => ({
-  useToast: () => toastService
-}))
+vi.mock<unknown>(
+  // eslint-disable-next-line primevue-removal/no-imports
+  import('primevue/usetoast'),
+  () => ({
+    useToast: () => toastService
+  })
+)
 
 function renderToast() {
   return render(GlobalToast, {

--- a/src/composables/billing/usePartnerNodesRunGate.cloud.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.cloud.test.ts
@@ -6,11 +6,11 @@ import {
   usePartnerNodesRunGate
 } from './usePartnerNodesRunGate'
 
-vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
 
 const partnerNodesInGraph = vi.fn()
 const scanPartnerNodes = vi.fn(() => [])
-vi.mock('@/composables/node/usePartnerNodesInGraph', () => ({
+vi.mock(import('@/composables/node/usePartnerNodesInGraph'), () => ({
   usePartnerNodesInGraph: () => partnerNodesInGraph(),
   scanPartnerNodesInGraph: () => scanPartnerNodes()
 }))

--- a/src/composables/billing/usePartnerNodesRunGate.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.test.ts
@@ -19,7 +19,7 @@ const state = vi.hoisted(
     }
 )
 
-vi.mock('@/composables/node/usePartnerNodesInGraph', async () => {
+vi.mock(import('@/composables/node/usePartnerNodesInGraph'), async () => {
   const { computed } = await import('vue')
   return {
     usePartnerNodesInGraph: () => ({
@@ -30,7 +30,7 @@ vi.mock('@/composables/node/usePartnerNodesInGraph', async () => {
   }
 })
 
-vi.mock('@/composables/auth/useCurrentUser', async () => {
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), async () => {
   const { computed, ref } = await import('vue')
   const loggedIn = ref(false)
   return {
@@ -43,7 +43,7 @@ vi.mock('@/composables/auth/useCurrentUser', async () => {
   }
 })
 
-vi.mock('@/stores/authStore', async () => {
+vi.mock<unknown>(import('@/stores/authStore'), async () => {
   const { ref } = await import('vue')
   const initialized = ref(true)
   return {
@@ -58,7 +58,7 @@ vi.mock('@/stores/authStore', async () => {
   }
 })
 
-vi.mock('@/composables/useFeatureFlags', async () => {
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), async () => {
   const { reactive } = await import('vue')
   const flags = reactive({ partnerRunGateEnabled: true })
   return {
@@ -70,7 +70,7 @@ vi.mock('@/composables/useFeatureFlags', async () => {
 })
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/composables/canvas/useFocusNode.test.ts
+++ b/src/composables/canvas/useFocusNode.test.ts
@@ -26,13 +26,13 @@ const { canvasStore, createCanvas } = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
   useCanvasStore: () => canvasStore
 }))
-vi.mock('@/composables/canvas/visibleCanvasViewport', () => ({
+vi.mock(import('@/composables/canvas/visibleCanvasViewport'), () => ({
   visibleCanvasViewport: () => viewport
 }))
-vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+vi.mock<unknown>(import('@/scripts/app'), () => ({ app: { rootGraph: {} } }))
 
 import { useFocusNode } from './useFocusNode'
 

--- a/src/composables/canvas/visibleCanvasViewport.test.ts
+++ b/src/composables/canvas/visibleCanvasViewport.test.ts
@@ -6,7 +6,9 @@ import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/ag
 
 import { visibleCanvasViewport } from './visibleCanvasViewport'
 
-vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
+  useTelemetry: () => undefined
+}))
 
 describe('visibleCanvasViewport', () => {
   beforeEach(() => {

--- a/src/composables/graph/useSelectionOperations.deleteGuard.test.ts
+++ b/src/composables/graph/useSelectionOperations.deleteGuard.test.ts
@@ -10,11 +10,11 @@ import { app } from '@/scripts/app'
  * site rather than inside litegraph, so that vendored library stays untouched;
  * the trade-off is that a new editing path has to opt in.
  */
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { canvas: undefined as unknown }
 }))
 
-vi.mock('@/services/dialogService', () => ({
+vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ prompt: vi.fn() })
 }))
 

--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -25,10 +25,10 @@ const canvas = {
 }
 let canvasReady = true
 
-vi.mock('@/systems/badgeSystem', () => ({
+vi.mock(import('@/systems/badgeSystem'), () => ({
   installNodeBadges: mocks.installNodeBadges
 }))
-vi.mock('@/stores/extensionStore', () => ({
+vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
   useExtensionStore: () => ({
     isExtensionInstalled: () => mocks.extensionInstalled,
     registerExtension: (extension: ComfyExtension) => {
@@ -37,7 +37,7 @@ vi.mock('@/stores/extensionStore', () => ({
     }
   })
 }))
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => ({
     get: (key: string) =>
       key === 'Comfy.NodeBadge.ShowApiPricing'
@@ -45,17 +45,17 @@ vi.mock('@/platform/settings/settingStore', () => ({
         : badgeMode.value
   })
 }))
-vi.mock('@/composables/node/useNodePricing', () => ({
+vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
   useNodePricing: () => ({ pricingRevision })
 }))
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
   useCanvasStore: () => ({
     get canvas() {
       return canvasReady ? canvas : undefined
     }
   })
 }))
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     get canvas() {
       return canvasReady ? canvas : undefined

--- a/src/composables/node/usePartnerNodesInGraph.test.ts
+++ b/src/composables/node/usePartnerNodesInGraph.test.ts
@@ -21,7 +21,7 @@ const hoisted = vi.hoisted(() => ({
   rootGraph: undefined as { nodes: unknown[] } | undefined
 }))
 
-vi.mock('@/stores/nodeDefStore', () => ({
+vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
   useNodeDefStore: () => ({
     fromLGraphNode: (node: FakeNode) => hoisted.nodeDefsByName[node.type]
   })
@@ -29,7 +29,7 @@ vi.mock('@/stores/nodeDefStore', () => ({
 
 // Mirrors ComfyApp: reading `rootGraph` before init logs an error, so
 // consumers must gate on `isGraphReady` instead.
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     get rootGraph() {
       if (!hoisted.rootGraph) {
@@ -43,7 +43,7 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
-vi.mock('@/scripts/api', () => {
+vi.mock<unknown>(import('@/scripts/api'), () => {
   const target = new EventTarget()
   return {
     api: target,
@@ -57,20 +57,23 @@ const { __dispatchGraphChanged } = apiModule as typeof apiModule & {
   __dispatchGraphChanged: () => void
 }
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
-  const { ref } = await import('vue')
-  const activeWorkflow = ref<{ path: string } | null>(null)
-  return {
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return activeWorkflow.value
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  async () => {
+    const { ref } = await import('vue')
+    const activeWorkflow = ref<{ path: string } | null>(null)
+    return {
+      useWorkflowStore: () => ({
+        get activeWorkflow() {
+          return activeWorkflow.value
+        }
+      }),
+      __setActiveWorkflow: (workflow: { path: string } | null) => {
+        activeWorkflow.value = workflow
       }
-    }),
-    __setActiveWorkflow: (workflow: { path: string } | null) => {
-      activeWorkflow.value = workflow
     }
   }
-})
+)
 
 const { __setActiveWorkflow } =
   workflowStoreModule as typeof workflowStoreModule & {

--- a/src/composables/queue/useResultGallery.test.ts
+++ b/src/composables/queue/useResultGallery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers')
+vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 import { useResultGallery } from '@/composables/queue/useResultGallery'
 import type { JobListItem as JobListViewItem } from '@/composables/queue/useJobList'

--- a/src/composables/useContextMenuTranslation.test.ts
+++ b/src/composables/useContextMenuTranslation.test.ts
@@ -10,7 +10,7 @@ import type {
 
 import { translateContextMenuItems } from './useContextMenuTranslation'
 
-vi.mock('@/i18n', () => ({
+vi.mock(import('@/i18n'), () => ({
   resolveNodeDefText: vi.fn(),
   st: (_key: string, fallback: string) => fallback,
   te: () => false

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -16,7 +16,7 @@ import { toNodeId } from '@/types/nodeId'
 import { test } from './__fixtures__/testExtensions'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -62,7 +62,7 @@ import { uniqueSubgraphNodeIds } from './__fixtures__/uniqueSubgraphNodeIds'
 import { test } from './__fixtures__/testExtensions'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/lib/litegraph/src/LGraphCanvas.selectOnly.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.selectOnly.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/litegraph/src/litegraph'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
+vi.mock<unknown>(import('@/renderer/core/layout/store/layoutStore'), () => ({
   layoutStore: {
     querySlotAtPoint: vi.fn(),
     queryRerouteAtPoint: vi.fn(),

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -24,7 +24,7 @@ import { normalizeConfiguredTopology } from './linkDeduplication'
 
 const trackLinkDedupDrop = vi.fn()
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackLinkDedupDrop
   })

--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -195,9 +195,6 @@ describe('AssetBrowserModal', () => {
           'i-lucide:folder': {
             template: '<div data-testid="folder-icon"></div>'
           }
-        },
-        mocks: {
-          $t: (key: string) => key
         }
       }
     })

--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18n } from '@/i18n'
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useAssetsStore } from '@/stores/assetsStore'
@@ -22,12 +23,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
       }
     }
   })
-}))
-
-vi.mock<unknown>(import('@/i18n'), () => ({
-  t: (key: string, params?: Record<string, string>) =>
-    params ? `${key}:${JSON.stringify(params)}` : key,
-  d: (date: Date) => date.toLocaleDateString()
 }))
 
 vi.mock<unknown>(import('@/stores/assetsStore'), () => {
@@ -163,19 +158,6 @@ vi.mock<unknown>(import('@/platform/assets/components/AssetGrid.vue'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string, params?: Record<string, string>) =>
-      params ? `${key}:${JSON.stringify(params)}` : key
-  }),
-  createI18n: () => ({
-    global: {
-      t: (key: string, params?: Record<string, string>) =>
-        params ? `${key}:${JSON.stringify(params)}` : key
-    }
-  })
-}))
-
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
@@ -208,7 +190,7 @@ describe('AssetBrowserModal', () => {
     return render(AssetBrowserModal, {
       props,
       global: {
-        plugins: [pinia],
+        plugins: [pinia, i18n],
         stubs: {
           'i-lucide:folder': {
             template: '<div data-testid="folder-icon"></div>'
@@ -428,7 +410,7 @@ describe('AssetBrowserModal', () => {
       await flushPromises()
 
       expect(screen.getByTestId('modal-title').textContent).toBe(
-        'assetBrowser.allCategory:{"category":"Checkpoints"}'
+        'All Checkpoints'
       )
     })
 
@@ -443,7 +425,7 @@ describe('AssetBrowserModal', () => {
       await flushPromises()
 
       expect(screen.getByTestId('modal-title').textContent).toBe(
-        'assetBrowser.allCategory:{"category":"Checkpoints"}'
+        'All Checkpoints'
       )
     })
   })

--- a/src/platform/assets/components/MediaAssetContextMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetContextMenu.test.ts
@@ -6,15 +6,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { PropType } from 'vue'
 import { defineComponent, nextTick, onMounted, ref } from 'vue'
 
+import { i18n } from '@/i18n'
 import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContextMenu.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type * as LoaderNodeUtil from '@/utils/loaderNodeUtil'
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string) => key
-  })
-}))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
@@ -132,6 +127,7 @@ function mountComponent(targetAsset: AssetItem = asset) {
     }),
     {
       global: {
+        plugins: [i18n],
         stubs: {
           ContextMenu: contextMenuStub,
           Button: buttonStub
@@ -164,7 +160,9 @@ function findMenuItem(label: string): MenuItem | undefined {
 }
 
 function findDownloadMenuItem(): MenuItemWithCommand {
-  const downloadItem = findMenuItem('mediaAsset.actions.download')
+  const downloadItem = findMenuItem(
+    i18n.global.t('mediaAsset.actions.download')
+  )
   if (!downloadItem?.command) {
     throw new Error('Download menu item or command was not registered')
   }
@@ -203,7 +201,7 @@ describe('MediaAssetContextMenu', () => {
     await showMenu(container)
 
     expect(
-      findMenuItem('mediaAsset.actions.insertAsNodeInWorkflow')
+      findMenuItem(i18n.global.t('mediaAsset.actions.insertAsNodeInWorkflow'))
     ).toBeDefined()
 
     unmount()

--- a/src/platform/assets/composables/useAssetBrowser.perf.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.perf.test.ts
@@ -1,24 +1,35 @@
-import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+import { createApp, defineComponent, nextTick, ref } from 'vue'
 
-import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
+import { i18n } from '@/i18n'
+import { useAssetBrowser as createAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import * as assetMetadataUtils from '@/platform/assets/utils/assetMetadataUtils'
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string) => key
-  })
-}))
-
-vi.mock<unknown>(import('@/i18n'), () => ({
-  t: (key: string) => key,
-  d: (date: Date) => date.toLocaleDateString()
-}))
 
 const ASSET_COUNT = 200
 const CATEGORIES = ['inputs', 'outputs'] as const
 const TAB_SWITCHES = 6
+const apps: App<Element>[] = []
+
+function useAssetBrowser(...args: Parameters<typeof createAssetBrowser>) {
+  let result: ReturnType<typeof createAssetBrowser> | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = createAssetBrowser(...args)
+        return () => null
+      }
+    })
+  )
+  app.use(i18n)
+  app.mount(document.createElement('div'))
+  apps.push(app)
+  if (!result) throw new Error('Asset browser was not initialized')
+  return result
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 function makeAsset(index: number): AssetItem {
   const category = CATEGORIES[index % CATEGORIES.length]

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -1,28 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+import { createApp, defineComponent, nextTick, ref } from 'vue'
 
-import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
+import { i18n } from '@/i18n'
+import { useAssetBrowser as createAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string) => key
-  })
-}))
-
-vi.mock<unknown>(import('@/i18n'), () => ({
-  t: (key: string) => {
-    const translations: Record<string, string> = {
-      'assetBrowser.allModels': 'All Models',
-      'assetBrowser.imported': 'Imported',
-      'assetBrowser.byType': 'By type',
-      'assetBrowser.assets': 'Assets',
-      'assetBrowser.unknown': 'unknown'
-    }
-    return translations[key] || key
-  },
-  d: (date: Date) => date.toLocaleDateString()
-}))
 
 const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: false }))
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
@@ -34,6 +16,27 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
     }
   })
 }))
+
+const apps: App<Element>[] = []
+
+function useAssetBrowser(...args: Parameters<typeof createAssetBrowser>) {
+  let result: ReturnType<typeof createAssetBrowser> | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = createAssetBrowser(...args)
+        return () => null
+      }
+    })
+  )
+  app.use(i18n)
+  app.mount(document.createElement('div'))
+  apps.push(app)
+  if (!result) throw new Error('Asset browser was not initialized')
+  return result
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 describe('useAssetBrowser', () => {
   beforeEach(() => {

--- a/src/platform/assets/composables/useAssetFilterOptions.test.ts
+++ b/src/platform/assets/composables/useAssetFilterOptions.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { App } from 'vue'
+import { createApp, defineComponent } from 'vue'
 
-import { useAssetFilterOptions } from '@/platform/assets/composables/useAssetFilterOptions'
+import { i18n } from '@/i18n'
+import { useAssetFilterOptions as createAssetFilterOptions } from '@/platform/assets/composables/useAssetFilterOptions'
 
 import {
   createAssetWithSpecificBaseModel,
@@ -10,11 +13,28 @@ import {
   createAssetWithoutUserMetadata
 } from '@/platform/assets/fixtures/ui-mock-assets'
 
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string) => key
-  })
-}))
+const apps: App<Element>[] = []
+
+function useAssetFilterOptions(
+  ...args: Parameters<typeof createAssetFilterOptions>
+) {
+  let result: ReturnType<typeof createAssetFilterOptions> | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = createAssetFilterOptions(...args)
+        return () => null
+      }
+    })
+  )
+  app.use(i18n)
+  app.mount(document.createElement('div'))
+  apps.push(app)
+  if (!result) throw new Error('Asset filter options were not initialized')
+  return result
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 describe('useAssetFilterOptions', () => {
   describe('File Format Extraction', () => {

--- a/src/platform/assets/composables/useAssetsQuery.test.ts
+++ b/src/platform/assets/composables/useAssetsQuery.test.ts
@@ -13,7 +13,7 @@ import { api } from '@/scripts/api'
 // pagination-dedup assertions no longer match current `doLoadMore`/`loadNew`
 // behavior on `main` (no overlap dedup, no updated knownIds mid-walk) and would
 // need separate, unrelated fixes to re-add; out of scope for this row.
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: { fetchApi: vi.fn() }
 }))
 

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1,10 +1,11 @@
 import type { CreateAssetExportData } from '@comfyorg/ingest-types'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { useToast } from 'primevue/usetoast'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
 import { createApp, defineComponent, h, provide, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
+import { i18n } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IWidget } from '@/lib/litegraph/src/types/widgets'
 import { MediaAssetKey } from '@/platform/assets/schemas/mediaAssetSchema'
@@ -12,7 +13,7 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { AssetMeta } from '@/platform/assets/schemas/mediaAssetSchema'
 import { api } from '@/scripts/api'
 import { resolveOutputAssetItems } from '../utils/outputAssetUtil'
-import { useMediaAssetActions } from './useMediaAssetActions'
+import { useMediaAssetActions as createMediaAssetActions } from './useMediaAssetActions'
 
 // Use vi.hoisted to create a mutable reference for isCloud
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
@@ -38,16 +39,6 @@ vi.mock<unknown>(
     }
   }
 )
-
-vi.mock<unknown>(import('vue-i18n'), () => {
-  const t = vi.fn((key: string) => key)
-  return {
-    useI18n: () => ({ t }),
-    createI18n: () => ({
-      global: { t }
-    })
-  }
-})
 
 const mockShowDialog = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
@@ -274,12 +265,14 @@ function getAddedImageWidgetValues() {
   )
 }
 
+const apps: App<Element>[] = []
+
 function mountMediaActions(asset?: AssetMeta) {
-  let actions: ReturnType<typeof useMediaAssetActions> | undefined
+  let actions: ReturnType<typeof createMediaAssetActions> | undefined
 
   const ChildComponent = defineComponent({
     setup() {
-      actions = useMediaAssetActions()
+      actions = createMediaAssetActions()
       return () => null
     }
   })
@@ -296,15 +289,26 @@ function mountMediaActions(asset?: AssetMeta) {
 
   const host = document.createElement('div')
   const app = createApp(HostComponent)
+  app.use(i18n)
   app.mount(host)
+  apps.push(app)
 
   if (!actions) throw new Error('media asset actions not initialized')
 
   return {
     actions,
-    unmount: () => app.unmount()
+    unmount: () => {
+      apps.splice(apps.indexOf(app), 1)
+      app.unmount()
+    }
   }
 }
+
+function useMediaAssetActions() {
+  return mountMediaActions().actions
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 describe('useMediaAssetActions', () => {
   beforeEach(() => {
@@ -1094,17 +1098,14 @@ describe('useMediaAssetActions', () => {
       await vi.waitFor(() => {
         expect(add).toHaveBeenCalledWith(
           expect.objectContaining({
-            detail: 'mediaAsset.selection.exportStarted'
+            detail: i18n.global.t(
+              'mediaAsset.selection.exportStarted',
+              { count },
+              count
+            )
           })
         )
       })
-
-      const { t } = useI18n()
-      expect(t).toHaveBeenCalledWith(
-        'mediaAsset.selection.exportStarted',
-        { count },
-        count
-      )
     }
 
     it('should report total file count, not job count, for multi-output jobs', async () => {
@@ -1304,8 +1305,8 @@ describe('useMediaAssetActions', () => {
       )
       expect(useToast().add).toHaveBeenCalledWith({
         severity: 'success',
-        summary: 'mediaAsset.assetDelete.success',
-        detail: 'mediaAsset.assetsDeleted',
+        summary: i18n.global.t('mediaAsset.assetDelete.success'),
+        detail: i18n.global.t('mediaAsset.assetsDeleted', { total: 1 }, 1),
         life: 2000
       })
 

--- a/src/platform/cloud/onboarding/UserCheckView.test.ts
+++ b/src/platform/cloud/onboarding/UserCheckView.test.ts
@@ -4,11 +4,11 @@ import { createI18n } from 'vue-i18n'
 
 import UserCheckView from './UserCheckView.vue'
 
-vi.mock('vue-router', () => ({
+vi.mock<unknown>(import('vue-router'), () => ({
   useRouter: () => ({ replace: vi.fn() })
 }))
 
-vi.mock('@/composables/useErrorHandling', () => ({
+vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: () => ({
     wrapWithErrorHandlingAsync:
       <T extends (...args: never[]) => unknown>(fn: T) =>
@@ -17,13 +17,13 @@ vi.mock('@/composables/useErrorHandling', () => ({
   })
 }))
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: { onboardingSurveyEnabled: true }
   })
 }))
 
-vi.mock('@/platform/cloud/onboarding/auth', () => ({
+vi.mock(import('@/platform/cloud/onboarding/auth'), () => ({
   getUserCloudStatus: () => new Promise(() => {}),
   getSurveyCompletedStatus: () => new Promise(() => {})
 }))

--- a/src/platform/cloud/subscription/composables/useFreeTierQuota.test.ts
+++ b/src/platform/cloud/subscription/composables/useFreeTierQuota.test.ts
@@ -4,29 +4,29 @@ import type { EffectScope } from 'vue'
 
 import { useFreeTierQuota } from './useFreeTierQuota'
 
-vi.mock('@vueuse/core', () => ({
+vi.mock(import('@vueuse/core'), () => ({
   createSharedComposable: <T extends (...args: unknown[]) => unknown>(fn: T) =>
     fn
 }))
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
-vi.mock('@/platform/distribution/types', () => ({
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
 }))
 
-vi.mock('@/composables/useFeatureFlags', () => ({
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: { freeTierJobAllowanceEnabled: true }
   })
 }))
 
 const mockCreditBadges = vi.hoisted<{ value: object[] }>(() => ({ value: [] }))
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { isGraphReady: true, rootGraph: {} }
 }))
-vi.mock('@/systems/badgeSystem', () => ({
+vi.mock<unknown>(import('@/systems/badgeSystem'), () => ({
   graphCreditsBadges: () => mockCreditBadges.value
 }))
 
@@ -34,7 +34,7 @@ const mockRemoteConfig = await vi.hoisted(async () => {
   const { ref } = await import('vue')
   return ref({ free_tier_balance: { allowance: 5, remaining: 5 } })
 })
-vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+vi.mock<unknown>(import('@/platform/remoteConfig/remoteConfig'), () => ({
   remoteConfig: mockRemoteConfig
 }))
 

--- a/src/platform/navigation/unmatchedRoute.test.ts
+++ b/src/platform/navigation/unmatchedRoute.test.ts
@@ -5,7 +5,7 @@ import type { RouteLocation } from 'vue-router'
 import { unmatchedRouteRedirect } from '@/platform/navigation/unmatchedRoute'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -7,6 +7,7 @@ import {
   canTransferReplacementOwnership,
   transferReplacementOwnership
 } from '@/core/graph/nodeShell/nodeShellState'
+import type * as LiteGraphModule from '@/lib/litegraph/src/litegraph'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
@@ -25,14 +26,13 @@ import type { NodeReplacement } from './types'
 vi.mock<unknown>(
   import('@/lib/litegraph/src/litegraph'),
   async (importOriginal) => {
-    const actual = await importOriginal<Record<string, unknown>>()
+    const actual = await importOriginal<typeof LiteGraphModule>()
     return {
       ...actual,
-      LiteGraph: {
-        ...(actual.LiteGraph as Record<string, unknown>),
+      LiteGraph: Object.assign({}, actual.LiteGraph, {
         createNode: vi.fn(),
         registered_node_types: {}
-      }
+      })
     }
   }
 )

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -7,7 +7,6 @@ import {
   canTransferReplacementOwnership,
   transferReplacementOwnership
 } from '@/core/graph/nodeShell/nodeShellState'
-import type * as LiteGraphModule from '@/lib/litegraph/src/litegraph'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
@@ -23,19 +22,16 @@ import { widgetId } from '@/types/widgetId'
 import type { UUID } from '@/utils/uuid'
 import type { NodeReplacement } from './types'
 
-vi.mock<unknown>(
-  import('@/lib/litegraph/src/litegraph'),
-  async (importOriginal) => {
-    const actual = await importOriginal<typeof LiteGraphModule>()
-    return {
-      ...actual,
-      LiteGraph: Object.assign({}, actual.LiteGraph, {
-        createNode: vi.fn(),
-        registered_node_types: {}
-      })
-    }
+vi.mock(import('@/lib/litegraph/src/litegraph'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    LiteGraph: Object.assign({}, actual.LiteGraph, {
+      createNode: vi.fn(),
+      registered_node_types: {}
+    })
   }
-)
+})
 
 vi.mock(import('@/core/graph/nodeShell/nodeShellState'), () => ({
   canTransferReplacementOwnership: vi.fn(() => true),

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -1,4 +1,6 @@
-import { nextTick, ref } from 'vue'
+import { render } from '@testing-library/vue'
+import { defineComponent, nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
 import { describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -6,11 +8,7 @@ import type {
   FirstClassSecretProvider,
   SecretProviderInfo
 } from '../types'
-import { useSecretForm } from './useSecretForm'
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({ t: (key: string) => key })
-}))
+import { useSecretForm as useSecretFormComposable } from './useSecretForm'
 
 const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
@@ -29,6 +27,27 @@ vi.mock<unknown>(import('../api/secretsApi'), () => ({
     }
   }
 }))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function useSecretForm(
+  ...options: Parameters<typeof useSecretFormComposable>
+): ReturnType<typeof useSecretFormComposable> {
+  let result!: ReturnType<typeof useSecretFormComposable>
+  const Wrapper = defineComponent({
+    setup() {
+      result = useSecretFormComposable(...options)
+      return () => null
+    }
+  })
+  render(Wrapper, { global: { plugins: [i18n] } })
+  return result
+}
 
 function createMockSecret(
   overrides: Partial<SecretMetadata> = {}

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -1,13 +1,12 @@
+import { render } from '@testing-library/vue'
+import { defineComponent } from 'vue'
+import { createI18n } from 'vue-i18n'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SecretMetadata } from '../types'
-import { useSecrets } from './useSecrets'
+import { useSecrets as useSecretsComposable } from './useSecrets'
 
 const mockAdd = vi.fn()
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({ t: (key: string) => key })
-}))
 
 vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
   useToastStore: () => ({ add: mockAdd })
@@ -32,6 +31,25 @@ vi.mock<unknown>(import('../api/secretsApi'), () => ({
     }
   }
 }))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function useSecrets(): ReturnType<typeof useSecretsComposable> {
+  let result!: ReturnType<typeof useSecretsComposable>
+  const Wrapper = defineComponent({
+    setup() {
+      result = useSecretsComposable()
+      return () => null
+    }
+  })
+  render(Wrapper, { global: { plugins: [i18n] } })
+  return result
+}
 
 function createMockSecret(
   overrides: Partial<SecretMetadata> = {}

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -1,7 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { render } from '@testing-library/vue'
+import { createPinia, setActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { defineComponent, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
 
 import {
   getSettingInfo,
@@ -9,7 +11,7 @@ import {
 } from '@/platform/settings/settingStore'
 import type { SettingTreeNode } from '@/platform/settings/settingStore'
 
-import { useSettingUI } from './useSettingUI'
+import { useSettingUI as useSettingUIComposable } from './useSettingUI'
 
 const env = vi.hoisted(() => {
   const state = {
@@ -35,10 +37,6 @@ const env = vi.hoisted(() => {
   })
   return { state, fakeRef }
 })
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({ t: (_: string, fallback: string) => fallback })
-}))
 
 vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({ isLoggedIn: env.fakeRef('isLoggedIn') })
@@ -106,6 +104,28 @@ interface MockSettingParams {
   category?: string[]
 }
 
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false
+})
+let pinia: Pinia
+
+function useSettingUI(
+  ...options: Parameters<typeof useSettingUIComposable>
+): ReturnType<typeof useSettingUIComposable> {
+  let result!: ReturnType<typeof useSettingUIComposable>
+  const Wrapper = defineComponent({
+    setup() {
+      result = useSettingUIComposable(...options)
+      return () => null
+    }
+  })
+  render(Wrapper, { global: { plugins: [pinia, i18n] } })
+  return result
+}
+
 describe('useSettingUI', () => {
   const mockSettings: Record<string, MockSettingParams> = {
     'Comfy.Locale': {
@@ -129,7 +149,8 @@ describe('useSettingUI', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia())
+    pinia = createPinia()
+    setActivePinia(pinia)
 
     Object.assign(env.state, {
       isCloud: false,

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -1,6 +1,4 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
-import type { Pinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -110,7 +108,6 @@ const i18n = createI18n({
   missingWarn: false,
   fallbackWarn: false
 })
-let pinia: Pinia
 
 function useSettingUI(
   ...options: Parameters<typeof useSettingUIComposable>
@@ -122,7 +119,7 @@ function useSettingUI(
       return () => null
     }
   })
-  render(Wrapper, { global: { plugins: [pinia, i18n] } })
+  render(Wrapper, { global: { plugins: [i18n] } })
   return result
 }
 
@@ -149,9 +146,6 @@ describe('useSettingUI', () => {
   }
 
   beforeEach(() => {
-    pinia = createPinia()
-    setActivePinia(pinia)
-
     Object.assign(env.state, {
       isCloud: false,
       isDesktop: false,

--- a/src/platform/surveys/ErrorPanelSurveyCta.test.ts
+++ b/src/platform/surveys/ErrorPanelSurveyCta.test.ts
@@ -2,14 +2,17 @@ import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 const FEATURE_USAGE_KEY = 'Comfy.FeatureUsage'
 const SURVEY_STATE_KEY = 'Comfy.SurveyState'
 const FEATURE_ID = 'error-panel'
 const PRESENTATION_INLINE_CTA = 'inline-cta'
 const CTA_TEST_ID = 'error-panel-survey-cta'
-const CTA_BUTTON_NAME = /errorPanelSurvey.ctaButton/
-const CLOSE_BUTTON_NAME = 'g.close'
+const CTA_BUTTON_NAME = /give feedback/i
+const CLOSE_BUTTON_NAME = 'Close'
 
 const mockIsNightly = vi.hoisted(() => ({ value: true }))
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
@@ -30,6 +33,11 @@ const mockSurveyConfig = vi.hoisted(() => ({
     | undefined
 }))
 const mockOpen = vi.hoisted(() => vi.fn())
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isNightly() {
@@ -55,12 +63,6 @@ vi.mock(import('./useErrorSurveyPopoverState'), () => ({
     open: mockOpen,
     close: vi.fn()
   })
-}))
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: vi.fn(() => ({
-    t: (key: string) => key
-  }))
 }))
 
 describe('ErrorPanelSurveyCta', () => {
@@ -98,7 +100,9 @@ describe('ErrorPanelSurveyCta', () => {
   async function renderComponent() {
     const { default: ErrorPanelSurveyCta } =
       await import('./ErrorPanelSurveyCta.vue')
-    return render(ErrorPanelSurveyCta)
+    return render(ErrorPanelSurveyCta, {
+      global: { plugins: [i18n] }
+    })
   }
 
   it('does not render CTA below threshold', async () => {

--- a/src/platform/telemetry/assertFailureReporter.test.ts
+++ b/src/platform/telemetry/assertFailureReporter.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('./reportError', () => ({
+vi.mock(import('./reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/platform/telemetry/assetLoadErrorReporting.test.ts
+++ b/src/platform/telemetry/assetLoadErrorReporting.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MockInstance } from 'vitest'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('./reportError', () => ({
+vi.mock(import('./reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/platform/telemetry/perf/bootstrapTracer.test.ts
+++ b/src/platform/telemetry/perf/bootstrapTracer.test.ts
@@ -28,11 +28,11 @@ const {
   }
 })
 
-vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
-vi.mock('@/platform/telemetry', () => ({ useTelemetry }))
-vi.mock('@/platform/telemetry/reportError', () => ({ reportError }))
-vi.mock(
-  '@/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider',
+vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({ useTelemetry }))
+vi.mock(import('@/platform/telemetry/reportError'), () => ({ reportError }))
+vi.mock<unknown>(
+  import('@/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider'),
   () => ({
     DatadogRumTelemetryProvider: class {
       trackBootstrapComplete = trackEarlyBootstrapComplete

--- a/src/platform/telemetry/perf/perfMark.test.ts
+++ b/src/platform/telemetry/perf/perfMark.test.ts
@@ -4,7 +4,7 @@ import { perfMark, perfPoint } from './perfMark'
 
 const { addBreadcrumb } = vi.hoisted(() => ({ addBreadcrumb: vi.fn() }))
 
-vi.mock('@sentry/vue', () => ({ addBreadcrumb }))
+vi.mock(import('@sentry/vue'), () => ({ addBreadcrumb }))
 
 describe('perfMark', () => {
   beforeEach(() => {

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
@@ -1,7 +1,9 @@
 import { render } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
 
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useFrontendVersionMismatchWarning } from '@/platform/updates/common/useFrontendVersionMismatchWarning'
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
@@ -30,48 +32,27 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string, params?: Record<string, string | number> | unknown) => {
-      if (key === 'g.versionMismatchWarning')
-        return 'Version Compatibility Warning'
-      if (key === 'g.versionMismatchWarningMessage' && params) {
-        const p = params as Record<string, string>
-        return `${p.warning}: ${p.detail} Visit https://docs.comfy.org/installation/update_comfyui#common-update-issues for update instructions.`
-      }
-      if (key === 'g.frontendOutdated' && params) {
-        const p = params as Record<string, string>
-        return `Frontend version ${p.frontendVersion} is outdated. Backend requires ${p.requiredVersion} or higher.`
-      }
-      if (key === 'g.frontendNewer' && params) {
-        const p = params as Record<string, string>
-        return `Frontend version ${p.frontendVersion} may not be compatible with backend version ${p.backendVersion}.`
-      }
-      if (key === 'g.comfyPackageOutdated' && params) {
-        const p = params as Record<string, string>
-        return `Installed ${p.name} version ${p.installedVersion} is lower than the required version ${p.requiredVersion}.`
-      }
-      return key
-    }
-  }),
-  createI18n: vi.fn(() => ({
-    global: {
-      locale: { value: 'en' },
-      t: vi.fn()
-    }
-  }))
-}))
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
 
 function mountVersionWarning(
   ...options: Parameters<typeof useFrontendVersionMismatchWarning>
 ) {
   let result: ReturnType<typeof useFrontendVersionMismatchWarning> | undefined
-  const { unmount } = render({
-    setup() {
-      result = useFrontendVersionMismatchWarning(...options)
-      return () => null
+  const { unmount } = render(
+    {
+      setup() {
+        result = useFrontendVersionMismatchWarning(...options)
+        return () => null
+      }
+    },
+    {
+      global: { plugins: [i18n] }
     }
-  })
+  )
 
   if (!result) throw new Error('Failed to mount version warning')
   return { ...result, unmount }

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -5,7 +5,9 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
 
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
 import type { ReleaseNote } from '../common/releaseService'
@@ -37,28 +39,11 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-// Mock dependencies
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: vi.fn(() => ({
-    locale: { value: 'en' },
-    t: vi.fn((key: string) => {
-      const translations: Record<string, string> = {
-        'releaseToast.newVersionAvailable': 'New update is out!',
-        'releaseToast.whatsNew': "See what's new",
-        'releaseToast.skip': 'Skip',
-        'releaseToast.update': 'Update',
-        'releaseToast.description':
-          'Check out the latest improvements and features in this update.'
-      }
-      return translations[key] || key
-    })
-  })),
-  createI18n: vi.fn(() => ({
-    global: {
-      locale: { value: 'en' }
-    }
-  }))
-}))
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
 
 vi.mock(import('@/utils/formatUtil'), () => ({
   formatVersionAnchor: vi.fn((version: string) => version.replace(/\./g, ''))
@@ -106,19 +91,7 @@ describe('ReleaseNotificationToast', () => {
   const renderComponent = (props = {}) => {
     return render(ReleaseNotificationToast, {
       global: {
-        mocks: {
-          $t: (key: string) => {
-            const translations: Record<string, string> = {
-              'releaseToast.newVersionAvailable': 'New update is out!',
-              'releaseToast.whatsNew': "See what's new",
-              'releaseToast.skip': 'Skip',
-              'releaseToast.update': 'Update',
-              'releaseToast.description':
-                'Check out the latest improvements and features in this update.'
-            }
-            return translations[key] || key
-          }
-        },
+        plugins: [i18n],
         stubs: {
           'i-lucide-rocket': true,
           'i-lucide-external-link': true

--- a/src/platform/updates/components/WhatsNewPopup.test.ts
+++ b/src/platform/updates/components/WhatsNewPopup.test.ts
@@ -6,7 +6,9 @@ import userEvent from '@testing-library/user-event'
 import Button from '@/components/ui/button/Button.vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
 
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import type { ReleaseNote } from '../common/releaseService'
 import WhatsNewPopup from './WhatsNewPopup.vue'
 
@@ -17,6 +19,11 @@ const mockTranslations: Record<string, string> = {
   'whatsNewPopup.learnMore': 'Learn More',
   'whatsNewPopup.noReleaseNotes': 'No release notes available'
 }
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
 
 vi.mock<unknown>(import('@/i18n'), () => ({
   i18n: {
@@ -32,15 +39,6 @@ vi.mock<unknown>(import('@/i18n'), () => ({
       : mockTranslations[key] || key
   },
   d: (date: Date) => date.toLocaleDateString()
-}))
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: vi.fn(() => ({
-    locale: { value: 'en' },
-    t: vi.fn((key: string) => {
-      return mockTranslations[key] || key
-    })
-  }))
 }))
 
 vi.mock(import('@/utils/formatUtil'), () => ({
@@ -68,13 +66,8 @@ describe('WhatsNewPopup', () => {
   const renderComponent = (props = {}) => {
     return render(WhatsNewPopup, {
       global: {
-        plugins: [PrimeVue],
+        plugins: [PrimeVue, i18n],
         components: { Button },
-        mocks: {
-          $t: (key: string) => {
-            return mockTranslations[key] || key
-          }
-        },
         stubs: {
           'i-lucide-x': true,
           'i-lucide-external-link': true

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -1,7 +1,10 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+import { createApp, defineComponent } from 'vue'
 
-import { useSharedWorkflowUrlLoader } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
+import { i18n } from '@/i18n'
+import { useSharedWorkflowUrlLoader as createSharedWorkflowUrlLoader } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
 import type { SharedWorkflowPayload } from '@/platform/workflow/sharing/types/shareTypes'
 
 const preservedQueryMocks = vi.hoisted(() => ({
@@ -88,23 +91,26 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: vi.fn((key: string) => {
-      if (key === 'g.error') return 'Error'
-      if (key === 'shareWorkflow.loadFailed') {
-        return 'Failed to load shared workflow'
+const apps: App<Element>[] = []
+
+function useSharedWorkflowUrlLoader() {
+  let result: ReturnType<typeof createSharedWorkflowUrlLoader> | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = createSharedWorkflowUrlLoader()
+        return () => null
       }
-      if (key === 'openSharedWorkflow.dialogTitle') {
-        return 'Open shared workflow'
-      }
-      if (key === 'openSharedWorkflow.importFailed') {
-        return 'Failed to import workflow assets'
-      }
-      return key
     })
-  })
-}))
+  )
+  app.use(i18n)
+  app.mount(document.createElement('div'))
+  apps.push(app)
+  if (!result) throw new Error('Shared workflow URL loader was not initialized')
+  return result
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockCloseDialog = vi.hoisted(() => vi.fn())

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+import { createApp, defineComponent } from 'vue'
 
-import { useTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
+import { i18n } from '@/i18n'
+import { useTemplateUrlLoader as createTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
 
 /**
  * Unit tests for useTemplateUrlLoader composable
@@ -61,19 +64,26 @@ vi.mock<unknown>(
   })
 )
 
-// Mock i18n
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: vi.fn((key: string, params?: unknown) => {
-      if (key === 'g.error') return 'Error'
-      if (key === 'templateWorkflows.error.templateNotFound') {
-        return `Template "${(params as { templateName?: string }).templateName}" not found`
+const apps: App<Element>[] = []
+
+function useTemplateUrlLoader() {
+  let result: ReturnType<typeof createTemplateUrlLoader> | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = createTemplateUrlLoader()
+        return () => null
       }
-      if (key === 'g.errorLoadingTemplate') return 'Failed to load template'
-      return key
     })
-  })
-}))
+  )
+  app.use(i18n)
+  app.mount(document.createElement('div'))
+  apps.push(app)
+  if (!result) throw new Error('Template URL loader was not initialized')
+  return result
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 // Mock canvas store
 const mockCanvasStore = {
@@ -245,7 +255,7 @@ describe('useTemplateUrlLoader', () => {
     expect(mockToastAdd).toHaveBeenCalledWith({
       severity: 'error',
       summary: 'Error',
-      detail: 'Failed to load template'
+      detail: i18n.global.t('g.errorLoadingTemplate')
     })
   })
 

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+import { createApp, defineComponent } from 'vue'
 
-import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
+import { i18n } from '@/i18n'
+import { useTemplateWorkflows as createTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
 import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
 
 async function flushPromises() {
@@ -39,17 +42,26 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   }
 }))
 
-// Mock Vue I18n
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: vi.fn((key, fallback) => fallback || key)
-  }),
-  createI18n: () => ({
-    global: {
-      t: (key: string) => key
-    }
-  })
-}))
+const apps: App<Element>[] = []
+
+function useTemplateWorkflows() {
+  let result: ReturnType<typeof createTemplateWorkflows> | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = createTemplateWorkflows()
+        return () => null
+      }
+    })
+  )
+  app.use(i18n)
+  app.mount(document.createElement('div'))
+  apps.push(app)
+  if (!result) throw new Error('Template workflows were not initialized')
+  return result
+}
+
+afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 // Mock the dialog store
 vi.mock<unknown>(import('@/stores/dialogStore'), () => ({

--- a/src/platform/workspace/components/PricingTableWorkspace.test.ts
+++ b/src/platform/workspace/components/PricingTableWorkspace.test.ts
@@ -11,7 +11,7 @@ import PricingTableWorkspace from '@/platform/workspace/components/PricingTableW
 
 const state = vi.hoisted(() => ({ plans: [] as Plan[] }))
 
-vi.mock('@/composables/billing/useBillingContext', () => ({
+vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({
     plans: computed(() => state.plans),
     currentPlanSlug: computed(() => null),
@@ -42,7 +42,7 @@ function apiPlan(
   }
 }
 
-vi.mock('@/stores/commandStore', () => ({
+vi.mock<unknown>(import('@/stores/commandStore'), () => ({
   useCommandStore: () => ({ execute: vi.fn() })
 }))
 

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -21,7 +21,7 @@ import type {
 } from '@/renderer/core/layout/types'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 

--- a/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
+++ b/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers')
+vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 import { flattenNodeOutput } from '@/renderer/extensions/linearMode/flattenNodeOutput'
 import type { NodeExecutionOutput } from '@/schemas/apiSchema'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetResolutionPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetResolutionPreview.test.ts
@@ -7,7 +7,9 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 const resolveNodeMock = vi.hoisted(() => vi.fn())
-vi.mock('@/utils/litegraphUtil', () => ({ resolveNode: resolveNodeMock }))
+vi.mock(import('@/utils/litegraphUtil'), () => ({
+  resolveNode: resolveNodeMock
+}))
 
 import type { IWidgetResolutionPreviewOptions } from '@/lib/litegraph/src/types/widgets'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -1,6 +1,5 @@
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
-import { createPinia, setActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
@@ -118,7 +117,6 @@ describe('auth token priority chain', () => {
   } as Partial<User> as MockUser
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockDistributionTypes.isCloud = true
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -1,5 +1,6 @@
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
+import { createPinia, setActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
@@ -74,11 +75,6 @@ vi.mock(import('vuefire'), () => ({
   useFirebaseAuth: vi.fn()
 }))
 
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({ t: (key: string) => key }),
-  createI18n: () => ({ global: { t: (key: string) => key } })
-}))
-
 vi.mock(import('firebase/auth'))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -122,6 +118,7 @@ describe('auth token priority chain', () => {
   } as Partial<User> as MockUser
 
   beforeEach(() => {
+    setActivePinia(createPinia())
     mockDistributionTypes.isCloud = true
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -8,7 +8,7 @@ import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 const dialogStack = vi.hoisted(() => [] as unknown[])
 
-vi.mock('@/stores/dialogStore', () => ({
+vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
   useDialogStore: () => ({ dialogStack })
 }))
 
@@ -24,7 +24,7 @@ const settings = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
   useSettingStore: () => settings
 }))
 

--- a/src/stores/apiKeyAuthStore.integration.test.ts
+++ b/src/stores/apiKeyAuthStore.integration.test.ts
@@ -1,8 +1,7 @@
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
-import { createTestingPinia } from '@pinia/testing'
 import type { Pinia } from 'pinia'
-import { disposePinia, setActivePinia } from 'pinia'
+import { createPinia, disposePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
@@ -13,11 +12,6 @@ const mockFetch = vi.fn()
 
 vi.mock(import('vuefire'), () => ({
   useFirebaseAuth: vi.fn()
-}))
-
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({ t: (key: string) => key }),
-  createI18n: () => ({ global: { t: (key: string) => key } })
 }))
 
 vi.mock(import('firebase/auth'))
@@ -69,7 +63,7 @@ describe('API key authentication initialization', () => {
 
   beforeEach(() => {
     localStorage.clear()
-    pinia = createTestingPinia({ stubActions: false })
+    pinia = createPinia()
     setActivePinia(pinia)
     vi.stubGlobal('fetch', mockFetch)
     mockFetch.mockResolvedValue({

--- a/src/stores/apiKeyAuthStore.integration.test.ts
+++ b/src/stores/apiKeyAuthStore.integration.test.ts
@@ -1,7 +1,6 @@
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
-import type { Pinia } from 'pinia'
-import { createPinia, disposePinia, setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
@@ -59,12 +58,8 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
 }))
 
 describe('API key authentication initialization', () => {
-  let pinia: Pinia
-
   beforeEach(() => {
     localStorage.clear()
-    pinia = createPinia()
-    setActivePinia(pinia)
     vi.stubGlobal('fetch', mockFetch)
     mockFetch.mockResolvedValue({
       ok: true,
@@ -85,7 +80,8 @@ describe('API key authentication initialization', () => {
   })
 
   afterEach(() => {
-    disposePinia(pinia)
+    const pinia = getActivePinia()
+    if (pinia) disposePinia(pinia)
   })
 
   const customerResponse = (id: string) => ({

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1,7 +1,6 @@
 import { FirebaseError } from 'firebase/app'
 import type { User, UserCredential } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
-import { createPinia, setActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
@@ -161,7 +160,6 @@ describe('useAuthStore', () => {
   } as Partial<User> as MockUser
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     vi.stubGlobal('fetch', mockFetch)
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1,10 +1,12 @@
 import { FirebaseError } from 'firebase/app'
 import type { User, UserCredential } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
+import { createPinia, setActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
+import { i18n } from '@/i18n'
 import {
   capturePreservedQuery,
   clearPreservedQuery
@@ -100,17 +102,6 @@ vi.mock(import('vuefire'), () => ({
   useFirebaseAuth: vi.fn()
 }))
 
-vi.mock<unknown>(import('vue-i18n'), () => ({
-  useI18n: () => ({
-    t: (key: string) => key
-  }),
-  createI18n: () => ({
-    global: {
-      t: (key: string) => key
-    }
-  })
-}))
-
 vi.mock(import('firebase/auth'))
 
 const mockTrackAuth = vi.fn()
@@ -170,6 +161,7 @@ describe('useAuthStore', () => {
   } as Partial<User> as MockUser
 
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.stubGlobal('fetch', mockFetch)
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 
@@ -364,7 +356,7 @@ describe('useAuthStore', () => {
 
       await expect(store.fetchBalance()).rejects.toMatchObject({
         name: 'AuthStoreError',
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
       expect(mockFetch).not.toHaveBeenCalled()
     })
@@ -453,7 +445,7 @@ describe('useAuthStore', () => {
 
       await expect(store.accessBillingPortal()).rejects.toMatchObject({
         name: 'AuthStoreError',
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
       expect(mockFetch).not.toHaveBeenCalled()
     })
@@ -522,7 +514,7 @@ describe('useAuthStore', () => {
       resolveCreate(mockCreateCustomerResponse)
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
       expect(billingCallCount).toBe(1)
     })
@@ -550,7 +542,7 @@ describe('useAuthStore', () => {
       resolveCreate(mockCreateCustomerResponse)
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
       expect(
         mockFetch.mock.calls.some(([url]) =>
@@ -587,7 +579,7 @@ describe('useAuthStore', () => {
       })
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -625,7 +617,7 @@ describe('useAuthStore', () => {
       })
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -653,7 +645,7 @@ describe('useAuthStore', () => {
 
       await expect(request).rejects.toMatchObject({
         name: 'AuthStoreError',
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -686,7 +678,7 @@ describe('useAuthStore', () => {
       resolvePortalBody({ billing_portal_url: 'https://stripe.test/portal' })
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -725,7 +717,7 @@ describe('useAuthStore', () => {
       resolveCreditBody({ checkout_url: 'https://stripe.test/checkout' })
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -797,7 +789,7 @@ describe('useAuthStore', () => {
       resolveCredit(accountAFailureResponse)
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -821,7 +813,7 @@ describe('useAuthStore', () => {
       resolveBilling(accountAFailureResponse)
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
 
@@ -845,7 +837,7 @@ describe('useAuthStore', () => {
       resolveCreate(accountAFailureResponse)
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
   })
@@ -1154,7 +1146,7 @@ describe('useAuthStore', () => {
       const dialogService = useDialogService()
 
       expect(dialogService.showErrorDialog).toHaveBeenCalledWith(authError, {
-        title: 'errorDialog.defaultTitle',
+        title: i18n.global.t('errorDialog.defaultTitle'),
         reportType: 'authenticationError'
       })
       expect(token).toBeUndefined()
@@ -1633,7 +1625,7 @@ describe('useAuthStore', () => {
 
       await expect(store.getAuthHeaderOrThrow()).rejects.toMatchObject({
         name: 'AuthStoreError',
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
   })
@@ -1649,7 +1641,7 @@ describe('useAuthStore', () => {
 
       await expect(store.getFirebaseAuthHeaderOrThrow()).rejects.toMatchObject({
         name: 'AuthStoreError',
-        message: 'toastMessages.userNotAuthenticated'
+        message: i18n.global.t('toastMessages.userNotAuthenticated')
       })
     })
   })

--- a/src/stores/linkPresentationStore.test.ts
+++ b/src/stores/linkPresentationStore.test.ts
@@ -6,7 +6,9 @@ import { toLinkId } from '@/types/linkId'
 
 import { useLinkPresentationStore } from './linkPresentationStore'
 
-vi.mock('@/platform/telemetry/reportError', () => ({ reportError: vi.fn() }))
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: vi.fn()
+}))
 
 const graphA = {
   rootGraphId: toRootGraphId('graph-a'),

--- a/src/stores/resultItemParsing.test.ts
+++ b/src/stores/resultItemParsing.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers')
+vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 import type { NodeExecutionOutput } from '@/schemas/apiSchema'
 import { isTextResult, resultItemSupportsPreview } from '@/utils/resultItem'

--- a/src/stores/workspace/assetsSidebarBadgeStore.test.ts
+++ b/src/stores/workspace/assetsSidebarBadgeStore.test.ts
@@ -1,7 +1,7 @@
 import { nextTick } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers')
+vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { useAssetsSidebarBadgeStore } from '@/stores/workspace/assetsSidebarBadgeStore'

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -46,7 +46,7 @@ const getServerFeature = vi.hoisted(() =>
 const focusNodeInstance = vi.hoisted(() => vi.fn())
 const socketSend = vi.hoisted(() => vi.fn())
 
-vi.mock('@/composables/canvas/useFocusNode', () => ({
+vi.mock<unknown>(import('@/composables/canvas/useFocusNode'), () => ({
   useFocusNode: () => ({ focusNodeInstance })
 }))
 
@@ -68,7 +68,7 @@ const ws = vi.hoisted(() => {
   return { add, remove, emit, clear }
 })
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: (route: string) => `/api${route}`,
     fetchApi: (route: string, options?: RequestInit) =>
@@ -118,10 +118,10 @@ const appMock = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/scripts/app', () => ({ app: appMock }))
+vi.mock<unknown>(import('@/scripts/app'), () => ({ app: appMock }))
 
-vi.mock(
-  '@/platform/workflow/validation/schemas/workflowSchema',
+vi.mock<unknown>(
+  import('@/platform/workflow/validation/schemas/workflowSchema'),
   async (importOriginal) => ({
     ...(await importOriginal<object>()),
     validateComfyWorkflow: vi.fn(async (content: unknown) => content)
@@ -162,66 +162,78 @@ const hostStores = vi.hoisted(() => ({
   }
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
-  const { reactive } = await import('vue')
-  const tabs = new Map<string, FakeTab>()
-  const openTabPaths = reactive(new Set<string>())
-  const store = reactive({
-    activeWorkflow: null as FakeTab | null,
-    get openWorkflows() {
-      return Array.from(openTabPaths).flatMap((path) => {
-        const tab = tabs.get(path)
-        return tab === undefined ? [] : [tab]
-      })
-    },
-    tabs,
-    openTabPaths,
-    getWorkflowByPath: (path: string) => tabs.get(path) ?? null,
-    nodeToNodeLocatorId: (node: {
-      graph?: { id?: string }
-      id: string | number
-    }) => (node.graph?.id ? `${node.graph.id}:${node.id}` : String(node.id)),
-    closeWorkflow: vi.fn(async (tab: FakeTab) => {
-      openTabPaths.delete(tab.path)
-      if (tab.isTemporary) tabs.delete(tab.path)
-    }),
-    createTemporary: (path?: string, data?: ComfyWorkflowJSON) => {
-      const requested = (path ?? 'Unsaved Workflow.json').replace(/\.json$/, '')
-      let stem = requested
-      let counter = 2
-      while (tabs.has(`workflows/${stem}.json`))
-        stem = `${requested} (${counter++})`
-      const tab: FakeTab = {
-        path: `workflows/${stem}.json`,
-        directory: 'workflows',
-        filename: stem,
-        isTemporary: true,
-        isModified: false,
-        activeState: data ?? null
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  async () => {
+    const { reactive } = await import('vue')
+    const tabs = new Map<string, FakeTab>()
+    const openTabPaths = reactive(new Set<string>())
+    const store = reactive({
+      activeWorkflow: null as FakeTab | null,
+      get openWorkflows() {
+        return Array.from(openTabPaths).flatMap((path) => {
+          const tab = tabs.get(path)
+          return tab === undefined ? [] : [tab]
+        })
+      },
+      tabs,
+      openTabPaths,
+      getWorkflowByPath: (path: string) => tabs.get(path) ?? null,
+      nodeToNodeLocatorId: (node: {
+        graph?: { id?: string }
+        id: string | number
+      }) => (node.graph?.id ? `${node.graph.id}:${node.id}` : String(node.id)),
+      closeWorkflow: vi.fn(async (tab: FakeTab) => {
+        openTabPaths.delete(tab.path)
+        if (tab.isTemporary) tabs.delete(tab.path)
+      }),
+      createTemporary: (path?: string, data?: ComfyWorkflowJSON) => {
+        const requested = (path ?? 'Unsaved Workflow.json').replace(
+          /\.json$/,
+          ''
+        )
+        let stem = requested
+        let counter = 2
+        while (tabs.has(`workflows/${stem}.json`))
+          stem = `${requested} (${counter++})`
+        const tab: FakeTab = {
+          path: `workflows/${stem}.json`,
+          directory: 'workflows',
+          filename: stem,
+          isTemporary: true,
+          isModified: false,
+          activeState: data ?? null
+        }
+        tabs.set(tab.path, tab)
+        openTabPaths.add(tab.path)
+        return tab
       }
-      tabs.set(tab.path, tab)
-      openTabPaths.add(tab.path)
-      return tab
-    }
-  })
-  hostStores.workflow = store
-  return { useWorkflowStore: () => store }
-})
-
-vi.mock('@/renderer/core/canvas/canvasStore', async () => {
-  const { reactive } = await import('vue')
-  const updateSelectedItems = () => {
-    hostStores.canvas.selectedItems = [...(appMock.canvas?.selectedItems ?? [])]
+    })
+    hostStores.workflow = store
+    return { useWorkflowStore: () => store }
   }
-  const store = reactive({
-    selectedItems: [] as unknown[],
-    updateSelectedItems,
-    currentGraph: null,
-    canvas: undefined
-  })
-  hostStores.canvas = store
-  return { useCanvasStore: () => store }
-})
+)
+
+vi.mock<unknown>(
+  // eslint-disable-next-line import-x/no-restricted-paths
+  import('@/renderer/core/canvas/canvasStore'),
+  async () => {
+    const { reactive } = await import('vue')
+    const updateSelectedItems = () => {
+      hostStores.canvas.selectedItems = [
+        ...(appMock.canvas?.selectedItems ?? [])
+      ]
+    }
+    const store = reactive({
+      selectedItems: [] as unknown[],
+      updateSelectedItems,
+      currentGraph: null,
+      canvas: undefined
+    })
+    hostStores.canvas = store
+    return { useCanvasStore: () => store }
+  }
+)
 
 const workflowService = vi.hoisted(() => ({
   saveWorkflow: vi.fn(async (tab: { isModified: boolean }) => {
@@ -247,11 +259,14 @@ const workflowService = vi.hoisted(() => ({
   })
 }))
 
-vi.mock('@/platform/workflow/core/services/workflowService', () => ({
-  useWorkflowService: () => workflowService
-}))
+vi.mock<unknown>(
+  import('@/platform/workflow/core/services/workflowService'),
+  () => ({
+    useWorkflowService: () => workflowService
+  })
+)
 
-vi.mock('@/utils/litegraphUtil', async (importOriginal) => ({
+vi.mock<unknown>(import('@/utils/litegraphUtil'), async (importOriginal) => ({
   ...(await importOriginal<object>()),
   isLGraphNode: (item: unknown) =>
     (item as { isNodeFake?: boolean } | null)?.isNodeFake === true
@@ -273,17 +288,17 @@ const executionErrors = vi.hoisted(() => {
   return store
 })
 
-vi.mock('@/stores/executionErrorStore', () => ({
+vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
   useExecutionErrorStore: () => executionErrors
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
+vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({ userDisplayName: { value: 'Jo Rivera' } })
 }))
 
 const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
 
-vi.mock('@vueuse/core', async (importOriginal) => {
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
   const { ref } = await import('vue')
   return {
     ...(await importOriginal<object>()),
@@ -306,18 +321,21 @@ const telemetry = vi.hoisted(() => ({
   trackAgentPanelOpened: vi.fn(),
   trackAgentPanelClosed: vi.fn()
 }))
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => telemetry
 }))
 
-vi.mock('@/platform/distribution/types', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  isCloud: true
-}))
+vi.mock<unknown>(
+  import('@/platform/distribution/types'),
+  async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    isCloud: true
+  })
+)
 
 const openAccountPrecondition = vi.hoisted(() => vi.fn())
 vi.mock(
-  '@/platform/cloud/subscription/composables/useAccountPreconditionDialog',
+  import('@/platform/cloud/subscription/composables/useAccountPreconditionDialog'),
   () => ({
     useAccountPreconditionDialog: () => ({ open: openAccountPrecondition })
   })
@@ -335,34 +353,43 @@ const paywallBilling = vi.hoisted(() => ({
   tier: 'STANDARD' as SubscriptionTier | null
 }))
 
-vi.mock('@/platform/workspace/composables/useWorkspaceUI', async () => {
-  const { computed } = await import('vue')
-  return {
-    useWorkspaceUI: () => ({
-      workspaceRole: computed(() => paywallWorkspace.role)
-    })
+vi.mock<unknown>(
+  import('@/platform/workspace/composables/useWorkspaceUI'),
+  async () => {
+    const { computed } = await import('vue')
+    return {
+      useWorkspaceUI: () => ({
+        workspaceRole: computed(() => paywallWorkspace.role)
+      })
+    }
   }
-})
+)
 
-vi.mock('@/composables/billing/useBillingContext', async () => {
-  const { computed } = await import('vue')
-  return {
-    useBillingContext: () => ({ tier: computed(() => paywallBilling.tier) })
+vi.mock<unknown>(
+  import('@/composables/billing/useBillingContext'),
+  async () => {
+    const { computed } = await import('vue')
+    return {
+      useBillingContext: () => ({ tier: computed(() => paywallBilling.tier) })
+    }
   }
-})
+)
 
-vi.mock('@/platform/workspace/composables/useBillingCapabilities', async () => {
-  const { computed } = await import('vue')
-  return {
-    useBillingCapabilities: () => ({
-      canTopUp: computed(() => paywallCapabilities.canTopUp),
-      canSubscribeSelfServe: computed(
-        () => paywallCapabilities.canSubscribeSelfServe
-      ),
-      isReady: computed(() => paywallCapabilities.isReady)
-    })
+vi.mock<unknown>(
+  import('@/platform/workspace/composables/useBillingCapabilities'),
+  async () => {
+    const { computed } = await import('vue')
+    return {
+      useBillingCapabilities: () => ({
+        canTopUp: computed(() => paywallCapabilities.canTopUp),
+        canSubscribeSelfServe: computed(
+          () => paywallCapabilities.canSubscribeSelfServe
+        ),
+        isReady: computed(() => paywallCapabilities.isReady)
+      })
+    }
   }
-})
+)
 
 import type { TurnId } from './schemas/agentApiSchema'
 import { zAgentWsEvent } from './schemas/agentApiSchema'

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -26,7 +26,7 @@ const tooltipDirectiveStub = {
 const fetchApi = vi.hoisted(() =>
   vi.fn<(route: string, init?: RequestInit) => Promise<Response>>()
 )
-vi.mock('@/scripts/api', () => ({ api: { fetchApi } }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { fetchApi } }))
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -19,7 +19,7 @@ import type * as VueUse from '@vueuse/core'
 const intersectionCallbacks = vi.hoisted(
   () => [] as ((entries: { isIntersecting: boolean }[]) => void)[]
 )
-vi.mock('@vueuse/core', async (importOriginal) => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
   ...(await importOriginal<typeof VueUse>()),
   useIntersectionObserver: (
     _target: unknown,

--- a/src/workbench/extensions/agent/components/agent/DockedAgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/DockedAgentPanel.test.ts
@@ -13,15 +13,17 @@ import { useAgentRunModeStore } from '@/workbench/extensions/agent/stores/agent/
 
 import DockedAgentPanel from './DockedAgentPanel.vue'
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => undefined
 }))
-vi.mock('@/platform/telemetry/reportError', () => ({ reportError: vi.fn() }))
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: vi.fn()
+}))
 
 const fetchApi = vi.hoisted(() =>
   vi.fn<(route: string, init?: RequestInit) => Promise<Response>>()
 )
-vi.mock('@/scripts/api', () => ({ api: { fetchApi } }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { fetchApi } }))
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -32,7 +34,7 @@ function jsonResponse(status: number, body: unknown): Response {
 
 const rootLiveness = vi.hoisted(() => ({ live: 0, maxLive: 0 }))
 
-vi.mock('@/workbench/extensions/agent/AgentPanelRoot.vue', async () => {
+vi.mock(import('@/workbench/extensions/agent/AgentPanelRoot.vue'), async () => {
   const { defineComponent, h, onUnmounted } = await import('vue')
   return {
     __esModule: true,

--- a/src/workbench/extensions/agent/components/agent/dockedAgentPanelLoadFailure.test.ts
+++ b/src/workbench/extensions/agent/components/agent/dockedAgentPanelLoadFailure.test.ts
@@ -9,14 +9,14 @@ import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/ag
 
 import DockedAgentPanel from './DockedAgentPanel.vue'
 
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: vi.fn()
 }))
 
 // The mocked module factory throws, so the dynamic import itself rejects -
 // the chunk-load failure path, distinct from a runtime error inside a
 // resolved panel (covered in DockedAgentPanel.test.ts).
-vi.mock('@/workbench/extensions/agent/AgentPanelRoot.vue', () => {
+vi.mock(import('@/workbench/extensions/agent/AgentPanelRoot.vue'), () => {
   throw new Error('agent panel chunk failed to load')
 })
 

--- a/src/workbench/extensions/agent/components/agent/message/CodeBlock.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/CodeBlock.test.ts
@@ -6,7 +6,7 @@ import { i18n } from '@/i18n'
 
 import CodeBlock from './CodeBlock.vue'
 
-vi.mock('shiki', () => ({
+vi.mock(import('shiki'), () => ({
   codeToHtml: vi.fn(async (code: string, options: { lang: string }) => {
     if (options.lang === 'nope') throw new Error('unknown language')
     return `<pre class="shiki"><code><span>HL:${code}</span></code></pre>`

--- a/src/workbench/extensions/agent/components/agent/message/MessageFeedback.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/MessageFeedback.test.ts
@@ -12,19 +12,19 @@ import MessageFeedback from './MessageFeedback.vue'
 const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
 
 const fetchApi = vi.hoisted(() => vi.fn())
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: (route: string) => '/api' + route,
     fetchApi
   }
 }))
 
-vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
+vi.mock(import('@/platform/assets/utils/assetPreviewUtil'), () => ({
   isAssetPreviewSupported: () => false,
   findOutputAsset: async () => undefined
 }))
 
-vi.mock('@vueuse/core', () => ({
+vi.mock<unknown>(import('@vueuse/core'), () => ({
   useClipboard: () => ({
     copy: clipboard.copy,
     copied: ref(false),

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -8,7 +8,7 @@ import type { ReplyAsset } from '../../../utils/replyAssets'
 import ReplyAssetGroup from './ReplyAssetGroup.vue'
 
 const showDialog = vi.hoisted(() => vi.fn())
-vi.mock('@/stores/dialogStore', () => ({
+vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
   useDialogStore: () => ({ showDialog })
 }))
 
@@ -19,7 +19,7 @@ const findServerPreviewUrl = vi.hoisted(() =>
 const findOutputAsset = vi.hoisted(() =>
   vi.fn(async (): Promise<{ name: string } | undefined> => undefined)
 )
-vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
+vi.mock<unknown>(import('@/platform/assets/utils/assetPreviewUtil'), () => ({
   isAssetPreviewSupported,
   findServerPreviewUrl,
   findOutputAsset
@@ -28,7 +28,7 @@ vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
 const generateModelThumbnail = vi.hoisted(() =>
   vi.fn(async (): Promise<string | null> => null)
 )
-vi.mock('@/components/load3d/modelThumbnail', () => ({
+vi.mock(import('@/components/load3d/modelThumbnail'), () => ({
   generateModelThumbnail
 }))
 

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAudioCard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAudioCard.test.ts
@@ -7,12 +7,12 @@ import { i18n } from '@/i18n'
 import type { ReplyAsset } from '../../../utils/replyAssets'
 import ReplyAudioCard from './ReplyAudioCard.vue'
 
-vi.mock('@/components/ui/slider/Slider.vue')
+vi.mock(import('@/components/ui/slider/Slider.vue'))
 
 const fetchApi = vi.hoisted(() =>
   vi.fn(async () => ({ ok: true, blob: async () => new Blob(['x']) }))
 )
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: (route: string) => `http://x/api${route}`,
     fetchApi
@@ -20,13 +20,13 @@ vi.mock('@/scripts/api', () => ({
 }))
 
 const downloadBlob = vi.hoisted(() => vi.fn())
-vi.mock('@/base/common/downloadUtil', () => ({ downloadBlob }))
+vi.mock(import('@/base/common/downloadUtil'), () => ({ downloadBlob }))
 
 const isAssetPreviewSupported = vi.hoisted(() => vi.fn(() => false))
 const findOutputAsset = vi.hoisted(() =>
   vi.fn(async (): Promise<{ name: string } | undefined> => undefined)
 )
-vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
+vi.mock<unknown>(import('@/platform/assets/utils/assetPreviewUtil'), () => ({
   isAssetPreviewSupported,
   findOutputAsset
 }))

--- a/src/workbench/extensions/agent/components/agent/message/TabLinkCard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/TabLinkCard.test.ts
@@ -25,30 +25,36 @@ const mocks = vi.hoisted(() => ({
   openWorkflows: [] as unknown[]
 }))
 
-vi.mock('../../../composables/agent/useAgentTargetNavigation', () => ({
+vi.mock(import('../../../composables/agent/useAgentTargetNavigation'), () => ({
   useAgentTargetNavigation: () => ({ navigate: mocks.navigate })
 }))
 
-vi.mock('@/scripts/api', () => ({ api: mocks.api }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: mocks.api }))
 
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mocks.reportError
 }))
 
-vi.mock('@/platform/workflow/core/services/workflowService', () => ({
-  useWorkflowService: () => ({ openWorkflow: mocks.openWorkflow })
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({
-    get openWorkflows() {
-      return mocks.openWorkflows
-    },
-    get activeWorkflow() {
-      return mocks.activeWorkflow
-    }
+vi.mock<unknown>(
+  import('@/platform/workflow/core/services/workflowService'),
+  () => ({
+    useWorkflowService: () => ({ openWorkflow: mocks.openWorkflow })
   })
-}))
+)
+
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  () => ({
+    useWorkflowStore: () => ({
+      get openWorkflows() {
+        return mocks.openWorkflows
+      },
+      get activeWorkflow() {
+        return mocks.activeWorkflow
+      }
+    })
+  })
+)
 
 const { useAgentWorkflowTabBindingStore } =
   await import('../../../stores/agent/agentWorkflowTabBindingStore')

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -19,7 +19,7 @@ import UserMessage from './UserMessage.vue'
 
 const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
 
-vi.mock('@vueuse/core', () => ({
+vi.mock<unknown>(import('@vueuse/core'), () => ({
   createSharedComposable: (composable: () => unknown) => composable,
   useClipboard: () => ({
     copy: clipboard.copy,

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -32,7 +32,9 @@ import type { SelectedNode } from './useCanvasSelection'
 import type { AgentEventSource, TurnOrigin } from './useAgentSession'
 import { useAgentSession } from './useAgentSession'
 
-vi.mock('@/platform/telemetry/reportError', () => ({ reportError: vi.fn() }))
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: vi.fn()
+}))
 
 function fakeRest(overrides: Partial<AgentRestClient> = {}): AgentRestClient {
   const base: AgentRestClient = {

--- a/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
+++ b/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
@@ -5,12 +5,14 @@ import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/ag
 
 import { useAgentDockMount } from './useAgentDockMount'
 
-vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
+  useTelemetry: () => undefined
+}))
 const { loadDockedAgentPanel } = vi.hoisted(() => ({
   loadDockedAgentPanel: vi.fn(() => ({ name: 'DockedAgentPanel' }))
 }))
-vi.mock(
-  '@/workbench/extensions/agent/components/agent/DockedAgentPanel.vue',
+vi.mock<unknown>(
+  import('@/workbench/extensions/agent/components/agent/DockedAgentPanel.vue'),
   () => ({ __esModule: true, default: loadDockedAgentPanel() })
 )
 

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -6,7 +6,7 @@ const { writeText } = vi.hoisted(() => ({
   writeText: vi.fn<(value: string) => Promise<void>>(() => Promise.resolve())
 }))
 
-vi.mock('@vueuse/core', async (importOriginal) => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
   ...(await importOriginal()),
   useClipboard: () => ({ copy: writeText })
 }))
@@ -21,7 +21,7 @@ import {
   stringifyDevEvents
 } from './devPanelLog'
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: (route: string) => `/api${route}`,
     clientId: 'client-test-1',
@@ -29,10 +29,10 @@ vi.mock('@/scripts/api', () => ({
     api_base: ''
   }
 }))
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { serialize: () => ({ nodes: [], links: [] }) } }
 }))
-vi.mock('@/stores/extensionStore', () => ({
+vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
   useExtensionStore: () => ({ extensions: [] })
 }))
 

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     getSystemStats: () => Promise.reject(new Error('offline')),
     getLogs: () => Promise.reject(new Error('offline')),
@@ -14,15 +14,15 @@ vi.mock('@/scripts/api', () => ({
     api_base: ''
   }
 }))
-vi.mock('@/scripts/app', () => ({
+vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { serialize: () => ({ nodes: [], links: [] }) } }
 }))
-vi.mock('@/stores/extensionStore', () => ({
+vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
   useExtensionStore: () => ({ extensions: [] })
 }))
 
 const { reportError } = vi.hoisted(() => ({ reportError: vi.fn() }))
-vi.mock('@/platform/telemetry/reportError', () => ({ reportError }))
+vi.mock(import('@/platform/telemetry/reportError'), () => ({ reportError }))
 
 import CrdtDevPanel from './CrdtDevPanel.vue'
 import { setCrdtDebugEnabled } from './crdtDebugGate'

--- a/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
@@ -50,7 +50,7 @@ import type { GraphOperation } from './graphOperations'
 import { attachMintPortWiring } from './mintPortWiring'
 import type { MintPortWiring } from './mintPortWiring'
 
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: vi.fn()
 }))
 

--- a/src/workbench/extensions/agent/crdt/apiTransport.test.ts
+++ b/src/workbench/extensions/agent/crdt/apiTransport.test.ts
@@ -10,8 +10,8 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/scripts/app', () => ({ app: { graph: null } }))
-vi.mock('@/scripts/api', () => ({ api: { socket: null } }))
+vi.mock<unknown>(import('@/scripts/app'), () => ({ app: { graph: null } }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { socket: null } }))
 
 import { api } from '@/scripts/api'
 

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -10,7 +10,7 @@ const { reportError } = vi.hoisted(() => ({
   reportError: vi.fn()
 }))
 
-vi.mock('@/scripts/api', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     getSystemStats: () => getSystemStats(),
     getLogs: () => getLogs(),
@@ -19,11 +19,11 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-vi.mock('@/stores/extensionStore', () => ({
+vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
   useExtensionStore: () => ({ extensions: [{ name: 'Comfy.TestExtension' }] })
 }))
 
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError
 }))
 

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -85,7 +85,7 @@ const apiState = vi.hoisted(() => {
   }
 })
 
-vi.mock('./layoutFollowerBridge', () => ({
+vi.mock<unknown>(import('./layoutFollowerBridge'), () => ({
   LayoutFollowerBridge: class {
     constructor() {
       const bridge = new bridgeState.FakeBridge()
@@ -95,14 +95,14 @@ vi.mock('./layoutFollowerBridge', () => ({
   }
 }))
 
-vi.mock('./docFrameClient', () => ({
+vi.mock<unknown>(import('./docFrameClient'), () => ({
   DocFrameClient: class {
     destroy = clientState.destroy
     sendOps = clientState.sendOps
   }
 }))
 
-vi.mock('./ecsFollowerAdapter', () => ({
+vi.mock<unknown>(import('./ecsFollowerAdapter'), () => ({
   EcsFollowerAdapter: class {
     bind = adapterState.bind
     unbind = adapterState.unbind
@@ -113,12 +113,14 @@ vi.mock('./ecsFollowerAdapter', () => ({
   }
 }))
 
-vi.mock('./devPanelLog', () => ({
+vi.mock(import('./devPanelLog'), () => ({
   recordDevEvent: devLogState.recordDevEvent
 }))
 
-vi.mock('@/scripts/api', () => ({ api: apiState.api }))
-vi.mock('@/scripts/app', () => ({ app: { graph: null, canvas: null } }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiState.api }))
+vi.mock<unknown>(import('@/scripts/app'), () => ({
+  app: { graph: null, canvas: null }
+}))
 
 import { useAgentCrdtFollower } from './useAgentCrdtFollower'
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -12,7 +12,9 @@ import {
 import { FollowerDoc } from './followerDoc'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
 
-vi.mock('@/platform/telemetry/reportError', () => ({ reportError: vi.fn() }))
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: vi.fn()
+}))
 
 class TestTransport extends EventTarget implements DocFrameTransport {
   readonly sent: string[] = []

--- a/src/workbench/extensions/agent/crdt/followerGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerGate.test.ts
@@ -14,7 +14,7 @@ import {
   resolveFollowerEnabled
 } from './followerGate'
 
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: vi.fn()
 }))
 

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -10,7 +10,7 @@ import type { LayoutChangeView, LayoutMintPort } from './layoutMintPort'
 import { createMintSession } from './mintSession'
 import type { MintSession } from './mintSession'
 
-vi.mock('@/platform/telemetry/reportError', () => ({
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: vi.fn()
 }))
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -87,7 +87,7 @@ const apiState = vi.hoisted(() => {
   }
 })
 
-vi.mock('./layoutFollowerBridge', () => ({
+vi.mock<unknown>(import('./layoutFollowerBridge'), () => ({
   LayoutFollowerBridge: class {
     constructor() {
       const bridge = new bridgeState.FakeBridge()
@@ -97,14 +97,14 @@ vi.mock('./layoutFollowerBridge', () => ({
   }
 }))
 
-vi.mock('./docFrameClient', () => ({
+vi.mock<unknown>(import('./docFrameClient'), () => ({
   DocFrameClient: class {
     destroy = clientState.destroy
     sendOps = clientState.sendOps
   }
 }))
 
-vi.mock('./ecsFollowerAdapter', () => ({
+vi.mock<unknown>(import('./ecsFollowerAdapter'), () => ({
   EcsFollowerAdapter: class {
     bind = adapterState.bind
     unbind = adapterState.unbind
@@ -115,22 +115,24 @@ vi.mock('./ecsFollowerAdapter', () => ({
   }
 }))
 
-vi.mock('./agentNodeMaterializer', () => ({
+vi.mock(import('./agentNodeMaterializer'), () => ({
   reconcileAgentAdapters: materializerState.reconcileAgentAdapters
 }))
 
-vi.mock('./agentSubgraphDefinitions', () => ({
+vi.mock(import('./agentSubgraphDefinitions'), () => ({
   readSubgraphDefinitionIds: definitionsState.readSubgraphDefinitionIds,
   readSubgraphDefinitions: definitionsState.readSubgraphDefinitions
 }))
 
-vi.mock('./devPanelLog', () => ({
+vi.mock(import('./devPanelLog'), () => ({
   recordDevEvent: vi.fn()
 }))
 
-vi.mock('@/scripts/api', () => ({ api: apiState.api }))
-vi.mock('@/scripts/app', () => ({ app: { graph: null, canvas: null } }))
-vi.mock('@/stores/authStore', () => ({
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiState.api }))
+vi.mock<unknown>(import('@/scripts/app'), () => ({
+  app: { graph: null, canvas: null }
+}))
+vi.mock<unknown>(import('@/stores/authStore'), () => ({
   useAuthStore: () => ({ userId: 'user-1' })
 }))
 

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
@@ -5,7 +5,7 @@ import type { CloudWorkflowEntry } from '../../schemas/agentApiSchema'
 const fetchApi = vi.hoisted(() =>
   vi.fn<(route: string, init?: RequestInit) => Promise<Response>>()
 )
-vi.mock('@/scripts/api', () => ({ api: { fetchApi } }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { fetchApi } }))
 
 import { AgentApiError, createAgentRestClient } from './agentRestClient'
 import type { AgentRestClient } from './agentRestClient'

--- a/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.test.ts
+++ b/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.test.ts
@@ -15,15 +15,18 @@ const hostWorkflow = vi.hoisted(() => ({
   }
 }))
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
-  const { reactive } = await import('vue')
-  const store = reactive({
-    activeWorkflow: null as FakeTab | null,
-    openWorkflows: [] as FakeTab[]
-  })
-  hostWorkflow.store = store
-  return { useWorkflowStore: () => store }
-})
+vi.mock<unknown>(
+  import('@/platform/workflow/management/stores/workflowStore'),
+  async () => {
+    const { reactive } = await import('vue')
+    const store = reactive({
+      activeWorkflow: null as FakeTab | null,
+      openWorkflows: [] as FakeTab[]
+    })
+    hostWorkflow.store = store
+    return { useWorkflowStore: () => store }
+  }
+)
 
 describe('registerWorkflowTabActivityTracker', () => {
   let stop: () => void

--- a/src/workbench/extensions/agent/stores/agent/agentPanelStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentPanelStore.test.ts
@@ -6,7 +6,7 @@ const telemetry = vi.hoisted(() => ({
   trackAgentPanelOpened: vi.fn(),
   trackAgentPanelClosed: vi.fn()
 }))
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => telemetry
 }))
 

--- a/src/workbench/extensions/agent/stores/agent/agentPanelStoreId.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentPanelStoreId.test.ts
@@ -8,7 +8,9 @@ import { useAgentDockMount } from '@/workbench/extensions/agent/composables/useA
 
 import { useAgentPanelStore } from './agentPanelStore'
 
-vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
+  useTelemetry: () => undefined
+}))
 
 /**
  * Regression pin for the duplicate Pinia id `agentPanel`.

--- a/src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const fetchApi = vi.hoisted(() =>
   vi.fn<(route: string, init?: RequestInit) => Promise<Response>>()
 )
-vi.mock('@/scripts/api', () => ({ api: { fetchApi } }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { fetchApi } }))
 
 import { useAgentRunModeStore } from './agentRunModeStore'
 

--- a/src/workbench/extensions/manager/components/ManagerProgressToast.test.ts
+++ b/src/workbench/extensions/manager/components/ManagerProgressToast.test.ts
@@ -9,14 +9,17 @@ import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comf
 
 import ManagerProgressToast from './ManagerProgressToast.vue'
 
-vi.mock('@/workbench/extensions/manager/services/comfyManagerService', () => ({
-  useComfyManagerService: () => ({
-    listInstalledPacks: vi.fn(async () => ({}))
+vi.mock<unknown>(
+  import('@/workbench/extensions/manager/services/comfyManagerService'),
+  () => ({
+    useComfyManagerService: () => ({
+      listInstalledPacks: vi.fn(async () => ({}))
+    })
   })
-}))
+)
 
 vi.mock(
-  '@/workbench/extensions/manager/composables/useApplyChanges',
+  import('@/workbench/extensions/manager/composables/useApplyChanges'),
   async () => {
     const { ref } = await import('vue')
     return {


### PR DESCRIPTION
## Summary

Enable `vitest/prefer-import-in-mock` for Oxlint-covered tests now that the split migration is complete.

## Changes

- **What**: Migrates tests added during the split rollout, replaces remaining `vue-i18n` module mocks with real plugins, enables the lint rule, and updates testing guidance.

## Review Focus

Check that `<unknown>` remains limited to legacy partial factories that cannot satisfy the full module type.