### PR TITLE
fix: hide agent auto-run with limits option

### DIFF
--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -299,6 +299,9 @@ describe('Composer', () => {
           screen.getByRole('button', { name: 'Save changes' })
         )
 
+        await vi.waitFor(() => expect(useAgentRunModeStore().mode).toBe(mode))
+        await nextTick()
+
         expect(fetchApi).toHaveBeenCalledWith(
           '/agent/run-mode',
           expect.objectContaining({ method: 'PUT' })
@@ -307,7 +310,6 @@ describe('Composer', () => {
           mode,
           credit_limit: null
         })
-        expect(useAgentRunModeStore().mode).toBe(mode)
         expect(useAgentRunModeStore().creditLimit).toBeNull()
       }
     )

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -189,12 +189,8 @@ describe('Composer', () => {
       ).toBeDisabled()
       expect(screen.getAllByRole('radio')).toHaveLength(2)
       expect(
-        screen.getByRole('radio', { name: /Auto-run without approval/ })
-      ).toBeVisible()
-      expect(
         screen.queryByRole('radio', { name: /Auto-run with limits/ })
       ).not.toBeInTheDocument()
-      expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument()
     })
 
     it('saves auto mode and closes', async () => {
@@ -208,6 +204,8 @@ describe('Composer', () => {
       const save = screen.getByRole('button', { name: 'Save changes' })
       expect(save).toBeEnabled()
       await userEvent.click(save)
+      await vi.waitFor(() => expect(store.mode).toBe('auto'))
+      await nextTick()
 
       expect(
         screen.queryByText('Choose when the agent needs your consent')
@@ -241,79 +239,6 @@ describe('Composer', () => {
       })
     })
 
-    it.for(['local', 'server'] as const)(
-      'presents a restored %s limited preference as Ask without rewriting it',
-      async (source) => {
-        const preference = { mode: 'auto_limited', credit_limit: 450 }
-        if (source === 'local') {
-          localStorage.setItem(
-            'Comfy.Agent.RunModePreference',
-            JSON.stringify(preference)
-          )
-        }
-        mount()
-        const store = useAgentRunModeStore()
-        if (source === 'server') {
-          fetchApi.mockResolvedValueOnce(jsonResponse(200, preference))
-          await store.load()
-        }
-
-        await userEvent.click(
-          await screen.findByRole('button', { name: 'Ask' })
-        )
-        expect(
-          await screen.findByRole('radio', {
-            name: /Ask before a workflow runs/
-          })
-        ).toBeChecked()
-        expect(store.mode).toBe('auto_limited')
-        expect(store.creditLimit).toBe(450)
-        expect(
-          fetchApi.mock.calls.some(([, init]) => init?.method === 'PUT')
-        ).toBe(false)
-      }
-    )
-
-    it.for(['ask_approval', 'auto'] as const)(
-      'replaces a restored limited preference only when saving %s',
-      async (mode) => {
-        localStorage.setItem(
-          'Comfy.Agent.RunModePreference',
-          JSON.stringify({ mode: 'auto_limited', credit_limit: 450 })
-        )
-        fetchApi.mockResolvedValueOnce(
-          jsonResponse(200, { mode, credit_limit: null })
-        )
-        mount()
-
-        await userEvent.click(screen.getByRole('button', { name: 'Ask' }))
-        await userEvent.click(
-          await screen.findByRole('radio', {
-            name:
-              mode === 'auto'
-                ? /Auto-run without approval/
-                : /Ask before a workflow runs/
-          })
-        )
-        await userEvent.click(
-          screen.getByRole('button', { name: 'Save changes' })
-        )
-
-        await vi.waitFor(() => expect(useAgentRunModeStore().mode).toBe(mode))
-        await nextTick()
-
-        expect(fetchApi).toHaveBeenCalledWith(
-          '/agent/run-mode',
-          expect.objectContaining({ method: 'PUT' })
-        )
-        expect(JSON.parse(String(fetchApi.mock.calls[0][1]?.body))).toEqual({
-          mode,
-          credit_limit: null
-        })
-        expect(useAgentRunModeStore().creditLimit).toBeNull()
-      }
-    )
-
     it('keeps unlimited auto mode distinct from limited auto mode', async () => {
       const store = useAgentRunModeStore()
       await store.save('auto', null)
@@ -329,7 +254,7 @@ describe('Composer', () => {
     it.for([
       ['ask_approval', 'Ask', 'Ask for permission'],
       ['auto', 'Auto', 'Run workflow without permission'],
-      ['auto_limited', 'Ask', 'Ask for permission']
+      ['auto_limited', 'Auto (limited)', 'Ask when credit limit is reached']
     ] as const)(
       'shows the %s mode tooltip copy',
       async ([mode, triggerName, tooltipCopy]) => {

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -187,22 +187,25 @@ describe('Composer', () => {
       expect(
         screen.getByRole('button', { name: 'Save changes' })
       ).toBeDisabled()
+      expect(screen.getAllByRole('radio')).toHaveLength(2)
+      expect(
+        screen.getByRole('radio', { name: /Auto-run without approval/ })
+      ).toBeVisible()
+      expect(
+        screen.queryByRole('radio', { name: /Auto-run with limits/ })
+      ).not.toBeInTheDocument()
+      expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument()
     })
 
-    it('saves a new run mode with its credit limit and closes', async () => {
+    it('saves auto mode and closes', async () => {
       mount()
       const store = useAgentRunModeStore()
 
       await userEvent.click(screen.getByRole('button', { name: 'Ask' }))
       await userEvent.click(
-        await screen.findByRole('radio', { name: /Auto-run with limits/ })
+        await screen.findByRole('radio', { name: /Auto-run without approval/ })
       )
       const save = screen.getByRole('button', { name: 'Save changes' })
-      expect(save).toBeEnabled()
-      const input = screen.getByRole('spinbutton', { name: 'credits' })
-      expect(input).toHaveValue(300)
-      await userEvent.clear(input)
-      await userEvent.type(input, '500')
       expect(save).toBeEnabled()
       await userEvent.click(save)
 
@@ -210,10 +213,10 @@ describe('Composer', () => {
         screen.queryByText('Choose when the agent needs your consent')
       ).toBeNull()
       expect(
-        await screen.findByRole('button', { name: 'Auto (limited)' })
+        await screen.findByRole('button', { name: 'Auto' })
       ).toBeInTheDocument()
-      expect(store.mode).toBe('auto_limited')
-      expect(store.creditLimit).toBe(500)
+      expect(store.mode).toBe('auto')
+      expect(store.creditLimit).toBeNull()
     })
 
     it('keeps the popover open and reports a failed save', async () => {
@@ -238,46 +241,75 @@ describe('Composer', () => {
       })
     })
 
-    it('keeps Save disabled while the limit draft is invalid', async () => {
-      mount()
-      const store = useAgentRunModeStore()
-      await store.save('auto_limited', 450)
+    it.for(['local', 'server'] as const)(
+      'presents a restored %s limited preference as Ask without rewriting it',
+      async (source) => {
+        const preference = { mode: 'auto_limited', credit_limit: 450 }
+        if (source === 'local') {
+          localStorage.setItem(
+            'Comfy.Agent.RunModePreference',
+            JSON.stringify(preference)
+          )
+        }
+        mount()
+        const store = useAgentRunModeStore()
+        if (source === 'server') {
+          fetchApi.mockResolvedValueOnce(jsonResponse(200, preference))
+          await store.load()
+        }
 
-      await userEvent.click(
-        await screen.findByRole('button', { name: 'Auto (limited)' })
-      )
-      const input = await screen.findByRole('spinbutton', { name: 'credits' })
-      await userEvent.clear(input)
+        await userEvent.click(
+          await screen.findByRole('button', { name: 'Ask' })
+        )
+        expect(
+          await screen.findByRole('radio', {
+            name: /Ask before a workflow runs/
+          })
+        ).toBeChecked()
+        expect(store.mode).toBe('auto_limited')
+        expect(store.creditLimit).toBe(450)
+        expect(
+          fetchApi.mock.calls.some(([, init]) => init?.method === 'PUT')
+        ).toBe(false)
+      }
+    )
 
-      expect(
-        screen.getByRole('button', { name: 'Save changes' })
-      ).toBeDisabled()
+    it.for(['ask_approval', 'auto'] as const)(
+      'replaces a restored limited preference only when saving %s',
+      async (mode) => {
+        localStorage.setItem(
+          'Comfy.Agent.RunModePreference',
+          JSON.stringify({ mode: 'auto_limited', credit_limit: 450 })
+        )
+        fetchApi.mockResolvedValueOnce(
+          jsonResponse(200, { mode, credit_limit: null })
+        )
+        mount()
 
-      await userEvent.type(input, '1.5')
-      expect(
-        screen.getByRole('button', { name: 'Save changes' })
-      ).toBeDisabled()
-    })
+        await userEvent.click(screen.getByRole('button', { name: 'Ask' }))
+        await userEvent.click(
+          await screen.findByRole('radio', {
+            name:
+              mode === 'auto'
+                ? /Auto-run without approval/
+                : /Ask before a workflow runs/
+          })
+        )
+        await userEvent.click(
+          screen.getByRole('button', { name: 'Save changes' })
+        )
 
-    it('enables Save when only the credit limit changes', async () => {
-      mount()
-      const store = useAgentRunModeStore()
-      await store.save('auto_limited', 450)
-
-      await userEvent.click(
-        await screen.findByRole('button', { name: 'Auto (limited)' })
-      )
-      const save = await screen.findByRole('button', { name: 'Save changes' })
-      expect(save).toBeDisabled()
-
-      const input = screen.getByRole('spinbutton', { name: 'credits' })
-      await userEvent.clear(input)
-      await userEvent.type(input, '460')
-      expect(save).toBeEnabled()
-
-      await userEvent.click(save)
-      await vi.waitFor(() => expect(store.creditLimit).toBe(460))
-    })
+        expect(fetchApi).toHaveBeenCalledWith(
+          '/agent/run-mode',
+          expect.objectContaining({
+            method: 'PUT',
+            body: JSON.stringify({ mode, credit_limit: null })
+          })
+        )
+        expect(useAgentRunModeStore().mode).toBe(mode)
+        expect(useAgentRunModeStore().creditLimit).toBeNull()
+      }
+    )
 
     it('keeps unlimited auto mode distinct from limited auto mode', async () => {
       const store = useAgentRunModeStore()
@@ -294,7 +326,7 @@ describe('Composer', () => {
     it.for([
       ['ask_approval', 'Ask', 'Ask for permission'],
       ['auto', 'Auto', 'Run workflow without permission'],
-      ['auto_limited', 'Auto (limited)', 'Ask when credit limit is reached']
+      ['auto_limited', 'Ask', 'Ask for permission']
     ] as const)(
       'shows the %s mode tooltip copy',
       async ([mode, triggerName, tooltipCopy]) => {

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -301,11 +301,12 @@ describe('Composer', () => {
 
         expect(fetchApi).toHaveBeenCalledWith(
           '/agent/run-mode',
-          expect.objectContaining({
-            method: 'PUT',
-            body: JSON.stringify({ mode, credit_limit: null })
-          })
+          expect.objectContaining({ method: 'PUT' })
         )
+        expect(JSON.parse(String(fetchApi.mock.calls[0][1]?.body))).toEqual({
+          mode,
+          credit_limit: null
+        })
         expect(useAgentRunModeStore().mode).toBe(mode)
         expect(useAgentRunModeStore().creditLimit).toBeNull()
       }

--- a/src/workbench/extensions/agent/components/agent/composer/RunModePopover.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/RunModePopover.vue
@@ -15,10 +15,11 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type { AgentRunModeValue } from '../../../stores/agent/agentRunModeStore'
-import { useAgentRunModeStore } from '../../../stores/agent/agentRunModeStore'
+import {
+  DEFAULT_CREDIT_LIMIT,
+  useAgentRunModeStore
+} from '../../../stores/agent/agentRunModeStore'
 import { cn } from '@comfyorg/tailwind-utils'
-
-type SelectableRunMode = Exclude<AgentRunModeValue, 'auto_limited'>
 
 const { t } = useI18n()
 const store = useAgentRunModeStore()
@@ -26,23 +27,24 @@ const toast = useToastStore()
 
 const open = ref(false)
 const saving = ref(false)
-
-const effectiveMode = computed(() =>
-  store.mode === 'auto_limited' ? 'ask_approval' : store.mode
-)
-const draftMode = ref<SelectableRunMode>(effectiveMode.value)
+const draftMode = ref<AgentRunModeValue>(store.mode)
+const draftLimit = ref(store.creditLimit ?? DEFAULT_CREDIT_LIMIT)
 
 function onOpenChange(next: boolean): void {
   open.value = next
   if (next) {
-    draftMode.value = effectiveMode.value
+    draftMode.value = store.mode
+    draftLimit.value = store.creditLimit ?? DEFAULT_CREDIT_LIMIT
   }
 }
 
 async function saveChanges(): Promise<void> {
   saving.value = true
   try {
-    await store.save(draftMode.value, null)
+    await store.save(
+      draftMode.value,
+      draftMode.value === 'auto_limited' ? draftLimit.value : null
+    )
     open.value = false
   } catch (error) {
     reportError(error, { errorType: 'agent_run_mode_save_failure' })
@@ -57,26 +59,41 @@ function onDraftMode(value: string | undefined): void {
   if (match) draftMode.value = match.mode
 }
 
-const saveable = computed(() => draftMode.value !== store.mode && !saving.value)
-
-const TRIGGER_LABEL_KEYS: Record<SelectableRunMode, string> = {
-  ask_approval: 'agent.runModeTriggerAsk',
-  auto: 'agent.runModeTriggerAuto'
-}
-
-const triggerLabel = computed(() => t(TRIGGER_LABEL_KEYS[effectiveMode.value]))
-
-const TRIGGER_TOOLTIP_KEYS: Record<SelectableRunMode, string> = {
-  ask_approval: 'agent.runModeTriggerAskTooltip',
-  auto: 'agent.runModeTriggerAutoTooltip'
-}
-
-const triggerTooltip = computed(() =>
-  t(TRIGGER_TOOLTIP_KEYS[effectiveMode.value])
+const dirty = computed(
+  () =>
+    draftMode.value !== store.mode ||
+    (draftMode.value === 'auto_limited' &&
+      draftLimit.value !== store.creditLimit)
 )
 
+const limitValid = computed(() => {
+  if (draftMode.value !== 'auto_limited') return true
+  const limit = draftLimit.value
+  return limit !== null && Number.isInteger(limit) && limit > 0
+})
+
+const saveable = computed(
+  () => dirty.value && limitValid.value && !saving.value
+)
+
+const TRIGGER_LABEL_KEYS: Record<AgentRunModeValue, string> = {
+  ask_approval: 'agent.runModeTriggerAsk',
+  auto: 'agent.runModeTriggerAuto',
+  auto_limited: 'agent.runModeTriggerAutoLimit'
+}
+
+const triggerLabel = computed(() => t(TRIGGER_LABEL_KEYS[store.mode]))
+
+const TRIGGER_TOOLTIP_KEYS: Record<AgentRunModeValue, string> = {
+  ask_approval: 'agent.runModeTriggerAskTooltip',
+  auto: 'agent.runModeTriggerAutoTooltip',
+  auto_limited: 'agent.runModeTriggerAutoLimitTooltip'
+}
+
+const triggerTooltip = computed(() => t(TRIGGER_TOOLTIP_KEYS[store.mode]))
+
 const options: {
-  mode: SelectableRunMode
+  mode: AgentRunModeValue
   icon: string
   title: string
   description: string
@@ -169,6 +186,23 @@ const options: {
                 "
               />
             </RadioGroupItem>
+            <div
+              v-if="
+                option.mode === 'auto_limited' && draftMode === 'auto_limited'
+              "
+              class="flex items-center gap-3 px-9.5 pb-2.5"
+            >
+              <input
+                v-model.number="draftLimit"
+                type="number"
+                min="1"
+                :aria-label="t('agent.credits')"
+                class="border-agent-border text-agent-fg focus:border-agent-fg-muted h-8 min-w-0 flex-1 rounded-[10px] border bg-transparent px-2.5 text-sm/5 outline-none"
+              />
+              <span class="text-agent-fg-muted text-xs/4">
+                {{ t('agent.credits') }}
+              </span>
+            </div>
           </div>
         </RadioGroupRoot>
 

--- a/src/workbench/extensions/agent/components/agent/composer/RunModePopover.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/RunModePopover.vue
@@ -15,11 +15,10 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type { AgentRunModeValue } from '../../../stores/agent/agentRunModeStore'
-import {
-  DEFAULT_CREDIT_LIMIT,
-  useAgentRunModeStore
-} from '../../../stores/agent/agentRunModeStore'
+import { useAgentRunModeStore } from '../../../stores/agent/agentRunModeStore'
 import { cn } from '@comfyorg/tailwind-utils'
+
+type SelectableRunMode = Exclude<AgentRunModeValue, 'auto_limited'>
 
 const { t } = useI18n()
 const store = useAgentRunModeStore()
@@ -27,24 +26,23 @@ const toast = useToastStore()
 
 const open = ref(false)
 const saving = ref(false)
-const draftMode = ref<AgentRunModeValue>(store.mode)
-const draftLimit = ref(store.creditLimit ?? DEFAULT_CREDIT_LIMIT)
+
+const effectiveMode = computed(() =>
+  store.mode === 'auto_limited' ? 'ask_approval' : store.mode
+)
+const draftMode = ref<SelectableRunMode>(effectiveMode.value)
 
 function onOpenChange(next: boolean): void {
   open.value = next
   if (next) {
-    draftMode.value = store.mode
-    draftLimit.value = store.creditLimit ?? DEFAULT_CREDIT_LIMIT
+    draftMode.value = effectiveMode.value
   }
 }
 
 async function saveChanges(): Promise<void> {
   saving.value = true
   try {
-    await store.save(
-      draftMode.value,
-      draftMode.value === 'auto_limited' ? draftLimit.value : null
-    )
+    await store.save(draftMode.value, null)
     open.value = false
   } catch (error) {
     reportError(error, { errorType: 'agent_run_mode_save_failure' })
@@ -59,41 +57,26 @@ function onDraftMode(value: string | undefined): void {
   if (match) draftMode.value = match.mode
 }
 
-const dirty = computed(
-  () =>
-    draftMode.value !== store.mode ||
-    (draftMode.value === 'auto_limited' &&
-      draftLimit.value !== store.creditLimit)
-)
+const saveable = computed(() => draftMode.value !== store.mode && !saving.value)
 
-const limitValid = computed(() => {
-  if (draftMode.value !== 'auto_limited') return true
-  const limit = draftLimit.value
-  return limit !== null && Number.isInteger(limit) && limit > 0
-})
-
-const saveable = computed(
-  () => dirty.value && limitValid.value && !saving.value
-)
-
-const TRIGGER_LABEL_KEYS: Record<AgentRunModeValue, string> = {
+const TRIGGER_LABEL_KEYS: Record<SelectableRunMode, string> = {
   ask_approval: 'agent.runModeTriggerAsk',
-  auto: 'agent.runModeTriggerAuto',
-  auto_limited: 'agent.runModeTriggerAutoLimit'
+  auto: 'agent.runModeTriggerAuto'
 }
 
-const triggerLabel = computed(() => t(TRIGGER_LABEL_KEYS[store.mode]))
+const triggerLabel = computed(() => t(TRIGGER_LABEL_KEYS[effectiveMode.value]))
 
-const TRIGGER_TOOLTIP_KEYS: Record<AgentRunModeValue, string> = {
+const TRIGGER_TOOLTIP_KEYS: Record<SelectableRunMode, string> = {
   ask_approval: 'agent.runModeTriggerAskTooltip',
-  auto: 'agent.runModeTriggerAutoTooltip',
-  auto_limited: 'agent.runModeTriggerAutoLimitTooltip'
+  auto: 'agent.runModeTriggerAutoTooltip'
 }
 
-const triggerTooltip = computed(() => t(TRIGGER_TOOLTIP_KEYS[store.mode]))
+const triggerTooltip = computed(() =>
+  t(TRIGGER_TOOLTIP_KEYS[effectiveMode.value])
+)
 
 const options: {
-  mode: AgentRunModeValue
+  mode: SelectableRunMode
   icon: string
   title: string
   description: string
@@ -109,12 +92,6 @@ const options: {
     icon: 'icon-[lucide--zap]',
     title: 'agent.runModeAuto',
     description: 'agent.runModeAutoDescription'
-  },
-  {
-    mode: 'auto_limited',
-    icon: 'icon-[lucide--gauge]',
-    title: 'agent.runModeLimit',
-    description: 'agent.runModeLimitDescription'
   }
 ]
 </script>
@@ -192,23 +169,6 @@ const options: {
                 "
               />
             </RadioGroupItem>
-            <div
-              v-if="
-                option.mode === 'auto_limited' && draftMode === 'auto_limited'
-              "
-              class="flex items-center gap-3 px-9.5 pb-2.5"
-            >
-              <input
-                v-model.number="draftLimit"
-                type="number"
-                min="1"
-                :aria-label="t('agent.credits')"
-                class="border-agent-border text-agent-fg focus:border-agent-fg-muted h-8 min-w-0 flex-1 rounded-[10px] border bg-transparent px-2.5 text-sm/5 outline-none"
-              />
-              <span class="text-agent-fg-muted text-xs/4">
-                {{ t('agent.credits') }}
-              </span>
-            </div>
           </div>
         </RadioGroupRoot>
 

--- a/src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts
@@ -17,7 +17,7 @@ const DEFAULT_PREFERENCE: AgentRunModePreference = {
   mode: 'ask_approval',
   credit_limit: null
 }
-const DEFAULT_CREDIT_LIMIT = 300
+export const DEFAULT_CREDIT_LIMIT = 300
 const PREFERENCE_STORAGE_KEY = 'Comfy.Agent.RunModePreference'
 const LEGACY_MODE_STORAGE_KEY = 'Comfy.Agent.RunMode'
 const LEGACY_CREDIT_LIMIT_STORAGE_KEY = 'Comfy.Agent.RunCreditLimit'

--- a/src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts
@@ -17,7 +17,7 @@ const DEFAULT_PREFERENCE: AgentRunModePreference = {
   mode: 'ask_approval',
   credit_limit: null
 }
-export const DEFAULT_CREDIT_LIMIT = 300
+const DEFAULT_CREDIT_LIMIT = 300
 const PREFERENCE_STORAGE_KEY = 'Comfy.Agent.RunModePreference'
 const LEGACY_MODE_STORAGE_KEY = 'Comfy.Agent.RunMode'
 const LEGACY_CREDIT_LIMIT_STORAGE_KEY = 'Comfy.Agent.RunCreditLimit'


### PR DESCRIPTION
## Summary
Remove “Auto-run with limits” from the Agent run-permissions picker for V1.

## Changes
Delete the third option from the options array. Its nested credit-limit input disappears with it. The production diff is six deleted lines; saved preferences, labels, API contracts, and backend behavior are unchanged.

## Review Focus
Component tests assert that only two options are offered and cover saving Auto. Tests for editing the unavailable credit limit were removed; the original saved-mode tooltip tests remain unchanged.

Validation: 86 Composer/store/REST-client tests passed, plus commit-hook formatting, lint, typecheck, and pre-push Knip. No new E2E test: availability is owned by this component and covered directly; no execution or API behavior changes.

## Screenshots
Local visual validation remains pending because the existing Agent Storybook story fails to load an imported PNG as a JavaScript module.
