### PR TITLE
test: use global testing Pinia instead of store module mocks

### DIFF
--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -7,26 +7,38 @@ globs:
 
 ## Setup
 
-Use `createTestingPinia` from `@pinia/testing`, not `createPinia`:
+`vitest.setup.ts` creates a fresh active testing Pinia before each test with
+`stubActions: false` and disposes the active Pinia afterward to stop store
+watchers. Use real store composables inside tests or `beforeEach`. Do not mock
+their modules or create another Pinia instance for the same defaults.
+
+Set scenario state on the store. Actions already have spies, but execute their
+implementations unless you stub them:
 
 ```typescript
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 
-describe('MyStore', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.useFakeTimers()
-  })
+import { useSettingStore } from '@/platform/settings/settingStore'
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
+beforeEach(() => {
+  const settings = useSettingStore()
+  settings.settingValues['Comfy.WorkflowActions.SeenItems'] = []
+  vi.mocked(settings.set).mockResolvedValue()
 })
 ```
 
-**Why `stubActions: false`?** By default, testing pinia stubs all actions. Set to `false` when testing actual store behavior.
+Stub actions only when the test needs to isolate their effects. Keep the action
+under test real. Use `vi.mocked(store.action)` to access `.mock` or configure
+return values without changing the store's types.
+
+For component tests, configure the same Pinia instance that the component uses.
+If a test needs a different action-stubbing policy or plugins, create a local
+`createTestingPinia` and pass it to the mount. Its `initialState` option patches
+stores by their store ID. See [Pinia's initial-state examples](https://pinia.vuejs.org/cookbook/testing.html#Initial-State).
+
+To list remaining store-module mock candidates, run
+`pnpm exec tsx scripts/audit-pinia-store-mocks.ts`. Modules such as `layoutStore`
+that do not use Pinia are outside this cleanup.
 
 ## Don't Mock `vue-i18n` — Use a Real Plugin
 

--- a/scripts/audit-pinia-store-mocks.test.ts
+++ b/scripts/audit-pinia-store-mocks.test.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+
+it('finds string, import-form, and helper mocks while excluding non-Pinia modules', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pinia-mock-audit-'))
+  try {
+    mkdirSync(join(directory, 'src'))
+    writeFileSync(
+      join(directory, 'src/store.ts'),
+      "export const useStore = defineStore('example', () => ({}))"
+    )
+    writeFileSync(
+      join(directory, 'src/layoutStore.ts'),
+      'export const layoutStore = new Map()'
+    )
+    writeFileSync(
+      join(directory, 'src/example.test.ts'),
+      [
+        "vi.mock('@/store', () => ({}))",
+        'vi.mock<unknown>(',
+        "  import('./store'),",
+        '  () => ({})',
+        ')',
+        "vi.mock(import('./layoutStore'), () => ({}))",
+        'vi.mocked(useStore().action).mockReturnValue(1)',
+        'const example = "vi.mock(\'@/store\')"'
+      ].join('\n')
+    )
+    writeFileSync(
+      join(directory, 'src/testHelper.ts'),
+      "vi.doMock(import('./store'), () => ({}))"
+    )
+    execFileSync('git', ['init', '--quiet'], { cwd: directory })
+    execFileSync(
+      'git',
+      ['add', 'src/example.test.ts', 'src/store.ts', 'src/layoutStore.ts'],
+      { cwd: directory }
+    )
+
+    const output = execFileSync(
+      process.execPath,
+      [
+        '--import',
+        import.meta.resolve('tsx'),
+        join(import.meta.dirname, 'audit-pinia-store-mocks.ts')
+      ],
+      { cwd: directory, encoding: 'utf8' }
+    )
+
+    expect(output.trim().split('\n')).toEqual([
+      'src/example.test.ts:1\t@/store',
+      'src/example.test.ts:2\t./store',
+      'src/testHelper.ts:1\t./store',
+      '3 store-module mock candidates in 2 files'
+    ])
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})

--- a/scripts/audit-pinia-store-mocks.ts
+++ b/scripts/audit-pinia-store-mocks.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import * as ts from 'typescript'
+
+const files = execFileSync(
+  'git',
+  ['ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+  { encoding: 'utf8' }
+)
+  .split('\0')
+  .filter((file) => /\.[cm]?[jt]sx?$/.test(file))
+  .sort((a, b) => a.localeCompare(b))
+
+const matches: { file: string; line: number; module: string }[] = []
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8')
+  if (!/\bvi\.(?:mock|doMock)\b/.test(text)) continue
+
+  const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true)
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.expression.getText(source) === 'vi' &&
+      ['mock', 'doMock'].includes(node.expression.name.text)
+    ) {
+      const argument = node.arguments.at(0)
+      const target =
+        argument && ts.isCallExpression(argument)
+          ? argument.arguments.at(0)
+          : argument
+      if (target && ts.isStringLiteralLike(target)) {
+        const module = target.text
+        const path = module.startsWith('@/')
+          ? resolve('src', module.slice(2))
+          : module.startsWith('.')
+            ? resolve(dirname(file), module)
+            : undefined
+        const resolved = path
+          ? [path, `${path}.ts`, `${path}/index.ts`].find(
+              (candidate) => candidate.endsWith('.ts') && existsSync(candidate)
+            )
+          : undefined
+        if (
+          module === 'pinia' ||
+          (resolved &&
+            /\bdefineStore\s*\(/.test(readFileSync(resolved, 'utf8')))
+        ) {
+          matches.push({
+            file,
+            line:
+              source.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+            module
+          })
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(source)
+}
+
+for (const { file, line, module } of matches) {
+  process.stdout.write(`${file}:${line}\t${module}\n`)
+}
+process.stdout.write(
+  `${matches.length} store-module mock candidates in ${new Set(matches.map(({ file }) => file)).size} files\n`
+)

--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,31 @@
+import { createTestingPinia } from '@pinia/testing'
+import { defineStore, setActivePinia } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it.for(['global', 'local'])(
+  'disposes the %s Pinia after the test',
+  (source, { onTestFinished }) => {
+    if (source === 'local') setActivePinia(createTestingPinia())
+
+    const value = ref(0)
+    const changed = vi.fn()
+    const disposed = vi.fn()
+    const useStore = defineStore('testing-pinia-lifecycle', () => {
+      watch(value, changed, { flush: 'sync' })
+      onScopeDispose(disposed)
+      return {}
+    })
+    useStore()
+
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).not.toHaveBeenCalled()
+
+    onTestFinished(() => {
+      value.value++
+      expect(changed).toHaveBeenCalledOnce()
+      expect(disposed).toHaveBeenCalledOnce()
+    })
+  }
+)

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -25,13 +25,6 @@ vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
-vi.mock<unknown>(
-  import('@/platform/updates/common/toastStore'), // eslint-disable-line import-x/no-restricted-paths
-  () => ({
-    useToastStore: vi.fn(() => ({ addAlert: vi.fn() }))
-  })
-)
-
 let createObjectURLSpy: MockInstance<typeof URL.createObjectURL>
 let revokeObjectURLSpy: MockInstance<typeof URL.revokeObjectURL>
 

--- a/src/components/LiteGraphCanvasSplitterOverlay.test.ts
+++ b/src/components/LiteGraphCanvasSplitterOverlay.test.ts
@@ -1,7 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import { readFileSync } from 'fs'
-import { setActivePinia } from 'pinia'
 import { resolve } from 'path'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -11,10 +10,8 @@ import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitter
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({ currentUser: null, loading: false }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 /**
  * Regression test: the graph-canvas-panel SplitterPanel must not clip
@@ -52,7 +49,7 @@ describe('LiteGraphCanvasSplitterOverlay', () => {
         'agent-panel': '<div data-testid="agent-panel-probe">docked panel</div>'
       },
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: { Splitter: true, SplitterPanel: true }
       }
     })
@@ -62,8 +59,7 @@ describe('LiteGraphCanvasSplitterOverlay', () => {
   })
 
   it('keeps tabs with the graph and Agent panel during graph node selection', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
     vi.mocked(useSettingStore().get).mockImplementation((id) => {
       if (id === 'Comfy.Sidebar.Location') return 'left'
       if (id === 'Comfy.UseNewMenu') return 'Top'

--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -1,26 +1,30 @@
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import type { MenuItem } from 'primevue/menuitem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick, onMounted, ref } from 'vue'
 import type { Component } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import TopMenuSection from '@/components/TopMenuSection.vue'
 import QueueNotificationBannerHost from '@/components/queue/QueueNotificationBannerHost.vue'
+import TopMenuSection from '@/components/TopMenuSection.vue'
 import type {
   JobListItem,
   JobStatus
 } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useReleaseStore } from '@/platform/updates/common/releaseStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
-import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const mockData = vi.hoisted(() => ({
   isLoggedIn: false,
@@ -38,12 +42,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false,
   isNightly: false
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/releaseStore'), () => ({
-  useReleaseStore: () => ({
-    shouldShowRedDot: computed(() => true)
-  })
 }))
 
 vi.mock<unknown>(
@@ -74,13 +72,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    currentUser: null,
-    loading: false
-  }))
-}))
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     menu: {
@@ -98,16 +89,17 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 }))
 
 type WrapperOptions = {
-  pinia?: ReturnType<typeof createTestingPinia>
+  pinia?: Pinia
   stubs?: Record<string, boolean | Component>
   attachTo?: HTMLElement
 }
 
 function createWrapper({
-  pinia = createTestingPinia({ createSpy: vi.fn }),
+  pinia = getActivePinia()!,
   stubs = {},
   attachTo
 }: WrapperOptions = {}) {
+  Object.assign(useReleaseStore(pinia), { shouldShowRedDot: true })
   const i18n = createI18n({
     legacy: false,
     locale: 'en',
@@ -208,7 +200,7 @@ describe('TopMenuSection', () => {
 
   describe('authentication state', () => {
     function createLegacyTabBarWrapper() {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       const settingStore = useSettingStore(pinia)
       vi.mocked(settingStore.get).mockImplementation((key) =>
         key === 'Comfy.UI.TabBarLayout' ? 'Legacy' : undefined
@@ -266,7 +258,7 @@ describe('TopMenuSection', () => {
   })
 
   it('keeps action bars mounted while hiding the error overlay in node selection mode', () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = getActivePinia()!
     useAgentNodeSelectionStore(pinia).isActionBarsHidden = true
 
     createWrapper({
@@ -299,7 +291,7 @@ describe('TopMenuSection', () => {
   })
 
   it('hides queue progress overlay when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -313,7 +305,7 @@ describe('TopMenuSection', () => {
   })
 
   it('toggles the queue progress overlay when QPO V2 is disabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? false : undefined
@@ -329,7 +321,7 @@ describe('TopMenuSection', () => {
   })
 
   it('opens the job history sidebar tab when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -343,7 +335,7 @@ describe('TopMenuSection', () => {
   })
 
   it('toggles the job history sidebar tab when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -361,7 +353,7 @@ describe('TopMenuSection', () => {
 
   describe('inline progress summary', () => {
     const configureSettings = (
-      pinia: ReturnType<typeof createTestingPinia>,
+      pinia: Pinia,
       qpoV2Enabled: boolean,
       showRunProgressBar = true
     ) => {
@@ -375,7 +367,7 @@ describe('TopMenuSection', () => {
     }
 
     it('renders inline progress summary when QPO V2 is enabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
 
       const { container } = createWrapper({ pinia })
@@ -388,7 +380,7 @@ describe('TopMenuSection', () => {
     })
 
     it('does not render inline progress summary when QPO V2 is disabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, false)
 
       const { container } = createWrapper({ pinia })
@@ -401,7 +393,7 @@ describe('TopMenuSection', () => {
     })
 
     it('does not render inline progress summary when run progress bar is disabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true, false)
 
       const { container } = createWrapper({ pinia })
@@ -417,7 +409,7 @@ describe('TopMenuSection', () => {
       localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
       const actionbarTarget = document.createElement('div')
       document.body.appendChild(actionbarTarget)
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
       const executionStore = useExecutionStore(pinia)
       executionStore.activeJobId = 'job-1'
@@ -445,10 +437,7 @@ describe('TopMenuSection', () => {
   })
 
   describe(QueueNotificationBannerHost, () => {
-    const configureSettings = (
-      pinia: ReturnType<typeof createTestingPinia>,
-      qpoV2Enabled: boolean
-    ) => {
+    const configureSettings = (pinia: Pinia, qpoV2Enabled: boolean) => {
       const settingStore = useSettingStore(pinia)
       vi.mocked(settingStore.get).mockImplementation((key) => {
         if (key === 'Comfy.Queue.QPOV2') return qpoV2Enabled
@@ -459,7 +448,7 @@ describe('TopMenuSection', () => {
     }
 
     it('renders queue notification banners when QPO V2 is enabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
 
       const { container } = createWrapper({ pinia })
@@ -472,7 +461,7 @@ describe('TopMenuSection', () => {
     })
 
     it('renders queue notification banners when QPO V2 is disabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, false)
 
       const { container } = createWrapper({ pinia })
@@ -485,7 +474,7 @@ describe('TopMenuSection', () => {
     })
 
     it('renders inline summary above banners when both are visible', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
       const { container } = createWrapper({ pinia })
 
@@ -508,7 +497,7 @@ describe('TopMenuSection', () => {
       localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
       const actionbarTarget = document.createElement('div')
       document.body.appendChild(actionbarTarget)
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
       const executionStore = useExecutionStore(pinia)
       executionStore.activeJobId = 'job-1'
@@ -586,7 +575,7 @@ describe('TopMenuSection', () => {
     })
     vi.stubGlobal('cancelAnimationFrame', vi.fn())
 
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) => {
       if (key === 'Comfy.UseNewMenu') return 'Top'

--- a/src/components/actionbar/BatchCountEdit.test.ts
+++ b/src/components/actionbar/BatchCountEdit.test.ts
@@ -1,21 +1,14 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useQueueSettingsStore } from '@/stores/queueSettingsStore'
 
 import BatchCountEdit from './BatchCountEdit.vue'
 
 const maxBatchCount = 16
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (settingId: string) =>
-      settingId === 'Comfy.QueueButton.BatchCountLimit' ? maxBatchCount : 1
-  })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -34,21 +27,15 @@ const i18n = createI18n({
 })
 
 function renderComponent(initialBatchCount = 1) {
-  const pinia = createTestingPinia({
-    createSpy: vi.fn,
-    stubActions: false,
-    initialState: {
-      queueSettingsStore: {
-        batchCount: initialBatchCount
-      }
-    }
-  })
+  useQueueSettingsStore().batchCount = initialBatchCount
+  useSettingStore().settingValues['Comfy.QueueButton.BatchCountLimit'] =
+    maxBatchCount
 
   const user = userEvent.setup()
 
   render(BatchCountEdit, {
     global: {
-      plugins: [pinia, i18n],
+      plugins: [i18n],
       directives: {
         tooltip: () => {}
       }

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import type { BillingStatus } from '@/platform/workspace/api/workspaceApi'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import CloudRunButtonWrapper from './CloudRunButtonWrapper.vue'
 
@@ -18,9 +19,7 @@ const state = vi.hoisted(() => ({
   fetchStatus: vi.fn(),
   fetchBalance: vi.fn(),
   toastErrorHandler: vi.fn(),
-  showLayoutDialog: vi.fn(),
-  closeDialog: vi.fn(),
-  updateDialog: vi.fn()
+  showLayoutDialog: vi.fn()
 }))
 
 vi.mock<unknown>(
@@ -77,13 +76,6 @@ vi.mock<unknown>(
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showLayoutDialog: state.showLayoutDialog })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: state.closeDialog,
-    updateDialog: state.updateDialog
-  })
 }))
 
 vi.mock<unknown>(
@@ -328,7 +320,7 @@ describe('CloudRunButtonWrapper', () => {
     expect(dialogOptions.props.status).toBe('paused')
 
     await dialogOptions.props.onUpdatePayment()
-    expect(state.closeDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'subscription-paused'
     })
     expect(state.manageSubscription).toHaveBeenCalledOnce()
@@ -357,7 +349,7 @@ describe('CloudRunButtonWrapper', () => {
     await dialogOptions.props.onUpdatePayment()
 
     expect(state.toastErrorHandler).toHaveBeenCalledWith(error)
-    expect(state.closeDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
   })
 
   it('refreshes billing once on focus after returning from the portal', async () => {
@@ -419,7 +411,7 @@ describe('CloudRunButtonWrapper', () => {
 
     resolvePortal()
     await firstRequest
-    expect(state.updateDialog).toHaveBeenLastCalledWith({
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenLastCalledWith({
       key: 'subscription-paused',
       contentProps: { isUpdatingPayment: false }
     })
@@ -446,9 +438,9 @@ describe('CloudRunButtonWrapper', () => {
 
     resolvePortal()
     await portalRequest
-    expect(state.closeDialog).not.toHaveBeenCalled()
-    expect(state.updateDialog).toHaveBeenCalledTimes(1)
-    expect(state.updateDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledWith({
       key: 'subscription-paused',
       contentProps: { isUpdatingPayment: true }
     })
@@ -467,7 +459,7 @@ describe('CloudRunButtonWrapper', () => {
     expect(dialogOptions.props.canManage).toBe(false)
     expect(dialogOptions.props.status).toBe('paused')
     dialogOptions.props.onClose()
-    expect(state.closeDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'subscription-paused'
     })
     expect(state.manageSubscription).not.toHaveBeenCalled()

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
@@ -1,27 +1,29 @@
 import { createTestingPinia } from '@pinia/testing'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type {
-  JobListItem,
-  JobStatus
-} from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import type {
+  JobListItem,
+  JobStatus
+} from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useQueueSettingsStore } from '@/stores/queueSettingsStore'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
-import { render, screen } from '@testing-library/vue'
-import userEvent from '@testing-library/user-event'
 
 import ComfyQueueButton from './ComfyQueueButton.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
@@ -29,12 +31,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 
 vi.mock(import('@/platform/telemetry'), () => ({
   useTelemetry: () => null
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    shiftDown: false
-  })
 }))
 
 const BatchCountEditStub = {

--- a/src/components/appMode/AppModeToolbar.test.ts
+++ b/src/components/appMode/AppModeToolbar.test.ts
@@ -1,30 +1,24 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useAppModeStore } from '@/stores/appModeStore'
 
 import AppModeToolbar from './AppModeToolbar.vue'
 
 const appModeState = vi.hoisted(() => ({
-  enableAppBuilder: true,
-  hasNodes: true
+  enableAppBuilder: true
 }))
-const enterBuilder = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ enableAppBuilder: appModeState.enableAppBuilder })
+  useAppMode: () => ({
+    enableAppBuilder: appModeState.enableAppBuilder,
+    isAppMode: { value: false },
+    isBuilderMode: { value: false },
+    isSelectMode: { value: false }
+  })
 }))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { computed, reactive } = await import('vue')
-  return {
-    useAppModeStore: () =>
-      reactive({
-        enterBuilder,
-        hasNodes: computed(() => appModeState.hasNodes)
-      })
-  }
-})
 
 const BUILD_AN_APP = 'Build an app'
 
@@ -54,7 +48,8 @@ function renderToolbar() {
 describe('AppModeToolbar', () => {
   beforeEach(() => {
     appModeState.enableAppBuilder = true
-    appModeState.hasNodes = true
+    Object.assign(useAppModeStore(), { hasNodes: true })
+    vi.mocked(useAppModeStore().enterBuilder).mockResolvedValue(undefined)
   })
 
   it('shows an enabled build button and enters the builder on click', async () => {
@@ -65,11 +60,11 @@ describe('AppModeToolbar', () => {
 
     await user.click(button)
 
-    expect(enterBuilder).toHaveBeenCalled()
+    expect(useAppModeStore().enterBuilder).toHaveBeenCalled()
   })
 
   it('disables the build button when there are no nodes', () => {
-    appModeState.hasNodes = false
+    Object.assign(useAppModeStore(), { hasNodes: false })
     renderToolbar()
 
     expect(screen.getByRole('button', { name: BUILD_AN_APP })).toBeDisabled()

--- a/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
+++ b/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useCommandStore } from '@/stores/commandStore'
 import type { ComfyCommandImpl } from '@/stores/commandStore'
+
+beforeEach(() => {
+  useCommandStore().registerCommands(mockCommands)
+})
 
 // Mock ShortcutsList component
 vi.mock<unknown>(
@@ -44,12 +49,6 @@ const mockCommands: ComfyCommandImpl[] = [
     keybinding: null
   }
 ]
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    commands: mockCommands
-  })
-}))
 
 describe('EssentialsPanel', () => {
   it('should render ShortcutsList with essentials commands', async () => {

--- a/src/components/breadcrumb/SubgraphBreadcrumb.test.ts
+++ b/src/components/breadcrumb/SubgraphBreadcrumb.test.ts
@@ -1,33 +1,11 @@
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import SubgraphBreadcrumb from './SubgraphBreadcrumb.vue'
-
-const canvasState = vi.hoisted(() => ({ linearMode: false }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ activeWorkflow: { filename: 'workflow.json' } })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => ({ navigationStack: [] })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: () => ({ isSubgraphBlueprint: () => false })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({ linearMode: canvasState.linearMode })
-  })
-)
 
 vi.mock<unknown>(import('@/composables/element/useOverflowObserver'), () => ({
   useOverflowObserver: () => ({
@@ -48,7 +26,10 @@ const i18n = createI18n({
 function renderBreadcrumb() {
   return render(SubgraphBreadcrumb, {
     global: {
-      plugins: [i18n],
+      plugins: [
+        i18n,
+        createRouter({ history: createMemoryHistory(), routes: [] })
+      ],
       directives: { tooltip: {} },
       stubs: {
         WorkflowActionsDropdown: { template: '<div data-testid="wad" />' },
@@ -62,7 +43,7 @@ function renderBreadcrumb() {
 
 describe('SubgraphBreadcrumb', () => {
   beforeEach(() => {
-    canvasState.linearMode = false
+    useCanvasStore().linearMode = false
   })
 
   it('renders the workflow actions dropdown when not in linear mode', () => {
@@ -71,7 +52,7 @@ describe('SubgraphBreadcrumb', () => {
   })
 
   it('hides the workflow actions dropdown in linear mode', () => {
-    canvasState.linearMode = true
+    useCanvasStore().linearMode = true
     renderBreadcrumb()
     expect(screen.queryByTestId('wad')).not.toBeInTheDocument()
   })

--- a/src/components/builder/BuilderFooterToolbar.test.ts
+++ b/src/components/builder/BuilderFooterToolbar.test.ts
@@ -1,15 +1,22 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import BuilderFooterToolbar from '@/components/builder/BuilderFooterToolbar.vue'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { toNodeId } from '@/types/nodeId'
 import type { AppMode } from '@/utils/appMode'
 
-import BuilderFooterToolbar from '@/components/builder/BuilderFooterToolbar.vue'
+beforeEach(() => {
+  vi.mocked(useAppModeStore().exitBuilder).mockImplementation(() => {})
+})
 
 const mockSetMode = vi.hoisted(() => vi.fn())
-const mockExitBuilder = vi.hoisted(() => vi.fn())
+
 const mockSave = vi.hoisted(() => vi.fn())
 const mockSaveAs = vi.hoisted(() => vi.fn())
 
@@ -21,46 +28,11 @@ vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
   useAppMode: () => ({
     mode: computed(() => mockState.mode),
     isBuilderMode: ref(true),
+    isAppMode: ref(false),
+    isSelectMode: ref(false),
     setMode: mockSetMode
   })
 }))
-
-const mockHasOutputs = ref(true)
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    exitBuilder: mockExitBuilder,
-    hasOutputs: mockHasOutputs,
-    $id: 'appMode'
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    dialogStack: []
-  })
-}))
-
-const mockActiveWorkflow = ref<{
-  isTemporary: boolean
-  initialMode?: string
-  isModified?: boolean
-  changeTracker?: { captureCanvasState: () => void }
-} | null>({
-  isTemporary: true,
-  initialMode: 'app'
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { extra: {} } }
@@ -102,8 +74,11 @@ const i18n = createI18n({
 describe('BuilderFooterToolbar', () => {
   beforeEach(() => {
     mockState.mode = 'builder:inputs'
-    mockHasOutputs.value = true
-    mockActiveWorkflow.value = { isTemporary: true, initialMode: 'app' }
+    useAppModeStore().selectedOutputs = [toNodeId('1')]
+    useWorkflowStore().activeWorkflow = fromPartial({
+      isTemporary: true,
+      initialMode: 'app'
+    })
   })
 
   function renderComponent() {
@@ -137,7 +112,7 @@ describe('BuilderFooterToolbar', () => {
 
   it('disables next on arrange step when no outputs', () => {
     mockState.mode = 'builder:arrange'
-    mockHasOutputs.value = false
+    useAppModeStore().selectedOutputs = []
     renderComponent()
     expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
   })
@@ -165,7 +140,7 @@ describe('BuilderFooterToolbar', () => {
   it('calls exitBuilder on exit button click', async () => {
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: /exit app builder/i }))
-    expect(mockExitBuilder).toHaveBeenCalledOnce()
+    expect(useAppModeStore().exitBuilder).toHaveBeenCalledOnce()
   })
 
   it('calls setMode app on view app click', async () => {
@@ -175,39 +150,45 @@ describe('BuilderFooterToolbar', () => {
   })
 
   it('shows "Save as" when workflow is temporary', () => {
-    mockActiveWorkflow.value = { isTemporary: true }
+    useWorkflowStore().activeWorkflow = fromPartial({ isTemporary: true })
     renderComponent()
     expect(screen.getByRole('button', { name: 'Save as' })).toBeDefined()
   })
 
   it('shows "Save" when workflow is saved', () => {
-    mockActiveWorkflow.value = { isTemporary: false }
+    useWorkflowStore().activeWorkflow = fromPartial({ isTemporary: false })
     renderComponent()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDefined()
   })
 
   it('calls saveAs when workflow is temporary', async () => {
-    mockActiveWorkflow.value = { isTemporary: true }
+    useWorkflowStore().activeWorkflow = fromPartial({ isTemporary: true })
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: 'Save as' }))
     expect(mockSaveAs).toHaveBeenCalledOnce()
   })
 
   it('calls save when workflow is saved and modified', async () => {
-    mockActiveWorkflow.value = { isTemporary: false, isModified: true }
+    useWorkflowStore().activeWorkflow = fromPartial({
+      isTemporary: false,
+      isModified: true
+    })
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: 'Save' }))
     expect(mockSave).toHaveBeenCalledOnce()
   })
 
   it('disables save button when workflow has no unsaved changes', () => {
-    mockActiveWorkflow.value = { isTemporary: false, isModified: false }
+    useWorkflowStore().activeWorkflow = fromPartial({
+      isTemporary: false,
+      isModified: false
+    })
     renderComponent()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
   it('does not call save when no outputs', async () => {
-    mockHasOutputs.value = false
+    useAppModeStore().selectedOutputs = []
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: 'Save as' }))
     expect(mockSave).not.toHaveBeenCalled()

--- a/src/components/builder/useBuilderSave.test.ts
+++ b/src/components/builder/useBuilderSave.test.ts
@@ -1,7 +1,17 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
 import { useBuilderSave } from './useBuilderSave'
+
+beforeEach(() => {
+  vi.mocked(useAppModeStore().exitBuilder).mockImplementation(() => {})
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
 
 const mockSetMode = vi.hoisted(() => vi.fn())
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
@@ -13,16 +23,15 @@ const mockSaveWorkflowAs = vi.hoisted(() =>
 )
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockShowConfirmDialog = vi.hoisted(() => vi.fn())
-const mockCloseDialog = vi.hoisted(() => vi.fn())
-const mockExitBuilder = vi.hoisted(() => vi.fn())
-
-const mockActiveWorkflow = ref<{
-  filename: string
-  initialMode?: string | null
-} | null>(null)
 
 vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ setMode: mockSetMode })
+  useAppMode: () => ({
+    setMode: mockSetMode,
+    mode: ref('builder:inputs'),
+    isAppMode: ref(false),
+    isBuilderMode: ref(true),
+    isSelectMode: ref(false)
+  })
 }))
 
 vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
@@ -46,27 +55,8 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showLayoutDialog: mockShowLayoutDialog })
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({ exitBuilder: mockExitBuilder })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
 }))
 
 vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
@@ -89,7 +79,7 @@ const SUCCESS_DIALOG_KEY = 'builder-save-success'
 
 describe('useBuilderSave', () => {
   beforeEach(() => {
-    mockActiveWorkflow.value = null
+    useWorkflowStore().activeWorkflow = null
   })
 
   describe('save()', () => {
@@ -102,7 +92,10 @@ describe('useBuilderSave', () => {
     })
 
     it('saves workflow directly without showing a dialog', async () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       mockSaveWorkflow.mockResolvedValueOnce(undefined)
       const { save } = useBuilderSave()
 
@@ -113,7 +106,10 @@ describe('useBuilderSave', () => {
     })
 
     it('toasts error on failure', async () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       const error = new Error('save failed')
       mockSaveWorkflow.mockRejectedValueOnce(error)
       const { save } = useBuilderSave()
@@ -125,7 +121,10 @@ describe('useBuilderSave', () => {
     })
 
     it('prevents concurrent saves', async () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       let resolveSave!: () => void
       mockSaveWorkflow.mockReturnValueOnce(
         new Promise<void>((r) => {
@@ -148,7 +147,7 @@ describe('useBuilderSave', () => {
 
   describe('saveAs()', () => {
     it('does nothing when there is no active workflow', () => {
-      mockActiveWorkflow.value = null
+      useWorkflowStore().activeWorkflow = null
       const { saveAs } = useBuilderSave()
 
       saveAs()
@@ -157,7 +156,10 @@ describe('useBuilderSave', () => {
     })
 
     it('opens save dialog with correct defaultFilename and defaultOpenAsApp', () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       const { saveAs } = useBuilderSave()
 
       saveAs()
@@ -172,10 +174,10 @@ describe('useBuilderSave', () => {
     })
 
     it('passes defaultOpenAsApp: false when initialMode is graph', () => {
-      mockActiveWorkflow.value = {
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'my-workflow',
         initialMode: 'graph'
-      }
+      })
       const { saveAs } = useBuilderSave()
 
       saveAs()
@@ -187,7 +189,10 @@ describe('useBuilderSave', () => {
 
   describe('save dialog callbacks', () => {
     function getSaveDialogProps() {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       const { saveAs } = useBuilderSave()
       saveAs()
       return mockShowLayoutDialog.mock.calls[0][0].props as {
@@ -203,7 +208,7 @@ describe('useBuilderSave', () => {
       await onSave('new-name', true)
 
       expect(mockSaveWorkflowAs).toHaveBeenCalledWith(
-        mockActiveWorkflow.value,
+        useWorkflowStore().activeWorkflow,
         {
           filename: 'new-name',
           isApp: true
@@ -221,7 +226,7 @@ describe('useBuilderSave', () => {
       await onSave('new-name', false)
 
       expect(mockSaveWorkflowAs).toHaveBeenCalledWith(
-        mockActiveWorkflow.value,
+        useWorkflowStore().activeWorkflow,
         {
           filename: 'new-name',
           isApp: false
@@ -239,7 +244,7 @@ describe('useBuilderSave', () => {
       await onSave('new-name', false)
 
       expect(mockTrackDefaultViewSet).not.toHaveBeenCalled()
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
     })
 
     it('onSave closes dialog and shows success dialog after successful save', async () => {
@@ -248,7 +253,9 @@ describe('useBuilderSave', () => {
 
       await onSave('new-name', true)
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SAVE_DIALOG_KEY })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SAVE_DIALOG_KEY
+      })
       expect(mockShowConfirmDialog).toHaveBeenCalledOnce()
       const successCall = mockShowConfirmDialog.mock.calls[0][0]
       expect(successCall.key).toBe(SUCCESS_DIALOG_KEY)
@@ -286,7 +293,9 @@ describe('useBuilderSave', () => {
       await onSave('new-name', false)
 
       expect(mockToastErrorHandler).toHaveBeenCalledWith(error)
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SAVE_DIALOG_KEY })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SAVE_DIALOG_KEY
+      })
     })
 
     it('prevents concurrent handleSaveAs calls', async () => {
@@ -310,7 +319,10 @@ describe('useBuilderSave', () => {
 
   describe('graph success dialog callbacks', () => {
     async function getGraphSuccessDialogProps() {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       mockSaveWorkflowAs.mockResolvedValueOnce(true)
       const { saveAs } = useBuilderSave()
       saveAs()
@@ -329,8 +341,10 @@ describe('useBuilderSave', () => {
 
       onConfirm()
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SUCCESS_DIALOG_KEY })
-      expect(mockExitBuilder).toHaveBeenCalledOnce()
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SUCCESS_DIALOG_KEY
+      })
+      expect(useAppModeStore().exitBuilder).toHaveBeenCalledOnce()
     })
 
     it('onCancel closes dialog and switches to app mode', async () => {
@@ -338,7 +352,9 @@ describe('useBuilderSave', () => {
 
       onCancel()
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SUCCESS_DIALOG_KEY })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SUCCESS_DIALOG_KEY
+      })
       expect(mockTrackEnterLinear).toHaveBeenCalledWith({
         source: 'app_builder'
       })

--- a/src/components/common/CustomizationDialog.test.ts
+++ b/src/components/common/CustomizationDialog.test.ts
@@ -1,20 +1,21 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 
 import CustomizationDialog from './CustomizationDialog.vue'
 
+beforeEach(() => {
+  Object.assign(useNodeBookmarkStore(), {
+    defaultBookmarkIcon: DEFAULT_ICON,
+    defaultBookmarkColor: DEFAULT_COLOR
+  })
+})
+
 const DEFAULT_ICON = 'pi-bookmark-fill'
 const DEFAULT_COLOR = '#a1a1aa'
-
-vi.mock<unknown>(import('@/stores/nodeBookmarkStore'), () => ({
-  useNodeBookmarkStore: () => ({
-    defaultBookmarkIcon: DEFAULT_ICON,
-    defaultBookmarkColor: DEFAULT_COLOR,
-    bookmarksCustomization: {}
-  })
-}))
 
 vi.mock<unknown>(
   import('primevue/selectbutton'), // eslint-disable-line primevue-removal/no-imports

--- a/src/components/common/TreeExplorerV2Node.test.ts
+++ b/src/components/common/TreeExplorerV2Node.test.ts
@@ -1,45 +1,29 @@
-import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
 import type { FlattenedItem } from 'reka-ui'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { useSubgraphStore } from '@/stores/subgraphStore'
 import type { RenderedTreeExplorerNode } from '@/types/treeExplorerTypes'
 import { InjectKeyContextMenuNode } from '@/types/treeExplorerTypes'
 
 import TreeExplorerV2Node from './TreeExplorerV2Node.vue'
+
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+  vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(false)
+  vi.mocked(useSubgraphStore().deleteBlueprint).mockResolvedValue(undefined)
+})
 
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
   messages: { en: { g: { delete: 'Delete' } } }
 })
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn().mockReturnValue('left')
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/nodeBookmarkStore'), () => ({
-  useNodeBookmarkStore: () => ({
-    isBookmarked: vi.fn().mockReturnValue(false),
-    toggleBookmark: vi.fn()
-  })
-}))
-
-const mockDeleteBlueprint = vi.fn()
-const mockIsUserBlueprint = vi.fn().mockReturnValue(false)
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: () => ({
-    isUserBlueprint: mockIsUserBlueprint,
-    deleteBlueprint: mockDeleteBlueprint,
-    typePrefix: 'SubgraphBlueprint.'
-  })
-}))
 
 vi.mock<unknown>(import('@/components/node/NodePreviewCard.vue'), () => ({
   default: { template: '<div />' }
@@ -220,7 +204,7 @@ describe('TreeExplorerV2Node', () => {
 
   describe('blueprint actions', () => {
     it('shows delete button for user blueprints', () => {
-      mockIsUserBlueprint.mockReturnValue(true)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(true)
       renderComponent({
         item: createMockItem('node', {
           data: { name: 'SubgraphBlueprint.test' }
@@ -231,7 +215,7 @@ describe('TreeExplorerV2Node', () => {
     })
 
     it('hides delete button for non-blueprint nodes', () => {
-      mockIsUserBlueprint.mockReturnValue(false)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(false)
       renderComponent({
         item: createMockItem('node', {
           data: { name: 'KSampler' }
@@ -244,7 +228,7 @@ describe('TreeExplorerV2Node', () => {
     })
 
     it('always shows bookmark button', () => {
-      mockIsUserBlueprint.mockReturnValue(true)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(true)
       renderComponent({
         item: createMockItem('node', {
           data: { name: 'SubgraphBlueprint.test' }
@@ -258,7 +242,7 @@ describe('TreeExplorerV2Node', () => {
 
     it('calls deleteBlueprint when delete button is clicked', async () => {
       const user = userEvent.setup()
-      mockIsUserBlueprint.mockReturnValue(true)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(true)
       const nodeName = 'SubgraphBlueprint.test'
       renderComponent({
         item: createMockItem('node', {
@@ -269,7 +253,9 @@ describe('TreeExplorerV2Node', () => {
       const deleteButton = screen.getByRole('button', { name: 'Delete' })
       await user.click(deleteButton)
 
-      expect(mockDeleteBlueprint).toHaveBeenCalledWith(nodeName)
+      expect(
+        vi.mocked(useSubgraphStore().deleteBlueprint)
+      ).toHaveBeenCalledWith(nodeName)
     })
   })
 

--- a/src/components/common/UserCredit.test.ts
+++ b/src/components/common/UserCredit.test.ts
@@ -1,51 +1,22 @@
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createPinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useAuthStore } from '@/stores/authStore'
 
 import UserCredit from './UserCredit.vue'
-
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
-
-const mockBalance = vi.hoisted(() => ({
-  value: {
-    amount_micros: 100_000,
-    effective_balance_micros: 100_000,
-    currency: 'usd'
-  }
-}))
-
-const mockIsFetchingBalance = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    balance: mockBalance.value,
-    isFetchingBalance: mockIsFetchingBalance.value
-  }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 describe('UserCredit', () => {
   beforeEach(() => {
-    mockBalance.value = {
+    useAuthStore().balance = {
       amount_micros: 100_000,
       effective_balance_micros: 100_000,
       currency: 'usd'
     }
-    mockIsFetchingBalance.value = false
+    useAuthStore().isFetchingBalance = false
   })
 
   const renderComponent = (props = {}) => {
@@ -58,7 +29,7 @@ describe('UserCredit', () => {
     return render(UserCredit, {
       props,
       global: {
-        plugins: [i18n, createPinia()],
+        plugins: [i18n],
         stubs: {
           Skeleton: { template: '<div data-testid="skeleton" />' },
           Tag: true
@@ -69,7 +40,7 @@ describe('UserCredit', () => {
 
   describe('effective_balance_micros handling', () => {
     it('uses effective_balance_micros when present (positive balance)', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 200_000,
         effective_balance_micros: 150_000,
         currency: 'usd'
@@ -80,7 +51,7 @@ describe('UserCredit', () => {
     })
 
     it('uses effective_balance_micros when zero', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 100_000,
         effective_balance_micros: 0,
         currency: 'usd'
@@ -91,7 +62,7 @@ describe('UserCredit', () => {
     })
 
     it('uses effective_balance_micros when negative', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 0,
         effective_balance_micros: -50_000,
         currency: 'usd'
@@ -102,19 +73,19 @@ describe('UserCredit', () => {
     })
 
     it('falls back to amount_micros when effective_balance_micros is missing', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 100_000,
         currency: 'usd'
-      } as typeof mockBalance.value
+      }
 
       renderComponent()
       expect(screen.getByText(/Credits/)).toBeInTheDocument()
     })
 
     it('falls back to 0 when both effective_balance_micros and amount_micros are missing', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         currency: 'usd'
-      } as typeof mockBalance.value
+      } as ReturnType<typeof useAuthStore>['balance']
 
       renderComponent()
       expect(screen.getByText(/\b0\b/)).toBeInTheDocument()
@@ -123,7 +94,7 @@ describe('UserCredit', () => {
 
   describe('loading state', () => {
     it('shows skeleton when loading', () => {
-      mockIsFetchingBalance.value = true
+      useAuthStore().isFetchingBalance = true
 
       renderComponent()
       expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)

--- a/src/components/common/WorkflowActionsDropdown.test.ts
+++ b/src/components/common/WorkflowActionsDropdown.test.ts
@@ -1,43 +1,29 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type { ViewMode } from '@/utils/appMode'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 import WorkflowActionsDropdown from './WorkflowActionsDropdown.vue'
 
-const spies = vi.hoisted(() => ({
-  execute: vi.fn(),
-  trackUiButtonClicked: vi.fn(),
-  markAsSeen: vi.fn()
-}))
-
-const viewState = vi.hoisted(() => ({
-  viewMode: 'graph' as ViewMode,
-  displayViewMode: 'graph' as ViewMode
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { computed, reactive } = await import('vue')
-  return {
-    useAppModeStore: () =>
-      reactive({
-        viewMode: computed(() => viewState.viewMode),
-        displayViewMode: computed(() => viewState.displayViewMode)
-      })
-  }
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  useKeybindingStore().addDefaultKeybinding(
+    new KeybindingImpl({
+      commandId: 'Comfy.ToggleLinear',
+      combo: { key: 'l', ctrl: true }
+    })
+  )
 })
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: spies.execute, commands: [] })
-}))
-
-vi.mock<unknown>(import('@/platform/keybindings/keybindingStore'), () => ({
-  useKeybindingStore: () => ({
-    getKeybindingByCommandId: () => ({ combo: { toString: () => 'Ctrl+L' } })
-  })
+const spies = vi.hoisted(() => ({
+  trackUiButtonClicked: vi.fn(),
+  markAsSeen: vi.fn()
 }))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -96,8 +82,8 @@ function renderDropdown() {
 
 describe('WorkflowActionsDropdown', () => {
   beforeEach(() => {
-    viewState.viewMode = 'graph'
-    viewState.displayViewMode = 'graph'
+    Object.assign(useAppModeStore(), { viewMode: 'graph' })
+    useAppModeStore().displayViewMode = 'graph'
     // A prior test's segment switch arms the module-level focus handoff;
     // a throwaway mount consumes it so it cannot steal focus mid-test.
     renderDropdown().unmount()
@@ -123,8 +109,8 @@ describe('WorkflowActionsDropdown', () => {
   })
 
   it('flips the segment roles when app mode is active', () => {
-    viewState.viewMode = 'app'
-    viewState.displayViewMode = 'app'
+    Object.assign(useAppModeStore(), { viewMode: 'app' })
+    useAppModeStore().displayViewMode = 'app'
     renderDropdown()
 
     const active = screen.getByRole('button', { name: /workflow actions/ })
@@ -136,8 +122,8 @@ describe('WorkflowActionsDropdown', () => {
 
   it('derives the active segment from the real mode, not the lagged display mode', () => {
     // Mid-animation: the mode has flipped to app but the display still lags.
-    viewState.viewMode = 'app'
-    viewState.displayViewMode = 'graph'
+    Object.assign(useAppModeStore(), { viewMode: 'app' })
+    useAppModeStore().displayViewMode = 'graph'
     renderDropdown()
 
     const active = screen.getByRole('button', { name: /workflow actions/ })
@@ -163,9 +149,12 @@ describe('WorkflowActionsDropdown', () => {
 
     await user.click(screen.getByRole('button', { name: 'Enter app mode' }))
 
-    expect(spies.execute).toHaveBeenCalledWith('Comfy.ToggleLinear', {
-      metadata: { source: 'test' }
-    })
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.ToggleLinear',
+      {
+        metadata: { source: 'test' }
+      }
+    )
     // The switch must not also open the menu as a side effect.
     expect(
       screen.getByRole('button', { name: /workflow actions/ })
@@ -180,7 +169,7 @@ describe('WorkflowActionsDropdown', () => {
 
     await user.click(active)
 
-    expect(spies.execute).not.toHaveBeenCalled()
+    expect(vi.mocked(useCommandStore().execute)).not.toHaveBeenCalled()
     expect(active).toHaveAttribute('aria-expanded', 'true')
     expect(spies.markAsSeen).toHaveBeenCalled()
     expect(spies.trackUiButtonClicked).toHaveBeenCalledWith({
@@ -206,9 +195,12 @@ describe('WorkflowActionsDropdown', () => {
     inactive.focus()
     await user.keyboard('{Enter}')
 
-    expect(spies.execute).toHaveBeenCalledWith('Comfy.ToggleLinear', {
-      metadata: { source: 'test' }
-    })
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.ToggleLinear',
+      {
+        metadata: { source: 'test' }
+      }
+    )
     // The keydown must not reach the trigger and open the menu.
     expect(
       screen.getByRole('button', { name: /workflow actions/ })
@@ -239,7 +231,7 @@ describe('WorkflowActionsDropdown', () => {
     active.focus()
     await user.keyboard('{Enter}')
 
-    expect(spies.execute).not.toHaveBeenCalled()
+    expect(vi.mocked(useCommandStore().execute)).not.toHaveBeenCalled()
     expect(active).toHaveAttribute('aria-expanded', 'true')
   })
 
@@ -272,8 +264,8 @@ describe('WorkflowActionsDropdown', () => {
     // The mode flip unmounts this instance and mounts a fresh one in the
     // other mode's host.
     unmount()
-    viewState.viewMode = 'app'
-    viewState.displayViewMode = 'app'
+    Object.assign(useAppModeStore(), { viewMode: 'app' })
+    useAppModeStore().displayViewMode = 'app'
     renderDropdown()
     await nextTick()
 

--- a/src/components/curve/WidgetCurve.test.ts
+++ b/src/components/curve/WidgetCurve.test.ts
@@ -1,11 +1,15 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { toNodeId } from '@/types/nodeId'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import type { CurveData } from './types'
+import WidgetCurve from './WidgetCurve.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -35,17 +39,6 @@ vi.mock<unknown>(import('@/composables/useUpstreamValue'), async () => {
     singleValueExtractor: () => () => undefined
   }
 })
-
-const outputsHolder = vi.hoisted(() => ({
-  nodeOutputs: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => outputsHolder
-}))
-
-import WidgetCurve from './WidgetCurve.vue'
-import type { CurveData } from './types'
 
 const CurveEditorStub = defineComponent({
   name: 'CurveEditor',
@@ -144,7 +137,7 @@ function renderWidget(
 describe('WidgetCurve', () => {
   beforeEach(() => {
     upstreamHolder.ref = null
-    outputsHolder.nodeOutputs = {}
+    useNodeOutputStore().nodeOutputs = {}
   })
 
   describe('Point forwarding', () => {

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -6,28 +6,24 @@
  */
 import { describe, expect, it, vi } from 'vitest'
 
-const showDialog = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
-
 import ConfirmBody from '@/components/dialog/confirm/ConfirmBody.vue'
+import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 import ConfirmFooter from '@/components/dialog/confirm/ConfirmFooter.vue'
 import ConfirmHeader from '@/components/dialog/confirm/ConfirmHeader.vue'
-import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
+import { useDialogStore } from '@/stores/dialogStore'
 
 describe('showConfirmDialog Reka renderer opt-in', () => {
   it("sets renderer 'reka' with size 'md' and zeroed section padding", () => {
     showConfirmDialog()
 
-    const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('md')
-    expect(args.dialogComponentProps.headerClass).toBe('p-0 pr-3')
-    expect(args.dialogComponentProps.bodyClass).toBe('p-0')
-    expect(args.dialogComponentProps.footerClass).toBe('p-0')
-    expect(args.dialogComponentProps.pt).toBeUndefined()
+    const { showDialog } = useDialogStore()
+    const [args] = vi.mocked(showDialog).mock.calls[0]
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('md')
+    expect(args.dialogComponentProps?.headerClass).toBe('p-0 pr-3')
+    expect(args.dialogComponentProps?.bodyClass).toBe('p-0')
+    expect(args.dialogComponentProps?.footerClass).toBe('p-0')
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
   })
 
   it('forwards the confirm section components and caller props', () => {
@@ -38,7 +34,8 @@ describe('showConfirmDialog Reka renderer opt-in', () => {
       footerProps: { confirmText: 'Delete' }
     })
 
-    const [args] = showDialog.mock.calls[0]
+    const { showDialog } = useDialogStore()
+    const [args] = vi.mocked(showDialog).mock.calls[0]
     expect(args.key).toBe('confirm-test')
     expect(args.headerComponent).toBe(ConfirmHeader)
     expect(args.component).toBe(ConfirmBody)

--- a/src/components/dialog/content/ApiNodesSignInContent.test.ts
+++ b/src/components/dialog/content/ApiNodesSignInContent.test.ts
@@ -4,16 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 
 import ApiNodesSignInContent from './ApiNodesSignInContent.vue'
-
-const hoisted = vi.hoisted(() => ({
-  nodeDefsByName: {} as Record<string, { display_name?: string }>
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({ nodeDefsByName: hoisted.nodeDefsByName })
-}))
 
 const buildDocsUrl = vi.hoisted(() =>
   vi.fn((path: string) => `https://docs.comfy.org${path}`)
@@ -47,12 +40,19 @@ function renderContent(props: {
 
 describe('ApiNodesSignInContent', () => {
   beforeEach(() => {
-    hoisted.nodeDefsByName = {}
+    useNodeDefStore().nodeDefsByName = {}
   })
 
   it('lists partner nodes with display names, falling back to raw names', () => {
-    hoisted.nodeDefsByName = {
-      PartnerA: { display_name: 'Partner A' }
+    useNodeDefStore().nodeDefsByName = {
+      PartnerA: new ComfyNodeDefImpl({
+        name: 'PartnerA',
+        display_name: 'Partner A',
+        category: '',
+        python_module: '',
+        description: '',
+        output_node: false
+      })
     }
     renderContent({ apiNodeNames: ['PartnerA', 'UnknownNode'] })
 

--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
@@ -1,16 +1,17 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { AuthStoreError } from '@/stores/authStore'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import TopUpCreditsDialogContentLegacy from './TopUpCreditsDialogContentLegacy.vue'
 
 const mockPurchaseCreditsDirect = vi.fn()
 const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
-const mockCloseDialog = vi.fn()
+
 const mockTrackTopUpPurchase = vi.fn()
 const mockTrackBillingEvent = vi.fn()
 const mockIsSubscriptionEnabled = vi.fn(() => true)
@@ -47,10 +48,6 @@ vi.mock<unknown>(
     useSettingsDialog: () => ({ show: mockShowSettings })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -147,7 +144,7 @@ describe('TopUpCreditsDialogContentLegacy', () => {
     await clickBuyCredits()
 
     expect(mockPurchaseCreditsDirect).toHaveBeenCalledWith(50)
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalled()
     expect(mockShowSettings).toHaveBeenCalledWith('workspace')
     expect(mockClearPendingTopup).not.toHaveBeenCalled()
   })
@@ -158,7 +155,7 @@ describe('TopUpCreditsDialogContentLegacy', () => {
     await user.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(mockClearPendingTopup).toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalled()
   })
 
   it('shows Plan & Credits when no billing rail is active', async () => {

--- a/src/components/dialog/content/setting/CreditsPanel.test.ts
+++ b/src/components/dialog/content/setting/CreditsPanel.test.ts
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -49,10 +49,6 @@ vi.mock(
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackHelpResourceClicked: vi.fn() })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
 }))
 
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -1,34 +1,19 @@
 import { Form } from '@primevue/forms'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import Button from '@/components/ui/button/Button.vue'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Message from 'primevue/message'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
+import { useAuthStore } from '@/stores/authStore'
 
 import ApiKeyForm from './ApiKeyForm.vue'
-
-const mockStoreApiKey = vi.fn()
-const mockLoadingRef = ref(false)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    get loading() {
-      return mockLoadingRef.value
-    }
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: vi.fn(() => ({
-    storeApiKey: mockStoreApiKey
-  }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const i18n = createI18n({
   legacy: false,
@@ -58,7 +43,7 @@ const i18n = createI18n({
 
 describe('ApiKeyForm', () => {
   beforeEach(() => {
-    mockLoadingRef.value = false
+    useAuthStore().loading = false
   })
 
   function renderComponent(props: Record<string, unknown> = {}) {
@@ -91,7 +76,7 @@ describe('ApiKeyForm', () => {
   })
 
   it('shows loading state when submitting', () => {
-    mockLoadingRef.value = true
+    useAuthStore().loading = true
     const { container } = renderComponent()
 
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access

--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -1,50 +1,27 @@
 import { Form } from '@primevue/forms'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import Button from '@/components/ui/button/Button.vue'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
 import ProgressSpinner from 'primevue/progressspinner'
 import ToastService from 'primevue/toastservice'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useAuthStore } from '@/stores/authStore'
 
 import SignInForm from './SignInForm.vue'
-
-// Mock firebase auth modules
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn(),
-  sendPasswordResetEmail: vi.fn()
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 // Mock the auth composables and stores
 const mockSendPasswordReset = vi.fn()
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: vi.fn(() => ({
     sendPasswordReset: mockSendPasswordReset
-  }))
-}))
-
-const mockLoadingRef = ref(false)
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    get loading() {
-      return mockLoadingRef.value
-    }
   }))
 }))
 
@@ -61,7 +38,7 @@ const loginButtonText = enMessages.auth.login.loginButton
 
 describe('SignInForm', () => {
   beforeEach(() => {
-    mockLoadingRef.value = false
+    useAuthStore().loading = false
   })
 
   function renderComponent(props: Record<string, unknown> = {}) {
@@ -141,7 +118,7 @@ describe('SignInForm', () => {
 
   describe('Loading State', () => {
     it('shows spinner when loading', () => {
-      mockLoadingRef.value = true
+      useAuthStore().loading = true
       renderComponent()
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument()

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -1,40 +1,20 @@
 import { Form, FormField } from '@primevue/forms'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import Button from '@/components/ui/button/Button.vue'
+import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
-import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useAuthStore } from '@/stores/authStore'
 
 import SignUpForm from './SignUpForm.vue'
-
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
-
-const mockLoadingRef = ref(false)
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    get loading() {
-      return mockLoadingRef.value
-    }
-  }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const mockTurnstileEnabled = ref(false)
 const mockTurnstileToken = ref('')
@@ -101,7 +81,7 @@ function globalOptions() {
 describe('SignUpForm', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockLoadingRef.value = false
+    useAuthStore().loading = false
     mockTurnstileEnabled.value = false
     mockTurnstileToken.value = ''
     mockTurnstileUnavailable.value = false
@@ -224,7 +204,7 @@ describe('SignUpForm', () => {
       screen.getByRole('button', { name: signUpButton })
 
     it('keeps its accessible name and disables while loading', async () => {
-      mockLoadingRef.value = true
+      useAuthStore().loading = true
       renderComponent()
       await nextTick()
 
@@ -233,7 +213,7 @@ describe('SignUpForm', () => {
     })
 
     it('does not emit submit when clicked', async () => {
-      mockLoadingRef.value = true
+      useAuthStore().loading = true
       const { user, emitted } = renderComponent()
       await nextTick()
 

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -1,35 +1,23 @@
+import { render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import { render } from '@testing-library/vue'
-
 import type { TurnstileRenderOptions } from '@/composables/auth/turnstileScript'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
 import TurnstileWidget from './TurnstileWidget.vue'
 
-const { mockLoadTurnstile, mockGetSiteKey, mockLightTheme } = vi.hoisted(
-  () => ({
-    mockLoadTurnstile: vi.fn(),
-    mockGetSiteKey: vi.fn(() => 'site-key'),
-    mockLightTheme: { value: true }
-  })
-)
+const { mockLoadTurnstile, mockGetSiteKey } = vi.hoisted(() => ({
+  mockLoadTurnstile: vi.fn(),
+  mockGetSiteKey: vi.fn(() => 'site-key')
+}))
 
 vi.mock(import('@/composables/auth/turnstileScript'), () => ({
   loadTurnstile: mockLoadTurnstile
 }))
 vi.mock(import('@/config/turnstile'), () => ({
   getTurnstileSiteKey: mockGetSiteKey
-}))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: {
-      get light_theme() {
-        return mockLightTheme.value
-      }
-    }
-  })
 }))
 
 const i18n = createI18n({
@@ -98,7 +86,7 @@ const renderWidgetWithExpose = () => {
 describe('TurnstileWidget', () => {
   beforeEach(() => {
     mockGetSiteKey.mockReturnValue('site-key')
-    mockLightTheme.value = true
+    useColorPaletteStore().activePaletteId = 'light'
     delete window.turnstile
   })
 
@@ -120,7 +108,7 @@ describe('TurnstileWidget', () => {
   })
 
   it('uses the dark theme when the active palette is not light', async () => {
-    mockLightTheme.value = false
+    useColorPaletteStore().activePaletteId = 'dark'
     const { api, options } = fakeTurnstile()
     mockLoadTurnstile.mockResolvedValue(api)
 

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
@@ -1,10 +1,10 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
-import userEvent from '@testing-library/user-event'
-import { render, screen, waitFor } from '@testing-library/vue'
-
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useDialogStore } from '@/stores/dialogStore'
 
 import CancelSubscriptionDialogContent from './CancelSubscriptionDialogContent.vue'
 
@@ -50,7 +50,7 @@ const mockSubscription = vi.hoisted(() => ({
 
 const mockCancelSubscription = vi.hoisted(() => vi.fn())
 const mockFetchStatus = vi.hoisted(() => vi.fn())
-const mockCloseDialog = vi.hoisted(() => vi.fn())
+
 const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockTier = vi.hoisted(() => ({ value: 'STANDARD' as string | null }))
 const mockTrackCancellation = vi.hoisted(() => vi.fn())
@@ -105,12 +105,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackSubscriptionCancellation: mockTrackCancellation
   })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: vi.fn(() => ({
-    closeDialog: mockCloseDialog
-  }))
 }))
 
 vi.mock<unknown>(
@@ -192,7 +186,9 @@ describe('CancelSubscriptionDialogContent', () => {
         screen.getByRole('button', { name: /^cancel subscription$/i })
       )
 
-      await waitFor(() => expect(mockCloseDialog).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalled()
+      )
       unmount()
       expect(mockTrackCancellation).toHaveBeenCalledWith(
         'confirmed',
@@ -254,7 +250,7 @@ describe('CancelSubscriptionDialogContent', () => {
         screen.getByRole('button', { name: /keep subscription/i })
       )
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
         key: 'cancel-subscription'
       })
       unmount()
@@ -299,7 +295,7 @@ describe('CancelSubscriptionDialogContent', () => {
           })
         )
       )
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
     })
 
     it('closes the dialog and shows a success toast when cancellation succeeds', async () => {
@@ -312,7 +308,7 @@ describe('CancelSubscriptionDialogContent', () => {
       )
 
       await waitFor(() =>
-        expect(mockCloseDialog).toHaveBeenCalledWith({
+        expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
           key: 'cancel-subscription'
         })
       )
@@ -339,7 +335,7 @@ describe('CancelSubscriptionDialogContent', () => {
         expect.anything()
       )
       expect(mockToastAdd).not.toHaveBeenCalled()
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
     })
 
     it('cancels off Cloud on the workspace permission, ignoring the Cloud-only capability', async () => {
@@ -392,7 +388,7 @@ describe('CancelSubscriptionDialogContent', () => {
           expect.objectContaining({ severity: 'success' })
         )
       )
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
         key: 'cancel-subscription'
       })
       expect(

--- a/src/components/error/ErrorOverlay.test.ts
+++ b/src/components/error/ErrorOverlay.test.ts
@@ -1,19 +1,20 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import ErrorOverlay from './ErrorOverlay.vue'
-import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import type { NodeError } from '@/schemas/apiSchema'
+import type { ErrorGroup } from '@/components/rightSidePanel/errors/types'
 import type {
   MissingPackGroup,
   SwapNodeGroup
 } from '@/components/rightSidePanel/errors/useErrorGroups'
-import type { ErrorGroup } from '@/components/rightSidePanel/errors/types'
 import type { MissingMediaGroup } from '@/platform/missingMedia/types'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type { NodeError } from '@/schemas/apiSchema'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+
+import ErrorOverlay from './ErrorOverlay.vue'
 
 const mockErrorGroups = vi.hoisted(() => ({
   allErrorGroups: { value: [] as ErrorGroup[] },
@@ -51,21 +52,6 @@ vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   getActiveGraphNodeIds: vi.fn(() => new Set()),
   getExecutionIdByNode: vi.fn(),
   getNodeByExecutionId: vi.fn()
-}))
-
-const mockOpenPanel = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), () => ({
-  useRightSidePanelStore: () => ({ openPanel: mockOpenPanel })
-}))
-
-const mockCanvasStore = vi.hoisted(() => ({
-  linearMode: false,
-  canvas: null,
-  currentGraph: null,
-  updateSelectedItems: vi.fn()
-}))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => mockCanvasStore
 }))
 
 function createTestI18n() {
@@ -106,12 +92,10 @@ function makeNodeError(messages: string[]): NodeError {
 }
 
 function renderOverlay(props: { appMode?: boolean } = {}) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
   return render(ErrorOverlay, {
     props,
     global: {
-      plugins: [pinia, createTestI18n()],
+      plugins: [createTestI18n()],
       stubs: {
         Button: {
           template: '<button v-bind="$attrs"><slot /></button>'
@@ -128,9 +112,9 @@ describe('ErrorOverlay', () => {
     mockErrorGroups.missingModelGroups.value = []
     mockErrorGroups.missingMediaGroups.value = []
     mockErrorGroups.swapNodeGroups.value = []
-    mockCanvasStore.linearMode = false
-    mockCanvasStore.canvas = null
-    mockCanvasStore.currentGraph = null
+    useCanvasStore().linearMode = false
+    useCanvasStore().canvas = null
+    useCanvasStore().currentGraph = null
   })
 
   it('renders a single overlay message without list markup', async () => {

--- a/src/components/graph/CanvasModeSelector.test.ts
+++ b/src/components/graph/CanvasModeSelector.test.ts
@@ -1,37 +1,20 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import CanvasModeSelector from '@/components/graph/CanvasModeSelector.vue'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useCommandStore } from '@/stores/commandStore'
 
-const mockExecute = vi.fn()
-const mockGetCommand = vi.fn(() => ({
-  keybinding: {
-    combo: {
-      getKeySequences: () => ['V']
-    }
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({ read_only: false })
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  for (const id of ['Comfy.Canvas.Unlock', 'Comfy.Canvas.Lock']) {
+    useCommandStore().registerCommand({ id, function: vi.fn() })
   }
-}))
-const mockFormatKeySequence = vi.fn(() => 'V')
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: mockExecute,
-    getCommand: mockGetCommand,
-    formatKeySequence: mockFormatKeySequence
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { read_only: false }
-    })
-  })
-)
+})
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -1,22 +1,24 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render } from '@testing-library/vue'
 import type { RenderOptions } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useReleaseStore } from '@/platform/updates/common/releaseStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useBootstrapStore } from '@/stores/bootstrapStore'
 import { useExecutionStore } from '@/stores/executionStore'
-import { createNodeLocatorId } from '@/types/nodeIdentification'
 import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 import GraphCanvas from './GraphCanvas.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 /**
  * GraphCanvas is the only place the first-run tour is wired into startup: it
@@ -34,12 +36,7 @@ const mocks = vi.hoisted(() => ({
   loadTemplateFromUrlIfPresent: vi.fn(),
   loadSharedWorkflowFromUrlIfPresent: vi.fn(),
   runUrlActionLoaders: vi.fn(),
-  setDirty: vi.fn(),
-  workspaceStore: {
-    spinner: false,
-    focusMode: false,
-    sidebarTab: { activeSidebarTab: null }
-  }
+  setDirty: vi.fn()
 }))
 
 vi.mock<unknown>(
@@ -104,10 +101,6 @@ vi.mock(import('@/composables/useUrlActionLoaders'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/releaseStore'), () => ({
-  useReleaseStore: () => ({ initialize: vi.fn() })
-}))
-
 vi.mock(import('@/composables/graph/useErrorClearingHooks'), () => ({
   installErrorClearingHooks: () => vi.fn()
 }))
@@ -141,10 +134,6 @@ vi.mock(import('@/composables/useContextMenuTranslation'), () => ({
 vi.mock(import('@/composables/graph/useGroupContextMenu'), () => ({
   useGroupContextMenu: vi.fn()
 }))
-// Instantiating the real one pulls in the Firebase auth store.
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => mocks.workspaceStore
-}))
 
 vi.mock(import('@/composables/useCopy'), () => ({ useCopy: vi.fn() }))
 vi.mock(import('@/composables/usePaste'), () => ({ usePaste: vi.fn() }))
@@ -156,8 +145,8 @@ vi.mock(
 async function mountGraphCanvas() {
   // Handed to the component rather than left to the active-Pinia fallback, so
   // the readiness gates below are set on the instance startup actually reads.
-  const pinia = createTestingPinia({ stubActions: false })
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
+  vi.mocked(useReleaseStore().initialize).mockResolvedValue(undefined)
   app.canvas.graph = null
 
   // Startup waits on both readiness gates before it reaches the tour hand-off.
@@ -186,13 +175,6 @@ async function mountGraphCanvas() {
 
 describe('GraphCanvas first-run tour wiring', () => {
   beforeEach(() => {
-    // Startup writes to the workspace store, and clearAllMocks does not undo
-    // writes to a plain object.
-    Object.assign(mocks.workspaceStore, {
-      spinner: false,
-      focusMode: false,
-      sidebarTab: { activeSidebarTab: null }
-    })
     mocks.initializeWorkflow.mockResolvedValue('url-intent')
     mocks.loadTemplateFromUrlIfPresent.mockResolvedValue('image_to_image')
     mocks.loadSharedWorkflowFromUrlIfPresent.mockResolvedValue(undefined)

--- a/src/components/graph/SelectionRectangle.test.ts
+++ b/src/components/graph/SelectionRectangle.test.ts
@@ -1,25 +1,20 @@
-import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type * as VueUse from '@vueuse/core'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
+
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import SelectionRectangle from './SelectionRectangle.vue'
 
 const rafCallbacks: Array<() => void> = []
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useRafFn: (cb: () => void) => {
     rafCallbacks.push(cb)
     return { pause: vi.fn(), resume: vi.fn() }
   }
-}))
-
-const mockCanvas = ref<unknown>(null)
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    get canvas() {
-      return mockCanvas.value
-    }
-  })
 }))
 
 function createPanelEl() {
@@ -35,21 +30,26 @@ function dragRectangle(eDown: [number, number], eMove: [number, number]) {
   vi.spyOn(canvasEl, 'getBoundingClientRect').mockReturnValue(
     fromPartial<DOMRect>({ left: 0, top: 0, right: 1000, bottom: 800 })
   )
-  mockCanvas.value = {
+  useCanvasStore().canvas = fromPartial({
     canvas: canvasEl,
-    dragging_rectangle: true,
+    dragging_rectangle: [
+      eDown[0],
+      eDown[1],
+      eMove[0] - eDown[0],
+      eMove[1] - eDown[1]
+    ],
     pointer: {
       eDown: { safeOffsetX: eDown[0], safeOffsetY: eDown[1] },
       eMove: { safeOffsetX: eMove[0], safeOffsetY: eMove[1] }
     }
-  }
+  })
   rafCallbacks[rafCallbacks.length - 1]()
 }
 
 describe('SelectionRectangle', () => {
   afterEach(() => {
     rafCallbacks.length = 0
-    mockCanvas.value = null
+    useCanvasStore().canvas = null
   })
 
   it('clips the rectangle to the canvas panel when dragged over the sidebar', async () => {

--- a/src/components/graph/agentPanelMount.test.ts
+++ b/src/components/graph/agentPanelMount.test.ts
@@ -1,13 +1,19 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import LiteGraphCanvasSplitterOverlay from '../LiteGraphCanvasSplitterOverlay.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
+
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+})
 
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { ref } = await import('vue')
@@ -16,58 +22,6 @@ vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
       isSelectMode: ref(false),
       isBuilderMode: ref(false)
     })
-  }
-})
-
-// The overlay's workspace stores reach Firebase auth and app bootstrap in
-// their real setups; the structure under test only needs these fields.
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn((key: string) =>
-      key === 'Comfy.Sidebar.Location' ? 'left' : undefined
-    ),
-    settingsById: {}
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), async () => {
-  const { defineStore } = await import('pinia')
-  const { ref } = await import('vue')
-  return {
-    useWorkspaceStore: defineStore('workspace-stub', () => ({
-      focusMode: ref(false)
-    }))
-  }
-})
-
-vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), async () => {
-  const { defineStore } = await import('pinia')
-  const { ref } = await import('vue')
-  return {
-    useRightSidePanelStore: defineStore('right-side-panel-stub', () => ({
-      isOpen: ref(false)
-    }))
-  }
-})
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), async () => {
-  const { defineStore } = await import('pinia')
-  const { ref } = await import('vue')
-  return {
-    useSidebarTabStore: defineStore('sidebar-tab-stub', () => ({
-      activeSidebarTabId: ref(null),
-      activeSidebarTab: ref(null)
-    }))
-  }
-})
-
-vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), async () => {
-  const { defineStore } = await import('pinia')
-  const { ref } = await import('vue')
-  return {
-    useBottomPanelStore: defineStore('bottom-panel-stub', () => ({
-      bottomPanelVisible: ref(false)
-    }))
   }
 })
 
@@ -81,7 +35,7 @@ function renderOverlay() {
   })
   return render(LiteGraphCanvasSplitterOverlay, {
     global: {
-      plugins: [i18n, createTestingPinia()],
+      plugins: [i18n],
       stubs: {
         Splitter: { template: '<div><slot /></div>' },
         SplitterPanel: { template: '<div><slot /></div>' }

--- a/src/components/graph/modals/ZoomControlsModal.test.ts
+++ b/src/components/graph/modals/ZoomControlsModal.test.ts
@@ -1,35 +1,38 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ZoomControlsModal from '@/components/graph/modals/ZoomControlsModal.vue'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useCommandStore } from '@/stores/commandStore'
 
-const mockExecute = vi.fn()
-const mockGetCommand = vi.fn((commandId: string) => ({
-  keybinding: {
-    combo: {
-      getKeySequences: () => [
-        'Ctrl',
-        commandId === 'Comfy.Canvas.ZoomIn'
-          ? '+'
-          : commandId === 'Comfy.Canvas.ZoomOut'
-            ? '-'
-            : '0'
-      ]
-    }
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  vi.mocked(useCommandStore().formatKeySequence).mockImplementation(
+    (command) =>
+      command.id === 'Comfy.Canvas.ZoomIn'
+        ? 'Ctrl+'
+        : command.id === 'Comfy.Canvas.ZoomOut'
+          ? 'Ctrl-'
+          : 'Ctrl+0'
+  )
+  for (const [commandId, key] of [
+    ['Comfy.Canvas.ZoomIn', '+'],
+    ['Comfy.Canvas.ZoomOut', '-'],
+    ['Comfy.Canvas.FitView', '0']
+  ]) {
+    useCommandStore().registerCommand({ id: commandId, function: vi.fn() })
+    useKeybindingStore().addDefaultKeybinding(
+      new KeybindingImpl({ commandId, combo: { key, ctrl: true } })
+    )
   }
-}))
-const mockFormatKeySequence = vi.fn(
-  (command: { keybinding: { combo: { getKeySequences: () => string[] } } }) => {
-    const seq = command.keybinding.combo.getKeySequences()
-    if (seq.includes('+')) return 'Ctrl+'
-    if (seq.includes('-')) return 'Ctrl-'
-    return 'Ctrl+0'
-  }
-)
-const mockSetAppZoom = vi.fn()
-const mockSettingGet = vi.fn(() => true)
+  vi.mocked(useCanvasStore().setAppZoomFromPercentage).mockImplementation(
+    () => {}
+  )
+})
 
 const i18n = createI18n({
   legacy: false,
@@ -48,31 +51,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: mockExecute,
-    getCommand: mockGetCommand,
-    formatKeySequence: mockFormatKeySequence
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      appScalePercentage: 100,
-      setAppZoomFromPercentage: mockSetAppZoom
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockSettingGet
-  })
-}))
 
 function renderComponent(props = {}) {
   return render(ZoomControlsModal, {
@@ -98,7 +76,9 @@ describe('ZoomControlsModal', () => {
     const zoomInButton = screen.getByTestId('zoom-in-action')
     await user.click(zoomInButton)
 
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ZoomIn')
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.Canvas.ZoomIn'
+    )
   })
 
   it('should execute zoom out command when zoom out button is clicked', async () => {
@@ -108,7 +88,9 @@ describe('ZoomControlsModal', () => {
     const zoomOutButton = screen.getByTestId('zoom-out-action')
     await user.click(zoomOutButton)
 
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.ZoomOut')
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.Canvas.ZoomOut'
+    )
   })
 
   it('should execute fit view command when fit view button is clicked', async () => {
@@ -118,7 +100,9 @@ describe('ZoomControlsModal', () => {
     const fitViewButton = screen.getByTestId('zoom-to-fit-action')
     await user.click(fitViewButton)
 
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.Canvas.FitView')
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.Canvas.FitView'
+    )
   })
 
   it('should call setAppZoomFromPercentage with valid zoom input values', async () => {
@@ -129,7 +113,9 @@ describe('ZoomControlsModal', () => {
     await user.tripleClick(input)
     await user.keyboard('150')
 
-    expect(mockSetAppZoom).toHaveBeenCalledWith(150)
+    expect(
+      vi.mocked(useCanvasStore().setAppZoomFromPercentage)
+    ).toHaveBeenCalledWith(150)
   })
 
   it('should not call setAppZoomFromPercentage when value is below minimum', async () => {
@@ -140,7 +126,9 @@ describe('ZoomControlsModal', () => {
     await user.tripleClick(input)
     await user.keyboard('0')
 
-    expect(mockSetAppZoom).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useCanvasStore().setAppZoomFromPercentage)
+    ).not.toHaveBeenCalled()
   })
 
   it('should not apply zoom values exceeding the maximum', async () => {
@@ -150,11 +138,13 @@ describe('ZoomControlsModal', () => {
     const input = screen.getByRole('spinbutton')
     await user.tripleClick(input)
     await user.keyboard('100')
-    mockSetAppZoom.mockClear()
+    vi.mocked(useCanvasStore().setAppZoomFromPercentage).mockClear()
 
     await user.keyboard('1')
 
-    expect(mockSetAppZoom).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useCanvasStore().setAppZoomFromPercentage)
+    ).not.toHaveBeenCalled()
   })
 
   it('should display keyboard shortcuts for commands', () => {
@@ -163,9 +153,15 @@ describe('ZoomControlsModal', () => {
     expect(screen.getByText('Ctrl+')).toBeInTheDocument()
     expect(screen.getByText('Ctrl-')).toBeInTheDocument()
     expect(screen.getByText('Ctrl+0')).toBeInTheDocument()
-    expect(mockGetCommand).toHaveBeenCalledWith('Comfy.Canvas.ZoomIn')
-    expect(mockGetCommand).toHaveBeenCalledWith('Comfy.Canvas.ZoomOut')
-    expect(mockGetCommand).toHaveBeenCalledWith('Comfy.Canvas.FitView')
+    expect(useCommandStore().getCommand).toHaveBeenCalledWith(
+      'Comfy.Canvas.ZoomIn'
+    )
+    expect(useCommandStore().getCommand).toHaveBeenCalledWith(
+      'Comfy.Canvas.ZoomOut'
+    )
+    expect(useCommandStore().getCommand).toHaveBeenCalledWith(
+      'Comfy.Canvas.FitView'
+    )
   })
 
   it('should not be visible when visible prop is false', () => {

--- a/src/components/graph/selectionToolbox/MaskEditorButton.test.ts
+++ b/src/components/graph/selectionToolbox/MaskEditorButton.test.ts
@@ -1,18 +1,14 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { ref } from 'vue'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import MaskEditorButton from '@/components/graph/selectionToolbox/MaskEditorButton.vue'
+import { useCommandStore } from '@/stores/commandStore'
 
-const mockExecute = vi.hoisted(() => vi.fn())
 const mockSelectionState = vi.hoisted(() => ({
   isSingleImageNode: { value: true }
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: mockExecute })
 }))
 
 vi.mock<unknown>(import('@/composables/graph/useSelectionState'), () => ({
@@ -71,6 +67,8 @@ describe('MaskEditorButton', () => {
       screen.getByRole('button', { name: 'Open in Mask Editor' })
     )
 
-    expect(mockExecute).toHaveBeenCalledWith('Comfy.MaskEditor.OpenMaskEditor')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.MaskEditor.OpenMaskEditor'
+    )
   })
 })

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -1,61 +1,41 @@
 import { render } from '@testing-library/vue'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, ref } from 'vue'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import type { DomWidgetState } from '@/stores/domWidgetStore'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
 import DomWidget from './DomWidget.vue'
 
-const mockUpdateClipPath = vi.fn()
-const mockClippingStyle = ref<Record<string, string>>({})
-const mockDomClippingEnabled = ref(false)
-const mockCanvasElement = document.createElement('canvas')
-const mockCanvasStore = {
-  canvas: {
-    graph: {
-      getNodeById: vi.fn(() => true)
-    },
-    ds: {
-      offset: [0, 0],
-      scale: 1
-    },
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({
+    graph: { getNodeById: vi.fn(() => true) },
+    ds: { offset: [0, 0], scale: 1 },
     canvas: mockCanvasElement,
     selected_nodes: {},
     selectNode: vi.fn(),
     bringToFront: vi.fn(),
     selectedItems: new Set()
-  },
-  getCanvas: () => ({
-    canvas: mockCanvasElement,
-    ds: mockCanvasStore.canvas.ds
-  }),
-  linearMode: false
-}
+  })
+  Object.assign(useCanvasStore(), { linearMode: false })
+  useSettingStore().settingValues['Comfy.DOMClippingEnabled'] = false
+})
+
+const mockUpdateClipPath = vi.fn()
+const mockClippingStyle = ref<Record<string, string>>({})
+
+const mockCanvasElement = document.createElement('canvas')
 
 vi.mock(import('@/composables/element/useDomClipping'), () => ({
   useDomClipping: () => ({
     style: mockClippingStyle,
     updateClipPath: mockUpdateClipPath
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => mockCanvasStore
-  })
-)
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn((key: string) =>
-      key === 'Comfy.DOMClippingEnabled' ? mockDomClippingEnabled.value : false
-    )
   })
 }))
 
@@ -95,10 +75,10 @@ function createWidgetState(
 describe('DomWidget style', () => {
   afterEach(() => {
     useDomWidgetStore().clear()
-    mockDomClippingEnabled.value = false
+    useSettingStore().settingValues['Comfy.DOMClippingEnabled'] = false
     mockClippingStyle.value = {}
-    mockCanvasStore.canvas.selected_nodes = {}
-    mockCanvasStore.canvas.selectedItems = new Set()
+    useCanvasStore().getCanvas().selected_nodes = {}
+    useCanvasStore().getCanvas().selectedItems = new Set()
   })
 
   it('positions a newly mounted widget', () => {
@@ -136,7 +116,7 @@ describe('DomWidget style', () => {
   })
 
   it('applies clipping style when DOM clipping is enabled', async () => {
-    mockDomClippingEnabled.value = true
+    useSettingStore().settingValues['Comfy.DOMClippingEnabled'] = true
     const widgetState = createWidgetState(false)
     const { container } = render(DomWidget, {
       props: {
@@ -161,7 +141,7 @@ describe('DomWidget style', () => {
     })
     mockUpdateClipPath.mockClear()
 
-    mockDomClippingEnabled.value = true
+    useSettingStore().settingValues['Comfy.DOMClippingEnabled'] = true
     await nextTick()
 
     expect(mockUpdateClipPath).toHaveBeenCalled()
@@ -177,8 +157,11 @@ describe('DomWidget style', () => {
     legacyFirst.pos = [50, 60]
     legacyFirst.size = [70, 80]
     legacyFirst.updateArea()
-    mockCanvasStore.canvas.selectedItems = new Set([firstSelected, legacyFirst])
-    mockCanvasStore.canvas.selected_nodes = {
+    useCanvasStore().getCanvas().selectedItems = new Set([
+      firstSelected,
+      legacyFirst
+    ])
+    useCanvasStore().getCanvas().selected_nodes = {
       1: legacyFirst,
       2: firstSelected
     }
@@ -188,7 +171,7 @@ describe('DomWidget style', () => {
         widgetState
       }
     })
-    mockDomClippingEnabled.value = true
+    useSettingStore().settingValues['Comfy.DOMClippingEnabled'] = true
     await nextTick()
 
     expect(mockUpdateClipPath).toHaveBeenCalledWith(
@@ -300,10 +283,10 @@ describe('native DOM widget interaction lifecycle', () => {
     await nextTick()
 
     input.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    expect(mockCanvasStore.canvas.selectNode).toHaveBeenCalledWith(
+    expect(useCanvasStore().getCanvas().selectNode).toHaveBeenCalledWith(
       widgetState.widget.node
     )
-    expect(mockCanvasStore.canvas.bringToFront).toHaveBeenCalledWith(
+    expect(useCanvasStore().getCanvas().bringToFront).toHaveBeenCalledWith(
       widgetState.widget.node
     )
 
@@ -311,12 +294,12 @@ describe('native DOM widget interaction lifecycle', () => {
     expect(blur).toHaveBeenCalledOnce()
 
     rendered.unmount()
-    vi.mocked(mockCanvasStore.canvas.selectNode).mockClear()
+    vi.mocked(useCanvasStore().getCanvas().selectNode).mockClear()
     blur.mockClear()
 
     input.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
-    expect(mockCanvasStore.canvas.selectNode).not.toHaveBeenCalled()
+    expect(useCanvasStore().getCanvas().selectNode).not.toHaveBeenCalled()
     expect(blur).not.toHaveBeenCalled()
   })
 

--- a/src/components/graph/widgets/TextPreviewWidget.test.ts
+++ b/src/components/graph/widgets/TextPreviewWidget.test.ts
@@ -6,33 +6,24 @@ import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 
+import type * as NodePreviewModule from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
+import type { ComfyApp } from '@/scripts/app'
+import { useExecutionStore } from '@/stores/executionStore'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 
-const execHolder = vi.hoisted(() => ({
-  state: null as {
-    executingNodeIds: Array<string | number>
-    isIdle: boolean
-  } | null
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), async () => {
-  const { reactive } = await import('vue')
-  execHolder.state = reactive({
-    executingNodeIds: [] as Array<string | number>,
-    isIdle: true
-  })
-  return {
-    useExecutionStore: () => execHolder.state
-  }
-})
-
-const execState = (): {
-  executingNodeIds: Array<string | number>
-  isIdle: boolean
-} => execHolder.state!
-
 import TextPreviewWidget from './TextPreviewWidget.vue'
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
+vi.mock(
+  import('@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'),
+  async () => {
+    const { fromPartial } = await import('@total-typescript/shoehorn')
+    return fromPartial<typeof NodePreviewModule>({ default: {} })
+  }
+)
 
 const SkeletonStub = defineComponent({
   name: 'Skeleton',
@@ -59,8 +50,8 @@ function renderPreview(
 
 describe('TextPreviewWidget', () => {
   beforeEach(() => {
-    execState().executingNodeIds = []
-    execState().isIdle = true
+    Object.assign(useExecutionStore(), { executingNodeIds: [] })
+    Object.assign(useExecutionStore(), { isIdle: true })
   })
 
   describe('Text formatting', () => {
@@ -170,38 +161,38 @@ describe('TextPreviewWidget', () => {
 
   describe('Execution state', () => {
     it('hides the Skeleton on mount when execution is already idle', () => {
-      execState().executingNodeIds = []
-      execState().isIdle = true
+      Object.assign(useExecutionStore(), { executingNodeIds: [] })
+      Object.assign(useExecutionStore(), { isIdle: true })
       renderPreview('text', { nodeId: toNodeId('n1') })
       expect(screen.queryByTestId('skeleton')).toBeNull()
     })
 
     it('shows a Skeleton on mount when the parent node is executing', () => {
-      execState().executingNodeIds = ['n1']
-      execState().isIdle = false
+      Object.assign(useExecutionStore(), { executingNodeIds: ['n1'] })
+      Object.assign(useExecutionStore(), { isIdle: false })
       renderPreview('text', { nodeId: toNodeId('n1') })
       expect(screen.getByTestId('skeleton')).toBeInTheDocument()
     })
 
     it('hides the Skeleton when execution transitions to idle', async () => {
-      execState().executingNodeIds = ['n1']
-      execState().isIdle = false
+      Object.assign(useExecutionStore(), { executingNodeIds: ['n1'] })
+      Object.assign(useExecutionStore(), { isIdle: false })
       renderPreview('text', { nodeId: toNodeId('n1') })
       expect(screen.getByTestId('skeleton')).toBeInTheDocument()
 
-      execState().executingNodeIds = []
-      execState().isIdle = true
+      Object.assign(useExecutionStore(), { executingNodeIds: [] })
+      Object.assign(useExecutionStore(), { isIdle: true })
       await nextTick()
 
       expect(screen.queryByTestId('skeleton')).toBeNull()
     })
 
     it('hides the Skeleton when the parent node leaves executingNodeIds', async () => {
-      execState().executingNodeIds = ['n1']
-      execState().isIdle = false
+      Object.assign(useExecutionStore(), { executingNodeIds: ['n1'] })
+      Object.assign(useExecutionStore(), { isIdle: false })
       renderPreview('text', { nodeId: toNodeId('n1') })
 
-      execState().executingNodeIds = ['other']
+      Object.assign(useExecutionStore(), { executingNodeIds: ['other'] })
       await nextTick()
 
       expect(screen.queryByTestId('skeleton')).toBeNull()

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -1,20 +1,25 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useReleaseStore } from '@/platform/updates/common/releaseStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 import HelpCenterMenuContent from './HelpCenterMenuContent.vue'
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  vi.mocked(useReleaseStore().fetchReleases).mockResolvedValue(undefined)
+})
 
 const distribution = vi.hoisted(() => ({
   isCloud: false,
   isDesktop: false,
   isNightly: false
 }))
-
-const commandStoreExecute = vi.hoisted(() => vi.fn())
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -39,31 +44,12 @@ vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => false
-  })
-}))
-
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackHelpResourceClicked: vi.fn(),
     trackHelpCenterOpened: vi.fn(),
     trackHelpCenterClosed: vi.fn()
   })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/releaseStore'), () => ({
-  useReleaseStore: () => ({
-    releases: [],
-    recentReleases: [],
-    isLoading: false,
-    fetchReleases: vi.fn().mockResolvedValue(undefined)
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: commandStoreExecute })
 }))
 
 vi.mock<unknown>(import('@/utils/envUtil'), () => ({
@@ -151,7 +137,7 @@ describe('HelpCenterMenuContent feedback item', () => {
       '_blank',
       'noopener,noreferrer'
     )
-    expect(commandStoreExecute).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
   })
 
   it('opens the Typeform survey tagged with help-center source on Nightly', async () => {
@@ -165,7 +151,7 @@ describe('HelpCenterMenuContent feedback item', () => {
       '_blank',
       'noopener,noreferrer'
     )
-    expect(commandStoreExecute).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
   })
 
   it('falls back to Comfy.ContactSupport on OSS builds', async () => {
@@ -174,7 +160,9 @@ describe('HelpCenterMenuContent feedback item', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).not.toHaveBeenCalled()
-    expect(commandStoreExecute).toHaveBeenCalledWith('Comfy.ContactSupport')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.ContactSupport'
+    )
   })
 })
 

--- a/src/components/load3d/Load3D.test.ts
+++ b/src/components/load3d/Load3D.test.ts
@@ -1,20 +1,20 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import Load3D from '@/components/load3d/Load3D.vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComponentWidget } from '@/scripts/domWidget'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 
-const { load3dState, resolveNodeMock, settingGetMock } = vi.hoisted(() => ({
+const { load3dState, resolveNodeMock } = vi.hoisted(() => ({
   load3dState: {
     current: null as ReturnType<typeof buildLoad3dStub> | null
   },
-  resolveNodeMock: vi.fn(),
-  settingGetMock: vi.fn()
+  resolveNodeMock: vi.fn()
 }))
 
 function buildLoad3dStub() {
@@ -65,10 +65,6 @@ vi.mock<unknown>(import('@/composables/useLoad3d'), () => ({
   useLoad3d: () => load3dState.current
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: settingGetMock })
-}))
-
 vi.mock(import('@/utils/litegraphUtil'), () => ({
   resolveNode: resolveNodeMock
 }))
@@ -99,11 +95,8 @@ function renderLoad3D(options: RenderOptions = {}) {
   }
   load3dState.current = stub
 
-  settingGetMock.mockImplementation((key: string) =>
-    key === 'Comfy.Load3D.3DViewerEnable'
-      ? (options.enable3DViewer ?? false)
-      : undefined
-  )
+  useSettingStore().settingValues['Comfy.Load3D.3DViewerEnable'] =
+    options.enable3DViewer ?? false
 
   return {
     ...render(Load3D, {

--- a/src/components/load3d/Load3dViewerContent.test.ts
+++ b/src/components/load3d/Load3dViewerContent.test.ts
@@ -1,12 +1,17 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import Load3dViewerContent from '@/components/load3d/Load3dViewerContent.vue'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useDialogStore } from '@/stores/dialogStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
 
 class NoopMutationObserver {
   observe() {}
@@ -20,7 +25,6 @@ const {
   viewerState,
   dragState,
   capturedDragOptions,
-  dialogCloseMock,
   serviceSourceLoad3d,
   getLoad3dAsyncMock
 } = vi.hoisted(() => {
@@ -35,7 +39,6 @@ const {
     capturedDragOptions: {
       current: null as { onModelDrop?: (file: File) => Promise<void> } | null
     },
-    dialogCloseMock: vi.fn(),
     serviceSourceLoad3d,
     getLoad3dAsyncMock: vi.fn()
   }
@@ -109,10 +112,6 @@ vi.mock<unknown>(import('@/services/load3dService'), () => ({
     getOrCreateViewerSync: () => viewerState.current,
     getLoad3dAsync: getLoad3dAsyncMock
   })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: dialogCloseMock })
 }))
 
 const i18n = createI18n({
@@ -341,7 +340,7 @@ describe('Load3dViewerContent', () => {
       await user.click(screen.getByRole('button', { name: /Cancel/ }))
 
       expect(viewer.restoreInitialState).toHaveBeenCalledOnce()
-      expect(dialogCloseMock).toHaveBeenCalledOnce()
+      expect(useDialogStore().closeDialog).toHaveBeenCalledOnce()
     })
 
     it('closes the dialog in standalone mode without touching initial state', async () => {
@@ -352,7 +351,7 @@ describe('Load3dViewerContent', () => {
       await user.click(screen.getByRole('button', { name: /Cancel/ }))
 
       expect(viewer.restoreInitialState).not.toHaveBeenCalled()
-      expect(dialogCloseMock).toHaveBeenCalledOnce()
+      expect(useDialogStore().closeDialog).toHaveBeenCalledOnce()
     })
   })
 })

--- a/src/components/load3d/controls/HDRIControls.test.ts
+++ b/src/components/load3d/controls/HDRIControls.test.ts
@@ -1,17 +1,19 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- hidden file input has no role/label, queried by selector */
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import HDRIControls from '@/components/load3d/controls/HDRIControls.vue'
 import type { HDRIConfig } from '@/extensions/core/load3d/interfaces'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
-const addAlert = vi.fn()
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert })
-}))
+beforeEach(() => {
+  addAlert = useToastStore().addAlert
+})
+
+let addAlert: ReturnType<typeof useToastStore>['addAlert']
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/LightControls.test.ts
+++ b/src/components/load3d/controls/LightControls.test.ts
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -9,6 +9,7 @@ import type {
   HDRIConfig,
   MaterialMode
 } from '@/extensions/core/load3d/interfaces'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 const settingValues: Record<string, unknown> = {
   'Comfy.Load3D.LightIntensityMaximum': 10,
@@ -16,11 +17,9 @@ const settingValues: Record<string, unknown> = {
   'Comfy.Load3D.LightAdjustmentIncrement': 0.5
 }
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => settingValues[key]
-  })
-}))
+beforeEach(() => {
+  useSettingStore().$patch({ settingValues })
+})
 
 vi.mock(import('@/composables/useDismissableOverlay'), () => ({
   useDismissableOverlay: vi.fn()

--- a/src/components/load3d/controls/ViewerControls.test.ts
+++ b/src/components/load3d/controls/ViewerControls.test.ts
@@ -1,17 +1,13 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ViewerControls from '@/components/load3d/controls/ViewerControls.vue'
+import { useDialogStore } from '@/stores/dialogStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
-const showDialog = vi.fn()
 const handleViewerClose = vi.fn()
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
 
 vi.mock<unknown>(import('@/services/load3dService'), () => ({
   useLoad3dService: () => ({ handleViewerClose })
@@ -63,15 +59,16 @@ describe('ViewerControls', () => {
 
     await user.click(screen.getByRole('button', { name: 'Open in 3D viewer' }))
 
+    const { showDialog } = useDialogStore()
     expect(showDialog).toHaveBeenCalledOnce()
-    const callArgs = showDialog.mock.calls[0][0]
+    const callArgs = vi.mocked(showDialog).mock.calls[0][0]
     expect(callArgs.key).toBe('global-load3d-viewer')
     expect(callArgs.title).toBe('3D viewer')
     expect(callArgs.component).toMatchObject({
       name: 'Load3DViewerContentStub'
     })
     expect(callArgs.props).toEqual({ node: mockNode })
-    expect(callArgs.dialogComponentProps.maximizable).toBe(true)
+    expect(callArgs.dialogComponentProps?.maximizable).toBe(true)
   })
 
   it('routes the dialog onClose handler through useLoad3dService.handleViewerClose with the node', async () => {
@@ -86,8 +83,11 @@ describe('ViewerControls', () => {
 
     await user.click(screen.getByRole('button', { name: 'Open in 3D viewer' }))
 
-    const onClose = showDialog.mock.calls[0][0].dialogComponentProps.onClose
-    await onClose()
+    const { showDialog } = useDialogStore()
+    const onClose =
+      vi.mocked(showDialog).mock.calls[0][0].dialogComponentProps?.onClose
+    expect(onClose).toBeDefined()
+    await onClose?.()
 
     expect(handleViewerClose).toHaveBeenCalledWith(mockNode)
   })

--- a/src/components/load3d/controls/viewer/ViewerLightControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerLightControls.test.ts
@@ -1,21 +1,20 @@
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import ViewerLightControls from '@/components/load3d/controls/viewer/ViewerLightControls.vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+beforeEach(() => {
+  useSettingStore().$patch({ settingValues })
+})
 
 const settingValues: Record<string, unknown> = {
   'Comfy.Load3D.LightIntensityMaximum': 10,
   'Comfy.Load3D.LightIntensityMinimum': 1,
   'Comfy.Load3D.LightAdjustmentIncrement': 0.5
 }
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => settingValues[key]
-  })
-}))
 
 vi.mock(import('@/components/ui/slider/Slider.vue'))
 

--- a/src/components/load3d/menubar/LightMenuGroup.test.ts
+++ b/src/components/load3d/menubar/LightMenuGroup.test.ts
@@ -1,21 +1,22 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import LightMenuGroup from '@/components/load3d/menubar/LightMenuGroup.vue'
 import type { LightConfig } from '@/extensions/core/load3d/interfaces'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+beforeEach(() => {
+  useSettingStore().$patch({ settingValues })
+})
 
 const settingValues: Record<string, number> = {
   'Comfy.Load3D.LightIntensityMinimum': 1,
   'Comfy.Load3D.LightIntensityMaximum': 10,
   'Comfy.Load3D.LightAdjustmentIncrement': 0.1
 }
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => settingValues[key] })
-}))
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/maskeditor/BrushCursor.test.ts
+++ b/src/components/maskeditor/BrushCursor.test.ts
@@ -1,31 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/vue'
-import { reactive } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import BrushCursor from '@/components/maskeditor/BrushCursor.vue'
 import { BrushShape } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-const initialMock = () =>
-  reactive({
-    brushVisible: true,
-    brushPreviewGradientVisible: false,
-    brushSettings: {
-      type: BrushShape.Arc,
-      size: 20,
-      opacity: 0.7,
-      hardness: 1,
-      stepSize: 5
-    },
-    zoomRatio: 1,
-    cursorPoint: { x: 100, y: 50 },
-    panOffset: { x: 0, y: 0 }
-  })
-
-let mockStore: ReturnType<typeof initialMock>
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 const styleOf = (el: Element): string => el.getAttribute('style') ?? ''
 
@@ -41,7 +21,21 @@ const getGradientEl = (): HTMLElement =>
 
 describe('BrushCursor', () => {
   beforeEach(() => {
-    mockStore = initialMock()
+    mockStore = useMaskEditorStore()
+    mockStore.$patch({
+      brushVisible: true,
+      brushPreviewGradientVisible: false,
+      brushSettings: {
+        type: BrushShape.Arc,
+        size: 20,
+        opacity: 0.7,
+        hardness: 1,
+        stepSize: 5
+      },
+      zoomRatio: 1,
+      cursorPoint: { x: 100, y: 50 },
+      panOffset: { x: 0, y: 0 }
+    })
   })
 
   describe('opacity', () => {

--- a/src/components/maskeditor/BrushSettingsPanel.test.ts
+++ b/src/components/maskeditor/BrushSettingsPanel.test.ts
@@ -1,35 +1,14 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- shape buttons are unlabeled divs and number inputs have no aria labels */
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { reactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import BrushSettingsPanel from '@/components/maskeditor/BrushSettingsPanel.vue'
 import { BrushShape } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-const initialMock = () => ({
-  brushSettings: reactive({
-    type: BrushShape.Arc,
-    size: 10,
-    opacity: 0.7,
-    hardness: 1,
-    stepSize: 5
-  }),
-  rgbColor: '#FF0000',
-  colorInput: null as HTMLInputElement | null,
-  setBrushSize: vi.fn(),
-  setBrushOpacity: vi.fn(),
-  setBrushHardness: vi.fn(),
-  setBrushStepSize: vi.fn(),
-  resetBrushToDefault: vi.fn()
-})
-
-let mockStore: ReturnType<typeof initialMock>
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(
   import('@/components/maskeditor/controls/SliderControl.vue'),
@@ -72,7 +51,18 @@ const setNumberInput = (input: HTMLInputElement, value: string): void => {
 
 describe('BrushSettingsPanel', () => {
   beforeEach(() => {
-    mockStore = initialMock()
+    mockStore = useMaskEditorStore()
+    mockStore.$patch({
+      brushSettings: {
+        type: BrushShape.Arc,
+        size: 10,
+        opacity: 0.7,
+        hardness: 1,
+        stepSize: 5
+      },
+      rgbColor: '#FF0000',
+      colorInput: null
+    })
   })
 
   describe('brush shape buttons', () => {
@@ -183,7 +173,7 @@ describe('BrushSettingsPanel', () => {
     })
 
     it('should return cached raw slider value when size matches the mapping', async () => {
-      mockStore.setBrushSize.mockImplementation((size: number) => {
+      vi.mocked(mockStore.setBrushSize).mockImplementation((size: number) => {
         mockStore.brushSettings.size = size
       })
       const { container } = renderPanel()

--- a/src/components/maskeditor/ColorSelectSettingsPanel.test.ts
+++ b/src/components/maskeditor/ColorSelectSettingsPanel.test.ts
@@ -1,27 +1,13 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ColorSelectSettingsPanel from '@/components/maskeditor/ColorSelectSettingsPanel.vue'
 import { ColorComparisonMethod } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-const mockStore = vi.hoisted(() => ({
-  colorSelectTolerance: 20,
-  selectionOpacity: 100,
-  colorSelectLivePreview: false,
-  applyWholeImage: false,
-  colorComparisonMethod: 'simple' as ColorComparisonMethod,
-  maskBoundary: false,
-  maskTolerance: 0,
-  setColorSelectTolerance: vi.fn(),
-  setSelectionOpacity: vi.fn(),
-  setMaskTolerance: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(
   import('@/components/maskeditor/controls/SliderControl.vue'),
@@ -83,13 +69,16 @@ const renderPanel = () =>
 
 describe('ColorSelectSettingsPanel', () => {
   beforeEach(() => {
-    mockStore.colorSelectTolerance = 20
-    mockStore.selectionOpacity = 100
-    mockStore.colorSelectLivePreview = false
-    mockStore.applyWholeImage = false
-    mockStore.colorComparisonMethod = ColorComparisonMethod.Simple
-    mockStore.maskBoundary = false
-    mockStore.maskTolerance = 0
+    mockStore = useMaskEditorStore()
+    mockStore.$patch({
+      colorSelectTolerance: 20,
+      selectionOpacity: 100,
+      colorSelectLivePreview: false,
+      applyWholeImage: false,
+      colorComparisonMethod: ColorComparisonMethod.Simple,
+      maskBoundary: false,
+      maskTolerance: 0
+    })
   })
 
   it('should call setColorSelectTolerance when tolerance slider emits', async () => {

--- a/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
+++ b/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
@@ -1,41 +1,19 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- layer rows have unlabeled checkboxes and the blend-mode select has no role-friendly label */
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { reactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type { useToolManager } from '@/composables/maskeditor/useToolManager'
 import ImageLayerSettingsPanel from '@/components/maskeditor/ImageLayerSettingsPanel.vue'
+import type { useToolManager } from '@/composables/maskeditor/useToolManager'
 import { MaskBlendMode, Tools } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
 type ToolManager = ReturnType<typeof useToolManager>
 
-const initialImage = (): { src: string } | null => ({
-  src: 'https://example.com/base.png'
-})
-
-const initialMock = () => {
-  return reactive({
-    maskOpacity: 0.8,
-    maskBlendMode: MaskBlendMode.Black,
-    activeLayer: 'mask',
-    currentTool: Tools.MaskPen,
-    image: initialImage(),
-    maskCanvas: null as HTMLCanvasElement | null,
-    rgbCanvas: null as HTMLCanvasElement | null,
-    imgCanvas: null as HTMLCanvasElement | null,
-    setMaskOpacity: vi.fn()
-  })
-}
-
-let mockStore: ReturnType<typeof initialMock>
+let mockStore: ReturnType<typeof useMaskEditorStore>
 const mockUpdateMaskColor = vi.fn().mockResolvedValue(undefined)
 const mockSetActiveLayer = vi.fn()
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
 
 vi.mock<unknown>(import('@/composables/maskeditor/useCanvasManager'), () => ({
   useCanvasManager: () => ({ updateMaskColor: mockUpdateMaskColor })
@@ -85,7 +63,9 @@ const makeCanvas = (): HTMLCanvasElement => document.createElement('canvas')
 
 describe('ImageLayerSettingsPanel', () => {
   beforeEach(() => {
-    mockStore = initialMock()
+    mockStore = useMaskEditorStore()
+    mockStore.image = new Image()
+    mockStore.image.src = 'https://example.com/base.png'
   })
 
   describe('mask opacity slider', () => {
@@ -273,7 +253,8 @@ describe('ImageLayerSettingsPanel', () => {
 
   describe('base image preview', () => {
     it('should render base image src from store', () => {
-      mockStore.image = { src: 'https://example.com/img.png' }
+      mockStore.image = new Image()
+      mockStore.image.src = 'https://example.com/img.png'
       renderPanel()
       const img = screen.getByAltText('Base layer preview')
 

--- a/src/components/maskeditor/MaskEditorContent.test.ts
+++ b/src/components/maskeditor/MaskEditorContent.test.ts
@@ -1,10 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/vue'
-import { reactive } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-
 import MaskEditorContent from '@/components/maskeditor/MaskEditorContent.vue'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
 const mockKeyboard = vi.hoisted(() => ({
   addListeners: vi.fn(),
@@ -34,32 +35,7 @@ const mockMaskEditorLoader = vi.hoisted(() => ({
   loadFromNode: vi.fn().mockResolvedValue(undefined)
 }))
 
-const mockCanvasHistory = vi.hoisted(() => ({
-  saveInitialState: vi.fn(),
-  clearStates: vi.fn()
-}))
-
-const initialMockStore = () =>
-  reactive({
-    activeLayer: 'mask',
-    maskCanvas: null as HTMLCanvasElement | null,
-    rgbCanvas: null as HTMLCanvasElement | null,
-    imgCanvas: null as HTMLCanvasElement | null,
-    canvasContainer: null as HTMLElement | null,
-    canvasBackground: null as HTMLElement | null,
-    canvasHistory: mockCanvasHistory,
-    resetState: vi.fn()
-  })
-
-let mockStore: ReturnType<typeof initialMockStore>
-
-const mockDataStore = vi.hoisted(() => ({
-  reset: vi.fn()
-}))
-
-const mockDialogStore = vi.hoisted(() => ({
-  closeDialog: vi.fn()
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(import('@/composables/maskeditor/useKeyboard'), () => ({
   useKeyboard: () => mockKeyboard
@@ -79,18 +55,6 @@ vi.mock(import('@/composables/maskeditor/useImageLoader'), () => ({
 
 vi.mock(import('@/composables/maskeditor/useMaskEditorLoader'), () => ({
   useMaskEditorLoader: () => mockMaskEditorLoader
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: () => mockDataStore
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => mockDialogStore
 }))
 
 vi.mock<unknown>(import('@/components/common/LoadingOverlay.vue'), () => ({
@@ -157,7 +121,13 @@ let originalResizeObserver: typeof ResizeObserver | undefined
 
 describe('MaskEditorContent', () => {
   beforeEach(() => {
-    mockStore = initialMockStore()
+    mockStore = useMaskEditorStore()
+    vi.spyOn(mockStore.canvasHistory, 'saveInitialState').mockImplementation(
+      () => {}
+    )
+    vi.spyOn(mockStore.canvasHistory, 'clearStates').mockImplementation(
+      () => {}
+    )
     mockMaskEditorLoader.loadFromNode.mockResolvedValue(undefined)
     mockImageLoader.loadImages.mockResolvedValue({ width: 100, height: 100 })
     mockPanZoom.initializeCanvasPanZoom.mockResolvedValue(undefined)
@@ -221,11 +191,11 @@ describe('MaskEditorContent', () => {
         orderOf(mockPanZoom.initializeCanvasPanZoom)
       )
       expect(orderOf(mockPanZoom.initializeCanvasPanZoom)).toBeLessThan(
-        orderOf(mockCanvasHistory.saveInitialState)
+        orderOf(vi.mocked(mockStore.canvasHistory).saveInitialState)
       )
-      expect(orderOf(mockCanvasHistory.saveInitialState)).toBeLessThan(
-        orderOf(mockBrushDrawing.initGPUResources)
-      )
+      expect(
+        orderOf(vi.mocked(mockStore.canvasHistory).saveInitialState)
+      ).toBeLessThan(orderOf(mockBrushDrawing.initGPUResources))
       expect(orderOf(mockBrushDrawing.initGPUResources)).toBeLessThan(
         orderOf(mockBrushDrawing.initPreviewCanvas)
       )
@@ -274,7 +244,7 @@ describe('MaskEditorContent', () => {
       renderContent()
 
       await waitFor(() => {
-        expect(mockDialogStore.closeDialog).toHaveBeenCalledTimes(1)
+        expect(useDialogStore().closeDialog).toHaveBeenCalledTimes(1)
       })
       expect(errorSpy).toHaveBeenCalledWith(
         '[MaskEditorContent] Initialization failed:',
@@ -292,7 +262,7 @@ describe('MaskEditorContent', () => {
       renderContent()
 
       await waitFor(() => {
-        expect(mockDialogStore.closeDialog).toHaveBeenCalledTimes(1)
+        expect(useDialogStore().closeDialog).toHaveBeenCalledTimes(1)
       })
       expect(errorSpy).toHaveBeenCalledWith(
         '[MaskEditorContent] Initialization failed:',
@@ -344,9 +314,11 @@ describe('MaskEditorContent', () => {
 
       expect(mockBrushDrawing.saveBrushSettings).toHaveBeenCalledTimes(1)
       expect(mockKeyboard.removeListeners).toHaveBeenCalledTimes(1)
-      expect(mockCanvasHistory.clearStates).toHaveBeenCalledTimes(1)
+      expect(
+        vi.mocked(mockStore.canvasHistory).clearStates
+      ).toHaveBeenCalledTimes(1)
       expect(mockStore.resetState).toHaveBeenCalledTimes(1)
-      expect(mockDataStore.reset).toHaveBeenCalledTimes(1)
+      expect(useMaskEditorDataStore().reset).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/maskeditor/PaintBucketSettingsPanel.test.ts
+++ b/src/components/maskeditor/PaintBucketSettingsPanel.test.ts
@@ -1,20 +1,12 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import PaintBucketSettingsPanel from '@/components/maskeditor/PaintBucketSettingsPanel.vue'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-const mockStore = vi.hoisted(() => ({
-  paintBucketTolerance: 5,
-  fillOpacity: 100,
-  setPaintBucketTolerance: vi.fn(),
-  setFillOpacity: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(
   import('@/components/maskeditor/controls/SliderControl.vue'),
@@ -47,8 +39,8 @@ const renderPanel = () =>
 
 describe('PaintBucketSettingsPanel', () => {
   beforeEach(() => {
-    mockStore.paintBucketTolerance = 5
-    mockStore.fillOpacity = 100
+    mockStore = useMaskEditorStore()
+    mockStore.$patch({ paintBucketTolerance: 5, fillOpacity: 100 })
   })
 
   it('should bind tolerance slider to store value', () => {

--- a/src/components/maskeditor/PointerZone.test.ts
+++ b/src/components/maskeditor/PointerZone.test.ts
@@ -1,23 +1,16 @@
 import { render, screen } from '@testing-library/vue'
-import { reactive, nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-import type { usePanAndZoom } from '@/composables/maskeditor/usePanAndZoom'
-import type { useToolManager } from '@/composables/maskeditor/useToolManager'
+import { nextTick } from 'vue'
 
 import PointerZone from '@/components/maskeditor/PointerZone.vue'
+import type { usePanAndZoom } from '@/composables/maskeditor/usePanAndZoom'
+import type { useToolManager } from '@/composables/maskeditor/useToolManager'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
 type ToolManager = ReturnType<typeof useToolManager>
 type PanZoom = ReturnType<typeof usePanAndZoom>
 
-const initialMock = () =>
-  reactive({
-    pointerZone: null as HTMLElement | null,
-    isPanning: false,
-    brushVisible: true
-  })
-
-let mockStore: ReturnType<typeof initialMock>
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 const mockToolManager = vi.hoisted(() => ({
   handlePointerDown: vi.fn().mockResolvedValue(undefined),
@@ -34,10 +27,6 @@ const mockPanZoom = vi.hoisted(() => ({
   updateCursorPosition: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
-
 const renderZone = () =>
   render(PointerZone, {
     props: {
@@ -51,7 +40,7 @@ const getZone = (): HTMLDivElement =>
 
 describe('PointerZone', () => {
   beforeEach(() => {
-    mockStore = initialMock()
+    mockStore = useMaskEditorStore()
   })
 
   describe('mount', () => {

--- a/src/components/maskeditor/SettingsPanelContainer.test.ts
+++ b/src/components/maskeditor/SettingsPanelContainer.test.ts
@@ -3,14 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SettingsPanelContainer from '@/components/maskeditor/SettingsPanelContainer.vue'
 import { Tools } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-const mockStore = vi.hoisted(() => ({
-  currentTool: 'pen' as Tools
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(
   import('@/components/maskeditor/BrushSettingsPanel.vue'),
@@ -44,6 +39,7 @@ vi.mock<unknown>(
 
 describe('SettingsPanelContainer', () => {
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
     mockStore.currentTool = Tools.MaskPen
   })
 

--- a/src/components/maskeditor/ToolPanel.test.ts
+++ b/src/components/maskeditor/ToolPanel.test.ts
@@ -1,29 +1,16 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { reactive } from 'vue'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
-import type { useToolManager } from '@/composables/maskeditor/useToolManager'
-
 import ToolPanel from '@/components/maskeditor/ToolPanel.vue'
+import type { useToolManager } from '@/composables/maskeditor/useToolManager'
 import { Tools, allTools } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
 type ToolManager = ReturnType<typeof useToolManager>
 
-const initialMock = () =>
-  reactive({
-    currentTool: Tools.MaskPen,
-    displayZoomRatio: 1,
-    image: null as { width: number; height: number } | null,
-    resetZoom: vi.fn()
-  })
-
-let mockStore: ReturnType<typeof initialMock>
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 const i18n = createI18n({
   legacy: false,
@@ -56,7 +43,12 @@ const getToolButton = (tool: Tools): HTMLElement => {
 
 describe('ToolPanel', () => {
   beforeEach(() => {
-    mockStore = initialMock()
+    mockStore = useMaskEditorStore()
+    mockStore.$patch({
+      currentTool: Tools.MaskPen,
+      displayZoomRatio: 1,
+      image: null
+    })
   })
 
   describe('tool list rendering', () => {
@@ -119,7 +111,7 @@ describe('ToolPanel', () => {
     })
 
     it('should render image dimensions when an image is loaded', () => {
-      mockStore.image = { width: 800, height: 600 }
+      mockStore.image = new Image(800, 600)
       renderPanel()
 
       expect(screen.getByTestId('zoom-dimensions').textContent).toBe('800x600')

--- a/src/components/maskeditor/dialog/TopBarHeader.test.ts
+++ b/src/components/maskeditor/dialog/TopBarHeader.test.ts
@@ -1,28 +1,13 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { reactive } from 'vue'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import TopBarHeader from '@/components/maskeditor/dialog/TopBarHeader.vue'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-const mockCanvasHistory = vi.hoisted(() => ({
-  undo: vi.fn(),
-  redo: vi.fn()
-}))
-
-const initialMock = () =>
-  reactive({
-    canvasHistory: mockCanvasHistory,
-    brushVisible: true,
-    triggerClear: vi.fn()
-  })
-
-let mockStore: ReturnType<typeof initialMock>
-
-const mockDialogStore = vi.hoisted(() => ({
-  closeDialog: vi.fn()
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 const mockCanvasTools = vi.hoisted(() => ({
   invertMask: vi.fn(),
@@ -38,14 +23,6 @@ const mockCanvasTransform = vi.hoisted(() => ({
 
 const mockSaver = vi.hoisted(() => ({
   save: vi.fn().mockResolvedValue(undefined)
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: () => mockStore
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => mockDialogStore
 }))
 
 vi.mock<unknown>(import('@/composables/maskeditor/useCanvasTools'), () => ({
@@ -98,7 +75,9 @@ const renderHeader = () => render(TopBarHeader, { global: { plugins: [i18n] } })
 
 describe('TopBarHeader', () => {
   beforeEach(() => {
-    mockStore = initialMock()
+    mockStore = useMaskEditorStore()
+    vi.spyOn(mockStore.canvasHistory, 'undo').mockImplementation(() => {})
+    vi.spyOn(mockStore.canvasHistory, 'redo').mockImplementation(() => {})
   })
 
   describe('title', () => {
@@ -115,7 +94,7 @@ describe('TopBarHeader', () => {
 
       await user.click(screen.getByRole('button', { name: 'Undo' }))
 
-      expect(mockCanvasHistory.undo).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(mockStore.canvasHistory).undo).toHaveBeenCalledTimes(1)
     })
 
     it('should call canvasHistory.redo when redo button is clicked', async () => {
@@ -124,7 +103,7 @@ describe('TopBarHeader', () => {
 
       await user.click(screen.getByRole('button', { name: 'Redo' }))
 
-      expect(mockCanvasHistory.redo).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(mockStore.canvasHistory).redo).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -201,7 +180,7 @@ describe('TopBarHeader', () => {
 
       expect(mockStore.brushVisible).toBe(false)
       expect(mockSaver.save).toHaveBeenCalledTimes(1)
-      expect(mockDialogStore.closeDialog).toHaveBeenCalledTimes(1)
+      expect(useDialogStore().closeDialog).toHaveBeenCalledTimes(1)
     })
 
     it('should switch the button text to "Saving" and disable the button while saving', async () => {
@@ -237,7 +216,7 @@ describe('TopBarHeader', () => {
         '[TopBarHeader] Save failed:',
         expect.any(Error)
       )
-      expect(mockDialogStore.closeDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
       // After failure, the Save button reads "Save" again (not "Saving")
       expect(
         screen.getByRole('button', { name: /save/i }).textContent.trim()
@@ -253,7 +232,7 @@ describe('TopBarHeader', () => {
 
       await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
-      expect(mockDialogStore.closeDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'global-mask-editor'
       })
     })

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/components/queue/JobHistoryActionsMenu.test.ts
+++ b/src/components/queue/JobHistoryActionsMenu.test.ts
@@ -1,40 +1,18 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import JobHistoryActionsMenu from '@/components/queue/JobHistoryActionsMenu.vue'
 import { popoverCloseSpy } from '@/components/ui/__mocks__/popoverMockState'
 import { i18n } from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 vi.mock(import('@/components/ui/Popover.vue'))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
-
-const mockGetSetting = vi.fn<(key: string) => boolean | undefined>((key) =>
-  key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-    ? true
-    : undefined
-)
-const mockSetSetting = vi.fn()
-const mockSetMany = vi.fn()
-const mockSidebarTabStore = {
-  activeSidebarTabId: null as string | null
-}
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting,
-    set: mockSetSetting,
-    setMany: mockSetMany
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => mockSidebarTabStore
-}))
-
-import JobHistoryActionsMenu from '@/components/queue/JobHistoryActionsMenu.vue'
 
 const renderMenu = () =>
   render(JobHistoryActionsMenu, {
@@ -47,12 +25,15 @@ const renderMenu = () =>
 describe('JobHistoryActionsMenu', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    mockSidebarTabStore.activeSidebarTabId = null
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-        ? true
-        : undefined
-    )
+    useSidebarTabStore().activeSidebarTabId = null
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.Queue.QPOV2': true,
+        'Comfy.Queue.ShowRunProgressBar': true
+      }
+    })
+    vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+    vi.mocked(useSettingStore().setMany).mockResolvedValue(undefined)
   })
 
   it('toggles show run progress bar setting from the menu', async () => {
@@ -62,8 +43,8 @@ describe('JobHistoryActionsMenu', () => {
 
     await user.click(screen.getByTestId('show-run-progress-bar-action'))
 
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith(
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
       'Comfy.Queue.ShowRunProgressBar',
       false
     )
@@ -71,21 +52,20 @@ describe('JobHistoryActionsMenu', () => {
 
   it('opens docked job history sidebar when enabling from the menu', async () => {
     const user = userEvent.setup()
-    mockGetSetting.mockImplementation((key: string) => {
-      if (key === 'Comfy.Queue.QPOV2') return false
-      if (key === 'Comfy.Queue.ShowRunProgressBar') return true
-      return undefined
-    })
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     renderMenu()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith('Comfy.Queue.QPOV2', true)
-    expect(mockSetMany).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('job-history')
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
+      'Comfy.Queue.QPOV2',
+      true
+    )
+    expect(vi.mocked(useSettingStore().setMany)).not.toHaveBeenCalled()
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('job-history')
   })
 
   it('emits clear history from the menu', async () => {

--- a/src/components/queue/QueueOverlayHeader.test.ts
+++ b/src/components/queue/QueueOverlayHeader.test.ts
@@ -1,37 +1,16 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { popoverCloseSpy } from '@/components/ui/__mocks__/popoverMockState'
+import * as tooltipConfig from '@/composables/useTooltipConfig'
 import { i18n } from '@/i18n'
-
-vi.mock(import('@/components/ui/Popover.vue'))
-
-const mockGetSetting = vi.fn<(key: string) => boolean | undefined>((key) =>
-  key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-    ? true
-    : undefined
-)
-const mockSetSetting = vi.fn()
-const mockSetMany = vi.fn()
-const mockSidebarTabStore = {
-  activeSidebarTabId: null as string | null
-}
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting,
-    set: mockSetSetting,
-    setMany: mockSetMany
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => mockSidebarTabStore
-}))
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 import QueueOverlayHeader from './QueueOverlayHeader.vue'
-import * as tooltipConfig from '@/composables/useTooltipConfig'
+
+vi.mock(import('@/components/ui/Popover.vue'))
 
 const tooltipDirectiveStub = {
   mounted: vi.fn(),
@@ -54,12 +33,15 @@ const renderHeader = (props = {}) =>
 describe('QueueOverlayHeader', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    mockSidebarTabStore.activeSidebarTabId = null
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-        ? true
-        : undefined
-    )
+    useSidebarTabStore().activeSidebarTabId = null
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.Queue.QPOV2': true,
+        'Comfy.Queue.ShowRunProgressBar': true
+      }
+    })
+    vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+    vi.mocked(useSettingStore().setMany).mockResolvedValue(undefined)
   })
 
   it('renders header title', () => {
@@ -112,58 +94,64 @@ describe('QueueOverlayHeader', () => {
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetMany).toHaveBeenCalledTimes(1)
-    expect(mockSetMany).toHaveBeenCalledWith({
+    expect(vi.mocked(useSettingStore().setMany)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().setMany)).toHaveBeenCalledWith({
       'Comfy.Queue.QPOV2': false,
       'Comfy.Queue.History.Expanded': true
     })
-    expect(mockSetSetting).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe(null)
+    expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalled()
+    expect(useSidebarTabStore().activeSidebarTabId).toBe(null)
   })
 
   it('opens docked job history sidebar when enabling from the menu', async () => {
     const user = userEvent.setup()
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? false : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     renderHeader()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith('Comfy.Queue.QPOV2', true)
-    expect(mockSetMany).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('job-history')
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
+      'Comfy.Queue.QPOV2',
+      true
+    )
+    expect(vi.mocked(useSettingStore().setMany)).not.toHaveBeenCalled()
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('job-history')
   })
 
   it('keeps docked target open even when enabling persistence fails', async () => {
     const user = userEvent.setup()
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? false : undefined
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
+    vi.mocked(useSettingStore().set).mockRejectedValueOnce(
+      new Error('persistence failed')
     )
-    mockSetSetting.mockRejectedValueOnce(new Error('persistence failed'))
 
     renderHeader()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith('Comfy.Queue.QPOV2', true)
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('job-history')
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
+      'Comfy.Queue.QPOV2',
+      true
+    )
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('job-history')
   })
 
   it('closes the menu when disabling persistence fails', async () => {
     const user = userEvent.setup()
-    mockSetMany.mockRejectedValueOnce(new Error('persistence failed'))
+    vi.mocked(useSettingStore().setMany).mockRejectedValueOnce(
+      new Error('persistence failed')
+    )
 
     renderHeader()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetMany).toHaveBeenCalledWith({
+    expect(vi.mocked(useSettingStore().setMany)).toHaveBeenCalledWith({
       'Comfy.Queue.QPOV2': false,
       'Comfy.Queue.History.Expanded': true
     })
@@ -176,8 +164,8 @@ describe('QueueOverlayHeader', () => {
 
     await user.click(screen.getByTestId('show-run-progress-bar-action'))
 
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith(
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
       'Comfy.Queue.ShowRunProgressBar',
       false
     )

--- a/src/components/range/WidgetRange.test.ts
+++ b/src/components/range/WidgetRange.test.ts
@@ -1,7 +1,5 @@
-import { render, screen } from '@testing-library/vue'
-import { createNodeLocatorId } from '@/types/nodeIdentification'
-import { toNodeId } from '@/types/nodeId'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 
@@ -9,7 +7,12 @@ import type {
   IWidgetRangeOptions,
   RangeValue
 } from '@/lib/litegraph/src/types/widgets'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetRange from './WidgetRange.vue'
 
 const upstreamHolder = vi.hoisted(() => ({
   ref: null as { value: unknown } | null
@@ -25,16 +28,6 @@ vi.mock<unknown>(import('@/composables/useUpstreamValue'), async () => {
     singleValueExtractor: () => () => undefined
   }
 })
-
-const outputsHolder = vi.hoisted(() => ({
-  nodeOutputs: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => outputsHolder
-}))
-
-import WidgetRange from './WidgetRange.vue'
 
 const RangeEditorStub = defineComponent({
   name: 'RangeEditor',
@@ -96,7 +89,7 @@ function renderWidget(
 describe('WidgetRange', () => {
   beforeEach(() => {
     upstreamHolder.ref = null
-    outputsHolder.nodeOutputs = {}
+    useNodeOutputStore().nodeOutputs = {}
   })
 
   describe('Value pass-through', () => {
@@ -170,7 +163,7 @@ describe('WidgetRange', () => {
     })
 
     it('passes a histogram when node output has a matching histogram entry', () => {
-      outputsHolder.nodeOutputs = {
+      useNodeOutputStore().nodeOutputs = {
         loc1: { histogram_range_w: [1, 2, 3, 4] }
       }
       renderWidget(
@@ -185,7 +178,7 @@ describe('WidgetRange', () => {
     })
 
     it('treats an empty histogram array as null', () => {
-      outputsHolder.nodeOutputs = {
+      useNodeOutputStore().nodeOutputs = {
         loc1: { histogram_range_w: [] }
       }
       renderWidget(

--- a/src/components/rightSidePanel/RightSidePanel.test.ts
+++ b/src/components/rightSidePanel/RightSidePanel.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { markRaw, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -13,13 +12,14 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
-import { getExecutionIdByNode } from '@/utils/graphTraversalUtil'
 import { toNodeId } from '@/types/nodeId'
+import { getExecutionIdByNode } from '@/utils/graphTraversalUtil'
 
 const mockApp = vi.hoisted(() => ({
   isGraphReady: true,
@@ -34,19 +34,6 @@ vi.mock(import('@/composables/graph/useGraphHierarchy'), () => ({
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => undefined
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => {
-      if (key === 'Comfy.RightSidePanel.ShowErrorsTab') return true
-      if (key === 'Comfy.Sidebar.Location') return 'left'
-      if (key === 'Comfy.UseNewMenu') return 'Top'
-      if (key === 'Comfy.RightSidePanel.IsOpen') return true
-      return undefined
-    },
-    set: vi.fn()
-  })
 }))
 
 function createPanelI18n() {
@@ -75,9 +62,16 @@ function renderPanel(
     currentGraph: LGraph
     node: LGraphNode
   },
-  pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+  pinia = getActivePinia()!
 ) {
-  setActivePinia(pinia)
+  useSettingStore().$patch({
+    settingValues: {
+      'Comfy.RightSidePanel.ShowErrorsTab': true,
+      'Comfy.Sidebar.Location': 'left',
+      'Comfy.UseNewMenu': 'Top',
+      'Comfy.RightSidePanel.IsOpen': true
+    }
+  })
 
   const rootGraph = graphContext?.rootGraph ?? new LGraph()
   const currentGraph = graphContext?.currentGraph ?? rootGraph
@@ -181,8 +175,16 @@ describe('RightSidePanel active tab fallback', () => {
   })
 
   it('keeps errors active for a pending subgraph interior node scan', () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
+
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.RightSidePanel.ShowErrorsTab': true,
+        'Comfy.Sidebar.Location': 'left',
+        'Comfy.UseNewMenu': 'Top',
+        'Comfy.RightSidePanel.IsOpen': true
+      }
+    })
     const subgraph = createTestSubgraph()
     const node = new LGraphNode('CheckpointLoaderSimple')
     node.id = toNodeId(7)
@@ -210,9 +212,16 @@ describe('RightSidePanel global parameters tab', () => {
 
   function renderWithNoSelection(
     activeWorkflowPath: string | null,
-    pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    pinia = getActivePinia()!
   ) {
-    setActivePinia(pinia)
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.RightSidePanel.ShowErrorsTab': true,
+        'Comfy.Sidebar.Location': 'left',
+        'Comfy.UseNewMenu': 'Top',
+        'Comfy.RightSidePanel.IsOpen': true
+      }
+    })
     const onTabGlobalParametersSetup = vi.fn()
 
     const rootGraph = new LGraph()

--- a/src/components/rightSidePanel/errors/ErrorNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.test.ts
@@ -1,15 +1,18 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { resolveRunErrorMessage } from '@/platform/errorCatalog/errorMessageResolver'
+import { useCommandStore } from '@/stores/commandStore'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
+import { validationError } from '@/utils/__tests__/nodeErrorHelpers'
+
 import ErrorNodeCard from './ErrorNodeCard.vue'
 import type { ErrorCardData } from './types'
-import { resolveRunErrorMessage } from '@/platform/errorCatalog/errorMessageResolver'
-import { createNodeExecutionId } from '@/types/nodeIdentification'
-import { toNodeId } from '@/types/nodeId'
-import { validationError } from '@/utils/__tests__/nodeErrorHelpers'
 
 const mockGetLogs = vi.fn(() => Promise.resolve('mock server logs'))
 const mockSerialize = vi.fn(() => ({ nodes: [] }))
@@ -41,13 +44,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: vi.fn(() => ({
     trackUiButtonClicked: vi.fn(),
     trackHelpResourceClicked: mockTrackHelpResourceClicked
-  }))
-}))
-
-const mockExecuteCommand = vi.fn()
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => ({
-    execute: mockExecuteCommand
   }))
 }))
 
@@ -413,7 +409,9 @@ describe('ErrorNodeCard.vue', () => {
 
     await user.click(screen.getByRole('button', { name: /Get Help/ }))
 
-    expect(mockExecuteCommand).toHaveBeenCalledWith('Comfy.ContactSupport')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.ContactSupport'
+    )
     expect(mockTrackHelpResourceClicked).toHaveBeenCalledWith(
       expect.objectContaining({
         resource_type: 'help_feedback',

--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -1,10 +1,15 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { MissingPackGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
+import { api } from '@/scripts/api'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+
+import MissingNodeCard from './MissingNodeCard.vue'
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
 vi.mock(import('@/platform/distribution/types'), () => ({
@@ -15,9 +20,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 
 const mockMissingCoreNodes = vi.hoisted(() => ({
   value: {} as Record<string, { type: string }[]>
-}))
-const mockSystemStats = vi.hoisted(() => ({
-  value: null as { system?: { comfyui_version?: string } } | null
 }))
 
 vi.mock<unknown>(
@@ -34,14 +36,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: () => ({
-    get systemStats() {
-      return mockSystemStats.value
-    }
-  })
-}))
-
 const mockApplyChanges = vi.hoisted(() => vi.fn())
 const mockIsRestarting = vi.hoisted(() => ({ value: false }))
 vi.mock<unknown>(
@@ -57,24 +51,14 @@ vi.mock<unknown>(
   })
 )
 
-const mockIsPackInstalled = vi.hoisted(() => vi.fn(() => false))
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: () => ({
-      isPackInstalled: mockIsPackInstalled
-    })
-  })
-)
-
 const mockShouldShowManagerButtons = vi.hoisted(() => ({ value: false }))
 vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useManagerState'),
 
   () => ({
     useManagerState: () => ({
-      shouldShowManagerButtons: mockShouldShowManagerButtons
+      shouldShowManagerButtons: mockShouldShowManagerButtons,
+      isNewManagerUI: { value: false }
     })
   })
 )
@@ -92,8 +76,6 @@ vi.mock<unknown>(import('./MissingPackGroupRow.vue'), () => ({
     emits: ['locate-node', 'open-manager-info']
   }
 }))
-
-import MissingNodeCard from './MissingNodeCard.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -145,7 +127,7 @@ function renderCard(
       ...props
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      plugins: [i18n],
       stubs: {
         DotSpinner: { template: '<span role="status" aria-label="loading" />' }
       }
@@ -155,13 +137,18 @@ function renderCard(
 }
 
 describe('MissingNodeCard', () => {
-  beforeEach(() => {
-    mockIsPackInstalled.mockReturnValue(false)
+  beforeEach(async () => {
+    vi.spyOn(api, 'getSystemStats').mockResolvedValue(
+      fromPartial({ system: {}, devices: [] })
+    )
+    useSystemStatsStore()
+    await useSystemStatsStore().refetchSystemStats()
+    vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
     mockIsCloud.value = false
     mockShouldShowManagerButtons.value = false
     mockIsRestarting.value = false
     mockMissingCoreNodes.value = {}
-    mockSystemStats.value = null
+    useSystemStatsStore().systemStats = null
   })
 
   describe('Rendering & Props', () => {
@@ -216,21 +203,21 @@ describe('MissingNodeCard', () => {
 
     it('hides Apply Changes when manager enabled but no packs pending', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       renderCard()
       expect(screen.queryByText('Apply Changes')).not.toBeInTheDocument()
     })
 
     it('shows Apply Changes when at least one pack is pending restart', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       renderCard()
       expect(screen.getByText('Apply Changes')).toBeInTheDocument()
     })
 
     it('displays spinner during restart', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       mockIsRestarting.value = true
       renderCard()
       expect(screen.getByRole('status')).toBeInTheDocument()
@@ -238,7 +225,7 @@ describe('MissingNodeCard', () => {
 
     it('disables button during restart', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       mockIsRestarting.value = true
       renderCard()
       expect(
@@ -248,7 +235,7 @@ describe('MissingNodeCard', () => {
 
     it('calls applyChanges when Apply Changes button is clicked', async () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       const { user } = renderCard()
       await user.click(screen.getByRole('button', { name: /apply changes/i }))
       expect(mockApplyChanges).toHaveBeenCalledOnce()
@@ -266,7 +253,7 @@ describe('MissingNodeCard', () => {
           onLocateNode
         },
         global: {
-          plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+          plugins: [i18n],
           stubs: {
             DotSpinner: {
               template: '<span role="status" aria-label="loading" />'
@@ -288,7 +275,7 @@ describe('MissingNodeCard', () => {
           onOpenManagerInfo
         },
         global: {
-          plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+          plugins: [i18n],
           stubs: {
             DotSpinner: {
               template: '<span role="status" aria-label="loading" />'
@@ -311,7 +298,9 @@ describe('MissingNodeCard', () => {
       mockMissingCoreNodes.value = {
         '1.2.0': [{ type: 'TestNode' }]
       }
-      mockSystemStats.value = { system: { comfyui_version: '1.0.0' } }
+      useSystemStatsStore().$patch({
+        systemStats: { system: { comfyui_version: '1.0.0' } }
+      })
       const { container } = renderCard()
       expect(container.textContent).toContain('(current: 1.0.0)')
       expect(container.textContent).toContain('Requires ComfyUI 1.2.0:')

--- a/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
+++ b/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
@@ -1,16 +1,18 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { MissingPackGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+
+import MissingPackGroupRow from './MissingPackGroupRow.vue'
 
 const mockInstallAllPacks = vi.fn()
 const mockIsInstalling = ref(false)
-const mockIsPackInstalled = vi.fn(() => false)
+
 const mockShouldShowManagerButtons = { value: false }
 const mockOpenManager = vi.fn()
 const mockMissingNodePacks = ref<Array<{ id: string; name: string }>>([])
@@ -39,20 +41,11 @@ vi.mock<unknown>(
 )
 
 vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: () => ({
-      isPackInstalled: mockIsPackInstalled
-    })
-  })
-)
-
-vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useManagerState'),
 
   () => ({
     useManagerState: () => ({
+      isNewManagerUI: { value: false },
       shouldShowManagerButtons: mockShouldShowManagerButtons,
       openManager: mockOpenManager
     })
@@ -66,8 +59,6 @@ vi.mock<unknown>(
     ManagerTab: { Missing: 'missing', All: 'all' }
   })
 )
-
-import MissingPackGroupRow from './MissingPackGroupRow.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -128,7 +119,7 @@ function renderRow(
       ...props
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue, i18n],
+      plugins: [PrimeVue, i18n],
       stubs: {
         DotSpinner: {
           template: '<span role="status" aria-label="loading" />'
@@ -141,7 +132,7 @@ function renderRow(
 
 describe('MissingPackGroupRow', () => {
   beforeEach(() => {
-    mockIsPackInstalled.mockReturnValue(false)
+    vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
     mockShouldShowManagerButtons.value = false
     mockIsInstalling.value = false
     mockMissingNodePacks.value = []
@@ -355,7 +346,7 @@ describe('MissingPackGroupRow', () => {
 
     it('shows Search when packId exists but pack not in registry', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       mockMissingNodePacks.value = []
       renderRow()
       expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument()
@@ -363,7 +354,7 @@ describe('MissingPackGroupRow', () => {
 
     it('shows "Installed" state when pack is installed', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       mockMissingNodePacks.value = [{ id: 'my-pack', name: 'My Pack' }]
       renderRow()
       expect(screen.getByText('Installed')).toBeInTheDocument()
@@ -379,7 +370,7 @@ describe('MissingPackGroupRow', () => {
 
     it('shows install button when not installed and pack found', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       mockMissingNodePacks.value = [{ id: 'my-pack', name: 'My Pack' }]
       renderRow()
       expect(
@@ -389,7 +380,7 @@ describe('MissingPackGroupRow', () => {
 
     it('calls installAllPacks when Install button is clicked', async () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       mockMissingNodePacks.value = [{ id: 'my-pack', name: 'My Pack' }]
       const { user } = renderRow()
       await user.click(screen.getByRole('button', { name: 'Install' }))

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -1,7 +1,7 @@
-import { createTestingPinia } from '@pinia/testing'
-import type { TestingPinia } from '@pinia/testing'
-import { render, screen, within } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
+import { render, screen, within } from '@testing-library/vue'
 import { fromAny } from '@total-typescript/shoehorn'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,20 +9,31 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import RightSidePanel from '@/components/rightSidePanel/RightSidePanel.vue'
-import { useSettingStore } from '@/platform/settings/settingStore'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
-import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { MissingNodeType } from '@/types/comfy'
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toNodeId } from '@/types/nodeId'
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
 
 import TabErrors from './TabErrors.vue'
+vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useComfyRegistryService: () => ({
+      ...actual.useComfyRegistryService(),
+      inferPackFromNodeName: vi.fn(async () => null),
+      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+    })
+  }
+})
 
 const { mockFocusNode, mockRefreshMissingModels } = vi.hoisted(() => ({
   mockFocusNode: vi.fn(),
@@ -62,17 +73,6 @@ vi.mock<unknown>(import('@/composables/canvas/useFocusNode'), () => ({
   useFocusNode: vi.fn(() => ({
     focusNode: mockFocusNode
   }))
-}))
-
-// Its pack lookup resolves after the test file ends, and the console.warn on a
-// rejection lands while the worker's rpc is closing - an unhandled error that
-// fails the whole run with every test green. Mocked as the sibling suites do.
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: () => ({
-    inferPackFromNodeName: vi.fn(),
-    // TabErrors mounts the node-pack tree, which cancels this on unmount.
-    getPacksByIds: { call: vi.fn().mockResolvedValue([]), cancel: vi.fn() }
-  })
 }))
 
 vi.mock(import('@/platform/missingModel/missingModelDownload'), () => ({
@@ -150,12 +150,9 @@ describe('TabErrors.vue', () => {
     })
   })
 
-  function renderComponent(seed?: (pinia: TestingPinia) => void) {
+  function renderComponent(seed?: (pinia: Pinia) => void) {
     const user = userEvent.setup()
-    const pinia = createTestingPinia({
-      createSpy: vi.fn,
-      stubActions: false
-    })
+    const pinia = getActivePinia()!
     seed?.(pinia)
     render(TabErrors, {
       global: {
@@ -174,11 +171,8 @@ describe('TabErrors.vue', () => {
     return { user }
   }
 
-  function renderRightSidePanel(seed: (pinia: TestingPinia) => void) {
-    const pinia = createTestingPinia({
-      createSpy: vi.fn,
-      stubActions: false
-    })
+  function renderRightSidePanel(seed: (pinia: Pinia) => void) {
+    const pinia = getActivePinia()!
     useSettingStore(pinia).settingValues['Comfy.RightSidePanel.ShowErrorsTab'] =
       true
     seed(pinia)

--- a/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
+++ b/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
@@ -1,8 +1,22 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { nextTick, ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import type { MissingNodeType } from '@/types/comfy'
+
+import { useErrorGroups } from './useErrorGroups'
+vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useComfyRegistryService: () => ({
+      ...actual.useComfyRegistryService(),
+      inferPackFromNodeName: vi.fn(async () => null),
+      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+    })
+  }
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -31,12 +45,6 @@ vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: () => ({
-    inferPackFromNodeName: vi.fn()
-  })
-}))
-
 vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: vi.fn(() => '')
 }))
@@ -44,9 +52,6 @@ vi.mock(import('@/utils/nodeTitleUtil'), () => ({
 vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   isLGraphNode: vi.fn(() => false)
 }))
-
-import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
-import { useErrorGroups } from './useErrorGroups'
 
 function makeMissingNodeType(
   type: string,

--- a/src/components/rightSidePanel/errors/useErrorActions.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorActions.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useCommandStore } from '@/stores/commandStore'
+
 import { useErrorActions } from './useErrorActions'
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
 
 const mocks = vi.hoisted(() => ({
   trackUiButtonClicked: vi.fn(),
   trackHelpResourceClicked: vi.fn(),
-  execute: vi.fn(),
   telemetry: null as {
     trackUiButtonClicked: ReturnType<typeof vi.fn>
     trackHelpResourceClicked: ReturnType<typeof vi.fn>
@@ -13,12 +18,6 @@ const mocks = vi.hoisted(() => ({
   staticUrls: {
     githubIssues: 'https://github.com/Comfy-Org/ComfyUI/issues'
   }
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: mocks.execute
-  })
 }))
 
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
@@ -79,26 +78,37 @@ describe('useErrorActions', () => {
   })
 
   describe('contactSupport', () => {
-    it('tracks the help resource click and executes the contact support command', () => {
-      mocks.execute.mockReturnValue('executed')
+    it('tracks the help resource click and executes the contact support command', async () => {
+      vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
       const { contactSupport } = useErrorActions()
 
-      const result = contactSupport()
+      const result = await contactSupport()
 
       expect(mocks.trackHelpResourceClicked).toHaveBeenCalledWith({
         resource_type: 'help_feedback',
         is_external: true,
         source: 'error_dialog'
       })
-      expect(mocks.execute).toHaveBeenCalledWith('Comfy.ContactSupport')
-      expect(result).toBe('executed')
+      expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+        'Comfy.ContactSupport'
+      )
+      expect(result).toBeUndefined()
     })
 
     it('returns the execute promise when the command is async', async () => {
-      mocks.execute.mockResolvedValue('done')
+      let resolve!: () => void
+      const promise = new Promise<void>((resolvePromise) => {
+        resolve = resolvePromise
+      })
+      vi.mocked(useCommandStore().execute).mockReturnValue(promise)
       const { contactSupport } = useErrorActions()
-
-      await expect(contactSupport()).resolves.toBe('done')
+      const settled = vi.fn()
+      const result = contactSupport().then(settled)
+      await Promise.resolve()
+      expect(settled).not.toHaveBeenCalled()
+      resolve()
+      await result
+      expect(settled).toHaveBeenCalledExactlyOnceWith(undefined)
     })
 
     it('still executes the command when telemetry is unavailable', () => {
@@ -108,7 +118,9 @@ describe('useErrorActions', () => {
       void contactSupport()
 
       expect(mocks.trackHelpResourceClicked).not.toHaveBeenCalled()
-      expect(mocks.execute).toHaveBeenCalledWith('Comfy.ContactSupport')
+      expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+        'Comfy.ContactSupport'
+      )
     })
   })
 

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -1,10 +1,37 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
+import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { createBoundaryLinkedSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { MissingNodeType } from '@/types/comfy'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
 import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
+import {
+  getExecutionIdByNode,
+  getNodeByExecutionId
+} from '@/utils/graphTraversalUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
+
+import { useErrorGroups } from './useErrorGroups'
+
+vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useComfyRegistryService: () => ({
+      ...actual.useComfyRegistryService(),
+      inferPackFromNodeName: vi.fn(async () => null),
+      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+    })
+  }
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -109,12 +136,6 @@ vi.mock<unknown>(import('@/i18n'), () => {
   }
 })
 
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: () => ({
-    inferPackFromNodeName: vi.fn()
-  })
-}))
-
 vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: vi.fn(() => '')
 }))
@@ -129,21 +150,6 @@ vi.mock<unknown>(
     clearMissingModelState: vi.fn()
   })
 )
-
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
-import { isLGraphNode } from '@/utils/litegraphUtil'
-import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
-import { createBoundaryLinkedSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
-import {
-  getExecutionIdByNode,
-  getNodeByExecutionId
-} from '@/utils/graphTraversalUtil'
-import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { useErrorGroups } from './useErrorGroups'
-import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 
 function makeMissingNodeType(
   type: string,

--- a/src/components/rightSidePanel/errors/useErrorReport.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorReport.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
-import type { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
 
 import type { ErrorCardData } from './types'
-import { createNodeExecutionId } from '@/types/nodeIdentification'
 import { useErrorReport } from './useErrorReport'
-import { toNodeId } from '@/types/nodeId'
 
 async function flushPromises() {
   await new Promise((resolve) => setTimeout(resolve, 0))
@@ -18,22 +18,14 @@ const mocks = vi.hoisted(() => {
   return {
     getLogs: vi.fn(),
     serialize: vi.fn(),
-    refetchSystemStats: vi.fn(),
     generateErrorReport: vi.fn()
-  }
-})
-
-const storeState = vi.hoisted(() => {
-  // Plain objects wired up in beforeEach. Tests use setStoreState to swap values.
-  return {
-    systemStats: null,
-    isLoading: false
   }
 })
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
-    getLogs: mocks.getLogs
+    getLogs: mocks.getLogs,
+    getSystemStats: vi.fn(async () => sampleSystemStats)
   }
 }))
 
@@ -49,46 +41,6 @@ vi.mock(import('@/utils/errorReportUtil'), () => ({
   generateErrorReport: mocks.generateErrorReport
 }))
 
-vi.mock<unknown>(import('@/stores/systemStatsStore'), async () => {
-  const { ref: vueRef } = await import('vue')
-  const systemStatsRef = vueRef<unknown>(null)
-  const isLoadingRef = vueRef(false)
-
-  return {
-    useSystemStatsStore: () => ({
-      get systemStats() {
-        return systemStatsRef.value
-      },
-      set systemStats(value: unknown) {
-        systemStatsRef.value = value
-      },
-      get isLoading() {
-        return isLoadingRef.value
-      },
-      set isLoading(value: boolean) {
-        isLoadingRef.value = value
-      },
-      refetchSystemStats: mocks.refetchSystemStats,
-      __setSystemStats(value: unknown) {
-        systemStatsRef.value = value
-      },
-      __setIsLoading(value: boolean) {
-        isLoadingRef.value = value
-      }
-    })
-  }
-})
-
-type TestStore = ReturnType<typeof useSystemStatsStore> & {
-  __setSystemStats: (value: unknown) => void
-  __setIsLoading: (value: boolean) => void
-}
-
-async function getStore(): Promise<TestStore> {
-  const mod = await import('@/stores/systemStatsStore')
-  return mod.useSystemStatsStore() as unknown as TestStore
-}
-
 const sampleSystemStats = {
   system: {
     os: 'Linux',
@@ -96,7 +48,9 @@ const sampleSystemStats = {
     argv: [],
     python_version: '3.11',
     embedded_python: false,
-    pytorch_version: '2.3.0'
+    pytorch_version: '2.3.0',
+    ram_total: 16000000000,
+    ram_free: 8000000000
   },
   devices: []
 }
@@ -115,11 +69,10 @@ describe('useErrorReport', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(async () => {
-    storeState.systemStats = null
-    storeState.isLoading = false
-    const store = await getStore()
-    store.__setSystemStats(null)
-    store.__setIsLoading(false)
+    const store = useSystemStatsStore()
+    await flushPromises()
+    store.systemStats = null
+    store.isLoading = false
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -141,8 +94,8 @@ describe('useErrorReport', () => {
   })
 
   it('enriches each runtime error with a generated report when systemStats is present', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('server logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(
@@ -202,8 +155,8 @@ describe('useErrorReport', () => {
   })
 
   it('awaits the systemStats loading flag before proceeding', async () => {
-    const store = await getStore()
-    store.__setIsLoading(true)
+    const store = useSystemStatsStore()
+    store.isLoading = true
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockReturnValue('report')
@@ -218,8 +171,8 @@ describe('useErrorReport', () => {
     expect(mocks.getLogs).not.toHaveBeenCalled()
     expect(displayedDetailsMap.value).toEqual({ 0: 'trace' })
 
-    store.__setSystemStats(sampleSystemStats)
-    store.__setIsLoading(false)
+    store.systemStats = sampleSystemStats
+    store.isLoading = false
     await flushPromises()
 
     expect(mocks.getLogs).toHaveBeenCalledTimes(1)
@@ -227,10 +180,13 @@ describe('useErrorReport', () => {
   })
 
   it('calls refetchSystemStats when not loading and stats are missing', async () => {
-    const store = await getStore()
-    mocks.refetchSystemStats.mockImplementation(async () => {
-      store.__setSystemStats(sampleSystemStats)
-    })
+    const store = useSystemStatsStore()
+    vi.mocked(useSystemStatsStore().refetchSystemStats).mockImplementation(
+      async () => {
+        store.systemStats = sampleSystemStats
+        return sampleSystemStats
+      }
+    )
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockReturnValue('report')
@@ -242,12 +198,16 @@ describe('useErrorReport', () => {
     useErrorReport(card)
     await flushPromises()
 
-    expect(mocks.refetchSystemStats).toHaveBeenCalledTimes(1)
+    expect(
+      vi.mocked(useSystemStatsStore().refetchSystemStats)
+    ).toHaveBeenCalledTimes(1)
     expect(mocks.generateErrorReport).toHaveBeenCalledTimes(1)
   })
 
   it('returns early and warns when refetchSystemStats throws', async () => {
-    mocks.refetchSystemStats.mockRejectedValue(new Error('boom'))
+    vi.mocked(useSystemStatsStore().refetchSystemStats).mockRejectedValue(
+      new Error('boom')
+    )
     mocks.getLogs.mockResolvedValue('logs')
 
     const card = makeCard({
@@ -257,15 +217,17 @@ describe('useErrorReport', () => {
     useErrorReport(card)
     await flushPromises()
 
-    expect(mocks.refetchSystemStats).toHaveBeenCalledTimes(1)
+    expect(
+      vi.mocked(useSystemStatsStore().refetchSystemStats)
+    ).toHaveBeenCalledTimes(1)
     expect(mocks.getLogs).not.toHaveBeenCalled()
     expect(mocks.generateErrorReport).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalled()
   })
 
   it('returns early and warns when workflow serialization throws', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockImplementation(() => {
       throw new Error('serialize failed')
@@ -284,8 +246,8 @@ describe('useErrorReport', () => {
   })
 
   it('falls back to original error.details when generateErrorReport throws', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(() => {
@@ -306,8 +268,8 @@ describe('useErrorReport', () => {
   })
 
   it('re-enriches and clears stale enriched details when the card ref changes', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(
@@ -340,8 +302,8 @@ describe('useErrorReport', () => {
   })
 
   it('drops stale results when the card changes mid-flight', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(
       ({ exceptionMessage }: { exceptionMessage: string }) =>

--- a/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -13,41 +14,22 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { toNodeId } from '@/types/nodeId'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
 import { getExecutionIdByNode } from '@/utils/graphTraversalUtil'
 
 import SectionWidgets from './SectionWidgets.vue'
 
-const { mockGetInputSpecForWidget, mockTrackUiButtonClicked } = vi.hoisted(
-  () => ({
-    mockGetInputSpecForWidget: vi.fn(),
-    mockTrackUiButtonClicked: vi.fn()
-  })
-)
+const { mockTrackUiButtonClicked } = vi.hoisted(() => ({
+  mockTrackUiButtonClicked: vi.fn()
+}))
 
 const setDirty = vi.fn()
 const getNodeById = vi.fn()
 const animateToBounds = vi.fn()
-const selectedItems: unknown[] = []
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { setDirty, graph: { getNodeById }, animateToBounds },
-      selectedItems
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    getInputSpecForWidget: mockGetInputSpecForWidget
-  })
-}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -139,7 +121,11 @@ function createHostWithPromotedModel(): {
 
 describe('SectionWidgets', () => {
   beforeEach(() => {
-    selectedItems.length = 0
+    useCanvasStore().canvas = fromPartial({
+      setDirty,
+      graph: fromPartial({ getNodeById }),
+      animateToBounds
+    })
   })
 
   it('clears promoted widget validation by source and missing model by host', async () => {
@@ -262,7 +248,8 @@ describe('SectionWidgets', () => {
 
   it('tracks and resets all widgets when the Reset all button is clicked', async () => {
     const { node, widget } = createSimpleNodeWithWidget()
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: widget.name,
       type: 'COMBO',
       default: 'default_model.safetensors'
     })

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -1,58 +1,29 @@
-import { render, screen } from '@testing-library/vue'
-import { createTestingPinia } from '@pinia/testing'
 import userEvent from '@testing-library/user-event'
-import { fromAny } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial, fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Slots } from 'vue'
 import { h } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { promoteWidget } from '@/core/graph/subgraph/promotionUtils'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { useFavoritedWidgetsStore } from '@/stores/workspace/favoritedWidgetsStore'
 import { widgetId } from '@/types/widgetId'
+
 import WidgetActions from './WidgetActions.vue'
 
-const {
-  mockGetInputSpecForWidget,
-  mockIsFavorited,
-  mockToggleFavorite,
-  mockTrackWidgetFavoriteToggled
-} = vi.hoisted(() => ({
-  mockGetInputSpecForWidget: vi.fn(),
-  mockIsFavorited: vi.fn().mockReturnValue(false),
-  mockToggleFavorite: vi.fn(),
+const { mockTrackWidgetFavoriteToggled } = vi.hoisted(() => ({
   mockTrackWidgetFavoriteToggled: vi.fn()
 }))
 
 vi.mock(import('@/core/graph/subgraph/promotionUtils'), () => ({
   promoteWidget: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    getInputSpecForWidget: mockGetInputSpecForWidget
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { setDirty: vi.fn() }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/favoritedWidgetsStore'), () => ({
-  useFavoritedWidgetsStore: () => ({
-    isFavorited: mockIsFavorited,
-    toggleFavorite: mockToggleFavorite
-  })
 }))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -93,9 +64,13 @@ const i18n = createI18n({
 
 describe('WidgetActions', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    mockIsFavorited.mockReturnValue(false)
-    mockGetInputSpecForWidget.mockReturnValue({
+    useCanvasStore().canvas = fromPartial({ setDirty: vi.fn() })
+    vi.mocked(useFavoritedWidgetsStore().toggleFavorite).mockImplementation(
+      () => {}
+    )
+    vi.mocked(useFavoritedWidgetsStore().isFavorited).mockReturnValue(false)
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'INT',
       default: 42
     })
@@ -195,7 +170,8 @@ describe('WidgetActions', () => {
   })
 
   it('does not show reset button when no default value exists', () => {
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'CUSTOM'
     })
 
@@ -210,7 +186,8 @@ describe('WidgetActions', () => {
   })
 
   it('uses fallback default for INT type without explicit default', async () => {
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'INT'
     })
 
@@ -225,7 +202,8 @@ describe('WidgetActions', () => {
   })
 
   it('uses first option as default for combo without explicit default', async () => {
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'COMBO',
       options: ['option1', 'option2', 'option3']
     })
@@ -241,7 +219,7 @@ describe('WidgetActions', () => {
   })
 
   it('tracks widget favorite toggled with is_favorited true when favoriting', async () => {
-    mockIsFavorited.mockReturnValue(false)
+    vi.mocked(useFavoritedWidgetsStore().isFavorited).mockReturnValue(false)
 
     const widget = createMockWidget()
     const node = createMockNode()
@@ -257,14 +235,13 @@ describe('WidgetActions', () => {
       is_favorited: true,
       source: 'right_side_panel'
     })
-    expect(mockToggleFavorite).toHaveBeenCalledExactlyOnceWith(
-      node,
-      'test_widget'
-    )
+    expect(
+      vi.mocked(useFavoritedWidgetsStore().toggleFavorite)
+    ).toHaveBeenCalledExactlyOnceWith(node, 'test_widget')
   })
 
   it('tracks widget favorite toggled with is_favorited false when unfavoriting', async () => {
-    mockIsFavorited.mockReturnValue(true)
+    vi.mocked(useFavoritedWidgetsStore().isFavorited).mockReturnValue(true)
 
     const widget = createMockWidget()
     const node = createMockNode()
@@ -332,6 +309,8 @@ describe('WidgetActions', () => {
 
     await user.click(screen.getByRole('button', { name: /Favorite/ }))
 
-    expect(mockToggleFavorite).toHaveBeenCalledWith(node, 'test_widget')
+    expect(
+      vi.mocked(useFavoritedWidgetsStore().toggleFavorite)
+    ).toHaveBeenCalledWith(node, 'test_widget')
   })
 })

--- a/src/components/rightSidePanel/parameters/WidgetItem.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetItem.test.ts
@@ -1,51 +1,33 @@
 import { render } from '@testing-library/vue'
-import { fromAny } from '@total-typescript/shoehorn'
+import { fromPartial, fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLinkStore } from '@/stores/linkStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
-import { widgetId } from '@/types/widgetId'
-import WidgetItem from './WidgetItem.vue'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 
-const { mockGetInputSpecForWidget, StubWidgetComponent } = vi.hoisted(() => ({
-  mockGetInputSpecForWidget: vi.fn(),
+import WidgetItem from './WidgetItem.vue'
+
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({ setDirty: vi.fn() })
+})
+
+const { StubWidgetComponent } = vi.hoisted(() => ({
   StubWidgetComponent: {
     name: 'StubWidget',
     props: ['widget', 'modelValue', 'nodeId', 'nodeType'],
     template:
       '<div class="stub-widget" :data-widget-options="JSON.stringify(widget?.options)" :data-widget-type="widget?.type" :data-widget-name="widget?.name" :data-widget-value="String(widget?.value)" />'
   }
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    getInputSpecForWidget: mockGetInputSpecForWidget
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { setDirty: vi.fn() }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/favoritedWidgetsStore'), () => ({
-  useFavoritedWidgetsStore: () => ({
-    isFavorited: vi.fn().mockReturnValue(false),
-    toggleFavorite: vi.fn()
-  })
 }))
 
 vi.mock(

--- a/src/components/searchbox/v2/NodeSearchInput.test.ts
+++ b/src/components/searchbox/v2/NodeSearchInput.test.ts
@@ -1,12 +1,12 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import NodeSearchInput from '@/components/searchbox/v2/NodeSearchInput.vue'
 import {
   setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
+import NodeSearchInput from '@/components/searchbox/v2/NodeSearchInput.vue'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type { FuseFilter, FuseFilterWithValue } from '@/utils/fuseUtil'
 
@@ -14,17 +14,6 @@ vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   getLinkTypeColor: vi.fn((type: string) =>
     type === 'IMAGE' ? '#64b5f6' : undefined
   )
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.NodeLibrary.Bookmarks.V2') return []
-      if (key === 'Comfy.NodeLibrary.BookmarksCustomization') return {}
-      return undefined
-    }),
-    set: vi.fn()
-  }))
 }))
 
 function createFilter(

--- a/src/components/sidebar/SideToolbar.test.ts
+++ b/src/components/sidebar/SideToolbar.test.ts
@@ -1,76 +1,42 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
-import SideToolbar from './SideToolbar.vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useUserStore } from '@/stores/userStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
 
-interface TestTab {
-  id: string
-  icon: string
-  tooltip: string
-  label: string
-  title: string
-}
+import SideToolbar from './SideToolbar.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
+
+beforeEach(() => {
+  useSettingStore().$patch({
+    settingValues: {
+      'Comfy.Sidebar.Size': 'normal',
+      'Comfy.Sidebar.Location': 'left'
+    }
+  })
+  useCommandStore().registerCommand({
+    id: 'Workspace.ToggleSidebarTab.assets',
+    function: spies.toggleAssets
+  })
+})
 
 const spies = vi.hoisted(() => ({
   trackUiButtonClicked: vi.fn(),
   toggleAssets: vi.fn()
 }))
 
-const state = vi.hoisted(() => ({
-  isMultiUserServer: false,
-  sidebarTabs: [] as TestTab[],
-  activeSidebarTab: null as { id: string } | null
-}))
-
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false,
   isDesktop: false,
   isNightly: false
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    getSidebarTabs: () => state.sidebarTabs,
-    sidebarTab: { activeSidebarTab: state.activeSidebarTab }
-  })
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => {
-      if (key === 'Comfy.Sidebar.Size') return 'large'
-      if (key === 'Comfy.Sidebar.Location') return 'left'
-      return 'floating'
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/userStore'), () => ({
-  useUserStore: () => ({ isMultiUserServer: state.isMultiUserServer })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    commands: [
-      { id: 'Workspace.ToggleSidebarTab.assets', function: spies.toggleAssets }
-    ]
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({ canvas: null })
-  })
-)
-
-vi.mock<unknown>(import('@/platform/keybindings/keybindingStore'), () => ({
-  useKeybindingStore: () => ({ getKeybindingByCommandId: () => undefined })
 }))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -109,7 +75,9 @@ function renderToolbar(props: SideToolbarProps = {}) {
   })
 }
 
-const assetsTab: TestTab = {
+const assetsTab: SidebarTabExtension = {
+  type: 'custom',
+  render: () => {},
   id: 'assets',
   icon: 'pi pi-image',
   tooltip: 'Assets',
@@ -117,7 +85,9 @@ const assetsTab: TestTab = {
   title: 'Assets'
 }
 
-const workflowsTab: TestTab = {
+const workflowsTab: SidebarTabExtension = {
+  type: 'custom',
+  render: () => {},
   id: 'workflows',
   icon: 'pi pi-folder',
   tooltip: 'Workflows',
@@ -127,9 +97,9 @@ const workflowsTab: TestTab = {
 
 describe('SideToolbar', () => {
   beforeEach(() => {
-    state.isMultiUserServer = false
-    state.sidebarTabs = [assetsTab, workflowsTab]
-    state.activeSidebarTab = null
+    Object.assign(useUserStore(), { isMultiUserServer: false })
+    useSidebarTabStore().sidebarTabs = [assetsTab, workflowsTab]
+    useSidebarTabStore().activeSidebarTabId = null
   })
 
   it('renders only the tabs listed in visibleTabIds', () => {
@@ -190,7 +160,7 @@ describe('SideToolbar', () => {
     expect(screen.queryByTestId('logout')).not.toBeInTheDocument()
     unmount()
 
-    state.isMultiUserServer = true
+    Object.assign(useUserStore(), { isMultiUserServer: true })
     renderToolbar()
     expect(screen.getByTestId('logout')).toBeInTheDocument()
   })

--- a/src/components/sidebar/SidebarHelpCenterIcon.test.ts
+++ b/src/components/sidebar/SidebarHelpCenterIcon.test.ts
@@ -1,9 +1,16 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+
 import SidebarHelpCenterIcon from './SidebarHelpCenterIcon.vue'
+
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+})
 
 const typeformState = vi.hoisted(() => ({
   typeformError: false,
@@ -11,8 +18,6 @@ const typeformState = vi.hoisted(() => ({
 }))
 
 const embedSpy = vi.hoisted(() => vi.fn())
-
-const canvasState = vi.hoisted(() => ({ linearMode: true }))
 
 const helpCenterSpies = vi.hoisted(() => ({ toggleHelpCenter: vi.fn() }))
 
@@ -40,22 +45,6 @@ vi.mock<unknown>(import('@/composables/useHelpCenter'), async () => {
     })
   }
 })
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => 'left' })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  async () => {
-    const { computed, reactive } = await import('vue')
-    return {
-      useCanvasStore: () =>
-        reactive({ linearMode: computed(() => canvasState.linearMode) })
-    }
-  }
-)
 
 const FEEDBACK_LOAD_ERROR =
   'Failed to load feedback form. Please try again later.'
@@ -96,7 +85,7 @@ describe('SidebarHelpCenterIcon', () => {
   beforeEach(() => {
     typeformState.typeformError = false
     typeformState.isValidTypeformId = true
-    canvasState.linearMode = true
+    useCanvasStore().linearMode = true
   })
 
   it('mounts the Typeform embed container wired to the feedback form', () => {
@@ -133,7 +122,7 @@ describe('SidebarHelpCenterIcon', () => {
   })
 
   it('shows the help center button instead of the feedback popover in graph mode', () => {
-    canvasState.linearMode = false
+    useCanvasStore().linearMode = false
     renderIcon()
 
     expect(
@@ -146,7 +135,7 @@ describe('SidebarHelpCenterIcon', () => {
   })
 
   it('toggles the help center on click in graph mode', async () => {
-    canvasState.linearMode = false
+    useCanvasStore().linearMode = false
     const { user } = renderIcon()
 
     await user.click(screen.getByRole('button', { name: 'Help Center' }))

--- a/src/components/sidebar/tabs/AppsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AppsSidebarTab.test.ts
@@ -1,46 +1,26 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import {
+  useWorkflowStore,
+  useWorkflowBookmarkStore
+} from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 import AppsSidebarTab from './AppsSidebarTab.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
-const execute = vi.hoisted(() => vi.fn())
-
-const workflowStoreState = vi.hoisted(() => ({
-  persistedWorkflows: [] as ComfyWorkflow[]
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { ComfyWorkflow } =
-      await import('@/platform/workflow/management/stores/comfyWorkflow')
-    return {
-      ComfyWorkflow,
-      useWorkflowStore: () => ({
-        get workflows() {
-          return workflowStoreState.persistedWorkflows
-        },
-        get persistedWorkflows() {
-          return workflowStoreState.persistedWorkflows
-        },
-        bookmarkedWorkflows: [],
-        openWorkflows: [],
-        activeWorkflow: undefined,
-        isSyncLoading: false,
-        syncWorkflows: vi.fn()
-      }),
-      useWorkflowBookmarkStore: () => ({ loadBookmarks: vi.fn() })
-    }
-  }
-)
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  vi.mocked(useWorkflowStore().syncWorkflows).mockResolvedValue(undefined)
+  vi.mocked(useWorkflowBookmarkStore().loadBookmarks).mockResolvedValue(
+    undefined
+  )
+})
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -56,18 +36,10 @@ vi.mock(
   })
 )
 
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({ shiftDown: false })
-}))
-
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { computed } = await import('vue')
   return { useAppMode: () => ({ isAppMode: computed(() => true) }) }
 })
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => undefined })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -152,7 +124,7 @@ function renderTabWithRealBase() {
 
 describe('AppsSidebarTab', () => {
   beforeEach(() => {
-    workflowStoreState.persistedWorkflows = []
+    Object.assign(useWorkflowStore(), { persistedWorkflows: [] })
   })
 
   it('shows the create action only when there are results', () => {
@@ -171,7 +143,9 @@ describe('AppsSidebarTab', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create' }))
 
-    expect(execute).toHaveBeenCalledWith('Comfy.NewBlankWorkflow')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.NewBlankWorkflow'
+    )
   })
 
   it('runs the new-workflow command from the empty-state action', async () => {
@@ -179,15 +153,19 @@ describe('AppsSidebarTab', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create app' }))
 
-    expect(execute).toHaveBeenCalledWith('Comfy.NewBlankWorkflow')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.NewBlankWorkflow'
+    )
   })
 
   describe('with the real workflows tab', () => {
     it('counts only app workflows as results', async () => {
-      workflowStoreState.persistedWorkflows = [
-        await makeWorkflow('workflows/my-app.app.json'),
-        await makeWorkflow('workflows/regular.json')
-      ]
+      Object.assign(useWorkflowStore(), {
+        persistedWorkflows: [
+          await makeWorkflow('workflows/my-app.app.json'),
+          await makeWorkflow('workflows/regular.json')
+        ]
+      })
 
       renderTabWithRealBase()
 
@@ -198,9 +176,9 @@ describe('AppsSidebarTab', () => {
     })
 
     it('shows the empty state when no app workflows exist', async () => {
-      workflowStoreState.persistedWorkflows = [
-        await makeWorkflow('workflows/regular.json')
-      ]
+      Object.assign(useWorkflowStore(), {
+        persistedWorkflows: [await makeWorkflow('workflows/regular.json')]
+      })
 
       renderTabWithRealBase()
 

--- a/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
@@ -1,8 +1,7 @@
-import { fromPartial } from '@total-typescript/shoehorn'
-
 import { render, fireEvent } from '@testing-library/vue'
-import { defineComponent } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -16,12 +15,6 @@ const i18n = createI18n({
   locale: 'en',
   messages: { en: enMessages }
 })
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    isAssetDeleting: () => false
-  })
-}))
 
 const VirtualGridStub = defineComponent({
   name: 'VirtualGrid',

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,12 +1,26 @@
-import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia } from 'pinia'
+import { render, screen, within } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
+import { useAssetsStore } from '@/stores/assetsStore'
 
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
+
+beforeEach(() => {
+  const store = useAssetsStore()
+  store.outputAssets = {
+    items: [],
+    hasMore: false,
+    isLoading: false,
+    loadMore: vi.fn(async () => {}),
+    loadNew: vi.fn(async () => {}),
+    invalidate: vi.fn(async () => {})
+  }
+  vi.spyOn(store.inputAssets, 'loadNew').mockResolvedValue(undefined)
+  vi.spyOn(store.inputAssets, 'loadMore').mockResolvedValue(undefined)
+})
 
 const folderAsset = vi.hoisted(() => ({
   id: 'multi-output',
@@ -21,42 +35,6 @@ const folderAsset = vi.hoisted(() => ({
     outputCount: 2
   }
 }))
-
-const outputAssetState = vi.hoisted(() => ({
-  items: [] as (typeof folderAsset)[],
-  hasMore: false
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), async () => {
-  const { ref } = await import('vue')
-
-  const store = {
-    outputAssets: {
-      get items() {
-        return outputAssetState.items
-      },
-      isLoading: ref(false),
-      get hasMore() {
-        return outputAssetState.hasMore
-      },
-      loadMore: vi.fn(),
-      loadNew: vi.fn(),
-      invalidate: vi.fn()
-    },
-    inputAssets: {
-      items: ref([]),
-      isLoading: ref(false),
-      hasMore: ref(false),
-      loadMore: vi.fn(),
-      loadNew: vi.fn(),
-      invalidate: vi.fn()
-    }
-  }
-
-  return {
-    useAssetsStore: () => store
-  }
-})
 
 vi.mock<unknown>(
   import('@/platform/assets/composables/useAssetGridSelection'),
@@ -163,7 +141,7 @@ const buttonStub = {
 function renderTab() {
   return render(AssetsSidebarTab, {
     global: {
-      plugins: [createPinia(), i18n],
+      plugins: [i18n],
       directives: {
         tooltip: {}
       },
@@ -184,13 +162,13 @@ function renderTab() {
 }
 
 beforeEach(() => {
-  outputAssetState.items = [folderAsset]
-  outputAssetState.hasMore = false
+  useAssetsStore().outputAssets.items = [folderAsset]
+  useAssetsStore().outputAssets.hasMore = false
 })
 
 it('keeps pagination mounted when more assets can be loaded', () => {
-  outputAssetState.items = []
-  outputAssetState.hasMore = true
+  useAssetsStore().outputAssets.items = []
+  useAssetsStore().outputAssets.hasMore = true
 
   renderTab()
 

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
@@ -1,16 +1,31 @@
-import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref, watchEffect } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { nextTick, reactive, ref, watchEffect } from 'vue'
+
+import BaseWorkflowsSidebarTab from '@/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import {
+  useWorkflowStore,
+  useWorkflowBookmarkStore
+} from '@/platform/workflow/management/stores/workflowStore'
 
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
 import { flattenTree } from '@/utils/treeUtil'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
-import BaseWorkflowsSidebarTab from '@/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue'
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Workflow.WorkflowTabsPosition'] =
+    'Sidebar'
+  vi.mocked(useWorkflowStore().syncWorkflows).mockResolvedValue(undefined)
+  vi.mocked(useWorkflowBookmarkStore().loadBookmarks).mockResolvedValue(
+    undefined
+  )
+})
 
 const {
   setSearchQuery,
@@ -20,24 +35,12 @@ const {
   resetCapturedSearchRoot,
   mockExpandNode,
   mockToggleNodeOnEvent,
-  mockLoadBookmarks,
   mockWorkflowService,
-  mockWorkflowStoreState,
   registerSearchHandlers
 } = vi.hoisted(() => {
   let updateQuery = (_query: string) => {}
   let triggerSearch = (_query: string) => {}
   let capturedSearchRoot: TreeExplorerNode<ComfyWorkflow> | null = null
-
-  const workflowStore = {
-    workflows: [] as ComfyWorkflow[],
-    persistedWorkflows: [] as ComfyWorkflow[],
-    bookmarkedWorkflows: [] as ComfyWorkflow[],
-    openWorkflows: [] as ComfyWorkflow[],
-    activeWorkflow: null as ComfyWorkflow | null,
-    isSyncLoading: false,
-    syncWorkflows: vi.fn().mockResolvedValue(undefined)
-  }
 
   return {
     setSearchQuery: (query: string) => {
@@ -55,7 +58,6 @@ const {
     },
     mockExpandNode: vi.fn(),
     mockToggleNodeOnEvent: vi.fn(),
-    mockLoadBookmarks: vi.fn().mockResolvedValue(undefined),
     mockWorkflowService: {
       openWorkflow: vi.fn().mockResolvedValue(undefined),
       closeWorkflow: vi.fn().mockResolvedValue(undefined),
@@ -64,7 +66,6 @@ const {
       insertWorkflow: vi.fn().mockResolvedValue(undefined),
       duplicateWorkflow: vi.fn().mockResolvedValue(undefined)
     },
-    mockWorkflowStoreState: workflowStore,
     registerSearchHandlers: (
       updateHandler: (query: string) => void,
       searchHandler: (query: string) => void
@@ -74,8 +75,6 @@ const {
     }
   }
 })
-
-const mockWorkflowStore = reactive(mockWorkflowStoreState)
 
 vi.mock<unknown>(
   import('@/components/common/NoResultsPlaceholder.vue'),
@@ -187,34 +186,10 @@ vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
   useAppMode: () => ({ isAppMode: ref(false) })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.Workflow.WorkflowTabsPosition') return 'Sidebar'
-      return undefined
-    })
-  })
-}))
-
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
   () => ({
     useWorkflowService: () => mockWorkflowService
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({ shiftDown: false })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => mockWorkflowStore,
-    useWorkflowBookmarkStore: () => ({ loadBookmarks: mockLoadBookmarks }),
-    ComfyWorkflow: class {
-      static basePath = 'workflows/'
-    }
   })
 )
 
@@ -248,12 +223,12 @@ describe('BaseWorkflowsSidebarTab', () => {
   beforeEach(() => {
     resetCapturedSearchRoot()
 
-    mockWorkflowStore.workflows = []
-    mockWorkflowStore.persistedWorkflows = []
-    mockWorkflowStore.bookmarkedWorkflows = []
-    mockWorkflowStore.openWorkflows = []
-    mockWorkflowStore.activeWorkflow = null
-    mockWorkflowStore.isSyncLoading = false
+    Object.assign(useWorkflowStore(), { workflows: [] })
+    Object.assign(useWorkflowStore(), { persistedWorkflows: [] })
+    Object.assign(useWorkflowStore(), { bookmarkedWorkflows: [] })
+    Object.assign(useWorkflowStore(), { openWorkflows: [] })
+    useWorkflowStore().activeWorkflow = null
+    useWorkflowStore().isSyncLoading = false
   })
 
   const renderComponent = () =>
@@ -264,16 +239,18 @@ describe('BaseWorkflowsSidebarTab', () => {
         dataTestid: 'workflows-sidebar'
       },
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [i18n],
         stubs: { teleport: true }
       }
     })
 
   it('returns an empty filtered workflow set when searchQuery is empty', async () => {
-    mockWorkflowStore.workflows = [
-      createMockWorkflow('workflows/test-alpha.json'),
-      createMockWorkflow('workflows/test-beta.json')
-    ]
+    Object.assign(useWorkflowStore(), {
+      workflows: [
+        createMockWorkflow('workflows/test-alpha.json'),
+        createMockWorkflow('workflows/test-beta.json')
+      ]
+    })
 
     renderComponent()
     emitSearch('alpha')
@@ -287,11 +264,13 @@ describe('BaseWorkflowsSidebarTab', () => {
   })
 
   it('filters workflows by case-insensitive path match', async () => {
-    mockWorkflowStore.workflows = [
-      createMockWorkflow('workflows/test-alpha.json'),
-      createMockWorkflow('workflows/other-workflow.json'),
-      createMockWorkflow('workflows/TEST-gamma.json')
-    ]
+    Object.assign(useWorkflowStore(), {
+      workflows: [
+        createMockWorkflow('workflows/test-alpha.json'),
+        createMockWorkflow('workflows/other-workflow.json'),
+        createMockWorkflow('workflows/TEST-gamma.json')
+      ]
+    })
 
     renderComponent()
 
@@ -312,15 +291,15 @@ describe('BaseWorkflowsSidebarTab', () => {
 
     await user.click(refreshButton)
 
-    expect(mockWorkflowStore.syncWorkflows).toHaveBeenCalledTimes(1)
+    expect(useWorkflowStore().syncWorkflows).toHaveBeenCalledTimes(1)
 
-    mockWorkflowStore.isSyncLoading = true
+    useWorkflowStore().isSyncLoading = true
     await nextTick()
 
     expect(refreshButton).toBeDisabled()
     expect(refreshButton).toHaveAttribute('aria-busy', 'true')
 
-    mockWorkflowStore.isSyncLoading = false
+    useWorkflowStore().isSyncLoading = false
     await nextTick()
 
     expect(refreshButton).toBeEnabled()
@@ -328,15 +307,17 @@ describe('BaseWorkflowsSidebarTab', () => {
 
     await user.click(refreshButton)
 
-    expect(mockWorkflowStore.syncWorkflows).toHaveBeenCalledTimes(2)
+    expect(useWorkflowStore().syncWorkflows).toHaveBeenCalledTimes(2)
   })
 
   it('reactively updates filtered workflows when a workflow is removed', async () => {
-    mockWorkflowStore.workflows = [
-      createMockWorkflow('workflows/test-alpha.json'),
-      createMockWorkflow('workflows/TEST-alpha-2.json'),
-      createMockWorkflow('workflows/test-beta.json')
-    ]
+    Object.assign(useWorkflowStore(), {
+      workflows: [
+        createMockWorkflow('workflows/test-alpha.json'),
+        createMockWorkflow('workflows/TEST-alpha-2.json'),
+        createMockWorkflow('workflows/test-beta.json')
+      ]
+    })
 
     renderComponent()
 
@@ -347,9 +328,11 @@ describe('BaseWorkflowsSidebarTab', () => {
       'workflows/test-alpha.json'
     ])
 
-    mockWorkflowStore.workflows = mockWorkflowStore.workflows.filter(
-      (workflow) => workflow.path !== 'workflows/TEST-alpha-2.json'
-    )
+    Object.assign(useWorkflowStore(), {
+      workflows: useWorkflowStore().workflows.filter(
+        (workflow) => workflow.path !== 'workflows/TEST-alpha-2.json'
+      )
+    })
     await nextTick()
 
     expect(getLeafPaths(getSearchRoot())).toEqual(['workflows/test-alpha.json'])

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
@@ -1,15 +1,29 @@
-import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { useModelStore } from '@/stores/modelStore'
 import type { ComfyModelDef } from '@/stores/modelStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
 
 import ModelLibrarySidebarTab from './ModelLibrarySidebarTab.vue'
+
+beforeEach(() => {
+  vi.mocked(useModelStore().loadModels).mockResolvedValue([])
+  vi.mocked(useModelStore().loadModelFolders).mockResolvedValue(true)
+  vi.mocked(useModelStore().getLoadedModelFolder).mockResolvedValue(null)
+  vi.mocked(useModelStore().refresh).mockResolvedValue(true)
+  vi.mocked(useModelStore().refreshModelFolder).mockResolvedValue(undefined)
+  useSettingStore().settingValues['Comfy.ModelLibrary.NameFormat'] = 'filename'
+})
 
 const {
   captureRoot,
@@ -18,13 +32,7 @@ const {
   captureExpandedKeys,
   getExpandedKeys,
   mockStartDrag,
-  mockGetNodeProvider,
-  mockToggleNodeOnEvent,
-  mockRefreshModelFolder,
-  mockLoadModels,
-  downloadStoreState,
-  settingState,
-  modelsState
+  mockToggleNodeOnEvent
 } = vi.hoisted(() => {
   let capturedRoot: TreeExplorerNode | null = null
   let capturedExpandedKeys: Record<string, boolean> = {}
@@ -41,30 +49,12 @@ const {
     },
     getExpandedKeys: () => capturedExpandedKeys,
     mockStartDrag: vi.fn(),
-    mockGetNodeProvider: vi.fn(),
-    mockToggleNodeOnEvent: vi.fn(),
-    mockRefreshModelFolder: vi.fn().mockResolvedValue(undefined),
-    mockLoadModels: vi.fn().mockResolvedValue([]),
-    downloadStoreState: { setLastCompleted: (_: unknown) => {} },
-    settingState: { useAssetAPI: false, autoLoadAll: false },
-    modelsState: {
-      push: (_: unknown) => {},
-      reset: () => {}
-    }
+    mockToggleNodeOnEvent: vi.fn()
   }
 })
 
 vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   useNodeDragToCanvas: () => ({ startDrag: mockStartDrag })
-}))
-
-const mockToastAdd = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mockToastAdd })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
 }))
 
 const mockModel = fromPartial<ComfyModelDef>({
@@ -75,65 +65,6 @@ const mockModel = fromPartial<ComfyModelDef>({
   directory: 'checkpoints',
   searchable: 'checkpoints/model.safetensors'
 })
-
-vi.mock<unknown>(import('@/stores/modelStore'), async () => {
-  const { reactive } = await import('vue')
-  const models = reactive<ComfyModelDef[]>([])
-  modelsState.push = (model: unknown) => {
-    models.push(model as ComfyModelDef)
-  }
-  modelsState.reset = () => {
-    models.splice(0, models.length, mockModel)
-  }
-  return {
-    ResourceState: {
-      Loading: 'loading',
-      Loaded: 'loaded'
-    },
-    useModelStore: () => ({
-      modelFolders: [],
-      visibleModelFolders: [],
-      models,
-      loadModels: mockLoadModels,
-      getLoadedModelFolder: vi.fn().mockResolvedValue(null),
-      loadModelFolders: vi.fn().mockResolvedValue([]),
-      refresh: vi.fn().mockResolvedValue(undefined),
-      refreshModelFolder: mockRefreshModelFolder
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/assetDownloadStore'), async () => {
-  const { ref } = await import('vue')
-  const lastCompletedDownload = ref<{
-    taskId: string
-    modelType: string
-    timestamp: number
-  } | null>(null)
-  downloadStoreState.setLastCompleted = (value) => {
-    lastCompletedDownload.value = value as typeof lastCompletedDownload.value
-  }
-  return {
-    useAssetDownloadStore: () => ({
-      get lastCompletedDownload() {
-        return lastCompletedDownload.value
-      }
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.ModelLibrary.NameFormat') return 'filename'
-      if (key === 'Comfy.Assets.UseAssetAPI') return settingState.useAssetAPI
-      if (key === 'Comfy.ModelLibrary.AutoLoadAll') {
-        return settingState.autoLoadAll
-      }
-      return false
-    })
-  })
-}))
 
 const mockExpandNode = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/composables/useTreeExpansion'), () => ({
@@ -231,16 +162,16 @@ const i18n = createI18n({
 describe('ModelLibrarySidebarTab', () => {
   beforeEach(() => {
     resetRoot()
-    downloadStoreState.setLastCompleted(null)
-    settingState.useAssetAPI = false
-    settingState.autoLoadAll = false
-    modelsState.reset()
+    useAssetDownloadStore().lastCompletedDownload = null
+    useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = false
+    useSettingStore().settingValues['Comfy.ModelLibrary.AutoLoadAll'] = false
+    Object.assign(useModelStore(), { models: [mockModel] })
   })
 
   function renderComponent() {
     return render(ModelLibrarySidebarTab, {
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [i18n],
         stubs: { teleport: true },
         directives: { tooltip: {} }
       }
@@ -253,9 +184,11 @@ describe('ModelLibrarySidebarTab', () => {
   })
 
   it('starts a ghost drag carrying the widget value to fill on placement', async () => {
-    const mockNodeDef = { name: 'CheckpointLoaderSimple' }
+    const mockNodeDef = fromPartial<ComfyNodeDefImpl>({
+      name: 'CheckpointLoaderSimple'
+    })
 
-    mockGetNodeProvider.mockReturnValue({
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
       nodeDef: mockNodeDef,
       key: 'ckpt_name'
     })
@@ -273,7 +206,9 @@ describe('ModelLibrarySidebarTab', () => {
     const mockEvent = new MouseEvent('click')
     await modelLeaf?.handleClick?.(mockEvent)
 
-    expect(mockGetNodeProvider).toHaveBeenCalledWith('checkpoints')
+    expect(
+      vi.mocked(useModelToNodeStore().getNodeProvider)
+    ).toHaveBeenCalledWith('checkpoints')
     expect(mockStartDrag).toHaveBeenCalledWith(mockNodeDef, {
       widgetValues: { ckpt_name: 'model.safetensors' },
       source: 'sidebar_drag'
@@ -297,23 +232,25 @@ describe('ModelLibrarySidebarTab', () => {
     renderComponent()
     await nextTick()
 
-    expect(mockRefreshModelFolder).not.toHaveBeenCalled()
+    expect(vi.mocked(useModelStore().refreshModelFolder)).not.toHaveBeenCalled()
 
-    downloadStoreState.setLastCompleted({
+    useAssetDownloadStore().lastCompletedDownload = {
       taskId: 'task-1',
       modelType: 'checkpoints',
       timestamp: Date.now()
-    })
+    }
     await nextTick()
 
-    expect(mockRefreshModelFolder).toHaveBeenCalledWith('checkpoints')
+    expect(vi.mocked(useModelStore().refreshModelFolder)).toHaveBeenCalledWith(
+      'checkpoints'
+    )
   })
 
   it('does not refresh when no download has completed', async () => {
     renderComponent()
     await nextTick()
 
-    expect(mockRefreshModelFolder).not.toHaveBeenCalled()
+    expect(vi.mocked(useModelStore().refreshModelFolder)).not.toHaveBeenCalled()
   })
 
   describe('search', () => {
@@ -325,7 +262,7 @@ describe('ModelLibrarySidebarTab', () => {
       await user.type(screen.getByTestId('search-input'), 'model')
       await nextTick()
 
-      expect(mockLoadModels).toHaveBeenCalled()
+      expect(vi.mocked(useModelStore().loadModels)).toHaveBeenCalled()
       const leafLabels = () => {
         const { children: folders = [] } = getRoot()
         return folders.flatMap(({ children: leaves = [] }) =>
@@ -335,16 +272,19 @@ describe('ModelLibrarySidebarTab', () => {
       expect(leafLabels()).toEqual(['model'])
 
       // A completed scan reloads the store while the search is still active.
-      modelsState.push(
-        fromPartial<ComfyModelDef>({
-          key: 'checkpoints/model-new.safetensors',
-          file_name: 'model-new.safetensors',
-          simplified_file_name: 'model-new',
-          title: 'Model New',
-          directory: 'checkpoints',
-          searchable: 'checkpoints/model-new.safetensors'
-        })
-      )
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          fromPartial<ComfyModelDef>({
+            key: 'checkpoints/model-new.safetensors',
+            file_name: 'model-new.safetensors',
+            simplified_file_name: 'model-new',
+            title: 'Model New',
+            directory: 'checkpoints',
+            searchable: 'checkpoints/model-new.safetensors'
+          })
+        ]
+      })
       await nextTick()
 
       expect(leafLabels()).toEqual(['model', 'model-new'])
@@ -381,16 +321,19 @@ describe('ModelLibrarySidebarTab', () => {
       renderComponent()
       await nextTick()
       for (let i = 0; i < 520; i++) {
-        modelsState.push(
-          fromPartial<ComfyModelDef>({
-            key: `checkpoints/bulk-${i}.safetensors`,
-            file_name: `bulk-${i}.safetensors`,
-            simplified_file_name: `bulk-${i}`,
-            title: `bulk-${i}`,
-            directory: 'checkpoints',
-            searchable: `checkpoints/bulk-${i}.safetensors`
-          })
-        )
+        Object.assign(useModelStore(), {
+          models: [
+            ...useModelStore().models,
+            fromPartial<ComfyModelDef>({
+              key: `checkpoints/bulk-${i}.safetensors`,
+              file_name: `bulk-${i}.safetensors`,
+              simplified_file_name: `bulk-${i}`,
+              title: `bulk-${i}`,
+              directory: 'checkpoints',
+              searchable: `checkpoints/bulk-${i}.safetensors`
+            })
+          ]
+        })
       }
 
       await user.type(screen.getByTestId('search-input'), 'bulk')
@@ -422,16 +365,19 @@ describe('ModelLibrarySidebarTab', () => {
 
       // A background reload adds another matching model to that folder; the
       // tree data updates but the manual collapse is preserved.
-      modelsState.push(
-        fromPartial<ComfyModelDef>({
-          key: 'checkpoints/model-late.safetensors',
-          file_name: 'model-late.safetensors',
-          simplified_file_name: 'model-late',
-          title: 'Model Late',
-          directory: 'checkpoints',
-          searchable: 'checkpoints/model-late.safetensors'
-        })
-      )
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          fromPartial<ComfyModelDef>({
+            key: 'checkpoints/model-late.safetensors',
+            file_name: 'model-late.safetensors',
+            simplified_file_name: 'model-late',
+            title: 'Model Late',
+            directory: 'checkpoints',
+            searchable: 'checkpoints/model-late.safetensors'
+          })
+        ]
+      })
       await nextTick()
       await nextTick()
 
@@ -453,16 +399,19 @@ describe('ModelLibrarySidebarTab', () => {
       // A scan completes mid-search and surfaces the first match; its
       // folder must render expanded or the result hides in a collapsed
       // node.
-      modelsState.push(
-        fromPartial<ComfyModelDef>({
-          key: 'checkpoints/zzz-model.safetensors',
-          file_name: 'zzz-model.safetensors',
-          simplified_file_name: 'zzz-model',
-          title: 'Zzz Model',
-          directory: 'checkpoints',
-          searchable: 'checkpoints/zzz-model.safetensors'
-        })
-      )
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          fromPartial<ComfyModelDef>({
+            key: 'checkpoints/zzz-model.safetensors',
+            file_name: 'zzz-model.safetensors',
+            simplified_file_name: 'zzz-model',
+            title: 'Zzz Model',
+            directory: 'checkpoints',
+            searchable: 'checkpoints/zzz-model.safetensors'
+          })
+        ]
+      })
       await nextTick()
       await nextTick()
 
@@ -473,14 +422,16 @@ describe('ModelLibrarySidebarTab', () => {
   describe('asset mode', () => {
     it('surfaces an error toast when the eager load fails on mount', async () => {
       const error = vi.spyOn(console, 'error').mockImplementation(() => {})
-      settingState.useAssetAPI = true
-      mockLoadModels.mockRejectedValueOnce(new Error('walk failed'))
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
+      vi.mocked(useModelStore().loadModels).mockRejectedValueOnce(
+        new Error('walk failed')
+      )
 
       renderComponent()
       await nextTick()
       await nextTick()
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'sideToolbar.modelLibraryLoadFailed'
@@ -490,13 +441,13 @@ describe('ModelLibrarySidebarTab', () => {
     })
 
     it('hides the load-all button and eager-loads models on mount', async () => {
-      settingState.useAssetAPI = true
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
       renderComponent()
       await nextTick()
 
       expect(screen.queryByLabelText('g.loadAllFolders')).toBeNull()
       expect(screen.getByLabelText('g.refresh')).toBeInTheDocument()
-      expect(mockLoadModels).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(useModelStore().loadModels)).toHaveBeenCalledTimes(1)
     })
 
     it('legacy mode keeps the load-all button and stays lazy by default', async () => {
@@ -504,15 +455,15 @@ describe('ModelLibrarySidebarTab', () => {
       await nextTick()
 
       expect(screen.getByLabelText('g.loadAllFolders')).toBeInTheDocument()
-      expect(mockLoadModels).not.toHaveBeenCalled()
+      expect(vi.mocked(useModelStore().loadModels)).not.toHaveBeenCalled()
     })
 
     it('legacy mode still honors AutoLoadAll', async () => {
-      settingState.autoLoadAll = true
+      useSettingStore().settingValues['Comfy.ModelLibrary.AutoLoadAll'] = true
       renderComponent()
       await nextTick()
 
-      expect(mockLoadModels).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(useModelStore().loadModels)).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
@@ -4,16 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { EssentialTile } from '@/constants/essentialsNodes'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 import EssentialNodeCard from './EssentialNodeCard.vue'
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn().mockReturnValue('left')
-  })
-}))
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+})
 
 const { mockStartDrag, mockHandleNativeDrop } = vi.hoisted(() => ({
   mockStartDrag: vi.fn(),

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
@@ -1,9 +1,10 @@
-import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type {
   TreeExplorerDragAndDropData,
@@ -13,11 +14,16 @@ import type {
 
 import NodeBookmarkTreeExplorer from './NodeBookmarkTreeExplorer.vue'
 
+beforeEach(() => {
+  Object.assign(useNodeBookmarkStore(), { bookmarkedRoot: mockBookmarkedRoot })
+  vi.mocked(useNodeBookmarkStore().addBookmark).mockResolvedValue(undefined)
+  vi.mocked(useNodeBookmarkStore().toggleBookmark).mockResolvedValue(undefined)
+  vi.mocked(useNodeBookmarkStore().deleteBookmarkFolder).mockResolvedValue(
+    undefined
+  )
+})
+
 const {
-  mockAddBookmark,
-  mockDeleteBookmarkFolder,
-  mockIsBookmarked,
-  mockToggleBookmark,
   mockAddNodeOnGraph,
   mockToggleNodeOnEvent,
   captureRoot,
@@ -26,10 +32,6 @@ const {
 } = vi.hoisted(() => {
   let capturedRoot: TreeExplorerNode | null = null
   return {
-    mockAddBookmark: vi.fn(),
-    mockDeleteBookmarkFolder: vi.fn(),
-    mockIsBookmarked: vi.fn().mockReturnValue(false),
-    mockToggleBookmark: vi.fn(),
     mockAddNodeOnGraph: vi.fn(),
     mockToggleNodeOnEvent: vi.fn(),
     captureRoot: (root: TreeExplorerNode) => {
@@ -79,23 +81,6 @@ const mockBookmarkedRoot: TreeNode = {
     }
   ]
 }
-
-vi.mock<unknown>(import('@/stores/nodeBookmarkStore'), () => ({
-  useNodeBookmarkStore: () => ({
-    bookmarks: [],
-    bookmarkedRoot: mockBookmarkedRoot,
-    isBookmarked: mockIsBookmarked,
-    toggleBookmark: mockToggleBookmark,
-    addBookmark: mockAddBookmark,
-    deleteBookmarkFolder: mockDeleteBookmarkFolder,
-    addNewBookmarkFolder: vi.fn(),
-    renameBookmarkFolder: vi.fn(),
-    bookmarksCustomization: {},
-    defaultBookmarkIcon: 'pi-bookmark-fill',
-    defaultBookmarkColor: '#a1a1aa',
-    updateCustomization: vi.fn()
-  })
-}))
 
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
@@ -153,7 +138,7 @@ const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
 
 describe('NodeBookmarkTreeExplorer', () => {
   beforeEach(() => {
-    mockIsBookmarked.mockReturnValue(false)
+    vi.mocked(useNodeBookmarkStore().isBookmarked).mockReturnValue(false)
     resetRoot()
   })
 
@@ -182,11 +167,11 @@ describe('NodeBookmarkTreeExplorer', () => {
         })
       )
 
-      expect(mockAddBookmark).toHaveBeenCalled()
+      expect(vi.mocked(useNodeBookmarkStore().addBookmark)).toHaveBeenCalled()
     })
 
     it('moves bookmark when a node is dragged onto a folder and is bookmarked', async () => {
-      mockIsBookmarked.mockReturnValue(true)
+      vi.mocked(useNodeBookmarkStore().isBookmarked).mockReturnValue(true)
       const root = await renderAndGetRoot()
       const folderNode = root.children?.[0]
 
@@ -197,8 +182,10 @@ describe('NodeBookmarkTreeExplorer', () => {
         })
       )
 
-      expect(mockToggleBookmark).toHaveBeenCalledWith(mockLeafNodeDef)
-      expect(mockAddBookmark).toHaveBeenCalled()
+      expect(
+        vi.mocked(useNodeBookmarkStore().toggleBookmark)
+      ).toHaveBeenCalledWith(mockLeafNodeDef)
+      expect(vi.mocked(useNodeBookmarkStore().addBookmark)).toHaveBeenCalled()
     })
 
     it('is a no-op when the dragged node carries no data', async () => {
@@ -212,7 +199,9 @@ describe('NodeBookmarkTreeExplorer', () => {
         })
       )
 
-      expect(mockAddBookmark).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useNodeBookmarkStore().addBookmark)
+      ).not.toHaveBeenCalled()
     })
   })
 
@@ -251,7 +240,9 @@ describe('NodeBookmarkTreeExplorer', () => {
         data: mockFolderNodeDef
       })
 
-      expect(mockDeleteBookmarkFolder).toHaveBeenCalledWith(mockFolderNodeDef)
+      expect(
+        vi.mocked(useNodeBookmarkStore().deleteBookmarkFolder)
+      ).toHaveBeenCalledWith(mockFolderNodeDef)
     })
 
     it('is a no-op when node data is missing', async () => {
@@ -260,7 +251,9 @@ describe('NodeBookmarkTreeExplorer', () => {
 
       await folderNode?.handleDelete?.call({ ...folderNode, data: undefined })
 
-      expect(mockDeleteBookmarkFolder).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useNodeBookmarkStore().deleteBookmarkFolder)
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -7,16 +7,6 @@ import { createI18n } from 'vue-i18n'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 
 import MediaLightbox from './MediaLightbox.vue'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => undefined })
-}))
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({
-    isExtensionInstalled: () => false,
-    isExtensionEnabled: () => false
-  })
-}))
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -1,57 +1,17 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createPinia } from 'pinia'
 import { defineComponent, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import CurrentUserButton from './CurrentUserButton.vue'
-
-const mockTeamWorkspaceStore = vi.hoisted(() => ({
-  workspaceName: { value: '' },
-  initState: { value: 'idle' },
-  isInPersonalWorkspace: { value: false }
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
-
-// Mock all firebase modules
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { defineStore } = await import('pinia')
-    const { computed } = await import('vue')
-
-    return {
-      useTeamWorkspaceStore: defineStore('teamWorkspace', () => ({
-        workspaceName: computed(
-          () => mockTeamWorkspaceStore.workspaceName.value
-        ),
-        initState: computed(() => mockTeamWorkspaceStore.initState.value),
-        isInPersonalWorkspace: computed(
-          () => mockTeamWorkspaceStore.isInPersonalWorkspace.value
-        ),
-        activeWorkspace: computed(() => null)
-      }))
-    }
-  }
-)
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -130,9 +90,9 @@ vi.mock(import('./CurrentUserPopoverLegacy.vue'), () => ({
 
 describe('CurrentUserButton', () => {
   beforeEach(() => {
-    mockTeamWorkspaceStore.workspaceName.value = ''
-    mockTeamWorkspaceStore.initState.value = 'idle'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: '' })
+    useTeamWorkspaceStore().initState = 'uninitialized'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     mockIsCloud.value = false
   })
 
@@ -146,7 +106,7 @@ describe('CurrentUserButton', () => {
 
     const result = render(CurrentUserButton, {
       global: {
-        plugins: [i18n, createPinia()],
+        plugins: [i18n],
         stubs: {
           CurrentUserPopoverWorkspace: CurrentUserPopoverWorkspaceStub,
           Popover: defineComponent({
@@ -187,11 +147,11 @@ describe('CurrentUserButton', () => {
     expect(screen.getByText('Popover Content')).toBeInTheDocument()
   })
 
-  it.for(['loading', 'error'])(
+  it.for(['loading', 'error'] as const)(
     'shows account actions while Cloud workspace initialization is %s',
     async (initState) => {
       mockIsCloud.value = true
-      mockTeamWorkspaceStore.initState.value = initState
+      useTeamWorkspaceStore().initState = initState
       const { user } = renderComponent()
 
       await user.click(screen.getByRole('button', { name: 'Current user' }))
@@ -214,8 +174,8 @@ describe('CurrentUserButton', () => {
 
   it('shows UserAvatar in personal workspace', () => {
     mockIsCloud.value = true
-    mockTeamWorkspaceStore.initState.value = 'ready'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = true
+    useTeamWorkspaceStore().initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
 
     renderComponent()
     expect(screen.getByText('Avatar')).toBeInTheDocument()
@@ -224,9 +184,9 @@ describe('CurrentUserButton', () => {
 
   it('shows WorkspaceProfilePic in team workspace', () => {
     mockIsCloud.value = true
-    mockTeamWorkspaceStore.initState.value = 'ready'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
-    mockTeamWorkspaceStore.workspaceName.value = 'My Team'
+    useTeamWorkspaceStore().initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: 'My Team' })
 
     renderComponent()
     expect(screen.getByText('WorkspaceProfilePic')).toBeInTheDocument()
@@ -234,9 +194,9 @@ describe('CurrentUserButton', () => {
   })
 
   it('shows WorkspaceProfilePic for an active local team workspace', () => {
-    mockTeamWorkspaceStore.initState.value = 'ready'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
-    mockTeamWorkspaceStore.workspaceName.value = 'My Team'
+    useTeamWorkspaceStore().initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: 'My Team' })
 
     renderComponent()
 
@@ -245,7 +205,7 @@ describe('CurrentUserButton', () => {
   })
 
   it('shows workspace actions after local workspace initialization', async () => {
-    mockTeamWorkspaceStore.initState.value = 'ready'
+    useTeamWorkspaceStore().initState = 'ready'
     const { user } = renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Current user' }))

--- a/src/components/topbar/WorkflowTab.test.ts
+++ b/src/components/topbar/WorkflowTab.test.ts
@@ -1,46 +1,21 @@
-import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { markRaw, nextTick } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
-import type { ComponentProps } from 'vue-component-type-helpers'
-
-import type * as ExecutionStoreModule from '@/stores/executionStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
 import type { WorkflowExecutionStatus } from '@/stores/executionStore'
+import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
 
-const { mockWorkflowStatus, mockCloseWorkflow } = await vi.hoisted(async () => {
-  const { shallowRef } = await import('vue')
-  return {
-    mockWorkflowStatus: shallowRef<Map<object, WorkflowExecutionStatus>>(
-      new Map()
-    ),
-    mockCloseWorkflow: vi.fn().mockResolvedValue(true)
-  }
-})
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    currentUser: null,
-    isAuthenticated: false,
-    isInitialized: true
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), async (importOriginal) => {
-  const actual = await importOriginal<typeof ExecutionStoreModule>()
-  return {
-    WORKFLOW_STATUS_I18N_KEYS: actual.WORKFLOW_STATUS_I18N_KEYS,
-    useExecutionStore: () => ({
-      getWorkflowStatus(workflow: object | undefined | null) {
-        if (!workflow) return undefined
-        return mockWorkflowStatus.value.get(workflow)
-      }
-    })
-  }
-})
+import WorkflowTab from './WorkflowTab.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
+const mockCloseWorkflow = vi.hoisted(() => vi.fn().mockResolvedValue(true))
 
 vi.mock(import('@/composables/usePragmaticDragAndDrop'), () => ({
   usePragmaticDraggable: vi.fn(),
@@ -82,10 +57,6 @@ vi.mock<unknown>(import('./WorkflowTabPopover.vue'), () => ({
     }
   }
 }))
-
-import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
-
-import WorkflowTab from './WorkflowTab.vue'
 
 type WorkflowTabProps = ComponentProps<typeof WorkflowTab>
 
@@ -145,24 +116,14 @@ function renderTab({
       ? workflowOption.workflow.path
       : '/workflows/other.json')
 
+  useWorkflowStore().activeWorkflow = fromPartial({
+    key: activeWorkflowKey,
+    path: resolvedActiveWorkflowPath
+  })
+  useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'off'
   return render(WorkflowTab, {
     global: {
-      plugins: [
-        createTestingPinia({
-          stubActions: false,
-          initialState: {
-            workspace: { shiftDown: false },
-            workflow: {
-              activeWorkflow: {
-                key: activeWorkflowKey,
-                path: resolvedActiveWorkflowPath
-              }
-            },
-            setting: { settingValues: { 'Comfy.Workflow.AutoSave': 'off' } }
-          }
-        }),
-        i18n
-      ],
+      plugins: [i18n],
       stubs: {
         WorkflowActionsList: true,
         Button: {
@@ -180,14 +141,14 @@ function renderTab({
 
 describe('WorkflowTab - workflow status indicator', () => {
   beforeEach(() => {
-    mockWorkflowStatus.value = new Map()
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue(undefined)
   })
 
   it.for(['running', 'completed', 'failed'] as const)(
     'labels the %s indicator with a translated status name',
     (status) => {
       const workflowOption = makeWorkflowOption()
-      mockWorkflowStatus.value = new Map([[workflowOption.workflow, status]])
+      vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue(status)
 
       renderTab({ workflowOption })
       expect(
@@ -198,7 +159,7 @@ describe('WorkflowTab - workflow status indicator', () => {
 
   it('does not badge the active tab with its own status', () => {
     const workflowOption = makeWorkflowOption()
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'running']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('running')
 
     renderTab({ workflowOption, activeWorkflowKey: 'test-key' })
     expect(screen.queryByRole('img')).toBeNull()
@@ -235,7 +196,7 @@ describe('WorkflowTab - workflow status indicator', () => {
 
   it('workflow status replaces the unsaved dot', () => {
     const workflowOption = makeWorkflowOption({ isPersisted: false })
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'running']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('running')
 
     renderTab({ workflowOption })
     expect(
@@ -247,7 +208,7 @@ describe('WorkflowTab - workflow status indicator', () => {
 
 describe('WorkflowTab - agent activity indicators', () => {
   beforeEach(() => {
-    mockWorkflowStatus.value = new Map()
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue(undefined)
   })
 
   it('T-17 / PM-658 / FE-1289 renders the active workflow tab loading state', async () => {
@@ -275,7 +236,7 @@ describe('WorkflowTab - agent activity indicators', () => {
 
   it('shows the unseen-changes dot ahead of non-failed execution status', async () => {
     const workflowOption = makeWorkflowOption()
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'running']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('running')
     renderTab({ workflowOption })
     useWorkflowTabActivityStore().markModified('/workflows/test.json')
     await nextTick()
@@ -291,7 +252,7 @@ describe('WorkflowTab - agent activity indicators', () => {
 
   it('a failed run outranks the unseen-changes dot', async () => {
     const workflowOption = makeWorkflowOption()
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'failed']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('failed')
     renderTab({ workflowOption })
     useWorkflowTabActivityStore().markModified('/workflows/test.json')
     await nextTick()

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -1,33 +1,30 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { FirebaseError } from 'firebase/app'
 import { AuthErrorCodes } from 'firebase/auth'
+import type { UserCredential } from 'firebase/auth'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import enLocale from '@/locales/en/main.json'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))
+
 type ModifiedWorkflow = Pick<ComfyWorkflow, 'path' | 'isModified'>
 
-const mockAuthStore = vi.hoisted(() => ({
-  login: vi.fn(async () => undefined),
-  loginWithGoogle: vi.fn(async () => undefined),
-  loginWithGithub: vi.fn(async () => undefined),
-  register: vi.fn(async () => undefined),
-  logout: vi.fn(async () => undefined),
-  initiateCreditPurchase: vi.fn(
-    async (): Promise<{ checkout_url?: string }> => ({
-      checkout_url: 'https://checkout.stripe.test'
-    })
-  )
-}))
+let mockAuthStore: ReturnType<typeof useAuthStore>
 
-const mockToastStore = vi.hoisted(() => ({
-  add: vi.fn()
-}))
+let mockToastStore: ReturnType<typeof useToastStore>
 
-const mockWorkflowStore = vi.hoisted(() => ({
-  modifiedWorkflows: [] as ModifiedWorkflow[]
-}))
+let mockWorkflowStore: ReturnType<typeof useWorkflowStore>
 
 const mockWorkflowService = vi.hoisted(() => ({
   saveWorkflow: vi.fn(async () => true)
@@ -90,21 +87,10 @@ vi.mock<unknown>(import('@/composables/billing/usePendingTopup'), () => ({
   usePendingTopup: () => ({ startPendingTopup: mockStartPendingTopup })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => mockToastStore)
-}))
-
 vi.mock(import('@/platform/workflow/persistence/base/storageIO'), () => ({
   clearAllWorkflowStorage: mockClearAllWorkflowStorage,
   prepareWorkflowLogoutTransition: mockPrepareWorkflowLogoutTransition
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => mockWorkflowStore)
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -115,10 +101,6 @@ vi.mock<unknown>(
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: vi.fn(() => mockDialogService)
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => mockAuthStore)
 }))
 
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
@@ -155,6 +137,18 @@ function makeWorkflow(path: string): ModifiedWorkflow {
 }
 
 beforeEach(() => {
+  mockAuthStore = useAuthStore()
+  mockToastStore = useToastStore()
+  mockWorkflowStore = useWorkflowStore()
+  vi.mocked(mockAuthStore.initiateCreditPurchase).mockResolvedValue({
+    checkout_url: 'https://checkout.stripe.test'
+  })
+  vi.mocked(mockAuthStore.logout).mockResolvedValue(undefined)
+  vi.mocked(mockAuthStore.sendPasswordReset).mockResolvedValue(undefined)
+  const credential = fromPartial<UserCredential>({ user: { uid: 'test-user' } })
+  vi.mocked(mockAuthStore.login).mockResolvedValue(credential)
+  vi.mocked(mockAuthStore.register).mockResolvedValue(credential)
+  vi.mocked(mockAuthStore.loginWithGoogle).mockResolvedValue(credential)
   mockDistributionState.isCloud = false
   mockBillingState.canAccessSubscriptionFeatures = false
 })
@@ -179,7 +173,7 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 
   it('does not start tracking or open checkout when no checkout URL is returned', async () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null)
-    mockAuthStore.initiateCreditPurchase.mockResolvedValueOnce({})
+    vi.mocked(mockAuthStore.initiateCreditPurchase).mockResolvedValueOnce({})
     const { purchaseCreditsDirect } = useAuthActions()
 
     await expect(purchaseCreditsDirect(25)).rejects.toThrow()
@@ -190,7 +184,7 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 
   it('does not start tracking or open checkout when the purchase request rejects', async () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null)
-    mockAuthStore.initiateCreditPurchase.mockRejectedValueOnce(
+    vi.mocked(mockAuthStore.initiateCreditPurchase).mockRejectedValueOnce(
       new Error('network down')
     )
     const { purchaseCreditsDirect } = useAuthActions()
@@ -205,12 +199,14 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 describe('useAuthActions.logout', () => {
   beforeEach(() => {
     mockDistributionState.isCloud = true
-    mockWorkflowStore.modifiedWorkflows = []
+    Object.assign(mockWorkflowStore, { modifiedWorkflows: [] })
   })
 
   it('logs out on non-cloud distributions without prompting when workflows are modified', async () => {
     mockDistributionState.isCloud = false
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     const { logout } = useAuthActions()
 
     await logout()
@@ -241,7 +237,9 @@ describe('useAuthActions.logout', () => {
 
     expect(mockPrepareWorkflowLogoutTransition).toHaveBeenCalledOnce()
     expect(mockClearAllWorkflowStorage).toHaveBeenCalledExactlyOnceWith()
-    expect(mockAuthStore.logout.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      vi.mocked(mockAuthStore.logout).mock.invocationCallOrder[0]
+    ).toBeLessThan(
       mockPrepareWorkflowLogoutTransition.mock.invocationCallOrder[0]
     )
     expect(
@@ -253,7 +251,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('does not clear cloud workflows when logout fails', async () => {
-    mockAuthStore.logout.mockRejectedValueOnce(new Error('network failed'))
+    vi.mocked(mockAuthStore.logout).mockRejectedValueOnce(
+      new Error('network failed')
+    )
     const { logout } = useAuthActions()
 
     await logout()
@@ -263,7 +263,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('cancels sign-out when the dialog is dismissed (null)', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(null)
     const { logout } = useAuthActions()
 
@@ -275,7 +277,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('signs out without saving when the user picks "Sign out anyway" (false)', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(false)
     const { logout } = useAuthActions()
 
@@ -287,7 +291,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('cancels sign-out when saving a workflow is cancelled', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(true)
     mockWorkflowService.saveWorkflow.mockResolvedValueOnce(false)
     const { logout } = useAuthActions()
@@ -299,10 +305,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('does not log out if a workflow save fails', async () => {
-    mockWorkflowStore.modifiedWorkflows = [
-      makeWorkflow('a.json'),
-      makeWorkflow('b.json')
-    ]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json'), makeWorkflow('b.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(true)
     mockWorkflowService.saveWorkflow.mockRejectedValueOnce(
       new Error('disk full')
@@ -320,7 +325,7 @@ describe('useAuthActions.logout', () => {
 
   it('saves every modified workflow before signing out when user picks Save (true)', async () => {
     const workflows = [makeWorkflow('a.json'), makeWorkflow('b.json')]
-    mockWorkflowStore.modifiedWorkflows = workflows
+    Object.assign(mockWorkflowStore, { modifiedWorkflows: workflows })
     mockDialogService.confirm.mockResolvedValueOnce(true)
     const { logout } = useAuthActions()
 
@@ -338,14 +343,16 @@ describe('useAuthActions.logout', () => {
     expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
     expect(
       mockWorkflowService.saveWorkflow.mock.invocationCallOrder[1]
-    ).toBeLessThan(mockAuthStore.logout.mock.invocationCallOrder[0])
+    ).toBeLessThan(vi.mocked(mockAuthStore.logout).mock.invocationCallOrder[0])
     expect(
       mockWorkflowService.saveWorkflow.mock.invocationCallOrder[0]
     ).toBeLessThan(mockWorkflowService.saveWorkflow.mock.invocationCallOrder[1])
   })
 
   it('passes denyLabel "Sign out anyway" to the dialog', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(null)
     const { logout } = useAuthActions()
 
@@ -364,12 +371,12 @@ describe('useAuthActions.logout', () => {
 
 describe('useAuthActions auth flow error telemetry', () => {
   beforeEach(() => {
-    mockWorkflowStore.modifiedWorkflows = []
+    Object.assign(mockWorkflowStore, { modifiedWorkflows: [] })
   })
 
   it('tracks email sign-in Firebase failures and still shows the error toast', async () => {
     const error = new FirebaseError('auth/user-not-found', 'msg')
-    mockAuthStore.login.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.login).mockRejectedValueOnce(error)
     const { signInWithEmail } = useAuthActions()
 
     await expect(
@@ -389,7 +396,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('tracks unknown errors for email sign-up failures', async () => {
     const error = new Error('network failed')
-    mockAuthStore.register.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.register).mockRejectedValueOnce(error)
     const { signUpWithEmail } = useAuthActions()
 
     await expect(
@@ -404,7 +411,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('tracks Google sign-up failures separately from sign-in failures', async () => {
     const error = new FirebaseError('auth/popup-closed-by-user', 'msg')
-    mockAuthStore.loginWithGoogle.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.loginWithGoogle).mockRejectedValueOnce(error)
     const { signInWithGoogle } = useAuthActions()
 
     await expect(signInWithGoogle({ isNewUser: true })).resolves.toBeUndefined()
@@ -417,7 +424,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('tracks GitHub sign-up failures separately from sign-in failures', async () => {
     const error = new FirebaseError('auth/popup-closed-by-user', 'msg')
-    mockAuthStore.loginWithGithub.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.loginWithGithub).mockRejectedValueOnce(error)
     const { signInWithGithub } = useAuthActions()
 
     await expect(signInWithGithub({ isNewUser: true })).resolves.toBeUndefined()
@@ -430,7 +437,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('does not track auth failures for logout failures', async () => {
     const error = new FirebaseError('auth/network-request-failed', 'msg')
-    mockAuthStore.logout.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.logout).mockRejectedValueOnce(error)
     const { logout } = useAuthActions()
 
     await logout()

--- a/src/composables/auth/useCurrentUser.test.ts
+++ b/src/composables/auth/useCurrentUser.test.ts
@@ -1,38 +1,30 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAuthStore } from '@/stores/authStore'
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCurrentUser } from './useCurrentUser'
 
-const mockAuthState = {
-  currentUser: null as { uid: string } | null,
-  loading: false,
-  tokenRefreshTrigger: 0
-}
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => mockAuthState
-}))
+vi.mock(import('firebase/auth'))
 
-const mockApiKeyState = {
-  isAuthenticated: false,
-  currentUser: null as { id: string; email?: string; name?: string } | null
-}
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => mockApiKeyState
-}))
+let mockAuthState: ReturnType<typeof useAuthStore>
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
-}))
+let mockApiKeyState: ReturnType<typeof useApiKeyAuthStore>
 
 describe('useCurrentUser', () => {
   beforeEach(() => {
+    mockAuthState = useAuthStore()
+    mockApiKeyState = useApiKeyAuthStore()
     mockAuthState.currentUser = null
-    mockApiKeyState.isAuthenticated = false
+    Object.assign(mockApiKeyState, { isAuthenticated: false })
     mockApiKeyState.currentUser = null
   })
 
   it('treats a key-only session as an API-key login', () => {
-    mockApiKeyState.isAuthenticated = true
-    mockApiKeyState.currentUser = { id: 'key-user' }
+    Object.assign(mockApiKeyState, { isAuthenticated: true })
+    mockApiKeyState.currentUser = fromPartial<
+      NonNullable<typeof mockApiKeyState.currentUser>
+    >({ id: 'key-user' })
 
     const { isApiKeyLogin, isLoggedIn, resolvedUserInfo } = useCurrentUser()
 
@@ -42,9 +34,13 @@ describe('useCurrentUser', () => {
   })
 
   it('gives the Firebase session precedence over a stored API key', () => {
-    mockAuthState.currentUser = { uid: 'firebase-user' }
-    mockApiKeyState.isAuthenticated = true
-    mockApiKeyState.currentUser = { id: 'key-user' }
+    mockAuthState.currentUser = fromPartial<
+      NonNullable<typeof mockAuthState.currentUser>
+    >({ uid: 'firebase-user' })
+    Object.assign(mockApiKeyState, { isAuthenticated: true })
+    mockApiKeyState.currentUser = fromPartial<
+      NonNullable<typeof mockApiKeyState.currentUser>
+    >({ id: 'key-user' })
 
     const { isApiKeyLogin, isLoggedIn, resolvedUserInfo } = useCurrentUser()
 

--- a/src/composables/billing/topupBalanceRefresh.test.ts
+++ b/src/composables/billing/topupBalanceRefresh.test.ts
@@ -1,21 +1,14 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from '@/stores/authStore'
+import { storeToRefs } from 'pinia'
+import type { Mock } from 'vitest'
+import type { Ref } from 'vue'
 
 import { watchForTopupBalanceUpdate } from './topupBalanceRefresh'
 
-const mockFetchBalance = vi.fn()
-const mockBalance = {
-  value: { amount_micros: 1_000 } as { amount_micros: number } | null
-}
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get balance() {
-      return mockBalance.value
-    },
-    fetchBalance: mockFetchBalance
-  })
-}))
+vi.mock(import('firebase/auth'))
+let mockFetchBalance: Mock<ReturnType<typeof useAuthStore>['fetchBalance']>
+let mockBalance: Ref<ReturnType<typeof useAuthStore>['balance']>
 
 function returnToApp() {
   vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
@@ -24,11 +17,15 @@ function returnToApp() {
 
 describe('watchForTopupBalanceUpdate', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    const store = useAuthStore()
+    mockFetchBalance = vi.mocked(store.fetchBalance)
+    mockBalance = storeToRefs(store).balance
     vi.useFakeTimers()
-    mockFetchBalance.mockReset()
-    mockFetchBalance.mockResolvedValue({ amount_micros: 1_000 })
-    mockBalance.value = { amount_micros: 1_000 }
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 1_000
+    })
+    mockBalance.value = { currency: 'usd', amount_micros: 1_000 }
   })
 
   it('does not refresh until the app tab is visible again', async () => {
@@ -58,7 +55,10 @@ describe('watchForTopupBalanceUpdate', () => {
   })
 
   it('stops retrying once the balance increases', async () => {
-    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 6_000
+    })
 
     watchForTopupBalanceUpdate()
     returnToApp()
@@ -78,7 +78,10 @@ describe('watchForTopupBalanceUpdate', () => {
     expect(spentOnBounce).toBeGreaterThan(1)
 
     // The real return, after paying, must still refresh.
-    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 6_000
+    })
     returnToApp()
     await vi.advanceTimersByTimeAsync(0)
 
@@ -116,7 +119,10 @@ describe('watchForTopupBalanceUpdate', () => {
       await vi.advanceTimersByTimeAsync(60_000)
     }
     mockFetchBalance.mockClear()
-    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 6_000
+    })
 
     returnToApp()
     await vi.advanceTimersByTimeAsync(0)

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import { effectScope, nextTick, computed } from 'vue'
+import type { Ref } from 'vue'
+import type { Mock } from 'vitest'
+import { storeToRefs } from 'pinia'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type {
@@ -13,6 +19,8 @@ import {
 } from '@/platform/remoteConfig/remoteConfig'
 
 import { useBillingContext as useSharedBillingContext } from './useBillingContext'
+
+vi.mock(import('firebase/auth'))
 
 function useBillingContext() {
   const scope = effectScope()
@@ -32,16 +40,11 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 }
 
 const {
-  mockIsPersonal,
-  mockBillingRail,
   mockPlans,
   mockFetchPlans,
   mockLegacyFetchStatus,
-  mockLegacyFetchBalance,
   mockLegacySubscribe,
   mockPurchaseCredits,
-  mockUpdateActiveWorkspace,
-  mockSetWorkspaceBillingRail,
   mockLegacyStatus,
   mockBillingStatus
 } = vi.hoisted(() => {
@@ -54,16 +57,11 @@ const {
     }
   }
   return {
-    mockIsPersonal: { value: true },
-    mockBillingRail: { value: undefined as BillingRail | undefined },
     mockPlans: { value: [] as Plan[] },
     mockFetchPlans: vi.fn(async () => undefined),
     mockLegacyFetchStatus: vi.fn(async () => undefined),
-    mockLegacyFetchBalance: vi.fn(async () => undefined),
     mockLegacySubscribe: vi.fn(async () => undefined),
     mockPurchaseCredits: vi.fn(),
-    mockUpdateActiveWorkspace: vi.fn(),
-    mockSetWorkspaceBillingRail: vi.fn(),
     mockLegacyStatus: {
       value: {
         is_active: true,
@@ -75,38 +73,19 @@ const {
   }
 })
 
-vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
+let mockIsPersonal: Ref<boolean>
+let mockBillingRail: Ref<BillingRail | null | undefined>
+let mockLegacyFetchBalance: Mock<
+  ReturnType<typeof useAuthStore>['fetchBalance']
+>
+let mockUpdateActiveWorkspace: Mock<
+  ReturnType<typeof useTeamWorkspaceStore>['updateActiveWorkspace']
+>
+let mockSetWorkspaceBillingRail: Mock<
+  ReturnType<typeof useTeamWorkspaceStore>['setWorkspaceBillingRail']
+>
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { ref } = await import('vue')
-    const billingRailRef = ref(mockBillingRail.value)
-    Object.defineProperty(mockBillingRail, 'value', {
-      get: () => billingRailRef.value,
-      set: (value: BillingRail | undefined) => {
-        billingRailRef.value = value
-      }
-    })
-    return {
-      useTeamWorkspaceStore: () => ({
-        get isInPersonalWorkspace() {
-          return mockIsPersonal.value
-        },
-        get activeWorkspace() {
-          return mockIsPersonal.value
-            ? { id: 'personal-123', type: 'personal' }
-            : { id: 'team-456', type: 'team' }
-        },
-        get activeWorkspaceBillingRail() {
-          return mockBillingRail.value
-        },
-        updateActiveWorkspace: mockUpdateActiveWorkspace,
-        setWorkspaceBillingRail: mockSetWorkspaceBillingRail
-      })
-    }
-  }
-)
+vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
 
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useSubscription'),
@@ -149,13 +128,6 @@ vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    balance: { amount_micros: 5000000 },
-    fetchBalance: mockLegacyFetchBalance
-  })
-}))
-
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useBillingPlans'),
   () => ({
@@ -189,6 +161,29 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
 
 describe('useBillingContext', () => {
   beforeEach(() => {
+    const workspaceStore = useTeamWorkspaceStore()
+    const refs = storeToRefs(workspaceStore)
+    mockIsPersonal = refs.isInPersonalWorkspace
+    mockBillingRail = refs.activeWorkspaceBillingRail
+    Object.assign(workspaceStore, {
+      activeWorkspace: computed(() =>
+        fromPartial<NonNullable<typeof workspaceStore.activeWorkspace>>({
+          id: mockIsPersonal.value ? 'personal-123' : 'team-456',
+          type: mockIsPersonal.value ? 'personal' : 'team'
+        })
+      )
+    })
+    const authStore = useAuthStore()
+    authStore.balance = { currency: 'usd', amount_micros: 5000000 }
+    mockLegacyFetchBalance = vi
+      .mocked(authStore.fetchBalance)
+      .mockResolvedValue(authStore.balance)
+    mockUpdateActiveWorkspace = vi
+      .mocked(workspaceStore.updateActiveWorkspace)
+      .mockImplementation(() => {})
+    mockSetWorkspaceBillingRail = vi.mocked(
+      workspaceStore.setWorkspaceBillingRail
+    )
     remoteConfig.value = {}
     remoteConfigState.value = 'unloaded'
     mockIsPersonal.value = true

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -1,24 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { storeToRefs } from 'pinia'
+import type { Ref } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 import type { BillingRail } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingRouting } from './useBillingRouting'
 
-const {
-  mockIsCloud,
-  mockLegacyBillingMigrationEnabled,
-  mockActiveWorkspace,
-  mockActiveWorkspaceBillingRail
-} = vi.hoisted(() => ({
+const { mockIsCloud, mockLegacyBillingMigrationEnabled } = vi.hoisted(() => ({
   mockIsCloud: { value: true },
-  mockLegacyBillingMigrationEnabled: { value: false },
-  mockActiveWorkspace: {
-    value: null as { id: string; type: 'personal' | 'team' } | null
-  },
-  mockActiveWorkspaceBillingRail: {
-    value: null as BillingRail | null
-  }
+  mockLegacyBillingMigrationEnabled: { value: false }
 }))
+
+let mockActiveWorkspace: Ref<
+  ReturnType<typeof useTeamWorkspaceStore>['activeWorkspace']
+>
+let mockActiveWorkspaceBillingRail: Ref<BillingRail | null>
 
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
@@ -36,25 +34,18 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspace() {
-        return mockActiveWorkspace.value
-      },
-      get activeWorkspaceBillingRail() {
-        return mockActiveWorkspaceBillingRail.value
-      }
-    })
-  })
-)
-
-const personal = { id: 'w-personal', type: 'personal' as const }
-const team = { id: 'w-team', type: 'team' as const }
+const personal = fromPartial<
+  NonNullable<ReturnType<typeof useTeamWorkspaceStore>['activeWorkspace']>
+>({ id: 'w-personal', type: 'personal' })
+const team = fromPartial<
+  NonNullable<ReturnType<typeof useTeamWorkspaceStore>['activeWorkspace']>
+>({ id: 'w-team', type: 'team' })
 
 describe('useBillingRouting', () => {
   beforeEach(() => {
+    const refs = storeToRefs(useTeamWorkspaceStore())
+    mockActiveWorkspace = refs.activeWorkspace
+    mockActiveWorkspaceBillingRail = refs.activeWorkspaceBillingRail
     mockIsCloud.value = true
     mockLegacyBillingMigrationEnabled.value = false
     mockActiveWorkspace.value = personal

--- a/src/composables/billing/useLegacyBilling.test.ts
+++ b/src/composables/billing/useLegacyBilling.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useLegacyBilling } from './useLegacyBilling'
 
+vi.mock(import('firebase/auth'))
+
 const mockSubscribe = vi.fn()
 const mockSubscribeDirect = vi.fn()
 
@@ -27,10 +29,6 @@ vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: () => ({
     purchaseCredits: vi.fn()
   })
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({ balance: null })
 }))
 
 describe('useLegacyBilling', () => {

--- a/src/composables/billing/usePartnerNodesRunGate.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.test.ts
@@ -4,7 +4,9 @@ import type { EffectScope, Ref } from 'vue'
 
 import * as currentUserModule from '@/composables/auth/useCurrentUser'
 import * as featureFlagsModule from '@/composables/useFeatureFlags'
-import * as authStoreModule from '@/stores/authStore'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock(import('firebase/auth'))
 
 import {
   partnerRunGateBlocksAutoQueue,
@@ -43,21 +45,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), async () => {
   }
 })
 
-vi.mock<unknown>(import('@/stores/authStore'), async () => {
-  const { ref } = await import('vue')
-  const initialized = ref(true)
-  return {
-    useAuthStore: () => ({
-      get isInitialized() {
-        return initialized.value
-      }
-    }),
-    __setAuthResolved: (value: boolean) => {
-      initialized.value = value
-    }
-  }
-})
-
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), async () => {
   const { reactive } = await import('vue')
   const flags = reactive({ partnerRunGateEnabled: true })
@@ -77,9 +64,6 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 const { __setLoggedIn } = currentUserModule as typeof currentUserModule & {
   __setLoggedIn: (value: boolean) => void
 }
-const { __setAuthResolved } = authStoreModule as typeof authStoreModule & {
-  __setAuthResolved: (value: boolean) => void
-}
 const { __setPartnerRunGateEnabled } =
   featureFlagsModule as typeof featureFlagsModule & {
     __setPartnerRunGateEnabled: (value: boolean) => void
@@ -97,7 +81,7 @@ describe('usePartnerNodesRunGate', () => {
     state.hasPartnerNodes = ref(false)
     state.partnerNodes = ref([])
     __setLoggedIn(false)
-    __setAuthResolved(true)
+    useAuthStore().isInitialized = true
     __setPartnerRunGateEnabled(true)
   })
 
@@ -180,14 +164,14 @@ describe('usePartnerNodesRunGate', () => {
 
   it('does not gate while auth is still resolving, then follows the outcome', async () => {
     state.hasPartnerNodes.value = true
-    __setAuthResolved(false)
+    useAuthStore().isInitialized = false
     const { gate } = setup()
     expect(gate.value, 'unresolved auth must never read as signed-out').toBe(
       'none'
     )
 
     __setLoggedIn(true)
-    __setAuthResolved(true)
+    useAuthStore().isInitialized = true
     await nextTick()
     expect(gate.value, 'a signed-in resolution keeps the gate open').toBe(
       'none'
@@ -214,7 +198,7 @@ describe('partnerRunGateBlocksAutoQueue', () => {
   beforeEach(() => {
     state.partnerNodes = ref([])
     __setLoggedIn(false)
-    __setAuthResolved(true)
+    useAuthStore().isInitialized = true
     __setPartnerRunGateEnabled(true)
   })
 
@@ -232,7 +216,7 @@ describe('partnerRunGateBlocksAutoQueue', () => {
 
   it('never blocks while auth is still resolving', () => {
     state.partnerNodes.value = [{ nodeName: 'Kling', displayName: 'Kling' }]
-    __setAuthResolved(false)
+    useAuthStore().isInitialized = false
     expect(partnerRunGateBlocksAutoQueue()).toBe(false)
   })
 

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -6,36 +6,19 @@ import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
 import { useBoundingBoxes } from './useBoundingBoxes'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import { toNodeId } from '@/types/nodeId'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
-const { appState, outputState } = vi.hoisted(() => {
-  const appState: { node: MockNode | null } = { node: null }
-  const outputState: {
-    outputs: { input_bboxes: unknown } | undefined
-    nodeOutputs: { value: Record<string, unknown> } | null
-  } = {
-    outputs: undefined,
-    nodeOutputs: null as { value: Record<string, unknown> } | null
-  }
-  return { appState, outputState }
-})
+const appState = vi.hoisted(() => ({ node: null as MockNode | null }))
+let incomingOutputs: { input_bboxes: unknown } | undefined
+let outputStore: ReturnType<typeof useNodeOutputStore>
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: { getNodeById: () => appState.node } } }
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), async () => {
-  const { ref } = await import('vue')
-  const nodeOutputs = ref<Record<string, unknown>>({})
-  outputState.nodeOutputs = nodeOutputs
-  return {
-    useNodeOutputStore: () => ({
-      nodeOutputs,
-      nodePreviewImages: ref({}),
-      getNodeImageUrls: () => undefined,
-      getNodeOutputs: () => outputState.outputs
-    })
+  app: {
+    canvas: { graph: { getNodeById: () => appState.node } },
+    nodeOutputs: {},
+    nodePreviewImages: {}
   }
-})
+}))
 
 const ctx = {
   measureText: (s: string) => ({ width: s.length * 7 }),
@@ -177,9 +160,12 @@ function makeConnectedNode(): MockNode {
 }
 
 beforeEach(() => {
+  outputStore = useNodeOutputStore()
+  vi.mocked(outputStore.getNodeOutputs).mockImplementation(
+    () => incomingOutputs
+  )
   appState.node = makeNode()
-  outputState.outputs = undefined
-  if (outputState.nodeOutputs) outputState.nodeOutputs.value = {}
+  incomingOutputs = undefined
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
     void Promise.resolve().then(() => cb(0))
     return 1
@@ -293,7 +279,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const node = makeConnectedNode()
     appState.node = node
     const incoming = [box({ x: 0, width: 100 })]
-    outputState.outputs = { input_bboxes: incoming }
+    incomingOutputs = { input_bboxes: incoming }
     const c = setup([box({ x: 200, width: 300 })])
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(300)
@@ -305,15 +291,15 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const incoming = [box({ x: 0, width: 100 })]
     setLastIncomingOf(node, incoming)
     appState.node = node
-    outputState.outputs = { input_bboxes: incoming }
+    incomingOutputs = { input_bboxes: incoming }
     const c = setup([box({ x: 200, width: 300 })])
-    outputState.nodeOutputs!.value = { updated: true }
+    outputStore.nodeOutputs = { output: { updated: true } }
     await flush()
     expect(modelBoxes(c)[0].width).toBe(300)
   })
 
   it('ignores incoming output when the input is not connected', () => {
-    outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
+    incomingOutputs = { input_bboxes: [box({ x: 0, width: 100 })] }
     const c = setup([])
     expect(modelBoxes(c)).toHaveLength(0)
   })
@@ -321,7 +307,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
   it('ignores an output containing an invalid bounding box', () => {
     const node = makeConnectedNode()
     appState.node = node
-    outputState.outputs = {
+    incomingOutputs = {
       input_bboxes: [box(), { x: 1 }]
     }
 
@@ -335,8 +321,8 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     appState.node = makeConnectedNode()
     const c = setup([])
 
-    outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
-    outputState.nodeOutputs!.value = { n: 1 }
+    incomingOutputs = { input_bboxes: [box({ x: 0, width: 100 })] }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(1)
 
@@ -344,7 +330,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     await flush()
     expect(modelBoxes(c)).toHaveLength(0)
 
-    outputState.nodeOutputs!.value = { n: 2 }
+    outputStore.nodeOutputs = { n: { revision: 2 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(100)
@@ -358,15 +344,15 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     }
     const c = setup([])
 
-    outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
-    outputState.nodeOutputs!.value = { n: 1 }
+    incomingOutputs = { input_bboxes: [box({ x: 0, width: 100 })] }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(1)
 
     c.clearAll()
     await flush()
     connected = false
-    outputState.nodeOutputs!.value = { n: 2 }
+    outputStore.nodeOutputs = { n: { revision: 2 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(0)
   })
@@ -378,10 +364,10 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     c.onPointerDown(pe(10, 10))
     c.onCanvasPointerMove(pe(50, 50))
 
-    outputState.outputs = {
+    incomingOutputs = {
       input_bboxes: [box({ x: 0, width: 100, height: 100 })]
     }
-    outputState.nodeOutputs!.value = { n: 1 }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
 
     c.onDocPointerUp(pe(50, 50))
@@ -397,8 +383,8 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     expect(modelBoxes(c)).toHaveLength(0)
 
     const incoming = [box({ x: 0, width: 100 })]
-    outputState.outputs = { input_bboxes: incoming }
-    outputState.nodeOutputs!.value = { updated: true }
+    incomingOutputs = { input_bboxes: incoming }
+    outputStore.nodeOutputs = { output: { updated: true } }
     await flush()
 
     expect(modelBoxes(c)).toHaveLength(1)
@@ -413,8 +399,8 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const c = setup([box({ x: 200, width: 300 })])
 
     const changed = [box({ x: 64, width: 128 })]
-    outputState.outputs = { input_bboxes: changed }
-    outputState.nodeOutputs!.value = { n: 1 }
+    incomingOutputs = { input_bboxes: changed }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
 
     expect(modelBoxes(c)[0].width).toBe(128)

--- a/src/composables/canvas/useFocusNode.test.ts
+++ b/src/composables/canvas/useFocusNode.test.ts
@@ -1,34 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const viewport = [0, 0, 900, 700] as const
-const { canvasStore, createCanvas } = vi.hoisted(() => {
-  function createCanvas() {
-    const canvas = {
-      graph: undefined as unknown,
-      subgraph: undefined as unknown,
-      setGraph: vi.fn(),
-      animateToBounds: vi.fn()
-    }
-    canvas.setGraph.mockImplementation((graph) => {
-      canvas.graph = graph
-    })
-    return canvas
-  }
-
-  const canvasStore: {
-    canvas: ReturnType<typeof createCanvas> | undefined
-  } = { canvas: createCanvas() }
-  return {
-    canvasStore,
-    createCanvas
-  }
-})
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => canvasStore
-}))
+function createCanvas() {
+  const canvas = fromPartial<LGraphCanvas>({
+    graph: null,
+    subgraph: undefined,
+    setGraph: vi.fn(),
+    animateToBounds: vi.fn()
+  })
+  vi.mocked(canvas.setGraph).mockImplementation((graph) => {
+    canvas.graph = graph
+  })
+  return canvas
+}
+let canvasStore: ReturnType<typeof useCanvasStore>
 vi.mock(import('@/composables/canvas/visibleCanvasViewport'), () => ({
   visibleCanvasViewport: () => viewport
 }))
@@ -40,6 +33,7 @@ describe('useFocusNode', () => {
   let animationFrames: FrameRequestCallback[]
 
   beforeEach(() => {
+    canvasStore = useCanvasStore()
     canvasStore.canvas = createCanvas()
     animationFrames = []
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
@@ -102,7 +96,7 @@ describe('useFocusNode', () => {
     const focusPromise = useFocusNode().focusNodeInstance(node)
 
     await vi.waitFor(() => expect(animationFrames).toHaveLength(1))
-    canvasStore.canvas = undefined
+    canvasStore.canvas = null
     finishNavigationFrames()
     await focusPromise
 

--- a/src/composables/graph/useGraphHierarchy.test.ts
+++ b/src/composables/graph/useGraphHierarchy.test.ts
@@ -1,8 +1,12 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
-import type { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  LGraphCanvas,
+  LGraphGroup,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
 import * as measure from '@/lib/litegraph/src/measure'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import {
@@ -10,8 +14,6 @@ import {
   createMockLGraphGroup
 } from '@/utils/__tests__/litegraphTestUtils'
 import { useGraphHierarchy } from './useGraphHierarchy'
-
-vi.mock(import('@/renderer/core/canvas/canvasStore'))
 
 function createMockNode(overrides: Partial<LGraphNode> = {}): LGraphNode {
   return Object.assign(
@@ -28,7 +30,7 @@ function createMockGroup(overrides: Partial<LGraphGroup> = {}): LGraphGroup {
 }
 
 describe('useGraphHierarchy', () => {
-  let mockCanvasStore: Partial<ReturnType<typeof useCanvasStore>>
+  let mockCanvasStore: ReturnType<typeof useCanvasStore>
   let mockNode: LGraphNode
   let mockGroups: LGraphGroup[]
 
@@ -36,29 +38,10 @@ describe('useGraphHierarchy', () => {
     mockNode = createMockNode()
     mockGroups = []
 
-    mockCanvasStore = fromAny<
-      Partial<ReturnType<typeof useCanvasStore>>,
-      unknown
-    >({
-      canvas: {
-        graph: {
-          groups: mockGroups
-        }
-      },
-      $id: 'canvas',
-      $state: {},
-      $patch: vi.fn(),
-      $reset: vi.fn(),
-      $subscribe: vi.fn(),
-      $onAction: vi.fn(),
-      $dispose: vi.fn(),
-      _customProperties: new Set(),
-      _p: {}
+    mockCanvasStore = useCanvasStore()
+    mockCanvasStore.canvas = fromPartial<LGraphCanvas>({
+      graph: { groups: mockGroups }
     })
-
-    vi.mocked(useCanvasStore).mockReturnValue(
-      mockCanvasStore as ReturnType<typeof useCanvasStore>
-    )
   })
 
   describe('findParentGroup', () => {

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -7,30 +7,20 @@ import type {
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
-const {
-  mockShowNodeOptions,
-  mockUpdateSelectedItems,
-  mockGetCanvasContextMenuTarget
-} = vi.hoisted(() => ({
-  mockShowNodeOptions: vi.fn(),
-  mockUpdateSelectedItems: vi.fn(),
-  mockGetCanvasContextMenuTarget: vi.fn<
-    () => { reroute?: unknown; group?: unknown }
-  >(() => ({}))
-}))
+const { mockShowNodeOptions, mockGetCanvasContextMenuTarget } = vi.hoisted(
+  () => ({
+    mockShowNodeOptions: vi.fn(),
+    mockGetCanvasContextMenuTarget: vi.fn<
+      () => { reroute?: unknown; group?: unknown }
+    >(() => ({}))
+  })
+)
 
 vi.mock(import('@/composables/graph/useMoreOptionsMenu'), () => ({
   showNodeOptions: mockShowNodeOptions
 }))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({ updateSelectedItems: mockUpdateSelectedItems })
-  })
-)
 
 vi.mock<unknown>(
   import('@/lib/litegraph/src/canvas/getCanvasContextMenuTarget'),
@@ -55,8 +45,12 @@ describe('useGroupContextMenu', () => {
   }
   let legacyMenuMock: ReturnType<typeof vi.fn>
   let stubCanvas: StubCanvas
+  let mockUpdateSelectedItems: ReturnType<
+    typeof vi.mocked<ReturnType<typeof useCanvasStore>['updateSelectedItems']>
+  >
 
   beforeEach(() => {
+    mockUpdateSelectedItems = vi.mocked(useCanvasStore().updateSelectedItems)
     LiteGraph.vueNodesMode = true
     group = { id: 1, recomputeInsideNodes: vi.fn() }
     mockGetCanvasContextMenuTarget.mockReturnValue({ group })

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -24,10 +24,6 @@ const i18n = createI18n({
   }
 })
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
-}))
-
 function setupComposable() {
   let composable!: ReturnType<typeof useImageMenuOptions>
   const Wrapper = defineComponent({

--- a/src/composables/graph/useSubgraphOperations.test.ts
+++ b/src/composables/graph/useSubgraphOperations.test.ts
@@ -1,11 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode, SubgraphNode } from '@/lib/litegraph/src/litegraph'
-
-const mocks = vi.hoisted(() => ({
-  publishSubgraph: vi.fn(),
-  selectedItems: [] as unknown[]
-}))
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSubgraphStore } from '@/stores/subgraphStore'
+import { useSubgraphOperations } from './useSubgraphOperations'
 
 vi.mock<unknown>(
   import('@/composables/canvas/useSelectedLiteGraphItems'),
@@ -15,41 +13,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: vi.fn(),
-      get selectedItems() {
-        return mocks.selectedItems
-      },
-      updateSelectedItems: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: null
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    revokeSubgraphPreviews: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: () => ({
-    publishSubgraph: mocks.publishSubgraph
-  })
-}))
 
 function createSubgraphNode(): SubgraphNode {
   const node = Object.create(SubgraphNode.prototype)
@@ -62,54 +25,45 @@ function createRegularNode(): LGraphNode {
 
 describe('useSubgraphOperations', () => {
   beforeEach(() => {
-    mocks.selectedItems = []
+    vi.mocked(useSubgraphStore().publishSubgraph).mockResolvedValue(undefined)
   })
 
   it('addSubgraphToLibrary calls publishSubgraph when single SubgraphNode selected', async () => {
-    mocks.selectedItems = [createSubgraphNode()]
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = [createSubgraphNode()]
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).toHaveBeenCalledOnce()
+    expect(useSubgraphStore().publishSubgraph).toHaveBeenCalledOnce()
   })
 
   it('addSubgraphToLibrary does not call publishSubgraph when no items selected', async () => {
-    mocks.selectedItems = []
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = []
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).not.toHaveBeenCalled()
+    expect(useSubgraphStore().publishSubgraph).not.toHaveBeenCalled()
   })
 
   it('addSubgraphToLibrary does not call publishSubgraph when multiple items selected', async () => {
-    mocks.selectedItems = [createSubgraphNode(), createSubgraphNode()]
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = [
+      createSubgraphNode(),
+      createSubgraphNode()
+    ]
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).not.toHaveBeenCalled()
+    expect(useSubgraphStore().publishSubgraph).not.toHaveBeenCalled()
   })
 
   it('addSubgraphToLibrary does not call publishSubgraph when selected item is not a SubgraphNode', async () => {
-    mocks.selectedItems = [createRegularNode()]
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = [createRegularNode()]
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).not.toHaveBeenCalled()
+    expect(useSubgraphStore().publishSubgraph).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -1,30 +1,12 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, ref } from 'vue'
 import type { EffectScope } from 'vue'
+import { BrushShape, Tools } from '@/extensions/core/maskeditor/types'
 
-// vi.hoisted runs before imports — only vi.fn() is safe here (no Vue)
-const saveStateSpy = vi.hoisted(() => vi.fn())
+let saveStateSpy: ReturnType<typeof vi.spyOn>
 
-const mockStoreDef = vi.hoisted(() => ({
-  brushSettings: {
-    size: 20,
-    hardness: 0.9,
-    opacity: 1,
-    stepSize: 5,
-    type: 'arc'
-  },
-  currentTool: 'pen' as string,
-  activeLayer: 'mask' as string,
-  maskCanvas: null as HTMLCanvasElement | null,
-  maskCtx: null as CanvasRenderingContext2D | null,
-  rgbCanvas: null as HTMLCanvasElement | null,
-  rgbCtx: null as CanvasRenderingContext2D | null,
-  maskBlendMode: 'black',
-  maskOpacity: 0.8,
-  maskColor: { r: 0, g: 0, b: 0 },
-  rgbColor: '#FF0000',
-  canvasHistory: { saveState: saveStateSpy }
-}))
+let mockStoreDef: ReturnType<typeof useMaskEditorStore>
 
 // vi.mock factory runs after hoisting — ref/computed from Vue are available
 vi.mock(import('./useGPUResources'), () => {
@@ -81,10 +63,6 @@ vi.mock(import('./useBrushAdjustment'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStoreDef)
-}))
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { registerExtension: vi.fn() }
 }))
@@ -128,8 +106,20 @@ function setup() {
 }
 
 beforeEach(() => {
+  mockStoreDef = useMaskEditorStore()
+  mockStoreDef.brushSettings = {
+    size: 20,
+    hardness: 0.9,
+    opacity: 1,
+    stepSize: 5,
+    type: BrushShape.Arc
+  }
+  saveStateSpy = vi
+    .spyOn(mockStoreDef.canvasHistory, 'saveState')
+    .mockImplementation(() => {})
   const mockCtx = makeMockCtx()
   const mockCanvas = {
+    getContext: vi.fn().mockImplementation(() => mockStoreDef.rgbCtx),
     width: 200,
     height: 200,
     style: { opacity: '' }
@@ -139,7 +129,7 @@ beforeEach(() => {
   mockStoreDef.maskCtx = mockCtx
   mockStoreDef.rgbCanvas = mockCanvas
   mockStoreDef.rgbCtx = mockCtx
-  mockStoreDef.currentTool = 'pen'
+  mockStoreDef.currentTool = Tools.MaskPen
   mockStoreDef.activeLayer = 'mask'
 
   const gpu = useGPUResources()
@@ -167,7 +157,7 @@ describe('startDrawing', () => {
   })
 
   it('sets DestinationOut composition when tool is eraser', async () => {
-    mockStoreDef.currentTool = 'eraser'
+    mockStoreDef.currentTool = Tools.Eraser
     const { startDrawing } = setup()
     await startDrawing(makePointerEvent(50, 50))
     expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
@@ -233,7 +223,7 @@ describe('handleDrawing', () => {
   })
 
   it('sets DestinationOut composition when tool is eraser during move', async () => {
-    mockStoreDef.currentTool = 'eraser'
+    mockStoreDef.currentTool = Tools.Eraser
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
       cb(0)
       return 0
@@ -266,6 +256,7 @@ describe('drawEnd canvas visibility', () => {
   it('restores rgb canvas opacity when activeLayer is rgb', async () => {
     mockStoreDef.activeLayer = 'rgb'
     const mockRgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStoreDef.rgbCtx),
       width: 200,
       height: 200,
       style: { opacity: '' }
@@ -308,7 +299,7 @@ describe('drawEnd', () => {
   })
 
   it('passes isErasing=true to compositeStroke when tool is eraser', async () => {
-    mockStoreDef.currentTool = 'eraser'
+    mockStoreDef.currentTool = Tools.Eraser
     const { startDrawing, drawEnd } = setup()
     await startDrawing(makePointerEvent(50, 50))
     await drawEnd(makePointerEvent(60, 60))
@@ -318,6 +309,7 @@ describe('drawEnd', () => {
   it('restores mask canvas opacity after drawing on mask layer', async () => {
     mockStoreDef.activeLayer = 'mask'
     const mockMaskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStoreDef.maskCtx),
       width: 200,
       height: 200,
       style: { opacity: '' }

--- a/src/composables/maskeditor/useCanvasHistory.test.ts
+++ b/src/composables/maskeditor/useCanvasHistory.test.ts
@@ -1,69 +1,9 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { useCanvasHistory } from '@/composables/maskeditor/useCanvasHistory'
 
-// Define the store shape to avoid 'any' and cast to the expected type
-interface MaskEditorStoreState {
-  maskCanvas: HTMLCanvasElement | null
-  rgbCanvas: HTMLCanvasElement | null
-  imgCanvas: HTMLCanvasElement | null
-  maskCtx: CanvasRenderingContext2D | null
-  rgbCtx: CanvasRenderingContext2D | null
-  imgCtx: CanvasRenderingContext2D | null
-}
-
-// Use vi.hoisted to create isolated mock state container
-const mockRefs = vi.hoisted(() => ({
-  maskCanvas: null as HTMLCanvasElement | null,
-  rgbCanvas: null as HTMLCanvasElement | null,
-  imgCanvas: null as HTMLCanvasElement | null,
-  maskCtx: null as CanvasRenderingContext2D | null,
-  rgbCtx: null as CanvasRenderingContext2D | null,
-  imgCtx: null as CanvasRenderingContext2D | null
-}))
-
-const mockStore: MaskEditorStoreState = {
-  get maskCanvas() {
-    return mockRefs.maskCanvas
-  },
-  set maskCanvas(val) {
-    mockRefs.maskCanvas = val
-  },
-  get rgbCanvas() {
-    return mockRefs.rgbCanvas
-  },
-  set rgbCanvas(val) {
-    mockRefs.rgbCanvas = val
-  },
-  get imgCanvas() {
-    return mockRefs.imgCanvas
-  },
-  set imgCanvas(val) {
-    mockRefs.imgCanvas = val
-  },
-  get maskCtx() {
-    return mockRefs.maskCtx
-  },
-  set maskCtx(val) {
-    mockRefs.maskCtx = val
-  },
-  get rgbCtx() {
-    return mockRefs.rgbCtx
-  },
-  set rgbCtx(val) {
-    mockRefs.rgbCtx = val
-  },
-  get imgCtx() {
-    return mockRefs.imgCtx
-  },
-  set imgCtx(val) {
-    mockRefs.imgCtx = val
-  }
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockRefs: ReturnType<typeof useMaskEditorStore>
 
 // Mock ImageBitmap using safe global augmentation pattern
 if (typeof globalThis.ImageBitmap === 'undefined') {
@@ -80,6 +20,7 @@ if (typeof globalThis.ImageBitmap === 'undefined') {
 
 describe('useCanvasHistory', () => {
   beforeEach(() => {
+    mockRefs = useMaskEditorStore()
     let rafCallCount = 0
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
       (cb: FrameRequestCallback) => {
@@ -122,16 +63,19 @@ describe('useCanvasHistory', () => {
 
     // Mock canvases using explicit partial-cast pattern
     mockRefs.maskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
       width: 100,
       height: 100
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockRefs.rgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockRefs.rgbCtx),
       width: 100,
       height: 100
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockRefs.imgCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockRefs.imgCtx),
       width: 100,
       height: 100
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
@@ -166,6 +110,7 @@ describe('useCanvasHistory', () => {
       const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
 
       mockRefs.maskCanvas = {
+        getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
         // oxlint-disable-next-line no-misused-spread
         ...mockRefs.maskCanvas,
         width: 0,
@@ -178,6 +123,7 @@ describe('useCanvasHistory', () => {
       expect(rafSpy).toHaveBeenCalled()
 
       mockRefs.maskCanvas = {
+        getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
         width: 100,
         height: 100
       } as Partial<HTMLCanvasElement> as HTMLCanvasElement
@@ -623,6 +569,7 @@ describe('useCanvasHistory', () => {
     it('should handle zero-sized canvas', () => {
       if (mockRefs.maskCanvas) {
         mockRefs.maskCanvas = {
+          getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
           width: 0,
           height: 0
         } as Partial<HTMLCanvasElement> as HTMLCanvasElement

--- a/src/composables/maskeditor/useCanvasManager.test.ts
+++ b/src/composables/maskeditor/useCanvasManager.test.ts
@@ -1,23 +1,11 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MaskBlendMode } from '@/extensions/core/maskeditor/types'
 import { useCanvasManager } from '@/composables/maskeditor/useCanvasManager'
-const mockStore = {
-  imgCanvas: null! as HTMLCanvasElement,
-  maskCanvas: null! as HTMLCanvasElement,
-  rgbCanvas: null! as HTMLCanvasElement,
-  imgCtx: null! as CanvasRenderingContext2D,
-  maskCtx: null! as CanvasRenderingContext2D,
-  rgbCtx: null! as CanvasRenderingContext2D,
-  canvasBackground: null! as HTMLElement,
-  maskColor: { r: 0, g: 0, b: 0 },
-  maskBlendMode: MaskBlendMode.Black,
-  maskOpacity: 0.8
-}
+import { fromPartial } from '@total-typescript/shoehorn'
 
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 function createMockImage(width: number, height: number): HTMLImageElement {
   return {
@@ -30,6 +18,7 @@ describe('useCanvasManager', () => {
   let mockImageData: ImageData
 
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
     mockImageData = {
       data: new Uint8ClampedArray(100 * 100 * 4),
       width: 100,
@@ -56,24 +45,27 @@ describe('useCanvasManager', () => {
     mockStore.rgbCtx = partialRgbCtx as CanvasRenderingContext2D
 
     const partialImgCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 0,
       height: 0
     }
     mockStore.imgCanvas = partialImgCanvas as HTMLCanvasElement
 
-    mockStore.maskCanvas = {
+    mockStore.maskCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 0,
       height: 0,
       style: {
         mixBlendMode: '',
         opacity: ''
-      } as Pick<CSSStyleDeclaration, 'mixBlendMode' | 'opacity'>
-    } as HTMLCanvasElement
+      }
+    })
 
-    mockStore.rgbCanvas = {
+    mockStore.rgbCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 0,
       height: 0
-    } as HTMLCanvasElement
+    })
 
     mockStore.canvasBackground = {
       style: {
@@ -81,7 +73,7 @@ describe('useCanvasManager', () => {
       } as Pick<CSSStyleDeclaration, 'backgroundColor'>
     } as HTMLElement
 
-    mockStore.maskColor = { r: 0, g: 0, b: 0 }
+    Object.assign(mockStore, { maskColor: { r: 0, g: 0, b: 0 } })
     mockStore.maskBlendMode = MaskBlendMode.Black
     mockStore.maskOpacity = 0.8
   })
@@ -95,12 +87,12 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.imgCanvas.width).toBe(512)
-      expect(mockStore.imgCanvas.height).toBe(512)
-      expect(mockStore.maskCanvas.width).toBe(512)
-      expect(mockStore.maskCanvas.height).toBe(512)
-      expect(mockStore.rgbCanvas.width).toBe(512)
-      expect(mockStore.rgbCanvas.height).toBe(512)
+      expect(mockStore.imgCanvas!.width).toBe(512)
+      expect(mockStore.imgCanvas!.height).toBe(512)
+      expect(mockStore.maskCanvas!.width).toBe(512)
+      expect(mockStore.maskCanvas!.height).toBe(512)
+      expect(mockStore.rgbCanvas!.width).toBe(512)
+      expect(mockStore.rgbCanvas!.height).toBe(512)
     })
 
     it('should draw original image', async () => {
@@ -111,7 +103,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.imgCtx.drawImage).toHaveBeenCalledWith(
+      expect(mockStore.imgCtx!.drawImage).toHaveBeenCalledWith(
         origImage,
         0,
         0,
@@ -129,7 +121,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, paintImage)
 
-      expect(mockStore.rgbCtx.drawImage).toHaveBeenCalledWith(
+      expect(mockStore.rgbCtx!.drawImage).toHaveBeenCalledWith(
         paintImage,
         0,
         0,
@@ -146,7 +138,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.rgbCtx.drawImage).not.toHaveBeenCalled()
+      expect(mockStore.rgbCtx!.drawImage).not.toHaveBeenCalled()
     })
 
     it('should prepare mask', async () => {
@@ -157,15 +149,15 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.maskCtx.drawImage).toHaveBeenCalled()
-      expect(mockStore.maskCtx.getImageData).toHaveBeenCalled()
-      expect(mockStore.maskCtx.putImageData).toHaveBeenCalled()
+      expect(mockStore.maskCtx!.drawImage).toHaveBeenCalled()
+      expect(mockStore.maskCtx!.getImageData).toHaveBeenCalled()
+      expect(mockStore.maskCtx!.putImageData).toHaveBeenCalled()
     })
 
     it('should throw error when canvas missing', async () => {
       const manager = useCanvasManager()
 
-      mockStore.imgCanvas = null! as HTMLCanvasElement
+      mockStore.imgCanvas = null
 
       const origImage = createMockImage(512, 512)
       const maskImage = createMockImage(512, 512)
@@ -194,14 +186,14 @@ describe('useCanvasManager', () => {
       const manager = useCanvasManager()
 
       mockStore.maskBlendMode = MaskBlendMode.Black
-      mockStore.maskColor = { r: 0, g: 0, b: 0 }
+      Object.assign(mockStore, { maskColor: { r: 0, g: 0, b: 0 } })
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCtx.fillStyle).toBe('rgb(0, 0, 0)')
-      expect(mockStore.maskCanvas.style.mixBlendMode).toBe('initial')
-      expect(mockStore.maskCanvas.style.opacity).toBe('0.8')
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe(
+      expect(mockStore.maskCtx!.fillStyle).toBe('rgb(0, 0, 0)')
+      expect(mockStore.maskCanvas!.style.mixBlendMode).toBe('initial')
+      expect(mockStore.maskCanvas!.style.opacity).toBe('0.8')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe(
         'rgba(0,0,0,1)'
       )
     })
@@ -210,13 +202,13 @@ describe('useCanvasManager', () => {
       const manager = useCanvasManager()
 
       mockStore.maskBlendMode = MaskBlendMode.White
-      mockStore.maskColor = { r: 255, g: 255, b: 255 }
+      Object.assign(mockStore, { maskColor: { r: 255, g: 255, b: 255 } })
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCtx.fillStyle).toBe('rgb(255, 255, 255)')
-      expect(mockStore.maskCanvas.style.mixBlendMode).toBe('initial')
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe(
+      expect(mockStore.maskCtx!.fillStyle).toBe('rgb(255, 255, 255)')
+      expect(mockStore.maskCanvas!.style.mixBlendMode).toBe('initial')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe(
         'rgba(255,255,255,1)'
       )
     })
@@ -225,13 +217,13 @@ describe('useCanvasManager', () => {
       const manager = useCanvasManager()
 
       mockStore.maskBlendMode = MaskBlendMode.Negative
-      mockStore.maskColor = { r: 255, g: 255, b: 255 }
+      Object.assign(mockStore, { maskColor: { r: 255, g: 255, b: 255 } })
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCanvas.style.mixBlendMode).toBe('difference')
-      expect(mockStore.maskCanvas.style.opacity).toBe('1')
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe(
+      expect(mockStore.maskCanvas!.style.mixBlendMode).toBe('difference')
+      expect(mockStore.maskCanvas!.style.opacity).toBe('1')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe(
         'rgba(255,255,255,1)'
       )
     })
@@ -239,9 +231,9 @@ describe('useCanvasManager', () => {
     it('should update all pixels with mask color', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskColor = { r: 128, g: 64, b: 32 }
-      mockStore.maskCanvas.width = 100
-      mockStore.maskCanvas.height = 100
+      Object.assign(mockStore, { maskColor: { r: 128, g: 64, b: 32 } })
+      mockStore.maskCanvas!.width = 100
+      mockStore.maskCanvas!.height = 100
 
       await manager.updateMaskColor()
 
@@ -251,7 +243,7 @@ describe('useCanvasManager', () => {
         expect(mockImageData.data[i + 2]).toBe(32)
       }
 
-      expect(mockStore.maskCtx.putImageData).toHaveBeenCalledWith(
+      expect(mockStore.maskCtx!.putImageData).toHaveBeenCalledWith(
         mockImageData,
         0,
         0
@@ -261,11 +253,11 @@ describe('useCanvasManager', () => {
     it('should return early when canvas missing', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskCanvas = null! as HTMLCanvasElement
+      mockStore.maskCanvas = null
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCtx.getImageData).not.toHaveBeenCalled()
+      expect(mockStore.maskCtx!.getImageData).not.toHaveBeenCalled()
     })
 
     it('should return early when context missing', async () => {
@@ -275,7 +267,7 @@ describe('useCanvasManager', () => {
 
       await manager.updateMaskColor()
 
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe('')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe('')
     })
 
     it('should handle different opacity values', async () => {
@@ -285,7 +277,7 @@ describe('useCanvasManager', () => {
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCanvas.style.opacity).toBe('0.5')
+      expect(mockStore.maskCanvas!.style.opacity).toBe('0.5')
     })
   })
 
@@ -310,7 +302,7 @@ describe('useCanvasManager', () => {
     it('should apply mask color to all pixels', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskColor = { r: 100, g: 150, b: 200 }
+      Object.assign(mockStore, { maskColor: { r: 100, g: 150, b: 200 } })
 
       const origImage = createMockImage(100, 100)
       const maskImage = createMockImage(100, 100)
@@ -332,7 +324,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.maskCtx.globalCompositeOperation).toBe('source-over')
+      expect(mockStore.maskCtx!.globalCompositeOperation).toBe('source-over')
     })
   })
 })

--- a/src/composables/maskeditor/useCanvasTools.test.ts
+++ b/src/composables/maskeditor/useCanvasTools.test.ts
@@ -1,61 +1,25 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ColorComparisonMethod } from '@/extensions/core/maskeditor/types'
+import {
+  ColorComparisonMethod,
+  MaskBlendMode
+} from '@/extensions/core/maskeditor/types'
 
 import { useCanvasTools } from '@/composables/maskeditor/useCanvasTools'
 
-// Mock store interface matching the real store's nullable fields
-interface MockMaskEditorStore {
-  maskCtx: CanvasRenderingContext2D | null
-  imgCtx: CanvasRenderingContext2D | null
-  maskCanvas: HTMLCanvasElement | null
-  imgCanvas: HTMLCanvasElement | null
-  rgbCtx: CanvasRenderingContext2D | null
-  rgbCanvas: HTMLCanvasElement | null
-  maskColor: { r: number; g: number; b: number }
-  paintBucketTolerance: number
-  fillOpacity: number
-  colorSelectTolerance: number
-  colorComparisonMethod: ColorComparisonMethod
-  selectionOpacity: number
-  applyWholeImage: boolean
-  maskBoundary: boolean
-  maskTolerance: number
-  canvasHistory: { saveState: ReturnType<typeof vi.fn> }
-}
+let mockCanvasHistory: ReturnType<typeof useMaskEditorStore>['canvasHistory']
 
-const mockCanvasHistory = {
-  saveState: vi.fn()
-}
-
-const mockStore: MockMaskEditorStore = {
-  maskCtx: null,
-  imgCtx: null,
-  maskCanvas: null,
-  imgCanvas: null,
-  rgbCtx: null,
-  rgbCanvas: null,
-  maskColor: { r: 255, g: 255, b: 255 },
-  paintBucketTolerance: 10,
-  fillOpacity: 100,
-  colorSelectTolerance: 30,
-  colorComparisonMethod: ColorComparisonMethod.Simple,
-  selectionOpacity: 100,
-  applyWholeImage: false,
-  maskBoundary: false,
-  maskTolerance: 10,
-  canvasHistory: mockCanvasHistory
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 describe('useCanvasTools', () => {
   let mockMaskImageData: ImageData
   let mockImgImageData: ImageData
 
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
+    mockCanvasHistory = mockStore.canvasHistory
+    vi.spyOn(mockCanvasHistory, 'saveState').mockImplementation(() => {})
     mockMaskImageData = {
       data: new Uint8ClampedArray(100 * 100 * 4),
       width: 100,
@@ -93,24 +57,27 @@ describe('useCanvasTools', () => {
     mockStore.rgbCtx = partialRgbCtx as CanvasRenderingContext2D
 
     const partialMaskCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 100,
       height: 100
     }
     mockStore.maskCanvas = partialMaskCanvas as HTMLCanvasElement
 
     const partialImgCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 100,
       height: 100
     }
     mockStore.imgCanvas = partialImgCanvas as HTMLCanvasElement
 
     const partialRgbCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 100,
       height: 100
     }
     mockStore.rgbCanvas = partialRgbCanvas as HTMLCanvasElement
 
-    mockStore.maskColor = { r: 255, g: 255, b: 255 }
+    mockStore.maskBlendMode = MaskBlendMode.White
     mockStore.paintBucketTolerance = 10
     mockStore.fillOpacity = 100
     mockStore.colorSelectTolerance = 30
@@ -203,7 +170,7 @@ describe('useCanvasTools', () => {
     })
 
     it('should apply mask color', () => {
-      mockStore.maskColor = { r: 128, g: 64, b: 32 }
+      Object.assign(mockStore, { maskColor: { r: 128, g: 64, b: 32 } })
 
       const tools = useCanvasTools()
 

--- a/src/composables/maskeditor/useCanvasTransform.test.ts
+++ b/src/composables/maskeditor/useCanvasTransform.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCanvasTransform } from '@/composables/maskeditor/useCanvasTransform'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 interface IMockCanvas {
   width: number
   height: number
+  getContext: () => CanvasRenderingContext2D | null
 }
 
 interface IMockContext {
@@ -13,53 +16,8 @@ interface IMockContext {
   drawImage: ReturnType<typeof vi.fn>
 }
 
-interface IMockCanvasHistory {
-  saveState: ReturnType<typeof vi.fn>
-}
-
-interface IMockStore {
-  maskCanvas: IMockCanvas | null
-  rgbCanvas: IMockCanvas | null
-  imgCanvas: IMockCanvas | null
-  maskCtx: IMockContext | null
-  rgbCtx: IMockContext | null
-  imgCtx: IMockContext | null
-  tgpuRoot: unknown
-  canvasHistory: IMockCanvasHistory
-  gpuTexturesNeedRecreation: boolean
-  gpuTextureWidth: number
-  gpuTextureHeight: number
-  pendingGPUMaskData: Uint8ClampedArray | null
-  pendingGPURgbData: Uint8ClampedArray | null
-}
-
-const { mockStore, mockCanvasHistory } = vi.hoisted(() => {
-  const mockCanvasHistory: IMockCanvasHistory = {
-    saveState: vi.fn()
-  }
-
-  const mockStore: IMockStore = {
-    maskCanvas: null,
-    rgbCanvas: null,
-    imgCanvas: null,
-    maskCtx: null,
-    rgbCtx: null,
-    imgCtx: null,
-    tgpuRoot: null,
-    canvasHistory: mockCanvasHistory,
-    gpuTexturesNeedRecreation: false,
-    gpuTextureWidth: 0,
-    gpuTextureHeight: 0,
-    pendingGPUMaskData: null,
-    pendingGPURgbData: null
-  }
-
-  return { mockStore, mockCanvasHistory }
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
+let mockCanvasHistory: ReturnType<typeof useMaskEditorStore>['canvasHistory']
 
 // Mock ImageData with improved type safety
 if (typeof globalThis.ImageData === 'undefined') {
@@ -120,6 +78,9 @@ describe('useCanvasTransform', () => {
   let mockImgCtx: IMockContext
 
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
+    mockCanvasHistory = mockStore.canvasHistory
+    vi.spyOn(mockCanvasHistory, 'saveState').mockImplementation(() => {})
     const createMockImageData = (width: number, height: number) => {
       const data = new Uint8ClampedArray(width * height * 4)
       for (let i = 0; i < data.length; i += 4) {
@@ -157,26 +118,29 @@ describe('useCanvasTransform', () => {
     }
 
     mockMaskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 100,
       height: 50
     }
 
     mockRgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 100,
       height: 50
     }
 
     mockImgCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 100,
       height: 50
     }
 
-    mockStore.maskCanvas = mockMaskCanvas
-    mockStore.rgbCanvas = mockRgbCanvas
-    mockStore.imgCanvas = mockImgCanvas
-    mockStore.maskCtx = mockMaskCtx
-    mockStore.rgbCtx = mockRgbCtx
-    mockStore.imgCtx = mockImgCtx
+    mockStore.maskCanvas = fromPartial<HTMLCanvasElement>(mockMaskCanvas)
+    mockStore.rgbCanvas = fromPartial<HTMLCanvasElement>(mockRgbCanvas)
+    mockStore.imgCanvas = fromPartial<HTMLCanvasElement>(mockImgCanvas)
+    mockStore.maskCtx = fromPartial<CanvasRenderingContext2D>(mockMaskCtx)
+    mockStore.rgbCtx = fromPartial<CanvasRenderingContext2D>(mockRgbCtx)
+    mockStore.imgCtx = fromPartial<CanvasRenderingContext2D>(mockImgCtx)
     mockStore.tgpuRoot = null
     mockStore.gpuTexturesNeedRecreation = false
     mockStore.gpuTextureWidth = 0
@@ -226,15 +190,15 @@ describe('useCanvasTransform', () => {
 
       expect(mockCanvasHistory.saveState).toHaveBeenCalled()
 
-      const savedArgs = mockCanvasHistory.saveState.mock.calls[0]
+      const savedArgs = vi.mocked(mockCanvasHistory.saveState).mock.calls[0]
       expect(savedArgs).toHaveLength(3)
 
-      expect(savedArgs[0].width).toBe(50)
-      expect(savedArgs[0].height).toBe(100)
-      expect(savedArgs[1].width).toBe(50)
-      expect(savedArgs[1].height).toBe(100)
-      expect(savedArgs[2].width).toBe(50)
-      expect(savedArgs[2].height).toBe(100)
+      expect(savedArgs[0]!.width).toBe(50)
+      expect(savedArgs[0]!.height).toBe(100)
+      expect(savedArgs[1]!.width).toBe(50)
+      expect(savedArgs[1]!.height).toBe(100)
+      expect(savedArgs[2]!.width).toBe(50)
+      expect(savedArgs[2]!.height).toBe(100)
     })
 
     it('should log error when canvas contexts not ready', async () => {
@@ -254,7 +218,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should handle GPU texture recreation when GPU is active', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
 
       const transform = useCanvasTransform()
       await transform.rotateClockwise()
@@ -464,7 +430,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should handle GPU texture recreation when GPU is active', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
 
       const transform = useCanvasTransform()
       await transform.mirrorHorizontal()
@@ -529,7 +497,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should handle GPU texture recreation when GPU is active', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
 
       const transform = useCanvasTransform()
       await transform.mirrorVertical()
@@ -619,7 +589,9 @@ describe('useCanvasTransform', () => {
 
   describe('GPU integration', () => {
     it('should set GPU recreation flags for rotation', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
       mockMaskCanvas.width = 100
       mockMaskCanvas.height = 50
 
@@ -634,7 +606,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should premultiply alpha when preparing GPU data', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
       mockMaskCanvas.width = 1
       mockMaskCanvas.height = 1
 

--- a/src/composables/maskeditor/useCoordinateTransform.test.ts
+++ b/src/composables/maskeditor/useCoordinateTransform.test.ts
@@ -1,22 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCoordinateTransform } from '@/composables/maskeditor/useCoordinateTransform'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-type MockStore = {
-  pointerZone: HTMLElement | null
-  canvasContainer: HTMLElement | null
-  maskCanvas: HTMLCanvasElement | null
-}
-
-const mockStore: MockStore = {
-  pointerZone: null,
-  canvasContainer: null,
-  maskCanvas: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock(import('@vueuse/core'), () => ({
   createSharedComposable: <T extends (...args: unknown[]) => unknown>(fn: T) =>
@@ -65,9 +52,7 @@ const createCanvasWithRect = (
 
 describe('useCoordinateTransform', () => {
   beforeEach(() => {
-    mockStore.pointerZone = null
-    mockStore.canvasContainer = null
-    mockStore.maskCanvas = null
+    mockStore = useMaskEditorStore()
   })
 
   describe('screenToCanvas', () => {

--- a/src/composables/maskeditor/useGPUResources.test.ts
+++ b/src/composables/maskeditor/useGPUResources.test.ts
@@ -1,6 +1,7 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 vi.mock<unknown>(import('typegpu'), () => ({
@@ -28,36 +29,7 @@ vi.mock<unknown>(import('./gpu/GPUBrushRenderer'), () => ({
   )
 }))
 
-const tgpuRoot: unknown = null
-const mockStore = reactive({
-  tgpuRoot,
-  maskCanvas: null as HTMLCanvasElement | null,
-  rgbCanvas: null as HTMLCanvasElement | null,
-  maskCtx: null as CanvasRenderingContext2D | null,
-  rgbCtx: null as CanvasRenderingContext2D | null,
-  clearTrigger: 0,
-  canvasHistory: { currentStateIndex: 0 },
-  gpuTexturesNeedRecreation: false,
-  gpuTextureWidth: 0,
-  gpuTextureHeight: 0,
-  pendingGPUMaskData: null,
-  pendingGPURgbData: null,
-  brushSettings: {
-    size: 20,
-    hardness: 0.9,
-    opacity: 1,
-    stepSize: 5,
-    type: 'arc'
-  },
-  activeLayer: 'mask',
-  currentTool: 'pen',
-  maskColor: { r: 0, g: 0, b: 0 },
-  rgbColor: '#FF0000'
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 import { resetDirtyRect } from './brushDrawingUtils'
 import { useGPUResources } from './useGPUResources'
@@ -70,6 +42,7 @@ function setup() {
 }
 
 beforeEach(() => {
+  mockStore = useMaskEditorStore()
   mockStore.tgpuRoot = null
   mockStore.maskCanvas = null
   mockStore.rgbCanvas = null
@@ -186,7 +159,9 @@ describe('watchers', () => {
 describe('initGPUResources with pre-existing tgpuRoot', () => {
   it('returns early with a warning when canvas contexts are not ready', async () => {
     const { initGPUResources, hasRenderer } = setup()
-    mockStore.tgpuRoot = { device: {} }
+    mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>({
+      device: {}
+    })
     await initGPUResources()
     expect(hasRenderer.value).toBe(false)
   })
@@ -235,12 +210,16 @@ describe('gpuRender', () => {
         writeTexture: vi.fn()
       }
     }
-    mockStore.tgpuRoot = { device: gpuDevice }
+    mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>({
+      device: gpuDevice
+    })
     mockStore.maskCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockReturnValue(context),
       width: 4,
       height: 4
     })
     mockStore.rgbCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockReturnValue(context),
       width: 4,
       height: 4
     })

--- a/src/composables/maskeditor/useImageLoader.test.ts
+++ b/src/composables/maskeditor/useImageLoader.test.ts
@@ -1,49 +1,18 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toNodeId } from '@/types/nodeId'
 
 import { useImageLoader } from '@/composables/maskeditor/useImageLoader'
-
-type MockStore = {
-  imgCanvas: HTMLCanvasElement | null
-  maskCanvas: HTMLCanvasElement | null
-  rgbCanvas: HTMLCanvasElement | null
-  imgCtx: CanvasRenderingContext2D | null
-  maskCtx: CanvasRenderingContext2D | null
-  image: HTMLImageElement | null
-}
-
-type MockDataStore = {
-  inputData: {
-    baseLayer: { image: HTMLImageElement }
-    maskLayer: { image: HTMLImageElement }
-    paintLayer: { image: HTMLImageElement } | null
-  } | null
-}
 
 const mockCanvasManager = {
   invalidateCanvas: vi.fn().mockResolvedValue(undefined),
   updateMaskColor: vi.fn().mockResolvedValue(undefined)
 }
 
-const mockStore: MockStore = {
-  imgCanvas: null,
-  maskCanvas: null,
-  rgbCanvas: null,
-  imgCtx: null,
-  maskCtx: null,
-  image: null
-}
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
-const mockDataStore: MockDataStore = {
-  inputData: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: vi.fn(() => mockDataStore)
-}))
+let mockDataStore: ReturnType<typeof useMaskEditorDataStore>
 
 vi.mock(import('@/composables/maskeditor/useCanvasManager'), () => ({
   useCanvasManager: vi.fn(() => mockCanvasManager)
@@ -60,20 +29,11 @@ describe('useImageLoader', () => {
   let mockPaintImage: HTMLImageElement
 
   beforeEach(() => {
-    mockBaseImage = {
-      width: 512,
-      height: 512
-    } as HTMLImageElement
-
-    mockMaskImage = {
-      width: 512,
-      height: 512
-    } as HTMLImageElement
-
-    mockPaintImage = {
-      width: 512,
-      height: 512
-    } as HTMLImageElement
+    mockStore = useMaskEditorStore()
+    mockDataStore = useMaskEditorDataStore()
+    mockBaseImage = new Image(512, 512)
+    mockMaskImage = new Image(512, 512)
+    mockPaintImage = new Image(512, 512)
 
     mockStore.imgCtx = {
       clearRect: vi.fn()
@@ -84,24 +44,29 @@ describe('useImageLoader', () => {
     } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
 
     mockStore.imgCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 0,
       height: 0
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockStore.maskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 0,
       height: 0
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockStore.rgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 0,
       height: 0
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockDataStore.inputData = {
-      baseLayer: { image: mockBaseImage },
-      maskLayer: { image: mockMaskImage },
-      paintLayer: { image: mockPaintImage }
+      baseLayer: { image: mockBaseImage, url: 'base.png' },
+      maskLayer: { image: mockMaskImage, url: 'mask.png' },
+      paintLayer: { image: mockPaintImage, url: 'paint.png' },
+      sourceRef: { filename: 'base.png' },
+      nodeId: toNodeId(1)
     }
   })
 
@@ -150,9 +115,10 @@ describe('useImageLoader', () => {
 
     it('should handle missing paintLayer', async () => {
       mockDataStore.inputData = {
-        baseLayer: { image: mockBaseImage },
-        maskLayer: { image: mockMaskImage },
-        paintLayer: null
+        baseLayer: { image: mockBaseImage, url: 'base.png' },
+        maskLayer: { image: mockMaskImage, url: 'mask.png' },
+        sourceRef: { filename: 'base.png', subfolder: '', type: 'input' },
+        nodeId: toNodeId(1)
       }
 
       const loader = useImageLoader()

--- a/src/composables/maskeditor/useKeyboard.test.ts
+++ b/src/composables/maskeditor/useKeyboard.test.ts
@@ -1,32 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeyboard } from '@/composables/maskeditor/useKeyboard'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-type MockCanvasHistory = {
-  undo: ReturnType<typeof vi.fn>
-  redo: ReturnType<typeof vi.fn>
-}
-
-type MockStore = {
-  canvasHistory: MockCanvasHistory
-}
-
-const { mockStore, mockCanvasHistory } = vi.hoisted(() => {
-  const mockCanvasHistory: MockCanvasHistory = {
-    undo: vi.fn(),
-    redo: vi.fn()
-  }
-
-  const mockStore: MockStore = {
-    canvasHistory: mockCanvasHistory
-  }
-
-  return { mockStore, mockCanvasHistory }
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockCanvasHistory: ReturnType<typeof useMaskEditorStore>['canvasHistory']
 
 const dispatchKeyDown = (
   init: KeyboardEventInit & { key: string }
@@ -44,6 +21,9 @@ describe('useKeyboard', () => {
   let keyboard: ReturnType<typeof useKeyboard>
 
   beforeEach(() => {
+    mockCanvasHistory = useMaskEditorStore().canvasHistory
+    vi.spyOn(mockCanvasHistory, 'undo').mockImplementation(() => {})
+    vi.spyOn(mockCanvasHistory, 'redo').mockImplementation(() => {})
     keyboard = useKeyboard()
     keyboard.addListeners()
   })

--- a/src/composables/maskeditor/useMaskEditor.test.ts
+++ b/src/composables/maskeditor/useMaskEditor.test.ts
@@ -1,14 +1,9 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
-const mockDialogStore = vi.hoisted(() => ({
-  showDialog: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => mockDialogStore
-}))
+let mockDialogStore: ReturnType<typeof useDialogStore>
 
 vi.mock<unknown>(
   import('@/components/maskeditor/dialog/TopBarHeader.vue'),
@@ -42,6 +37,7 @@ describe('useMaskEditor', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    mockDialogStore = useDialogStore()
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -1,3 +1,4 @@
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,23 +9,7 @@ import { widgetId } from '@/types/widgetId'
 import { api } from '@/scripts/api'
 import { useMaskEditorLoader } from './useMaskEditorLoader'
 
-// ---- Module Mocks ----
-
-const mockDataStore: Record<string, unknown> = {
-  inputData: null,
-  sourceNode: null,
-  setLoading: vi.fn()
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: vi.fn(() => mockDataStore)
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: vi.fn(() => ({
-    getNodeOutputs: vi.fn(() => undefined)
-  }))
-}))
+let mockDataStore: ReturnType<typeof useMaskEditorDataStore>
 
 const distribution = vi.hoisted(() => ({ isCloud: false }))
 
@@ -43,6 +28,8 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     getPreviewFormatParam: vi.fn(() => ''),
     getRandParam: vi.fn(() => '')
   }
@@ -100,6 +87,7 @@ function requestedLayerUrls(layerFilename: string): string[] {
 
 describe('useMaskEditorLoader', () => {
   beforeEach(() => {
+    mockDataStore = useMaskEditorDataStore()
     requestedUrls.length = 0
     failUrlPattern = null
     distribution.isCloud = false

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -1,5 +1,8 @@
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { markRaw } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -11,17 +14,7 @@ import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { decodePng } from '@/utils/__fixtures__/decodePng'
 import { useMaskEditorSaver } from './useMaskEditorSaver'
 
-// ---- Module Mocks ----
-
-const mockDataStore: Record<string, unknown> = {
-  sourceNode: null,
-  inputData: null,
-  outputData: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: vi.fn(() => mockDataStore)
-}))
+let mockDataStore: ReturnType<typeof useMaskEditorDataStore>
 
 const CANVAS_SIZE = 4
 const CANVAS_BYTES = CANVAS_SIZE * CANVAS_SIZE * 4
@@ -73,18 +66,10 @@ function createMockCanvas(seed?: Uint8ClampedArray): HTMLCanvasElement {
     toDataURL: vi.fn(() => 'data:image/png;base64,mock')
   })
   canvasPixels.set(canvas, pixels)
-  return canvas
+  return markRaw(canvas)
 }
 
-const mockEditorStore: Record<string, HTMLCanvasElement | null> = {
-  maskCanvas: null,
-  rgbCanvas: null,
-  imgCanvas: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockEditorStore)
-}))
+let mockEditorStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -105,16 +90,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: false }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
-      nodeToNodeLocatorId: vi.fn((node: { id: number }) => String(node.id))
-    }))
-  })
-)
-
 vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   executionIdToNodeLocatorId: vi.fn((_rootGraph: unknown, id: string) => id)
 }))
@@ -124,6 +99,8 @@ describe('useMaskEditorSaver', () => {
   const originalCreateElement = document.createElement.bind(document)
 
   beforeEach(() => {
+    mockDataStore = useMaskEditorDataStore()
+    mockEditorStore = useMaskEditorStore()
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
 
@@ -152,7 +129,7 @@ describe('useMaskEditorSaver', () => {
       baseLayer: { image: {} as HTMLImageElement, url: 'base.png' },
       maskLayer: { image: {} as HTMLImageElement, url: 'mask.png' },
       sourceRef: { filename: 'original.png', subfolder: '', type: 'input' },
-      nodeId: 42
+      nodeId: toNodeId(42)
     }
     mockDataStore.outputData = null
 

--- a/src/composables/maskeditor/usePanAndZoom.test.ts
+++ b/src/composables/maskeditor/usePanAndZoom.test.ts
@@ -1,41 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { usePanAndZoom } from '@/composables/maskeditor/usePanAndZoom'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-interface IMockStore {
-  canvasContainer: HTMLElement | null
-  maskCanvas: HTMLCanvasElement | null
-  rgbCanvas: HTMLCanvasElement | null
-  isPanning: boolean
-  brushVisible: boolean
-  displayZoomRatio: number
-  resetZoomTrigger: number
-  canvasHistory: { undo: ReturnType<typeof vi.fn> }
-  setCursorPoint: ReturnType<typeof vi.fn>
-  setPanOffset: ReturnType<typeof vi.fn>
-  setZoomRatio: ReturnType<typeof vi.fn>
-}
-
-const { mockStore } = vi.hoisted(() => {
-  const mockStore: IMockStore = {
-    canvasContainer: null,
-    maskCanvas: null,
-    rgbCanvas: null,
-    isPanning: false,
-    brushVisible: true,
-    displayZoomRatio: 1,
-    resetZoomTrigger: 0,
-    canvasHistory: { undo: vi.fn() },
-    setCursorPoint: vi.fn(),
-    setPanOffset: vi.fn(),
-    setZoomRatio: vi.fn()
-  }
-  return { mockStore }
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 function createMockElement(width = 1200, height = 800): HTMLElement {
   return {
@@ -58,6 +26,7 @@ function createMockCanvas(width: number, height: number): HTMLCanvasElement {
   return {
     width,
     height,
+    getContext: vi.fn().mockImplementation(() => null),
     clientWidth: width,
     clientHeight: height,
     style: {} as CSSStyleDeclaration,
@@ -107,6 +76,8 @@ async function initComposable() {
 
 describe('usePanAndZoom', () => {
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
+    vi.spyOn(mockStore.canvasHistory, 'undo').mockImplementation(() => {})
     mockStore.canvasContainer = null
     mockStore.maskCanvas = null
     mockStore.rgbCanvas = null
@@ -207,7 +178,7 @@ describe('usePanAndZoom', () => {
   describe('zoom', () => {
     it('zooms in with negative deltaY and updates store', async () => {
       const { pz } = await initComposable()
-      const initialZoom = vi.mocked(mockStore.setZoomRatio).mock.calls[0]?.[0]
+      const initialZoom = mockStore.zoomRatio
 
       await pz.zoom({
         clientX: 400,
@@ -216,7 +187,7 @@ describe('usePanAndZoom', () => {
       } as WheelEvent)
 
       const zoomValue = vi.mocked(mockStore.setZoomRatio).mock.calls[0][0]
-      expect(zoomValue).toBeGreaterThan(initialZoom ?? 0)
+      expect(zoomValue).toBeGreaterThan(initialZoom)
     })
 
     it('zooms out with positive deltaY producing smaller zoom', async () => {
@@ -252,7 +223,7 @@ describe('usePanAndZoom', () => {
         } as WheelEvent)
       }
 
-      const calls = mockStore.setZoomRatio.mock.calls
+      const calls = vi.mocked(mockStore.setZoomRatio).mock.calls
       expect(calls[calls.length - 1][0]).toBeGreaterThanOrEqual(0.2)
     })
 
@@ -267,7 +238,7 @@ describe('usePanAndZoom', () => {
         } as WheelEvent)
       }
 
-      const calls = mockStore.setZoomRatio.mock.calls
+      const calls = vi.mocked(mockStore.setZoomRatio).mock.calls
       expect(calls[calls.length - 1][0]).toBeLessThanOrEqual(10)
     })
 

--- a/src/composables/maskeditor/useToolManager.test.ts
+++ b/src/composables/maskeditor/useToolManager.test.ts
@@ -1,30 +1,13 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 import { useBrushDrawing } from '@/composables/maskeditor/useBrushDrawing'
 import { useToolManager } from '@/composables/maskeditor/useToolManager'
 import { Tools } from '@/extensions/core/maskeditor/types'
 
-type MockStore = {
-  currentTool: Tools
-  activeLayer: 'mask' | 'rgb'
-  pointerZone: HTMLElement | null
-  brushVisible: boolean
-  brushPreviewGradientVisible: boolean
-  isAdjustingBrush: boolean
-  isPanning: boolean
-}
-
-const mockStore = reactive<MockStore>({
-  currentTool: Tools.MaskPen,
-  activeLayer: 'mask',
-  pointerZone: null,
-  brushVisible: true,
-  brushPreviewGradientVisible: false,
-  isAdjustingBrush: false,
-  isPanning: false
-})
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 const mockBrushDrawing = {
   startDrawing: vi.fn().mockResolvedValue(undefined),
@@ -47,10 +30,6 @@ const mockCoordinateTransform = {
   })),
   canvasToScreen: vi.fn()
 }
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
 
 vi.mock<unknown>(import('@/composables/maskeditor/useBrushDrawing'), () => ({
   useBrushDrawing: vi.fn(() => mockBrushDrawing)
@@ -137,6 +116,7 @@ const setup = (): ReturnType<typeof useToolManager> => {
 
 describe('useToolManager', () => {
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
     mockStore.currentTool = Tools.MaskPen
     mockStore.activeLayer = 'mask'
     mockStore.pointerZone = document.createElement('div')

--- a/src/composables/node/badgeRendererParity.test.ts
+++ b/src/composables/node/badgeRendererParity.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { effectScope } from 'vue'
 
 import { badgeDrawObjects } from '@/lib/litegraph/src/nodeBadgeDraw'
@@ -16,27 +15,13 @@ import { nodeBadges } from '@/systems/badgeSystem'
 import type { NodeState } from '@/types/nodeState'
 import { NodeBadgeMode } from '@/types/nodeSource'
 
-const settings = vi.hoisted(() => ({ values: new Map<string, unknown>() }))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => settings.values.get(key) })
-}))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: {
-      colors: {
-        litegraph_base: { BADGE_FG_COLOR: '#fff', BADGE_BG_COLOR: '#000' }
-      }
-    }
-  })
-}))
-
 const CORE_SOURCE_BADGE = '🦊'
 
 function setModes(mode: NodeBadgeMode) {
-  settings.values.set('Comfy.NodeBadge.NodeIdBadgeMode', mode)
-  settings.values.set('Comfy.NodeBadge.NodeLifeCycleBadgeMode', mode)
-  settings.values.set('Comfy.NodeBadge.NodeSourceBadgeMode', mode)
+  useSettingStore().settingValues['Comfy.NodeBadge.NodeIdBadgeMode'] = mode
+  useSettingStore().settingValues['Comfy.NodeBadge.NodeLifeCycleBadgeMode'] =
+    mode
+  useSettingStore().settingValues['Comfy.NodeBadge.NodeSourceBadgeMode'] = mode
 }
 
 function seedNodeDef(name: string, pythonModule: string) {
@@ -89,11 +74,6 @@ function vueBadgeText(node: LGraphNode): string {
 }
 
 describe('badge renderer parity (I2)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    settings.values = new Map<string, unknown>()
-  })
-
   function setup(
     mode: NodeBadgeMode,
     type: string,

--- a/src/composables/node/startModelNodeDragFromAsset.test.ts
+++ b/src/composables/node/startModelNodeDragFromAsset.test.ts
@@ -2,18 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { startModelNodeDragFromAsset } from '@/composables/node/startModelNodeDragFromAsset'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 
-const { mockStartDrag, mockGetNodeProvider } = vi.hoisted(() => ({
-  mockStartDrag: vi.fn(),
-  mockGetNodeProvider: vi.fn()
-}))
+const mockStartDrag = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   useNodeDragToCanvas: () => ({ startDrag: mockStartDrag })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
 }))
 
 function createAsset(overrides: Partial<AssetItem> = {}): AssetItem {
@@ -35,8 +31,13 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('starts a ghost drag for the resolved node carrying the widget value', () => {
-    const nodeDef = { name: 'CheckpointLoaderSimple' }
-    mockGetNodeProvider.mockReturnValue({ nodeDef, key: 'ckpt_name' })
+    const nodeDef = fromPartial<ComfyNodeDefImpl>({
+      name: 'CheckpointLoaderSimple'
+    })
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
+      nodeDef,
+      key: 'ckpt_name'
+    })
 
     const error = startModelNodeDragFromAsset(createAsset())
 
@@ -48,8 +49,13 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('threads the node-add source through to the drag', () => {
-    const nodeDef = { name: 'CheckpointLoaderSimple' }
-    mockGetNodeProvider.mockReturnValue({ nodeDef, key: 'ckpt_name' })
+    const nodeDef = fromPartial<ComfyNodeDefImpl>({
+      name: 'CheckpointLoaderSimple'
+    })
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
+      nodeDef,
+      key: 'ckpt_name'
+    })
 
     startModelNodeDragFromAsset(createAsset(), 'asset_browser')
 
@@ -60,8 +66,11 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('carries no widget value when the provider has no key', () => {
-    const nodeDef = { name: 'FL_ChatterboxVC' }
-    mockGetNodeProvider.mockReturnValue({ nodeDef, key: '' })
+    const nodeDef = fromPartial<ComfyNodeDefImpl>({ name: 'FL_ChatterboxVC' })
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
+      nodeDef,
+      key: ''
+    })
 
     startModelNodeDragFromAsset(
       createAsset({
@@ -77,7 +86,7 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('returns the resolution error and does not start a drag for an invalid asset', () => {
-    mockGetNodeProvider.mockReturnValue(null)
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue(undefined)
 
     const error = startModelNodeDragFromAsset(createAsset())
 

--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -1,18 +1,22 @@
 import { render } from '@testing-library/vue'
-import { defineComponent, nextTick, ref } from 'vue'
+import { defineComponent, nextTick, ref, toRef } from 'vue'
+import type { Ref } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useExtensionStore } from '@/stores/extensionStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { NodeBadgeMode } from '@/types/nodeSource'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ComfyExtension } from '@/types/comfy'
 import { app } from '@/scripts/app'
 
 const mocks = vi.hoisted(() => ({
-  extensionInstalled: false,
-  installNodeBadges: vi.fn(),
-  registerExtension: vi.fn()
+  installNodeBadges: vi.fn()
 }))
 
-const badgeMode = ref(false)
-const showApiPricingBadge = ref(false)
+let badgeMode: Ref<string | undefined>
+let showApiPricingBadge: Ref<boolean | undefined>
 const pricingRevision = ref(0)
 const canvasEventListeners = new Map<string, EventListener>()
 const canvas = {
@@ -23,42 +27,18 @@ const canvas = {
   },
   setDirty: vi.fn()
 }
-let canvasReady = true
+let canvasStore: ReturnType<typeof useCanvasStore>
 
 vi.mock(import('@/systems/badgeSystem'), () => ({
   installNodeBadges: mocks.installNodeBadges
 }))
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({
-    isExtensionInstalled: () => mocks.extensionInstalled,
-    registerExtension: (extension: ComfyExtension) => {
-      mocks.extensionInstalled = true
-      mocks.registerExtension(extension)
-    }
-  })
-}))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.NodeBadge.ShowApiPricing'
-        ? showApiPricingBadge.value
-        : badgeMode.value
-  })
-}))
 vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
   useNodePricing: () => ({ pricingRevision })
-}))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    get canvas() {
-      return canvasReady ? canvas : undefined
-    }
-  })
 }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     get canvas() {
-      return canvasReady ? canvas : undefined
+      return canvasStore.canvas
     }
   }
 }))
@@ -78,40 +58,44 @@ function renderComposable() {
 
 describe('useNodeBadge', () => {
   beforeEach(() => {
-    mocks.extensionInstalled = false
-    badgeMode.value = false
+    const settings = useSettingStore().settingValues
+    badgeMode = toRef(settings, 'Comfy.NodeBadge.NodeIdBadgeMode')
+    showApiPricingBadge = toRef(settings, 'Comfy.NodeBadge.ShowApiPricing')
+    canvasStore = useCanvasStore()
+    badgeMode.value = NodeBadgeMode.None
     showApiPricingBadge.value = false
     pricingRevision.value = 0
     canvasEventListeners.clear()
-    canvasReady = true
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
   })
 
   it('keeps the extension-owned provider installed across canvas remounts', async () => {
     const firstMount = renderComposable()
-    const extension = mocks.registerExtension.mock.calls[0][0] as ComfyExtension
+    const extension = vi.mocked(useExtensionStore().registerExtension).mock
+      .calls[0][0]
     await extension.init?.(app)
 
     firstMount.unmount()
 
     const secondMount = renderComposable()
 
-    expect(mocks.registerExtension).toHaveBeenCalledOnce()
+    expect(useExtensionStore().registerExtension).toHaveBeenCalledOnce()
     expect(mocks.installNodeBadges).toHaveBeenCalledOnce()
 
     secondMount.unmount()
   })
 
   it('allows badge settings to change before the canvas is ready', async () => {
-    canvasReady = false
+    canvasStore.canvas = null
     const component = renderComposable()
 
-    badgeMode.value = true
+    badgeMode.value = NodeBadgeMode.ShowAll
     await nextTick()
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
 
-    canvasReady = true
-    badgeMode.value = false
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
+    badgeMode.value = NodeBadgeMode.None
     await nextTick()
 
     expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
@@ -120,7 +104,7 @@ describe('useNodeBadge', () => {
 
   it('allows pricing to update before the canvas is ready', async () => {
     showApiPricingBadge.value = true
-    canvasReady = false
+    canvasStore.canvas = null
     const component = renderComposable()
 
     pricingRevision.value++
@@ -128,7 +112,7 @@ describe('useNodeBadge', () => {
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
 
-    canvasReady = true
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
     pricingRevision.value++
     await nextTick()
 
@@ -138,9 +122,10 @@ describe('useNodeBadge', () => {
 
   it('allows the canvas to be removed before a graph event arrives', async () => {
     const component = renderComposable()
-    const extension = mocks.registerExtension.mock.calls[0][0] as ComfyExtension
+    const extension = vi.mocked(useExtensionStore().registerExtension).mock
+      .calls[0][0]
     await extension.init?.(app)
-    canvasReady = false
+    canvasStore.canvas = null
 
     canvasEventListeners.get('litegraph:set-graph')?.(
       new Event('litegraph:set-graph')
@@ -148,7 +133,7 @@ describe('useNodeBadge', () => {
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
 
-    canvasReady = true
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
     canvasEventListeners.get('litegraph:set-graph')?.(
       new Event('litegraph:set-graph')
     )

--- a/src/composables/node/useNodeDragToCanvas.test.ts
+++ b/src/composables/node/useNodeDragToCanvas.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
-import type { useNodeDragToCanvas as UseNodeDragToCanvasType } from './useNodeDragToCanvas'
+import { useNodeDragToCanvas } from './useNodeDragToCanvas'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const {
   mockAddNodeOnGraph,
   mockConvertEventToCanvasOffset,
   mockSelectItems,
-  mockCanvas,
-  mockToastAdd
+  mockCanvas
 } = vi.hoisted(() => {
   const mockConvertEventToCanvasOffset = vi.fn()
   const mockSelectItems = vi.fn()
@@ -16,9 +19,10 @@ const {
     mockAddNodeOnGraph: vi.fn(),
     mockConvertEventToCanvasOffset,
     mockSelectItems,
-    mockToastAdd: vi.fn(),
     mockCanvas: {
       canvas: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
         getBoundingClientRect: vi.fn()
       },
       convertEventToCanvasOffset: mockConvertEventToCanvasOffset,
@@ -27,11 +31,7 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => ({
-    canvas: mockCanvas
-  }))
-}))
+let mockToastAdd: ReturnType<typeof useToastStore>['add']
 
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: vi.fn(() => ({
@@ -39,25 +39,17 @@ vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({ add: mockToastAdd }))
-}))
-
 vi.mock(import('@/i18n'), () => ({ t: (key: string) => key }))
 
 describe('useNodeDragToCanvas', () => {
-  let useNodeDragToCanvas: typeof UseNodeDragToCanvasType
-
   const mockNodeDef = {
     name: 'TestNode',
     display_name: 'Test Node'
   } as ComfyNodeDefImpl
 
-  beforeEach(async () => {
-    vi.resetModules()
-
-    const module = await import('./useNodeDragToCanvas')
-    useNodeDragToCanvas = module.useNodeDragToCanvas
+  beforeEach(() => {
+    useCanvasStore().canvas = fromPartial<LGraphCanvas>(mockCanvas)
+    mockToastAdd = useToastStore().add
   })
 
   afterEach(() => {

--- a/src/composables/node/useNodeImage.test.ts
+++ b/src/composables/node/useNodeImage.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import { useNodeVideo } from '@/composables/node/useNodeImage'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { createMockMediaNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
 
-const { canvasInteractionsMock, nodeOutputStoreMock } = vi.hoisted(() => ({
+const { canvasInteractionsMock } = vi.hoisted(() => ({
   canvasInteractionsMock: {
     handleWheel: vi.fn(),
     handlePointerDown: vi.fn(),
     handlePointerMove: vi.fn()
-  },
-  nodeOutputStoreMock: {
-    getNodeImageUrls: vi.fn<(node: unknown) => string[] | undefined>()
   }
 }))
 
@@ -20,9 +18,6 @@ vi.mock<unknown>(
     useCanvasInteractions: () => canvasInteractionsMock
   })
 )
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => nodeOutputStoreMock
-}))
 vi.mock(import('@/utils/imageUtil'), () => ({
   fitDimensionsToNodeWidth: () => ({ minHeight: 256, minWidth: 256 })
 }))
@@ -31,7 +26,9 @@ describe('useNodeVideo', () => {
   async function setup() {
     vi.clearAllMocks()
 
-    nodeOutputStoreMock.getNodeImageUrls.mockReturnValue(['http://video/1.mp4'])
+    vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([
+      'http://video/1.mp4'
+    ])
     const node = createMockMediaNode({
       size: [400, 400],
       graph: { setDirtyCanvas: vi.fn() }

--- a/src/composables/node/useNodeImageUpload.test.ts
+++ b/src/composables/node/useNodeImageUpload.test.ts
@@ -3,12 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ResultItem } from '@/schemas/apiSchema'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useNodeImageUpload } from './useNodeImageUpload'
+import type { Mock } from 'vitest'
 
-const { mockFetchApi, mockAddAlert, mockInvalidateInputs } = vi.hoisted(() => ({
-  mockFetchApi: vi.fn(),
-  mockAddAlert: vi.fn(),
-  mockInvalidateInputs: vi.fn()
-}))
+const mockFetchApi = vi.hoisted(() => vi.fn())
+let mockAddAlert: ReturnType<typeof useToastStore>['addAlert']
+let mockInvalidateInputs: Mock<
+  ReturnType<typeof useAssetsStore>['inputAssets']['invalidate']
+>
 
 let capturedDragOnDrop: (files: File[]) => Promise<string[]>
 
@@ -33,18 +37,13 @@ vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert: mockAddAlert })
-}))
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: { fetchApi: mockFetchApi }
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    inputAssets: { invalidate: mockInvalidateInputs }
-  })
+  api: {
+    fetchApi: mockFetchApi,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getServerFeature: vi.fn()
+  }
 }))
 
 function createMockNode(): LGraphNode {
@@ -80,14 +79,16 @@ describe('useNodeImageUpload', () => {
   let onUploadStart: (files: File[]) => void
   let onUploadError: () => void
 
-  beforeEach(async () => {
-    vi.resetModules()
+  beforeEach(() => {
+    mockAddAlert = useToastStore().addAlert
+    mockInvalidateInputs = vi
+      .spyOn(useAssetsStore().inputAssets, 'invalidate')
+      .mockResolvedValue(undefined)
     node = createMockNode()
     onUploadComplete = vi.fn()
     onUploadStart = vi.fn()
     onUploadError = vi.fn()
 
-    const { useNodeImageUpload } = await import('./useNodeImageUpload')
     useNodeImageUpload(node, {
       onUploadComplete,
       onUploadStart,

--- a/src/composables/node/useNodePreviewAndDrag.test.ts
+++ b/src/composables/node/useNodePreviewAndDrag.test.ts
@@ -15,12 +15,6 @@ vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn().mockReturnValue('left')
-  })
-}))
-
 describe('useNodePreviewAndDrag', () => {
   const mockNodeDef = {
     name: 'TestNode',

--- a/src/composables/node/usePartnerNodesInGraph.test.ts
+++ b/src/composables/node/usePartnerNodesInGraph.test.ts
@@ -3,7 +3,11 @@ import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 import * as apiModule from '@/scripts/api'
-import * as workflowStoreModule from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 import { usePartnerNodesInGraph } from './usePartnerNodesInGraph'
 
@@ -14,17 +18,7 @@ interface FakeNode {
 }
 
 const hoisted = vi.hoisted(() => ({
-  nodeDefsByName: {} as Record<
-    string,
-    { name: string; display_name: string; api_node: boolean }
-  >,
   rootGraph: undefined as { nodes: unknown[] } | undefined
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    fromLGraphNode: (node: FakeNode) => hoisted.nodeDefsByName[node.type]
-  })
 }))
 
 // Mirrors ComfyApp: reading `rootGraph` before init logs an error, so
@@ -57,38 +51,15 @@ const { __dispatchGraphChanged } = apiModule as typeof apiModule & {
   __dispatchGraphChanged: () => void
 }
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { ref } = await import('vue')
-    const activeWorkflow = ref<{ path: string } | null>(null)
-    return {
-      useWorkflowStore: () => ({
-        get activeWorkflow() {
-          return activeWorkflow.value
-        }
-      }),
-      __setActiveWorkflow: (workflow: { path: string } | null) => {
-        activeWorkflow.value = workflow
-      }
-    }
-  }
-)
-
-const { __setActiveWorkflow } =
-  workflowStoreModule as typeof workflowStoreModule & {
-    __setActiveWorkflow: (workflow: { path: string } | null) => void
-  }
-
 function defineNodeDef(
   name: string,
   { apiNode = false, displayName = '' } = {}
 ) {
-  hoisted.nodeDefsByName[name] = {
+  useNodeDefStore().nodeDefsByName[name] = fromPartial<ComfyNodeDefImpl>({
     name,
     display_name: displayName,
     api_node: apiNode
-  }
+  })
 }
 
 function node(type: string): FakeNode {
@@ -108,9 +79,7 @@ function setup() {
 
 describe('usePartnerNodesInGraph', () => {
   beforeEach(() => {
-    hoisted.nodeDefsByName = {}
     hoisted.rootGraph = undefined
-    __setActiveWorkflow(null)
   })
 
   afterEach(() => {
@@ -151,10 +120,11 @@ describe('usePartnerNodesInGraph', () => {
   })
 
   it('ignores a def that is missing the api_node field entirely', () => {
-    hoisted.nodeDefsByName['MalformedDef'] = {
-      name: 'MalformedDef',
-      display_name: 'Malformed'
-    } as (typeof hoisted.nodeDefsByName)[string]
+    useNodeDefStore().nodeDefsByName['MalformedDef'] =
+      fromPartial<ComfyNodeDefImpl>({
+        name: 'MalformedDef',
+        display_name: 'Malformed'
+      })
     hoisted.rootGraph = { nodes: [node('MalformedDef')] }
 
     const { hasPartnerNodes } = setup()
@@ -206,7 +176,11 @@ describe('usePartnerNodesInGraph', () => {
     nodes.push(node('Partner'))
     expect(hasPartnerNodes.value).toBe(false)
 
-    __setActiveWorkflow({ path: 'workflows/partner.json' })
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: fromPartial<ComfyWorkflow>({
+        path: 'workflows/partner.json'
+      })
+    })
     await nextTick()
 
     expect(hasPartnerNodes.value).toBe(true)

--- a/src/composables/node/usePromotedPreviews.test.ts
+++ b/src/composables/node/usePromotedPreviews.test.ts
@@ -1,5 +1,4 @@
-import { reactive } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import {
@@ -16,35 +15,6 @@ import { toNodeId } from '@/types/nodeId'
 
 import { CANVAS_IMAGE_PREVIEW_WIDGET } from './canvasImagePreviewTypes'
 import { usePromotedPreviews } from './usePromotedPreviews'
-
-type MockNodeOutputStore = Pick<
-  ReturnType<typeof useNodeOutputStore>,
-  | 'nodeOutputs'
-  | 'nodePreviewImages'
-  | 'getNodeImageUrls'
-  | 'getNodeImageUrlsByExecutionId'
-  | 'getNodeOutputByExecutionId'
-  | 'getNodePreviewImagesByExecutionId'
->
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => {
-  const store: MockNodeOutputStore = {
-    nodeOutputs: reactive<MockNodeOutputStore['nodeOutputs']>({}),
-    nodePreviewImages: reactive<MockNodeOutputStore['nodePreviewImages']>({}),
-    getNodeImageUrls: vi.fn(),
-    getNodeImageUrlsByExecutionId: vi.fn(),
-    getNodeOutputByExecutionId: vi.fn(),
-    getNodePreviewImagesByExecutionId: vi.fn()
-  }
-  return { useNodeOutputStore: () => store }
-})
-
-function clearMockNodeOutputStore() {
-  const { nodeOutputs, nodePreviewImages } = useNodeOutputStore()
-  for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
-  for (const key of Object.keys(nodePreviewImages))
-    delete nodePreviewImages[key]
-}
 
 function createSetup() {
   const subgraph = createTestSubgraph()
@@ -125,10 +95,6 @@ function arrangePromotedPreview(options: ArrangeOptions = {}) {
 }
 
 describe(usePromotedPreviews, () => {
-  beforeEach(() => {
-    clearMockNodeOutputStore()
-  })
-
   it('returns empty array for non-SubgraphNode', () => {
     const node = new LGraphNode('test')
     const { promotedPreviews } = usePromotedPreviews(() => node)

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -13,10 +13,12 @@ import type { NodeId } from '@/types/nodeId'
 
 import { usePainter } from './usePainter'
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal()),
   useElementSize: vi.fn(() => ({
     width: ref(512),
-    height: ref(512)
+    height: ref(512),
+    stop: vi.fn()
   }))
 }))
 
@@ -31,20 +33,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => {
-  const store = { addAlert: vi.fn() }
-  return { useToastStore: () => store }
-})
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => {
-  const store = {
-    getNodeImageUrls: vi.fn(() => undefined),
-    nodeOutputs: {},
-    nodePreviewImages: {}
-  }
-  return { useNodeOutputStore: () => store }
-})
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: vi.fn((path: string) => `http://localhost:8188${path}`),
@@ -55,7 +43,11 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 const fixture = vi.hoisted((): { node: LGraphNode | null } => ({ node: null }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: { getNodeById: () => fixture.node } } }
+  app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
+    canvas: { graph: { getNodeById: () => fixture.node } }
+  }
 }))
 
 const i18n = createI18n({

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -1,6 +1,11 @@
 import { render } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useQueueStore } from '@/stores/queueStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useJobPreviewStore } from '@/stores/jobPreviewStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { nextTick, reactive, ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -76,111 +81,22 @@ vi.mock<unknown>(import('@/utils/queueUtil'), () => ({
   jobStateFromTask: vi.fn((task: TestTask): JobState => task.mockState)
 }))
 
-let queueStoreMock:
-  | {
-      pendingTasks: TestTask[]
-      runningTasks: TestTask[]
-      historyTasks: TestTask[]
-    }
-  | undefined
-const ensureQueueStore = () => {
-  if (!queueStoreMock) {
-    queueStoreMock = reactive({
-      pendingTasks: [] as TestTask[],
-      runningTasks: [] as TestTask[],
-      historyTasks: [] as TestTask[]
-    })
-  }
-  return queueStoreMock
-}
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => {
-    return ensureQueueStore()
-  }
-}))
-
-let executionStoreMock:
-  | {
-      activeJobId: string | null
-      executingNode: null | { title?: string; type?: string }
-      isJobInitializing: (jobId?: string | number) => boolean
-    }
-  | undefined
-let isJobInitializingMock: ((jobId?: string | number) => boolean) | undefined
-const ensureExecutionStore = () => {
-  if (!isJobInitializingMock) {
-    isJobInitializingMock = vi.fn(() => false)
-  }
-  const isJobInitializing = isJobInitializingMock
-  if (!executionStoreMock) {
-    executionStoreMock = reactive({
-      activeJobId: null as string | null,
-      executingNode: null as null | { title?: string; type?: string },
-      isJobInitializing: (jobId?: string | number) => isJobInitializing(jobId)
-    })
-  }
-  return executionStoreMock
-}
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => {
-    return ensureExecutionStore()
-  }
-}))
-
-let jobPreviewStoreMock:
-  | {
-      previewsByPromptId: Record<string, string>
-      isPreviewEnabled: boolean
-    }
-  | undefined
-const ensureJobPreviewStore = () => {
-  if (!jobPreviewStoreMock) {
-    jobPreviewStoreMock = reactive({
-      previewsByPromptId: {},
-      isPreviewEnabled: true
-    })
-  }
-  return jobPreviewStoreMock
-}
-vi.mock<unknown>(import('@/stores/jobPreviewStore'), () => ({
-  useJobPreviewStore: () => {
-    return ensureJobPreviewStore()
-  }
-}))
-
-let workflowStoreMock:
-  | {
-      activeWorkflow: null | { activeState?: { id?: string } }
-    }
-  | undefined
-const ensureWorkflowStore = () => {
-  if (!workflowStoreMock) {
-    workflowStoreMock = reactive({
-      activeWorkflow: null as null | { activeState?: { id?: string } }
-    })
-  }
-  return workflowStoreMock
-}
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => {
-      return ensureWorkflowStore()
-    }
-  })
-)
+let isJobInitializingMock: ReturnType<
+  typeof useExecutionStore
+>['isJobInitializing']
 
 const createTask = (
   overrides: Partial<TestTask> & { mockState?: JobState } = {}
-): TestTask => ({
-  jobId: overrides.jobId ?? `task-${Math.random().toString(36).slice(2, 7)}`,
-  job: overrides.job ?? { priority: 0 },
-  mockState: overrides.mockState ?? 'pending',
-  executionTime: overrides.executionTime,
-  executionEndTimestamp: overrides.executionEndTimestamp,
-  createTime: overrides.createTime,
-  workflowId: overrides.workflowId
-})
+): TaskItemImpl & TestTask =>
+  fromPartial<TaskItemImpl & TestTask>({
+    jobId: overrides.jobId ?? `task-${Math.random().toString(36).slice(2, 7)}`,
+    job: overrides.job ?? { priority: 0 },
+    mockState: overrides.mockState ?? 'pending',
+    executionTime: overrides.executionTime,
+    executionEndTimestamp: overrides.executionEndTimestamp,
+    createTime: overrides.createTime,
+    workflowId: overrides.workflowId
+  })
 
 const mountUseJobList = () => {
   let composable: ReturnType<typeof useJobList>
@@ -202,30 +118,28 @@ const mountUseJobList = () => {
 }
 
 const resetStores = () => {
-  const queueStore = ensureQueueStore()
+  isJobInitializingMock = useExecutionStore().isJobInitializing
+  const queueStore = useQueueStore()
   queueStore.pendingTasks = []
   queueStore.runningTasks = []
   queueStore.historyTasks = []
 
-  const executionStore = ensureExecutionStore()
+  const executionStore = useExecutionStore()
   executionStore.activeJobId = null
-  executionStore.executingNode = null
+  Object.assign(executionStore, { executingNode: null })
 
-  const jobPreviewStore = ensureJobPreviewStore()
-  jobPreviewStore.previewsByPromptId = {}
-  jobPreviewStore.isPreviewEnabled = true
+  const jobPreviewStore = useJobPreviewStore()
+  Object.assign(jobPreviewStore, { previewsByPromptId: {} })
+  Object.assign(jobPreviewStore, { isPreviewEnabled: true })
 
-  const workflowStore = ensureWorkflowStore()
+  const workflowStore = useWorkflowStore()
   workflowStore.activeWorkflow = null
 
   const progress = ensureProgressRefs()
   progress.totalPercent.value = 0
   progress.currentNodePercent.value = 0
 
-  if (isJobInitializingMock) {
-    vi.mocked(isJobInitializingMock).mockReset()
-    vi.mocked(isJobInitializingMock).mockReturnValue(false)
-  }
+  vi.mocked(isJobInitializingMock).mockReturnValue(false)
 }
 
 const flush = async () => {
@@ -257,7 +171,7 @@ describe('useJobList', () => {
   }
 
   it('tracks recently added pending jobs and clears the hint after expiry', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: '1', job: { priority: 1 }, mockState: 'pending' })
     ]
 
@@ -285,7 +199,7 @@ describe('useJobList', () => {
 
   it('removes pending hint immediately when the task leaves the queue', async () => {
     const taskId = '2'
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: taskId, job: { priority: 1 }, mockState: 'pending' })
     ]
 
@@ -293,12 +207,12 @@ describe('useJobList', () => {
     await flush()
     void jobItems.value
 
-    ensureQueueStore().pendingTasks = []
+    useQueueStore().pendingTasks = []
     await flush()
     expect(vi.getTimerCount()).toBe(0)
 
     vi.mocked(buildJobDisplay).mockClear()
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: taskId, job: { priority: 2 }, mockState: 'pending' })
     ]
     await flush()
@@ -311,7 +225,7 @@ describe('useJobList', () => {
   })
 
   it('cleans up timeouts on unmount', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: '3', job: { priority: 1 }, mockState: 'pending' })
     ]
 
@@ -326,7 +240,7 @@ describe('useJobList', () => {
   })
 
   it('sorts all tasks by create time', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({
         jobId: 'p',
         job: { priority: 1 },
@@ -334,7 +248,7 @@ describe('useJobList', () => {
         createTime: 3000
       })
     ]
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'r',
         job: { priority: 5 },
@@ -342,7 +256,7 @@ describe('useJobList', () => {
         createTime: 2000
       })
     ]
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'h',
         job: { priority: 3 },
@@ -363,7 +277,7 @@ describe('useJobList', () => {
   })
 
   it('filters by job tab and resets failed tab when failures disappear', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({ jobId: 'c', job: { priority: 3 }, mockState: 'completed' }),
       createTask({ jobId: 'f', job: { priority: 2 }, mockState: 'failed' }),
       createTask({ jobId: 'p', job: { priority: 1 }, mockState: 'pending' })
@@ -381,7 +295,7 @@ describe('useJobList', () => {
     expect(instance.filteredTasks.value.map((t) => t.jobId)).toEqual(['f'])
     expect(instance.hasFailedJobs.value).toBe(true)
 
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({ jobId: 'c', job: { priority: 3 }, mockState: 'completed' })
     ]
     await flush()
@@ -391,7 +305,7 @@ describe('useJobList', () => {
   })
 
   it('filters by active workflow when requested', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({
         jobId: 'wf-1',
         job: { priority: 2 },
@@ -413,14 +327,16 @@ describe('useJobList', () => {
     await flush()
     expect(instance.filteredTasks.value).toEqual([])
 
-    ensureWorkflowStore().activeWorkflow = { activeState: { id: 'workflow-1' } }
+    useWorkflowStore().activeWorkflow = fromPartial<
+      NonNullable<ReturnType<typeof useWorkflowStore>['activeWorkflow']>
+    >({ activeState: { id: 'workflow-1' } })
     await flush()
 
     expect(instance.filteredTasks.value.map((t) => t.jobId)).toEqual(['wf-1'])
   })
 
   it('filters jobs by search query', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'alpha',
         job: { priority: 2 },
@@ -465,7 +381,7 @@ describe('useJobList', () => {
   })
 
   it('hydrates job items with active progress and compute hours', async () => {
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'active',
         job: { priority: 3 },
@@ -480,9 +396,9 @@ describe('useJobList', () => {
       })
     ]
 
-    const executionStore = ensureExecutionStore()
+    const executionStore = useExecutionStore()
     executionStore.activeJobId = 'active'
-    executionStore.executingNode = { title: 'Render Node' }
+    Object.assign(executionStore, { executingNode: { title: 'Render Node' } })
     const progress = ensureProgressRefs()
     progress.totalPercent.value = 80
     progress.currentNodePercent.value = 40
@@ -503,17 +419,19 @@ describe('useJobList', () => {
   })
 
   it('assigns preview urls for running jobs when previews enabled', async () => {
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'live-preview',
         job: { priority: 1 },
         mockState: 'running'
       })
     ]
-    ensureJobPreviewStore().previewsByPromptId = {
-      'live-preview': 'blob:preview-url'
-    }
-    ensureJobPreviewStore().isPreviewEnabled = true
+    Object.assign(useJobPreviewStore(), {
+      previewsByPromptId: {
+        'live-preview': 'blob:preview-url'
+      }
+    })
+    Object.assign(useJobPreviewStore(), { isPreviewEnabled: true })
 
     const { jobItems } = initComposable()
     await flush()
@@ -522,17 +440,19 @@ describe('useJobList', () => {
   })
 
   it('omits preview urls when previews are disabled', async () => {
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'disabled-preview',
         job: { priority: 1 },
         mockState: 'running'
       })
     ]
-    ensureJobPreviewStore().previewsByPromptId = {
-      'disabled-preview': 'blob:preview-url'
-    }
-    ensureJobPreviewStore().isPreviewEnabled = false
+    Object.assign(useJobPreviewStore(), {
+      previewsByPromptId: {
+        'disabled-preview': 'blob:preview-url'
+      }
+    })
+    Object.assign(useJobPreviewStore(), { isPreviewEnabled: false })
 
     const { jobItems } = initComposable()
     await flush()
@@ -546,14 +466,18 @@ describe('useJobList', () => {
 
     expect(instance.currentNodeName.value).toBe('--')
 
-    ensureExecutionStore().executingNode = { title: '  Visible Node  ' }
+    Object.assign(useExecutionStore(), {
+      executingNode: { title: '  Visible Node  ' }
+    })
     await flush()
     expect(instance.currentNodeName.value).toBe('Visible Node')
 
-    ensureExecutionStore().executingNode = {
-      title: '   ',
-      type: 'My Node Type'
-    }
+    Object.assign(useExecutionStore(), {
+      executingNode: {
+        title: '   ',
+        type: 'My Node Type'
+      }
+    })
     await flush()
     expect(instance.currentNodeName.value).toBe(
       'i18n(My Node Type.display_name)'
@@ -561,7 +485,7 @@ describe('useJobList', () => {
   })
 
   it('groups terminal jobs without an execution end timestamp by create time', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'failed-before-execution',
         job: { priority: 1 },
@@ -588,7 +512,7 @@ describe('useJobList', () => {
   })
 
   it('groups job items by date label and sorts by total generation time when requested', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'today-small',
         job: { priority: 4 },

--- a/src/composables/queue/useJobMenu.test.ts
+++ b/src/composables/queue/useJobMenu.test.ts
@@ -1,3 +1,9 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useQueueStore } from '@/stores/queueStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
@@ -11,6 +17,8 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 
 const downloadFileMock = vi.fn()
 vi.mock(import('@/base/common/downloadUtil'), () => ({
+  downloadBlob: (filename: string, blob: Blob) =>
+    downloadBlobMock(filename, blob),
   downloadFile: (url: string, filename?: string) => {
     if (filename === undefined) {
       return downloadFileMock(url)
@@ -51,12 +59,7 @@ vi.mock<unknown>(
   })
 )
 
-const settingStoreMock = {
-  get: vi.fn()
-}
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settingStoreMock
-}))
+let settingStoreMock: ReturnType<typeof useSettingStore>
 
 const workflowServiceMock = {
   openWorkflow: vi.fn()
@@ -68,30 +71,18 @@ vi.mock<unknown>(
   })
 )
 
-const workflowStoreMock = {
-  createTemporary: vi.fn()
-}
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => workflowStoreMock,
-    ComfyWorkflow: class {}
-  })
-)
+let workflowStoreMock: ReturnType<typeof useWorkflowStore>
 
 const cancelJobMock = vi.fn()
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
     cancelJob: (jobId: string) => cancelJobMock(jobId)
   }
 }))
 
 const downloadBlobMock = vi.fn()
-vi.mock(import('@/scripts/utils'), () => ({
-  downloadBlob: (filename: string, blob: Blob) =>
-    downloadBlobMock(filename, blob)
-}))
-
 const dialogServiceMock = {
   showErrorDialog: vi.fn(),
   showExecutionErrorDialog: vi.fn(),
@@ -109,30 +100,9 @@ vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => litegraphServiceMock
 }))
 
-const nodeDefStoreMock: {
-  nodeDefsByName: Record<string, Partial<ComfyNodeDefImpl>>
-} = {
-  nodeDefsByName: {}
-}
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => nodeDefStoreMock,
-  ComfyNodeDefImpl: class {}
-}))
+let nodeDefStoreMock: ReturnType<typeof useNodeDefStore>
 
-const queueStoreMock = {
-  update: vi.fn(),
-  delete: vi.fn()
-}
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => queueStoreMock
-}))
-
-const executionStoreMock = {
-  clearInitializationByJobId: vi.fn()
-}
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => executionStoreMock
-}))
+let queueStoreMock: ReturnType<typeof useQueueStore>
 
 const getJobWorkflowMock = vi.fn()
 vi.mock(import('@/services/jobOutputCache'), () => ({
@@ -140,7 +110,6 @@ vi.mock(import('@/services/jobOutputCache'), () => ({
 }))
 
 import { useJobMenu } from '@/composables/queue/useJobMenu'
-import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type { TaskItemImpl } from '@/stores/queueStore'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 
@@ -181,17 +150,24 @@ const findActionEntry = (entries: MenuEntry[], key: string) =>
 
 describe('useJobMenu', () => {
   beforeEach(() => {
+    settingStoreMock = useSettingStore()
+    workflowStoreMock = useWorkflowStore()
+    nodeDefStoreMock = useNodeDefStore()
+    queueStoreMock = useQueueStore()
     currentItem = ref<JobListItem | null>(null)
-    settingStoreMock.get.mockReturnValue(false)
+    vi.mocked(settingStoreMock.get).mockReturnValue(false)
     dialogServiceMock.prompt.mockResolvedValue(undefined)
     litegraphServiceMock.getCanvasCenter.mockReturnValue([100, 200])
     litegraphServiceMock.addNodeOnGraph.mockReturnValue(null)
-    workflowStoreMock.createTemporary.mockImplementation((filename, data) => ({
-      filename,
-      data
-    }))
-    queueStoreMock.update.mockResolvedValue(undefined)
-    queueStoreMock.delete.mockResolvedValue(undefined)
+    vi.mocked(workflowStoreMock.createTemporary).mockImplementation(
+      (filename, data) =>
+        fromPartial<ReturnType<typeof workflowStoreMock.createTemporary>>({
+          filename: filename ?? 'Untitled',
+          content: JSON.stringify(data)
+        })
+    )
+    vi.mocked(queueStoreMock.update).mockResolvedValue(undefined)
+    vi.mocked(queueStoreMock.delete).mockResolvedValue(undefined)
     cancelJobMock.mockResolvedValue(undefined)
     mediaAssetActionsMock.deleteAssets.mockResolvedValue(false)
     mapTaskOutputToAssetItemMock.mockImplementation((task, output) => ({
@@ -199,9 +175,9 @@ describe('useJobMenu', () => {
       output
     }))
     nodeDefStoreMock.nodeDefsByName = {
-      LoadImage: { name: 'LoadImage' },
-      LoadVideo: { name: 'LoadVideo' },
-      LoadAudio: { name: 'LoadAudio' }
+      LoadImage: fromPartial<ComfyNodeDefImpl>({ name: 'LoadImage' }),
+      LoadVideo: fromPartial<ComfyNodeDefImpl>({ name: 'LoadVideo' }),
+      LoadAudio: fromPartial<ComfyNodeDefImpl>({ name: 'LoadAudio' })
     }
     // Default: no workflow available via lazy loading
     getJobWorkflowMock.mockResolvedValue(undefined)
@@ -227,7 +203,7 @@ describe('useJobMenu', () => {
     )
     expect(workflowServiceMock.openWorkflow).toHaveBeenCalledWith({
       filename: 'Job 55.json',
-      data: workflow
+      content: JSON.stringify(workflow)
     })
   })
 
@@ -648,7 +624,7 @@ describe('useJobMenu', () => {
   })
 
   it('prompts for filename when setting enabled', async () => {
-    settingStoreMock.get.mockReturnValue(true)
+    vi.mocked(settingStoreMock.get).mockReturnValue(true)
     dialogServiceMock.prompt.mockResolvedValue('custom-name')
     getJobWorkflowMock.mockResolvedValue({})
     const { jobMenuEntries } = mountJobMenu()
@@ -672,7 +648,7 @@ describe('useJobMenu', () => {
   })
 
   it('keeps existing json extension when exporting workflow', async () => {
-    settingStoreMock.get.mockReturnValue(true)
+    vi.mocked(settingStoreMock.get).mockReturnValue(true)
     dialogServiceMock.prompt.mockResolvedValue('existing.json')
     getJobWorkflowMock.mockResolvedValue({ foo: 'bar' })
     const { jobMenuEntries } = mountJobMenu()
@@ -692,7 +668,7 @@ describe('useJobMenu', () => {
   })
 
   it('abandons export when prompt cancelled', async () => {
-    settingStoreMock.get.mockReturnValue(true)
+    vi.mocked(settingStoreMock.get).mockReturnValue(true)
     dialogServiceMock.prompt.mockResolvedValue('')
     getJobWorkflowMock.mockResolvedValue({})
     const { jobMenuEntries } = mountJobMenu()

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive } from 'vue'
+import { nextTick } from 'vue'
 
 import { useQueueNotificationBanners } from '@/composables/queue/useQueueNotificationBanners'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useQueueStore } from '@/stores/queueStore'
+import type { TaskItemImpl } from '@/stores/queueStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const mockApi = vi.hoisted(() => new EventTarget())
 
@@ -21,28 +23,6 @@ type MockTask = {
   }
 }
 
-vi.mock<unknown>(import('@/stores/queueStore'), () => {
-  const state = reactive({
-    pendingTasks: [] as MockTask[],
-    runningTasks: [] as MockTask[],
-    historyTasks: [] as MockTask[]
-  })
-
-  return {
-    useQueueStore: () => state
-  }
-})
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => {
-  const state = reactive({
-    isIdle: true
-  })
-
-  return {
-    useExecutionStore: () => state
-  }
-})
-
 const mountComposable = () => {
   let composable: ReturnType<typeof useQueueNotificationBanners>
   const result = render({
@@ -56,19 +36,11 @@ const mountComposable = () => {
 }
 
 describe(useQueueNotificationBanners, () => {
-  const queueStore = () =>
-    useQueueStore() as {
-      pendingTasks: MockTask[]
-      runningTasks: MockTask[]
-      historyTasks: MockTask[]
-    }
-  const executionStore = () => useExecutionStore() as { isIdle: boolean }
-
   const resetState = () => {
-    queueStore().pendingTasks = []
-    queueStore().runningTasks = []
-    queueStore().historyTasks = []
-    executionStore().isIdle = true
+    useQueueStore().pendingTasks = []
+    useQueueStore().runningTasks = []
+    useQueueStore().historyTasks = []
+    Object.assign(useExecutionStore(), { isIdle: true })
   }
 
   const createTask = (
@@ -78,7 +50,7 @@ describe(useQueueNotificationBanners, () => {
       previewUrl?: string
       isImage?: boolean
     } = {}
-  ): MockTask => {
+  ): TaskItemImpl => {
     const {
       state = 'Completed',
       ts = Date.now(),
@@ -98,23 +70,26 @@ describe(useQueueNotificationBanners, () => {
       }
     }
 
-    return task
+    return fromPartial<TaskItemImpl>({
+      ...task,
+      displayStatus: state as TaskItemImpl['displayStatus']
+    })
   }
 
   const runBatch = async (options: {
     start: number
     finish: number
-    tasks: MockTask[]
+    tasks: TaskItemImpl[]
   }) => {
     const { start, finish, tasks } = options
 
     vi.setSystemTime(start)
-    executionStore().isIdle = false
+    Object.assign(useExecutionStore(), { isIdle: false })
     await nextTick()
 
     vi.setSystemTime(finish)
-    queueStore().historyTasks = tasks
-    executionStore().isIdle = true
+    useQueueStore().historyTasks = tasks
+    Object.assign(useExecutionStore(), { isIdle: true })
     await nextTick()
   }
 
@@ -124,7 +99,6 @@ describe(useQueueNotificationBanners, () => {
 
   afterEach(() => {
     vi.runOnlyPendingTimers()
-    resetState()
   })
 
   it('shows queued notifications from promptQueued events', async () => {
@@ -235,17 +209,17 @@ describe(useQueueNotificationBanners, () => {
 
     try {
       vi.setSystemTime(now + 4_000)
-      executionStore().isIdle = false
+      Object.assign(useExecutionStore(), { isIdle: false })
       await nextTick()
 
       vi.setSystemTime(now + 4_100)
-      executionStore().isIdle = true
-      queueStore().historyTasks = []
+      Object.assign(useExecutionStore(), { isIdle: true })
+      useQueueStore().historyTasks = []
       await nextTick()
 
       expect(composable.currentNotification.value).toBeNull()
 
-      queueStore().historyTasks = [
+      useQueueStore().historyTasks = [
         createTask({
           ts: now + 4_050,
           previewUrl: 'https://example.com/race-preview.png'

--- a/src/composables/queue/useQueueProgress.test.ts
+++ b/src/composables/queue/useQueueProgress.test.ts
@@ -1,35 +1,17 @@
 import { render } from '@testing-library/vue'
-import { nextTick, ref } from 'vue'
-import type { Ref } from 'vue'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useExecutionStore } from '@/stores/executionStore'
 
 import { useQueueProgress } from '@/composables/queue/useQueueProgress'
 import { formatPercent0 } from '@/utils/numberUtil'
-
-type ProgressValue = number | null
-
-const executionProgressRef: Ref<ProgressValue> = ref(null)
-const executingNodeProgressRef: Ref<ProgressValue> = ref(null)
 
 const i18n = createI18n({
   legacy: false,
   locale: 'en-US',
   messages: { 'en-US': {}, 'fr-FR': {} }
 })
-
-const createExecutionStoreMock = () => ({
-  get executionProgress() {
-    return executionProgressRef.value ?? undefined
-  },
-  get executingNodeProgress() {
-    return executingNodeProgressRef.value ?? undefined
-  }
-})
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => createExecutionStoreMock()
-}))
 
 const mountUseQueueProgress = () => {
   let composable: ReturnType<typeof useQueueProgress>
@@ -47,11 +29,13 @@ const mountUseQueueProgress = () => {
 }
 
 const setExecutionProgress = (value?: number | null) => {
-  executionProgressRef.value = value ?? null
+  Object.assign(useExecutionStore(), { executionProgress: value ?? undefined })
 }
 
 const setExecutingNodeProgress = (value?: number | null) => {
-  executingNodeProgressRef.value = value ?? null
+  Object.assign(useExecutionStore(), {
+    executingNodeProgress: value ?? undefined
+  })
 }
 
 describe('useQueueProgress', () => {

--- a/src/composables/sidebarTabs/useAssetsSidebarTab.test.ts
+++ b/src/composables/sidebarTabs/useAssetsSidebarTab.test.ts
@@ -1,17 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAssetsSidebarBadgeStore } from '@/stores/workspace/assetsSidebarBadgeStore'
 
 import { useAssetsSidebarTab } from '@/composables/sidebarTabs/useAssetsSidebarTab'
-
-const { mockGetSetting, mockUnseenAddedAssetsCount } = vi.hoisted(() => ({
-  mockGetSetting: vi.fn(),
-  mockUnseenAddedAssetsCount: { value: 0 }
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting
-  })
-}))
 
 vi.mock<unknown>(
   import('@/components/sidebar/tabs/AssetsSidebarTab.vue'),
@@ -20,16 +11,10 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/workspace/assetsSidebarBadgeStore'), () => ({
-  useAssetsSidebarBadgeStore: () => ({
-    unseenAddedAssetsCount: mockUnseenAddedAssetsCount.value
-  })
-}))
-
 describe('useAssetsSidebarTab', () => {
   it('hides icon badge when QPO V2 is disabled', () => {
-    mockGetSetting.mockReturnValue(false)
-    mockUnseenAddedAssetsCount.value = 3
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
+    Object.assign(useAssetsSidebarBadgeStore(), { unseenAddedAssetsCount: 3 })
 
     const sidebarTab = useAssetsSidebarTab()
 
@@ -38,8 +23,8 @@ describe('useAssetsSidebarTab', () => {
   })
 
   it('shows unseen added assets count when QPO V2 is enabled', () => {
-    mockGetSetting.mockReturnValue(true)
-    mockUnseenAddedAssetsCount.value = 3
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
+    Object.assign(useAssetsSidebarBadgeStore(), { unseenAddedAssetsCount: 3 })
 
     const sidebarTab = useAssetsSidebarTab()
 
@@ -48,8 +33,7 @@ describe('useAssetsSidebarTab', () => {
   })
 
   it('hides badge when there are no unseen added assets', () => {
-    mockGetSetting.mockReturnValue(true)
-    mockUnseenAddedAssetsCount.value = 0
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
 
     const sidebarTab = useAssetsSidebarTab()
 

--- a/src/composables/sidebarTabs/useJobHistorySidebarTab.test.ts
+++ b/src/composables/sidebarTabs/useJobHistorySidebarTab.test.ts
@@ -1,11 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { useQueueStore } from '@/stores/queueStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 import { useJobHistorySidebarTab } from '@/composables/sidebarTabs/useJobHistorySidebarTab'
-
-const { mockActiveJobsCount, mockActiveSidebarTabId } = vi.hoisted(() => ({
-  mockActiveJobsCount: { value: 0 },
-  mockActiveSidebarTabId: { value: null as string | null }
-}))
 
 vi.mock<unknown>(
   import('@/components/sidebar/tabs/JobHistorySidebarTab.vue'),
@@ -14,27 +11,10 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    activeJobsCount: mockActiveJobsCount.value
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => ({
-    activeSidebarTabId: mockActiveSidebarTabId.value
-  })
-}))
-
 describe('useJobHistorySidebarTab', () => {
-  beforeEach(() => {
-    mockActiveSidebarTabId.value = null
-    mockActiveJobsCount.value = 0
-  })
-
   it('shows active jobs count while the panel is closed', () => {
-    mockActiveSidebarTabId.value = 'assets'
-    mockActiveJobsCount.value = 3
+    useSidebarTabStore().activeSidebarTabId = 'assets'
+    Object.assign(useQueueStore(), { activeJobsCount: 3 })
 
     const sidebarTab = useJobHistorySidebarTab()
 
@@ -43,8 +23,8 @@ describe('useJobHistorySidebarTab', () => {
   })
 
   it('hides badge while the job history panel is open', () => {
-    mockActiveSidebarTabId.value = 'job-history'
-    mockActiveJobsCount.value = 3
+    useSidebarTabStore().activeSidebarTabId = 'job-history'
+    Object.assign(useQueueStore(), { activeJobsCount: 3 })
 
     const sidebarTab = useJobHistorySidebarTab()
 
@@ -52,8 +32,7 @@ describe('useJobHistorySidebarTab', () => {
   })
 
   it('hides badge when there are no active jobs', () => {
-    mockActiveSidebarTabId.value = null
-    mockActiveJobsCount.value = 0
+    useSidebarTabStore().activeSidebarTabId = null
 
     const sidebarTab = useJobHistorySidebarTab()
 

--- a/src/composables/useBrowserTabTitle.test.ts
+++ b/src/composables/useBrowserTabTitle.test.ts
@@ -1,7 +1,14 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive } from 'vue'
+import { effectScope, nextTick } from 'vue'
 
 import { useBrowserTabTitle } from '@/composables/useBrowserTabTitle'
+
+vi.mock(import('firebase/auth'))
 
 // Mock i18n module
 vi.mock<unknown>(import('@/i18n'), () => ({
@@ -9,73 +16,31 @@ vi.mock<unknown>(import('@/i18n'), () => ({
     key === 'g.nodesRunning' ? 'nodes running' : fallback
 }))
 
-// Mock the execution store
-const executionStore = reactive<{
-  isIdle: boolean
-  executionProgress: number
-  executingNode: null | {
-    title?: string
-    type?: string
-  }
-  executingNodeProgress: number
-  nodeProgressStates: Record<string, unknown>
-}>({
-  isIdle: true,
-  executionProgress: 0,
-  executingNode: null,
-  executingNodeProgress: 0,
-  nodeProgressStates: {}
-})
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => executionStore
-}))
+let executionStore: ReturnType<typeof useExecutionStore>
 
-// Mock the setting store
-const settingStore = reactive({
-  get: vi.fn((_key: string) => 'Enabled')
-})
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settingStore
-}))
+let settingStore: ReturnType<typeof useSettingStore>
 
-// Mock the workflow store
-const workflowStore = reactive<{
-  activeWorkflow: {
-    filename: string
-    isModified: boolean
-    isPersisted: boolean
-  } | null
-}>({
-  activeWorkflow: null
-})
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => workflowStore
-  })
-)
+let workflowStore: ReturnType<typeof useWorkflowStore>
 
-// Mock the workspace store
-const workspaceStore = reactive({
-  shiftDown: false
-})
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => workspaceStore
-}))
+let workspaceStore: ReturnType<typeof useWorkspaceStore>
 
 describe('useBrowserTabTitle', () => {
   beforeEach(() => {
+    executionStore = useExecutionStore()
+    settingStore = useSettingStore()
+    workflowStore = useWorkflowStore()
+    workspaceStore = useWorkspaceStore()
     // reset execution store
-    executionStore.isIdle = true
-    executionStore.executionProgress = 0
-    executionStore.executingNode = null
-    executionStore.executingNodeProgress = 0
+    Object.assign(executionStore, { isIdle: true })
+    Object.assign(executionStore, { executionProgress: 0 })
+    Object.assign(executionStore, { executingNode: null })
+    Object.assign(executionStore, { executingNodeProgress: 0 })
     executionStore.nodeProgressStates = {}
 
     // reset setting and workflow stores
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
     workflowStore.activeWorkflow = null
-    workspaceStore.shiftDown = false
+    Object.assign(workspaceStore, { shiftDown: false })
 
     // reset document title
     document.title = ''
@@ -90,11 +55,13 @@ describe('useBrowserTabTitle', () => {
 
   it('sets workflow name as title when workflow exists and menu enabled', async () => {
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: false,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -104,11 +71,13 @@ describe('useBrowserTabTitle', () => {
 
   it('adds asterisk for unsaved workflow', async () => {
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: true,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -122,11 +91,13 @@ describe('useBrowserTabTitle', () => {
       if (key === 'Comfy.UseNewMenu') return 'Enabled'
       return 'Enabled'
     })
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: true,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -140,12 +111,14 @@ describe('useBrowserTabTitle', () => {
       if (key === 'Comfy.UseNewMenu') return 'Enabled'
       return 'Enabled'
     })
-    workspaceStore.shiftDown = true
-    workflowStore.activeWorkflow = {
+    Object.assign(workspaceStore, { shiftDown: true })
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: true,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -155,11 +128,13 @@ describe('useBrowserTabTitle', () => {
 
   it('disables workflow title when menu disabled', async () => {
     vi.mocked(settingStore.get).mockReturnValue('Disabled')
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: false,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -168,8 +143,8 @@ describe('useBrowserTabTitle', () => {
   })
 
   it('shows execution progress when not idle without workflow', async () => {
-    executionStore.isIdle = false
-    executionStore.executionProgress = 0.3
+    Object.assign(executionStore, { isIdle: false })
+    Object.assign(executionStore, { executionProgress: 0.3 })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -178,13 +153,21 @@ describe('useBrowserTabTitle', () => {
   })
 
   it('shows node execution title when executing a node using nodeProgressStates', async () => {
-    executionStore.isIdle = false
-    executionStore.executionProgress = 0.4
-    executionStore.executingNode = {
-      type: 'Foo'
-    }
+    Object.assign(executionStore, { isIdle: false })
+    Object.assign(executionStore, { executionProgress: 0.4 })
+    Object.assign(executionStore, {
+      executingNode: {
+        type: 'Foo'
+      }
+    })
     executionStore.nodeProgressStates = {
-      '1': { state: 'running', value: 5, max: 10, node: '1', prompt_id: 'test' }
+      '1': {
+        state: 'running',
+        value: 5,
+        max: 10,
+        node_id: '1',
+        prompt_id: 'test'
+      }
     }
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
@@ -194,17 +177,23 @@ describe('useBrowserTabTitle', () => {
   })
 
   it('shows multiple nodes running when multiple nodes are executing', async () => {
-    executionStore.isIdle = false
-    executionStore.executionProgress = 0.4
+    Object.assign(executionStore, { isIdle: false })
+    Object.assign(executionStore, { executionProgress: 0.4 })
     executionStore.nodeProgressStates = {
       '1': {
         state: 'running',
         value: 5,
         max: 10,
-        node: '1',
+        node_id: '1',
         prompt_id: 'test'
       },
-      '2': { state: 'running', value: 8, max: 10, node: '2', prompt_id: 'test' }
+      '2': {
+        state: 'running',
+        value: 8,
+        max: 10,
+        node_id: '2',
+        prompt_id: 'test'
+      }
     }
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())

--- a/src/composables/useCameraInfo.test.ts
+++ b/src/composables/useCameraInfo.test.ts
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 interface ViewportInstance {
   ctorArgs: unknown[]
@@ -18,7 +19,7 @@ interface ViewportInstance {
   }
 }
 
-const { ViewportMock, instances, addAlert } = vi.hoisted(() => {
+const { ViewportMock, instances } = vi.hoisted(() => {
   const instances: ViewportInstance[] = []
   const ViewportMock = vi.fn(function (...ctorArgs: unknown[]) {
     const instance: ViewportInstance = {
@@ -37,7 +38,7 @@ const { ViewportMock, instances, addAlert } = vi.hoisted(() => {
     instances.push(instance)
     return instance
   })
-  return { ViewportMock, instances, addAlert: vi.fn() }
+  return { ViewportMock, instances }
 })
 
 vi.mock<unknown>(
@@ -46,9 +47,6 @@ vi.mock<unknown>(
     CameraInfoViewport: ViewportMock
   })
 )
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert })
-}))
 
 import { useCameraInfo } from './useCameraInfo'
 
@@ -83,7 +81,6 @@ function nodeRef(node: FakeNode) {
 beforeEach(() => {
   instances.length = 0
   ViewportMock.mockClear()
-  addAlert.mockClear()
 })
 
 describe('useCameraInfo', () => {
@@ -120,7 +117,7 @@ describe('useCameraInfo', () => {
     const camera = useCameraInfo(nodeRef(makeNode({ mode: 'orbit' })))
 
     expect(() => camera.initialize(document.createElement('div'))).not.toThrow()
-    expect(addAlert).toHaveBeenCalledOnce()
+    expect(useToastStore().addAlert).toHaveBeenCalledOnce()
 
     consoleError.mockRestore()
   })

--- a/src/composables/useCopy.test.ts
+++ b/src/composables/useCopy.test.ts
@@ -1,36 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, onTestFinished } from 'vitest'
+import { effectScope } from 'vue'
 import { useCopy } from './useCopy'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const copyMocks = vi.hoisted(() => ({
-  copyHandler: undefined as ((event: ClipboardEvent) => unknown) | undefined,
   canvas: {
     selectedItems: new Set<object>([{}]),
     copyToClipboard: vi.fn()
   }
 }))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useEventListener: vi.fn(
-    (
-      _target: EventTarget,
-      event: string,
-      handler: (event: ClipboardEvent) => unknown
-    ) => {
-      if (event === 'copy') copyMocks.copyHandler = handler
-      return vi.fn()
-    }
-  )
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: copyMocks.canvas
-    })
-  })
-)
 
 vi.mock(
   import('@/workbench/eventHelpers'),
@@ -45,17 +25,23 @@ const multiChunkPayloadLength = 0x8000 * 6 + 123
 function copySerializedData(serializedData: string): DataTransfer {
   copyMocks.canvas.copyToClipboard.mockReturnValue(serializedData)
 
-  useCopy()
+  const listenerSpy = vi.spyOn(document, 'addEventListener')
+  const scope = effectScope()
+  scope.run(useCopy)
+  onTestFinished(() => scope.stop())
 
   const dataTransfer = new DataTransfer()
   const event = new ClipboardEvent('copy', {
     clipboardData: dataTransfer
   })
-  const copyHandler = copyMocks.copyHandler
+  const copyHandler = listenerSpy.mock.calls.find(
+    ([name]) => name === 'copy'
+  )?.[1]
   expect(copyHandler).toBeDefined()
-  if (!copyHandler) throw new Error('Expected copy handler to be registered')
+  if (typeof copyHandler !== 'function')
+    throw new Error('Expected copy handler to be registered')
 
-  expect(() => copyHandler(event)).not.toThrow()
+  expect(() => copyHandler.call(document, event)).not.toThrow()
 
   return dataTransfer
 }
@@ -74,7 +60,7 @@ function readSerializedClipboardMetadata(dataTransfer: DataTransfer): string {
 
 describe('useCopy', () => {
   beforeEach(() => {
-    copyMocks.copyHandler = undefined
+    useCanvasStore().canvas = fromPartial<LGraphCanvas>(copyMocks.canvas)
   })
 
   it('should write large serialized node data to clipboard metadata', () => {

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCoreCommands } from '@/composables/useCoreCommands'
@@ -8,7 +9,11 @@ import type * as DistributionModule from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import type * as ModelStoreModule from '@/stores/modelStore'
+import { useModelStore } from '@/stores/modelStore'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type { Mock } from 'vitest'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { fromPartial } from '@total-typescript/shoehorn'
 
@@ -40,7 +45,11 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
     selectItems: vi.fn(),
     deleteSelected: vi.fn(),
     selectOnly: false,
-    canvas: { dispatchEvent: vi.fn() },
+    canvas: {
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    },
     read_only: false,
     ds: mockDs,
     setDirty: vi.fn()
@@ -68,19 +77,14 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
     dispatchCustomEvent: vi.fn(),
     apiURL: vi.fn(() => 'http://localhost:8188'),
     addEventListener: vi.fn(),
+    addCustomEventListener: vi.fn(),
     removeEventListener: vi.fn(),
+    removeCustomEventListener: vi.fn(),
     getServerFeature: vi.fn(() => false)
   }
 }))
 
-const mockModelStoreRefresh = vi.fn().mockResolvedValue(undefined)
-vi.mock<unknown>(import('@/stores/modelStore'), async (importOriginal) => {
-  const actual = await importOriginal<typeof ModelStoreModule>()
-  return {
-    ...actual,
-    useModelStore: () => ({ refresh: mockModelStoreRefresh })
-  }
-})
+let mockModelStoreRefresh: Mock<ReturnType<typeof useModelStore>['refresh']>
 
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
@@ -90,26 +94,11 @@ vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
   }
 }))
 
-const mockMissingModelStoreRefresh = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(undefined)
-)
-vi.mock<unknown>(import('@/platform/missingModel/missingModelStore'), () => ({
-  useMissingModelStore: () => ({
-    refreshMissingModels: mockMissingModelStoreRefresh
-  })
-}))
+let mockMissingModelStoreRefresh: Mock<
+  ReturnType<typeof useMissingModelStore>['refreshMissingModels']
+>
 
-vi.mock(import('@/platform/settings/settingStore'))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({}))
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -153,14 +142,7 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({}))
-}))
-
-const mockToastAdd = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({ add: mockToastAdd }))
-}))
+let mockToastAdd: ReturnType<typeof useToastStore>['add']
 
 const mockAssetBrowse = vi.hoisted(() =>
   vi.fn<(options: { onAssetSelected?: (asset: AssetItem) => void }) => void>()
@@ -180,39 +162,8 @@ vi.mock(import('@/composables/node/startModelNodeDragFromAsset'), () => ({
 const mockChangeTracker = vi.hoisted(() => ({
   captureCanvasState: vi.fn()
 }))
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: {
-    changeTracker: mockChangeTracker
-  }
-}))
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => mockWorkflowStore)
-  })
-)
 
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: vi.fn(() => ({}))
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: vi.fn(() => ({
-      getCanvas: () => app.canvas,
-      canvas: app.canvas
-    })),
-    useTitleEditorStore: vi.fn(() => ({
-      titleEditorTarget: null
-    }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({}))
-}))
+let mockWorkflowStore: ReturnType<typeof useWorkflowStore>
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: vi.fn(() => ({}))
@@ -249,10 +200,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     },
     showSubscriptionDialog: mockBillingState.showSubscriptionDialog
   }))
-}))
-
-vi.mock<unknown>(import('@/stores/queueSettingsStore'), () => ({
-  useQueueSettingsStore: vi.fn(() => ({ batchCount: 1 }))
 }))
 
 describe('useCoreCommands', () => {
@@ -310,52 +257,28 @@ describe('useCoreCommands', () => {
 
   const mockSubgraph = createMockSubgraph()!
 
-  function createMockSettingStore(
-    getReturnValue: boolean
-  ): ReturnType<typeof useSettingStore> {
-    return fromPartial<ReturnType<typeof useSettingStore>>({
-      get: vi.fn().mockReturnValue(getReturnValue),
-      addSetting: vi.fn(),
-      load: vi.fn(),
-      set: vi.fn(),
-      setMany: vi.fn(),
-      exists: vi.fn(),
-      getDefaultValue: vi.fn(),
-      isReady: true,
-      isLoading: false,
-      error: undefined,
-      settingValues: {},
-      settingsById: {},
-      $id: 'setting',
-      $state: {
-        settingValues: {},
-        settingsById: {},
-        isReady: true,
-        isLoading: false,
-        error: undefined
-      },
-      $patch: vi.fn(),
-      $reset: vi.fn(),
-      $subscribe: vi.fn(),
-      $onAction: vi.fn(),
-      $dispose: vi.fn(),
-      _customProperties: new Set()
-    })
-  }
-
   beforeEach(() => {
+    mockWorkflowStore = useWorkflowStore()
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({ changeTracker: mockChangeTracker })
+    useCanvasStore().canvas = app.canvas
+    mockModelStoreRefresh = vi.mocked(useModelStore().refresh)
+    mockMissingModelStoreRefresh = vi.mocked(
+      useMissingModelStore().refreshMissingModels
+    )
+    mockToastAdd = useToastStore().add
     mockDistributionState.isCloud = false
     mockBillingState.canAccessSubscriptionFeatures = true
     mockBillingState.subscriptionTier = null
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
-    mockModelStoreRefresh.mockResolvedValue(undefined)
+    mockModelStoreRefresh.mockResolvedValue(true)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
 
     // Reset app state
     app.canvas.subgraph = undefined
 
-    // Mock settings store
-    vi.mocked(useSettingStore).mockReturnValue(createMockSettingStore(false))
+    useSettingStore().settingValues['Comfy.ConfirmClear'] = false
 
     // Mock global confirm
     global.confirm = vi.fn().mockReturnValue(true)
@@ -407,7 +330,7 @@ describe('useCoreCommands', () => {
 
     it('should respect confirmation setting', async () => {
       // Mock confirmation required
-      vi.mocked(useSettingStore).mockReturnValue(createMockSettingStore(true))
+      useSettingStore().settingValues['Comfy.ConfirmClear'] = true
 
       global.confirm = vi.fn().mockReturnValue(false) // User cancels
 
@@ -695,6 +618,7 @@ describe('useCoreCommands', () => {
       })
       mockModelStoreRefresh.mockImplementation(async () => {
         order.push('models')
+        return true
       })
       mockMissingModelStoreRefresh.mockImplementation(async () => {
         order.push('missing')
@@ -856,7 +780,7 @@ describe('useCoreCommands', () => {
     const asset = fromPartial<AssetItem>({ id: 'asset-1' })
 
     async function selectAssetFromBrowser() {
-      vi.mocked(useSettingStore).mockReturnValue(createMockSettingStore(true))
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
 
       const command = useCoreCommands().find(
         (cmd) => cmd.id === 'Comfy.BrowseModelAssets'

--- a/src/composables/useImageCrop.test.ts
+++ b/src/composables/useImageCrop.test.ts
@@ -1,17 +1,19 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { createApp, defineComponent, nextTick, reactive, ref } from 'vue'
+import { createApp, defineComponent, nextTick, ref, computed } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import WidgetImageCrop from '@/components/imagecrop/WidgetImageCrop.vue'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import type { resolveNode } from '@/utils/litegraphUtil'
 import {
   createMockLGraphNode,
   createMockSubgraphNode
@@ -21,55 +23,30 @@ import { imageCropLoadingAfterUrlChange, useImageCrop } from './useImageCrop'
 
 const resizeObserverCallbacks: Array<() => void> = []
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useResizeObserver: (_target: unknown, cb: () => void) => {
-    resizeObserverCallbacks.push(cb)
-    return { stop: vi.fn() }
+vi.mock(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  useResizeObserver: (_target: unknown, cb: ResizeObserverCallback) => {
+    resizeObserverCallbacks.push(() => cb([], fromPartial<ResizeObserver>({})))
+    return { stop: vi.fn(), isSupported: computed(() => true) }
   }
 }))
 
-const mockResolveNode = vi.hoisted(() =>
-  vi.fn<(id: NodeId) => LGraphNode | null>()
-)
-vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
-  resolveNode: (id: NodeId) => mockResolveNode(id)
+const mockResolveNode = vi.hoisted(() => vi.fn<typeof resolveNode>())
+vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveNode: mockResolveNode
 }))
 
-const mockGetNodeImageUrls = vi.hoisted(() =>
-  vi.fn<(node: LGraphNode) => string[] | null | undefined>()
-)
+let mockGetNodeImageUrls: Mock<
+  ReturnType<typeof useNodeOutputStore>['getNodeImageUrls']
+>
 
-type MockOutputStore = {
-  nodeOutputs: Record<string, unknown>
-  nodePreviewImages: Record<string, unknown>
-  getNodeImageUrls: typeof mockGetNodeImageUrls
-}
-
-const useNodeOutputStoreMock = vi.hoisted(() => vi.fn<() => MockOutputStore>())
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => useNodeOutputStoreMock()
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: {
-        graph: {
-          rootGraph: { id: 'test-graph' }
-        }
-      }
-    })
+beforeEach(() => {
+  mockGetNodeImageUrls = vi.mocked(useNodeOutputStore().getNodeImageUrls)
+  useCanvasStore().canvas = fromPartial<LGraphCanvas>({
+    graph: { rootGraph: { id: 'test-graph' } }
   })
-)
-
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => ({
-    getNodeWidgets: vi.fn(() => [])
-  })
-}))
+})
 
 const ImageCropHarness = defineComponent({
   name: 'ImageCropHarness',
@@ -227,16 +204,11 @@ describe('imageCropLoadingAfterUrlChange', () => {
 describe('useImageCrop', () => {
   let sourceNode: LGraphNode
   let cropNode: LGraphNode
-  let outputStore: MockOutputStore
+  let outputStore: ReturnType<typeof useNodeOutputStore>
 
   beforeEach(() => {
     resizeObserverCallbacks.length = 0
-    outputStore = {
-      nodeOutputs: reactive<Record<string, unknown>>({}),
-      nodePreviewImages: reactive<Record<string, unknown>>({}),
-      getNodeImageUrls: mockGetNodeImageUrls
-    }
-    useNodeOutputStoreMock.mockReturnValue(outputStore)
+    outputStore = useNodeOutputStore()
     sourceNode = createMockLGraphNode({
       id: 99,
       isSubgraphNode: () => false
@@ -249,9 +221,8 @@ describe('useImageCrop', () => {
     })
     mockResolveNode.mockReturnValue(cropNode)
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? ['https://example.com/a.png'] : null
+      n === sourceNode ? ['https://example.com/a.png'] : undefined
     )
-    setActivePinia(createTestingPinia({ stubActions: true }))
   })
 
   afterEach(() => {
@@ -267,7 +238,7 @@ describe('useImageCrop', () => {
   })
 
   it('returns null image URL when the graph node cannot be resolved', async () => {
-    mockResolveNode.mockReturnValue(null)
+    mockResolveNode.mockReturnValue(undefined)
     const vm = await mountHarness()
     expect(vm.imageUrl).toBeNull()
   })
@@ -318,7 +289,7 @@ describe('useImageCrop', () => {
     })
     mockResolveNode.mockReturnValue(sgCrop)
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === innerSource ? ['https://subgraph.png'] : null
+      n === innerSource ? ['https://subgraph.png'] : undefined
     )
 
     const vm = await mountHarness()
@@ -330,7 +301,7 @@ describe('useImageCrop', () => {
     expect(vm.imageUrl).toBe('https://example.com/a.png')
 
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? ['https://example.com/b.png'] : null
+      n === sourceNode ? ['https://example.com/b.png'] : undefined
     )
     outputStore.nodeOutputs['touch'] = { updated: true }
 
@@ -341,7 +312,7 @@ describe('useImageCrop', () => {
   it('updates imageUrl when nodePreviewImages change', async () => {
     let url = 'https://example.com/a.png'
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? [url] : null
+      n === sourceNode ? [url] : undefined
     )
     const vm = await mountHarness()
     expect(vm.imageUrl).toBe('https://example.com/a.png')
@@ -402,7 +373,7 @@ describe('useImageCrop', () => {
     expect(vm.imageUrl).toBe('https://example.com/a.png')
 
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? ['https://example.com/b.png'] : null
+      n === sourceNode ? ['https://example.com/b.png'] : undefined
     )
     outputStore.nodeOutputs['touch'] = {}
     await flushTicks()
@@ -422,7 +393,7 @@ describe('useImageCrop', () => {
   })
 
   it('does not start dragging when there is no image', async () => {
-    mockGetNodeImageUrls.mockReturnValue(null)
+    mockGetNodeImageUrls.mockReturnValue(undefined)
     const vm = await mountHarness()
     expect(vm.imageUrl).toBeNull()
     const xBefore = vm.cropX as number
@@ -623,12 +594,6 @@ describe('WidgetImageCrop', () => {
 
   beforeEach(() => {
     resizeObserverCallbacks.length = 0
-    const outputStore: MockOutputStore = {
-      nodeOutputs: reactive<Record<string, unknown>>({}),
-      nodePreviewImages: reactive<Record<string, unknown>>({}),
-      getNodeImageUrls: mockGetNodeImageUrls
-    }
-    useNodeOutputStoreMock.mockReturnValue(outputStore)
     const source = createMockLGraphNode({ id: 99, isSubgraphNode: () => false })
     const crop = createMockLGraphNode({
       id: 2,
@@ -638,13 +603,12 @@ describe('WidgetImageCrop', () => {
     })
     mockResolveNode.mockReturnValue(crop)
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === source ? ['https://example.com/a.png'] : null
+      n === source ? ['https://example.com/a.png'] : undefined
     )
-    setActivePinia(createTestingPinia({ stubActions: true }))
   })
 
   it('renders empty state copy when no image URL is available', async () => {
-    mockGetNodeImageUrls.mockReturnValue(null)
+    mockGetNodeImageUrls.mockReturnValue(undefined)
     const widget = fromPartial<SimplifiedWidget>({
       type: 'imagecrop',
       options: {}

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref, shallowRef } from 'vue'
-import { createPinia, setActivePinia } from 'pinia'
+import { nextTick, ref, shallowRef, effectScope } from 'vue'
+import type { EffectScope } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import {
   getLoad3dOutputCache,
@@ -8,7 +9,7 @@ import {
   markLoad3dSceneDirty,
   nodeToLoad3dMap,
   setLoad3dOutputCache,
-  useLoad3d
+  useLoad3d as useLoad3dImpl
 } from '@/composables/useLoad3d'
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
@@ -51,10 +52,6 @@ vi.mock<unknown>(import('@/extensions/core/load3d/Load3dUtils'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn()
-}))
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: vi.fn(),
@@ -68,38 +65,25 @@ vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key) => key)
 }))
 
-const { settingGetMock } = vi.hoisted(() => ({
-  settingGetMock: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: settingGetMock })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: vi.fn()
-  })
-)
-
 vi.mock(import('@/platform/assets/utils/assetPreviewUtil'), () => ({
   isAssetPreviewSupported: vi.fn(() => false),
   persistThumbnail: vi.fn().mockResolvedValue(undefined)
 }))
 
 describe('useLoad3d', () => {
+  let scope: EffectScope
+  function useLoad3d(...args: Parameters<typeof useLoad3dImpl>) {
+    return scope.run(() => useLoad3dImpl(...args))!
+  }
+  afterEach(() => scope.stop())
   let mockLoad3d: Partial<Load3d>
   let mockNode: LGraphNode
   let mockToastStore: ReturnType<typeof useToastStore>
 
   beforeEach(() => {
+    scope = effectScope()
     nodeToLoad3dMap.clear()
-    setActivePinia(undefined)
-    settingGetMock.mockImplementation((key: string) =>
-      key === 'Comfy.Load3D.BackgroundColor' ? '282828' : undefined
-    )
+    useSettingStore().settingValues['Comfy.Load3D.BackgroundColor'] = '282828'
 
     mockNode = createMockLGraphNode({
       properties: {
@@ -217,12 +201,7 @@ describe('useLoad3d', () => {
     })
     vi.mocked(createLoad3d).mockImplementation(() => mockLoad3d as Load3d)
 
-    mockToastStore = {
-      addAlert: vi.fn()
-    } as Partial<ReturnType<typeof useToastStore>> as ReturnType<
-      typeof useToastStore
-    >
-    vi.mocked(useToastStore).mockReturnValue(mockToastStore)
+    mockToastStore = useToastStore()
   })
 
   describe('initialization', () => {
@@ -399,15 +378,7 @@ describe('useLoad3d', () => {
     })
 
     it('defaults background color from the Comfy.Load3D.BackgroundColor setting', () => {
-      setActivePinia(createPinia())
-      vi.mocked(useCanvasStore).mockReturnValue(
-        reactive({ appScalePercentage: 100 }) as unknown as ReturnType<
-          typeof useCanvasStore
-        >
-      )
-      settingGetMock.mockImplementation((key: string) =>
-        key === 'Comfy.Load3D.BackgroundColor' ? '123456' : undefined
-      )
+      useSettingStore().settingValues['Comfy.Load3D.BackgroundColor'] = '123456'
 
       const composable = useLoad3d(mockNode)
 
@@ -443,11 +414,7 @@ describe('useLoad3d', () => {
 
   describe('zoom watcher', () => {
     it('calls load3d.handleResize after debounce when canvas appScalePercentage changes', async () => {
-      const canvasStore = reactive({ appScalePercentage: 100 })
-      setActivePinia(createPinia())
-      vi.mocked(useCanvasStore).mockReturnValue(
-        canvasStore as unknown as ReturnType<typeof useCanvasStore>
-      )
+      const canvasStore = useCanvasStore()
 
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')
@@ -464,11 +431,7 @@ describe('useLoad3d', () => {
     })
 
     it('debounces rapid zoom changes into a single handleResize call', async () => {
-      const canvasStore = reactive({ appScalePercentage: 100 })
-      setActivePinia(createPinia())
-      vi.mocked(useCanvasStore).mockReturnValue(
-        canvasStore as unknown as ReturnType<typeof useCanvasStore>
-      )
+      const canvasStore = useCanvasStore()
 
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')

--- a/src/composables/useLoad3dDrag.test.ts
+++ b/src/composables/useLoad3dDrag.test.ts
@@ -6,10 +6,6 @@ import { SUPPORTED_EXTENSIONS } from '@/extensions/core/load3d/constants'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { createMockFileList } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn()
-}))
-
 vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key) => key)
 }))
@@ -40,12 +36,7 @@ describe('useLoad3dDrag', () => {
   let mockOnModelDrop: (file: File) => void | Promise<void>
 
   beforeEach(() => {
-    mockToastStore = {
-      addAlert: vi.fn()
-    } as Partial<ReturnType<typeof useToastStore>> as ReturnType<
-      typeof useToastStore
-    >
-    vi.mocked(useToastStore).mockReturnValue(mockToastStore)
+    mockToastStore = useToastStore()
 
     mockOnModelDrop = vi.fn()
   })

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -15,10 +15,6 @@ vi.mock(import('@/services/load3dService'), () => ({
   useLoad3dService: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn()
-}))
-
 vi.mock<unknown>(import('@/extensions/core/load3d/Load3dUtils'), () => ({
   default: {
     uploadFile: vi.fn(),
@@ -194,12 +190,7 @@ describe('useLoad3dViewer', () => {
     >
     vi.mocked(useLoad3dService).mockReturnValue(mockLoad3dService)
 
-    mockToastStore = {
-      addAlert: vi.fn()
-    } as Partial<ReturnType<typeof useToastStore>> as ReturnType<
-      typeof useToastStore
-    >
-    vi.mocked(useToastStore).mockReturnValue(mockToastStore)
+    mockToastStore = useToastStore()
   })
 
   describe('initialization', () => {

--- a/src/composables/useNewMenuItemIndicator.test.ts
+++ b/src/composables/useNewMenuItemIndicator.test.ts
@@ -1,16 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNewMenuItemIndicator } from '@/composables/useNewMenuItemIndicator'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { WorkflowMenuItem } from '@/types/workflowMenuItem'
-
-const mockSettingStore = vi.hoisted(() => ({
-  get: vi.fn((): string[] => []),
-  set: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => mockSettingStore)
-}))
 
 function createItems(...ids: string[]): WorkflowMenuItem[] {
   return ids.map((id) => ({
@@ -24,8 +16,12 @@ function createItems(...ids: string[]): WorkflowMenuItem[] {
 }
 
 describe('useNewMenuItemIndicator', () => {
+  let settingStore: ReturnType<typeof useSettingStore>
+
   beforeEach(() => {
-    mockSettingStore.get.mockReturnValue([])
+    settingStore = useSettingStore()
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = []
+    vi.mocked(settingStore.set).mockResolvedValue()
   })
 
   it('reports unseen items when no items have been seen', () => {
@@ -36,7 +32,9 @@ describe('useNewMenuItemIndicator', () => {
   })
 
   it('reports no unseen items when all new items are already seen', () => {
-    mockSettingStore.get.mockReturnValue(['feature-a'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'feature-a'
+    ]
     const items = createItems('feature-a')
     const { hasUnseenItems } = useNewMenuItemIndicator(() => items)
 
@@ -44,7 +42,9 @@ describe('useNewMenuItemIndicator', () => {
   })
 
   it('reports unseen when some new items are not yet seen', () => {
-    mockSettingStore.get.mockReturnValue(['feature-a'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'feature-a'
+    ]
     const items = createItems('feature-a', 'feature-b')
     const { hasUnseenItems } = useNewMenuItemIndicator(() => items)
 
@@ -76,20 +76,23 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a', 'feature-b']
     )
   })
 
   it('markAsSeen replaces stale entries with current new items', () => {
-    mockSettingStore.get.mockReturnValue(['old-feature', 'feature-a'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'old-feature',
+      'feature-a'
+    ]
     const items = createItems('feature-a')
     const { markAsSeen } = useNewMenuItemIndicator(() => items)
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a']
     )
@@ -129,14 +132,16 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a']
     )
   })
 
   it('markAsSeen retains previously-seen hidden items', () => {
-    mockSettingStore.get.mockReturnValue(['hidden-feature'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'hidden-feature'
+    ]
     const items: WorkflowMenuItem[] = [
       ...createItems('feature-a'),
       {
@@ -153,20 +158,23 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a', 'hidden-feature']
     )
   })
 
   it('markAsSeen skips write when stored list already matches', () => {
-    mockSettingStore.get.mockReturnValue(['feature-a', 'feature-b'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'feature-a',
+      'feature-b'
+    ]
     const items = createItems('feature-a', 'feature-b')
     const { markAsSeen } = useNewMenuItemIndicator(() => items)
 
     markAsSeen()
 
-    expect(mockSettingStore.set).not.toHaveBeenCalled()
+    expect(settingStore.set).not.toHaveBeenCalled()
   })
 
   it('markAsSeen does nothing when there are no new items', () => {
@@ -177,6 +185,6 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).not.toHaveBeenCalled()
+    expect(settingStore.set).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/usePaste.test.ts
+++ b/src/composables/usePaste.test.ts
@@ -1,4 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import type { EffectScope } from 'vue'
 import type {
   LGraphCanvas,
   LGraph,
@@ -7,12 +11,7 @@ import type {
 } from '@/lib/litegraph/src/litegraph'
 import { app } from '@/scripts/app'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
-import {
-  createNode,
-  isAudioNode,
-  isImageNode,
-  isVideoNode
-} from '@/utils/litegraphUtil'
+import { createNode } from '@/utils/litegraphUtil'
 import {
   cloneDataTransfer,
   pasteAudioNode,
@@ -21,8 +20,10 @@ import {
   pasteImageNodes,
   pasteVideoNode,
   pasteVideoNodes,
-  usePaste
+  usePaste as usePasteImpl
 } from './usePaste'
+
+vi.mock(import('firebase/auth'))
 
 function createMockNode(): LGraphNode {
   return createMockLGraphNode({
@@ -70,55 +71,35 @@ const mockCanvas = {
   _deserializeItems: vi.fn()
 } as Partial<LGraphCanvas> as LGraphCanvas
 
-const mockCanvasStore = {
-  canvas: mockCanvas,
-  getCanvas: vi.fn(() => mockCanvas)
+let mockCanvasStore: ReturnType<typeof useCanvasStore>
+
+let mockWorkspaceStore: ReturnType<typeof useWorkspaceStore>
+let scope: EffectScope
+
+function usePaste() {
+  scope.run(usePasteImpl)
 }
 
-const mockWorkspaceStore = {
-  shiftDown: false
-}
+afterEach(() => scope.stop())
 
-vi.mock(import('@vueuse/core'), () => ({
-  useEventListener: vi.fn((target, event, handler) => {
-    target.addEventListener(event, handler)
-    return () => target.removeEventListener(event, handler)
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => mockCanvasStore
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => mockWorkspaceStore
-}))
+beforeEach(() => {
+  scope = effectScope()
+  mockWorkspaceStore = useWorkspaceStore()
+  mockCanvasStore = useCanvasStore()
+  mockCanvasStore.canvas = mockCanvas
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     loadGraphData: vi.fn()
   }
 }))
 
-vi.mock<unknown>(
-  import('@/lib/litegraph/src/litegraph'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    LiteGraph: {
-      createNode: vi.fn()
-    }
-  })
-)
-
-vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
-  createNode: vi.fn(),
-  isAudioNode: vi.fn(),
-  isImageNode: vi.fn(),
-  isVideoNode: vi.fn()
+vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  createNode: vi.fn()
 }))
 
 vi.mock(
@@ -403,7 +384,7 @@ describe('pasteVideoNodes', () => {
 describe('usePaste', () => {
   beforeEach(() => {
     mockCanvas.current_node = null
-    mockWorkspaceStore.shiftDown = false
+    Object.assign(mockWorkspaceStore, { shiftDown: false })
     vi.mocked(mockCanvas.graph!.add).mockImplementation(
       (node: LGraphNode | LGraphGroup | null) => node as LGraphNode
     )
@@ -450,7 +431,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isAudioNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'audio'
 
     usePaste()
 
@@ -489,7 +470,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isVideoNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'video'
 
     usePaste()
 
@@ -561,7 +542,7 @@ describe('usePaste', () => {
   })
 
   it('should ignore paste when shift is down', () => {
-    mockWorkspaceStore.shiftDown = true
+    Object.assign(mockWorkspaceStore, { shiftDown: true })
 
     usePaste()
 
@@ -580,7 +561,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isImageNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'image'
 
     usePaste()
 
@@ -632,7 +613,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isImageNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'image'
 
     usePaste()
 

--- a/src/composables/useReconnectingNotification.test.ts
+++ b/src/composables/useReconnectingNotification.test.ts
@@ -4,6 +4,7 @@ import { defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { useReconnectingNotification } from '@/composables/useReconnectingNotification'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 const mockToastAdd = vi.fn()
 const mockToastRemove = vi.fn()
@@ -43,23 +44,10 @@ function setupComposable(): ReturnType<typeof useReconnectingNotification> {
   return result
 }
 
-const settingMocks = vi.hoisted(() => ({
-  disableToast: false
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.Toast.DisableReconnectingToast')
-        return settingMocks.disableToast
-      return undefined
-    })
-  }))
-}))
-
 describe('useReconnectingNotification', () => {
   beforeEach(() => {
-    settingMocks.disableToast = false
+    useSettingStore().settingValues['Comfy.Toast.DisableReconnectingToast'] =
+      false
   })
 
   it('does not show toast immediately on reconnecting', () => {
@@ -121,7 +109,8 @@ describe('useReconnectingNotification', () => {
   })
 
   it('does nothing when toast is disabled via setting', () => {
-    settingMocks.disableToast = true
+    useSettingStore().settingValues['Comfy.Toast.DisableReconnectingToast'] =
+      true
     const { onReconnecting, onReconnected } = setupComposable()
 
     onReconnecting()

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -1,53 +1,19 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useTemplateRankingStore } from '@/stores/templateRankingStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
 import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
 
-const defaultSettingStore = {
-  get: vi.fn((key: string) => {
-    switch (key) {
-      case 'Comfy.Templates.SelectedModels':
-      case 'Comfy.Templates.SelectedUseCases':
-      case 'Comfy.Templates.SelectedRunsOn':
-        return []
-      case 'Comfy.Templates.SortBy':
-        return 'newest'
-      default:
-        return undefined
-    }
-  }),
-  set: vi.fn().mockResolvedValue(undefined)
-}
+let defaultSettingStore: ReturnType<typeof useSettingStore>
 
-const defaultRankingStore = {
-  computeDefaultScore: vi.fn(
-    (_date?: string, _rank?: number, usage: number = 0) => usage
-  ),
-  computeFreshness: vi.fn(() => 0.5),
-  largestUsageScore: 0
-}
+let defaultRankingStore: ReturnType<typeof useTemplateRankingStore>
 
-const mockSystemStatsStore = {
-  systemStats: {
-    system: {
-      os: 'linux'
-    }
-  }
-}
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => defaultSettingStore)
-}))
-
-vi.mock<unknown>(import('@/stores/templateRankingStore'), () => ({
-  useTemplateRankingStore: vi.fn(() => defaultRankingStore)
-}))
-
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: vi.fn(() => mockSystemStatsStore)
-}))
+let mockSystemStatsStore: ReturnType<typeof useSystemStatsStore>
 
 const trackTemplateFilterChanged = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -66,8 +32,24 @@ vi.mock(
 
 describe('useTemplateFiltering', () => {
   beforeEach(() => {
+    defaultSettingStore = useSettingStore()
+    defaultRankingStore = useTemplateRankingStore()
+    mockSystemStatsStore = useSystemStatsStore()
+    defaultSettingStore.settingValues = {
+      'Comfy.Templates.SelectedModels': [],
+      'Comfy.Templates.SelectedUseCases': [],
+      'Comfy.Templates.SelectedRunsOn': [],
+      'Comfy.Templates.SortBy': 'newest'
+    }
+    vi.mocked(defaultSettingStore.set).mockResolvedValue(undefined)
+    vi.mocked(defaultRankingStore.computeDefaultScore).mockImplementation(
+      (_date, _rank, usage = 0) => usage
+    )
+    vi.mocked(defaultRankingStore.computeFreshness).mockReturnValue(0.5)
     vi.stubGlobal('__DISTRIBUTION__', 'localhost')
-    mockSystemStatsStore.systemStats.system.os = 'linux'
+    mockSystemStatsStore.systemStats = fromPartial<
+      NonNullable<typeof mockSystemStatsStore.systemStats>
+    >({ system: { os: 'linux' } })
   })
 
   it('filters by search text, models, tags, and license with debounce handling', async () => {
@@ -1087,7 +1069,7 @@ describe('useTemplateFiltering', () => {
 
     it('mac distribution matches templates with mac includeOnDistributions', () => {
       setDistribution('desktop')
-      mockSystemStatsStore.systemStats.system.os = 'darwin'
+      mockSystemStatsStore.systemStats!.system.os = 'darwin'
 
       const macTemplate: TemplateInfo = {
         name: 'mac-template',

--- a/src/composables/useWorkflowActionsMenu.test.ts
+++ b/src/composables/useWorkflowActionsMenu.test.ts
@@ -1,3 +1,12 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import {
+  useWorkflowBookmarkStore,
+  useWorkflowStore
+} from '@/platform/workflow/management/stores/workflowStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useSubgraphStore } from '@/stores/subgraphStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useAppModeStore } from '@/stores/appModeStore'
 import { render } from '@testing-library/vue'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -6,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useWorkflowActionsMenu as useWorkflowActionsMenuComposable } from '@/composables/useWorkflowActionsMenu'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import type { WorkflowMenuAction } from '@/types/workflowMenuItem'
+import { toNodeId } from '@/types/nodeId'
 
 const i18n = createI18n({
   legacy: false,
@@ -15,14 +25,9 @@ const i18n = createI18n({
   fallbackWarn: false
 })
 
-const mockBookmarkStore = vi.hoisted(() => ({
-  isBookmarked: vi.fn(() => false),
-  toggleBookmarked: vi.fn()
-}))
+let mockBookmarkStore: ReturnType<typeof useWorkflowBookmarkStore>
 
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: { path: 'test.json', isPersisted: true } as ComfyWorkflow
-}))
+let mockWorkflowStore: ReturnType<typeof useWorkflowStore>
 
 const mockWorkflowService = vi.hoisted(() => ({
   openWorkflow: vi.fn(),
@@ -31,46 +36,17 @@ const mockWorkflowService = vi.hoisted(() => ({
   deleteWorkflow: vi.fn()
 }))
 
-const mockCommandStore = vi.hoisted(() => ({
-  execute: vi.fn()
-}))
+let mockCommandStore: ReturnType<typeof useCommandStore>
 
-const mockSubgraphStore = vi.hoisted(() => ({
-  isSubgraphBlueprint: vi.fn(() => false)
-}))
+let mockSubgraphStore: ReturnType<typeof useSubgraphStore>
 
-const mockMenuItemStore = vi.hoisted(() => ({
-  hasSeenLinear: false
-}))
+let mockMenuItemStore: ReturnType<typeof useMenuItemStore>
 
-const mockAppModeStore = vi.hoisted(() => ({
-  enterBuilder: vi.fn(),
-  pruneLinearData: vi.fn(
-    (
-      data?: Partial<{
-        inputs: [number | string, string][]
-        outputs: (number | string)[]
-      }>
-    ) => ({
-      inputs: data?.inputs ?? [],
-      outputs: data?.outputs ?? []
-    })
-  ),
-  selectedInputs: [] as [number | string, string][],
-  selectedOutputs: [] as (number | string)[]
-}))
+let mockAppModeStore: ReturnType<typeof useAppModeStore>
 
 const mockFeatureFlags = vi.hoisted(() => ({
   flags: { linearToggleEnabled: false }
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => mockWorkflowStore),
-    useWorkflowBookmarkStore: vi.fn(() => mockBookmarkStore)
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -78,24 +54,6 @@ vi.mock<unknown>(
     useWorkflowService: vi.fn(() => mockWorkflowService)
   })
 )
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => mockCommandStore)
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: vi.fn(() => mockSubgraphStore)
-}))
-
-vi.mock<unknown>(import('@/stores/menuItemStore'), () => ({
-  useMenuItemStore: vi.fn(() => mockMenuItemStore)
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: vi.fn(() => mockAppModeStore)
-}))
-
-vi.mock(import('@/composables/useErrorHandling'), () => ({}))
 
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: vi.fn(() => mockFeatureFlags)
@@ -135,16 +93,26 @@ function findItem(items: MenuItems, label: string): WorkflowMenuAction {
 
 describe('useWorkflowActionsMenu', () => {
   beforeEach(() => {
-    mockBookmarkStore.isBookmarked.mockReturnValue(false)
-    mockSubgraphStore.isSubgraphBlueprint.mockReturnValue(false)
+    mockBookmarkStore = useWorkflowBookmarkStore()
+    mockWorkflowStore = useWorkflowStore()
+    mockCommandStore = useCommandStore()
+    mockSubgraphStore = useSubgraphStore()
+    mockMenuItemStore = useMenuItemStore()
+    mockAppModeStore = useAppModeStore()
+    vi.mocked(mockCommandStore.execute).mockResolvedValue(undefined)
+    vi.mocked(mockBookmarkStore.toggleBookmarked).mockResolvedValue(undefined)
+    vi.mocked(mockBookmarkStore.isBookmarked).mockReturnValue(false)
+    vi.mocked(mockSubgraphStore.isSubgraphBlueprint).mockReturnValue(false)
     mockMenuItemStore.hasSeenLinear = false
     mockFeatureFlags.flags.linearToggleEnabled = false
     mockAppModeStore.selectedInputs.length = 0
     mockAppModeStore.selectedOutputs.length = 0
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true
-    } as ComfyWorkflow
+    })
   })
 
   it('shows root-level items by default', () => {
@@ -221,11 +189,13 @@ describe('useWorkflowActionsMenu', () => {
 
   it('shows "go to workflow mode" when in linear mode', () => {
     mockFeatureFlags.flags.linearToggleEnabled = true
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true,
       activeMode: 'app'
-    } as ComfyWorkflow
+    })
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const labels = menuLabels(menuItems.value)
@@ -235,7 +205,7 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('shows bookmark label based on bookmark state', () => {
-    mockBookmarkStore.isBookmarked.mockReturnValue(true)
+    vi.mocked(mockBookmarkStore.isBookmarked).mockReturnValue(true)
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const labels = menuLabels(menuItems.value)
@@ -274,7 +244,7 @@ describe('useWorkflowActionsMenu', () => {
       isTemporary: false
     } as ComfyWorkflow)
 
-    mockBookmarkStore.isBookmarked.mockReturnValue(false)
+    vi.mocked(mockBookmarkStore.isBookmarked).mockReturnValue(false)
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), {
       isRoot: true,
@@ -286,7 +256,7 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('shows publish item for blueprints', () => {
-    mockSubgraphStore.isSubgraphBlueprint.mockReturnValue(true)
+    vi.mocked(mockSubgraphStore.isSubgraphBlueprint).mockReturnValue(true)
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const labels = menuLabels(menuItems.value)
@@ -345,12 +315,14 @@ describe('useWorkflowActionsMenu', () => {
 
   it('shows "Edit app" when workflow has linear data', async () => {
     mockFeatureFlags.flags.linearToggleEnabled = true
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true
-    } as ComfyWorkflow
+    })
     mockAppModeStore.selectedInputs.push([1, 'widget'])
-    mockAppModeStore.selectedOutputs.push(2)
+    mockAppModeStore.selectedOutputs.push(toNodeId(2))
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const item = findItem(menuItems.value, 'breadcrumbsMenu.editBuilderMode')
@@ -372,10 +344,12 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('rename is disabled for unpersisted root workflows', () => {
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: false
-    } as ComfyWorkflow
+    })
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const rename = findItem(menuItems.value, 'g.rename')
@@ -384,11 +358,13 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('bookmark is disabled for temporary workflows', () => {
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true,
       isTemporary: true
-    } as ComfyWorkflow
+    })
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const bookmark = findItem(menuItems.value, 'tabMenu.addToBookmarks')

--- a/src/composables/useWorkflowStatusDismissal.test.ts
+++ b/src/composables/useWorkflowStatusDismissal.test.ts
@@ -1,43 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import { effectScope, nextTick, shallowRef, markRaw } from 'vue'
+import { storeToRefs } from 'pinia'
+import type { Ref } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
 
 import type { WorkflowExecutionStatus } from '@/stores/executionStore'
 
-const { mockActiveWorkflow, statusMap } = await vi.hoisted(async () => {
-  const { shallowRef } = await import('vue')
-  return {
-    mockActiveWorkflow: shallowRef<object | null>(null),
-    statusMap: shallowRef<Map<object, WorkflowExecutionStatus>>(new Map())
-  }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    getWorkflowStatus: (workflow: object | null | undefined) =>
-      workflow ? statusMap.value.get(workflow) : undefined,
-    clearWorkflowStatus: (workflow: object) => {
-      const next = new Map(statusMap.value)
-      next.delete(workflow)
-      statusMap.value = next
-    }
-  })
-}))
+let mockActiveWorkflow: Ref<ComfyWorkflow | null>
+const statusMap = shallowRef(new Map<ComfyWorkflow, WorkflowExecutionStatus>())
 
 import { useWorkflowStatusDismissal } from './useWorkflowStatusDismissal'
 
-const workflowA = { path: '/a.json' }
-const workflowB = { path: '/b.json' }
+const workflowA = markRaw(fromPartial<ComfyWorkflow>({ path: '/a.json' }))
+const workflowB = markRaw(fromPartial<ComfyWorkflow>({ path: '/b.json' }))
 
 function mount() {
   const scope = effectScope()
@@ -47,6 +25,18 @@ function mount() {
 
 describe('useWorkflowStatusDismissal', () => {
   beforeEach(() => {
+    mockActiveWorkflow = storeToRefs(useWorkflowStore()).activeWorkflow
+    const executionStore = useExecutionStore()
+    vi.mocked(executionStore.getWorkflowStatus).mockImplementation(
+      (workflow) => (workflow ? statusMap.value.get(workflow) : undefined)
+    )
+    vi.mocked(executionStore.clearWorkflowStatus).mockImplementation(
+      (workflow) => {
+        statusMap.value = new Map(
+          [...statusMap.value].filter(([entry]) => entry !== workflow)
+        )
+      }
+    )
     mockActiveWorkflow.value = null
     statusMap.value = new Map()
   })

--- a/src/composables/useWorkflowTemplateSelectorDialog.test.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDialogStore } from '@/stores/dialogStore'
 
 const mockDialogService = vi.hoisted(() => ({
   showLayoutDialog: vi.fn()
 }))
 
-const mockDialogStore = vi.hoisted(() => ({
-  closeDialog: vi.fn()
-}))
+let mockDialogStore: ReturnType<typeof useDialogStore>
 
 const mockNewUserService = vi.hoisted(() => ({
   isNewUser: vi.fn()
@@ -18,10 +17,6 @@ const mockTelemetry = vi.hoisted(() => ({
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => mockDialogService
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => mockDialogStore
 }))
 
 vi.mock<unknown>(import('@/services/useNewUserService'), () => ({
@@ -42,6 +37,10 @@ vi.mock<unknown>(
 import { useWorkflowTemplateSelectorDialog } from './useWorkflowTemplateSelectorDialog'
 
 describe('useWorkflowTemplateSelectorDialog', () => {
+  beforeEach(() => {
+    mockDialogStore = useDialogStore()
+  })
+
   describe('show', () => {
     it('defaults to "all" category for non-new users', () => {
       mockNewUserService.isNewUser.mockReturnValue(false)

--- a/src/composables/video/useVideoSourceUrl.test.ts
+++ b/src/composables/video/useVideoSourceUrl.test.ts
@@ -1,55 +1,31 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 import { useVideoSourceUrl } from './useVideoSourceUrl'
 
-const mocks = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { reactive } = require('vue')
-  return {
-    nodeOutputs: reactive({}) as Record<string, unknown>,
-    nodePreviewImages: reactive({}) as Record<string, unknown>,
-    getNodeImageUrls: vi.fn<(node: unknown) => string[] | undefined>(),
-    getWidget: vi.fn()
-  }
-})
+let outputStore: ReturnType<typeof useNodeOutputStore>
+let widgetStore: ReturnType<typeof useWidgetValueStore>
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: { apiURL: (path: string) => `/api${path}` }
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { getPreviewFormatParam: () => '' }
+  app: {
+    getPreviewFormatParam: () => '',
+    nodeOutputs: {},
+    nodePreviewImages: {}
+  }
 }))
 
 vi.mock(import('@/platform/distribution/cloudPreviewUtil'), () => ({
   appendCloudResParam: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeToNodeLocatorId: (node: { id: string }) => node.id
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    nodeOutputs: mocks.nodeOutputs,
-    nodePreviewImages: mocks.nodePreviewImages,
-    getNodeImageUrls: mocks.getNodeImageUrls
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => ({
-    getWidget: mocks.getWidget
-  })
 }))
 
 function fakeNode(overrides: Record<string, unknown> = {}): LGraphNode {
@@ -79,11 +55,13 @@ function mountSource(node: LGraphNode) {
 
 describe('useVideoSourceUrl', () => {
   beforeEach(() => {
-    for (const key of Object.keys(mocks.nodeOutputs)) {
-      delete mocks.nodeOutputs[key]
+    outputStore = useNodeOutputStore()
+    widgetStore = useWidgetValueStore()
+    for (const key of Object.keys(outputStore.nodeOutputs)) {
+      delete outputStore.nodeOutputs[key]
     }
-    for (const key of Object.keys(mocks.nodePreviewImages)) {
-      delete mocks.nodePreviewImages[key]
+    for (const key of Object.keys(outputStore.nodePreviewImages)) {
+      delete outputStore.nodePreviewImages[key]
     }
   })
 
@@ -104,10 +82,10 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('recovers when the input link appears after mount', async () => {
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=out.mp4&type=temp&rand=0.5'
     ])
-    mocks.getWidget.mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(undefined)
     const upstream = fakeNode({ id: 'upstream' })
     let connected = false
     const node = fakeNode({
@@ -119,7 +97,7 @@ describe('useVideoSourceUrl', () => {
     expect(videoUrl.value).toBeUndefined()
 
     connected = true
-    mocks.nodeOutputs['upstream'] = { images: [{ filename: 'out.mp4' }] }
+    outputStore.nodeOutputs['upstream'] = { images: [{ filename: 'out.mp4' }] }
     const fireConnectionsChange =
       node.onConnectionsChange as unknown as () => void
     fireConnectionsChange()
@@ -129,8 +107,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('switches from the file widget to the executed preview when outputs arrive', async () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'clip.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'clip.mp4'
+      })
+    )
 
     const upstream = fakeNode({ id: 'up' })
     const node = fakeNode({
@@ -141,20 +123,20 @@ describe('useVideoSourceUrl', () => {
     const { videoUrl } = mountSource(node)
     expect(videoUrl.value).toContain('filename=clip.mp4')
 
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=out.mp4&type=temp'
     ])
-    mocks.nodeOutputs['up'] = { images: [{ filename: 'out.mp4' }] }
+    outputStore.nodeOutputs['up'] = { images: [{ filename: 'out.mp4' }] }
     await nextTick()
 
     expect(videoUrl.value).toBe('/api/view?filename=out.mp4&type=temp')
   })
 
   it('prefers upstream outputs and strips the rand cache-buster', () => {
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=out.mp4&type=temp&rand=0.123'
     ])
-    mocks.getWidget.mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(undefined)
 
     const upstream = fakeNode({ id: 'up' })
     const node = fakeNode({
@@ -168,8 +150,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('falls back to the upstream file widget before any execution', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'clip.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'clip.mp4'
+      })
+    )
 
     const upstream = fakeNode({ id: 'up' })
     const node = fakeNode({
@@ -184,10 +170,14 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('uses the node itself as source when there is no video input', () => {
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=already-trimmed.mp4&type=temp'
     ])
-    mocks.getWidget.mockReturnValue({ value: 'raw.mp4' })
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'raw.mp4'
+      })
+    )
 
     const node = fakeNode()
 
@@ -197,8 +187,8 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves nothing when the video input is not linked', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue(undefined)
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(undefined)
 
     const node = fakeNode({
       inputs: [{ name: 'video' }],
@@ -211,8 +201,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves through a subgraph output to the inner source node', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'inner.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'inner.mp4'
+      })
+    )
 
     const innerNode = fakeNode({ id: 'inner' })
     const subgraphNode = fakeNode({
@@ -232,8 +226,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves through nested subgraph outputs to the innermost source node', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'deep.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'deep.mp4'
+      })
+    )
 
     const innerNode = fakeNode({ id: 'inner' })
     const innerSubgraphNode = fakeNode({
@@ -264,8 +262,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves nothing when subgraph resolution loops back on itself', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'loop.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'loop.mp4'
+      })
+    )
 
     const loopingSubgraphNode = fakeNode({
       id: 'loop-sub',
@@ -289,8 +291,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves nothing when the subgraph link is missing', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'inner.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'inner.mp4'
+      })
+    )
 
     const subgraphNode = fakeNode({
       id: 'sub',

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
@@ -25,13 +25,6 @@ import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/subgraph/resolveConcretePromotedWidget.test.ts
+++ b/src/core/graph/subgraph/resolveConcretePromotedWidget.test.ts
@@ -10,16 +10,6 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ widgetStates: new Map() })
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/subgraph/resolveSubgraphInputLink.test.ts
+++ b/src/core/graph/subgraph/resolveSubgraphInputLink.test.ts
@@ -11,16 +11,6 @@ import {
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ widgetStates: new Map() })
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/subgraph/resolveSubgraphInputTarget.test.ts
+++ b/src/core/graph/subgraph/resolveSubgraphInputTarget.test.ts
@@ -10,16 +10,6 @@ import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { toNodeId } from '@/types/nodeId'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ widgetStates: new Map() })
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -1,31 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
 
 import type { ComfyExtension } from '@/types/comfy'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/agentPanelStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
+
+let agentStore: Mocked<ReturnType<typeof useAgentPanelStore>>
+let canvasStore: Mocked<ReturnType<typeof useCanvasStore>>
+let nodeSelectionStore: Mocked<ReturnType<typeof useAgentNodeSelectionStore>>
+let workflowStore: ReturnType<typeof useWorkflowStore>
 
 const mocks = vi.hoisted(() => ({
   capturedExtensions: [] as ComfyExtension[],
   notifyAfterGraphConfigure: vi.fn(),
   notifyBeforeGraphLoad: vi.fn(),
-  agentStore: { enabled: false, isOpen: true, close: vi.fn() },
-  canvasStore: { updateSelectedItems: vi.fn() },
   getNodeByLocatorId: vi.fn(),
   flagEnabled: undefined as boolean | undefined,
   flagListener: null as (() => void) | null,
-  nodeSelectionStore: {
-    beginWorkflowLoad: vi.fn(),
-    finishWorkflowLoad: vi.fn(),
-    isLoadingWorkflow: false,
-    nodeIds: vi.fn(() => [] as string[]),
-    restoreNodeIds: vi.fn(),
-    saveNodeIds: vi.fn()
-  },
-  registerTracker: vi.fn(() => () => {}),
-  workflowStore: {
-    activeWorkflow: { path: 'workflows/first.json' },
-    nodeToNodeLocatorId: vi.fn((node: { locatorId?: string; id: number }) =>
-      node.locatorId ? node.locatorId : String(node.id)
-    )
-  }
+  registerTracker: vi.fn(() => () => {})
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -41,28 +37,14 @@ vi.mock('@/workbench/extensions/agent/crdt/mintPortWiring', () => ({
   notifyMintPortsBeforeGraphLoad: mocks.notifyBeforeGraphLoad
 }))
 
-vi.mock('@/workbench/extensions/agent/stores/agent/agentPanelStore', () => ({
-  useAgentPanelStore: () => mocks.agentStore
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => mocks.workflowStore
-}))
-
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => mocks.canvasStore
-}))
-
-vi.mock('@/stores/agentNodeSelectionStore', () => ({
-  useAgentNodeSelectionStore: () => mocks.nodeSelectionStore
-}))
-
-vi.mock('@/utils/litegraphUtil', () => ({
-  isLGraphNode: (node: unknown): node is { id: number } =>
+vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  isLGraphNode: (node: unknown): node is LGraphNode =>
     typeof node === 'object' && node !== null && 'id' in node
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
   getNodeByLocatorId: mocks.getNodeByLocatorId
 }))
 
@@ -100,25 +82,33 @@ async function loadEntryAndSetup(): Promise<void> {
 
 describe('AgentPanel extension flag gate', () => {
   beforeEach(() => {
+    agentStore = vi.mocked(useAgentPanelStore())
+    canvasStore = vi.mocked(useCanvasStore())
+    nodeSelectionStore = vi.mocked(useAgentNodeSelectionStore())
+    workflowStore = useWorkflowStore()
+    canvasStore.updateSelectedItems.mockImplementation(() => {})
+    nodeSelectionStore.restoreNodeIds.mockImplementation(() => {})
     mocks.capturedExtensions.length = 0
     mocks.notifyAfterGraphConfigure.mockClear()
     mocks.notifyBeforeGraphLoad.mockClear()
-    mocks.agentStore.close.mockClear()
-    mocks.agentStore.enabled = false
-    mocks.agentStore.isOpen = true
+    agentStore.close.mockClear()
+    agentStore.enabled = false
+    agentStore.isOpen = true
     mocks.flagEnabled = undefined
     mocks.flagListener = null
     mocks.registerTracker.mockClear()
-    mocks.canvasStore.updateSelectedItems.mockClear()
+    canvasStore.updateSelectedItems.mockClear()
     mocks.getNodeByLocatorId.mockReset()
-    mocks.nodeSelectionStore.beginWorkflowLoad.mockClear()
-    mocks.nodeSelectionStore.finishWorkflowLoad.mockClear()
-    mocks.nodeSelectionStore.nodeIds.mockReset()
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue([])
-    mocks.nodeSelectionStore.restoreNodeIds.mockClear()
-    mocks.nodeSelectionStore.saveNodeIds.mockClear()
-    mocks.nodeSelectionStore.isLoadingWorkflow = false
-    mocks.workflowStore.activeWorkflow = { path: 'workflows/first.json' }
+    nodeSelectionStore.beginWorkflowLoad.mockClear()
+    nodeSelectionStore.finishWorkflowLoad.mockClear()
+    nodeSelectionStore.nodeIds.mockReset()
+    nodeSelectionStore.nodeIds.mockReturnValue([])
+    nodeSelectionStore.restoreNodeIds.mockClear()
+    nodeSelectionStore.saveNodeIds.mockClear()
+    nodeSelectionStore.isLoadingWorkflow = false
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/first.json'
+    })
     vi.resetModules()
   })
 
@@ -134,12 +124,12 @@ describe('AgentPanel extension flag gate', () => {
 
     await loadEntryAndSetup()
 
-    expect(mocks.agentStore.enabled).toBe(true)
+    expect(agentStore.enabled).toBe(true)
   })
 
   it('leaves the panel disabled while the flag is undefined', async () => {
     await loadEntryAndSetup()
-    expect(mocks.agentStore.enabled).toBe(false)
+    expect(agentStore.enabled).toBe(false)
   })
 
   it('registers the tab-activity tracker once at setup, not gated on the flag', async () => {
@@ -151,7 +141,7 @@ describe('AgentPanel extension flag gate', () => {
     await loadEntryAndSetup()
     mocks.flagEnabled = true
     mocks.flagListener!()
-    expect(mocks.agentStore.enabled).toBe(true)
+    expect(agentStore.enabled).toBe(true)
   })
 
   it('disables the panel without closing it when the flag flips back to false', async () => {
@@ -161,21 +151,21 @@ describe('AgentPanel extension flag gate', () => {
     mocks.flagEnabled = false
     mocks.flagListener!()
 
-    expect(mocks.agentStore.enabled).toBe(false)
-    expect(mocks.agentStore.close).not.toHaveBeenCalled()
-    expect(mocks.agentStore.isOpen).toBe(true)
+    expect(agentStore.enabled).toBe(false)
+    expect(agentStore.close).not.toHaveBeenCalled()
+    expect(agentStore.isOpen).toBe(true)
   })
 
   it('finishes a pending selection restore when the flag is disabled', async () => {
     await loadEntryAndSetup()
     mocks.flagEnabled = true
     mocks.flagListener!()
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.isLoadingWorkflow = true
 
     mocks.flagEnabled = false
     mocks.flagListener!()
 
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
   })
 
   it('restores each workflow reference after the shared graph load', async () => {
@@ -187,17 +177,19 @@ describe('AgentPanel extension flag gate', () => {
     const secondNode = { id: 12 }
     const rootGraph = {}
     const selectItems = vi.fn()
-    mocks.agentStore.enabled = true
+    agentStore.enabled = true
 
     extension!.beforeLoadGraph!({} as never)
 
     expect(mocks.notifyBeforeGraphLoad).toHaveBeenCalledOnce()
-    expect(mocks.nodeSelectionStore.beginWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.beginWorkflowLoad).toHaveBeenCalledOnce()
 
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue(['12'])
+    nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.nodeIds.mockReturnValue(['12'])
     mocks.getNodeByLocatorId.mockReturnValue(secondNode)
-    mocks.workflowStore.activeWorkflow = { path: 'workflows/second.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/second.json'
+    })
 
     extension!.afterLoadGraph!({
       rootGraph,
@@ -208,9 +200,9 @@ describe('AgentPanel extension flag gate', () => {
 
     expect(mocks.getNodeByLocatorId).toHaveBeenCalledWith(rootGraph, '12')
     expect(selectItems).toHaveBeenCalledWith([secondNode])
-    expect(mocks.nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith(['12'])
-    expect(mocks.canvasStore.updateSelectedItems).toHaveBeenCalledOnce()
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).not.toHaveBeenCalled()
+    expect(nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith(['12'])
+    expect(canvasStore.updateSelectedItems).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).not.toHaveBeenCalled()
   })
 
   it('closes the mint suppression bracket after graph configuration', async () => {
@@ -232,22 +224,23 @@ describe('AgentPanel extension flag gate', () => {
       (item) => item.name === 'Comfy.AgentPanel'
     )
     const locator = '12345678-1234-1234-1234-123456789abc:shared'
-    const subgraphNode = { id: 'shared', locatorId: locator }
+    const subgraphNode = {
+      id: 'shared',
+      graph: { id: '12345678-1234-1234-1234-123456789abc', isRootGraph: false }
+    }
     const rootGraph = {}
     const selectItems = vi.fn()
 
-    mocks.agentStore.enabled = true
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue([locator])
+    agentStore.enabled = true
+    nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.nodeIds.mockReturnValue([locator])
     mocks.getNodeByLocatorId.mockReturnValue(subgraphNode)
 
     extension!.afterLoadGraph!({ rootGraph, canvas: { selectItems } } as never)
 
     expect(mocks.getNodeByLocatorId).toHaveBeenCalledWith(rootGraph, locator)
     expect(selectItems).toHaveBeenCalledWith([subgraphNode])
-    expect(mocks.nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith([
-      locator
-    ])
+    expect(nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith([locator])
   })
 
   it('skips graph-load selection tracking while the panel is closed', async () => {
@@ -256,12 +249,12 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.agentStore.isOpen = false
+    agentStore.isOpen = false
 
     extension!.beforeLoadGraph!({} as never)
 
     expect(mocks.notifyBeforeGraphLoad).toHaveBeenCalledOnce()
-    expect(mocks.nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
+    expect(nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
   })
 
   it('finishes restoration when the panel closes during graph load', async () => {
@@ -270,14 +263,14 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.agentStore.isOpen = false
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
+    agentStore.isOpen = false
+    nodeSelectionStore.isLoadingWorkflow = true
 
     extension!.afterLoadGraph!({} as never)
 
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
     expect(mocks.getNodeByLocatorId).not.toHaveBeenCalled()
-    expect(mocks.canvasStore.updateSelectedItems).not.toHaveBeenCalled()
+    expect(canvasStore.updateSelectedItems).not.toHaveBeenCalled()
   })
 
   it('finishes restoration when graph configuration fails', async () => {
@@ -286,11 +279,11 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.isLoadingWorkflow = true
 
     extension!.onGraphLoadError!(new Error('bad workflow json'), {} as never)
 
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
   })
 
   it('finishes restoration when selection restoration throws', async () => {
@@ -299,10 +292,10 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.agentStore.enabled = true
-    mocks.agentStore.isOpen = true
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue(['12'])
+    agentStore.enabled = true
+    agentStore.isOpen = true
+    nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.nodeIds.mockReturnValue(['12'])
     mocks.getNodeByLocatorId.mockImplementation(() => {
       throw new Error('selection restore failed')
     })
@@ -310,7 +303,7 @@ describe('AgentPanel extension flag gate', () => {
     expect(() =>
       extension!.afterLoadGraph!({ rootGraph: {} } as never)
     ).toThrow('selection restore failed')
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
   })
 
   it('does not start selection restoration while the flag is disabled', async () => {
@@ -322,6 +315,6 @@ describe('AgentPanel extension flag gate', () => {
 
     extension!.beforeLoadGraph!({} as never)
 
-    expect(mocks.nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
+    expect(nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
   })
 })

--- a/src/extensions/core/agentPanelGateDependencyFailure.test.ts
+++ b/src/extensions/core/agentPanelGateDependencyFailure.test.ts
@@ -1,18 +1,13 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/agentPanelStore'
+import { registerAgentPanelExtension } from './agentPanel'
 
 const registered = vi.hoisted(() => ({
   setup: null as (() => Promise<void> | void) | null
 }))
 
 const reportErrorMock = vi.hoisted(() => vi.fn())
-const agentStore = vi.hoisted(() => ({
-  enabled: false,
-  gateSettled: false,
-  isOpen: false
-}))
 
 vi.mock('@/platform/telemetry/reportError', () => ({
   reportError: reportErrorMock
@@ -23,26 +18,6 @@ vi.mock('@/platform/telemetry/reportError', () => ({
 vi.mock('@/workbench/extensions/agent/utils/postHogFlagSource', () => {
   throw new Error('flag source chunk failed to load')
 })
-
-vi.mock('@/workbench/extensions/agent/stores/agent/agentPanelStore', () => ({
-  useAgentPanelStore: () => agentStore
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({ activeWorkflow: null })
-}))
-
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => ({ updateSelectedItems: vi.fn() })
-}))
-
-vi.mock('@/stores/agentNodeSelectionStore', () => ({
-  useAgentNodeSelectionStore: () => ({
-    isLoadingWorkflow: false,
-    beginWorkflowLoad: vi.fn(),
-    finishWorkflowLoad: vi.fn()
-  })
-}))
 
 vi.mock('@/utils/graphTraversalUtil', () => ({
   getNodeByLocatorId: vi.fn()
@@ -67,17 +42,14 @@ vi.mock('@/services/extensionService', () => ({
 
 describe('the agent panel gate under a dependency-chunk failure', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     reportErrorMock.mockClear()
-    agentStore.enabled = false
-    agentStore.gateSettled = false
+    useAgentPanelStore().enabled = false
+    useAgentPanelStore().gateSettled = false
   })
 
   it('settles fail-closed, reports, and resolves the setup promise', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.stubGlobal('__DISTRIBUTION__', 'cloud')
-    vi.resetModules()
-    const { registerAgentPanelExtension } = await import('./agentPanel')
     registerAgentPanelExtension()
 
     // The gate promise is HANDED BACK to the extension service - a

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -1,20 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ActionBarButton } from '@/types/comfy'
 
-const tabBarLayout = vi.hoisted(() => ({ value: 'Default' }))
 const registerExtension = vi.hoisted(() => vi.fn())
 const openFeedbackDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('@/i18n', () => ({
   t: (key: string) => key
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.UI.TabBarLayout' ? tabBarLayout.value : undefined
-  })
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -41,7 +34,7 @@ describe('cloudFeedbackTopbarButton', () => {
   }
 
   it('opens the feedback survey tagged with the action-bar source', async () => {
-    tabBarLayout.value = 'Legacy'
+    vi.mocked(useSettingStore().get).mockReturnValue('Legacy')
     await import('./cloudFeedbackTopbarButton')
 
     const buttons = getRegisteredButtons()
@@ -53,7 +46,7 @@ describe('cloudFeedbackTopbarButton', () => {
   })
 
   it('only registers the action bar button when the tab bar is Legacy', async () => {
-    tabBarLayout.value = 'Default'
+    vi.mocked(useSettingStore().get).mockReturnValue('Default')
     await import('./cloudFeedbackTopbarButton')
 
     expect(getRegisteredButtons()).toEqual([])

--- a/src/extensions/core/groupOptions.test.ts
+++ b/src/extensions/core/groupOptions.test.ts
@@ -12,6 +12,7 @@ import type {
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyExtension } from '@/types/comfy'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
@@ -21,10 +22,6 @@ const { registerExtension } = vi.hoisted(() => ({
 
 vi.mock('@/scripts/app', () => ({
   app: { registerExtension }
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: () => 10 })
 }))
 
 import '@/extensions/core/groupOptions'
@@ -83,6 +80,7 @@ const BASE_GROUP_ITEMS: (string | null)[] = [
 
 beforeEach(() => {
   graphChange.mockClear()
+  vi.mocked(useSettingStore().get).mockReturnValue(10)
 })
 
 describe('Comfy.GroupOptions canvas menu', () => {

--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CameraState } from '@/extensions/core/load3d/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { ComfyExtension } from '@/types/comfy'
 
@@ -12,7 +13,6 @@ const {
   configureMock,
   configureForSaveMeshMock,
   getLoad3dMock,
-  toastAddAlertMock,
   getNodeByLocatorIdMock,
   nodeToLoad3dMap
 } = vi.hoisted(() => ({
@@ -22,7 +22,6 @@ const {
   configureMock: vi.fn(),
   configureForSaveMeshMock: vi.fn(),
   getLoad3dMock: vi.fn(),
-  toastAddAlertMock: vi.fn(),
   getNodeByLocatorIdMock: vi.fn(),
   nodeToLoad3dMap: new Map<object, unknown>()
 }))
@@ -110,13 +109,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: toastAddAlertMock })
-}))
-
-vi.mock('@/stores/dialogStore', () => ({
-  useDialogStore: () => ({ showDialog: vi.fn() })
-}))
+let toastAddAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  toastAddAlertMock = useToastStore().addAlert
+})
 
 vi.mock('@/utils/litegraphUtil', () => ({
   isLoad3dNode: vi.fn(() => true)

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -15,14 +15,7 @@ import type {
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import type { Dictionary } from '@/lib/litegraph/src/interfaces'
 import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
-
-const { settingsGetMock } = vi.hoisted(() => ({
-  settingsGetMock: vi.fn()
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: settingsGetMock })
-}))
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -61,7 +54,7 @@ function createConfig(properties?: Dictionary<NodeProperty | undefined>) {
 }
 
 function stubSettings(values: Record<string, unknown>) {
-  settingsGetMock.mockImplementation((key: string) => values[key])
+  vi.mocked(useSettingStore().get).mockImplementation((key) => values[key])
 }
 
 const defaultGizmo: GizmoConfig = {
@@ -372,7 +365,7 @@ describe('Load3DConfiguration.loadSceneConfig', () => {
     })
 
     expect(createConfig(properties).loadSceneConfig()).toEqual(stored)
-    expect(settingsGetMock).not.toHaveBeenCalled()
+    expect(useSettingStore().get).not.toHaveBeenCalled()
   })
 
   it('falls back to settings and prepends # to the background color', () => {
@@ -401,7 +394,7 @@ describe('Load3DConfiguration.loadCameraConfig', () => {
     stubSettings({ 'Comfy.Load3D.CameraType': 'perspective' })
 
     expect(createConfig(properties).loadCameraConfig()).toEqual(stored)
-    expect(settingsGetMock).not.toHaveBeenCalled()
+    expect(useSettingStore().get).not.toHaveBeenCalled()
   })
 
   it('falls back to settings and a default fov of 35', () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useToastStore } from '@/platform/updates/common/toastStore'
+
 import type {
   EventManagerInterface,
   MaterialMode,
@@ -56,15 +58,13 @@ const {
   splatLoad,
   pointCloudLoad,
   fetchModelDataMock,
-  isGaussianSplatPLYMock,
-  addAlert
+  isGaussianSplatPLYMock
 } = vi.hoisted(() => ({
   meshLoad: vi.fn(),
   splatLoad: vi.fn(),
   pointCloudLoad: vi.fn(),
   fetchModelDataMock: vi.fn<() => Promise<ArrayBuffer>>(),
-  isGaussianSplatPLYMock: vi.fn<(b: ArrayBuffer) => Promise<boolean>>(),
-  addAlert: vi.fn()
+  isGaussianSplatPLYMock: vi.fn<(b: ArrayBuffer) => Promise<boolean>>()
 }))
 
 vi.mock('./MeshModelAdapter', () => ({
@@ -115,9 +115,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert })
-}))
+let addAlert: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  addAlert = useToastStore().addAlert
+})
 
 type LoaderManagerInternals = {
   pickAdapter(

--- a/src/extensions/core/load3d/ModelExporter.test.ts
+++ b/src/extensions/core/load3d/ModelExporter.test.ts
@@ -1,18 +1,18 @@
 import * as THREE from 'three'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import { ModelExporter } from './ModelExporter'
 
 const {
   downloadBlobMock,
-  addAlertMock,
   gltfParseMock,
   objParseMock,
   stlParseMock,
   fbxParseAsyncMock
 } = vi.hoisted(() => ({
   downloadBlobMock: vi.fn(),
-  addAlertMock: vi.fn(),
   gltfParseMock: vi.fn(),
   objParseMock: vi.fn(),
   stlParseMock: vi.fn(),
@@ -28,9 +28,10 @@ vi.mock('@/i18n', () => ({
     vars ? `${key}:${JSON.stringify(vars)}` : key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: addAlertMock })
-}))
+let addAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  addAlertMock = useToastStore().addAlert
+})
 
 vi.mock('three/examples/jsm/exporters/GLTFExporter', () => ({
   GLTFExporter: class {

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -1,15 +1,11 @@
 import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+
 import type { ModelLoadContext } from './ModelAdapter'
 import * as ModelAdapterModule from './ModelAdapter'
 import { PointCloudModelAdapter } from './PointCloudModelAdapter'
-
-const mockSettingGet = vi.fn<(key: string) => unknown>()
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: mockSettingGet })
-}))
 
 vi.mock('@/scripts/metadata/ply', () => ({
   isPLYAsciiFormat: vi.fn().mockReturnValue(false)
@@ -89,7 +85,7 @@ describe('PointCloudModelAdapter', () => {
 
   describe('load', () => {
     beforeEach(() => {
-      mockSettingGet.mockReturnValue('three')
+      vi.mocked(useSettingStore().get).mockReturnValue('three')
       vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(
         new ArrayBuffer(0)
       )

--- a/src/extensions/core/load3d/exportMenuHelper.test.ts
+++ b/src/extensions/core/load3d/exportMenuHelper.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type Load3d from './Load3d'
 import { createExportMenuItems } from './exportMenuHelper'
 
-const { contextMenuMock, addToastMock, addAlertMock } = vi.hoisted(() => ({
-  contextMenuMock: vi.fn(),
-  addToastMock: vi.fn(),
-  addAlertMock: vi.fn()
+const { contextMenuMock } = vi.hoisted(() => ({
+  contextMenuMock: vi.fn()
 }))
 
 vi.mock('@/i18n', () => ({
@@ -14,9 +14,12 @@ vi.mock('@/i18n', () => ({
     vars ? `${key}:${JSON.stringify(vars)}` : key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ add: addToastMock, addAlert: addAlertMock })
-}))
+let addToastMock: ReturnType<typeof useToastStore>['add']
+let addAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  addToastMock = useToastStore().add
+  addAlertMock = useToastStore().addAlert
+})
 
 vi.mock(import('@/lib/litegraph/src/litegraph'), async (importOriginal) => {
   const actual = await importOriginal()

--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -1,24 +1,26 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { ComfyExtension } from '@/types/comfy'
+import { useExtensionStore } from '@/stores/extensionStore'
 
-const { registerExtensionMock, enabledExtensionsGetter } = vi.hoisted(() => ({
-  registerExtensionMock: vi.fn(),
-  enabledExtensionsGetter: vi.fn(() => [] as ComfyExtension[])
+const { registerExtensionMock } = vi.hoisted(() => ({
+  registerExtensionMock: vi.fn()
 }))
+
+let enabledExtensionsGetter: MockInstance<() => ComfyExtension[]>
+beforeEach(() => {
+  enabledExtensionsGetter = vi.spyOn(
+    useExtensionStore(),
+    'enabledExtensions',
+    'get'
+  )
+})
 
 vi.mock('@/services/extensionService', () => ({
   useExtensionService: () => ({ registerExtension: registerExtensionMock })
-}))
-
-vi.mock('@/stores/extensionStore', () => ({
-  useExtensionStore: () => ({
-    get enabledExtensions() {
-      return enabledExtensionsGetter()
-    }
-  })
 }))
 
 vi.mock('@/scripts/app', () => ({

--- a/src/extensions/core/load3dPreviewExtensions.test.ts
+++ b/src/extensions/core/load3dPreviewExtensions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyExtension } from '@/types/comfy'
 
 const {
@@ -9,7 +10,6 @@ const {
   onLoad3dReadyMock,
   configureForSaveMeshMock,
   getLoad3dMock,
-  toastAddAlertMock,
   getNodeByLocatorIdMock,
   nodeToLoad3dMapMock
 } = vi.hoisted(() => ({
@@ -18,7 +18,6 @@ const {
   onLoad3dReadyMock: vi.fn(),
   configureForSaveMeshMock: vi.fn(),
   getLoad3dMock: vi.fn(),
-  toastAddAlertMock: vi.fn(),
   getNodeByLocatorIdMock: vi.fn(),
   nodeToLoad3dMapMock: new Map()
 }))
@@ -61,9 +60,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: toastAddAlertMock })
-}))
+let toastAddAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  toastAddAlertMock = useToastStore().addAlert
+})
 
 type ExtCreated = ComfyExtension & {
   nodeCreated: (node: LGraphNode) => Promise<void>

--- a/src/extensions/core/textPreviewWidgets.test.ts
+++ b/src/extensions/core/textPreviewWidgets.test.ts
@@ -24,10 +24,6 @@ vi.mock(
   })
 )
 
-vi.mock('@/stores/widgetValueStore', () => ({
-  useWidgetValueStore: () => ({ getWidget: () => undefined })
-}))
-
 vi.mock('@/scripts/domWidget', () => ({
   ComponentWidgetImpl: class {
     name: string

--- a/src/extensions/core/uploadAudio.test.ts
+++ b/src/extensions/core/uploadAudio.test.ts
@@ -2,15 +2,14 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyExtension } from '@/types/comfy'
 
-const { mockAddAlert, mockApiURL, mockFetchApi, mockRegisterExtension } =
-  vi.hoisted(() => ({
-    mockAddAlert: vi.fn(),
-    mockApiURL: vi.fn((url: string) => `api:${url}`),
-    mockFetchApi: vi.fn(),
-    mockRegisterExtension: vi.fn()
-  }))
+const { mockApiURL, mockFetchApi, mockRegisterExtension } = vi.hoisted(() => ({
+  mockApiURL: vi.fn((url: string) => `api:${url}`),
+  mockFetchApi: vi.fn(),
+  mockRegisterExtension: vi.fn()
+}))
 
 let capturedDragDrop: ((files: File[]) => Promise<File[] | never[]>) | undefined
 let capturedFileSelect:
@@ -56,9 +55,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: mockAddAlert })
-}))
+let mockAddAlert: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  mockAddAlert = useToastStore().addAlert
+})
 
 vi.mock('@/renderer/extensions/vueNodes/widgets/utils/audioUtils', () => ({
   getResourceURL: (subfolder = '', filename = '', type = 'input') =>
@@ -78,12 +78,6 @@ vi.mock('@/scripts/app', () => ({
     registerExtension: mockRegisterExtension,
     rootGraph: { id: 'root' }
   }
-}))
-
-vi.mock('@/stores/widgetValueStore', () => ({
-  useWidgetValueStore: () => ({
-    getWidget: vi.fn()
-  })
 }))
 
 vi.mock('@/utils/graphTraversalUtil', () => ({

--- a/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
@@ -2,8 +2,6 @@ import {
   SUBGRAPH_INPUT_ID,
   SUBGRAPH_OUTPUT_ID
 } from '@/lib/litegraph/src/constants'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import {
   afterEach,
   beforeEach,
@@ -43,18 +41,9 @@ import { graphScopeOf } from '@/types/graphScopeId'
 import { toRerouteId } from '@/types/rerouteId'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function createSerialisedNode(
   id: number,

--- a/src/lib/litegraph/src/LGraphCanvas.subgraphPasteDelete.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.subgraphPasteDelete.test.ts
@@ -41,13 +41,6 @@ import {
  * on host deletion — the delta is intended and called out inline.
  */
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -160,7 +160,6 @@ export { BaseWidget } from './widgets/BaseWidget'
 export { LegacyWidget } from './widgets/LegacyWidget'
 
 export { isComboWidget } from './widgets/widgetMap'
-/** @knipIgnoreUnusedButUsedByCustomNodes */
 export { isAssetWidget } from './widgets/widgetMap'
 // Additional test-specific exports
 export { LGraphButton } from './LGraphButton'

--- a/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
@@ -24,13 +24,6 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -43,13 +43,6 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -288,7 +288,6 @@ export function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
 
 /**
  * Type guard: Narrow **from {@link IBaseWidget}** to {@link IAssetWidget}.
- * @knipIgnoreUnusedButUsedByCustomNodes
  */
 export function isAssetWidget(widget: IBaseWidget): widget is IAssetWidget {
   return widget.type === 'asset'

--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -1,6 +1,6 @@
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@/i18n'
@@ -22,29 +22,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
         return false
       }
     }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => {
-  const getAssets = vi.fn((key: string) => mockAssetsByKey.get(key) ?? [])
-  const isModelLoading = vi.fn(
-    (key: string) => mockLoadingByKey.get(key) ?? false
-  )
-  const updateModelsForNodeType = vi.fn()
-  const updateModelsForTag = vi.fn()
-  return {
-    useAssetsStore: () => ({
-      getAssets,
-      isModelLoading,
-      updateModelsForNodeType,
-      updateModelsForTag
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getCategoryForNodeType: () => 'checkpoints'
   })
 }))
 
@@ -161,6 +138,25 @@ vi.mock<unknown>(import('@/platform/assets/components/AssetGrid.vue'), () => ({
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
+beforeEach(() => {
+  vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockImplementation(
+    () => 'checkpoints'
+  )
+})
+
+beforeEach(() => {
+  const getAssets = vi.fn((key: string) => mockAssetsByKey.get(key) ?? [])
+  const isModelLoading = vi.fn(
+    (key: string) => mockLoadingByKey.get(key) ?? false
+  )
+  vi.mocked(useAssetsStore().getAssets).mockImplementation(getAssets)
+  vi.mocked(useAssetsStore().isModelLoading).mockImplementation(isModelLoading)
+  vi.mocked(useAssetsStore().updateModelsForNodeType).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useAssetsStore().updateModelsForTag).mockResolvedValue(undefined)
+})
+
 describe('AssetBrowserModal', () => {
   const createTestAsset = (
     id: string,
@@ -184,13 +180,10 @@ describe('AssetBrowserModal', () => {
   })
 
   function renderModal(props: Record<string, unknown>) {
-    const pinia = createPinia()
-    setActivePinia(pinia)
-
     return render(AssetBrowserModal, {
       props,
       global: {
-        plugins: [pinia, i18n],
+        plugins: [i18n],
         stubs: {
           'i-lucide:folder': {
             template: '<div data-testid="folder-icon"></div>'

--- a/src/platform/assets/components/AssetCard.test.ts
+++ b/src/platform/assets/components/AssetCard.test.ts
@@ -1,30 +1,15 @@
+import type * as VueUseModule from '@vueuse/core'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import AssetCard from '@/platform/assets/components/AssetCard.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => 0
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/assetDownloadStore'), () => ({
-  useAssetDownloadStore: () => ({
-    isDownloadedThisSession: () => false,
-    acknowledgeAsset: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: vi.fn()
-  })
-}))
 
 vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   assetService: {
@@ -36,7 +21,8 @@ vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
   showConfirmDialog: vi.fn()
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUseModule>()),
   useImage: () => ({ isLoading: false, error: null })
 }))
 
@@ -86,6 +72,17 @@ function renderCard(asset: AssetDisplayItem) {
     }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => 0)
+  vi.mocked(useAssetDownloadStore().isDownloadedThisSession).mockImplementation(
+    () => false
+  )
+  vi.mocked(useAssetDownloadStore().acknowledgeAsset).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => undefined)
+})
 
 describe('AssetCard', () => {
   describe('FE-228: filename rendering', () => {

--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -1,7 +1,8 @@
+import { useAssetsStore } from '@/stores/assetsStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
@@ -11,10 +12,6 @@ import { MIME_ASSET_INFO } from '@/platform/assets/schemas/mediaAssetSchema'
 
 const { downloadAssets } = vi.hoisted(() => ({
   downloadAssets: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({ isAssetDeleting: () => false })
 }))
 
 vi.mock<unknown>(import('../composables/useMediaAssetActions'), () => ({
@@ -84,6 +81,10 @@ function dispatchDragStart(
   container.querySelector('[data-asset-id="a"]')!.dispatchEvent(event)
   return { event, add }
 }
+
+beforeEach(() => {
+  vi.mocked(useAssetsStore().isAssetDeleting).mockImplementation(() => false)
+})
 
 describe('MediaAssetCard', () => {
   describe('dragStart', () => {

--- a/src/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -1,14 +1,16 @@
+import type * as I18nModule from '@/i18n'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { describe, expect, it, vi } from 'vitest'
+import type { ComponentProps } from 'vue-component-type-helpers'
 
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import type AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
-vi.mock(import('@/stores/dialogStore'))
-
-vi.mock<unknown>(import('@/i18n'), () => ({
+vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: (key: string, params?: Record<string, string>) => {
     if (params) {
       return `${key}:${JSON.stringify(params)}`
@@ -32,12 +34,15 @@ function createMockAsset(overrides: Partial<AssetItem> = {}): AssetItem {
 }
 
 function setupDialogMocks() {
-  const mockShowDialog = vi.fn()
-  const mockCloseDialog = vi.fn()
-  vi.mocked(useDialogStore, { partial: true }).mockReturnValue({
-    showDialog: mockShowDialog,
-    closeDialog: mockCloseDialog
-  })
+  const dialogStore = useDialogStore()
+  type BrowserProps = ComponentProps<typeof AssetBrowserModal>
+  const showDialog: (
+    options: Omit<Parameters<typeof dialogStore.showDialog>[0], 'props'> & {
+      props: BrowserProps & Required<Pick<BrowserProps, 'onSelect' | 'onClose'>>
+    }
+  ) => ReturnType<typeof dialogStore.showDialog> = dialogStore.showDialog
+  const mockShowDialog = vi.mocked(showDialog)
+  const mockCloseDialog = vi.mocked(dialogStore.closeDialog)
 
   return { mockShowDialog, mockCloseDialog }
 }

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1,3 +1,10 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useAssetExportStore } from '@/stores/assetExportStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { CreateAssetExportData } from '@comfyorg/ingest-types'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { useToast } from 'primevue/usetoast'
@@ -23,7 +30,8 @@ vi.mock(import('@/base/common/downloadUtil'), () => ({
   downloadFile: mockDownloadFile
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -41,38 +49,11 @@ vi.mock<unknown>(
 )
 
 const mockShowDialog = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    showDialog: mockShowDialog
-  })
-}))
 
 const mockInvalidateModelsForCategory = vi.hoisted(() => vi.fn())
 const mockSetAssetDeleting = vi.hoisted(() => vi.fn())
 const mockHasCategory = vi.hoisted(() => vi.fn())
 const mockInputAssets = vi.hoisted(() => ({ items: [] as AssetItem[] }))
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    setAssetDeleting: mockSetAssetDeleting,
-    inputAssets: {
-      get items() {
-        return mockInputAssets.items
-      },
-      invalidate: (stale?: string[]) => {
-        const ids = new Set(stale)
-        mockInputAssets.items = mockInputAssets.items.filter(
-          (item) => !ids.has(item.id)
-        )
-      }
-    },
-    invalidateModelsForCategory: mockInvalidateModelsForCategory,
-    hasCategory: mockHasCategory
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({})
-}))
 
 vi.mock(import('@/composables/useCopyToClipboard'), () => ({
   useCopyToClipboard: () => ({
@@ -103,17 +84,6 @@ const litegraphServiceMock = vi.hoisted(() => ({
 }))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => litegraphServiceMock
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    nodeDefsByName: {
-      LoadImage: {
-        name: 'LoadImage',
-        display_name: 'Load Image'
-      }
-    }
-  })
 }))
 
 vi.mock<unknown>(import('@/utils/loaderNodeUtil'), () => ({
@@ -162,11 +132,6 @@ vi.mock<unknown>(import('../services/assetService'), () => ({
 }))
 
 const mockTrackExport = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/assetExportStore'), () => ({
-  useAssetExportStore: () => ({
-    trackExport: mockTrackExport
-  })
-}))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -185,6 +150,8 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 const mockAppGraph = vi.hoisted(() => ({ value: { _nodes: [] as unknown[] } }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     get graph() {
       return mockAppGraph.value
     },
@@ -196,24 +163,8 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 const mockRemoveNodeOutputs = vi.hoisted(() => vi.fn())
 const mockRemoveNodeOutputsForNode = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    removeNodeOutputs: mockRemoveNodeOutputs,
-    removeNodeOutputsForNode: mockRemoveNodeOutputsForNode
-  })
-}))
 
 const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: { captureCanvasState: mockCaptureCanvasState }
-      }
-    })
-  })
-)
 
 const mockClearNodePreviewCache = vi.hoisted(() => vi.fn())
 vi.mock(import('../utils/clearNodePreviewCacheForValues'), () => ({
@@ -309,6 +260,49 @@ function useMediaAssetActions() {
 }
 
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
+
+beforeEach(() => {
+  useNodeDefStore().nodeDefsByName = {
+    LoadImage: fromPartial({
+      name: 'LoadImage',
+      display_name: 'Load Image'
+    })
+  }
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { captureCanvasState: mockCaptureCanvasState }
+  })
+})
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().showDialog).mockImplementation(mockShowDialog)
+  vi.mocked(useAssetsStore().setAssetDeleting).mockImplementation(
+    mockSetAssetDeleting
+  )
+  vi.spyOn(useAssetsStore().inputAssets, 'items', 'get').mockImplementation(
+    () => mockInputAssets.items
+  )
+  vi.spyOn(useAssetsStore().inputAssets, 'invalidate').mockImplementation(
+    async (stale?: string[]) => {
+      const ids = new Set(stale)
+      mockInputAssets.items = mockInputAssets.items.filter(
+        (item) => !ids.has(item.id)
+      )
+    }
+  )
+  vi.mocked(useAssetsStore().invalidateModelsForCategory).mockImplementation(
+    mockInvalidateModelsForCategory
+  )
+  vi.mocked(useAssetsStore().hasCategory).mockImplementation(mockHasCategory)
+  vi.mocked(useAssetExportStore().trackExport).mockImplementation(
+    mockTrackExport
+  )
+  vi.mocked(useNodeOutputStore().removeNodeOutputs).mockImplementation(
+    mockRemoveNodeOutputs
+  )
+  vi.mocked(useNodeOutputStore().removeNodeOutputsForNode).mockImplementation(
+    mockRemoveNodeOutputsForNode
+  )
+})
 
 describe('useMediaAssetActions', () => {
   beforeEach(() => {

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -1,3 +1,9 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import type { ComfyApp } from '@/scripts/app'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import { useAssetsStore } from '@/stores/assetsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -14,7 +20,8 @@ const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 const mockSettingStoreGet = vi.hoisted(() => vi.fn(() => false))
 const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: true }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockDistributionState.isCloud
   }
@@ -30,47 +37,19 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: mockSettingStoreGet
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => {
-  const registeredNodeTypes: Record<string, string> = {
-    CheckpointLoaderSimple: 'ckpt_name',
-    LoraLoader: 'lora_name'
-  }
-  const nodeTypeCategories: Record<string, string> = {
-    CheckpointLoaderSimple: 'checkpoints',
-    LoraLoader: 'loras'
-  }
-  return {
-    useModelToNodeStore: vi.fn(() => ({
-      getRegisteredNodeTypes: () => registeredNodeTypes,
-      getCategoryForNodeType: vi.fn(
-        (nodeType: string) => nodeTypeCategories[nodeType]
-      )
-    }))
-  }
-})
-
 const mockInvalidateInputAssets = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    inputAssets: { invalidate: mockInvalidateInputAssets }
-  })
-}))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     fetchApi: vi.fn(),
+    addEventListener: vi.fn(),
     addCustomEventListener: vi.fn(),
     removeCustomEventListener: vi.fn()
   }
 }))
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
@@ -121,6 +100,30 @@ function validAsset(overrides: Partial<AssetItem> = {}): AssetItem {
     ...overrides
   }
 }
+
+beforeEach(() => {
+  const registeredNodeTypes: Record<string, string> = {
+    CheckpointLoaderSimple: 'ckpt_name',
+    LoraLoader: 'lora_name'
+  }
+  const nodeTypeCategories: Record<string, string> = {
+    CheckpointLoaderSimple: 'checkpoints',
+    LoraLoader: 'loras'
+  }
+  vi.mocked(useModelToNodeStore().getRegisteredNodeTypes).mockImplementation(
+    () => registeredNodeTypes
+  )
+  vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockImplementation(
+    (nodeType: string) => nodeTypeCategories[nodeType]
+  )
+  vi.spyOn(useAssetsStore().inputAssets, 'invalidate').mockImplementation(
+    mockInvalidateInputAssets
+  )
+})
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(mockSettingStoreGet)
+})
 
 describe(assetService.shouldUseAssetBrowser, () => {
   beforeEach(() => {
@@ -1178,4 +1181,9 @@ describe(assetService.getAssetsForNodeType, () => {
     expect(assets).toEqual([])
     expect(fetchApiMock).not.toHaveBeenCalled()
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/assets/utils/assetPreviewUtil.test.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import type { ComfyApp } from '@/scripts/app'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   findOutputAsset,
@@ -19,6 +21,7 @@ const mockInvalidateOutputAssets = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
+    addEventListener: vi.fn(),
     fetchApi: mockFetchApi,
     apiURL: mockApiURL,
     api_base: '',
@@ -32,12 +35,6 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
     uploadAssetFromBase64: mockUploadAssetFromBase64,
     updateAsset: mockUpdateAsset
   }
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    outputAssets: { invalidate: mockInvalidateOutputAssets }
-  })
 }))
 
 function mockFetchResponse(assets: Record<string, unknown>[]) {
@@ -82,6 +79,12 @@ const localAssetWithPreview = {
   preview_id: '3df94ee8-preview',
   preview_url: '/api/view?type=output&filename=preview.png'
 }
+
+beforeEach(() => {
+  vi.spyOn(useAssetsStore().outputAssets, 'invalidate').mockImplementation(
+    mockInvalidateOutputAssets
+  )
+})
 
 describe('isAssetPreviewSupported', () => {
   it('returns true when asset API is enabled (cloud)', () => {
@@ -315,4 +318,9 @@ describe('persistThumbnail', () => {
 
     expect(mockInvalidateOutputAssets).not.toHaveBeenCalled()
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -1,3 +1,4 @@
+import type * as DistributionModule from '@/platform/distribution/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -10,7 +11,8 @@ import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 
 import { markDeletedAssetsAsMissingMedia } from './markDeletedAssetsAsMissingMedia'
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: true
 }))
 
@@ -18,14 +20,6 @@ const mockScanNodeMediaCandidates = vi.hoisted(() => vi.fn())
 vi.mock(import('@/platform/missingMedia/missingMediaScan'), () => ({
   scanNodeMediaCandidates: mockScanNodeMediaCandidates
 }))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({ currentGraph: null })
-  })
-)
 
 function makeGraph(nodes: unknown[]): LGraph {
   return { nodes } as unknown as LGraph

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
@@ -1,3 +1,4 @@
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
@@ -5,10 +6,6 @@ import { resolveModelNodeFromAsset } from '@/platform/assets/utils/resolveModelN
 
 const mockGetNodeProvider = vi.hoisted(() => vi.fn())
 const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
-}))
 
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
@@ -56,6 +53,12 @@ function mockProvider(
 ) {
   mockGetNodeProvider.mockReturnValue(provider)
 }
+
+beforeEach(() => {
+  vi.mocked(useModelToNodeStore().getNodeProvider).mockImplementation(
+    mockGetNodeProvider
+  )
+})
 
 describe('resolveModelNodeFromAsset', () => {
   beforeEach(() => {

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -1,24 +1,20 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type { ComfyApp } from '@/scripts/app'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockGetIdToken = vi.fn()
-const mockGetAuthHeader = vi.fn()
-const mockAuthState = vi.hoisted(() => ({
-  currentUser: { uid: 'user-a' } as { uid: string } | null
-}))
+const mockGetIdToken = vi.fn<ReturnType<typeof useAuthStore>['getIdToken']>(
+  async () => undefined
+)
+const mockGetAuthHeader = vi.fn<
+  ReturnType<typeof useAuthStore>['getAuthHeader']
+>(async () => null)
 const originalFetch = globalThis.fetch
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: true
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    getIdToken: mockGetIdToken,
-    getAuthHeader: mockGetAuthHeader,
-    get currentUser() {
-      return mockAuthState.currentUser
-    }
-  })
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -27,15 +23,20 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-const mockReportError = vi.fn()
+const mockReportError = vi.hoisted(() => vi.fn())
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 
+beforeEach(() => {
+  vi.mocked(useAuthStore().getIdToken).mockImplementation(mockGetIdToken)
+  vi.mocked(useAuthStore().getAuthHeader).mockImplementation(mockGetAuthHeader)
+})
+
 describe('useSessionCookie', () => {
   beforeEach(() => {
     vi.resetModules()
-    mockAuthState.currentUser = { uid: 'user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-a' })
     globalThis.fetch = vi.fn()
   })
 
@@ -59,14 +60,14 @@ describe('useSessionCookie', () => {
       method: 'POST',
       credentials: 'include',
       headers: {
-        Authorization: 'Bearer firebase-id-token',
+        Authorization: 'Bearer firebase-id-token' as const,
         'Content-Type': 'application/json'
       }
     })
   })
 
   it('createSessionOrThrow fails fast without a Firebase token', async () => {
-    mockGetIdToken.mockResolvedValue(null)
+    mockGetIdToken.mockResolvedValue(undefined)
     const { useSessionCookie } =
       await import('@/platform/auth/session/useSessionCookie')
 
@@ -150,7 +151,7 @@ describe('useSessionCookie', () => {
 
   it('serializes strict session creation after the previous user response', async () => {
     mockGetIdToken.mockImplementation(() =>
-      Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
+      Promise.resolve(`firebase-${useAuthStore().currentUser?.uid}`)
     )
     let resolveFirstFetch: (value: Response) => void = () => {}
     vi.mocked(globalThis.fetch)
@@ -166,7 +167,7 @@ describe('useSessionCookie', () => {
     const first = useSessionCookie().createSession()
     await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
 
-    mockAuthState.currentUser = { uid: 'user-b' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-b' })
     const second = useSessionCookie().createSessionOrThrow()
     await Promise.resolve()
     await Promise.resolve()
@@ -189,7 +190,7 @@ describe('useSessionCookie', () => {
 
   it('reconfirms a cached owner after another owner mutates the cookie', async () => {
     mockGetIdToken.mockImplementation(() =>
-      Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
+      Promise.resolve(`firebase-${useAuthStore().currentUser?.uid}`)
     )
     let resolveUserB: (value: Response) => void = () => {}
     vi.mocked(globalThis.fetch)
@@ -204,11 +205,11 @@ describe('useSessionCookie', () => {
       await import('@/platform/auth/session/useSessionCookie')
 
     await useSessionCookie().ensureSessionCookie()
-    mockAuthState.currentUser = { uid: 'user-b' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-b' })
     const userBSession = useSessionCookie().createSession()
     await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2))
 
-    mockAuthState.currentUser = { uid: 'user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-a' })
     const userASession = useSessionCookie().ensureSessionCookie()
     await Promise.resolve()
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
@@ -285,3 +286,14 @@ describe('useSessionCookie', () => {
     )
   })
 })
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -1,3 +1,5 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { AxiosAdapter } from 'axios'
 import axios, { AxiosError } from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,13 +21,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({ remintUnifiedOnce: mockRemint })
-  })
-)
-
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: {
@@ -38,7 +33,16 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
 
 // The axios interceptor gates on shouldRemintCloudRequest(), which is a no-op
 // off-cloud; the unit env is not a cloud build, so force it on.
-vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
+  isCloud: true
+}))
+
+beforeEach(() => {
+  vi.mocked(useWorkspaceAuthStore().remintUnifiedOnce).mockImplementation(
+    mockRemint
+  )
+})
 
 describe('fetchWithUnifiedRemint', () => {
   const ok = { status: 200 } as Response
@@ -57,7 +61,9 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer tokenA', 'Comfy-User': 'u1' } },
+      {
+        headers: { Authorization: 'Bearer tokenA' as const, 'Comfy-User': 'u1' }
+      },
       true
     )
 
@@ -85,7 +91,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer tokenA' } },
+      { headers: { Authorization: 'Bearer tokenA' as const } },
       true
     )
 
@@ -105,7 +111,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer tokenA' } },
+      { headers: { Authorization: 'Bearer tokenA' as const } },
       false
     )
 
@@ -121,7 +127,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer t' } },
+      { headers: { Authorization: 'Bearer t' as const } },
       true
     )
 
@@ -136,7 +142,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer t' } },
+      { headers: { Authorization: 'Bearer t' as const } },
       true
     )
 
@@ -155,7 +161,7 @@ describe('fetchWithUnifiedRemint', () => {
     mockFetch.mockResolvedValueOnce(unauthorized).mockResolvedValueOnce(ok)
     mockRemint.mockResolvedValue('tokenB')
     const request = new Request('https://cloud/x', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
 
     const result = await fetchWithUnifiedRemint(request, {}, true)
@@ -171,7 +177,7 @@ describe('fetchWithUnifiedRemint', () => {
     const request = new Request('https://cloud/x', {
       method: 'POST',
       body,
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
     mockFetch
       .mockImplementationOnce(async (input: Request) => {
@@ -215,7 +221,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer t' } },
+      { headers: { Authorization: 'Bearer t' as const } },
       true
     )
 
@@ -233,7 +239,7 @@ describe('fetchWithUnifiedRemint', () => {
       {
         method: 'POST',
         body: new ReadableStream<Uint8Array>(),
-        headers: { Authorization: 'Bearer tokenA' }
+        headers: { Authorization: 'Bearer tokenA' as const }
       },
       true
     )
@@ -252,7 +258,7 @@ describe('fetchWithUnifiedRemint', () => {
   it.for([
     {
       shape: 'object',
-      headers: { Authorization: 'Bearer tokenA', 'Comfy-User': 'u1' }
+      headers: { Authorization: 'Bearer tokenA' as const, 'Comfy-User': 'u1' }
     },
     {
       shape: 'array of tuples',
@@ -264,7 +270,7 @@ describe('fetchWithUnifiedRemint', () => {
     {
       shape: 'Headers',
       headers: new Headers({
-        Authorization: 'Bearer tokenA',
+        Authorization: 'Bearer tokenA' as const,
         'Comfy-User': 'u1'
       })
     }
@@ -336,7 +342,7 @@ describe('attachUnifiedRemintInterceptor', () => {
     mockRemint.mockResolvedValue('tokenB')
 
     const res = await client.get('https://cloud/x', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
 
     expect(res.status).toBe(200)
@@ -359,7 +365,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     await expect(
       client.get('https://cloud/x', {
-        headers: { Authorization: 'Bearer tokenA' }
+        headers: { Authorization: 'Bearer tokenA' as const }
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
 
@@ -379,7 +385,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     await expect(
       client.get('https://cloud/x', {
-        headers: { Authorization: 'Bearer tokenA' }
+        headers: { Authorization: 'Bearer tokenA' as const }
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
 
@@ -394,7 +400,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     await expect(
       client.post('https://cloud/invites/x/accept', null, {
-        headers: { Authorization: 'Bearer firebase' },
+        headers: { Authorization: 'Bearer firebase' as const },
         __skipUnifiedRemint: true
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
@@ -418,7 +424,9 @@ describe('attachUnifiedRemintInterceptor', () => {
     const { client } = makeClient([500])
 
     await expect(
-      client.get('https://cloud/x', { headers: { Authorization: 'Bearer t' } })
+      client.get('https://cloud/x', {
+        headers: { Authorization: 'Bearer t' as const }
+      })
     ).rejects.toMatchObject({ response: { status: 500 } })
 
     expect(mockRemint).not.toHaveBeenCalled()
@@ -431,7 +439,7 @@ describe('attachUnifiedRemintInterceptor', () => {
     const res = await client.post(
       'https://cloud/topup',
       { amount: 5 },
-      { headers: { Authorization: 'Bearer tokenA' } }
+      { headers: { Authorization: 'Bearer tokenA' as const } }
     )
 
     expect(res.status).toBe(200)
@@ -473,10 +481,10 @@ describe('attachUnifiedRemintInterceptor', () => {
     mockRemint.mockResolvedValue('tokenB')
 
     const a = await client.get('https://cloud/a', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
     const b = await client.get('https://cloud/b', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
 
     expect(a.status).toBe(200)

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -1,28 +1,13 @@
+import type * as DistributionModule from '@/platform/distribution/types'
 import { render } from '@testing-library/vue'
 import { useAsyncState } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import DesktopCloudNotificationController from './DesktopCloudNotificationController.vue'
 
-const settingState = {
-  shown: false
-}
-
-const settingStore = {
-  get error(): unknown {
-    return undefined
-  },
-  load: vi.fn<() => Promise<void>>(),
-  get: vi.fn((key: string) =>
-    key === 'Comfy.Desktop.CloudNotificationShown'
-      ? settingState.shown
-      : undefined
-  ),
-  set: vi.fn(async (_key: string, value: boolean) => {
-    settingState.shown = value
-  })
-}
+let settingStore: ReturnType<typeof useSettingStore>
 
 const dialogService = {
   showCloudNotification: vi.fn<() => Promise<void>>()
@@ -34,12 +19,9 @@ const electron = {
 
 const errorReporter = vi.hoisted(() => vi.fn())
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isDesktop: true
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settingStore
 }))
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
@@ -65,12 +47,16 @@ function createDeferred() {
 
 describe('DesktopCloudNotificationController', () => {
   beforeEach(() => {
-    settingState.shown = false
+    settingStore = useSettingStore()
+    useSettingStore().settingValues['Comfy.Desktop.CloudNotificationShown'] =
+      false
     electron.getPlatform.mockReturnValue('darwin')
-    settingStore.load.mockResolvedValue(undefined)
-    settingStore.set.mockImplementation(
+    vi.mocked(settingStore.load).mockResolvedValue(undefined)
+    vi.mocked(settingStore.set).mockImplementation(
       async (_key: string, value: boolean) => {
-        settingState.shown = value
+        useSettingStore().settingValues[
+          'Comfy.Desktop.CloudNotificationShown'
+        ] = value
       }
     )
     dialogService.showCloudNotification.mockResolvedValue(undefined)
@@ -78,12 +64,13 @@ describe('DesktopCloudNotificationController', () => {
 
   it('waits for settings to load before deciding whether to show the notification', async () => {
     const loadSettings = createDeferred()
-    settingStore.load.mockImplementation(() => loadSettings.promise)
+    vi.mocked(settingStore.load).mockImplementation(() => loadSettings.promise)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await nextTick()
 
-    settingState.shown = true
+    useSettingStore().settingValues['Comfy.Desktop.CloudNotificationShown'] =
+      true
     loadSettings.resolve()
 
     await vi.advanceTimersByTimeAsync(0)
@@ -96,7 +83,7 @@ describe('DesktopCloudNotificationController', () => {
 
   it('does not schedule or show the notification after unmounting before settings load resolves', async () => {
     const loadSettings = createDeferred()
-    settingStore.load.mockImplementation(() => loadSettings.promise)
+    vi.mocked(settingStore.load).mockImplementation(() => loadSettings.promise)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await nextTick()
@@ -126,7 +113,9 @@ describe('DesktopCloudNotificationController', () => {
       'Comfy.Desktop.CloudNotificationShown',
       true
     )
-    expect(settingStore.set.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      vi.mocked(settingStore.set).mock.invocationCallOrder[0]
+    ).toBeLessThan(
       dialogService.showCloudNotification.mock.invocationCallOrder[0]
     )
 
@@ -141,7 +130,7 @@ describe('DesktopCloudNotificationController', () => {
     const settingsLoad = useAsyncState(() => Promise.reject(error), undefined, {
       immediate: false
     })
-    settingStore.load.mockImplementation(async () => {
+    vi.mocked(settingStore.load).mockImplementation(async () => {
       await settingsLoad.execute()
     })
     vi.spyOn(settingStore, 'error', 'get').mockImplementation(
@@ -179,7 +168,7 @@ describe('DesktopCloudNotificationController', () => {
 
   it('reports an initial save failure, resets state, and never opens the dialog', async () => {
     const error = new Error('save failed')
-    settingStore.set.mockRejectedValueOnce(error)
+    vi.mocked(settingStore.set).mockRejectedValueOnce(error)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await vi.advanceTimersByTimeAsync(2000)
@@ -255,11 +244,13 @@ describe('DesktopCloudNotificationController', () => {
       const initialError = new Error('initial failure')
       const resetError = new Error('reset failed')
       dialogService.showCloudNotification.mockRejectedValue(initialError)
-      settingStore.set.mockImplementation(
+      vi.mocked(settingStore.set).mockImplementation(
         async (_key: string, value: boolean) => {
           if (!value) throw resetError
           if (failure === 'save') throw initialError
-          settingState.shown = value
+          useSettingStore().settingValues[
+            'Comfy.Desktop.CloudNotificationShown'
+          ] = value
         }
       )
 

--- a/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
+++ b/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/stores/authStore'
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
@@ -7,15 +8,6 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
-
-const loading = vi.hoisted(() => ({ value: false }))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get loading() {
-      return loading.value
-    }
-  })
-}))
 
 const LOGIN_COPY = enMessages.auth.login
 
@@ -56,7 +48,7 @@ const submitButton = () =>
 
 beforeEach(() => {
   vi.useRealTimers()
-  loading.value = false
+  Object.assign(useAuthStore(), { loading: false })
 })
 
 describe('CloudSignInForm', () => {
@@ -177,7 +169,7 @@ describe('CloudSignInForm submit gating', () => {
 
 describe('CloudSignInForm in-flight state', () => {
   it('disables submit and marks it busy while an auth action runs', () => {
-    loading.value = true
+    Object.assign(useAuthStore(), { loading: true })
     renderRealForm()
 
     expect(submitButton()).toBeDisabled()
@@ -186,7 +178,7 @@ describe('CloudSignInForm in-flight state', () => {
 
   it('does not emit submit while loading', async () => {
     const user = userEvent.setup()
-    loading.value = true
+    Object.assign(useAuthStore(), { loading: true })
     const { emitted } = renderRealForm()
 
     await user.click(submitButton())
@@ -194,3 +186,10 @@ describe('CloudSignInForm in-flight state', () => {
     expect(emitted().submit).toBeUndefined()
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/onboarding/composables/usePostAuthRedirect.test.ts
+++ b/src/platform/cloud/onboarding/composables/usePostAuthRedirect.test.ts
@@ -1,3 +1,7 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -17,11 +21,6 @@ const resumeOAuthIfNeeded = vi.hoisted(() =>
 )
 vi.mock(import('@/platform/cloud/oauth/useOAuthPostLoginRedirect'), () => ({
   useOAuthPostLoginRedirect: () => ({ resumeOAuthIfNeeded })
-}))
-
-const toasts = vi.hoisted(() => ({ add: vi.fn() }))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => toasts
 }))
 
 const DEFAULT_REDIRECT = { name: 'cloud-user-check' }
@@ -70,7 +69,7 @@ describe('usePostAuthRedirect', () => {
 
     await onAuthSuccess()
 
-    expect(toasts.add).toHaveBeenCalledWith(
+    expect(useToastStore().add).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'success',
         summary: 'Login Completed'
@@ -140,7 +139,7 @@ describe('usePostAuthRedirect', () => {
     await onAuthSuccess()
 
     expect(
-      toasts.add,
+      useToastStore().add,
       'authError only renders in email-form mode, so a Google/GitHub user would see the failure nowhere at all'
     ).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -1,5 +1,8 @@
+import type * as I18nModule from '@/i18n'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { reactive } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
 
@@ -19,35 +22,19 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
 }))
 
 const mockToastAdd = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd
-  })
-}))
-
-interface MockAuthStore {
-  currentUser: {
-    uid: string
-    getIdToken: (forceRefresh?: boolean) => Promise<string>
-  } | null
-  getIdToken: () => Promise<string>
-}
 
 const mockUserGetIdToken = vi.hoisted(() => vi.fn())
 const mockStoreGetIdToken = vi.hoisted(() => vi.fn())
 
-// Reactive so the module's watcher on currentUser fires without a navigation.
-// The mock factory is cached across vi.resetModules(), so it reads a holder
-// refilled per test; watchers leaked by earlier module generations stay
-// subscribed to earlier stores and remain dormant.
-const authStoreHolder = vi.hoisted(() => ({
-  store: null as MockAuthStore | null
-}))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => authStoreHolder.store
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
 }))
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: (key: string) => key
 }))
 
@@ -66,7 +53,7 @@ const RETRY_DELAY_MS = 5_000
 
 const mockFetch = vi.fn()
 
-let mockAuthStore: MockAuthStore
+let mockAuthStore: ReturnType<typeof useAuthStore>
 
 function okResponse() {
   return new Response(JSON.stringify({ status: 'redeemed' }), { status: 200 })
@@ -76,7 +63,7 @@ function expectedFetchOptions(code: string) {
   return {
     method: 'POST',
     headers: {
-      Authorization: 'Bearer firebase-id-token',
+      Authorization: 'Bearer firebase-id-token' as const,
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({ code }),
@@ -125,6 +112,10 @@ async function setup(
   }
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+})
+
 describe('installDesktopLoginRedemption', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -132,14 +123,12 @@ describe('installDesktopLoginRedemption', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockConfirm.mockResolvedValue(true)
     mockUserGetIdToken.mockResolvedValue('firebase-id-token')
-    mockAuthStore = reactive({
-      currentUser: {
-        uid: 'user-1',
-        getIdToken: mockUserGetIdToken
-      },
-      getIdToken: mockStoreGetIdToken
+    mockAuthStore = useAuthStore()
+    mockAuthStore.currentUser = fromPartial({
+      uid: 'user-1',
+      getIdToken: mockUserGetIdToken
     })
-    authStoreHolder.store = mockAuthStore
+    vi.mocked(mockAuthStore.getIdToken).mockImplementation(mockStoreGetIdToken)
   })
 
   it('does nothing on navigation when no code is stashed', async () => {
@@ -267,10 +256,10 @@ describe('installDesktopLoginRedemption', () => {
     expect(mockConfirm).not.toHaveBeenCalled()
 
     // Signing in on the login page fires the auth watcher mid-handoff.
-    mockAuthStore.currentUser = {
+    mockAuthStore.currentUser = fromPartial({
       uid: 'user-1',
       getIdToken: mockUserGetIdToken
-    }
+    })
     await flushRedemption()
 
     expect(mockConfirm).not.toHaveBeenCalled()
@@ -501,10 +490,10 @@ describe('installDesktopLoginRedemption', () => {
 
     // A session appearing without any further navigation redeems via the
     // watcher.
-    mockAuthStore.currentUser = {
+    mockAuthStore.currentUser = fromPartial({
       uid: 'user-1',
       getIdToken: mockUserGetIdToken
-    }
+    })
 
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
     expect(mockFetch).toHaveBeenCalledWith(
@@ -575,10 +564,10 @@ describe('installDesktopLoginRedemption', () => {
 
     // The session changes to user-2 before the retry: user-1's approval must
     // not authorize redeeming with user-2's token.
-    mockAuthStore.currentUser = {
+    mockAuthStore.currentUser = fromPartial({
       uid: 'user-2',
       getIdToken: vi.fn().mockResolvedValue('second-user-token')
-    }
+    })
 
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(2))
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
@@ -586,7 +575,7 @@ describe('installDesktopLoginRedemption', () => {
       REDEEM_URL,
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'Bearer second-user-token'
+          Authorization: 'Bearer second-user-token' as const
         })
       })
     )
@@ -614,7 +603,7 @@ describe('installDesktopLoginRedemption', () => {
       uid: 'user-2',
       getIdToken: vi.fn().mockResolvedValue('second-user-token')
     }
-    mockAuthStore.currentUser = secondUser
+    mockAuthStore.currentUser = fromPartial(secondUser)
     await flushRedemption()
     approve(true)
     await flushRedemption()
@@ -625,7 +614,7 @@ describe('installDesktopLoginRedemption', () => {
       REDEEM_URL,
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'Bearer second-user-token'
+          Authorization: 'Bearer second-user-token' as const
         })
       })
     )

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -1,8 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, reactive, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import PricingTable from '@/platform/cloud/subscription/components/PricingTable.vue'
@@ -30,9 +31,9 @@ const mockAccessBillingPortal = vi.fn()
 const mockReportError = vi.fn()
 const mockTrackBeginCheckout = vi.fn()
 const mockTrackBillingEvent = vi.fn()
-const mockUserId = ref<string | undefined>('user-123')
+
 const mockGetAuthHeader = vi.fn(() =>
-  Promise.resolve({ Authorization: 'Bearer test-token' })
+  Promise.resolve({ Authorization: 'Bearer test-token' as const })
 )
 const mockGetCheckoutAttribution = vi.hoisted(() => vi.fn(() => ({})))
 const mockLocalStorage = vi.hoisted(() => {
@@ -114,23 +115,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () =>
-    reactive({
-      getFirebaseAuthHeader: mockGetAuthHeader,
-      fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
-        fetch(input, init),
-      userId: computed(() => mockUserId.value)
-    }),
-  AuthStoreError: class extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.status = status
-    }
-  }
-}))
-
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackBeginCheckout: mockTrackBeginCheckout,
@@ -145,7 +129,8 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: true
 }))
 
@@ -211,7 +196,7 @@ function renderComponent() {
       // verify checkout-failure telemetry; without an app-level errorHandler,
       // Vue's dev-mode default handler re-throws it as an unhandled rejection.
       config: { errorHandler: () => {} },
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      plugins: [i18n],
       components: {
         Button
       },
@@ -242,12 +227,22 @@ function renderComponent() {
 
 const onChooseTeamWorkspace = vi.fn()
 
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-123' })
+  vi.mocked(useAuthStore().getFirebaseAuthHeader).mockImplementation(
+    mockGetAuthHeader
+  )
+  vi.mocked(useAuthStore().fetchWithCustomerRecovery).mockImplementation(
+    (input, init) => fetch(input, init)
+  )
+})
+
 describe('PricingTable', () => {
   beforeEach(() => {
     mockCanAccessSubscriptionFeatures.value = false
     mockSubscriptionTier.value = null
     mockSubscriptionDuration.value = 'MONTHLY'
-    mockUserId.value = 'user-123'
+    Object.assign(useAuthStore(), { userId: 'user-123' })
     mockAccessBillingPortal.mockResolvedValue(true)
     mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
@@ -364,12 +359,12 @@ describe('PricingTable', () => {
     it('should use the latest userId value when it changes after mount', async () => {
       mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
-      mockUserId.value = 'user-early'
+      Object.assign(useAuthStore(), { userId: 'user-early' })
 
       renderComponent()
       await flushPromises()
 
-      mockUserId.value = 'user-late'
+      Object.assign(useAuthStore(), { userId: 'user-late' })
 
       const creatorButton = screen
         .getAllByRole('button')
@@ -567,3 +562,10 @@ describe('PricingTable', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
@@ -12,25 +15,25 @@ const {
   mockGetAuthHeader,
   mockGetCheckoutAttribution,
   mockTelemetry,
-  mockUserId,
+
   mockIsCloud,
-  mockAuthStoreInitialized,
+
   mockGetBillingStatus,
-  mockActiveWorkspaceId,
+
   mockSetWorkspaceBillingRail,
   mockLocalStorage
 } = vi.hoisted(() => ({
   mockIsLoggedIn: { value: false },
   mockIsCloud: { value: true },
-  mockAuthStoreInitialized: { value: true },
+
   mockGetBillingStatus: vi.fn(),
-  mockActiveWorkspaceId: { value: 'workspace-123' },
+
   mockSetWorkspaceBillingRail: vi.fn(),
   mockReportError: vi.fn(),
   mockAccessBillingPortal: vi.fn(),
   mockShowSubscriptionRequiredDialog: vi.fn(),
   mockGetAuthHeader: vi.fn(() =>
-    Promise.resolve({ Authorization: 'Bearer test-token' })
+    Promise.resolve({ Authorization: 'Bearer test-token' as const })
   ),
   mockGetCheckoutAttribution: vi.fn(() => ({
     im_ref: 'impact-click-001',
@@ -42,7 +45,7 @@ const {
     trackMonthlySubscriptionCancelled: vi.fn(),
     trackBillingEvent: vi.fn()
   },
-  mockUserId: { value: 'user-123' },
+
   mockLocalStorage: (() => {
     const store = new Map<string, string>()
 
@@ -131,7 +134,8 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   }))
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -150,41 +154,28 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      setWorkspaceBillingRail: mockSetWorkspaceBillingRail
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: vi.fn(() => ({
     showSubscriptionRequiredDialog: mockShowSubscriptionRequiredDialog
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    getFirebaseAuthHeader: mockGetAuthHeader,
-    fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
-      fetch(input, init),
-    get isInitialized() {
-      return mockAuthStoreInitialized.value
-    },
-    get userId() {
-      return mockUserId.value
-    }
-  })),
-  AuthStoreError: class extends Error {}
-}))
-
 // Mock fetch
 global.fetch = vi.fn()
+
+beforeEach(() => {
+  Object.assign(useAuthStore(), { isInitialized: true, userId: 'user-123' })
+  vi.mocked(useAuthStore().getFirebaseAuthHeader).mockImplementation(
+    mockGetAuthHeader
+  )
+  vi.mocked(useAuthStore().fetchWithCustomerRecovery).mockImplementation(
+    (input, init) => fetch(input, init)
+  )
+
+  vi.mocked(useTeamWorkspaceStore().setWorkspaceBillingRail).mockImplementation(
+    mockSetWorkspaceBillingRail
+  )
+})
 
 describe('useSubscription', () => {
   afterEach(() => {
@@ -202,10 +193,12 @@ describe('useSubscription', () => {
     mockLocalStorage.__reset()
     mockIsLoggedIn.value = false
     mockAccessBillingPortal.mockResolvedValue(true)
-    mockUserId.value = 'user-123'
+    Object.assign(useAuthStore(), { userId: 'user-123' })
     mockIsCloud.value = true
-    mockAuthStoreInitialized.value = true
-    mockActiveWorkspaceId.value = 'workspace-123'
+    Object.assign(useAuthStore(), { isInitialized: true })
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: 'workspace-123'
+    })
     mockGetBillingStatus.mockResolvedValue({
       is_active: false,
       has_funds: false,
@@ -387,8 +380,10 @@ describe('useSubscription', () => {
       const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
       const previousAccountRequest = fetchStatus()
 
-      mockUserId.value = 'user-456'
-      mockActiveWorkspaceId.value = 'workspace-456'
+      Object.assign(useAuthStore(), { userId: 'user-456' })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-456'
+      })
       const currentAccountRequest = fetchStatus()
       await currentAccountRequest
 
@@ -474,7 +469,7 @@ describe('useSubscription', () => {
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
-            Authorization: 'Bearer test-token',
+            Authorization: 'Bearer test-token' as const,
             'Content-Type': 'application/json'
           }),
           body: JSON.stringify({
@@ -786,7 +781,7 @@ describe('useSubscription', () => {
     })
 
     it('does not clear pending attempts before auth initialization resolves', async () => {
-      mockAuthStoreInitialized.value = false
+      Object.assign(useAuthStore(), { isInitialized: false })
       mockIsLoggedIn.value = false
 
       localStorage.setItem(
@@ -1032,3 +1027,10 @@ describe('useSubscription', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
@@ -1,3 +1,5 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
@@ -6,7 +8,9 @@ const mockBillingFetchBalance = vi.fn()
 const mockAuthFetchBalance = vi.fn()
 const mockFetchStatus = vi.fn()
 const mockShowTopUpCreditsDialog = vi.fn()
-const mockExecute = vi.fn()
+const mockExecute = vi.fn<ReturnType<typeof useCommandStore>['execute']>(
+  async () => undefined
+)
 const mockToastAdd = vi.fn()
 
 const { mockReportError } = vi.hoisted(() => ({
@@ -15,10 +19,6 @@ const { mockReportError } = vi.hoisted(() => ({
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mockToastAdd })
 }))
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
@@ -37,12 +37,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     showTopUpCreditsDialog: mockShowTopUpCreditsDialog
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: mockExecute
   })
 }))
 
@@ -74,10 +68,14 @@ Object.defineProperty(window, 'open', {
   value: mockOpen
 })
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+  vi.mocked(useCommandStore().execute).mockImplementation(mockExecute)
+})
+
 describe('useSubscriptionActions', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockReportError.mockReset()
   })
 
   describe('handleAddApiCredits', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -1,3 +1,8 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SubscriptionInfo } from '@/composables/billing/types'
@@ -17,7 +22,7 @@ const mockCloseDialog = vi.fn()
 const mockShowLayoutDialog = vi.fn()
 const mockShowTeamWorkspacesDialog = vi.fn()
 const mockTrackSubscription = vi.hoisted(() => vi.fn())
-const mockIsInPersonalWorkspace = vi.hoisted(() => ({ value: true }))
+
 const mockIsFreeTier = vi.hoisted(() => ({ value: false }))
 const mockTier = vi.hoisted(() => ({ value: 'FREE' as string | null }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
@@ -30,8 +35,7 @@ const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockCurrentPlanSlug = vi.hoisted(() => ({ value: null as string | null }))
 const mockCanManageSubscription = vi.hoisted(() => ({ value: true }))
 const mockEmbeddedCheckoutEnabled = vi.hoisted(() => ({ value: false }))
-const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
-const mockUserId = vi.hoisted(() => ({ value: 'user-1' as string | undefined }))
+
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockFetchPlans = vi.hoisted(() => vi.fn())
 const mockFetchStatus = vi.hoisted(() => vi.fn())
@@ -46,12 +50,6 @@ const mockSubscription = vi.hoisted(() => ({
 }))
 const mockSubscriptionStatus = vi.hoisted(() => ({
   value: null as BillingSubscriptionStatus | null
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
 }))
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
@@ -86,39 +84,11 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      get isInPersonalWorkspace() {
-        return mockIsInPersonalWorkspace.value
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({ startOperation: mockStartOperation })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get userId() {
-      return mockUserId.value
-    }
-  })
 }))
 
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
@@ -166,10 +136,19 @@ function expectRekaPricingDialogProps(
   expect(dialogComponentProps).not.toHaveProperty('pt')
 }
 
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-1' })
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(mockCloseDialog)
+
+  vi.mocked(useBillingOperationStore().startOperation).mockImplementation(
+    mockStartOperation
+  )
+})
+
 describe('useSubscriptionDialog', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsFreeTier.value = false
     mockTier.value = 'FREE'
     mockShouldUseWorkspaceBilling.value = false
@@ -179,8 +158,8 @@ describe('useSubscriptionDialog', () => {
     mockCurrentPlanSlug.value = null
     mockCanManageSubscription.value = true
     mockEmbeddedCheckoutEnabled.value = false
-    mockActiveWorkspaceId.value = 'workspace-1'
-    mockUserId.value = 'user-1'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
+    Object.assign(useAuthStore(), { userId: 'user-1' })
     mockStartOperation.mockResolvedValue({ status: 'succeeded' })
     mockFetchPlans.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
@@ -212,7 +191,7 @@ describe('useSubscriptionDialog', () => {
 
     it('does not wire onChooseTeam on the unified table (personal subscribes directly)', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -224,7 +203,7 @@ describe('useSubscriptionDialog', () => {
 
     it('sizes the unified pricing dialog via the Reka contentClass, not the ignored PrimeVue style', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -235,7 +214,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults to the personal tab in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -246,7 +225,7 @@ describe('useSubscriptionDialog', () => {
 
     it('opens the team tab when planMode is forced from a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockCurrentPlanSlug.value = 'creator-monthly'
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -273,7 +252,7 @@ describe('useSubscriptionDialog', () => {
 
     it('routes a personal deep link through the legacy Team downgrade flow', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
       const initialCheckout = {
@@ -290,7 +269,7 @@ describe('useSubscriptionDialog', () => {
 
     it('keeps a Team stop deep link table-only for a legacy Team plan', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -314,7 +293,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults to the team tab for a Team plan in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsTeamPlan.value = true
       mockCurrentPlanSlug.value = 'team_per_credit_monthly'
       const { showPricingTable } = useSubscriptionDialog()
@@ -327,7 +306,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults to the personal tab for a personal plan in a team workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockCurrentPlanSlug.value = 'creator-monthly'
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -339,7 +318,7 @@ describe('useSubscriptionDialog', () => {
 
     it('keeps personal checkout deep links table-only on the legacy billing flow', () => {
       mockShouldUseWorkspaceBilling.value = false
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable({
@@ -365,7 +344,7 @@ describe('useSubscriptionDialog', () => {
     it('uses the unified table when pricing is unified but billing remains legacy', () => {
       mockShouldUseWorkspaceBilling.value = false
       mockShouldUseUnifiedPricing.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -390,7 +369,7 @@ describe('useSubscriptionDialog', () => {
 
     it('routes an existing per-member (legacy) team subscriber to the old team table', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -408,7 +387,7 @@ describe('useSubscriptionDialog', () => {
 
     it('sizes the legacy workspace pricing dialog via Reka contentClass', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -423,7 +402,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults an unsubscribed team workspace to the team tab', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -435,7 +414,7 @@ describe('useSubscriptionDialog', () => {
 
     it('shows the read-only member dialog in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockCanManageSubscription.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -474,7 +453,7 @@ describe('useSubscriptionDialog', () => {
 
     it('does not track modal_opened for the inactive member dialog', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockCanManageSubscription.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -486,7 +465,7 @@ describe('useSubscriptionDialog', () => {
 
     it('shows the read-only member dialog for out-of-credits too, not the pricing table', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockCanManageSubscription.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -512,7 +491,7 @@ describe('useSubscriptionDialog', () => {
   describe('show', () => {
     it('sends a free-tier personal user straight to the pricing table', () => {
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { show } = useSubscriptionDialog()
 
       show()
@@ -525,7 +504,7 @@ describe('useSubscriptionDialog', () => {
     it('checks workspace member permission before the personal free-tier path', () => {
       mockShouldUseWorkspaceBilling.value = true
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockCanManageSubscription.value = false
       const { show } = useSubscriptionDialog()
 
@@ -550,7 +529,7 @@ describe('useSubscriptionDialog', () => {
 
     it('falls back to the pricing table for a free-tier team workspace', () => {
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       const { show } = useSubscriptionDialog()
 
       show()
@@ -562,7 +541,7 @@ describe('useSubscriptionDialog', () => {
 
     it('tracks modal_opened with the reason for the free-tier dialog', () => {
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { show } = useSubscriptionDialog()
 
       show({ reason: 'out_of_credits' })
@@ -635,7 +614,7 @@ describe('useSubscriptionDialog', () => {
 
     it('shows pricing table and clears intent when in team workspace', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockShouldUseWorkspaceBilling.value = true
       mockCurrentPlanSlug.value = 'creator-monthly'
 
@@ -653,7 +632,7 @@ describe('useSubscriptionDialog', () => {
 
     it('clears intent but does not show pricing if still in personal workspace', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
       void resumePendingPricingFlow()
@@ -664,7 +643,7 @@ describe('useSubscriptionDialog', () => {
 
     it('consumes intent so second call is a no-op', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
       void resumePendingPricingFlow()
@@ -930,3 +909,10 @@ describe('useSubscriptionDialog', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/launchCancellationFlow.test.ts
+++ b/src/platform/cloud/subscription/launchCancellationFlow.test.ts
@@ -1,3 +1,5 @@
+import type * as I18nModule from '@/i18n'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SubscriptionInfo } from '@/composables/billing/types'
@@ -30,7 +32,10 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock(import('@/i18n'), () => ({ t: (key: string) => key }))
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
+  t: (key: string) => key
+}))
 
 vi.mock(import('@/platform/cloud/churnkey/churnkeyClient'), () => ({
   prepareChurnkey: mocks.prepare
@@ -42,20 +47,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mocks.activeWorkspaceId
-      },
-      get activeWorkspaceBillingRail() {
-        return mocks.billingRail
-      }
-    })
-  })
-)
-
 import { launchCancellationFlow } from './launchCancellationFlow'
 
 function session(
@@ -63,6 +54,23 @@ function session(
 ): ChurnkeySession {
   return { show }
 }
+
+beforeEach(() => {
+  vi.spyOn(
+    useTeamWorkspaceStore(),
+    'activeWorkspaceId',
+    'get'
+  ).mockImplementation(() => {
+    return mocks.activeWorkspaceId
+  })
+  vi.spyOn(
+    useTeamWorkspaceStore(),
+    'activeWorkspaceBillingRail',
+    'get'
+  ).mockImplementation(() => {
+    return mocks.billingRail
+  })
+})
 
 describe('launchCancellationFlow', () => {
   beforeEach(() => {

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -1,5 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, reactive } from 'vue'
 
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { performSubscriptionCheckout } from './subscriptionCheckoutUtil'
@@ -7,7 +8,7 @@ import { performSubscriptionCheckout } from './subscriptionCheckoutUtil'
 const {
   mockTelemetry,
   mockGetAuthHeader,
-  mockUserId,
+
   mockIsCloud,
   mockGetCheckoutAttribution,
   mockLocalStorage
@@ -16,10 +17,10 @@ const {
     trackBeginCheckout: vi.fn(),
     trackBillingEvent: vi.fn()
   },
-  mockGetAuthHeader: vi.fn(() =>
-    Promise.resolve({ Authorization: 'Bearer test-token' })
-  ),
-  mockUserId: { value: 'user-123' },
+  mockGetAuthHeader: vi.fn<
+    ReturnType<typeof useAuthStore>['getFirebaseAuthHeader']
+  >(() => Promise.resolve({ Authorization: 'Bearer test-token' as const })),
+
   mockIsCloud: { value: true },
   mockGetCheckoutAttribution: vi.fn(() => ({
     ga_client_id: 'ga-client-id',
@@ -68,25 +69,8 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: vi.fn(() => mockTelemetry)
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() =>
-    reactive({
-      getFirebaseAuthHeader: mockGetAuthHeader,
-      fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
-        fetch(input, init),
-      userId: computed(() => mockUserId.value)
-    })
-  ),
-  AuthStoreError: class extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.status = status
-    }
-  }
-}))
-
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -118,11 +102,21 @@ function createDeferred<T>() {
   return { promise, resolve }
 }
 
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-123' })
+  vi.mocked(useAuthStore().getFirebaseAuthHeader).mockImplementation(
+    mockGetAuthHeader
+  )
+  vi.mocked(useAuthStore().fetchWithCustomerRecovery).mockImplementation(
+    (input, init) => fetch(input, init)
+  )
+})
+
 describe('performSubscriptionCheckout', () => {
   beforeEach(() => {
     setDistribution('cloud')
     mockIsCloud.value = true
-    mockUserId.value = 'user-123'
+    Object.assign(useAuthStore(), { userId: 'user-123' })
     mockLocalStorage.__reset()
   })
 
@@ -256,9 +250,14 @@ describe('performSubscriptionCheckout', () => {
   it('uses the latest userId when it changes after checkout starts', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window)
-    const authHeader = createDeferred<{ Authorization: string }>()
+    const authHeader =
+      createDeferred<
+        Awaited<
+          ReturnType<ReturnType<typeof useAuthStore>['getFirebaseAuthHeader']>
+        >
+      >()
 
-    mockUserId.value = 'user-early'
+    Object.assign(useAuthStore(), { userId: 'user-early' })
     mockGetAuthHeader.mockImplementationOnce(() => authHeader.promise)
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -267,8 +266,8 @@ describe('performSubscriptionCheckout', () => {
 
     const checkoutPromise = performSubscriptionCheckout('pro', 'yearly')
 
-    mockUserId.value = 'user-late'
-    authHeader.resolve({ Authorization: 'Bearer test-token' })
+    Object.assign(useAuthStore(), { userId: 'user-late' })
+    authHeader.resolve({ Authorization: 'Bearer test-token' as const })
 
     await checkoutPromise
 
@@ -336,3 +335,10 @@ describe('performSubscriptionCheckout', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -1,21 +1,21 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, reactive } from 'vue'
 
 const {
   mockIsCloud,
   mockSubscribe,
   mockTrackBeginCheckout,
-  mockTrackBillingEvent,
-  mockUserId
+  mockTrackBillingEvent
 } = vi.hoisted(() => ({
   mockIsCloud: { value: true },
   mockSubscribe: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
-  mockTrackBillingEvent: vi.fn(),
-  mockUserId: { value: 'user-1' }
+  mockTrackBillingEvent: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -42,17 +42,12 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     trackBillingEvent: mockTrackBillingEvent
   })
 }))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => reactive({ userId: computed(() => mockUserId.value) }),
-  AuthStoreError: class AuthStoreError extends Error {
-    constructor(message: string) {
-      super(message)
-      this.name = 'AuthStoreError'
-    }
-  }
-}))
 
 import { performTeamSubscriptionCheckout } from './teamSubscriptionCheckoutUtil'
+
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-1' })
+})
 
 describe('performTeamSubscriptionCheckout', () => {
   let assignedHref: string | undefined
@@ -169,3 +164,10 @@ describe('performTeamSubscriptionCheckout', () => {
     expect(assignedHref).toBeUndefined()
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/keybindings/keybindingService.canvas.test.ts
+++ b/src/platform/keybindings/keybindingService.canvas.test.ts
@@ -1,20 +1,9 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => [])
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: vi.fn(() => ({
-    dialogStack: []
-  }))
-}))
 
 function createTestKeyboardEvent(
   key: string,
@@ -50,6 +39,11 @@ function createTestKeyboardEvent(
   return event
 }
 
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+  useDialogStore().dialogStack = []
+})
+
 describe('keybindingService - Canvas Keybindings', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
   let canvasContainer: HTMLDivElement
@@ -59,11 +53,7 @@ describe('keybindingService - Canvas Keybindings', () => {
     const commandStore = useCommandStore()
     commandStore.execute = vi.fn()
 
-    vi.mocked(useDialogStore).mockReturnValue({
-      dialogStack: []
-    } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-      typeof useDialogStore
-    >)
+    Object.assign(useDialogStore(), { dialogStack: [] })
 
     canvasContainer = document.createElement('div')
     canvasContainer.id = 'graph-canvas-container'

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -1,4 +1,5 @@
-import { markRaw, reactive } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
@@ -21,24 +22,15 @@ function createTestDialogInstance(
   }
 }
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => [])
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => {
-  const dialogStack = reactive<DialogInstance[]>([])
-  return {
-    useDialogStore: () => ({ dialogStack })
-  }
-})
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: null
   }
 }))
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+})
 
 describe('keybindingService - dialog gate', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
@@ -46,8 +38,8 @@ describe('keybindingService - dialog gate', () => {
 
   beforeEach(() => {
     const commandStore = useCommandStore()
-    mockCommandExecute = vi.fn()
-    commandStore.execute = mockCommandExecute
+    mockCommandExecute = commandStore.execute
+    vi.mocked(mockCommandExecute).mockResolvedValue(undefined)
 
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -1,5 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { markRaw, reactive } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CORE_KEYBINDINGS } from '@/platform/keybindings/defaults'
@@ -26,24 +26,15 @@ function createTestDialogInstance(
   }
 }
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => [])
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => {
-  const dialogStack = reactive<DialogInstance[]>([])
-  return {
-    useDialogStore: () => ({ dialogStack })
-  }
-})
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: null
   }
 }))
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+})
 
 describe('keybindingService - Escape key handling', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
@@ -51,8 +42,8 @@ describe('keybindingService - Escape key handling', () => {
 
   beforeEach(() => {
     const commandStore = useCommandStore()
-    mockCommandExecute = vi.fn()
-    commandStore.execute = mockCommandExecute
+    mockCommandExecute = commandStore.execute
+    vi.mocked(mockCommandExecute).mockResolvedValue(undefined)
 
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0
@@ -167,7 +158,9 @@ describe('keybindingService - Escape key handling', () => {
   })
 
   it('should still close legacy modals on Escape when no keybinding matched', async () => {
-    setActivePinia(createPinia())
+    useKeybindingStore().removeAllKeybindingsForCommand(
+      'Comfy.Graph.ExitSubgraph'
+    )
     keybindingService = useKeybindingService()
 
     const mockModal = document.createElement('div')

--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -1,3 +1,4 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
@@ -5,21 +6,12 @@ import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useCommandStore } from '@/stores/commandStore'
 
-const settings = vi.hoisted(() => ({
-  values: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => settings.values[key] ?? [])
-  }))
-}))
-
 describe('keybindingService - registerUserKeybindings', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    settings.values = {}
+    useSettingStore().settingValues['Comfy.Keybinding.NewBindings'] = []
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = []
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -30,7 +22,7 @@ describe('keybindingService - registerUserKeybindings', () => {
   it('does not warn when unset binding targets a command that no longer exists', () => {
     // A command removed from the app (e.g. ConvertSelectedNodesToGroupNode,
     // removed in #12931) can still linger in the persisted UnsetBindings.
-    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = [
       {
         commandId: 'ConvertSelectedNodesToGroupNode',
         combo: { key: 'g', ctrl: true, alt: false, shift: false }
@@ -57,7 +49,7 @@ describe('keybindingService - registerUserKeybindings', () => {
       new KeybindingImpl({ commandId: 'Comfy.Test.Registered', combo })
     )
 
-    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = [
       { commandId: 'Comfy.Test.Registered', combo }
     ]
 

--- a/src/platform/keybindings/presetService.test.ts
+++ b/src/platform/keybindings/presetService.test.ts
@@ -1,3 +1,8 @@
+import type * as I18nModule from '@/i18n'
+import type { ComfyApp } from '@/scripts/app'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
@@ -24,7 +29,9 @@ const mockShowSmallLayoutDialog = vi.hoisted(() =>
     onResult?.(true)
   })
 )
-const mockSettingSet = vi.hoisted(() => vi.fn())
+const mockSettingSet = vi.hoisted(() =>
+  vi.fn<ReturnType<typeof useSettingStore>['set']>(async () => undefined)
+)
 const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockPersistUserKeybindings = vi.hoisted(() =>
   vi.fn(async () => undefined)
@@ -50,19 +57,6 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    set: mockSettingSet,
-    get: vi.fn(() => 'default')
-  })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd
-  })
-}))
-
 vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: () => ({
     wrapWithErrorHandling: <T extends (...args: unknown[]) => unknown>(fn: T) =>
@@ -80,17 +74,21 @@ vi.mock<unknown>(import('@/platform/keybindings/keybindingService'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    showDialog: vi.fn(),
-    closeDialog: vi.fn(),
-    dialogStack: []
-  })
-}))
-
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: (key: string) => key
 }))
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => undefined)
+  useDialogStore().dialogStack = []
+})
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().set).mockImplementation(mockSettingSet)
+  vi.mocked(useSettingStore().get).mockImplementation(() => 'default')
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+})
 
 describe('useKeybindingPresetService', () => {
   let store: ReturnType<typeof useKeybindingStore>
@@ -800,4 +798,9 @@ describe('useKeybindingPresetService', () => {
       )
     })
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/missingMedia/missingMediaPipeline.test.ts
+++ b/src/platform/missingMedia/missingMediaPipeline.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -11,23 +12,17 @@ import { runMissingMediaPipeline } from '@/platform/missingMedia/missingMediaPip
 import * as missingMediaScan from '@/platform/missingMedia/missingMediaScan'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
-import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
 
-const { activeWorkflow } = vi.hoisted(() => {
-  const activeWorkflow: Pick<ComfyWorkflow, 'pendingWarnings'> = {
-    pendingWarnings: null
-  }
-  return { activeWorkflow }
-})
-
-// The real store reaches authStore -> firebase setPersistence, which has no
-// config under vitest. Mirrors missingModelPipeline.test.ts.
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({ workflow: { activeWorkflow } })
-}))
+let activeWorkflow: ComfyWorkflow
 
 beforeEach(() => {
-  activeWorkflow.pendingWarnings = null
+  activeWorkflow = new ComfyWorkflow({
+    path: 'test.json',
+    modified: 0,
+    size: 0
+  })
+  Object.assign(useWorkflowStore(), { activeWorkflow })
 })
 
 async function startPendingWorkflowLoadMediaVerification(
@@ -120,3 +115,10 @@ describe('runMissingMediaPipeline', () => {
     expect(activeWorkflow.pendingWarnings).toBeNull()
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 
@@ -6,14 +6,6 @@ import { useMissingMediaStore } from './missingMediaStore'
 import type { MissingMediaCandidate } from './types'
 
 // Mock dependencies
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-  () => ({
-    useCanvasStore: () => ({
-      currentGraph: null
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {

--- a/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
@@ -1,3 +1,8 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import type { App } from 'vue'
@@ -10,13 +15,21 @@ const mockGetNodeByExecutionId = vi.fn()
 const mockResolveNodeDisplayName = vi.fn()
 const mockTrackDownload = vi.fn()
 const mockInvalidateModelsForCategory = vi.fn()
-const mockUpdateModelsForNodeType = vi.fn()
-const mockGetAllNodeProviders = vi.fn()
+const mockUpdateModelsForNodeType = vi.fn<
+  ReturnType<typeof useAssetsStore>['updateModelsForNodeType']
+>(async () => undefined)
+const mockGetAllNodeProviders = vi.fn<
+  ReturnType<typeof useModelToNodeStore>['getAllNodeProviders']
+>(() => [])
 const mockDownloadList = vi.fn(
-  (): Array<{ taskId: string; status: string }> => []
+  (): Pick<
+    ReturnType<typeof useAssetDownloadStore>['downloadList'][number],
+    'taskId' | 'status'
+  >[] => []
 )
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
 
@@ -34,37 +47,6 @@ vi.mock(import('@/utils/graphTraversalUtil'), () => ({
 vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: (...args: unknown[]) =>
     mockResolveNodeDisplayName(...args)
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    updateModelsForNodeType: mockUpdateModelsForNodeType,
-    invalidateModelsForCategory: mockInvalidateModelsForCategory,
-    updateModelsForTag: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/assetDownloadStore'), () => ({
-  useAssetDownloadStore: () => ({
-    get downloadList() {
-      return mockDownloadList()
-    },
-    trackDownload: mockTrackDownload
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getAllNodeProviders: mockGetAllNodeProviders
-  })
 }))
 
 import { app } from '@/scripts/app'
@@ -88,6 +70,31 @@ function makeCandidate(
     ...overrides
   }
 }
+
+beforeEach(() => {
+  vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+    mockUpdateModelsForNodeType
+  )
+  vi.mocked(useAssetsStore().invalidateModelsForCategory).mockImplementation(
+    mockInvalidateModelsForCategory
+  )
+  vi.mocked(useAssetsStore().updateModelsForTag).mockResolvedValue(undefined)
+  vi.spyOn(useAssetDownloadStore(), 'downloadList', 'get').mockImplementation(
+    () => {
+      return mockDownloadList().map((download) =>
+        fromPartial<
+          ReturnType<typeof useAssetDownloadStore>['downloadList'][number]
+        >(download)
+      )
+    }
+  )
+  vi.mocked(useAssetDownloadStore().trackDownload).mockImplementation(
+    mockTrackDownload
+  )
+  vi.mocked(useModelToNodeStore().getAllNodeProviders).mockImplementation(
+    mockGetAllNodeProviders
+  )
+})
 
 describe('useMissingModelInteractions', () => {
   const mountedApps: App<Element>[] = []
@@ -124,9 +131,7 @@ describe('useMissingModelInteractions', () => {
   }
 
   beforeEach(() => {
-    mockDownloadList.mockImplementation(
-      (): Array<{ taskId: string; status: string }> => []
-    )
+    mockDownloadList.mockReturnValue([])
     ;(app as { rootGraph: unknown }).rootGraph = null
   })
 
@@ -274,7 +279,7 @@ describe('useMissingModelInteractions', () => {
       ;(app as { rootGraph: unknown }).rootGraph = {}
       mockGetNodeByExecutionId.mockReturnValue(null)
       mockGetAllNodeProviders.mockReturnValue([
-        { nodeDef: { name: 'CheckpointLoaderSimple' } }
+        fromPartial({ nodeDef: { name: 'CheckpointLoaderSimple' } })
       ])
 
       const store = useMissingModelStore()

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -10,41 +13,37 @@ import {
   toBrowsableUrl
 } from './missingModelDownload'
 
-const { fetchMock, mockIsDesktop, mockSidebarTabStore, mockStartDownload } =
-  vi.hoisted(() => ({
-    fetchMock: vi.fn(),
-    mockIsDesktop: { value: false },
-    mockSidebarTabStore: { activeSidebarTabId: null as string | null },
-    mockStartDownload: vi.fn()
-  }))
+const { fetchMock, mockIsDesktop, mockStartDownload } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  mockIsDesktop: { value: false },
+  mockStartDownload: vi.fn()
+}))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isDesktop() {
     return mockIsDesktop.value
   }
 }))
 
-vi.mock<unknown>(import('@/stores/electronDownloadStore'), () => ({
-  useElectronDownloadStore: () => ({
-    start: mockStartDownload
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => mockSidebarTabStore
-}))
-
 beforeEach(() => {
+  mockIsDesktop.value = false
   vi.stubGlobal('fetch', fetchMock)
   clearMetadataCache()
   delete window.__comfyDesktop2Remote
   delete window.__comfyDesktop2
 })
 
+beforeEach(() => {
+  vi.mocked(useElectronDownloadStore().start).mockImplementation(
+    mockStartDownload
+  )
+})
+
 describe('fetchModelMetadata', () => {
   beforeEach(() => {
     mockIsDesktop.value = false
-    mockSidebarTabStore.activeSidebarTabId = null
+    useSidebarTabStore().activeSidebarTabId = null
   })
 
   it('fetches file size via HEAD for non-Civitai URLs', async () => {
@@ -469,7 +468,7 @@ describe('isModelDownloadable', () => {
 describe('downloadModel', () => {
   beforeEach(() => {
     mockIsDesktop.value = false
-    mockSidebarTabStore.activeSidebarTabId = null
+    useSidebarTabStore().activeSidebarTabId = null
   })
 
   it.for([
@@ -550,7 +549,7 @@ describe('downloadModel', () => {
 
   it('does not dispatch blocked localhost URLs through Electron', () => {
     mockIsDesktop.value = true
-    mockSidebarTabStore.activeSidebarTabId = 'node-library'
+    useSidebarTabStore().activeSidebarTabId = 'node-library'
 
     downloadModel(
       {
@@ -562,7 +561,7 @@ describe('downloadModel', () => {
     )
 
     expect(mockStartDownload).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('node-library')
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('node-library')
   })
 
   it('uses the Desktop2 bridge directly instead of the browser fallback', () => {
@@ -750,7 +749,7 @@ describe('downloadModel', () => {
       { checkpoints: ['/models/checkpoints'] }
     )
 
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('model-library')
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('model-library')
     expect(mockStartDownload).toHaveBeenCalledWith({
       url: 'https://huggingface.co/org/model/resolve/main/model.safetensors',
       savePath: '/models/checkpoints',

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -1,3 +1,11 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import type * as DistributionModule from '@/platform/distribution/types'
+import type { ComfyApp } from '@/scripts/app'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useMissingModelStore } from './missingModelStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -29,25 +37,6 @@ const { mockHandles } = vi.hoisted(() => {
   return {
     mockHandles: {
       state,
-      missingModelStore: {
-        missingModelCandidates: null as MissingModelCandidate[] | null,
-        createVerificationAbortController: vi.fn(() => new AbortController()),
-        setFolderPaths: vi.fn(),
-        setFileSize: vi.fn(),
-        setGatedRepoUrl: vi.fn()
-      },
-      workspaceWorkflow: {
-        activeWorkflow: null as {
-          activeState?: Pick<ComfyWorkflowJSON, 'models'> | null
-          pendingWarnings?: unknown
-        } | null
-      },
-      executionErrorStore: {
-        surfaceMissingModels: vi.fn()
-      },
-      modelToNodeStore: {
-        getCategoryForNodeType: vi.fn()
-      },
       scanAllModelCandidates: vi.fn(
         (
           _graph: LGraph,
@@ -67,9 +56,6 @@ const { mockHandles } = vi.hoisted(() => {
           _signal: AbortSignal
         ) => undefined
       ),
-      toastStore: {
-        add: vi.fn()
-      },
       assetService: {
         shouldUseAssetBrowser: vi.fn()
       },
@@ -86,7 +72,8 @@ const { mockHandles } = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
 
@@ -97,19 +84,12 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    workflow: mockHandles.workspaceWorkflow
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
-  useExecutionErrorStore: () => mockHandles.executionErrorStore
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => mockHandles.modelToNodeStore
-}))
+beforeEach(() => {
+  vi.mocked(useExecutionErrorStore().surfaceMissingModels).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
 
 vi.mock<unknown>(import('@/platform/missingModel/missingModelScan'), () => ({
   scanAllModelCandidates: (
@@ -126,10 +106,6 @@ vi.mock<unknown>(import('@/platform/missingModel/missingModelScan'), () => ({
     candidates: readonly MissingModelCandidate[],
     signal: AbortSignal
   ) => mockHandles.verifyAssetSupportedCandidates(candidates, signal)
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => mockHandles.toastStore
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -173,12 +149,12 @@ function createGraph(graphData = createWorkflowGraphData()): LGraph {
 describe('missingModelPipeline', () => {
   beforeEach(() => {
     mockHandles.state.enrichedCandidates = []
-    mockHandles.missingModelStore.missingModelCandidates = null
-    mockHandles.workspaceWorkflow.activeWorkflow = null
-    mockHandles.missingModelStore.createVerificationAbortController.mockImplementation(
-      () => new AbortController()
-    )
-    mockHandles.modelToNodeStore.getCategoryForNodeType.mockReturnValue(
+    useMissingModelStore().missingModelCandidates = null
+    useWorkflowStore().activeWorkflow = null
+    vi.mocked(
+      useMissingModelStore().createVerificationAbortController
+    ).mockImplementation(() => new AbortController())
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
       undefined
     )
     mockHandles.scanAllModelCandidates.mockReturnValue([])
@@ -220,7 +196,7 @@ describe('missingModelPipeline', () => {
       const refreshPromise = refreshMissingModelPipeline({
         graph,
         reloadNodeDefs,
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(order).toEqual(['reload:start'])
@@ -233,7 +209,7 @@ describe('missingModelPipeline', () => {
     it('scans the current graph when node definition reload is omitted', async () => {
       await refreshMissingModelPipeline({
         graph: createGraph(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(mockHandles.scanAllModelCandidates).toHaveBeenCalled()
@@ -247,11 +223,11 @@ describe('missingModelPipeline', () => {
           directory: 'checkpoints'
         }
       ]
-      mockHandles.workspaceWorkflow.activeWorkflow = {
+      useWorkflowStore().activeWorkflow = fromPartial({
         activeState: { models: activeModels },
         pendingWarnings: null
-      }
-      mockHandles.missingModelStore.missingModelCandidates = [
+      })
+      useMissingModelStore().missingModelCandidates = [
         {
           nodeId: '1',
           nodeType: 'CheckpointLoaderSimple',
@@ -267,7 +243,7 @@ describe('missingModelPipeline', () => {
       await refreshMissingModelPipeline({
         graph: createGraph(),
         reloadNodeDefs: vi.fn(),
-        missingModelStore: mockHandles.missingModelStore,
+        missingModelStore: useMissingModelStore(),
         silent: false
       })
 
@@ -276,12 +252,12 @@ describe('missingModelPipeline', () => {
         expect.objectContaining({ models: activeModels })
       )
       expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).toHaveBeenCalledWith([], { silent: false })
     })
 
     it('falls back to current missing model metadata when workflow state has no models', async () => {
-      mockHandles.missingModelStore.missingModelCandidates = [
+      useMissingModelStore().missingModelCandidates = [
         {
           nodeId: '1',
           nodeType: 'CheckpointLoaderSimple',
@@ -308,7 +284,7 @@ describe('missingModelPipeline', () => {
       await refreshMissingModelPipeline({
         graph: createGraph(),
         reloadNodeDefs: vi.fn(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(mockHandles.enrichWithEmbeddedMetadata).toHaveBeenCalledWith(
@@ -326,7 +302,7 @@ describe('missingModelPipeline', () => {
         })
       )
       expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).toHaveBeenCalledWith([], { silent: true })
     })
 
@@ -336,7 +312,7 @@ describe('missingModelPipeline', () => {
       await refreshMissingModelPipeline({
         graph: createGraph(graphData),
         reloadNodeDefs: vi.fn(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(mockHandles.enrichWithEmbeddedMetadata).toHaveBeenCalledWith(
@@ -352,7 +328,7 @@ describe('missingModelPipeline', () => {
         refreshMissingModelPipeline({
           graph: createGraph(),
           reloadNodeDefs: vi.fn().mockRejectedValue(error),
-          missingModelStore: mockHandles.missingModelStore
+          missingModelStore: useMissingModelStore()
         })
       ).rejects.toThrow(error)
 
@@ -380,19 +356,19 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: null
       }
       mockHandles.state.enrichedCandidates = [
         confirmedCandidate,
         installedCandidate
       ]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
 
       const result = await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore,
+        missingModelStore: useMissingModelStore(),
         missingNodeTypes: ['MissingCustomNode']
       })
       await vi.dynamicImportSettled()
@@ -430,7 +406,7 @@ describe('missingModelPipeline', () => {
       const result = await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(result).toEqual({
@@ -469,7 +445,7 @@ describe('missingModelPipeline', () => {
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
@@ -477,7 +453,7 @@ describe('missingModelPipeline', () => {
       expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
         'https://example.com/downloadable.safetensors'
       )
-      expect(mockHandles.missingModelStore.setFileSize).toHaveBeenCalledWith(
+      expect(useMissingModelStore().setFileSize).toHaveBeenCalledWith(
         'https://example.com/downloadable.safetensors',
         1024
       )
@@ -502,17 +478,15 @@ describe('missingModelPipeline', () => {
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
-      expect(
-        mockHandles.missingModelStore.setGatedRepoUrl
-      ).toHaveBeenCalledWith(
+      expect(useMissingModelStore().setGatedRepoUrl).toHaveBeenCalledWith(
         'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors',
         'https://huggingface.co/bfl/FLUX.1'
       )
-      expect(mockHandles.missingModelStore.setFileSize).not.toHaveBeenCalled()
+      expect(useMissingModelStore().setFileSize).not.toHaveBeenCalled()
     })
 
     it('does not store gated repo URLs after verification is aborted', async () => {
@@ -527,9 +501,9 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       mockHandles.state.enrichedCandidates = [downloadableCandidate]
-      mockHandles.missingModelStore.createVerificationAbortController.mockReturnValueOnce(
-        controller
-      )
+      vi.mocked(
+        useMissingModelStore().createVerificationAbortController
+      ).mockReturnValueOnce(controller)
       mockHandles.fetchModelMetadata.mockResolvedValue({
         fileSize: null,
         gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
@@ -539,16 +513,14 @@ describe('missingModelPipeline', () => {
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
       expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
         'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors'
       )
-      expect(
-        mockHandles.missingModelStore.setGatedRepoUrl
-      ).not.toHaveBeenCalled()
+      expect(useMissingModelStore().setGatedRepoUrl).not.toHaveBeenCalled()
     })
 
     it('clears surfaced and cached missing models when no candidates are confirmed missing', async () => {
@@ -561,7 +533,7 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: {
           missingModelCandidates: [
             {
@@ -578,16 +550,16 @@ describe('missingModelPipeline', () => {
         }
       }
       mockHandles.state.enrichedCandidates = [installedCandidate]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
 
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).toHaveBeenCalledWith([], { silent: false })
       expect(activeWorkflow.pendingWarnings).toBeNull()
     })
@@ -612,7 +584,7 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: null
       }
       const graph = createGraph()
@@ -620,7 +592,7 @@ describe('missingModelPipeline', () => {
         activeCandidate,
         inactiveCandidate
       ]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
       mockHandles.isAncestorPathActive.mockImplementation(
         (_graph: LGraph, nodeId: string) => nodeId !== '2'
       )
@@ -628,7 +600,7 @@ describe('missingModelPipeline', () => {
       const result = await runMissingModelPipeline({
         graph,
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(result.confirmedCandidates).toEqual([activeCandidate])
@@ -651,12 +623,12 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       }
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: null
       }
       const graph = createGraph()
       mockHandles.state.enrichedCandidates = [promotedCandidate]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
       mockHandles.isAncestorPathActive.mockImplementation(
         (_graph: LGraph, nodeId: string) => nodeId !== '65:77:42'
       )
@@ -664,7 +636,7 @@ describe('missingModelPipeline', () => {
       const result = await runMissingModelPipeline({
         graph,
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(result.confirmedCandidates).toEqual([])
@@ -689,15 +661,15 @@ describe('missingModelPipeline', () => {
         }
       )
       mockHandles.state.enrichedCandidates = [confirmedCandidate]
-      mockHandles.missingModelStore.createVerificationAbortController.mockReturnValueOnce(
-        controller
-      )
+      vi.mocked(
+        useMissingModelStore().createVerificationAbortController
+      ).mockReturnValueOnce(controller)
       mockHandles.api.getFolderPaths.mockReturnValueOnce(folderPathsPromise)
 
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       controller.abort()
@@ -707,12 +679,22 @@ describe('missingModelPipeline', () => {
       await Promise.resolve()
       await Promise.resolve()
 
+      expect(useMissingModelStore().setFolderPaths).not.toHaveBeenCalled()
       expect(
-        mockHandles.missingModelStore.setFolderPaths
-      ).not.toHaveBeenCalled()
-      expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).not.toHaveBeenCalled()
     })
   })
 })
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/missingModel/missingModelScan.test.ts
+++ b/src/platform/missingModel/missingModelScan.test.ts
@@ -1,5 +1,8 @@
+import type * as I18nModule from '@/i18n'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
@@ -253,6 +256,17 @@ function makeNestedPromotedModelGraph({
 }
 
 const noAssetSupport = () => false
+
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
+beforeEach(() => {
+  vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+    mockUpdateModelsForNodeType
+  )
+  vi.mocked(useAssetsStore().getAssets).mockImplementation(mockGetAssets)
+})
 
 describe('isModelFileName', () => {
   it('should return true for common model extensions', () => {
@@ -1727,20 +1741,8 @@ const { mockUpdateModelsForNodeType, mockGetAssets } = vi.hoisted(() => ({
   mockGetAssets: vi.fn().mockReturnValue([])
 }))
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    updateModelsForNodeType: mockUpdateModelsForNodeType,
-    getAssets: mockGetAssets
-  })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: vi.fn()
-  })
-}))
-
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: (_key: string, fallback: string) => fallback
 }))
 

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeExecutionId } from '@/types/nodeIdentification'
@@ -12,23 +15,16 @@ const mockNodeLocatorIdToNodeExecutionId = vi.hoisted(() =>
   vi.fn((nodeLocatorId: string) => nodeLocatorId)
 )
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: vi.fn((key: string) => `translated:${key}`),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeLocatorIdToNodeExecutionId: mockNodeLocatorIdToNodeExecutionId
-    })
-  })
-)
 
 import { useMissingModelStore } from './missingModelStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -57,6 +53,14 @@ function makeModelCandidate(
     isMissing: true
   }
 }
+
+beforeEach(() => {
+  vi.mocked(
+    useWorkflowStore().nodeLocatorIdToNodeExecutionId
+  ).mockImplementation((id) =>
+    createNodeExecutionId(mockNodeLocatorIdToNodeExecutionId(id).split(':'))
+  )
+})
 
 describe('missingModelStore', () => {
   beforeEach(() => {

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -27,18 +30,14 @@ vi.mock(import('@/platform/nodeReplacement/cnrIdUtil'), () => ({
   getCnrIdFromNode: vi.fn(() => undefined)
 }))
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn(() => true)
-  })
 }))
 
 import {
@@ -76,6 +75,10 @@ function getMissingNodesError(
   if (!error) throw new Error('Expected missingNodesError to be defined')
   return error
 }
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => true)
+})
 
 describe('scanMissingNodes (via rescanAndSurfaceMissingNodes)', () => {
   beforeEach(() => {

--- a/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
+++ b/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
@@ -1,24 +1,29 @@
-import { describe, expect, it, vi } from 'vitest'
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
 
 const mockShowErrorsTab = vi.hoisted(() => ({ value: false }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => mockShowErrorsTab.value)
-  }))
-}))
-
 import { useMissingNodesErrorStore } from './missingNodesErrorStore'
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(
+    () => mockShowErrorsTab.value
+  )
+})
 
 describe('missingNodesErrorStore', () => {
   describe('setMissingNodeTypes', () => {

--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -1,6 +1,6 @@
 import type { NodeReplacementResponse } from './types'
+import type { ComfyApp } from '@/scripts/app'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ServerFeatureFlag } from '@/composables/useFeatureFlags'
@@ -8,10 +8,6 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { fetchNodeReplacements } from './nodeReplacementService'
 import { useNodeReplacementStore } from './nodeReplacementStore'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn()
-}))
 
 vi.mock(import('./nodeReplacementService'), () => ({
   fetchNodeReplacements: vi.fn()
@@ -23,21 +19,10 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-function mockSettingStore(enabled: boolean) {
-  vi.mocked(useSettingStore, { partial: true }).mockReturnValue({
-    get: vi.fn().mockImplementation((key: string) => {
-      if (key === 'Comfy.NodeReplacement.Enabled') {
-        return enabled
-      }
-      return false
-    }),
-    load: vi.fn().mockResolvedValue(undefined)
-  })
-}
-
 function createStore(settingEnabled = true, serverFeatureEnabled = true) {
-  setActivePinia(createPinia())
-  mockSettingStore(settingEnabled)
+  useSettingStore().settingValues['Comfy.NodeReplacement.Enabled'] =
+    settingEnabled
+  vi.mocked(useSettingStore().load).mockResolvedValue(undefined)
   vi.mocked(api.getServerFeature).mockImplementation(
     (flag: string, defaultValue?: unknown) => {
       if (flag === ServerFeatureFlag.NODE_REPLACEMENTS) {
@@ -269,4 +254,9 @@ describe('useNodeReplacementStore', () => {
       expect(fetchNodeReplacements).toHaveBeenCalledOnce()
     })
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -1,4 +1,7 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { fromPartial, fromAny } from '@total-typescript/shoehorn'
+import type * as I18nModule from '@/i18n'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -10,7 +13,6 @@ import {
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
-import type { PendingWarnings } from '@/platform/workflow/management/stores/comfyWorkflow'
 import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -55,42 +57,11 @@ vi.mock(import('@/utils/graphTraversalUtil'), () => ({
 
 const { mockToastAdd } = vi.hoisted(() => ({ mockToastAdd: vi.fn() }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({
-    add: mockToastAdd
-  }))
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    ComfyWorkflow: class {},
-    useWorkflowStore: vi.fn(() => workflowMocks)
-  })
-)
-
-vi.mock<unknown>(import('@/i18n'), () => ({
+vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: (_key: string, fallback: string) => fallback,
   t: (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key
-}))
-
-interface ActiveWorkflowMock {
-  pendingWarnings: PendingWarnings | null
-  changeTracker: {
-    beforeChange: () => void
-    afterChange: () => void
-  }
-}
-
-const workflowMocks = vi.hoisted(() => ({
-  activeWorkflow: {
-    pendingWarnings: null,
-    changeTracker: {
-      beforeChange: vi.fn(),
-      afterChange: vi.fn()
-    }
-  } as ActiveWorkflowMock | null
 }))
 
 import { app } from '@/scripts/app'
@@ -99,13 +70,13 @@ import { collectAllNodes } from '@/utils/graphTraversalUtil'
 import { useNodeReplacement } from './useNodeReplacement'
 
 beforeEach(() => {
-  workflowMocks.activeWorkflow = {
+  useWorkflowStore().activeWorkflow = fromPartial({
     pendingWarnings: null,
     changeTracker: {
       beforeChange: vi.fn(),
       afterChange: vi.fn()
     }
-  }
+  })
 })
 
 function createMockLink(
@@ -262,7 +233,7 @@ function makeMissingNodeType(
 }
 
 function getActiveWorkflowMock() {
-  const activeWorkflow = workflowMocks.activeWorkflow
+  const activeWorkflow = useWorkflowStore().activeWorkflow
   if (!activeWorkflow) throw new Error('Expected an active workflow')
   return activeWorkflow
 }
@@ -271,6 +242,10 @@ function seedMissingNodeTypes(types: MissingNodeType[]): void {
   getActiveWorkflowMock().pendingWarnings = { missingNodeTypes: types }
   useMissingNodesErrorStore().setMissingNodeTypes(types)
 }
+
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+})
 
 describe('useNodeReplacement', () => {
   describe('replaceNodesInPlace', () => {
@@ -1577,7 +1552,7 @@ describe('useNodeReplacement', () => {
         oldNodeType,
         'OtherNode'
       ])
-      workflowMocks.activeWorkflow = null
+      useWorkflowStore().activeWorkflow = null
 
       const { replaceGroup } = useNodeReplacement()
       replaceGroup({

--- a/src/platform/onboarding/TourOverlay.test.ts
+++ b/src/platform/onboarding/TourOverlay.test.ts
@@ -1,8 +1,7 @@
-import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { defineComponent, h } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -10,29 +9,6 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import TourOverlay from './TourOverlay.vue'
 import type { CoachStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
-
-vi.mock<unknown>(import('./onboardingTourStore'), () => ({
-  useOnboardingTourStore: vi.fn()
-}))
-
-function makeTourState() {
-  return {
-    step: ref<CoachStep | null>(null),
-    title: ref('Canvas title'),
-    body: ref('Canvas body'),
-    isLast: ref(false),
-    canGoBack: ref(true),
-    primaryLabel: ref('Next'),
-    skipLabel: ref('Skip'),
-    backLabel: ref('Back'),
-    countedStepIdx: ref(0),
-    countedStepsTotal: ref(0),
-    waitingForTarget: ref(false),
-    next: vi.fn(),
-    back: vi.fn(),
-    skip: vi.fn()
-  }
-}
 
 // Stubbed so the suite covers only TourOverlay's branching and intent wiring.
 vi.mock(import('./TourSpotlight.vue'), () => ({
@@ -55,7 +31,7 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-let s: ReturnType<typeof makeTourState>
+let s: ReturnType<typeof useOnboardingTourStore>
 
 const spotlightStep: CoachStep = {
   kind: 'spotlight',
@@ -73,8 +49,27 @@ function renderOverlay() {
 
 describe('TourOverlay', () => {
   beforeEach(() => {
-    s = makeTourState()
-    vi.mocked(useOnboardingTourStore).mockReturnValue(fromPartial(reactive(s)))
+    const store = useOnboardingTourStore()
+    Object.assign(store, {
+      step: null,
+      title: 'Canvas title',
+      body: 'Canvas body',
+      isLast: false,
+      canGoBack: true,
+      primaryLabel: 'Next',
+      skipLabel: 'Skip',
+      backLabel: 'Back',
+      countedStepIdx: 0,
+      countedStepsTotal: 0,
+      waitingForTarget: false
+    })
+    vi.mocked(store.next).mockResolvedValue(undefined)
+    vi.mocked(store.back).mockResolvedValue(undefined)
+    vi.mocked(store.skip).mockImplementation(() => undefined)
+    s = store
+    vi.spyOn(s, 'step', 'get').mockReturnValue(null)
+    vi.spyOn(s, 'primaryLabel', 'get').mockReturnValue('Next')
+    vi.spyOn(s, 'skipLabel', 'get').mockReturnValue('Skip')
   })
 
   it('renders nothing when no tour step is active', () => {
@@ -85,7 +80,7 @@ describe('TourOverlay', () => {
 
   it('renders the spotlight for a non-landing step and wires its intents', async () => {
     const user = userEvent.setup()
-    s.step.value = spotlightStep
+    vi.spyOn(s, 'step', 'get').mockReturnValue(spotlightStep)
     renderOverlay()
 
     expect(screen.getByTestId('spotlight')).toBeTruthy()
@@ -102,8 +97,8 @@ describe('TourOverlay', () => {
 
   it('renders the landing step and starts the tour on its primary action', async () => {
     const user = userEvent.setup()
-    s.step.value = landingStep()
-    s.primaryLabel.value = 'Start tutorial'
+    vi.spyOn(s, 'step', 'get').mockReturnValue(landingStep())
+    vi.spyOn(s, 'primaryLabel', 'get').mockReturnValue('Start tutorial')
     renderOverlay()
 
     await user.click(
@@ -113,9 +108,9 @@ describe('TourOverlay', () => {
   })
 
   it('disables the landing primary action while waiting for a deferred target', async () => {
-    s.step.value = landingStep()
-    s.primaryLabel.value = 'Start tutorial'
-    s.waitingForTarget.value = true
+    vi.spyOn(s, 'step', 'get').mockReturnValue(landingStep())
+    vi.spyOn(s, 'primaryLabel', 'get').mockReturnValue('Start tutorial')
+    vi.spyOn(s, 'waitingForTarget', 'get').mockReturnValue(true)
     renderOverlay()
 
     expect(
@@ -125,7 +120,7 @@ describe('TourOverlay', () => {
 
   it('ends the tour when the landing is dismissed', async () => {
     const user = userEvent.setup()
-    s.step.value = landingStep()
+    vi.spyOn(s, 'step', 'get').mockReturnValue(landingStep())
     renderOverlay()
 
     await user.click(await screen.findByRole('button', { name: 'Skip' }))

--- a/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
@@ -1,6 +1,6 @@
-import { createPinia, disposePinia, setActivePinia } from 'pinia'
-import type { Pinia } from 'pinia'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
 
@@ -11,18 +11,6 @@ import { TOUR_SEEN_SETTING, registerTour } from './onboardingTours'
 import type { SpotlightStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
-const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
-    set: (key: string, value: unknown) => {
-      settings.store.set(key, value)
-      return Promise.resolve()
-    }
-  })
-}))
-
 const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
@@ -30,13 +18,24 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 
 const appModeMock = vi.hoisted(() => ({ mode: null as Ref<AppMode> | null }))
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
-  const { ref } = await import('vue')
+  const { ref, computed } = await import('vue')
   appModeMock.mode = ref<AppMode>('graph')
-  return { useAppMode: () => ({ mode: appModeMock.mode }) }
+  return {
+    useAppMode: () => ({
+      mode: appModeMock.mode,
+      isAppMode: computed(() => appModeMock.mode?.value === 'app'),
+      isBuilderMode: computed(() =>
+        appModeMock.mode?.value.startsWith('builder:')
+      ),
+      isSelectMode: computed(
+        () =>
+          appModeMock.mode?.value === 'builder:inputs' ||
+          appModeMock.mode?.value === 'builder:outputs'
+      ),
+      setMode: vi.fn()
+    })
+  }
 })
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({ hasOutputs: false })
-}))
 
 function step(
   name: string,
@@ -49,20 +48,24 @@ function stages(): string[] {
   return telemetry.track.mock.calls.map(([stage]) => stage)
 }
 
-let pinia: Pinia | undefined
-
 function mountStore() {
-  pinia = createPinia()
-  setActivePinia(pinia)
   return useOnboardingTourStore()
 }
 
+beforeEach(() => {
+  useSettingStore().settingValues[TOUR_SEEN_SETTING] = []
+  vi.mocked(useSettingStore().set).mockImplementation(
+    (key: string, value: unknown) => {
+      Object.assign(useSettingStore().settingValues, { [key]: value })
+      return Promise.resolve()
+    }
+  )
+  Object.assign(useAppModeStore(), { hasOutputs: false })
+})
+
 describe('onboardingTourStore — runtime-resolved tours', () => {
   afterEach(() => {
-    if (pinia) disposePinia(pinia)
-    pinia = undefined
     clearCoachmarks()
-    settings.store.clear()
     telemetry.track.mockClear()
   })
 
@@ -70,8 +73,6 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
     vi.resetModules()
     const { useOnboardingTourStore: freshStore } =
       await import('./onboardingTourStore')
-    pinia = createPinia()
-    setActivePinia(pinia)
     const store = freshStore()
 
     await expect(store.startTour('firstRun')).resolves.toBe(false)
@@ -94,7 +95,7 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
   })
 
   it('tells a repeat user apart from a coverage failure', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['firstRun'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['firstRun']
     registerTour('firstRun', () => Promise.resolve([]))
     const store = mountStore()
 
@@ -151,7 +152,7 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
   })
 
   it('counts a user once however often the trigger re-fires', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['firstRun'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['firstRun']
     const store = mountStore()
 
     await store.startTour('firstRun')

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -1,6 +1,6 @@
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { DetachedWindowAPI } from 'happy-dom'
-import { createPinia, disposePinia, setActivePinia } from 'pinia'
-import type { Pinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import type { Ref } from 'vue'
@@ -18,46 +18,34 @@ import { TOUR_SEEN_SETTING, tourDefinition } from './onboardingTours'
 import type { CoachId, CoachStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
-const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
-    set: (key: string, value: unknown) => {
-      settings.store.set(key, value)
-      return Promise.resolve()
-    }
-  })
-}))
-
 const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
 }))
 
-const appModeMock = vi.hoisted(
-  (): { mode: Ref<AppMode> | null; hasOutputs: Ref<boolean> | null } => ({
-    mode: null,
-    hasOutputs: null
-  })
-)
+const appModeMock = vi.hoisted((): { mode: Ref<AppMode> | null } => ({
+  mode: null
+}))
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
-  const { ref: r } = await import('vue')
+  const { ref: r, computed } = await import('vue')
   appModeMock.mode = r<AppMode>('graph')
-  return { useAppMode: () => ({ mode: appModeMock.mode }) }
-})
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { ref: r } = await import('vue')
-  appModeMock.hasOutputs = r(false)
-  const hasOutputs = appModeMock.hasOutputs
   return {
-    useAppModeStore: () => ({
-      get hasOutputs() {
-        return hasOutputs.value
-      }
+    useAppMode: () => ({
+      mode: appModeMock.mode,
+      isAppMode: computed(() => appModeMock.mode?.value === 'app'),
+      isBuilderMode: computed(() =>
+        appModeMock.mode?.value.startsWith('builder:')
+      ),
+      isSelectMode: computed(
+        () =>
+          appModeMock.mode?.value === 'builder:inputs' ||
+          appModeMock.mode?.value === 'builder:outputs'
+      ),
+      setMode: vi.fn()
     })
   }
 })
+
 const APP_MODE_TARGETS: CoachId[] = [
   'inputs-list',
   'app-run-button',
@@ -66,7 +54,7 @@ const APP_MODE_TARGETS: CoachId[] = [
 ]
 
 function seenTours(): string[] {
-  return (settings.store.get(TOUR_SEEN_SETTING) as string[] | undefined) ?? []
+  return useSettingStore().get(TOUR_SEEN_SETTING)
 }
 
 function setViewport(viewport: { width: number; height: number }) {
@@ -78,11 +66,7 @@ function setViewport(viewport: { width: number; height: number }) {
   happyDOM.setViewport(viewport)
 }
 
-let pinia: Pinia | undefined
-
 function mountStore() {
-  pinia = createPinia()
-  setActivePinia(pinia)
   return useOnboardingTourStore()
 }
 
@@ -102,23 +86,33 @@ function shownCount(coachId?: CoachId) {
   ).length
 }
 
+beforeEach(() => {
+  useSettingStore().settingValues[TOUR_SEEN_SETTING] = []
+  vi.mocked(useSettingStore().set).mockImplementation(
+    (key: string, value: unknown) => {
+      Object.assign(useSettingStore().settingValues, { [key]: value })
+      return Promise.resolve()
+    }
+  )
+})
+
+beforeEach(() => {
+  Object.assign(useAppModeStore(), { hasOutputs: false })
+})
+
 describe('onboardingTourStore', () => {
   // Removed in teardown even when a test throws before its own cleanup.
   const appendedTargets: HTMLElement[] = []
   const restoreOnEnter: (() => void)[] = []
 
   afterEach(() => {
-    if (pinia) disposePinia(pinia)
-    pinia = undefined
     clearCoachmarks()
     restoreOnEnter.forEach((restore) => restore())
     restoreOnEnter.length = 0
     appendedTargets.forEach((el) => el.remove())
     appendedTargets.length = 0
-    settings.store.clear()
     setViewport({ width: 1024, height: 768 })
     if (appModeMock.mode) appModeMock.mode.value = 'graph'
-    if (appModeMock.hasOutputs) appModeMock.hasOutputs.value = false
     telemetry.track.mockClear()
   })
 
@@ -140,11 +134,9 @@ describe('onboardingTourStore', () => {
 
   function enterApp(mode: AppMode, hasOutputs: boolean) {
     const modeRef = appModeMock.mode
-    const outputsRef = appModeMock.hasOutputs
-    if (!modeRef || !outputsRef)
-      throw new Error('app mode mock not initialised')
+    if (!modeRef) throw new Error('app mode mock not initialised')
     modeRef.value = mode
-    outputsRef.value = hasOutputs
+    Object.assign(useAppModeStore(), { hasOutputs })
   }
 
   beforeEach(() => enterApp('app', false))
@@ -186,7 +178,7 @@ describe('onboardingTourStore', () => {
   })
 
   it('does not auto-open a populated app once the tour has been dismissed', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
     mountStore()
     enterApp('app', true)
     await nextTick()
@@ -194,7 +186,7 @@ describe('onboardingTourStore', () => {
   })
 
   it('replays a seen tour when explicitly requested', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
     const store = mountStore()
     store.replayTour('appMode')
     await nextTick()
@@ -202,7 +194,7 @@ describe('onboardingTourStore', () => {
   })
 
   it('dismisses a replayed tour without the seen-flag when the user leaves its mode', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
     const store = mountStore()
     enterApp('app', false)
     await nextTick()
@@ -292,7 +284,7 @@ describe('onboardingTourStore', () => {
     })
 
     it('records a tour that lost the context its steps point at', async () => {
-      settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+      useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
       const store = mountStore()
       enterApp('app', false)
       await nextTick()

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -1,22 +1,8 @@
 import { render } from '@testing-library/vue'
-import { nextTick, reactive } from 'vue'
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useQueuePolling } from '@/platform/remote/comfyui/useQueuePolling'
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => {
-  const state = reactive({
-    activeJobsCount: 0,
-    isLoading: false,
-    update: vi.fn()
-  })
-
-  return {
-    useQueueStore: () => state
-  }
-})
-
-// Re-import to get the mock instance for assertions
 import { useQueueStore } from '@/stores/queueStore'
 
 function mountUseQueuePolling() {
@@ -30,17 +16,13 @@ function mountUseQueuePolling() {
 }
 
 describe('useQueuePolling', () => {
-  const store = useQueueStore() as Partial<
-    ReturnType<typeof useQueueStore>
-  > as {
-    activeJobsCount: number
-    isLoading: boolean
-    update: ReturnType<typeof vi.fn>
-  }
+  let store: ReturnType<typeof useQueueStore>
 
   beforeEach(() => {
-    store.activeJobsCount = 0
+    store = useQueueStore()
+    Object.assign(store, { activeJobsCount: 0 })
     store.isLoading = false
+    vi.mocked(store.update).mockResolvedValue(undefined)
   })
 
   it('does not call update on creation', () => {
@@ -51,7 +33,7 @@ describe('useQueuePolling', () => {
   it('polls when activeJobsCount is exactly 1', async () => {
     mountUseQueuePolling()
 
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     await vi.advanceTimersByTimeAsync(8_000)
 
     expect(store.update).toHaveBeenCalledOnce()
@@ -60,24 +42,24 @@ describe('useQueuePolling', () => {
   it('does not poll when activeJobsCount > 1', async () => {
     mountUseQueuePolling()
 
-    store.activeJobsCount = 2
+    Object.assign(store, { activeJobsCount: 2 })
     await vi.advanceTimersByTimeAsync(16_000)
 
     expect(store.update).not.toHaveBeenCalled()
   })
 
   it('stops polling when activeJobsCount drops to 0', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
-    store.activeJobsCount = 0
+    Object.assign(store, { activeJobsCount: 0 })
     await vi.advanceTimersByTimeAsync(16_000)
 
     expect(store.update).not.toHaveBeenCalled()
   })
 
   it('resets timer when loading completes', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // Advance 5s toward the 8s timeout
@@ -100,7 +82,7 @@ describe('useQueuePolling', () => {
   })
 
   it('applies exponential backoff on successive polls', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // First poll at 8s
@@ -121,7 +103,7 @@ describe('useQueuePolling', () => {
   })
 
   it('skips poll when an update is already in-flight', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // Simulate an external update starting before the timer fires
@@ -138,7 +120,7 @@ describe('useQueuePolling', () => {
   })
 
   it('resets backoff when activeJobsCount changes', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // First poll at 8s (backs off delay to 12s)
@@ -152,12 +134,12 @@ describe('useQueuePolling', () => {
     await nextTick()
 
     // Count changes — backoff should reset to 8s
-    store.activeJobsCount = 0
+    Object.assign(store, { activeJobsCount: 0 })
     await nextTick()
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     await nextTick()
 
-    store.update.mockClear()
+    vi.mocked(store.update).mockClear()
     await vi.advanceTimersByTimeAsync(8_000)
     expect(store.update).toHaveBeenCalledOnce()
   })

--- a/src/platform/secrets/components/SecretsPanel.test.ts
+++ b/src/platform/secrets/components/SecretsPanel.test.ts
@@ -1,3 +1,4 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -32,12 +33,6 @@ vi.mock<unknown>(import('@/platform/secrets/composables/useSecrets'), () => ({
     fetchSecrets: mockFetchSecrets,
     fetchProviders: mockFetchProviders,
     deleteSecret: mockDeleteSecret
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
   })
 }))
 
@@ -111,6 +106,10 @@ function renderPanel() {
     }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(mockCloseDialog)
+})
 
 describe('SecretsPanel', () => {
   beforeEach(() => {

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -1,16 +1,13 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { render } from '@testing-library/vue'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SecretMetadata } from '../types'
 import { useSecrets as useSecretsComposable } from './useSecrets'
 
 const mockAdd = vi.fn()
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mockAdd })
-}))
 
 const mockListSecrets = vi.fn()
 const mockListSecretProviders = vi.fn()
@@ -63,6 +60,10 @@ function createMockSecret(
     ...overrides
   }
 }
+
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockAdd)
+})
 
 describe('useSecrets', () => {
   describe('fetchSecrets', () => {

--- a/src/platform/settings/components/SettingItem.test.ts
+++ b/src/platform/settings/components/SettingItem.test.ts
@@ -1,3 +1,4 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { render } from '@testing-library/vue'
 import { defineComponent } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,13 +11,9 @@ const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
 const mockGet = vi.fn()
-const mockSet = vi.fn()
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGet,
-    set: mockSet
-  })
-}))
+const mockSet = vi.fn<ReturnType<typeof useSettingStore>['set']>(
+  async () => undefined
+)
 
 let emitFormValue: ((value: unknown) => void) | null = null
 
@@ -31,6 +28,11 @@ const FormItemUpdateStub = defineComponent({
     return {}
   },
   template: '<div data-testid="form-item-stub" />'
+})
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(mockGet)
+  vi.mocked(useSettingStore().set).mockImplementation(mockSet)
 })
 
 describe('SettingItem', () => {

--- a/src/platform/settings/composables/useLitegraphSettings.test.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.test.ts
@@ -6,33 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
-
-const testState = vi.hoisted(
-  (): { canvasStore: { canvas: LGraphCanvas | null } | null } => ({
-    canvasStore: null
-  })
-)
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  async () => {
-    const { reactive } = await import('vue')
-    testState.canvasStore = reactive({ canvas: null })
-    return { useCanvasStore: () => testState.canvasStore }
-  }
-)
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
 
 import { useLitegraphSettings } from './useLitegraphSettings'
 
 function createCanvas(draw: () => void): LGraphCanvas {
   return fromPartial<LGraphCanvas>({ draw, setDirty: vi.fn() })
-}
-
-function getCanvasStore(): { canvas: LGraphCanvas | null } {
-  if (!testState.canvasStore)
-    throw new Error('Canvas store was not initialized')
-  return testState.canvasStore
 }
 
 describe('useLitegraphSettings', () => {
@@ -49,7 +28,7 @@ describe('useLitegraphSettings', () => {
     const node = new LGraphNode('test')
     const slot = node.addInput('input', '*')
     const draw = vi.fn(() => slot.pos)
-    getCanvasStore().canvas = createCanvas(draw)
+    useCanvasStore().canvas = createCanvas(draw)
 
     scope.run(useLitegraphSettings)
 
@@ -64,7 +43,7 @@ describe('useLitegraphSettings', () => {
   it('redraws when CanvasInfo or the canvas changes', async () => {
     const firstDraw = vi.fn()
     const secondDraw = vi.fn()
-    const canvasStore = getCanvasStore()
+    const canvasStore = useCanvasStore()
     const settingStore = useSettingStore()
     canvasStore.canvas = createCanvas(firstDraw)
 

--- a/src/platform/settings/composables/useSettingSearch.test.ts
+++ b/src/platform/settings/composables/useSettingSearch.test.ts
@@ -1,64 +1,49 @@
+import type * as I18nModule from '@/i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { st } from '@/i18n'
 import { useSettingSearch } from '@/platform/settings/composables/useSettingSearch'
-import {
-  getSettingInfo,
-  useSettingStore
-} from '@/platform/settings/settingStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingTreeNode } from '@/platform/settings/settingStore'
-
-// Test-specific type for mock settings
-interface MockSettingParams {
-  id: string
-  name: string
-  type: string
-  defaultValue: unknown
-  category?: string[]
-  deprecated?: boolean
-}
+import type { SettingParams } from '@/platform/settings/types'
 
 // Mock dependencies
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_: string, fallback: string) => fallback)
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(),
-  getSettingInfo: vi.fn()
 }))
 
 describe('useSettingSearch', () => {
   let mockSettingStore: ReturnType<typeof useSettingStore>
-  let mockSettings: Record<string, MockSettingParams>
+  let mockSettings: Record<string, SettingParams>
 
   beforeEach(() => {
     // Mock settings data
     mockSettings = {
       'Category.Setting1': {
-        id: 'Category.Setting1',
+        id: 'Category.Setting1' as SettingParams['id'],
         name: 'Setting One',
         type: 'text',
         defaultValue: 'default',
         category: ['Category', 'Basic']
       },
       'Category.Setting2': {
-        id: 'Category.Setting2',
+        id: 'Category.Setting2' as SettingParams['id'],
         name: 'Setting Two',
         type: 'boolean',
         defaultValue: false,
         category: ['Category', 'Advanced']
       },
       'Category.HiddenSetting': {
-        id: 'Category.HiddenSetting',
+        id: 'Category.HiddenSetting' as SettingParams['id'],
         name: 'Hidden Setting',
         type: 'hidden',
         defaultValue: 'hidden',
         category: ['Category', 'Basic']
       },
       'Category.DeprecatedSetting': {
-        id: 'Category.DeprecatedSetting',
+        id: 'Category.DeprecatedSetting' as SettingParams['id'],
         name: 'Deprecated Setting',
         type: 'text',
         defaultValue: 'deprecated',
@@ -66,28 +51,18 @@ describe('useSettingSearch', () => {
         category: ['Category', 'Advanced']
       },
       'Other.Setting3': {
-        id: 'Other.Setting3',
+        id: 'Other.Setting3' as SettingParams['id'],
         name: 'Other Setting',
-        type: 'select',
+        type: 'combo',
+        options: ['option1', 'option2'],
         defaultValue: 'option1',
         category: ['Other', 'SubCategory']
       }
     }
 
     // Mock setting store
-    mockSettingStore = {
-      settingsById: mockSettings
-    } as ReturnType<typeof useSettingStore>
-    vi.mocked(useSettingStore).mockReturnValue(mockSettingStore)
-
-    // Mock getSettingInfo function
-    vi.mocked(getSettingInfo).mockImplementation((setting) => {
-      const parts = setting.category || setting.id.split('.')
-      return {
-        category: parts[0] ?? 'Other',
-        subCategory: parts[1] ?? 'Other'
-      }
-    })
+    mockSettingStore = useSettingStore()
+    mockSettingStore.settingsById = mockSettings
 
     // Mock st function to return fallback value
     vi.mocked(st).mockImplementation((_: string, fallback: string) => fallback)
@@ -345,14 +320,14 @@ describe('useSettingSearch', () => {
       // Simulates the "badge" scenario: same term matches settings in
       // multiple categories (e.g. LiteGraph and Comfy)
       mockSettings['LiteGraph.BadgeSetting'] = {
-        id: 'LiteGraph.BadgeSetting',
+        id: 'LiteGraph.BadgeSetting' as SettingParams['id'],
         name: 'Node source badge mode',
         type: 'combo',
         defaultValue: 'default',
         category: ['LiteGraph', 'Node']
       }
       mockSettings['Comfy.BadgeSetting'] = {
-        id: 'Comfy.BadgeSetting',
+        id: 'Comfy.BadgeSetting' as SettingParams['id'],
         name: 'Show API node pricing badge',
         type: 'boolean',
         defaultValue: true,
@@ -388,7 +363,7 @@ describe('useSettingSearch', () => {
 
       // Add another setting to Basic subcategory
       mockSettings['Category.Setting4'] = {
-        id: 'Category.Setting4',
+        id: 'Category.Setting4' as SettingParams['id'],
         name: 'Setting Four',
         type: 'text',
         defaultValue: 'default',
@@ -496,7 +471,7 @@ describe('useSettingSearch', () => {
 
     it('handles settings with undefined category', () => {
       mockSettings['NoCategorySetting'] = {
-        id: 'NoCategorySetting',
+        id: 'NoCategorySetting' as SettingParams['id'],
         name: 'No Category',
         type: 'text',
         defaultValue: 'default'

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -1,12 +1,13 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import {
-  getSettingInfo,
-  useSettingStore
-} from '@/platform/settings/settingStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingTreeNode } from '@/platform/settings/settingStore'
 
 import { useSettingUI as useSettingUIComposable } from './useSettingUI'
@@ -57,7 +58,8 @@ vi.mock<unknown>(import('@/composables/useVueFeatureFlags'), () => ({
   useVueFeatureFlags: () => ({ shouldRenderVueNodes: ref(false) })
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return env.state.isCloud
   },
@@ -66,30 +68,11 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(),
-  getSettingInfo: vi.fn()
-}))
-
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
   () => ({
     useWorkspaceUI: () => ({
       workspaceRole: env.fakeRef('workspaceRole')
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/partnerNodeGovernanceStore'),
-  () => ({
-    usePartnerNodeGovernanceStore: () => ({
-      get status() {
-        return env.state.partnerNodeGovernanceStatus
-      },
-      get providers() {
-        return env.state.partnerNodeGovernanceProviders
-      }
     })
   })
 )
@@ -122,6 +105,25 @@ function useSettingUI(
   render(Wrapper, { global: { plugins: [i18n] } })
   return result
 }
+
+beforeEach(() => {
+  vi.spyOn(usePartnerNodeGovernanceStore(), 'status', 'get').mockImplementation(
+    () => {
+      return env.state.partnerNodeGovernanceStatus
+    }
+  )
+  vi.spyOn(
+    usePartnerNodeGovernanceStore(),
+    'providers',
+    'get'
+  ).mockImplementation(() => {
+    return env.state.partnerNodeGovernanceProviders.map((provider) =>
+      fromPartial<
+        ReturnType<typeof usePartnerNodeGovernanceStore>['providers'][number]
+      >(provider)
+    )
+  })
+})
 
 describe('useSettingUI', () => {
   const mockSettings: Record<string, MockSettingParams> = {
@@ -157,17 +159,7 @@ describe('useSettingUI', () => {
       partnerNodeGovernanceProviders: []
     })
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      settingsById: mockSettings
-    } as ReturnType<typeof useSettingStore>)
-
-    vi.mocked(getSettingInfo).mockImplementation((setting) => {
-      const parts = setting.category || setting.id.split('.')
-      return {
-        category: parts[0] ?? 'Other',
-        subCategory: parts[1] ?? 'Other'
-      }
-    })
+    Object.assign(useSettingStore(), { settingsById: mockSettings })
   })
 
   function findCategory(

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useDialogStore } from '@/stores/dialogStore'
 /**
  * Settings dialog migration regression net: `useSettingsDialog().show()` must
  * open the Reka-renderer path with sizing that matches the previous
@@ -9,17 +12,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const showDialog = vi.hoisted(() => vi.fn())
 const isCloudRef = vi.hoisted(() => ({ value: false }))
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog, closeDialog: vi.fn() })
-}))
-
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return isCloudRef.value
   }
 }))
 
-vi.mock(import('@/i18n'), () => ({ t: (k: string) => k }))
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
+  t: (k: string) => k
+}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackEvent: vi.fn() })
@@ -34,6 +37,11 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
 }))
 
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+
+beforeEach(() => {
+  useDialogStore().showDialog = showDialog
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => undefined)
+})
 
 describe('useSettingsDialog', () => {
   beforeEach(() => {

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -1,6 +1,6 @@
-import { defineStore } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 
 const trackFeatureUsed = vi.hoisted(() => vi.fn())
 
@@ -11,20 +11,11 @@ vi.mock<unknown>(import('./useSurveyFeatureTracking'), () => ({
   })
 }))
 
-const useFakeExecutionErrorStore = defineStore('fakeExecutionError', () => {
-  const hasAnyError = ref(false)
-  return { hasAnyError }
-})
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
-  useExecutionErrorStore: () => useFakeExecutionErrorStore()
-}))
-
 import { useErrorSurveyTracking } from './useErrorSurveyTracking'
 
 describe('useErrorSurveyTracking', () => {
   let scope: ReturnType<typeof effectScope>
-  let store: ReturnType<typeof useFakeExecutionErrorStore>
+  let store: ReturnType<typeof useExecutionErrorStore>
 
   function setup() {
     scope = effectScope()
@@ -32,7 +23,8 @@ describe('useErrorSurveyTracking', () => {
   }
 
   beforeEach(() => {
-    store = useFakeExecutionErrorStore()
+    store = useExecutionErrorStore()
+    Object.assign(store, { hasAnyError: false })
   })
 
   afterEach(() => {
@@ -41,14 +33,14 @@ describe('useErrorSurveyTracking', () => {
 
   it('counts false → true transition once', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
   })
 
   it('counts initial true state on mount', async () => {
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     setup()
     await nextTick()
 
@@ -64,9 +56,9 @@ describe('useErrorSurveyTracking', () => {
 
   it('does not count true → false transition', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
-    store.hasAnyError = false
+    Object.assign(store, { hasAnyError: false })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
@@ -74,11 +66,11 @@ describe('useErrorSurveyTracking', () => {
 
   it('counts a fresh error after clear as a second use', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
-    store.hasAnyError = false
+    Object.assign(store, { hasAnyError: false })
     await nextTick()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(2)
@@ -86,9 +78,9 @@ describe('useErrorSurveyTracking', () => {
 
   it('does not double-count when state stays true', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(1)

--- a/src/platform/telemetry/hostUserIdSync.test.ts
+++ b/src/platform/telemetry/hostUserIdSync.test.ts
@@ -1,24 +1,14 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as VueModule from 'vue'
 import { nextTick } from 'vue'
+import { useAuthStore } from '@/stores/authStore'
 
-type MockAuthStore = {
-  isInitialized: boolean
-  currentUser: { uid: string } | null
-}
-
-const hoisted = vi.hoisted(() => ({
-  authStore: null as unknown as MockAuthStore
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
 }))
-
-vi.mock<unknown>(import('@/stores/authStore'), async () => {
-  const { reactive } = await vi.importActual<typeof VueModule>('vue')
-  hoisted.authStore = reactive<MockAuthStore>({
-    isInitialized: false,
-    currentUser: null
-  })
-  return { useAuthStore: () => hoisted.authStore }
-})
 
 import { syncHostUserIdWithFirebaseAuth } from './hostUserIdSync'
 
@@ -43,8 +33,8 @@ function startSync(): void {
 
 describe('host user ID sync', () => {
   beforeEach(() => {
-    hoisted.authStore.isInitialized = false
-    hoisted.authStore.currentUser = null
+    useAuthStore().isInitialized = false
+    useAuthStore().currentUser = null
   })
 
   afterEach(() => {
@@ -61,12 +51,12 @@ describe('host user ID sync', () => {
       status: 'pending'
     })
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
 
-    hoisted.authStore.isInitialized = true
+    useAuthStore().isInitialized = true
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
@@ -77,8 +67,8 @@ describe('host user ID sync', () => {
 
   it('reports a restored Firebase session immediately', () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
 
     startSync()
 
@@ -90,7 +80,7 @@ describe('host user ID sync', () => {
 
   it('reports an initially signed-out Firebase session', () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.isInitialized = true
+    useAuthStore().isInitialized = true
 
     startSync()
 
@@ -106,7 +96,7 @@ describe('host user ID sync', () => {
 
     expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
 
-    hoisted.authStore.isInitialized = true
+    useAuthStore().isInitialized = true
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
@@ -116,11 +106,11 @@ describe('host user ID sync', () => {
 
   it('reports account switches, logout, and subsequent login', async () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
     startSync()
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-b' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-b' })
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
@@ -128,14 +118,14 @@ describe('host user ID sync', () => {
       userId: 'firebase-user-b'
     })
 
-    hoisted.authStore.currentUser = null
+    useAuthStore().currentUser = null
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
       status: 'signed_out'
     })
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-c' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-c' })
     await nextTick()
 
     expect(reportFirebaseAuthState.mock.calls).toEqual([
@@ -149,11 +139,11 @@ describe('host user ID sync', () => {
 
   it('does not report again when Firebase replaces the user object with the same UID', async () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
     startSync()
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
     await nextTick()
 
     expect(reportFirebaseAuthState.mock.calls).toEqual([
@@ -170,8 +160,8 @@ describe('host user ID sync', () => {
 
     expect(() => startSync()).not.toThrow()
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
@@ -1,45 +1,25 @@
 import { createHash } from 'node:crypto'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { User } from 'firebase/auth'
+import { getActivePinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-type MockApiKeyUser = {
-  id: string
-  email?: string
-} | null
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useAuthStore } from '@/stores/authStore'
 
-type MockAuthUser = {
-  uid: string
-  email?: string | null
-} | null
-
-const {
-  mockCaptureCheckoutAttributionFromSearch,
-  mockUseApiKeyAuthStore,
-  mockUseAuthStore,
-  mockApiKeyAuthStore,
-  mockAuthStore
-} = vi.hoisted(() => ({
-  mockCaptureCheckoutAttributionFromSearch: vi.fn(),
-  mockUseApiKeyAuthStore: vi.fn(),
-  mockUseAuthStore: vi.fn(),
-  mockApiKeyAuthStore: {
-    isAuthenticated: false,
-    currentUser: null as MockApiKeyUser
-  },
-  mockAuthStore: {
-    currentUser: null as MockAuthUser
-  }
+const { mockCaptureCheckoutAttributionFromSearch } = vi.hoisted(() => ({
+  mockCaptureCheckoutAttributionFromSearch: vi.fn()
 }))
 
 vi.mock(import('@/platform/telemetry/utils/checkoutAttribution'), () => ({
   captureCheckoutAttributionFromSearch: mockCaptureCheckoutAttributionFromSearch
 }))
 
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: mockUseApiKeyAuthStore
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: mockUseAuthStore
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn(),
+  setPersistence: vi.fn()
 }))
 
 import { ImpactTelemetryProvider } from './ImpactTelemetryProvider'
@@ -61,12 +41,12 @@ function toUint8Array(data: BufferSource): Uint8Array {
 }
 
 describe('ImpactTelemetryProvider', () => {
+  let apiKeyAuthStore: ReturnType<typeof useApiKeyAuthStore>
+  let authStore: ReturnType<typeof useAuthStore>
+
   beforeEach(() => {
-    mockApiKeyAuthStore.isAuthenticated = false
-    mockApiKeyAuthStore.currentUser = null
-    mockAuthStore.currentUser = null
-    mockUseApiKeyAuthStore.mockReturnValue(mockApiKeyAuthStore)
-    mockUseAuthStore.mockReturnValue(mockAuthStore)
+    apiKeyAuthStore = useApiKeyAuthStore()
+    authStore = useAuthStore()
 
     const queueFn: NonNullable<Window['ire']> = (...args: unknown[]) => {
       ;(queueFn.a ??= []).push(args)
@@ -84,10 +64,10 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('captures attribution and invokes identify with hashed email', async () => {
-    mockAuthStore.currentUser = {
+    authStore.currentUser = fromPartial<User>({
       uid: 'user-123',
       email: ' User@Example.com '
-    }
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(
@@ -119,16 +99,18 @@ describe('ImpactTelemetryProvider', () => {
     })
   })
 
-  it('falls back to current URL search and empty identify values when user is unresolved', async () => {
-    mockUseApiKeyAuthStore.mockImplementation(() => {
-      throw new Error('No active pinia')
-    })
+  it('falls back to current URL search and empty identify values when Pinia is unavailable', async () => {
     window.history.pushState({}, '', '/?im_ref=fallback-123')
 
     const provider = new ImpactTelemetryProvider()
-    provider.trackPageView('home')
-
-    await flushAsyncWork()
+    const pinia = getActivePinia()
+    setActivePinia(undefined)
+    try {
+      provider.trackPageView('home')
+      await flushAsyncWork()
+    } finally {
+      setActivePinia(pinia)
+    }
 
     expect(mockCaptureCheckoutAttributionFromSearch).toHaveBeenCalledWith(
       '?im_ref=fallback-123'
@@ -144,10 +126,10 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('invokes identify on each page view even with identical identity payloads', async () => {
-    mockAuthStore.currentUser = {
+    authStore.currentUser = fromPartial<User>({
       uid: 'user-123',
       email: 'user@example.com'
-    }
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(async () => new Uint8Array([16, 32, 48]).buffer)
@@ -175,15 +157,14 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('prefers firebase identity when both firebase and API key identity are available', async () => {
-    mockApiKeyAuthStore.isAuthenticated = true
-    mockApiKeyAuthStore.currentUser = {
+    apiKeyAuthStore.currentUser = fromPartial({
       id: 'api-key-user-123',
       email: 'apikey@example.com'
-    }
-    mockAuthStore.currentUser = {
+    })
+    authStore.currentUser = fromPartial<User>({
       uid: 'firebase-user-123',
       email: 'firebase@example.com'
-    }
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(
@@ -214,12 +195,10 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('falls back to API key identity when firebase user is unavailable', async () => {
-    mockApiKeyAuthStore.isAuthenticated = true
-    mockApiKeyAuthStore.currentUser = {
+    apiKeyAuthStore.currentUser = fromPartial({
       id: 'api-key-user-123',
       email: 'apikey@example.com'
-    }
-    mockAuthStore.currentUser = null
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
@@ -1,3 +1,5 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ExecutionContext, ShellLayoutMetadata } from '../../types'
@@ -44,17 +46,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        isModified: mocks.workflowIsModified
-      }
-    })
-  })
-)
-
 vi.mock(import('../../utils/getExecutionContext'), () => ({
   getExecutionContext: () => mocks.executionContext
 }))
@@ -69,6 +60,12 @@ const shellLayout: ShellLayoutMetadata = {
   bottom_panel_open: true,
   open_workflow_tabs: 2
 }
+
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    isModified: mocks.workflowIsModified
+  })
+})
 
 describe('SentryTelemetryProvider', () => {
   beforeEach(() => {

--- a/src/platform/telemetry/utils/getExecutionContext.test.ts
+++ b/src/platform/telemetry/utils/getExecutionContext.test.ts
@@ -1,52 +1,16 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { NodeSourceType } from '@/types/nodeSource'
 
 const hoisted = vi.hoisted(() => ({
   mockNodeDefsByName: {} as Partial<Record<string, Record<string, unknown>>>,
-  mockNodes: [] as Pick<LGraphNode, 'type' | 'isSubgraphNode'>[],
-  mockActiveWorkflow: null as null | {
-    filename: string
-    fullFilename: string
-  },
-  mockKnownTemplateNames: new Set<string>(),
-  mockTemplateByName: null as null | { sourceModule?: string }
+  mockNodes: [] as Pick<LGraphNode, 'type' | 'isSubgraphNode'>[]
 }))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    fromLGraphNode: (node: Pick<LGraphNode, 'type'>) => {
-      const nodeDef = hoisted.mockNodeDefsByName[node.type]
-      return nodeDef
-        ? { nodeSource: { type: 'unknown' }, ...nodeDef }
-        : undefined
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return hoisted.mockActiveWorkflow
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
-  () => ({
-    useWorkflowTemplatesStore: () => ({
-      get knownTemplateNames() {
-        return hoisted.mockKnownTemplateNames
-      },
-      getTemplateByName: (_name: string) => hoisted.mockTemplateByName,
-      getEnglishMetadata: () => null
-    })
-  })
-)
 
 function mockNode(
   type: string,
@@ -74,15 +38,35 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 import { getExecutionContext } from './getExecutionContext'
 
+beforeEach(() => {
+  vi.mocked(useNodeDefStore().fromLGraphNode).mockImplementation(
+    (node: Pick<LGraphNode, 'type'>) => {
+      const nodeDef = hoisted.mockNodeDefsByName[node.type]
+      return nodeDef
+        ? fromPartial({
+            nodeSource: { type: NodeSourceType.Unknown },
+            ...nodeDef
+          })
+        : null
+    }
+  )
+})
+
+beforeEach(() => {
+  vi.mocked(useWorkflowTemplatesStore().getTemplateByName).mockReturnValue(
+    fromPartial({ sourceModule: 'default' })
+  )
+  vi.mocked(useWorkflowTemplatesStore().getEnglishMetadata).mockImplementation(
+    () => null
+  )
+})
+
 describe('getExecutionContext', () => {
   beforeEach(() => {
     hoisted.mockNodes.length = 0
     for (const key of Object.keys(hoisted.mockNodeDefsByName)) {
       delete hoisted.mockNodeDefsByName[key]
     }
-    hoisted.mockActiveWorkflow = null
-    hoisted.mockKnownTemplateNames = new Set()
-    hoisted.mockTemplateByName = null
   })
 
   it('returns has_toolkit_nodes false when no toolkit nodes are present', () => {
@@ -173,12 +157,13 @@ describe('getExecutionContext', () => {
 
   describe('template detection', () => {
     it('detects a regular template by name', () => {
-      hoisted.mockKnownTemplateNames = new Set(['flux-dev'])
-      hoisted.mockTemplateByName = { sourceModule: 'default' }
-      hoisted.mockActiveWorkflow = {
+      Object.assign(useWorkflowTemplatesStore(), {
+        knownTemplateNames: new Set(['flux-dev'])
+      })
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'flux-dev',
         fullFilename: 'flux-dev.json'
-      }
+      })
 
       const context = getExecutionContext()
 
@@ -187,16 +172,15 @@ describe('getExecutionContext', () => {
     })
 
     it('detects an app mode template whose name ends with .app', () => {
-      hoisted.mockKnownTemplateNames = new Set([
-        'templates-qwen_multiangle.app'
-      ])
-      hoisted.mockTemplateByName = { sourceModule: 'default' }
+      Object.assign(useWorkflowTemplatesStore(), {
+        knownTemplateNames: new Set(['templates-qwen_multiangle.app'])
+      })
       // getFilenameDetails strips ".app.json" as a compound extension, yielding
       // filename = "templates-qwen_multiangle" — the previous code would fail here.
-      hoisted.mockActiveWorkflow = {
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'templates-qwen_multiangle',
         fullFilename: 'templates-qwen_multiangle.app.json'
-      }
+      })
 
       const context = getExecutionContext()
 
@@ -205,11 +189,13 @@ describe('getExecutionContext', () => {
     })
 
     it('does not flag a non-template workflow as a template', () => {
-      hoisted.mockKnownTemplateNames = new Set(['flux-dev'])
-      hoisted.mockActiveWorkflow = {
+      Object.assign(useWorkflowTemplatesStore(), {
+        knownTemplateNames: new Set(['flux-dev'])
+      })
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'my-custom-workflow',
         fullFilename: 'my-custom-workflow.json'
-      }
+      })
 
       const context = getExecutionContext()
 

--- a/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
+++ b/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
@@ -1,49 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const state = vi.hoisted(() => ({
-  settings: {} as Record<string, unknown>,
-  activeSidebarTabId: null as string | null,
-  rightSidePanelOpen: false,
-  bottomPanelVisible: false,
-  openWorkflows: [] as unknown[]
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => state.settings[key] })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ openWorkflows: state.openWorkflows })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), () => ({
-  useBottomPanelStore: () => ({
-    bottomPanelVisible: state.bottomPanelVisible
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), () => ({
-  useRightSidePanelStore: () => ({ isOpen: state.rightSidePanelOpen })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => ({
-    activeSidebarTabId: state.activeSidebarTabId
-  })
-}))
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { getShellLayoutSnapshot } from './getShellLayoutSnapshot'
 
 describe('getShellLayoutSnapshot', () => {
   beforeEach(() => {
-    state.settings = { 'Comfy.UseNewMenu': 'Top' }
-    state.activeSidebarTabId = null
-    state.rightSidePanelOpen = false
-    state.bottomPanelVisible = false
-    state.openWorkflows = []
+    useSettingStore().settingValues = { 'Comfy.UseNewMenu': 'Top' }
+    useSidebarTabStore().activeSidebarTabId = null
+    useRightSidePanelStore().isOpen = false
+    useBottomPanelStore().bottomPanelVisible = false
+    Object.assign(useWorkflowStore(), { openWorkflows: [] })
   })
 
   it('captures the default layout', () => {
@@ -63,10 +33,10 @@ describe('getShellLayoutSnapshot', () => {
 
   it('captures a customized layout', () => {
     localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
-    state.activeSidebarTabId = 'node-library'
-    state.rightSidePanelOpen = true
-    state.bottomPanelVisible = true
-    state.openWorkflows = [{}, {}, {}]
+    useSidebarTabStore().activeSidebarTabId = 'node-library'
+    useRightSidePanelStore().isOpen = true
+    useBottomPanelStore().bottomPanelVisible = true
+    Object.assign(useWorkflowStore(), { openWorkflows: [{}, {}, {}] })
 
     expect(
       getShellLayoutSnapshot({ view_mode: 'app', is_app_mode: true })

--- a/src/platform/updates/common/releaseStore.test.ts
+++ b/src/platform/updates/common/releaseStore.test.ts
@@ -1,15 +1,18 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as VueUseModule from '@vueuse/core'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { until } from '@vueuse/core'
 import { compare } from 'semver'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import type { Ref } from 'vue'
 
-import type { EntryPath } from '@/platform/onboarding/onboardingTours'
+import { useOnboardingTourStore } from '@/platform/onboarding/onboardingTourStore'
 import type { ReleaseNote } from '@/platform/updates/common/releaseService'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useReleaseStore } from '@/platform/updates/common/releaseStore'
 import { useReleaseService } from '@/platform/updates/common/releaseService'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
-import type { SystemStats } from '@/types'
 
 // Mock the dependencies
 vi.mock(import('semver'), () => ({
@@ -19,7 +22,8 @@ vi.mock(import('semver'), () => ({
 
 const mockData = vi.hoisted(() => ({ isDesktop: true, isCloud: false }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isDesktop() {
     return mockData.isDesktop
   },
@@ -41,79 +45,34 @@ vi.mock(import('@/platform/updates/common/releaseService'), () => {
   }
 })
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => {
-  const get = vi.fn((key: string) => {
-    if (key === 'Comfy.Notification.ShowVersionUpdates') return true
-    return null
-  })
-  const set = vi.fn()
-  const setMany = vi.fn()
-  return {
-    useSettingStore: () => ({ get, set, setMany })
-  }
-})
-
-const mockSystemStatsState = vi.hoisted(() => ({
-  systemStats: {
-    system: {
-      comfyui_version: '1.0.0',
-      argv: []
-    }
-  } satisfies {
-    system: Partial<SystemStats['system']>
-  },
-  isInitialized: true,
-  reset() {
-    this.systemStats = {
-      system: {
-        comfyui_version: '1.0.0',
-        argv: []
-      } satisfies Partial<SystemStats['system']>
-    }
-    this.isInitialized = true
-  }
-}))
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => {
-  const refetchSystemStats = vi.fn()
-  const getFormFactor = vi.fn(() => 'git-windows')
-  return {
-    useSystemStatsStore: () => ({
-      get systemStats() {
-        return mockSystemStatsState.systemStats
-      },
-      set systemStats(val) {
-        mockSystemStatsState.systemStats = val
-      },
-      get isInitialized() {
-        return mockSystemStatsState.isInitialized
-      },
-      set isInitialized(val) {
-        mockSystemStatsState.isInitialized = val
-      },
-      refetchSystemStats,
-      getFormFactor
-    })
-  }
-})
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUseModule>()),
   until: vi.fn(() => Promise.resolve()),
   useStorage: vi.fn(() => ({ value: {} })),
   createSharedComposable: vi.fn((fn) => fn)
 }))
 
-const mocks = vi.hoisted(() => ({
-  tour: { activeTour: null as EntryPath | null }
-}))
-vi.mock<unknown>(
-  import('@/platform/onboarding/onboardingTourStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mocks.tour = reactive(mocks.tour)
-    return { useOnboardingTourStore: () => mocks.tour }
-  }
-)
+beforeEach(() => {
+  const get = vi.fn((key: string) => {
+    if (key === 'Comfy.Notification.ShowVersionUpdates') return true
+    return null
+  })
+  vi.mocked(useSettingStore().get).mockImplementation(get)
+  vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+  vi.mocked(useSettingStore().setMany).mockResolvedValue(undefined)
+  const getFormFactor = vi.fn(() => 'git-windows')
+  useSystemStatsStore().systemStats = fromPartial({
+    system: { comfyui_version: '1.0.0', argv: [] }
+  })
+  useSystemStatsStore().isInitialized = true
+  vi.mocked(useSystemStatsStore().refetchSystemStats).mockResolvedValue(null)
+  vi.mocked(useSystemStatsStore().getFormFactor).mockImplementation(
+    getFormFactor
+  )
+})
 
 describe('useReleaseStore', () => {
+  let activeTour: Ref<ReturnType<typeof useOnboardingTourStore>['activeTour']>
   const mockRelease = {
     id: 1,
     project: 'comfyui' as const,
@@ -124,9 +83,11 @@ describe('useReleaseStore', () => {
   }
 
   beforeEach(() => {
-    mockSystemStatsState.reset()
     mockData.isCloud = false
-    mocks.tour.activeTour = null
+    activeTour = ref(null)
+    vi.spyOn(useOnboardingTourStore(), 'activeTour', 'get').mockImplementation(
+      () => activeTour.value
+    )
   })
 
   describe('initial state', () => {
@@ -667,10 +628,10 @@ describe('useReleaseStore', () => {
 
       store.releases = [mockRelease]
 
-      mocks.tour.activeTour = 'firstRun'
+      activeTour.value = 'firstRun'
       expect(store.shouldShowPopup).toBe(false)
 
-      mocks.tour.activeTour = null
+      activeTour.value = null
       expect(store.shouldShowPopup).toBe(true)
     })
 
@@ -686,7 +647,7 @@ describe('useReleaseStore', () => {
       vi.mocked(compare).mockReturnValue(0)
 
       store.releases = [mockRelease]
-      mocks.tour.activeTour = 'appMode'
+      activeTour.value = 'appMode'
 
       expect(store.shouldShowPopup).toBe(true)
     })

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -1,8 +1,11 @@
+import type * as VueUseModule from '@vueuse/core'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { until } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 vi.mock<unknown>(import('@/config'), () => ({
   default: {
@@ -10,62 +13,41 @@ vi.mock<unknown>(import('@/config'), () => ({
   }
 }))
 
-const mockUseSystemStatsStore = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: mockUseSystemStatsStore
-}))
-
-const mockUseSettingStore = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: mockUseSettingStore
-}))
-
-// Mock useStorage and until from VueUse
-const mockDismissalStorage = ref({} as Record<string, number>)
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+const { mockDismissalStorage } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return { mockDismissalStorage: ref({} as Record<string, number>) }
+})
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUseModule>()),
   useStorage: vi.fn(() => mockDismissalStorage),
   until: vi.fn(() => Promise.resolve())
 }))
 
-type MockSystemStatsStore = {
-  systemStats: unknown
-  isInitialized: boolean
-  refetchSystemStats: ReturnType<typeof vi.fn>
-}
-
 describe('useVersionCompatibilityStore', () => {
   let store: ReturnType<typeof useVersionCompatibilityStore>
-  let mockSystemStatsStore: MockSystemStatsStore
-  let mockSettingStore: { get: ReturnType<typeof vi.fn> }
+  let mockSystemStatsStore: ReturnType<typeof useSystemStatsStore>
+  let mockSettingStore: ReturnType<typeof useSettingStore>
 
   beforeEach(() => {
     // Clear the mock dismissal storage
     mockDismissalStorage.value = {}
 
-    mockSystemStatsStore = {
-      systemStats: null,
-      isInitialized: false,
-      refetchSystemStats: vi.fn()
-    }
-
-    mockSettingStore = {
-      get: vi.fn(() => false) // Default to warnings enabled
-    }
-
-    mockUseSystemStatsStore.mockReturnValue(mockSystemStatsStore)
-    mockUseSettingStore.mockReturnValue(mockSettingStore)
+    mockSystemStatsStore = useSystemStatsStore()
+    vi.mocked(mockSystemStatsStore.refetchSystemStats).mockResolvedValue(null)
+    mockSettingStore = useSettingStore()
+    vi.mocked(mockSettingStore.get).mockReturnValue(false)
 
     store = useVersionCompatibilityStore()
   })
 
   describe('version compatibility detection', () => {
     it('should detect frontend is outdated when required version is higher', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -78,12 +60,12 @@ describe('useVersionCompatibilityStore', () => {
     it('should not warn when frontend is newer than backend', async () => {
       // Frontend: 1.24.0, Backend: 1.23.0, Required: 1.23.0
       // Frontend meets required version, no warning needed
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.23.0',
           required_frontend_version: '1.23.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -94,12 +76,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not detect mismatch when versions are compatible', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -110,12 +92,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should handle missing version information gracefully', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '',
           required_frontend_version: ''
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -126,12 +108,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not detect mismatch when versions are not valid semver', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '080e6d4af809a46852d1c4b7ed85f06e8a3a72be', // git hash
           required_frontend_version: 'not-a-version' // invalid semver format
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -143,12 +125,12 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should not warn when frontend exceeds required version', async () => {
       // Frontend: 1.24.0 (from mock config)
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.22.0', // Backend is older
           required_frontend_version: '1.23.0' // Required is 1.23.0, frontend 1.24.0 meets this
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -163,12 +145,12 @@ describe('useVersionCompatibilityStore', () => {
     it('should show warning when there is a version mismatch and not dismissed', async () => {
       // No dismissals in storage
       mockDismissalStorage.value = {}
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -183,12 +165,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': futureTime
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -197,12 +179,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not show warning when no version mismatch', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -212,15 +194,15 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should not show warning when disabled via setting', async () => {
       // Enable the disable setting
-      mockSettingStore.get.mockReturnValue(true)
+      vi.mocked(mockSettingStore.get).mockReturnValue(true)
 
       // Set up version mismatch that would normally show warning
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -234,12 +216,12 @@ describe('useVersionCompatibilityStore', () => {
 
   describe('warning messages', () => {
     it('should generate outdated message when frontend is outdated', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -252,12 +234,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should return null when no mismatch', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -270,12 +252,12 @@ describe('useVersionCompatibilityStore', () => {
     it('should save dismissal to reactive storage with expiration', async () => {
       const now = Date.now()
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -293,12 +275,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': futureTime
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -312,12 +294,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': pastTime
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -332,12 +314,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': futureTime // Different version was dismissed
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.26.0',
           required_frontend_version: '1.26.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -357,12 +339,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not fetch system stats if already available', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -373,7 +355,7 @@ describe('useVersionCompatibilityStore', () => {
 
   describe('comfy package version warnings', () => {
     it('should detect outdated comfy packages and skip comfyui-frontend-package', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -395,7 +377,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -419,7 +401,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should ignore packages with missing or invalid versions', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -436,7 +418,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -446,7 +428,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should detect outdated PEP 440 versions via coerce', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -463,7 +445,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -476,7 +458,7 @@ describe('useVersionCompatibilityStore', () => {
     it('should include outdated packages in dismissal key', async () => {
       const now = Date.now()
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -488,7 +470,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -512,26 +494,26 @@ describe('useVersionCompatibilityStore', () => {
         required: '0.9.5'
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
           comfy_package_versions: [packageA, packageB]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
       await store.checkVersionCompatibility()
       store.dismissWarning()
       const firstKey = Object.keys(mockDismissalStorage.value)[0]
 
       mockDismissalStorage.value = {}
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
           comfy_package_versions: [packageB, packageA]
         }
-      }
+      })
       await store.checkVersionCompatibility()
       store.dismissWarning()
       const secondKey = Object.keys(mockDismissalStorage.value)[0]
@@ -547,12 +529,12 @@ describe('useVersionCompatibilityStore', () => {
         'still-valid-key': now + 5000
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
       await store.checkVersionCompatibility()
       store.dismissWarning()
@@ -563,7 +545,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should allow dismissal when only package warnings are present', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '',
           required_frontend_version: '',
@@ -575,7 +557,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -1,3 +1,16 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useReleaseStore } from '../common/releaseStore'
+beforeEach(() => {
+  Object.assign(useReleaseStore(), {
+    recentRelease: null as ReleaseNote | null
+  })
+  Object.assign(useReleaseStore(), { shouldShowToast: false })
+  vi.mocked(useReleaseStore().handleSkipRelease).mockResolvedValue(undefined)
+  vi.mocked(useReleaseStore().handleShowChangelog).mockResolvedValue(undefined)
+  Object.assign(useReleaseStore(), { releases: [] })
+  vi.mocked(useReleaseStore().fetchReleases).mockResolvedValue(undefined)
+})
+import { useCommandStore } from '@/stores/commandStore'
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
@@ -24,14 +37,17 @@ vi.hoisted(() => {
 const mockData = vi.hoisted(() => ({ isDesktop: false }))
 
 const { commandExecuteMock } = vi.hoisted(() => ({
-  commandExecuteMock: vi.fn()
+  commandExecuteMock: vi.fn<ReturnType<typeof useCommandStore>['execute']>(
+    async () => undefined
+  )
 }))
 
 const { toastErrorHandlerMock } = vi.hoisted(() => ({
   toastErrorHandlerMock: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false,
   isNightly: false,
   get isDesktop() {
@@ -59,12 +75,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => ({
-    execute: commandExecuteMock
-  }))
-}))
-
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   useExternalLink: vi.fn(() => ({
     buildDocsUrl: vi.fn((path: string) => `https://docs.comfy.org${path}`),
@@ -74,18 +84,10 @@ vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
 }))
 
 // Mock release store
-const mockReleaseStore = {
-  recentRelease: null as ReleaseNote | null,
-  shouldShowToast: false,
-  handleSkipRelease: vi.fn(),
-  handleShowChangelog: vi.fn(),
-  releases: [],
-  fetchReleases: vi.fn()
-}
 
-vi.mock<unknown>(import('../common/releaseStore'), () => ({
-  useReleaseStore: vi.fn(() => mockReleaseStore)
-}))
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockImplementation(commandExecuteMock)
+})
 
 describe('ReleaseNotificationToast', () => {
   const renderComponent = (props = {}) => {
@@ -103,25 +105,29 @@ describe('ReleaseNotificationToast', () => {
 
   beforeEach(() => {
     mockData.isDesktop = false
-    mockReleaseStore.recentRelease = null
-    mockReleaseStore.shouldShowToast = true
+    Object.assign(useReleaseStore(), { recentRelease: null })
+    Object.assign(useReleaseStore(), { shouldShowToast: true })
   })
 
   it('renders correctly when shouldShow is true', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release\n\nSome content'
+      } as ReleaseNote
+    })
 
     renderComponent()
     expect(screen.getByText('New update is out!')).toBeInTheDocument()
   })
 
   it('stays hidden while node selection mode is active', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release\n\nSome content'
+      } as ReleaseNote
+    })
     useAgentNodeSelectionStore().isActive = true
 
     renderComponent()
@@ -129,10 +135,12 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('displays rocket icon', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const { container } = renderComponent()
     /* eslint-disable testing-library/no-container, testing-library/no-node-access */
@@ -143,34 +151,40 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('displays release version', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
     expect(screen.getByText('1.2.3')).toBeInTheDocument()
   })
 
   it('calls handleSkipRelease when skip button is clicked', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
     const user = userEvent.setup()
 
     await user.click(screen.getByRole('button', { name: /skip/i }))
 
-    expect(mockReleaseStore.handleSkipRelease).toHaveBeenCalledWith('1.2.3')
+    expect(useReleaseStore().handleSkipRelease).toHaveBeenCalledWith('1.2.3')
   })
 
   it('opens update URL when update button is clicked', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const mockWindowOpen = vi.fn()
     Object.defineProperty(window, 'open', {
@@ -191,10 +205,12 @@ describe('ReleaseNotificationToast', () => {
 
   it('executes desktop updater flow when running on desktop', async () => {
     mockData.isDesktop = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     commandExecuteMock.mockResolvedValueOnce(undefined)
 
@@ -218,10 +234,12 @@ describe('ReleaseNotificationToast', () => {
 
   it('shows an error toast if the desktop updater flow fails on desktop', async () => {
     mockData.isDesktop = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const error = new Error('Command Comfy-Desktop.CheckForUpdates not found')
     commandExecuteMock.mockRejectedValueOnce(error)
@@ -242,24 +260,28 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('calls handleShowChangelog when learn more link is clicked', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
     const user = userEvent.setup()
 
     await user.click(screen.getByRole('link', { name: /what's new/i }))
 
-    expect(mockReleaseStore.handleShowChangelog).toHaveBeenCalledWith('1.2.3')
+    expect(useReleaseStore().handleShowChangelog).toHaveBeenCalledWith('1.2.3')
   })
 
   it('generates correct changelog URL', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -279,10 +301,12 @@ describe('ReleaseNotificationToast', () => {
     )
     mockMarkdownRenderer.mockReturnValue('<div>Content without title</div>')
 
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release Title\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release Title\n\nSome content'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -290,19 +314,21 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('fetches releases on mount when not already loaded', () => {
-    mockReleaseStore.releases = []
+    useReleaseStore().releases = []
 
     renderComponent()
 
-    expect(mockReleaseStore.fetchReleases).toHaveBeenCalled()
+    expect(useReleaseStore().fetchReleases).toHaveBeenCalled()
   })
 
   it('handles missing release content gracefully', () => {
-    mockReleaseStore.shouldShowToast = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: ''
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowToast: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: ''
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -310,10 +336,12 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('auto-hides after timeout', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -326,10 +354,12 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('clears auto-hide timer when manually dismissed', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
 
@@ -340,6 +370,6 @@ describe('ReleaseNotificationToast', () => {
     await user.click(screen.getByRole('button', { name: /skip/i }))
 
     expect(vi.getTimerCount()).toBe(0)
-    expect(mockReleaseStore.handleSkipRelease).toHaveBeenCalled()
+    expect(useReleaseStore().handleSkipRelease).toHaveBeenCalled()
   })
 })

--- a/src/platform/updates/components/WhatsNewPopup.test.ts
+++ b/src/platform/updates/components/WhatsNewPopup.test.ts
@@ -1,4 +1,16 @@
 // @vitest-environment jsdom
+import type * as I18nModule from '@/i18n'
+import type { ComfyApp } from '@/scripts/app'
+import { useReleaseStore } from '../common/releaseStore'
+beforeEach(() => {
+  Object.assign(useReleaseStore(), {
+    recentRelease: null as ReleaseNote | null
+  })
+  Object.assign(useReleaseStore(), { shouldShowPopup: false })
+  vi.mocked(useReleaseStore().handleWhatsNewSeen).mockResolvedValue(undefined)
+  Object.assign(useReleaseStore(), { releases: [] as ReleaseNote[] })
+  vi.mocked(useReleaseStore().fetchReleases).mockResolvedValue(undefined)
+})
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
 import { render, screen } from '@testing-library/vue'
@@ -11,6 +23,14 @@ import { createI18n } from 'vue-i18n'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import type { ReleaseNote } from '../common/releaseService'
 import WhatsNewPopup from './WhatsNewPopup.vue'
+
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
 
 // Mock dependencies
 const mockTranslations: Record<string, string> = {
@@ -25,7 +45,8 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-vi.mock<unknown>(import('@/i18n'), () => ({
+vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   i18n: {
     global: {
       locale: {
@@ -49,18 +70,12 @@ vi.mock(import('@/utils/markdownRendererUtil'), () => ({
   renderMarkdownToHtml: vi.fn((content: string) => `<div>${content}</div>`)
 }))
 
-// Mock release store
-const mockReleaseStore = {
-  recentRelease: null as ReleaseNote | null,
-  shouldShowPopup: false,
-  handleWhatsNewSeen: vi.fn(),
-  releases: [] as ReleaseNote[],
-  fetchReleases: vi.fn()
-}
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
 
-vi.mock<unknown>(import('../common/releaseStore'), () => ({
-  useReleaseStore: vi.fn(() => mockReleaseStore)
-}))
+// Mock release store
 
 describe('WhatsNewPopup', () => {
   const renderComponent = (props = {}) => {
@@ -78,19 +93,21 @@ describe('WhatsNewPopup', () => {
   }
 
   beforeEach(() => {
-    mockReleaseStore.recentRelease = null
-    mockReleaseStore.shouldShowPopup = false
-    mockReleaseStore.releases = []
-    mockReleaseStore.handleWhatsNewSeen = vi.fn()
-    mockReleaseStore.fetchReleases = vi.fn()
+    Object.assign(useReleaseStore(), { recentRelease: null })
+    Object.assign(useReleaseStore(), { shouldShowPopup: false })
+    useReleaseStore().releases = []
+    useReleaseStore().handleWhatsNewSeen = vi.fn()
+    useReleaseStore().fetchReleases = vi.fn()
   })
 
   it('renders correctly when shouldShow is true', () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release\n\nSome content'
+      } as ReleaseNote
+    })
 
     const { container } = renderComponent()
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -98,33 +115,37 @@ describe('WhatsNewPopup', () => {
   })
 
   it('does not render when shouldShow is false', () => {
-    mockReleaseStore.shouldShowPopup = false
+    Object.assign(useReleaseStore(), { shouldShowPopup: false })
     const { container } = renderComponent()
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('.whats-new-popup')).toBeNull()
   })
 
   it('calls handleWhatsNewSeen when close button is clicked', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const user = userEvent.setup()
     renderComponent()
 
     await user.click(screen.getByRole('button', { name: /close/i }))
 
-    expect(mockReleaseStore.handleWhatsNewSeen).toHaveBeenCalledWith('1.2.3')
+    expect(useReleaseStore().handleWhatsNewSeen).toHaveBeenCalledWith('1.2.3')
   })
 
   it('generates correct changelog URL', () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -135,11 +156,13 @@ describe('WhatsNewPopup', () => {
   })
 
   it('handles missing release content gracefully', () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: ''
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: ''
+      } as ReleaseNote
+    })
 
     const { container } = renderComponent()
 
@@ -148,11 +171,13 @@ describe('WhatsNewPopup', () => {
   })
 
   it('emits whats-new-dismissed event when popup is closed', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const onDismissed = vi.fn()
     const user = userEvent.setup()
@@ -164,21 +189,21 @@ describe('WhatsNewPopup', () => {
   })
 
   it('fetches releases on mount when not already loaded', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.releases = []
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    useReleaseStore().releases = []
 
     renderComponent()
 
-    expect(mockReleaseStore.fetchReleases).toHaveBeenCalled()
+    expect(useReleaseStore().fetchReleases).toHaveBeenCalled()
   })
 
   it('does not fetch releases when already loaded', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.releases = [{ version: '1.0.0' } as ReleaseNote]
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    useReleaseStore().releases = [{ version: '1.0.0' } as ReleaseNote]
 
     renderComponent()
 
-    expect(mockReleaseStore.fetchReleases).not.toHaveBeenCalled()
+    expect(useReleaseStore().fetchReleases).not.toHaveBeenCalled()
   })
 
   it('processes markdown content correctly', async () => {
@@ -190,11 +215,13 @@ describe('WhatsNewPopup', () => {
     )
     mockMarkdownRenderer.mockReturnValue('<h1>Processed Content</h1>')
 
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Original Title\n\nContent'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Original Title\n\nContent'
+      } as ReleaseNote
+    })
 
     renderComponent()
 

--- a/src/platform/workflow/core/services/workflowActionsService.test.ts
+++ b/src/platform/workflow/core/services/workflowActionsService.test.ts
@@ -1,29 +1,14 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import * as utils from '@/scripts/utils'
 import { useWorkflowActionsService } from './workflowActionsService'
 
 const mockPrompt = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ prompt: mockPrompt })
 }))
-
-const mockGetSetting = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: mockGetSetting })
-}))
-
-const mockDownloadBlob = vi.hoisted(() => vi.fn())
-vi.mock(import('@/scripts/utils'), () => ({
-  downloadBlob: mockDownloadBlob
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ createTemporary: vi.fn() })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -40,41 +25,45 @@ const minimalWorkflow: ComfyWorkflowJSON = {
   links: []
 }
 
+beforeEach(() => {
+  vi.spyOn(utils, 'downloadBlob').mockImplementation(() => {})
+})
+
 describe('workflowActionsService.exportWorkflowAction', () => {
   it('returns { cancelled: true } when the user dismisses the filename prompt', async () => {
-    mockGetSetting.mockReturnValue(true)
+    useSettingStore().settingValues['Comfy.PromptFilename'] = true
     mockPrompt.mockResolvedValue(null)
     const { exportWorkflowAction } = useWorkflowActionsService()
 
     const result = await exportWorkflowAction(minimalWorkflow, 'wf.json')
 
     expect(result).toEqual({ success: false, cancelled: true })
-    expect(mockDownloadBlob).not.toHaveBeenCalled()
+    expect(utils.downloadBlob).not.toHaveBeenCalled()
   })
 
   it('downloads with the prompted filename and returns success', async () => {
-    mockGetSetting.mockReturnValue(true)
+    useSettingStore().settingValues['Comfy.PromptFilename'] = true
     mockPrompt.mockResolvedValue('custom')
     const { exportWorkflowAction } = useWorkflowActionsService()
 
     const result = await exportWorkflowAction(minimalWorkflow, 'wf.json')
 
     expect(result).toEqual({ success: true })
-    expect(mockDownloadBlob).toHaveBeenCalledWith(
+    expect(utils.downloadBlob).toHaveBeenCalledWith(
       'custom.json',
       expect.any(Blob)
     )
   })
 
   it('skips the prompt and uses the default filename when the setting is off', async () => {
-    mockGetSetting.mockReturnValue(false)
+    useSettingStore().settingValues['Comfy.PromptFilename'] = false
     const { exportWorkflowAction } = useWorkflowActionsService()
 
     const result = await exportWorkflowAction(minimalWorkflow, 'default.json')
 
     expect(result).toEqual({ success: true })
     expect(mockPrompt).not.toHaveBeenCalled()
-    expect(mockDownloadBlob).toHaveBeenCalledWith(
+    expect(utils.downloadBlob).toHaveBeenCalledWith(
       'default.json',
       expect.any(Blob)
     )
@@ -89,6 +78,6 @@ describe('workflowActionsService.exportWorkflowAction', () => {
       success: false,
       error: 'No workflow data available'
     })
-    expect(mockDownloadBlob).not.toHaveBeenCalled()
+    expect(utils.downloadBlob).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workflow/core/services/workflowService.insertWorkflow.test.ts
+++ b/src/platform/workflow/core/services/workflowService.insertWorkflow.test.ts
@@ -1,5 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
+import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -35,14 +36,6 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
@@ -64,30 +57,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     trackWorkflowSaved: vi.fn(),
     trackEnterLinear: vi.fn()
   })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/persistence/stores/workflowDraftStoreV2'),
-  () => ({
-    useWorkflowDraftStoreV2: () => ({
-      saveDraft: vi.fn(() => true),
-      getDraft: vi.fn(),
-      removeDraft: vi.fn(),
-      markDraftUsed: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ clear: vi.fn() })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => ({ saveCurrentViewport: vi.fn() })
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({})
 }))
 
 const PROBE_NODE_TYPE = 'test/insert-workflow-probe'
@@ -148,9 +117,21 @@ beforeEach(() => {
   )
 })
 
+beforeEach(() => {
+  vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockImplementation(() => true)
+  vi.mocked(useWorkflowDraftStoreV2().getDraft).mockReturnValue(null)
+  vi.mocked(useWorkflowDraftStoreV2().removeDraft).mockImplementation(() => {})
+  vi.mocked(useWorkflowDraftStoreV2().markDraftUsed).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useDomWidgetStore().clear).mockImplementation(() => {})
+  vi.mocked(
+    useSubgraphNavigationStore().saveCurrentViewport
+  ).mockImplementation(() => {})
+})
+
 describe('insertWorkflow scratch graph isolation', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()
   })
 
@@ -218,4 +199,9 @@ describe('insertWorkflow scratch graph isolation', () => {
       { position: [100, 200] }
     )
   })
+})
+
+vi.mock(import('@vueuse/router'), async () => {
+  const { ref } = await import('vue')
+  return { useRouteHash: () => ref('') }
 })

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1,5 +1,7 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
+import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
+import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -77,22 +79,6 @@ const { mockConfirm, mockTrackWorkflowSaved } = vi.hoisted(() => ({
   mockTrackWorkflowSaved: vi.fn()
 }))
 
-const draftStoreMocks = vi.hoisted(() => ({
-  saveDraft: vi.fn(() => true),
-  getDraft: vi.fn(),
-  removeDraft: vi.fn(),
-  markDraftUsed: vi.fn()
-}))
-
-const subgraphNavigationMocks = vi.hoisted(() => ({
-  navigationIntentId: 0,
-  beginWorkflowNavigation: vi.fn(
-    () => ++subgraphNavigationMocks.navigationIntentId
-  ),
-  endWorkflowNavigation: vi.fn(),
-  saveCurrentViewport: vi.fn()
-}))
-
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     prompt: vi.fn(),
@@ -103,7 +89,7 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: { ds: { offset: [0, 0], scale: 1 } },
-    rootGraph: { serialize: vi.fn(() => ({})), extra: {} },
+    rootGraph: { serialize: vi.fn(() => ({})), extra: {}, nodes: [] },
     loadGraphData: vi.fn(),
     nodeOutputs: {},
     nodePreviewImages: {}
@@ -114,14 +100,6 @@ vi.mock<unknown>(import('@/scripts/defaultGraph'), () => ({
   defaultGraph: {},
   blankGraph: {}
 }))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({ linearMode: false })
-  })
-)
 
 vi.mock<unknown>(
   import('@/renderer/core/thumbnail/useWorkflowThumbnail'), // eslint-disable-line import-x/no-restricted-paths
@@ -145,31 +123,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     trackDefaultViewSet: vi.fn(),
     trackWorkflowSaved: mockTrackWorkflowSaved,
     trackEnterLinear: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/persistence/stores/workflowDraftStoreV2'),
-  () => ({
-    useWorkflowDraftStoreV2: () => draftStoreMocks
-  })
-)
-
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({
-    clear: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => subgraphNavigationMocks
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    get workflow() {
-      return useWorkflowStore()
-    }
   })
 }))
 
@@ -198,12 +151,28 @@ function enableWarningSettings() {
   )
 }
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { linearMode: false })
+  vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockImplementation(() => true)
+  vi.mocked(useWorkflowDraftStoreV2().getDraft).mockReturnValue(null)
+  vi.mocked(useWorkflowDraftStoreV2().removeDraft).mockImplementation(() => {})
+  vi.mocked(useWorkflowDraftStoreV2().markDraftUsed).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useDomWidgetStore().clear).mockImplementation(() => {})
+  vi.mocked(
+    useSubgraphNavigationStore().saveCurrentViewport
+  ).mockImplementation(() => {})
+  vi.mocked(
+    useSubgraphNavigationStore().endWorkflowNavigation
+  ).mockImplementation(() => {})
+})
+
 describe('useWorkflowService', () => {
   beforeEach(() => {
     vi.mocked(app.loadGraphData).mockResolvedValue(true)
     resetWorkflowLoadQueueForTests()
-    draftStoreMocks.saveDraft.mockReturnValue(true)
-    subgraphNavigationMocks.navigationIntentId = 0
+    vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -330,9 +299,9 @@ describe('useWorkflowService', () => {
 
       useWorkflowService().beforeLoadNewGraph(false)
 
-      expect(subgraphNavigationMocks.saveCurrentViewport).toHaveBeenCalledWith(
-        false
-      )
+      expect(
+        useSubgraphNavigationStore().saveCurrentViewport
+      ).toHaveBeenCalledWith(false)
     })
 
     it('arms suppression by default for a clean workflow load', () => {
@@ -340,9 +309,9 @@ describe('useWorkflowService', () => {
 
       useWorkflowService().beforeLoadNewGraph()
 
-      expect(subgraphNavigationMocks.saveCurrentViewport).toHaveBeenCalledWith(
-        true
-      )
+      expect(
+        useSubgraphNavigationStore().saveCurrentViewport
+      ).toHaveBeenCalledWith(true)
     })
 
     it('should cache missingModelCandidates and missingMediaCandidates to activeWorkflow.pendingWarnings', () => {
@@ -372,8 +341,12 @@ describe('useWorkflowService', () => {
         }
       ]
 
-      useMissingModelStore().missingModelCandidates = modelCandidates
-      useMissingMediaStore().missingMediaCandidates = mediaCandidates
+      Object.assign(useMissingModelStore(), {
+        missingModelCandidates: modelCandidates
+      })
+      Object.assign(useMissingMediaStore(), {
+        missingMediaCandidates: mediaCandidates
+      })
 
       useWorkflowService().beforeLoadNewGraph()
 
@@ -411,7 +384,7 @@ describe('useWorkflowService', () => {
 
       useWorkflowService().beforeLoadNewGraph()
 
-      expect(draftStoreMocks.saveDraft).toHaveBeenCalledWith(
+      expect(useWorkflowDraftStoreV2().saveDraft).toHaveBeenCalledWith(
         activeWorkflow.path,
         JSON.stringify(activeWorkflow.activeState),
         {
@@ -426,7 +399,7 @@ describe('useWorkflowService', () => {
         return key === 'Comfy.Workflow.Persist'
       })
       const addToastSpy = vi.spyOn(useToastStore(), 'add')
-      draftStoreMocks.saveDraft.mockReturnValue(false)
+      vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockReturnValue(false)
       const activeWorkflow = createModeTestWorkflow({
         path: 'workflows/test.json'
       })
@@ -452,7 +425,7 @@ describe('useWorkflowService', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {})
       const error = new Error('storage unavailable')
-      draftStoreMocks.saveDraft.mockImplementation(() => {
+      vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockImplementation(() => {
         throw error
       })
       const activeWorkflow = createModeTestWorkflow({
@@ -569,7 +542,7 @@ describe('useWorkflowService', () => {
       // The Aug-12 review's baked-in gap, un-baked: a tab that failed to
       // close must keep its draft.
       expect(storeClose).not.toHaveBeenCalled()
-      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalled()
+      expect(useWorkflowDraftStoreV2().removeDraft).not.toHaveBeenCalled()
       consoleError.mockRestore()
     })
 
@@ -600,14 +573,14 @@ describe('useWorkflowService', () => {
       ).resolves.toBe(false)
 
       expect(storeClose).not.toHaveBeenCalled()
-      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalled()
+      expect(useWorkflowDraftStoreV2().removeDraft).not.toHaveBeenCalled()
       expect(workflowStore.openWorkflows.map((open) => open.path)).toContain(
         'workflows/closing.json'
       )
       // The failed load's intent is released (guarded no-op when the hash
       // publish already superseded it) - pins the sibling of the catch path.
       expect(
-        subgraphNavigationMocks.endWorkflowNavigation
+        useSubgraphNavigationStore().endWorkflowNavigation
       ).toHaveBeenCalledWith(1)
     })
 
@@ -631,7 +604,7 @@ describe('useWorkflowService', () => {
       ).resolves.toBe(false)
 
       expect(storeClose).not.toHaveBeenCalled()
-      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalled()
+      expect(useWorkflowDraftStoreV2().removeDraft).not.toHaveBeenCalled()
       expect(workflowStore.openWorkflows.map((open) => open.path)).toContain(
         'workflows/closing.json'
       )
@@ -748,7 +721,7 @@ describe('useWorkflowService', () => {
         errorType: 'workflow_load_failure'
       })
       expect(
-        subgraphNavigationMocks.endWorkflowNavigation
+        useSubgraphNavigationStore().endWorkflowNavigation
       ).toHaveBeenCalledWith(1)
       expect(
         vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
@@ -1647,7 +1620,6 @@ describe('useWorkflowService', () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>
 
     beforeEach(() => {
-      setActivePinia(createTestingPinia())
       workflowStore = useWorkflowStore()
     })
 
@@ -1741,7 +1713,6 @@ describe('useWorkflowService', () => {
     let existingWorkflow: LoadedComfyWorkflow
 
     beforeEach(() => {
-      setActivePinia(createTestingPinia())
       workflowStore = useWorkflowStore()
       existingWorkflow = createModeTestWorkflow({
         path: 'workflows/repeat.json'
@@ -2245,7 +2216,6 @@ describe('useWorkflowService', () => {
 
   describe('renameWorkflow', () => {
     it('keeps run errors attached to a renamed workflow', async () => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
       const workflowStore = useWorkflowStore()
       const service = useWorkflowService()
       const executionErrorStore = useExecutionErrorStore()
@@ -2745,3 +2715,15 @@ describe('useWorkflowService', () => {
     })
   })
 })
+
+vi.mock(import('@vueuse/router'), async () => {
+  const { ref } = await import('vue')
+  return { useRouteHash: () => ref('') }
+})
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workflow/core/utils/workflowToClipboardItems.integration.test.ts
+++ b/src/platform/workflow/core/utils/workflowToClipboardItems.integration.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ISlotType } from '@/lib/litegraph/src/interfaces'
 import {
@@ -21,19 +19,9 @@ import { createUuidv4 } from '@/utils/uuid'
 
 import { workflowToClipboardItems } from './workflowToClipboardItems'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('workflow clipboard insertion', () => {
   it('pastes reroutes at their source-relative position', () => {

--- a/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
@@ -1,5 +1,7 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
 
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowAutoSave } from '@/platform/workflow/persistence/composables/useWorkflowAutoSave'
@@ -21,35 +23,18 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key) => {
-      if (key === 'Comfy.Workflow.AutoSave') return mockAutoSaveSetting
-      if (key === 'Comfy.Workflow.AutoSaveDelay') return mockAutoSaveDelay
-      return null
-    })
-  }))
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      activeWorkflow: mockActiveWorkflow
-    }))
-  })
-)
-
-let mockAutoSaveSetting: string = 'off'
-let mockAutoSaveDelay: number = 1000
-let mockActiveWorkflow: { isModified: boolean; isPersisted?: boolean } | null =
-  null
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'off'
+  useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+})
 
 describe('useWorkflowAutoSave', () => {
   it('should auto-save workflow after delay when modified and autosave enabled', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -63,14 +48,16 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).toHaveBeenCalledWith(
-      mockActiveWorkflow
+      useWorkflowStore().activeWorkflow
     )
   })
 
   it('should not auto-save workflow after delay when not modified and autosave enabled', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: false, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: false, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -84,14 +71,16 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalledWith(
-      mockActiveWorkflow
+      useWorkflowStore().activeWorkflow
     )
   })
 
   it('should not auto save workflow when autosave is off', async () => {
-    mockAutoSaveSetting = 'off'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'off'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -101,16 +90,18 @@ describe('useWorkflowAutoSave', () => {
       }
     })
 
-    vi.advanceTimersByTime(mockAutoSaveDelay)
+    vi.advanceTimersByTime(1000)
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalled()
   })
 
   it('should respect the user specified auto save delay', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 2000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 2000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -131,9 +122,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should debounce save requests', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 2000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 2000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -161,9 +154,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should handle save error gracefully', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -195,9 +190,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should queue autosave requests during saving and reschedule after save completes', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -229,7 +226,7 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should clean up event listeners on component unmount', async () => {
-    mockAutoSaveSetting = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
 
     const { unmount } = render({
       template: `<div></div>`,
@@ -245,9 +242,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should handle edge case delay values properly', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 0
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 0
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -263,7 +262,7 @@ describe('useWorkflowAutoSave', () => {
     expect(serviceInstance.saveWorkflow).toHaveBeenCalledTimes(1)
     serviceInstance.saveWorkflow.mockClear()
 
-    mockAutoSaveDelay = -500
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = -500
 
     const graphChangedCallback = vi.mocked(api.addEventListener).mock
       .calls[0][1]
@@ -275,9 +274,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should not autosave if workflow is not persisted', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: false }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: false }
+    })
 
     render({
       template: `<div></div>`,
@@ -291,7 +292,7 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalledWith(
-      mockActiveWorkflow
+      useWorkflowStore().activeWorkflow
     )
   })
 })

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -1,5 +1,8 @@
+import { useCommandStore } from '@/stores/commandStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, nextTick, reactive } from 'vue'
+import { createApp, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
@@ -8,28 +11,6 @@ import { StorageKeys } from '../base/storageKeys'
 import * as storageIO from '../base/storageIO'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowPersistenceV2 } from './useWorkflowPersistenceV2'
-
-const settingMocks = vi.hoisted(() => ({
-  persistRef: null as { value: boolean } | null,
-  values: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), async () => {
-  const { ref } = await import('vue')
-  settingMocks.persistRef = ref(true)
-  return {
-    useSettingStore: vi.fn(() => ({
-      get: vi.fn((key: string) => {
-        if (key === 'Comfy.Workflow.Persist')
-          return settingMocks.persistRef!.value
-        return settingMocks.values[key]
-      }),
-      set: vi.fn((key: string, value: unknown) => {
-        settingMocks.values[key] = value
-      })
-    }))
-  }
-})
 
 const mockToastAdd = vi.fn()
 vi.mock<unknown>(
@@ -80,16 +61,6 @@ vi.mock(
     })
   })
 )
-
-const commandStoreMocks = vi.hoisted(() => ({
-  execute: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: commandStoreMocks.execute
-  })
-}))
 
 const routeMocks = vi.hoisted(() => ({
   query: {} as Record<string, unknown>
@@ -155,18 +126,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-const teamWorkspaceStoreMocks = reactive({
-  initState: 'uninitialized',
-  activeWorkspaceId: null as string | null
-})
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => teamWorkspaceStoreMocks
-  })
-)
-
 vi.mock(import('../migration/migrateV1toV2'), () => ({
   migrateV1toV2: vi.fn()
 }))
@@ -212,6 +171,10 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 
 type WorkflowPersistence = ReturnType<typeof useWorkflowPersistenceV2>
 
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
+
 describe('useWorkflowPersistenceV2', () => {
   const mountedApps: Array<{
     app: ReturnType<typeof createApp>
@@ -219,8 +182,7 @@ describe('useWorkflowPersistenceV2', () => {
   }> = []
 
   beforeEach(() => {
-    settingMocks.persistRef!.value = true
-    settingMocks.values = {}
+    useSettingStore().settingValues['Comfy.Workflow.Persist'] = true
     mocks.state.graphChangedHandler = null
     mocks.state.currentGraph = { initial: true }
     mocks.serializeMock.mockImplementation(() => mocks.state.currentGraph)
@@ -237,8 +199,8 @@ describe('useWorkflowPersistenceV2', () => {
     routeMocks.query = {}
     preservedQueryMocks.payloads = {}
     distributionMocks.isCloud = false
-    teamWorkspaceStoreMocks.initState = 'uninitialized'
-    teamWorkspaceStoreMocks.activeWorkspaceId = null
+    Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
   })
 
   afterEach(() => {
@@ -329,7 +291,7 @@ describe('useWorkflowPersistenceV2', () => {
       mountWorkflowPersistence()
       expect(resetSpy).not.toHaveBeenCalled()
 
-      settingMocks.persistRef!.value = false
+      useSettingStore().settingValues['Comfy.Workflow.Persist'] = false
       await nextTick()
 
       expect(resetSpy).toHaveBeenCalledOnce()
@@ -582,7 +544,7 @@ describe('useWorkflowPersistenceV2', () => {
     })
 
     it('skips activation when persistence is disabled', async () => {
-      settingMocks.persistRef!.value = false
+      useSettingStore().settingValues['Comfy.Workflow.Persist'] = false
       vi.spyOn(useWorkflowStore(), 'loadWorkflows').mockResolvedValue()
 
       const { restoreWorkflowTabsState } = mountWorkflowPersistence()
@@ -608,7 +570,7 @@ describe('useWorkflowPersistenceV2', () => {
       await mountWorkflowPersistence().initializeWorkflow()
 
       expect(
-        settingMocks.values['Comfy.TutorialCompleted'],
+        useSettingStore().settingValues['Comfy.TutorialCompleted'],
         'Startup must not mark the tutorial completed; deciding that is the onboarding entry point’s job, not the graph loader’s'
       ).toBeUndefined()
     })
@@ -678,7 +640,7 @@ describe('useWorkflowPersistenceV2', () => {
     })
 
     it('reports restored for a user who already completed the tutorial', async () => {
-      settingMocks.values['Comfy.TutorialCompleted'] = true
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
 
       const { initializeWorkflow } = mountWorkflowPersistence()
 
@@ -863,8 +825,8 @@ describe('useWorkflowPersistenceV2', () => {
       })
     ).toBe(false)
 
-    teamWorkspaceStoreMocks.activeWorkspaceId = 'workspace-a'
-    teamWorkspaceStoreMocks.initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-a' })
+    Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
     await nextTick()
 
     expect(
@@ -890,8 +852,8 @@ describe('useWorkflowPersistenceV2', () => {
     onLogout()
     onUserResolved({ id: 'user-c' })
 
-    teamWorkspaceStoreMocks.activeWorkspaceId = 'workspace-c'
-    teamWorkspaceStoreMocks.initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-c' })
+    Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
     await nextTick()
 
     expect(completeTransitionSpy).toHaveBeenCalledOnce()
@@ -912,7 +874,7 @@ describe('useWorkflowPersistenceV2', () => {
 
     expect(completeTransitionSpy).not.toHaveBeenCalled()
 
-    teamWorkspaceStoreMocks.initState = 'error'
+    Object.assign(useTeamWorkspaceStore(), { initState: 'error' })
     await nextTick()
 
     expect(completeTransitionSpy).toHaveBeenCalledOnce()
@@ -961,8 +923,10 @@ describe('useWorkflowPersistenceV2', () => {
       WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
       JSON.stringify({ id: destinationWorkspaceId, type: 'team' })
     )
-    teamWorkspaceStoreMocks.activeWorkspaceId = destinationWorkspaceId
-    teamWorkspaceStoreMocks.initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: destinationWorkspaceId
+    })
+    Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
     await nextTick()
 
     mocks.state.currentGraph = { marker: 'destination-edit' }

--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
@@ -1,30 +1,11 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive } from 'vue'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import ShareWorkflowDialogContent from '@/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue'
-
-const mockWorkflowStore = reactive<{
-  activeWorkflow: {
-    path: string
-    directory: string
-    filename: string
-    isTemporary: boolean
-    isModified: boolean
-    lastModified: number
-  } | null
-}>({
-  activeWorkflow: null
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => mockWorkflowStore
-  })
-)
 
 const mockTrackShareFlow = vi.hoisted(() => vi.fn())
 
@@ -164,14 +145,16 @@ describe('ShareWorkflowDialogContent', () => {
   const onClose = vi.fn()
 
   beforeEach(() => {
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: false,
-      lastModified: 1000
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: false,
+        lastModified: 1000
+      }
+    })
     mockGetPublishStatus.mockResolvedValue({
       isPublished: false,
       shareId: null,
@@ -233,14 +216,16 @@ describe('ShareWorkflowDialogContent', () => {
   }
 
   it('renders in unsaved state when workflow is modified', async () => {
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: true,
-      lastModified: 1000
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: true,
+        lastModified: 1000
+      }
+    })
     const { container } = renderComponent()
     await flushPromises()
 
@@ -429,14 +414,16 @@ describe('ShareWorkflowDialogContent', () => {
     const publishedAt = new Date('2026-01-15T00:00:00Z')
     const savedAfterPublishMs = publishedAt.getTime() + 60_000
 
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: false,
-      lastModified: savedAfterPublishMs
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: false,
+        lastModified: savedAfterPublishMs
+      }
+    })
     mockGetPublishStatus.mockResolvedValue({
       isPublished: true,
       shareId: 'abc-123',
@@ -455,14 +442,16 @@ describe('ShareWorkflowDialogContent', () => {
     const publishedAt = new Date('2026-01-15T00:00:00Z')
     const savedBeforePublishMs = publishedAt.getTime() - 60_000
 
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: false,
-      lastModified: savedBeforePublishMs
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: false,
+        lastModified: savedBeforePublishMs
+      }
+    })
     mockGetPublishStatus.mockResolvedValue({
       isPublished: true,
       shareId: 'abc-123',
@@ -479,14 +468,16 @@ describe('ShareWorkflowDialogContent', () => {
 
   describe('error and edge cases', () => {
     it('renders unsaved state when workflow is temporary', async () => {
-      mockWorkflowStore.activeWorkflow = {
-        path: 'workflows/Unsaved Workflow.json',
-        directory: 'workflows',
-        filename: 'Unsaved Workflow.json',
-        isTemporary: true,
-        isModified: false,
-        lastModified: 1000
-      }
+      Object.assign(useWorkflowStore(), {
+        activeWorkflow: {
+          path: 'workflows/Unsaved Workflow.json',
+          directory: 'workflows',
+          filename: 'Unsaved Workflow.json',
+          isTemporary: true,
+          isModified: false,
+          lastModified: 1000
+        }
+      })
       const { container } = renderComponent()
       await flushPromises()
 
@@ -532,7 +523,7 @@ describe('ShareWorkflowDialogContent', () => {
     })
 
     it('renders unsaved state when no active workflow exists', async () => {
-      mockWorkflowStore.activeWorkflow = null
+      Object.assign(useWorkflowStore(), { activeWorkflow: null })
       const { container } = renderComponent()
       await flushPromises()
 
@@ -547,7 +538,7 @@ describe('ShareWorkflowDialogContent', () => {
       renderComponent()
       await flushPromises()
 
-      mockWorkflowStore.activeWorkflow = null
+      Object.assign(useWorkflowStore(), { activeWorkflow: null })
 
       const publishButton = screen.getByRole('button', {
         name: /Create link/i

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -109,41 +110,8 @@ vi.mock<unknown>(
   })
 )
 
-const mockWorkflowStore = vi.hoisted(() => {
-  return {
-    instance: null as { activeWorkflow: Record<string, unknown> | null } | null
-  }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mockWorkflowStore.instance = reactive({
-      activeWorkflow: {
-        path: 'workflows/test.json',
-        filename: 'test.json',
-        directory: 'workflows',
-        isTemporary: false,
-        isModified: false
-      }
-    })
-    return {
-      useWorkflowStore: () => ({
-        ...mockWorkflowStore.instance,
-        get activeWorkflow() {
-          return mockWorkflowStore.instance?.activeWorkflow ?? null
-        },
-        saveWorkflow: vi.fn()
-      })
-    }
-  }
-)
-
 function setActiveWorkflow(workflow: Record<string, unknown> | null) {
-  if (mockWorkflowStore.instance) {
-    mockWorkflowStore.instance.activeWorkflow = workflow
-  }
+  Object.assign(useWorkflowStore(), { activeWorkflow: workflow })
 }
 
 function createTestI18n() {
@@ -171,6 +139,10 @@ function createTestI18n() {
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
+
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().saveWorkflow).mockResolvedValue(undefined)
+})
 
 describe('ComfyHubPublishDialog', () => {
   const onClose = vi.fn()

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyHubProfile } from '@/schemas/apiSchema'
@@ -40,19 +41,6 @@ vi.mock<unknown>(
   })
 )
 
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: {
-    path: 'workflows/demo-workflow.json'
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => mockWorkflowStore
-  })
-)
-
 const { useComfyHubPublishSubmission } =
   await import('./useComfyHubPublishSubmission')
 
@@ -78,6 +66,12 @@ function createFormData(
     ...overrides
   }
 }
+
+beforeEach(() => {
+  Object.assign(useWorkflowStore(), {
+    activeWorkflow: { path: 'workflows/demo-workflow.json' }
+  })
+})
 
 describe('useComfyHubPublishSubmission', () => {
   beforeEach(() => {

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
@@ -1,26 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const mockActiveWorkflow = vi.hoisted(() => ({
-  value: { filename: 'my-workflow.json' } as { filename: string } | null
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 const { cachePublishPrefill, getCachedPrefill, useComfyHubPublishWizard } =
   await import('./useComfyHubPublishWizard')
 
 describe('useComfyHubPublishWizard', () => {
   beforeEach(() => {
-    mockActiveWorkflow.value = { filename: 'my-workflow.json' }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { filename: 'my-workflow.json' }
+    })
   })
 
   describe('createDefaultFormData', () => {
@@ -30,7 +18,7 @@ describe('useComfyHubPublishWizard', () => {
     })
 
     it('defaults name to empty string when no active workflow', () => {
-      mockActiveWorkflow.value = null
+      Object.assign(useWorkflowStore(), { activeWorkflow: null })
       const { formData } = useComfyHubPublishWizard()
       expect(formData.value.name).toBe('')
     })

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -1,3 +1,4 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
@@ -113,7 +114,7 @@ function useSharedWorkflowUrlLoader() {
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
-const mockCloseDialog = vi.hoisted(() => vi.fn())
+
 const mockHideTemplateSelector = vi.hoisted(() => vi.fn())
 const mockDialogStack = vi.hoisted(
   () =>
@@ -123,19 +124,10 @@ const mockDialogStack = vi.hoisted(
       dialogComponentProps: Record<string, unknown>
     }>
 )
-const mockUpdateDialog = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     showLayoutDialog: mockShowLayoutDialog
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    dialogStack: mockDialogStack,
-    closeDialog: mockCloseDialog,
-    updateDialog: mockUpdateDialog
   })
 }))
 
@@ -208,13 +200,19 @@ function createDeferred() {
   return { promise, resolve }
 }
 
+beforeEach(() => {
+  Object.assign(useDialogStore(), { dialogStack: [] })
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+  vi.mocked(useDialogStore().updateDialog).mockReturnValue(false)
+})
+
 describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
     mockQueryParams = {}
     mockIsLoggedIn.value = false
     mockDialogStack.length = 0
     mockShowLayoutDialog.mockImplementation(createDialogInstance)
-    mockUpdateDialog.mockImplementation(
+    vi.mocked(useDialogStore().updateDialog).mockImplementation(
       (options: {
         key: string
         contentProps?: Record<string, unknown>
@@ -335,19 +333,19 @@ describe('useSharedWorkflowUrlLoader', () => {
     await Promise.resolve()
 
     expect(dialogInstance.contentProps.openingAction).toBe('copy-and-open')
-    expect(mockUpdateDialog).toHaveBeenCalledWith({
+    expect(useDialogStore().updateDialog).toHaveBeenCalledWith({
       key: 'open-shared-workflow',
       contentProps: { openingAction: 'copy-and-open' }
     })
     expect(dialogInstance.dialogComponentProps.closable).toBeUndefined()
     expect(dialogInstance.dialogComponentProps.closeOnEscape).toBeUndefined()
     expect(dialogInstance.dialogComponentProps.dismissableMask).toBeUndefined()
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
 
     graphLoad.resolve()
     await loadPromise
 
-    expect(mockCloseDialog).toHaveBeenLastCalledWith({
+    expect(useDialogStore().closeDialog).toHaveBeenLastCalledWith({
       key: 'open-shared-workflow'
     })
   })

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -1,3 +1,4 @@
+import { useAssetsStore } from '@/stores/assetsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HubWorkflowDetail } from '@comfyorg/ingest-types'
@@ -19,22 +20,23 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 const mockGetShareableAssets = vi.fn()
 const mockFetchApi = vi.fn()
-const mockInvalidateInputAssets = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    inputAssets: { invalidate: mockInvalidateInputAssets }
-  })
-}))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
+    addEventListener: vi.fn(),
+    getServerFeature: (_name: string, defaultValue: unknown) => defaultValue,
     getShareableAssets: (...args: unknown[]) => mockGetShareableAssets(...args),
     fetchApi: (...args: unknown[]) => mockFetchApi(...args),
     apiURL: (route: string) => `/api${route}`,
     fileURL: (route: string) => route
   }
 }))
+
+beforeEach(() => {
+  vi.spyOn(useAssetsStore().inputAssets, 'invalidate').mockResolvedValue(
+    undefined
+  )
+})
 
 describe(useWorkflowShareService, () => {
   const mockShareableAssets: AssetInfo[] = [
@@ -387,7 +389,7 @@ describe(useWorkflowShareService, () => {
         share_id: 'share-id-1'
       })
     })
-    expect(mockInvalidateInputAssets).toHaveBeenCalledOnce()
+    expect(useAssetsStore().inputAssets.invalidate).toHaveBeenCalledOnce()
   })
 
   it('omits share_id from the payload when not provided', async () => {
@@ -424,7 +426,7 @@ describe(useWorkflowShareService, () => {
     await expect(
       service.importPublishedAssets(['bad-id'], 'share-id-1')
     ).rejects.toThrow('Failed to import assets: 400')
-    expect(mockInvalidateInputAssets).not.toHaveBeenCalled()
+    expect(useAssetsStore().inputAssets.invalidate).not.toHaveBeenCalled()
   })
 
   it('throws when shared workflow payload is invalid', async () => {

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -1,3 +1,4 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent } from 'vue'
@@ -85,23 +86,14 @@ function useTemplateUrlLoader() {
 
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
-// Mock canvas store
-const mockCanvasStore = {
-  linearMode: false
-}
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => mockCanvasStore
-  })
-)
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { linearMode: false })
+})
 
 describe('useTemplateUrlLoader', () => {
   beforeEach(() => {
     mockQueryParams = {}
-    mockCanvasStore.linearMode = false
+    Object.assign(useCanvasStore(), { linearMode: false })
   })
 
   it('does not load template when no query param present', () => {
@@ -309,7 +301,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(true)
+    expect(useCanvasStore().linearMode).toBe(true)
   })
 
   it('does not set linear mode when template loading fails', async () => {
@@ -319,7 +311,7 @@ describe('useTemplateUrlLoader', () => {
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
 
-    expect(mockCanvasStore.linearMode).toBe(false)
+    expect(useCanvasStore().linearMode).toBe(false)
   })
 
   it('does not set linear mode when mode parameter is not linear', async () => {
@@ -332,7 +324,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(false)
+    expect(useCanvasStore().linearMode).toBe(false)
   })
 
   it('rejects invalid mode parameter with special characters', () => {
@@ -372,7 +364,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(false)
+    expect(useCanvasStore().linearMode).toBe(false)
 
     consoleSpy.mockRestore()
   })
@@ -387,7 +379,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(true)
+    expect(useCanvasStore().linearMode).toBe(true)
   })
 
   it('accepts valid format but warns about unsupported modes', async () => {
@@ -397,7 +389,7 @@ describe('useTemplateUrlLoader', () => {
     for (const mode of unsupportedModes) {
       vi.clearAllMocks()
       consoleSpy.mockClear()
-      mockCanvasStore.linearMode = false
+      Object.assign(useCanvasStore(), { linearMode: false })
       mockQueryParams = { template: 'flux_simple', mode }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -410,7 +402,7 @@ describe('useTemplateUrlLoader', () => {
         'flux_simple',
         'default'
       )
-      expect(mockCanvasStore.linearMode).toBe(false)
+      expect(useCanvasStore().linearMode).toBe(false)
     }
 
     consoleSpy.mockRestore()

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -1,3 +1,5 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { usePartnerNodesEducationStore } from '@/platform/workflow/templates/stores/partnerNodesEducationStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent } from 'vue'
@@ -9,14 +11,6 @@ import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/reposit
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
-
-// Mock the store
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
-  () => ({
-    useWorkflowTemplatesStore: vi.fn()
-  })
-)
 
 // Mock the API
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -63,13 +57,6 @@ function useTemplateWorkflows() {
 
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
-// Mock the dialog store
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: vi.fn(() => ({
-    closeDialog: vi.fn()
-  }))
-}))
-
 // useTelemetry() returns null in OSS, a dispatcher in cloud — toggle via mockIsCloud.
 const { mockIsCloud, mockTrackTemplate } = vi.hoisted(() => ({
   mockIsCloud: { value: true },
@@ -81,12 +68,9 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     mockIsCloud.value ? { trackTemplate: mockTrackTemplate } : null
 }))
 
-const { mockDistributionIsCloud, mockRequestCard, mockDismissCard } =
-  vi.hoisted(() => ({
-    mockDistributionIsCloud: { value: false },
-    mockRequestCard: vi.fn(),
-    mockDismissCard: vi.fn()
-  }))
+const { mockDistributionIsCloud } = vi.hoisted(() => ({
+  mockDistributionIsCloud: { value: false }
+}))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -94,20 +78,20 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/stores/partnerNodesEducationStore'),
-  () => ({
-    usePartnerNodesEducationStore: () => ({
-      requestCard: mockRequestCard,
-      dismissCard: mockDismissCard
-    })
-  })
-)
-
 // Mock fetch
 global.fetch = vi.fn()
 
 type MockWorkflowTemplatesStore = ReturnType<typeof useWorkflowTemplatesStore>
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+  vi.mocked(usePartnerNodesEducationStore().requestCard).mockImplementation(
+    () => {}
+  )
+  vi.mocked(usePartnerNodesEducationStore().dismissCard).mockImplementation(
+    () => {}
+  )
+})
 
 describe('useTemplateWorkflows', () => {
   let mockWorkflowTemplatesStore: MockWorkflowTemplatesStore
@@ -117,9 +101,12 @@ describe('useTemplateWorkflows', () => {
     mockDistributionIsCloud.value = false
     mockLoadedWorkflow.value = { key: 'loaded-template' }
 
-    mockWorkflowTemplatesStore = {
+    mockWorkflowTemplatesStore = useWorkflowTemplatesStore()
+    vi.mocked(
+      mockWorkflowTemplatesStore.loadWorkflowTemplates
+    ).mockResolvedValue(undefined)
+    Object.assign(mockWorkflowTemplatesStore, {
       isLoaded: false,
-      loadWorkflowTemplates: vi.fn().mockResolvedValue(true),
       enhancedTemplates: [],
       groupedTemplates: [
         {
@@ -165,11 +152,7 @@ describe('useTemplateWorkflows', () => {
           ]
         }
       ]
-    } as Partial<MockWorkflowTemplatesStore> as MockWorkflowTemplatesStore
-
-    vi.mocked(useWorkflowTemplatesStore).mockReturnValue(
-      mockWorkflowTemplatesStore
-    )
+    })
 
     // Mock fetch response
     vi.mocked(fetch).mockResolvedValue({
@@ -386,7 +369,9 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).toHaveBeenCalledWith('loaded-template')
+    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledWith(
+      'loaded-template'
+    )
   })
 
   it('retires the card instead of requesting it when no workflow was activated', async () => {
@@ -397,8 +382,8 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).not.toHaveBeenCalled()
-    expect(mockDismissCard).toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().requestCard).not.toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().dismissCard).toHaveBeenCalled()
   })
 
   it('binds to the workflow this load activated, resolved by loadGraphData', async () => {
@@ -413,7 +398,9 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).toHaveBeenCalledWith('template-a')
+    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledWith(
+      'template-a'
+    )
   })
 
   it('does not request the education card for open-source templates', async () => {
@@ -423,7 +410,7 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).not.toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().requestCard).not.toHaveBeenCalled()
   })
 
   it('retires an earlier request when an open-source template loads next', async () => {
@@ -435,12 +422,12 @@ describe('useTemplateWorkflows', () => {
     )
 
     await loadWorkflowTemplate('template1', 'default')
-    expect(mockRequestCard).toHaveBeenCalledTimes(1)
+    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledTimes(1)
 
     // The open-source template may still contain partner nodes, so the card
     // would otherwise linger and describe the wrong template.
     await loadWorkflowTemplate('template2', 'default')
-    expect(mockDismissCard).toHaveBeenCalledTimes(1)
+    expect(usePartnerNodesEducationStore().dismissCard).toHaveBeenCalledTimes(1)
   })
 
   it('should handle errors when loading templates', async () => {

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -5,20 +6,14 @@ import type {
   SavedPaymentMethod
 } from './workspaceApi'
 
-const {
-  mockAxiosInstance,
-  mockGetWorkspaceAuthHeaderOrThrow,
-  mockGetFirebaseAuthHeaderOrThrow
-} = vi.hoisted(() => ({
+const { mockAxiosInstance } = vi.hoisted(() => ({
   mockAxiosInstance: {
     get: vi.fn(),
     post: vi.fn(),
     patch: vi.fn(),
     delete: vi.fn(),
     interceptors: { response: { use: vi.fn() } }
-  },
-  mockGetWorkspaceAuthHeaderOrThrow: vi.fn(),
-  mockGetFirebaseAuthHeaderOrThrow: vi.fn()
+  }
 }))
 
 vi.mock<unknown>(import('axios'), () => ({
@@ -39,44 +34,45 @@ vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) => key)
 }))
 
-vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: {
+vi.mock(import('@/scripts/api'), async (importOriginal) => ({
+  api: Object.assign((await importOriginal()).api, {
     apiURL: vi.fn((path: string) => `/api${path}`)
-  }
+  })
 }))
 
 vi.mock(import('./workspaceApiUrl'), () => ({
   workspaceApiUrl: (path: string) => `/api${path}`
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    getWorkspaceAuthHeaderOrThrow: mockGetWorkspaceAuthHeaderOrThrow,
-    getFirebaseAuthHeaderOrThrow: mockGetFirebaseAuthHeaderOrThrow
-  })
-}))
-
 import { workspaceApi } from './workspaceApi'
 
-const AUTH_HEADER = { Authorization: 'Bearer test-token' }
+const AUTH_HEADER = { Authorization: 'Bearer test-token' } as const
 
 describe('workspaceApi', () => {
   beforeEach(() => {
-    mockGetWorkspaceAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
-    mockGetFirebaseAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
+    vi.mocked(useAuthStore().getWorkspaceAuthHeaderOrThrow).mockResolvedValue(
+      AUTH_HEADER
+    )
+    vi.mocked(useAuthStore().getFirebaseAuthHeaderOrThrow).mockResolvedValue(
+      AUTH_HEADER
+    )
   })
 
   describe('authentication', () => {
     it('propagates error when workspace authentication rejects', async () => {
       const authError = new Error('toastMessages.userNotAuthenticated')
-      mockGetWorkspaceAuthHeaderOrThrow.mockRejectedValue(authError)
+      vi.mocked(useAuthStore().getWorkspaceAuthHeaderOrThrow).mockRejectedValue(
+        authError
+      )
 
       await expect(workspaceApi.list()).rejects.toBe(authError)
     })
 
     it('propagates error when getFirebaseAuthHeaderOrThrow rejects', async () => {
       const authError = new Error('toastMessages.userNotAuthenticated')
-      mockGetFirebaseAuthHeaderOrThrow.mockRejectedValue(authError)
+      vi.mocked(useAuthStore().getFirebaseAuthHeaderOrThrow).mockRejectedValue(
+        authError
+      )
 
       await expect(workspaceApi.acceptInvite('token')).rejects.toBe(authError)
     })
@@ -340,8 +336,10 @@ describe('workspaceApi', () => {
 
       const result = await workspaceApi.acceptInvite('abc-token')
 
-      expect(mockGetFirebaseAuthHeaderOrThrow).toHaveBeenCalled()
-      expect(mockGetWorkspaceAuthHeaderOrThrow).not.toHaveBeenCalled()
+      expect(useAuthStore().getFirebaseAuthHeaderOrThrow).toHaveBeenCalled()
+      expect(
+        useAuthStore().getWorkspaceAuthHeaderOrThrow
+      ).not.toHaveBeenCalled()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/invites/abc-token/accept',
         null,
@@ -789,3 +787,10 @@ describe('workspaceApi', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -1,7 +1,10 @@
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -17,16 +20,7 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 
-const mockIsInitialized = ref(false)
-const mockCurrentUser = ref<object | null>(null)
 const mockLogout = vi.fn()
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    isInitialized: mockIsInitialized,
-    currentUser: mockCurrentUser
-  })
-}))
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: () => ({ logout: mockLogout })
@@ -63,52 +57,7 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-const mockMintAtLogin = vi.fn()
-const mockGetUnifiedToken = vi.fn()
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({
-      mintAtLogin: mockMintAtLogin,
-      getUnifiedToken: mockGetUnifiedToken
-    })
-  })
-)
-
-const mockWorkspaceStoreInitialize = vi.fn()
-const mockWorkspaceStoreReset = vi.fn()
 const mockBillingCapabilitiesInitialize = vi.hoisted(() => vi.fn())
-const mockWorkspaceStoreInitState = vi.hoisted(() => ({
-  value: 'uninitialized' as string
-}))
-const mockActiveWorkspaceId = vi.hoisted(() => ({
-  value: 'workspace-123' as string | null
-}))
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get initState() {
-        return mockWorkspaceStoreInitState.value
-      },
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      initialize: mockWorkspaceStoreInitialize,
-      resetForIdentityChange: mockWorkspaceStoreReset
-    })
-  })
-)
-
-const mockApiKeyAuthenticated = ref(false)
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => ({
-    get isAuthenticated() {
-      return mockApiKeyAuthenticated.value
-    },
-    getApiKey: () => (mockApiKeyAuthenticated.value ? 'comfyui-test-key' : null)
-  })
-}))
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useBillingCapabilities'),
@@ -126,27 +75,50 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
+beforeEach(() => {
+  vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(false)
+  vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockReturnValue(undefined)
+})
+
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().initialize).mockResolvedValue(undefined)
+  vi.mocked(useTeamWorkspaceStore().resetForIdentityChange).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useApiKeyAuthStore().getApiKey).mockImplementation(() =>
+    useApiKeyAuthStore().isAuthenticated ? 'comfyui-test-key' : null
+  )
+})
+
 describe('WorkspaceAuthGate', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockIsInitialized.value = false
-    mockCurrentUser.value = null
-    mockApiKeyAuthenticated.value = false
+    Object.assign(useAuthStore(), { isInitialized: false })
+    Object.assign(useAuthStore(), { currentUser: null })
+    Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
     mockUnifiedCloudAuthEnabled.value = false
     mockRemoteConfigState.value = 'authenticated'
     mockRemoteConfigErrorStatus.value = null
-    mockWorkspaceStoreInitState.value = 'uninitialized'
-    mockActiveWorkspaceId.value = 'workspace-123'
+    Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: 'workspace-123'
+    })
     mockRefreshRemoteConfig.mockResolvedValue(undefined)
     mockBillingCapabilitiesInitialize.mockResolvedValue(undefined)
-    mockWorkspaceStoreInitialize.mockImplementation(async () => {
-      mockWorkspaceStoreInitState.value = 'ready'
+    vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+      async () => {
+        Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
+      }
+    )
+    vi.mocked(
+      useTeamWorkspaceStore().resetForIdentityChange
+    ).mockImplementation(() => {
+      Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
     })
-    mockWorkspaceStoreReset.mockImplementation(() => {
-      mockWorkspaceStoreInitState.value = 'uninitialized'
-    })
-    mockMintAtLogin.mockResolvedValue(true)
-    mockGetUnifiedToken.mockReturnValue('cloud-jwt')
+    vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(true)
+    vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockReturnValue(
+      'cloud-jwt'
+    )
   })
 
   const i18n = createI18n({
@@ -176,41 +148,41 @@ describe('WorkspaceAuthGate', () => {
 
     it('initializes workspace context in the background for a signed-in user', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
 
       mountComponent()
       await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
       expect(mockBillingCapabilitiesInitialize).not.toHaveBeenCalled()
       expect(mockRefreshRemoteConfig).not.toHaveBeenCalled()
     })
 
     it('initializes workspace context after a mid-session sign-in', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { isInitialized: true })
 
       mountComponent()
       await flushPromises()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
 
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
     })
 
     it('deduplicates mount and auth-hydration initialization', async () => {
       mockIsCloud.value = false
 
       mountComponent()
-      mockCurrentUser.value = { uid: 'user-123' }
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
     })
 
     it('cancels pending initialization when unmounted', async () => {
@@ -218,71 +190,71 @@ describe('WorkspaceAuthGate', () => {
 
       const { unmount } = mountComponent()
       unmount()
-      mockCurrentUser.value = { uid: 'user-123' }
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('cancels pending initialization on logout', async () => {
       mockIsCloud.value = false
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
 
       mountComponent()
-      mockCurrentUser.value = null
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { currentUser: null })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('initializes workspace context after an API-key sign-in', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { isInitialized: true })
 
       mountComponent()
       await flushPromises()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
 
-      mockApiKeyAuthenticated.value = true
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
     })
 
     it('cancels pending initialization on API-key sign-out', async () => {
       mockIsCloud.value = false
-      mockApiKeyAuthenticated.value = true
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
 
       mountComponent()
-      mockApiKeyAuthenticated.value = false
-      mockIsInitialized.value = true
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('resets workspace state when the session identity changes', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
-      mockApiKeyAuthenticated.value = true
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
 
       mountComponent()
       await flushPromises()
 
-      mockApiKeyAuthenticated.value = false
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
       await flushPromises()
 
-      expect(mockWorkspaceStoreReset).toHaveBeenCalled()
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledTimes(2)
+      expect(useTeamWorkspaceStore().resetForIdentityChange).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledTimes(2)
     })
   })
 
   describe('cloud builds - unauthenticated user', () => {
     it('hides slot while waiting for Firebase auth', () => {
-      mockIsInitialized.value = false
+      Object.assign(useAuthStore(), { isInitialized: false })
 
       mountComponent()
 
@@ -290,13 +262,13 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('renders slot when Firebase initializes with no user', async () => {
-      mockIsInitialized.value = false
+      Object.assign(useAuthStore(), { isInitialized: false })
 
       mountComponent()
       expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
 
-      mockIsInitialized.value = true
-      mockCurrentUser.value = null
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: null })
       await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
@@ -317,8 +289,8 @@ describe('WorkspaceAuthGate', () => {
 
   describe('cloud builds - authenticated user', () => {
     beforeEach(() => {
-      mockIsInitialized.value = true
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
     })
 
     it('refreshes remote config with auth after Firebase init', async () => {
@@ -339,7 +311,7 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(mockMintAtLogin).toHaveBeenCalledOnce()
+      expect(useWorkspaceAuthStore().mintAtLogin).toHaveBeenCalledOnce()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
 
@@ -347,7 +319,7 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalled()
       expect(mockBillingCapabilitiesInitialize).toHaveBeenCalled()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
@@ -408,25 +380,25 @@ describe('WorkspaceAuthGate', () => {
       await flushPromises()
 
       expect(signal.aborted).toBe(true)
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
       expect(mockReportError).not.toHaveBeenCalled()
     })
 
     it('skips workspace init when store is already initialized', async () => {
-      mockWorkspaceStoreInitState.value = 'ready'
+      Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
 
       mountComponent()
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
   })
 
   describe('error handling', () => {
     beforeEach(() => {
-      mockIsInitialized.value = true
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
     })
 
     it('shows a recoverable error when remote config refresh fails', async () => {
@@ -482,7 +454,7 @@ describe('WorkspaceAuthGate', () => {
       expect(
         screen.getByText("Couldn't load your workspace")
       ).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('requires sign out when authenticated config rejects the credential', async () => {
@@ -506,7 +478,7 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows a recoverable error when unified auth initialization fails', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockMintAtLogin.mockResolvedValue(false)
+      vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(false)
 
       mountComponent()
       await flushPromises()
@@ -514,11 +486,11 @@ describe('WorkspaceAuthGate', () => {
       expect(
         screen.getByText("Couldn't load your workspace")
       ).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('shows a recoverable error when workspace store initialization fails', async () => {
-      mockWorkspaceStoreInitialize.mockRejectedValue(
+      vi.mocked(useTeamWorkspaceStore().initialize).mockRejectedValue(
         new Error('Workspace init failed')
       )
 
@@ -531,7 +503,7 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('requires sign out when no workspace is available', async () => {
-      mockWorkspaceStoreInitialize.mockRejectedValue(
+      vi.mocked(useTeamWorkspaceStore().initialize).mockRejectedValue(
         new Error('No workspaces available')
       )
 
@@ -548,7 +520,9 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows a recoverable error when workspace setup clears unified auth', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetUnifiedToken.mockReturnValue(undefined)
+      vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockReturnValue(
+        undefined
+      )
 
       mountComponent()
       await flushPromises()
@@ -559,7 +533,7 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error without a ready workspace context', async () => {
-      mockWorkspaceStoreInitState.value = 'loading'
+      Object.assign(useTeamWorkspaceStore(), { initState: 'loading' })
 
       mountComponent()
       await flushPromises()
@@ -571,13 +545,13 @@ describe('WorkspaceAuthGate', () => {
 
     it('renders the app after retrying a failed initialization', async () => {
       const user = userEvent.setup()
-      mockWorkspaceStoreInitialize
+      vi.mocked(useTeamWorkspaceStore().initialize)
         .mockImplementationOnce(async () => {
-          mockWorkspaceStoreInitState.value = 'error'
+          Object.assign(useTeamWorkspaceStore(), { initState: 'error' })
           throw new Error('Workspace init failed')
         })
         .mockImplementationOnce(async () => {
-          mockWorkspaceStoreInitState.value = 'ready'
+          Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
         })
 
       mountComponent()
@@ -586,7 +560,7 @@ describe('WorkspaceAuthGate', () => {
       await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledTimes(2)
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledTimes(2)
     })
 
     it('keeps the retry action named while retrying', async () => {
@@ -635,7 +609,14 @@ describe('WorkspaceAuthGate', () => {
 
       expect(retrySignal.aborted).toBe(true)
       expect(mockLogout).toHaveBeenCalledOnce()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -1,4 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { getActivePinia } from 'pinia'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -30,27 +31,6 @@ const state = vi.hoisted(() => ({
   showPricingTable: vi.fn(),
   showSettingsDialog: vi.fn()
 }))
-
-const workspaceStoreMock = vi.hoisted(() => ({
-  store: null as null | {
-    initState: string
-    workspaceName: string
-    isInPersonalWorkspace: boolean
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { reactive, ref } = await import('vue')
-    workspaceStoreMock.store = reactive({
-      initState: ref('ready'),
-      workspaceName: ref('Personal Workspace'),
-      isInPersonalWorkspace: ref(true)
-    })
-    return { useTeamWorkspaceStore: () => workspaceStoreMock.store }
-  }
-)
 
 vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({
@@ -173,19 +153,17 @@ function renderComponent(
   type: 'personal' | 'team' = 'personal',
   accountActionsOnly = false
 ) {
-  if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
-  workspaceStoreMock.store.workspaceName = `${type === 'personal' ? 'Personal' : 'Team'} Workspace`
-  workspaceStoreMock.store.isInPersonalWorkspace = type === 'personal'
+  useTeamWorkspaceStore().initState = 'ready'
+  Object.assign(useTeamWorkspaceStore(), {
+    workspaceName: `${type === 'personal' ? 'Personal' : 'Team'} Workspace`
+  })
+  Object.assign(useTeamWorkspaceStore(), {
+    isInPersonalWorkspace: type === 'personal'
+  })
   return render(CurrentUserPopoverWorkspace, {
     props: { accountActionsOnly },
     global: {
-      plugins: [
-        createTestingPinia({
-          createSpy: vi.fn
-        }),
-        PrimeVue,
-        i18n
-      ],
+      plugins: [getActivePinia()!, PrimeVue, i18n],
       directives: {
         tooltip: Tooltip
       },
@@ -376,9 +354,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       screen.queryByRole('button', { name: 'Subscribe' })
     ).not.toBeInTheDocument()
 
-    if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
-    workspaceStoreMock.store.workspaceName = 'Team Workspace'
-    workspaceStoreMock.store.isInPersonalWorkspace = false
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: 'Team Workspace' })
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     await rerender({})
 
     expect(screen.getByTestId('workspace-switcher-trigger')).toHaveTextContent(

--- a/src/platform/workspace/components/InviteMembersForm.test.ts
+++ b/src/platform/workspace/components/InviteMembersForm.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,18 +9,12 @@ import InviteMembersForm from './InviteMembersForm.vue'
 import type { WorkspacePendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const {
-  mockCreateInvite,
-  mockFetchPendingInvites,
   mockFetchStatus,
-  mockPendingInvites,
   mockToastAdd,
   mockTrackInviteSent,
   mockTrackInviteFailed
 } = vi.hoisted(() => ({
-  mockCreateInvite: vi.fn(),
-  mockFetchPendingInvites: vi.fn(),
   mockFetchStatus: vi.fn(),
-  mockPendingInvites: { value: [] as WorkspacePendingInvite[] },
   mockToastAdd: vi.fn(),
   mockTrackInviteSent: vi.fn(),
   mockTrackInviteFailed: vi.fn()
@@ -28,21 +23,6 @@ const {
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({ fetchStatus: mockFetchStatus })
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      createInvite: mockCreateInvite as (
-        email: string
-      ) => Promise<WorkspacePendingInvite>,
-      fetchPendingInvites: mockFetchPendingInvites,
-      get pendingInvites() {
-        return [...mockPendingInvites.value]
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(
   import('primevue/usetoast'), // eslint-disable-line primevue-removal/no-imports
@@ -102,11 +82,13 @@ function submitButton() {
 describe('InviteMembersForm', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockPendingInvites.value = []
-    mockFetchPendingInvites.mockResolvedValue([...mockPendingInvites.value])
+    Object.assign(useTeamWorkspaceStore(), { pendingInvites: [] })
+    vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([
+      ...useTeamWorkspaceStore().pendingInvites
+    ])
     mockFetchStatus.mockResolvedValue(undefined)
-    mockCreateInvite.mockImplementation(async (email: string) =>
-      pendingInviteFor(email)
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => pendingInviteFor(email)
     )
   })
 
@@ -142,9 +124,11 @@ describe('InviteMembersForm', () => {
     await user.type(emailInput(), 'A@B.com C@D.com{Enter}')
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
-    expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
-    expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('a@b.com')
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('c@d.com')
     expect(mockTrackInviteSent).toHaveBeenCalledWith({
       source: 'post_upgrade_success',
       count: 2
@@ -170,8 +154,12 @@ describe('InviteMembersForm', () => {
 
   it('ignores stale cached invites when pending invites cannot be refreshed', async () => {
     const refreshError = new Error('pending invites failed')
-    mockPendingInvites.value.push(pendingInviteFor('stale@example.com'))
-    mockFetchPendingInvites.mockRejectedValueOnce(refreshError)
+    useTeamWorkspaceStore().pendingInvites.push(
+      pendingInviteFor('stale@example.com')
+    )
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockRejectedValueOnce(refreshError)
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { user, emitted } = renderForm()
 
@@ -194,7 +182,9 @@ describe('InviteMembersForm', () => {
     let resolvePendingInvites: (
       invites: WorkspacePendingInvite[]
     ) => void = () => {}
-    mockFetchPendingInvites.mockImplementationOnce(
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolvePendingInvites = resolve
@@ -210,24 +200,28 @@ describe('InviteMembersForm', () => {
     await waitFor(() =>
       expect(submitButton()).toHaveAttribute('aria-busy', 'false')
     )
-    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
   })
 
   it('keeps failed emails for retry and emits all invited emails after recovery', async () => {
     let shouldFail = true
-    mockCreateInvite.mockImplementation(async (email: string) => {
-      if (email === 'fail@x.com' && shouldFail) {
-        shouldFail = false
-        throw new Error('nope')
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => {
+        if (email === 'fail@x.com' && shouldFail) {
+          shouldFail = false
+          throw new Error('nope')
+        }
+        return pendingInviteFor(email)
       }
-      return pendingInviteFor(email)
-    })
+    )
     const { user, emitted } = renderForm()
 
     await user.type(emailInput(), 'ok@x.com fail@x.com{Enter}')
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(screen.getByText('fail@x.com')).toBeInTheDocument()
     expect(screen.queryByText('ok@x.com')).not.toBeInTheDocument()
     expect(mockToastAdd).toHaveBeenCalledWith(
@@ -241,7 +235,9 @@ describe('InviteMembersForm', () => {
 
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(3))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(3)
+    )
     expect(emitted().submitted).toEqual([[['ok@x.com', 'fail@x.com']]])
     expect(mockTrackInviteSent).toHaveBeenCalledTimes(2)
     expect(mockTrackInviteSent).toHaveBeenLastCalledWith({
@@ -251,13 +247,17 @@ describe('InviteMembersForm', () => {
   })
 
   it('keeps all chips, toasts, and emits nothing when every invite fails', async () => {
-    mockCreateInvite.mockRejectedValue(new Error('nope'))
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockRejectedValue(
+      new Error('nope')
+    )
     const { user, emitted } = renderForm()
 
     await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(screen.getByText('a@b.com')).toBeInTheDocument()
     expect(screen.getByText('c@d.com')).toBeInTheDocument()
     expect(mockToastAdd).toHaveBeenCalledWith(
@@ -295,8 +295,10 @@ describe('InviteMembersForm', () => {
 
   it('disables submit when every email has a pending invite', async () => {
     const pendingInvite = pendingInviteFor('ALREADY@EXAMPLE.COM')
-    mockPendingInvites.value.push(pendingInvite)
-    mockFetchPendingInvites.mockResolvedValueOnce([pendingInvite])
+    useTeamWorkspaceStore().pendingInvites.push(pendingInvite)
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockResolvedValueOnce([pendingInvite])
     const { user } = renderForm()
 
     await user.type(emailInput(), 'already@example.com{Enter}')
@@ -305,7 +307,7 @@ describe('InviteMembersForm', () => {
       screen.getByText('workspacePanel.inviteMemberDialog.pendingInviteSingle')
     ).toBeInTheDocument()
     expect(submitButton()).toBeDisabled()
-    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
   })
 
   it('skips pending invites and sends the rest of the batch', async () => {
@@ -313,8 +315,10 @@ describe('InviteMembersForm', () => {
       pendingInviteFor('first@example.com'),
       pendingInviteFor('second@example.com')
     ]
-    mockPendingInvites.value.push(...pendingInvites)
-    mockFetchPendingInvites.mockResolvedValueOnce(pendingInvites)
+    useTeamWorkspaceStore().pendingInvites.push(...pendingInvites)
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockResolvedValueOnce(pendingInvites)
     const { user, emitted } = renderForm({ maxSeats: 3, occupiedSeats: 2 })
 
     await user.type(
@@ -329,8 +333,12 @@ describe('InviteMembersForm', () => {
 
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledOnce())
-    expect(mockCreateInvite).toHaveBeenCalledWith('new@example.com')
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledOnce()
+    )
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith(
+      'new@example.com'
+    )
     expect(emitted().submitted).toEqual([[['new@example.com']]])
   })
 
@@ -354,7 +362,7 @@ describe('InviteMembersForm', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(emitted().cancel).toBeTruthy()
-    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
   })
 
   it('hides the built-in submit row when showSubmit is false', () => {

--- a/src/platform/workspace/components/PricingTableWorkspace.test.ts
+++ b/src/platform/workspace/components/PricingTableWorkspace.test.ts
@@ -1,3 +1,4 @@
+import { useCommandStore } from '@/stores/commandStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -42,10 +43,6 @@ function apiPlan(
   }
 }
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
-}))
-
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -75,6 +72,10 @@ function renderComponent() {
     }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
 
 describe('PricingTableWorkspace credit allotment copy', () => {
   beforeEach(() => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -1,8 +1,10 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import { toRef, computed, ref } from 'vue'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { BillingType, SubscriptionInfo } from '@/composables/billing/types'
@@ -18,12 +20,6 @@ import type {
 
 import SubscriptionPanelContentWorkspace from './SubscriptionPanelContentWorkspace.vue'
 
-const { mockIsSettingUp, mockSubscriptionActionOperation } = vi.hoisted(() => ({
-  mockIsSettingUp: { value: false },
-  mockSubscriptionActionOperation: {
-    value: undefined as { actionUrl: string } | undefined
-  }
-}))
 const mockDistributionState = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock<unknown>(import('@/composables/billing/useBillingRouting'), () => ({
@@ -89,8 +85,7 @@ function scheduledChange(
 }
 const mockHasSubscription = ref(true)
 const mockIsActiveSubscription = ref(true)
-const mockIsInPersonalWorkspace = ref(false)
-const mockIsWorkspaceSubscribed = ref(true)
+
 const mockCanManageSubscription = ref(true)
 const mockCanManageSubscriptionLifecycle = ref(true)
 const mockCanCancel = ref(true)
@@ -207,16 +202,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      isInPersonalWorkspace: mockIsInPersonalWorkspace,
-      isWorkspaceSubscribed: mockIsWorkspaceSubscribed
-    })
-  })
-)
-
 const mockIsTeamPlanCancelled = computed(
   () => mockHasTeamPlan.value && (mockSubscription.value?.isCancelled ?? false)
 )
@@ -243,7 +228,10 @@ vi.mock<unknown>(
       canReactivatePlan: mockCanReactivatePlan,
       canOpenPricingSurface: mockCanOpenPricingSurface,
       uiConfig: computed(() => mockUiConfig.value),
-      isInPersonalWorkspace: mockIsInPersonalWorkspace,
+      isInPersonalWorkspace: toRef(
+        useTeamWorkspaceStore(),
+        'isInPersonalWorkspace'
+      ),
       canAccessSubscriptionFeatures: computed(
         () => mockIsActiveSubscription.value
       ),
@@ -267,20 +255,6 @@ vi.mock<unknown>(
       canReactivate: mockCanReactivate,
       canChangeSeats: mockCanChangeSeats,
       canSubscribeSelfServe: mockCanSubscribeSelfServe
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({
-      get isSettingUp() {
-        return mockIsSettingUp.value
-      },
-      get subscriptionActionOperation() {
-        return mockSubscriptionActionOperation.value
-      }
     })
   })
 )
@@ -347,7 +321,7 @@ const DropdownMenuStub = {
 function renderComponent({ stubFooter = true } = {}) {
   return render(SubscriptionPanelContentWorkspace, {
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      plugins: [getActivePinia()!, i18n],
       directives: { tooltip: {} },
       stubs: {
         CreditsTile: CreditsTileStub,
@@ -373,8 +347,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockScheduledChange.value = null
     mockHasSubscription.value = true
     mockIsActiveSubscription.value = true
-    mockIsInPersonalWorkspace.value = false
-    mockIsWorkspaceSubscribed.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: true })
     mockCanManageSubscription.value = true
     mockCanManageSubscriptionLifecycle.value = true
     mockCanCancel.value = true
@@ -398,15 +372,19 @@ describe('SubscriptionPanelContentWorkspace', () => {
     }
     mockIsLoading.value = false
     mockError.value = null
-    mockIsSettingUp.value = false
-    mockSubscriptionActionOperation.value = undefined
+    Object.assign(useBillingOperationStore(), { isSettingUp: false })
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: undefined
+    })
   })
 
   it('keeps verification available in settings without exposing its URL', async () => {
     const actionUrl = 'https://verify.example/sensitive-token'
     const open = vi.spyOn(window, 'open').mockReturnValue({} as Window)
-    mockIsSettingUp.value = true
-    mockSubscriptionActionOperation.value = { actionUrl }
+    Object.assign(useBillingOperationStore(), { isSettingUp: true })
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: { actionUrl }
+    })
     const { container } = renderComponent()
 
     expect(open).not.toHaveBeenCalled()
@@ -422,13 +400,15 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('hides verification from users without billing permission', () => {
-    mockIsSettingUp.value = true
+    Object.assign(useBillingOperationStore(), { isSettingUp: true })
     mockCanManageSubscription.value = false
     mockCanChangeSeats.value = false
     mockCanSubscribeSelfServe.value = false
-    mockSubscriptionActionOperation.value = {
-      actionUrl: 'https://verify.example/sensitive-token'
-    }
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: {
+        actionUrl: 'https://verify.example/sensitive-token'
+      }
+    })
 
     renderComponent()
 
@@ -547,7 +527,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     })
 
     it('marks an ended Personal plan inactive when it cannot self-serve', () => {
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsActiveSubscription.value = false
       mockSubscriptionStatus.value = 'ended'
       mockBillingStatus.value = 'inactive'
@@ -729,7 +709,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('keeps a Personal workspace Team-plan member view read-only', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
     mockCanCancel.value = false
@@ -762,7 +742,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('uses Team-plan change copy in a Personal workspace', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     renderComponent()
 
     expect(
@@ -776,7 +756,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps billing access in the ended state for an inactive paid Personal workspace', async () => {
     const user = userEvent.setup()
     mockBillingType.value = 'legacy'
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsActiveSubscription.value = false
     mockBillingStatus.value = 'inactive'
     renderComponent()
@@ -818,7 +798,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it.for(['paid', 'payment_failed', 'paused'] as BillingStatus[])(
     'keeps billing access for a non-terminal %s personal plan',
     (billingStatus) => {
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsActiveSubscription.value = false
       mockBillingStatus.value = billingStatus
       renderComponent()
@@ -873,7 +853,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('drops the state card for an inactive ended subscription without a date', () => {
     mockSubscriptionStatus.value = 'ended'
     mockIsActiveSubscription.value = false
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockEndDate.value = null
     renderComponent()
 
@@ -891,7 +871,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockDistributionState.isCloud = false
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     renderComponent({ stubFooter: false })
 
     expect(
@@ -906,7 +886,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('renders an ended Team plan for its owner and routes reactivation to checkout', async () => {
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     const user = userEvent.setup()
     renderComponent()
 
@@ -961,7 +941,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps ended Team credits inactive when self-serve capabilities are unavailable', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockCanSubscribeSelfServe.value = false
     renderComponent()
 
@@ -1001,7 +981,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps a cancelled Personal plan in a Team workspace reactivatable', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockHasTeamPlan.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     renderComponent()
 
     expect(
@@ -1018,7 +998,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('hides Reactivate plan when the server denies reactivation to a client-side owner', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockHasTeamPlan.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockCanManageSubscriptionLifecycle.value = true
     mockCanReactivatePlan.value = false
     renderComponent()
@@ -1034,7 +1014,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps Billing & invoices available to unsubscribed team owners', async () => {
     const user = userEvent.setup()
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     renderComponent()
 
@@ -1056,7 +1036,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('lets a never-subscribed team workspace top up on Local instead of upselling', () => {
     mockDistributionState.isCloud = false
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     renderComponent()
 
@@ -1099,7 +1079,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('hides Subscribe Now when the server denies self-serve to a client-side owner', () => {
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     mockCanManageSubscription.value = true
     mockCanSubscribeSelfServe.value = false
@@ -1112,7 +1092,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('shows the zero-state contact-owner view to unsubscribed members', () => {
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
@@ -1136,10 +1116,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('renders the Free plan header with Subscribe CTA for unsubscribed personal workspaces', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsActiveSubscription.value = false
     mockHasSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockUiConfig.value = personalUiConfig
     mockCanLeaveWorkspace.value = false
     renderComponent()
@@ -1173,10 +1153,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
       mockBillingType.value = 'legacy'
       mockBillingStatus.value = 'inactive'
       mockSubscriptionTier.value = tier
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsActiveSubscription.value = false
       mockHasSubscription.value = hasSubscription
-      mockIsWorkspaceSubscribed.value = false
+      Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
       mockUiConfig.value = personalUiConfig
       mockCanLeaveWorkspace.value = false
       renderComponent()
@@ -1193,13 +1173,13 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('lets a Free personal workspace only rename itself (no Cancel or Delete)', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     // A Free personal workspace routes to legacy billing, where lifecycle
     // authorization stays on the client.
     mockShouldUseWorkspaceBilling.value = false
     mockIsActiveSubscription.value = false
     mockHasSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockUiConfig.value = personalUiConfig
     mockCanLeaveWorkspace.value = false
     renderComponent()
@@ -1218,10 +1198,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('offers a subscribed personal workspace Edit and Cancel without Delete', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsActiveSubscription.value = true
     mockHasSubscription.value = true
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockUiConfig.value = personalUiConfig
     mockCanLeaveWorkspace.value = false
     renderComponent()
@@ -1262,7 +1242,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('shows the Team plan identity when a personal workspace holds a Team subscription', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     renderComponent()
 
     expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,7 +11,7 @@ const mockHandleSubscribeTeamClick = vi.fn()
 const mockHandleBackToPricing = vi.fn()
 const mockHandleSubscribeClick = vi.fn()
 const mockInvalidateQuote = vi.fn()
-const mockIsInPersonalWorkspace = ref(false)
+
 const mockCheckoutStep = ref('pricing')
 const mockPreviewVariant = ref<string | null>(null)
 const mockPreviewData = ref<Record<string, unknown> | null>(null)
@@ -53,17 +54,6 @@ vi.mock<unknown>(
       applyPromotionCode: vi.fn(),
       invalidateQuote: mockInvalidateQuote,
       handleResubscribe: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get isInPersonalWorkspace() {
-        return mockIsInPersonalWorkspace.value
-      }
     })
   })
 )
@@ -130,7 +120,7 @@ function renderComponent(props: Record<string, unknown> = {}) {
 
 describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
   beforeEach(() => {
-    mockIsInPersonalWorkspace.value = false
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     mockCheckoutStep.value = 'pricing'
     mockPreviewVariant.value = null
     mockPreviewData.value = null
@@ -197,7 +187,7 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
 
   it('advances to team checkout from a team workspace', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = false
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     renderComponent()
 
     await user.click(screen.getByTestId('subscribe-team-btn'))
@@ -209,7 +199,7 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
 
   it('advances to team checkout from a personal workspace (no reroute)', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     renderComponent()
 
     await user.click(screen.getByTestId('subscribe-team-btn'))

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -1,3 +1,5 @@
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,6 +10,7 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import type { CreateTopupResponse } from '@/platform/workspace/api/workspaceApi'
+import { billingOperation } from '@/platform/workspace/composables/billingOperationTestUtils'
 
 import TopUpCreditsDialogContentWorkspace from './TopUpCreditsDialogContentWorkspace.vue'
 
@@ -21,19 +24,10 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 }))
 const mockTopup =
   vi.fn<(amountCents: number) => Promise<CreateTopupResponse | void>>()
-const mockStartOperation = vi.fn()
-const mockRetryPaymentAuthentication = vi.fn()
-const mockDismissOperation = vi.fn((opId: string) => {
-  if (mockBillingOperationState.topupActionOperation?.value?.opId === opId) {
-    mockBillingOperationState.topupActionOperation.value = undefined
-  }
-  if (mockBillingOperationState.isAddingCredits) {
-    mockBillingOperationState.isAddingCredits.value = false
-  }
-})
+
 const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
-const mockCloseDialog = vi.fn()
+
 const mockTrackTopUpPurchase = vi.fn()
 const mockTrackBillingEvent = vi.fn()
 const mockCanTopUp = vi.hoisted(() => ({
@@ -70,13 +64,6 @@ interface MockTopupOperation {
   isAuthenticating?: boolean
 }
 
-const mockBillingOperationState = vi.hoisted(() => ({
-  isAddingCredits: undefined as { value: boolean } | undefined,
-  topupActionOperation: undefined as
-    | { value: MockTopupOperation | undefined }
-    | undefined
-}))
-
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({
     fetchBalance: mockFetchBalance,
@@ -85,29 +72,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     topup: (amountCents: number) => mockTopup(amountCents)
   })
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  async () => {
-    const { ref } = await import('vue')
-    mockBillingOperationState.isAddingCredits = ref(false)
-    mockBillingOperationState.topupActionOperation = ref(undefined)
-    return {
-      useBillingOperationStore: () => ({
-        hasPendingOperations: true,
-        get isAddingCredits() {
-          return mockBillingOperationState.isAddingCredits?.value ?? false
-        },
-        get topupActionOperation() {
-          return mockBillingOperationState.topupActionOperation?.value
-        },
-        startOperation: mockStartOperation,
-        retryPaymentAuthentication: mockRetryPaymentAuthentication,
-        dismissOperation: mockDismissOperation
-      })
-    }
-  }
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useBillingCapabilities'),
@@ -126,10 +90,6 @@ vi.mock<unknown>(
     useSettingsDialog: () => ({ show: mockShowSettings })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -200,17 +160,11 @@ function setCanTopUp(canTopUp: boolean) {
 }
 
 function setIsAddingCredits(isAddingCredits: boolean) {
-  if (!mockBillingOperationState.isAddingCredits) {
-    throw new Error('Billing operation mock not initialized')
-  }
-  mockBillingOperationState.isAddingCredits.value = isAddingCredits
+  Object.assign(useBillingOperationStore(), { isAddingCredits })
 }
 
 function setTopupActionOperation(operation: MockTopupOperation | undefined) {
-  if (!mockBillingOperationState.topupActionOperation) {
-    throw new Error('Billing operation mock not initialized')
-  }
-  mockBillingOperationState.topupActionOperation.value = operation
+  Object.assign(useBillingOperationStore(), { topupActionOperation: operation })
 }
 
 function setHasSavedPaymentMethod(value: boolean | null) {
@@ -225,6 +179,29 @@ async function clickAddCredits() {
   await user.click(screen.getByRole('button', { name: 'Add credits' }))
 }
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
+beforeEach(() => {
+  Object.assign(useBillingOperationStore(), { hasPendingOperations: true })
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation({ type: 'topup' })
+  )
+  vi.mocked(
+    useBillingOperationStore().retryPaymentAuthentication
+  ).mockResolvedValue(false)
+  vi.mocked(useBillingOperationStore().dismissOperation).mockImplementation(
+    (opId) => {
+      const store = useBillingOperationStore()
+      if (store.topupActionOperation?.opId === opId) {
+        Object.assign(store, { topupActionOperation: undefined })
+      }
+      Object.assign(store, { isAddingCredits: false })
+    }
+  )
+})
+
 describe('TopUpCreditsDialogContentWorkspace', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
@@ -234,10 +211,12 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     mockFetchBalance.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
     setHasSavedPaymentMethod(true)
-    mockStartOperation.mockImplementation(() => {
-      setIsAddingCredits(true)
-      return new Promise(() => {})
-    })
+    vi.mocked(useBillingOperationStore().startOperation).mockImplementation(
+      () => {
+        setIsAddingCredits(true)
+        return new Promise(() => {})
+      }
+    )
   })
 
   it('fires a started event before the purchase resolves', async () => {
@@ -504,7 +483,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Complete verification' })
     )
-    expect(mockRetryPaymentAuthentication).toHaveBeenCalledWith('op-resume')
+    expect(
+      useBillingOperationStore().retryPaymentAuthentication
+    ).toHaveBeenCalledWith('op-resume')
   })
 
   it('reports a failed challenge without offering to resume it', async () => {
@@ -525,7 +506,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(
       screen.queryByRole('button', { name: 'Complete verification' })
     ).not.toBeInTheDocument()
-    expect(mockRetryPaymentAuthentication).not.toHaveBeenCalled()
+    expect(
+      useBillingOperationStore().retryPaymentAuthentication
+    ).not.toHaveBeenCalled()
   })
 
   it('lets the customer start over after a failed challenge', async () => {
@@ -548,7 +531,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Start over' }))
     await nextTick()
 
-    expect(mockDismissOperation).toHaveBeenCalledWith('op-1')
+    expect(useBillingOperationStore().dismissOperation).toHaveBeenCalledWith(
+      'op-1'
+    )
     expect(
       screen.queryByText('Your bank rejected the verification.')
     ).not.toBeInTheDocument()
@@ -584,10 +569,14 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
 
     expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
     expect(payButton).toBeDisabled()
-    expect(mockStartOperation).toHaveBeenCalledWith('op-1', 'topup', {
-      attemptStartedAt: expect.any(Number),
-      autoHandleRequiresAction: true
-    })
+    expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+      'op-1',
+      'topup',
+      {
+        attemptStartedAt: expect.any(Number),
+        autoHandleRequiresAction: true
+      }
+    )
 
     payButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(mockTopup).toHaveBeenCalledOnce()
@@ -596,7 +585,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
   it('unlocks payment and reports an operation start failure', async () => {
     const error = new Error('Operation unavailable')
     mockTopup.mockResolvedValue(topupResponse('pending'))
-    mockStartOperation.mockRejectedValue(error)
+    vi.mocked(useBillingOperationStore().startOperation).mockRejectedValue(
+      error
+    )
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     renderDialog()
@@ -656,7 +647,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(mockClearPendingTopup).toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('opens Credits settings after a completed local top-up', async () => {
@@ -697,10 +688,14 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await clickAddCredits()
     await userEvent.click(screen.getByRole('button', { name: 'Pay $50.00' }))
 
-    expect(mockStartOperation).toHaveBeenCalledWith('op-1', 'topup', {
-      attemptStartedAt: expect.any(Number),
-      autoHandleRequiresAction: true
-    })
+    expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+      'op-1',
+      'topup',
+      {
+        attemptStartedAt: expect.any(Number),
+        autoHandleRequiresAction: true
+      }
+    )
     expect(mockFetchBalance).not.toHaveBeenCalled()
     expect(mockFetchStatus).not.toHaveBeenCalled()
     expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
@@ -766,6 +761,6 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(mockTopup).not.toHaveBeenCalled()
     expect(mockTrackTopUpPurchase).not.toHaveBeenCalled()
     expect(mockToastAdd).not.toHaveBeenCalled()
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.test.ts
@@ -1,3 +1,5 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,28 +9,7 @@ import ChangeMemberRoleDialogContent from './ChangeMemberRoleDialogContent.vue'
 
 import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
 
-const { mockChangeMemberRole, mockCloseDialog, mockToastAdd } = vi.hoisted(
-  () => ({
-    mockChangeMemberRole: vi.fn(),
-    mockCloseDialog: vi.fn(),
-    mockToastAdd: vi.fn()
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      changeMemberRole: mockChangeMemberRole
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
+const { mockToastAdd } = vi.hoisted(() => ({ mockToastAdd: vi.fn() }))
 
 vi.mock<unknown>(
   import('primevue/usetoast'), // eslint-disable-line primevue-removal/no-imports
@@ -56,9 +37,18 @@ function renderDialog(targetRole: WorkspaceRole) {
   return { ...result, user }
 }
 
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().changeMemberRole).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('ChangeMemberRoleDialogContent', () => {
   beforeEach(() => {
-    mockChangeMemberRole.mockResolvedValue(undefined)
+    vi.mocked(useTeamWorkspaceStore().changeMemberRole).mockResolvedValue(
+      undefined
+    )
   })
 
   it('shows promote copy and confirms with Make owner', async () => {
@@ -78,9 +68,12 @@ describe('ChangeMemberRoleDialogContent', () => {
       })
     )
 
-    expect(mockChangeMemberRole).toHaveBeenCalledWith('mem-1', 'owner')
+    expect(useTeamWorkspaceStore().changeMemberRole).toHaveBeenCalledWith(
+      'mem-1',
+      'owner'
+    )
     await waitFor(() =>
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'change-member-role'
       })
     )
@@ -105,11 +98,16 @@ describe('ChangeMemberRoleDialogContent', () => {
       })
     )
 
-    expect(mockChangeMemberRole).toHaveBeenCalledWith('mem-1', 'member')
+    expect(useTeamWorkspaceStore().changeMemberRole).toHaveBeenCalledWith(
+      'mem-1',
+      'member'
+    )
   })
 
   it('keeps the dialog open and toasts on failure', async () => {
-    mockChangeMemberRole.mockRejectedValue(new Error('boom'))
+    vi.mocked(useTeamWorkspaceStore().changeMemberRole).mockRejectedValue(
+      new Error('boom')
+    )
     const { user } = renderDialog('owner')
 
     await user.click(
@@ -123,7 +121,7 @@ describe('ChangeMemberRoleDialogContent', () => {
         expect.objectContaining({ severity: 'error' })
       )
     )
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
   })
 
   it('closes without changing the role on cancel', async () => {
@@ -131,7 +129,9 @@ describe('ChangeMemberRoleDialogContent', () => {
 
     await user.click(screen.getByRole('button', { name: 'g.cancel' }))
 
-    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'change-member-role' })
-    expect(mockChangeMemberRole).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+      key: 'change-member-role'
+    })
+    expect(useTeamWorkspaceStore().changeMemberRole).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
@@ -1,11 +1,11 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import DowngradeRemoveMembersDialogContent from './DowngradeRemoveMembersDialogContent.vue'
 
-const mockCloseDialog = vi.fn()
 const mockToastAdd = vi.fn()
 
 vi.mock<unknown>(
@@ -16,12 +16,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -71,6 +65,10 @@ const getChangePlanButton = () =>
   screen.getByRole('button', { name: 'Change plan' })
 const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' })
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('DowngradeRemoveMembersDialogContent', () => {
   it('disables Change plan until the exact phrase is typed', async () => {
     const { user } = mountComponent()
@@ -95,7 +93,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     await user.click(getChangePlanButton())
 
     expect(onConfirm).toHaveBeenCalledWith('founder-monthly', false)
-    expect(mockCloseDialog).toHaveBeenCalledWith({
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
   })
@@ -149,7 +147,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     await user.click(getCancelButton())
 
     expect(onConfirm).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalledWith({
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
   })
@@ -163,7 +161,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
     )
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
   })
 
   // Regression guard: a drift refresh (dialogService's onConfirm handler)

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
@@ -1,3 +1,5 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,9 +10,6 @@ import InviteMemberDialogContent from './InviteMemberDialogContent.vue'
 import type { WorkspacePendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const {
-  mockCreateInvite,
-  mockFetchPendingInvites,
-  mockCloseDialog,
   mockToastAdd,
   mockTrackInviteSent,
   mockTrackInviteFailed,
@@ -20,9 +19,6 @@ const {
 } = vi.hoisted(() => {
   const nullableNumber = (value: number | null) => ({ value })
   return {
-    mockCreateInvite: vi.fn(),
-    mockFetchPendingInvites: vi.fn(),
-    mockCloseDialog: vi.fn(),
     mockToastAdd: vi.fn(),
     mockTrackInviteSent: vi.fn(),
     mockTrackInviteFailed: vi.fn(),
@@ -40,27 +36,10 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      createInvite: mockCreateInvite,
-      fetchPendingInvites: mockFetchPendingInvites,
-      pendingInvites: []
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackWorkspaceInviteSent: mockTrackInviteSent,
     trackWorkspaceInviteFailed: mockTrackInviteFailed
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
   })
 }))
 
@@ -106,15 +85,20 @@ function inviteButton() {
   return screen.getByRole('button', { name: 'workspacePanel.invite' })
 }
 
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), { pendingInvites: [] })
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('InviteMemberDialogContent', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockFetchPendingInvites.mockResolvedValue([])
+    vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([])
     mockFetchStatus.mockResolvedValue(undefined)
     mockMaxSeats.value = 73
     mockOccupiedSeats.value = 0
-    mockCreateInvite.mockImplementation(async (email: string) =>
-      pendingInviteFor(email)
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => pendingInviteFor(email)
     )
   })
 
@@ -218,9 +202,9 @@ describe('InviteMemberDialogContent', () => {
         'workspacePanel.inviteMemberDialog.invitedMessage'
       )
     ).toBeInTheDocument()
-    expect(mockCreateInvite).toHaveBeenCalledTimes(2)
-    expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
-    expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('a@b.com')
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('c@d.com')
     expect(mockTrackInviteSent).toHaveBeenCalledWith({
       source: 'settings_members',
       count: 2
@@ -231,20 +215,26 @@ describe('InviteMemberDialogContent', () => {
       .find((button) => button.textContent.includes('g.close'))
     await user.click(closeButton!)
 
-    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'invite-member' })
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+      key: 'invite-member'
+    })
   })
 
   it('keeps only failed emails as chips and toasts on partial failure', async () => {
-    mockCreateInvite.mockImplementation(async (email: string) => {
-      if (email === 'fail@x.com') throw new Error('nope')
-      return pendingInviteFor(email)
-    })
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => {
+        if (email === 'fail@x.com') throw new Error('nope')
+        return pendingInviteFor(email)
+      }
+    )
     const { user } = renderDialog()
 
     await user.type(emailInput(), 'ok@x.com,fail@x.com{Enter}')
     await user.click(inviteButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(screen.getByText('fail@x.com')).toBeInTheDocument()
     expect(screen.queryByText('ok@x.com')).not.toBeInTheDocument()
     expect(mockToastAdd).toHaveBeenCalledWith(
@@ -258,13 +248,17 @@ describe('InviteMemberDialogContent', () => {
   })
 
   it('stays on the form and keeps every chip when all invites fail', async () => {
-    mockCreateInvite.mockRejectedValue(new Error('nope'))
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockRejectedValue(
+      new Error('nope')
+    )
     const { user } = renderDialog()
 
     await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
     await user.click(inviteButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(
       screen.queryByText('workspacePanel.inviteMemberDialog.invitedMessage')
     ).not.toBeInTheDocument()
@@ -282,7 +276,9 @@ describe('InviteMemberDialogContent', () => {
 
     await user.click(screen.getByRole('button', { name: 'g.cancel' }))
 
-    expect(mockCreateInvite).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'invite-member' })
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+      key: 'invite-member'
+    })
   })
 })

--- a/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.test.ts
@@ -1,27 +1,15 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import SetMemberCreditLimitDialogContent from './SetMemberCreditLimitDialogContent.vue'
 
-const { mockSetMemberCreditLimit, mockCloseDialog } = vi.hoisted(() => ({
-  mockSetMemberCreditLimit: vi.fn(),
-  mockCloseDialog: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      setMemberCreditLimit: mockSetMemberCreditLimit
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
+let workspaceStore: ReturnType<typeof useTeamWorkspaceStore>
+let dialogStore: ReturnType<typeof useDialogStore>
 
 const i18n = createI18n({
   legacy: false,
@@ -68,6 +56,11 @@ function renderDialog(options: RenderDialogOptions = {}) {
 }
 
 describe('SetMemberCreditLimitDialogContent', () => {
+  beforeEach(() => {
+    workspaceStore = useTeamWorkspaceStore()
+    dialogStore = useDialogStore()
+  })
+
   it('updates an existing limit', async () => {
     const { user } = renderDialog()
     const input = screen.getByRole('textbox')
@@ -76,8 +69,11 @@ describe('SetMemberCreditLimitDialogContent', () => {
     await user.type(input, '2500')
     await user.click(screen.getByRole('button', { name: 'Update limit' }))
 
-    expect(mockSetMemberCreditLimit).toHaveBeenCalledWith('mem-1', 2500)
-    expect(mockCloseDialog).toHaveBeenCalledWith({
+    expect(workspaceStore.setMemberCreditLimit).toHaveBeenCalledWith(
+      'mem-1',
+      2500
+    )
+    expect(dialogStore.closeDialog).toHaveBeenCalledWith({
       key: 'set-member-credit-limit'
     })
   })
@@ -95,7 +91,10 @@ describe('SetMemberCreditLimitDialogContent', () => {
     const { user } = renderDialog()
     await user.click(screen.getByRole('radio', { name: 'No limit' }))
     await user.click(screen.getByRole('button', { name: 'Update limit' }))
-    expect(mockSetMemberCreditLimit).toHaveBeenCalledWith('mem-1', null)
+    expect(workspaceStore.setMemberCreditLimit).toHaveBeenCalledWith(
+      'mem-1',
+      null
+    )
   })
 
   it('supports keyboard navigation between limit modes', async () => {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -1,6 +1,8 @@
+import type { Pinia } from 'pinia'
+import { getActivePinia } from 'pinia'
+import { useDialogStore } from '@/stores/dialogStore'
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,11 +16,10 @@ import TeamWorkspacesDialogContent from './TeamWorkspacesDialogContent.vue'
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-const mockCloseDialog = vi.fn()
 const mockToastAdd = vi.fn()
 const mockSwitchWorkspace = vi.fn()
 
-let pinia: ReturnType<typeof createTestingPinia>
+let pinia: Pinia
 let workspaceStore: ReturnType<typeof useTeamWorkspaceStore>
 
 vi.mock<unknown>(
@@ -29,12 +30,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
 
 vi.mock(import('@/platform/workspace/composables/useWorkspaceSwitch'), () => ({
   useWorkspaceSwitch: () => ({
@@ -134,10 +129,14 @@ function setOwnedWorkspaces() {
   ]
 }
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('TeamWorkspacesDialogContent', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    pinia = getActivePinia()!
     workspaceStore = useTeamWorkspaceStore(pinia)
     workspaceStore.workspaces = []
   })
@@ -190,7 +189,7 @@ describe('TeamWorkspacesDialogContent', () => {
       await flushPromises()
 
       expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })
@@ -204,7 +203,7 @@ describe('TeamWorkspacesDialogContent', () => {
       await user.click(switchButton)
       await flushPromises()
 
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
@@ -287,7 +286,7 @@ describe('TeamWorkspacesDialogContent', () => {
 
       expect(workspaceStore.createWorkspace).toHaveBeenCalledWith('New Team')
       expect(onConfirm).toHaveBeenCalledWith('New Team')
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })
@@ -306,7 +305,7 @@ describe('TeamWorkspacesDialogContent', () => {
           detail: 'Limit reached'
         })
       )
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
     })
 
     it('shows separate toast when onConfirm fails but still closes dialog', async () => {
@@ -329,7 +328,7 @@ describe('TeamWorkspacesDialogContent', () => {
           detail: 'Setup failed'
         })
       )
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })
@@ -388,7 +387,7 @@ describe('TeamWorkspacesDialogContent', () => {
       const closeBtn = container.querySelector('header button')!
       await user.click(closeBtn)
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -1,87 +1,40 @@
+import { getActivePinia } from 'pinia'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
-import type {
-  PartnerNodePolicy,
-  PartnerProvider
-} from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 
 import PartnerNodeAccessPanel from './PartnerNodeAccessPanel.vue'
 
-const {
-  mockCloseDialog,
-  mockGovernedWorkspaceId,
-  mockIsProviderEnabled,
-  mockIsSaving,
-  mockLoadPolicy,
-  mockNodeDefsByName,
-  mockPolicy,
-  mockProviders,
-  mockSetAllProvidersEnabled,
-  mockSetEnforcementEnabled,
-  mockSetProviderEnabled,
-  mockSetProvidersEnabled,
-  mockShowConfirmDialog,
-  mockStatus,
-  mockWorkspaceRole
-} = vi.hoisted(() => {
+const { mockShowConfirmDialog, mockWorkspaceRole } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
   const { ref } = require('vue') as typeof import('vue')
   return {
-    mockCloseDialog: vi.fn(),
-    mockGovernedWorkspaceId: ref('workspace-one'),
-    mockIsProviderEnabled: vi.fn(),
-    mockIsSaving: ref(false),
-    mockLoadPolicy: vi.fn(),
-    mockNodeDefsByName: ref<Record<string, ComfyNodeDefImpl>>({}),
-    mockPolicy: ref<PartnerNodePolicy | null>(null),
-    mockProviders: ref<PartnerProvider[]>([]),
-    mockSetAllProvidersEnabled: vi.fn(),
-    mockSetEnforcementEnabled: vi.fn(),
-    mockSetProviderEnabled: vi.fn(),
-    mockSetProvidersEnabled: vi.fn(),
     mockShowConfirmDialog: vi.fn(),
-    mockStatus: ref('configured'),
     mockWorkspaceRole: ref<'owner' | 'member'>('owner')
   }
 })
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/partnerNodeGovernanceStore'),
-  () => ({
-    usePartnerNodeGovernanceStore: () => ({
-      governedWorkspaceId: mockGovernedWorkspaceId,
-      policy: mockPolicy,
-      providers: mockProviders,
-      status: mockStatus,
-      isSaving: mockIsSaving,
-      isProviderEnabled: mockIsProviderEnabled,
-      loadPolicy: mockLoadPolicy,
-      setAllProvidersEnabled: mockSetAllProvidersEnabled,
-      setEnforcementEnabled: mockSetEnforcementEnabled,
-      setProviderEnabled: mockSetProviderEnabled,
-      setProvidersEnabled: mockSetProvidersEnabled
-    })
-  })
-)
 
 vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
   showConfirmDialog: mockShowConfirmDialog
 }))
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({ nodeDefsByName: mockNodeDefsByName })
-}))
+vi.mock(
+  import('@/platform/workspace/api/partnerNodePolicyApi'),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    getPartnerNodePolicy: vi.fn(() => new Promise<never>(() => {})),
+    getPartnerProviders: vi.fn(() => new Promise<never>(() => {}))
+  })
+)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -111,7 +64,7 @@ function nodeDef(
 
 function renderComponent() {
   return render(PartnerNodeAccessPanel, {
-    global: { plugins: [createPinia(), i18n], directives: { tooltip: {} } }
+    global: { plugins: [getActivePinia()!, i18n], directives: { tooltip: {} } }
   })
 }
 
@@ -120,7 +73,12 @@ function restrictPolicy(
     { providerId: 'openai', enabled: true }
   ]
 ) {
-  mockPolicy.value = { enforcementEnabled: true, providers: entries }
+  Object.assign(usePartnerNodeGovernanceStore(), {
+    policy: {
+      enforcementEnabled: true,
+      providers: entries
+    }
+  })
 }
 
 const allowAllSwitchName = 'Allow all partner models'
@@ -129,35 +87,80 @@ async function openBulkMenu(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Disable all' }))
 }
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
+beforeEach(async () => {
+  vi.mocked(usePartnerNodeGovernanceStore().isProviderEnabled).mockReturnValue(
+    false
+  )
+  vi.mocked(usePartnerNodeGovernanceStore().loadPolicy).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setAllProvidersEnabled
+  ).mockResolvedValue(undefined)
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setEnforcementEnabled
+  ).mockResolvedValue(undefined)
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setProviderEnabled
+  ).mockResolvedValue(undefined)
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setProvidersEnabled
+  ).mockResolvedValue(undefined)
+  Object.assign(usePartnerNodeGovernanceStore(), {
+    governedWorkspaceId: 'workspace-one'
+  })
+  await nextTick()
+})
+
 describe('PartnerNodeAccessPanel', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockGovernedWorkspaceId.value = 'workspace-one'
-    mockStatus.value = 'configured'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-one'
+    })
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'configured' })
     mockWorkspaceRole.value = 'owner'
-    mockIsSaving.value = false
-    mockPolicy.value = null
-    mockProviders.value = [
-      {
-        id: 'openai',
-        displayName: 'OpenAI (inc. Sora)',
-        nodeCategories: ['OpenAI', 'Sora']
-      },
-      {
-        id: 'route-only',
-        displayName: 'Route only',
-        nodeCategories: []
+    Object.assign(usePartnerNodeGovernanceStore(), { isSaving: false })
+    Object.assign(usePartnerNodeGovernanceStore(), { policy: null })
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        {
+          id: 'openai',
+          displayName: 'OpenAI (inc. Sora)',
+          nodeCategories: ['OpenAI', 'Sora']
+        },
+        {
+          id: 'route-only',
+          displayName: 'Route only',
+          nodeCategories: []
+        }
+      ]
+    })
+    Object.assign(useNodeDefStore(), {
+      nodeDefsByName: {
+        ImageNode: nodeDef('ImageNode', 'Create image', 'partner/image/OpenAI'),
+        VideoNode: nodeDef('VideoNode', 'Create video', 'partner/video/Sora')
       }
-    ]
-    mockNodeDefsByName.value = {
-      ImageNode: nodeDef('ImageNode', 'Create image', 'partner/image/OpenAI'),
-      VideoNode: nodeDef('VideoNode', 'Create video', 'partner/video/Sora')
-    }
-    mockIsProviderEnabled.mockReturnValue(true)
-    mockSetAllProvidersEnabled.mockResolvedValue(undefined)
-    mockSetEnforcementEnabled.mockResolvedValue(undefined)
-    mockSetProviderEnabled.mockResolvedValue(undefined)
-    mockSetProvidersEnabled.mockResolvedValue(undefined)
+    })
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(true)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).mockResolvedValue(undefined)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).mockResolvedValue(undefined)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setProviderEnabled
+    ).mockResolvedValue(undefined)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setProvidersEnabled
+    ).mockResolvedValue(undefined)
     mockShowConfirmDialog.mockReturnValue({ key: 'disable-all-dialog' })
   })
 
@@ -182,14 +185,16 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: true },
       { providerId: 'acme', enabled: true }
     ])
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
 
     const table = screen.getByRole('table', {
@@ -215,15 +220,17 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: true },
       { providerId: 'acme', enabled: true }
     ])
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
-    mockNodeDefsByName.value.AcmeNode = nodeDef(
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
+    useNodeDefStore().nodeDefsByName.AcmeNode = nodeDef(
       'AcmeNode',
       'Enhance image',
       'partner/image/Acme'
@@ -252,17 +259,19 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: false },
       { providerId: 'acme', enabled: true }
     ])
-    mockIsProviderEnabled.mockImplementation(
-      (providerId: string) => providerId !== 'openai'
-    )
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockImplementation((providerId: string) => providerId !== 'openai')
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
 
     const table = screen.getByRole('table', {
@@ -280,20 +289,22 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('searches both provider and model names', async () => {
     const user = userEvent.setup()
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
-    mockNodeDefsByName.value.AcmeNode = nodeDef(
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
+    useNodeDefStore().nodeDefsByName.AcmeNode = nodeDef(
       'AcmeNode',
       'Enhance image',
       'partner/image/Acme'
     )
-    mockNodeDefsByName.value.AcmeResize = nodeDef(
+    useNodeDefStore().nodeDefsByName.AcmeResize = nodeDef(
       'AcmeResize',
       'Resize video',
       'partner/video/Acme'
@@ -321,15 +332,17 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('keeps provider-name matches collapsed while searching', async () => {
     const user = userEvent.setup()
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
-    mockNodeDefsByName.value.AcmeNode = nodeDef(
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
+    useNodeDefStore().nodeDefsByName.AcmeNode = nodeDef(
       'AcmeNode',
       'Enhance image',
       'partner/image/Acme'
@@ -349,14 +362,16 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('keeps name-matched providers without loaded nodes', async () => {
     const user = userEvent.setup()
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
     const search = screen.getByRole('combobox', {
       name: 'Search providers and partner models...'
@@ -377,7 +392,9 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('shows stored disabled state while restricted', () => {
     restrictPolicy([{ providerId: 'openai', enabled: false }])
-    mockIsProviderEnabled.mockReturnValue(false)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(false)
     renderComponent()
 
     expect(
@@ -405,11 +422,15 @@ describe('PartnerNodeAccessPanel', () => {
   })
 
   it('hides provider controls while access is unrestricted', () => {
-    mockPolicy.value = {
-      enforcementEnabled: false,
-      providers: [{ providerId: 'openai', enabled: false }]
-    }
-    mockIsProviderEnabled.mockReturnValue(false)
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      policy: {
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: false }]
+      }
+    })
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(false)
     renderComponent()
 
     expect(
@@ -456,7 +477,9 @@ describe('PartnerNodeAccessPanel', () => {
   it('applies bulk enable to every provider from the menu', async () => {
     const user = userEvent.setup()
     restrictPolicy([{ providerId: 'openai', enabled: false }])
-    mockIsProviderEnabled.mockReturnValue(false)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(false)
     renderComponent()
 
     await openBulkMenu(user)
@@ -464,7 +487,9 @@ describe('PartnerNodeAccessPanel', () => {
       screen.getByRole('menuitem', { name: 'Enable all 1 provider' })
     )
 
-    expect(mockSetProvidersEnabled).toHaveBeenCalledWith(['openai'], true)
+    expect(
+      usePartnerNodeGovernanceStore().setProvidersEnabled
+    ).toHaveBeenCalledWith(['openai'], true)
   })
 
   it('disables no-op bulk actions in the menu', async () => {
@@ -488,14 +513,16 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: true },
       { providerId: 'acme', enabled: true }
     ])
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
 
     await user.type(
@@ -510,13 +537,17 @@ describe('PartnerNodeAccessPanel', () => {
     )
 
     expect(mockShowConfirmDialog).not.toHaveBeenCalled()
-    expect(mockSetProvidersEnabled).toHaveBeenCalledWith(['acme'], false)
+    expect(
+      usePartnerNodeGovernanceStore().setProvidersEnabled
+    ).toHaveBeenCalledWith(['acme'], false)
   })
 
   it('surfaces save failures', async () => {
     const user = userEvent.setup()
     restrictPolicy()
-    mockSetProviderEnabled.mockRejectedValueOnce(new Error('Save failed'))
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setProviderEnabled
+    ).mockRejectedValueOnce(new Error('Save failed'))
     renderComponent()
 
     await user.click(
@@ -532,7 +563,7 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('locks provider controls while saving', () => {
     restrictPolicy()
-    mockIsSaving.value = true
+    Object.assign(usePartnerNodeGovernanceStore(), { isSaving: true })
     renderComponent()
 
     expect(
@@ -584,8 +615,10 @@ describe('PartnerNodeAccessPanel', () => {
     const options = mockShowConfirmDialog.mock.calls[0][0]
     expect(options.headerProps.title).toBe('Disable all providers?')
     await options.footerProps.onConfirm()
-    expect(mockSetAllProvidersEnabled).toHaveBeenCalledWith(false)
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).toHaveBeenCalledWith(false)
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('ignores a disable-all confirmation after the workspace changes', async () => {
@@ -598,11 +631,15 @@ describe('PartnerNodeAccessPanel', () => {
       screen.getByRole('menuitem', { name: 'Disable all 1 provider' })
     )
     const options = mockShowConfirmDialog.mock.calls[0][0]
-    mockGovernedWorkspaceId.value = 'workspace-two'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-two'
+    })
     await options.footerProps.onConfirm()
 
-    expect(mockSetAllProvidersEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('ignores a disable-all confirmation after the owner loses access', async () => {
@@ -618,8 +655,10 @@ describe('PartnerNodeAccessPanel', () => {
     mockWorkspaceRole.value = 'member'
     await options.footerProps.onConfirm()
 
-    expect(mockSetAllProvidersEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('confirms before turning on restrictions', async () => {
@@ -631,7 +670,9 @@ describe('PartnerNodeAccessPanel', () => {
     const options = mockShowConfirmDialog.mock.calls[0][0]
     expect(options.headerProps.title).toBe('Restrict access to partner models?')
     await options.footerProps.onConfirm()
-    expect(mockSetEnforcementEnabled).toHaveBeenCalledWith(true)
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).toHaveBeenCalledWith(true)
   })
 
   it('ignores a restriction confirmation after the workspace changes', async () => {
@@ -640,33 +681,47 @@ describe('PartnerNodeAccessPanel', () => {
 
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
     const options = mockShowConfirmDialog.mock.calls[0][0]
-    mockGovernedWorkspaceId.value = 'workspace-two'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-two'
+    })
     await options.footerProps.onConfirm()
 
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('ignores a restriction confirmation after a workspace round trip', async () => {
     const user = userEvent.setup()
-    mockPolicy.value = {
-      enforcementEnabled: false,
-      providers: [{ providerId: 'openai', enabled: true }]
-    }
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      policy: {
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: true }]
+      }
+    })
     renderComponent()
 
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
     const options = mockShowConfirmDialog.mock.calls[0][0]
-    mockGovernedWorkspaceId.value = 'workspace-two'
-    mockPolicy.value = {
-      enforcementEnabled: false,
-      providers: [{ providerId: 'openai', enabled: false }]
-    }
-    mockGovernedWorkspaceId.value = 'workspace-one'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-two'
+    })
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      policy: {
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: false }]
+      }
+    })
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-one'
+    })
     await options.footerProps.onConfirm()
 
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('keeps the access toggle in place until the change is confirmed', async () => {
@@ -684,7 +739,9 @@ describe('PartnerNodeAccessPanel', () => {
     await nextTick()
 
     expect(toggle.getAttribute('aria-checked')).toBe('true')
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
   })
 
   it('toggles access mode from the keyboard', async () => {
@@ -700,7 +757,7 @@ describe('PartnerNodeAccessPanel', () => {
   it.for(['loading', 'error'] as const)(
     'locks the access toggle while policy status is %s',
     (status) => {
-      mockStatus.value = status
+      Object.assign(usePartnerNodeGovernanceStore(), { status: status })
       renderComponent()
 
       expect(
@@ -712,8 +769,8 @@ describe('PartnerNodeAccessPanel', () => {
   it.for(['ineligible', 'inactive'] as const)(
     'shows an unavailable state while policy status is %s',
     (status) => {
-      mockStatus.value = status
-      mockProviders.value = []
+      Object.assign(usePartnerNodeGovernanceStore(), { status: status })
+      Object.assign(usePartnerNodeGovernanceStore(), { providers: [] })
       renderComponent()
 
       expect(
@@ -726,7 +783,7 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('offers the enterprise dialog when the gated toggle is clicked', async () => {
     const user = userEvent.setup()
-    mockStatus.value = 'ineligible'
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'ineligible' })
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     renderComponent()
 
@@ -745,12 +802,12 @@ describe('PartnerNodeAccessPanel', () => {
       'https://comfy.org/cloud/enterprise/',
       '_blank'
     )
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
     openSpy.mockRestore()
   })
 
   it('shows the enterprise upsell when the catalog loads but policy access is forbidden', () => {
-    mockStatus.value = 'ineligible'
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'ineligible' })
     renderComponent()
 
     expect(screen.getByText('Enterprise')).toBeTruthy()
@@ -773,9 +830,9 @@ describe('PartnerNodeAccessPanel', () => {
   it('confirms expanded access when a restricted provider is disabled', async () => {
     const user = userEvent.setup()
     restrictPolicy([{ providerId: 'openai', enabled: false }])
-    mockIsProviderEnabled.mockImplementation(
-      (providerId: string) => providerId !== 'openai'
-    )
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockImplementation((providerId: string) => providerId !== 'openai')
     renderComponent()
 
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
@@ -785,7 +842,9 @@ describe('PartnerNodeAccessPanel', () => {
       'Allow access to all partner models?'
     )
     await options.footerProps.onConfirm()
-    expect(mockSetEnforcementEnabled).toHaveBeenCalledWith(false)
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).toHaveBeenCalledWith(false)
   })
 
   it('confirms before returning to unrestricted when every provider is enabled', async () => {
@@ -796,7 +855,9 @@ describe('PartnerNodeAccessPanel', () => {
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
 
     expect(mockShowConfirmDialog).toHaveBeenCalledOnce()
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
     const options = mockShowConfirmDialog.mock.calls[0][0]
     expect(options.headerProps.title).toBe(
       'Allow access to all partner models?'
@@ -805,12 +866,14 @@ describe('PartnerNodeAccessPanel', () => {
       'Partner models from every provider will become available to every workspace member. This can take up to 10 minutes to apply across your workspace.'
     )
     await options.footerProps.onConfirm()
-    expect(mockSetEnforcementEnabled).toHaveBeenCalledWith(false)
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).toHaveBeenCalledWith(false)
   })
 
   it('retries a failed load', async () => {
     const user = userEvent.setup()
-    mockStatus.value = 'error'
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'error' })
     renderComponent()
 
     expect(
@@ -818,6 +881,6 @@ describe('PartnerNodeAccessPanel', () => {
     ).toBeTruthy()
     await user.click(screen.getByRole('button', { name: 'Try again' }))
 
-    expect(mockLoadPolicy).toHaveBeenCalledOnce()
+    expect(usePartnerNodeGovernanceStore().loadPolicy).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMembersPanelContent.test.ts
@@ -2,22 +2,9 @@ import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
 import WorkspaceMembersPanelContent from './WorkspaceMembersPanelContent.vue'
-
-const { mockFetchMembers, mockFetchPendingInvites } = vi.hoisted(() => ({
-  mockFetchMembers: vi.fn(),
-  mockFetchPendingInvites: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      fetchMembers: mockFetchMembers,
-      fetchPendingInvites: mockFetchPendingInvites
-    })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -31,25 +18,32 @@ const stubs = {
 }
 
 describe('WorkspaceMembersPanelContent', () => {
+  let workspaceStore: ReturnType<typeof useTeamWorkspaceStore>
+
   beforeEach(() => {
-    mockFetchMembers.mockResolvedValue(undefined)
-    mockFetchPendingInvites.mockResolvedValue(undefined)
+    workspaceStore = useTeamWorkspaceStore()
+    vi.mocked(workspaceStore.fetchMembers).mockResolvedValue([])
+    vi.mocked(workspaceStore.fetchPendingInvites).mockResolvedValue([])
   })
 
   it('fetches members and pending invites on mount', () => {
     render(WorkspaceMembersPanelContent, { global: { stubs } })
-    expect(mockFetchMembers).toHaveBeenCalled()
-    expect(mockFetchPendingInvites).toHaveBeenCalled()
+    expect(workspaceStore.fetchMembers).toHaveBeenCalled()
+    expect(workspaceStore.fetchPendingInvites).toHaveBeenCalled()
   })
 
   it('settles rejected loading requests', async () => {
-    mockFetchMembers.mockRejectedValueOnce(new Error('members failed'))
-    mockFetchPendingInvites.mockRejectedValueOnce(new Error('invites failed'))
+    vi.mocked(workspaceStore.fetchMembers).mockRejectedValueOnce(
+      new Error('members failed')
+    )
+    vi.mocked(workspaceStore.fetchPendingInvites).mockRejectedValueOnce(
+      new Error('invites failed')
+    )
 
     render(WorkspaceMembersPanelContent, { global: { stubs } })
     await Promise.resolve()
 
-    expect(mockFetchMembers).toHaveBeenCalled()
-    expect(mockFetchPendingInvites).toHaveBeenCalled()
+    expect(workspaceStore.fetchMembers).toHaveBeenCalled()
+    expect(workspaceStore.fetchPendingInvites).toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -28,7 +29,6 @@ const personalConfig = {
 const mockUiConfig = ref<Record<string, unknown>>(ownerConfig)
 const mockCanLeaveWorkspace = ref(false)
 const mockCanManageSubscription = ref(true)
-const mockIsWorkspaceSubscribed = ref(false)
 
 const mockShowLeaveWorkspaceDialog = vi.fn()
 const mockShowDeleteWorkspaceDialog = vi.fn()
@@ -43,15 +43,6 @@ vi.mock<unknown>(
         canManageSubscription: mockCanManageSubscription.value
       })),
       uiConfig: mockUiConfig
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      isWorkspaceSubscribed: mockIsWorkspaceSubscribed
     })
   })
 )
@@ -91,7 +82,7 @@ describe('WorkspaceMenuButton', () => {
     mockUiConfig.value = ownerConfig
     mockCanLeaveWorkspace.value = false
     mockCanManageSubscription.value = true
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
   })
 
   it('lets a member leave and offers no destructive workspace actions', () => {
@@ -133,7 +124,7 @@ describe('WorkspaceMenuButton', () => {
   })
 
   it('disables Delete while the additional workspace is subscribed', () => {
-    mockIsWorkspaceSubscribed.value = true
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: true })
     renderComponent()
 
     expect(
@@ -187,7 +178,7 @@ describe('WorkspaceMenuButton', () => {
     const deleteWorkspace = screen.getByRole('button', {
       name: 'Delete Workspace'
     })
-    mockIsWorkspaceSubscribed.value = true
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: true })
     deleteWorkspace.click()
 
     expect(mockShowDeleteWorkspaceDialog).not.toHaveBeenCalled()

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceSettingsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceSettingsPanelContent.test.ts
@@ -1,32 +1,14 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { defineComponent, h, onMounted, onUnmounted, ref } from 'vue'
 
 import WorkspaceSettingsPanelContent from './WorkspaceSettingsPanelContent.vue'
 
-const {
-  mockBannerMounted,
-  mockBannerUnmounted,
-  mockFetchMembers,
-  mockFetchPendingInvites
-} = vi.hoisted(() => ({
+const { mockBannerMounted, mockBannerUnmounted } = vi.hoisted(() => ({
   mockBannerMounted: vi.fn(),
-  mockBannerUnmounted: vi.fn(),
-  mockFetchMembers: vi.fn(),
-  mockFetchPendingInvites: vi.fn()
+  mockBannerUnmounted: vi.fn()
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () =>
-      reactive({
-        workspaceName: ref('Acme Team'),
-        fetchMembers: mockFetchMembers,
-        fetchPendingInvites: mockFetchPendingInvites
-      })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -51,10 +33,16 @@ const stubs = {
   WorkspaceProfilePic: { template: '<div />' }
 }
 
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), { workspaceName: 'Acme Team' })
+  vi.mocked(useTeamWorkspaceStore().fetchMembers).mockResolvedValue([])
+  vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([])
+})
+
 describe('WorkspaceSettingsPanelContent', () => {
   beforeEach(() => {
-    mockFetchMembers.mockResolvedValue(undefined)
-    mockFetchPendingInvites.mockResolvedValue(undefined)
+    vi.mocked(useTeamWorkspaceStore().fetchMembers).mockResolvedValue([])
+    vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([])
   })
 
   it('keeps the billing banner mounted while switching sections', async () => {
@@ -75,8 +63,8 @@ describe('WorkspaceSettingsPanelContent', () => {
 
     expect(screen.queryByTestId('plan-body')).not.toBeInTheDocument()
     expect(screen.getByTestId('members-body')).toBeInTheDocument()
-    expect(mockFetchMembers).toHaveBeenCalledTimes(1)
-    expect(mockFetchPendingInvites).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchMembers).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchPendingInvites).toHaveBeenCalledTimes(1)
     expect(mockBannerMounted).toHaveBeenCalledTimes(1)
     expect(mockBannerUnmounted).not.toHaveBeenCalled()
 
@@ -84,8 +72,8 @@ describe('WorkspaceSettingsPanelContent', () => {
 
     expect(screen.queryByTestId('members-body')).not.toBeInTheDocument()
     expect(screen.getByTestId('allowlist-body')).toBeInTheDocument()
-    expect(mockFetchMembers).toHaveBeenCalledTimes(1)
-    expect(mockFetchPendingInvites).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchMembers).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchPendingInvites).toHaveBeenCalledTimes(1)
     expect(mockBannerMounted).toHaveBeenCalledTimes(1)
     expect(mockBannerUnmounted).not.toHaveBeenCalled()
 

--- a/src/platform/workspace/composables/billingOperationTestUtils.ts
+++ b/src/platform/workspace/composables/billingOperationTestUtils.ts
@@ -1,0 +1,27 @@
+import type { useBillingOperationStore } from '../stores/billingOperationStore'
+
+export type BillingOperation = Awaited<
+  ReturnType<ReturnType<typeof useBillingOperationStore>['startOperation']>
+>
+
+export function billingOperation(
+  overrides: Partial<BillingOperation> = {}
+): BillingOperation {
+  return {
+    opId: 'op-test',
+    type: 'subscription',
+    status: 'pending',
+    errorMessage: null,
+    startedAt: 0,
+    operationStartedAt: 0,
+    actionUrl: null,
+    authenticationState: null,
+    isAuthenticating: false,
+    canRetryAuthentication: false,
+    authenticationRequiredSeen: false,
+    workspaceId: 'workspace-1',
+    autoHandleRequiresAction: false,
+    dismissed: false,
+    ...overrides
+  }
+}

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -1,8 +1,10 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import axios, { AxiosError, AxiosHeaders } from 'axios'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
@@ -12,11 +14,6 @@ import { useBillingCapabilities } from './useBillingCapabilities'
 const mockGetBillingCapabilities = vi.hoisted(() => vi.fn())
 const mockReportError = vi.hoisted(() => vi.fn())
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
-const mockScope = vi.hoisted(() => ({
-  workspaceId: 'workspace-1' as string | null,
-  authUid: 'firebase-user-1' as string | null,
-  role: 'owner' as 'owner' | 'member'
-}))
 
 vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   WorkspaceApiError: class WorkspaceApiError extends Error {
@@ -39,30 +36,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockScope.workspaceId
-      },
-      get activeWorkspace() {
-        return mockScope.workspaceId
-          ? { id: mockScope.workspaceId, role: mockScope.role }
-          : null
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get currentUser() {
-      return mockScope.authUid ? { uid: mockScope.authUid } : null
-    }
-  })
 }))
 
 function capabilitiesResponse(
@@ -175,15 +148,28 @@ function capabilityReadsThroughInterceptor() {
   }
 }
 
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), {
+    activeWorkspaceId: 'workspace-1',
+    activeWorkspace: { id: 'workspace-1', role: 'owner' }
+  })
+  Object.assign(useAuthStore(), {
+    userId: 'firebase-user-1',
+    currentUser: { uid: 'firebase-user-1' }
+  })
+})
+
 describe('useBillingCapabilities', () => {
   let scope: EffectScope
   let billingCapabilities: ReturnType<typeof useBillingCapabilities>
 
   beforeEach(() => {
     mockIsCloud.value = true
-    mockScope.workspaceId = 'workspace-1'
-    mockScope.authUid = 'firebase-user-1'
-    mockScope.role = 'owner'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
+    Object.assign(useAuthStore(), { userId: 'firebase-user-1' })
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1', role: 'owner' }
+    })
     scope = effectScope()
     billingCapabilities = scope.run(() => useBillingCapabilities())!
   })
@@ -293,7 +279,9 @@ describe('useBillingCapabilities', () => {
   })
 
   it('withholds top-up from members when the endpoint is unavailable', async () => {
-    mockScope.role = 'member'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1', role: 'member' }
+    })
     mockGetBillingCapabilities.mockRejectedValueOnce(new Error('unavailable'))
 
     await billingCapabilities.initialize()
@@ -369,8 +357,11 @@ describe('useBillingCapabilities', () => {
       .mockResolvedValueOnce(capabilitiesResponse(false, 'workspace-2', false))
 
     const firstInitialization = billingCapabilities.initialize()
-    mockScope.workspaceId = 'workspace-2'
-    await billingCapabilities.initialize()
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-2' })
+    await nextTick()
+    await vi.waitFor(() =>
+      expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
+    )
 
     resolveFirstRequest(capabilitiesResponse(true, 'workspace-1', true))
     await firstInitialization
@@ -392,7 +383,9 @@ describe('useBillingCapabilities', () => {
 
   it('preserves the local role gate for workspace members', async () => {
     mockIsCloud.value = false
-    mockScope.role = 'member'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1', role: 'member' }
+    })
 
     await billingCapabilities.initialize()
 
@@ -402,7 +395,7 @@ describe('useBillingCapabilities', () => {
   })
 
   it('does not enter pending state without an authenticated scope', async () => {
-    mockScope.workspaceId = null
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
 
     await billingCapabilities.initialize()
 
@@ -514,8 +507,11 @@ describe('useBillingCapabilities', () => {
       )
 
     await billingCapabilities.initialize()
-    mockScope.workspaceId = 'workspace-2'
-    await billingCapabilities.initialize()
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-2' })
+    await nextTick()
+    await vi.waitFor(() =>
+      expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
+    )
     expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
 
     await vi.advanceTimersByTimeAsync(60_000)
@@ -984,3 +980,10 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canTopUp.value).toBe(false)
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -1,4 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -7,6 +8,7 @@ import type { ListMembersParams } from '@/platform/workspace/api/workspaceApi'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
+import { billingOperation } from './billingOperationTestUtils'
 import {
   ReactivationConfirmationRequiredError,
   useDowngradeToPersonal
@@ -21,7 +23,7 @@ const mockFetchMembers =
 const mockSubscribe = vi.hoisted(() => vi.fn())
 const mockPreviewSubscribe = vi.hoisted(() => vi.fn())
 const mockFetchStatus = vi.hoisted(() => vi.fn())
-const mockStartOperation = vi.hoisted(() => vi.fn())
+
 const mockTrackBillingEvent = vi.hoisted(() => vi.fn())
 const mockPermissions = vi.hoisted(() => ({
   value: {
@@ -58,13 +60,6 @@ const mockMembers = {
     workspaceStore.activeWorkspaceId = 'workspace-one'
   }
 }
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({ startOperation: mockStartOperation })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -141,11 +136,17 @@ function teamWithOwnerAnd(...memberIds: string[]) {
   ]
 }
 
+beforeEach(() => {
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation()
+  )
+})
+
 describe('useDowngradeToPersonal', () => {
   let windowOpen: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     workspaceStore = useTeamWorkspaceStore(pinia)
     vi.mocked(workspaceStore.removeMember).mockImplementation(mockRemoveMember)
     vi.mocked(workspaceStore.fetchMembers).mockImplementation(mockFetchMembers)
@@ -603,18 +604,22 @@ describe('useDowngradeToPersonal', () => {
         'https://pay.test/method',
         '_blank'
       )
-      expect(mockStartOperation).toHaveBeenCalledWith('op-2', 'subscription', {
-        tier: undefined,
-        cycle: undefined,
-        checkoutType: 'change',
-        downgradeToPersonal: {
-          memberRemovalCount: 1,
-          memberRemovalFailures: 0,
-          targetTier: undefined,
-          startedAt: expect.any(Number)
-        },
-        attemptStartedAt: expect.any(Number)
-      })
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+        'op-2',
+        'subscription',
+        {
+          tier: undefined,
+          cycle: undefined,
+          checkoutType: 'change',
+          downgradeToPersonal: {
+            memberRemovalCount: 1,
+            memberRemovalFailures: 0,
+            targetTier: undefined,
+            startedAt: expect.any(Number)
+          },
+          attemptStartedAt: expect.any(Number)
+        }
+      )
     })
 
     it('falls back to the generic message when the transition is disallowed without a reason', async () => {
@@ -640,7 +645,7 @@ describe('useDowngradeToPersonal', () => {
       await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
         'subscription.downgrade.paymentPageBlocked'
       )
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
     })
 
     it('throws when a payment method is needed but no url is provided', async () => {
@@ -654,7 +659,7 @@ describe('useDowngradeToPersonal', () => {
       await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
         'subscription.downgrade.paymentMethodRequired'
       )
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
     })
 
     it('polls without opening a tab when the payment is pending', async () => {
@@ -668,18 +673,22 @@ describe('useDowngradeToPersonal', () => {
       await downgradeToPersonal('founder-monthly')
 
       expect(windowOpen).not.toHaveBeenCalled()
-      expect(mockStartOperation).toHaveBeenCalledWith('op-4', 'subscription', {
-        tier: undefined,
-        cycle: undefined,
-        checkoutType: 'change',
-        downgradeToPersonal: {
-          memberRemovalCount: 1,
-          memberRemovalFailures: 0,
-          targetTier: undefined,
-          startedAt: expect.any(Number)
-        },
-        attemptStartedAt: expect.any(Number)
-      })
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+        'op-4',
+        'subscription',
+        {
+          tier: undefined,
+          cycle: undefined,
+          checkoutType: 'change',
+          downgradeToPersonal: {
+            memberRemovalCount: 1,
+            memberRemovalFailures: 0,
+            targetTier: undefined,
+            startedAt: expect.any(Number)
+          },
+          attemptStartedAt: expect.any(Number)
+        }
+      )
       expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ stage: 'succeeded' })
       )

--- a/src/platform/workspace/composables/useInviteUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useInviteUrlLoader.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent } from 'vue'
@@ -52,13 +53,6 @@ vi.mock<unknown>(
   })
 )
 
-const mockAcceptInvite = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('../stores/teamWorkspaceStore'), () => ({
-  useTeamWorkspaceStore: () => ({
-    acceptInvite: mockAcceptInvite
-  })
-}))
-
 const apps: App<Element>[] = []
 
 function useInviteUrlLoader(): ReturnType<typeof createInviteUrlLoader> {
@@ -110,7 +104,7 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().acceptInvite).not.toHaveBeenCalled()
       expect(mockToastAdd).not.toHaveBeenCalled()
       expect(mockRouterReplace).not.toHaveBeenCalled()
     })
@@ -120,7 +114,7 @@ describe('useInviteUrlLoader', () => {
       preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
         invite: 'preserved-token'
       })
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -134,12 +128,14 @@ describe('useInviteUrlLoader', () => {
       expect(mockRouterReplace).toHaveBeenCalledWith({
         query: { invite: 'preserved-token' }
       })
-      expect(mockAcceptInvite).toHaveBeenCalledWith('preserved-token')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'preserved-token'
+      )
     })
 
     it('accepts invite and shows success toast on success', async () => {
       mockRouteQuery.value = { invite: 'valid-token' }
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -147,7 +143,9 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).toHaveBeenCalledWith('valid-token')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'valid-token'
+      )
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'Invite Accepted',
@@ -163,12 +161,16 @@ describe('useInviteUrlLoader', () => {
 
     it('shows error toast when invite acceptance fails', async () => {
       mockRouteQuery.value = { invite: 'invalid-token' }
-      mockAcceptInvite.mockRejectedValue(new Error('Invalid invite'))
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockRejectedValue(
+        new Error('Invalid invite')
+      )
 
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).toHaveBeenCalledWith('invalid-token')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'invalid-token'
+      )
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'Failed to Accept Invite',
@@ -178,7 +180,7 @@ describe('useInviteUrlLoader', () => {
 
     it('cleans up URL after processing invite', async () => {
       mockRouteQuery.value = { invite: 'valid-token', other: 'param' }
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -194,7 +196,7 @@ describe('useInviteUrlLoader', () => {
 
     it('clears preserved query after processing', async () => {
       mockRouteQuery.value = { invite: 'valid-token' }
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -209,7 +211,9 @@ describe('useInviteUrlLoader', () => {
 
     it('clears preserved query even on error', async () => {
       mockRouteQuery.value = { invite: 'invalid-token' }
-      mockAcceptInvite.mockRejectedValue(new Error('Invalid invite'))
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockRejectedValue(
+        new Error('Invalid invite')
+      )
 
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
@@ -221,13 +225,17 @@ describe('useInviteUrlLoader', () => {
 
     it('sends any token format to backend for validation', async () => {
       mockRouteQuery.value = { invite: 'any-token-format==' }
-      mockAcceptInvite.mockRejectedValue(new Error('Invalid token'))
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockRejectedValue(
+        new Error('Invalid token')
+      )
 
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
       // Token is sent to backend, which validates and rejects
-      expect(mockAcceptInvite).toHaveBeenCalledWith('any-token-format==')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'any-token-format=='
+      )
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'Failed to Accept Invite',
@@ -241,7 +249,7 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().acceptInvite).not.toHaveBeenCalled()
     })
 
     it('ignores non-string invite param', async () => {
@@ -252,7 +260,7 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().acceptInvite).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, ref } from 'vue'
@@ -17,53 +17,6 @@ import {
   sortPendingInvites,
   useMembersPanel
 } from './useMembersPanel'
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { defineStore } = await import('pinia')
-    const { computed, ref } = await import('vue')
-    return {
-      useTeamWorkspaceStore: defineStore('teamWorkspace', () => {
-        const workspaces = ref<
-          Array<{
-            id: string
-            type: 'personal' | 'team'
-            members: WorkspaceMember[]
-            pendingInvites: WorkspacePendingInvite[]
-          }>
-        >([])
-        const activeWorkspaceId = ref<string | null>(null)
-        const activeWorkspace = computed(
-          () =>
-            workspaces.value.find(
-              (workspace) => workspace.id === activeWorkspaceId.value
-            ) ?? null
-        )
-        const members = computed(() => activeWorkspace.value?.members ?? [])
-        const pendingInvites = computed(
-          () => activeWorkspace.value?.pendingInvites ?? []
-        )
-        const originalOwnerId = computed(
-          () =>
-            members.value.find((member) => member.isOriginalOwner)?.id ?? null
-        )
-        return {
-          workspaces,
-          activeWorkspaceId,
-          activeWorkspace,
-          isInPersonalWorkspace: computed(
-            () => activeWorkspace.value?.type === 'personal'
-          ),
-          members,
-          pendingInvites,
-          originalOwnerId,
-          resendInvite: vi.fn()
-        }
-      })
-    }
-  }
-)
 
 function createMember(
   overrides: Partial<WorkspaceMember> = {}
@@ -528,8 +481,7 @@ describe('useMembersPanel', () => {
   let pinia: Pinia
 
   beforeEach(() => {
-    pinia = createPinia()
-    setActivePinia(pinia)
+    pinia = getActivePinia()!
     workspaceStore = useTeamWorkspaceStore(pinia)
     vi.spyOn(workspaceStore, 'resendInvite').mockImplementation(
       mockResendInvite

--- a/src/platform/workspace/composables/useResubscribe.test.ts
+++ b/src/platform/workspace/composables/useResubscribe.test.ts
@@ -74,17 +74,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock(import('@/stores/authStore'), () => ({
-  AuthStoreError: class AuthStoreError extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.name = 'AuthStoreError'
-      this.status = status
-    }
-  }
-}))
-
 vi.mock<unknown>(
   import('primevue/usetoast'), // eslint-disable-line primevue-removal/no-imports
   () => ({

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1,12 +1,9 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { billingOperation } from './billingOperationTestUtils'
+import type { BillingOperation } from './billingOperationTestUtils'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  computed,
-  createApp,
-  defineComponent,
-  effectScope,
-  reactive
-} from 'vue'
+import { computed, createApp, defineComponent, effectScope } from 'vue'
 import type { App } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -16,15 +13,9 @@ import type {
   Plan,
   PreviewSubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
-import type { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import { findPlanSlug } from './useSubscriptionCheckout'
-
-type SubscriptionActionOperation = NonNullable<
-  ReturnType<typeof useBillingOperationStore>['subscriptionActionOperation']
->
-type MockSubscriptionActionOperation = Partial<SubscriptionActionOperation> &
-  Pick<SubscriptionActionOperation, 'status' | 'workspaceId'>
 
 function makeStandardYearly(): Plan {
   return {
@@ -133,6 +124,13 @@ function makeReactivationAuthorityPreview({
   }
 }
 
+beforeEach(() => {
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation()
+  )
+  vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(undefined)
+})
+
 describe('findPlanSlug', () => {
   it('finds an annual plan by tier key and yearly billing cycle', () => {
     expect(findPlanSlug(allPlans(), 'standard', 'yearly')).toBe(
@@ -168,25 +166,18 @@ const {
   mockPlans,
   mockResubscribe,
   mockToastAdd,
-  mockStartOperation,
-  mockGetOperation,
-  mockSubscriptionActionOperation,
   mockListSavedPaymentMethods,
   mockTrackBeginCheckout,
   mockTrackBillingEvent,
   mockShowDowngradeToPersonalDialog,
-  mockUserId,
   mockIsTeamPlan,
   mockShouldUseWorkspaceBilling,
   mockIncompleteEmbeddedPreview,
-  mockSetActiveWorkspaceIdImpl,
-  mockSetActiveWorkspaceId,
   mockPermissions,
   mockCanReactivatePlan,
   mockCapabilities,
   mockSubscription
 } = vi.hoisted(() => {
-  const nullableString = (value: string | null) => ({ value })
   return {
     mockSubscribe: vi.fn(),
     mockPreviewSubscribe: vi.fn(),
@@ -200,27 +191,13 @@ const {
     mockPlans: { value: [] as Plan[] },
     mockResubscribe: vi.fn(),
     mockToastAdd: vi.fn(),
-    mockStartOperation: vi.fn(),
-    mockGetOperation: vi.fn(),
-    mockSubscriptionActionOperation: {
-      value: undefined as MockSubscriptionActionOperation | undefined
-    },
     mockListSavedPaymentMethods: vi.fn(),
     mockTrackBeginCheckout: vi.fn(),
     mockTrackBillingEvent: vi.fn(),
     mockShowDowngradeToPersonalDialog: vi.fn(),
-    mockUserId: nullableString('user-1'),
     mockIsTeamPlan: { value: false },
     mockShouldUseWorkspaceBilling: { value: true },
     mockIncompleteEmbeddedPreview: { value: false },
-    mockSetActiveWorkspaceIdImpl: {
-      value: undefined as ((workspaceId: string) => void) | undefined
-    },
-    mockSetActiveWorkspaceId: vi.fn<(workspaceId: string) => void>(
-      (workspaceId) => {
-        mockSetActiveWorkspaceIdImpl.value?.(workspaceId)
-      }
-    ),
     mockPermissions: {
       value: {
         canManageSubscription: true,
@@ -362,37 +339,6 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({
-      startOperation: mockStartOperation,
-      getOperation: mockGetOperation,
-      get subscriptionActionOperation() {
-        return mockSubscriptionActionOperation.value
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { ref } = await import('vue')
-    const activeWorkspaceId = ref('workspace-1')
-    mockSetActiveWorkspaceIdImpl.value = (workspaceId) => {
-      activeWorkspaceId.value = workspaceId
-    }
-    return {
-      useTeamWorkspaceStore: () => ({
-        get activeWorkspaceId() {
-          return activeWorkspaceId.value
-        }
-      })
-    }
-  }
-)
-
 vi.mock(import('@/config/comfyApi'), () => ({
   getComfyPlatformBaseUrl: () => 'https://platform.comfy.org'
 }))
@@ -418,18 +364,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => reactive({ userId: computed(() => mockUserId.value) }),
-  AuthStoreError: class AuthStoreError extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.name = 'AuthStoreError'
-      this.status = status
-    }
-  }
 }))
 
 describe('useSubscriptionCheckout', () => {
@@ -491,14 +425,15 @@ describe('useSubscriptionCheckout', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockSubscribe.mockReset()
     mockPreviewSubscribe.mockReset()
     mockFetchPlans.mockReset()
     mockFetchStatus.mockReset()
-    mockStartOperation.mockReset()
+    vi.mocked(useBillingOperationStore().startOperation).mockReset()
     mockListSavedPaymentMethods.mockReset()
-    mockSubscriptionActionOperation.value = undefined
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: undefined
+    })
     mockPlans.value = allPlans()
     mockFetchPlans.mockResolvedValue(undefined)
     mockPreviewSubscribe.mockResolvedValue({
@@ -507,14 +442,18 @@ describe('useSubscriptionCheckout', () => {
       is_immediate: true,
       requires_reactivation_confirmation: false
     })
-    mockStartOperation.mockResolvedValue({
-      status: 'succeeded',
-      workspaceId: 'workspace-1'
-    })
+    vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+      billingOperation({
+        status: 'succeeded',
+        workspaceId: 'workspace-1'
+      })
+    )
     mockListSavedPaymentMethods.mockResolvedValue([])
-    mockGetOperation.mockReturnValue(undefined)
+    vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+      undefined
+    )
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
-    mockUserId.value = 'user-1'
+    Object.assign(useAuthStore(), { userId: 'user-1' })
     mockIsTeamPlan.value = false
     mockOpen.mockReturnValue({})
     mockGetBillingStatus.mockResolvedValue({ billing_status: 'paid' })
@@ -529,7 +468,7 @@ describe('useSubscriptionCheckout', () => {
     vi.stubGlobal('open', mockOpen)
     mockShouldUseWorkspaceBilling.value = true
     mockIncompleteEmbeddedPreview.value = false
-    mockSetActiveWorkspaceId('workspace-1')
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
     mockPermissions.value = {
       canManageSubscription: true,
       canManageSubscriptionLifecycle: true,
@@ -2740,12 +2679,14 @@ describe('useSubscriptionCheckout', () => {
 
   describe('handleBackToPricing', () => {
     it('surfaces a subscription operation recovered from billing status', async () => {
-      mockSubscriptionActionOperation.value = {
-        opId: 'op-recovered-3ds',
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        actionUrl: 'https://verify.example/sensitive-token'
-      }
+      Object.assign(useBillingOperationStore(), {
+        subscriptionActionOperation: {
+          opId: 'op-recovered-3ds',
+          status: 'pending',
+          workspaceId: 'workspace-1',
+          actionUrl: 'https://verify.example/sensitive-token'
+        }
+      })
 
       const checkout = await setup()
 
@@ -2756,15 +2697,17 @@ describe('useSubscriptionCheckout', () => {
     })
 
     it('surfaces recovered failed authentication and releases the confirm action', async () => {
-      mockSubscriptionActionOperation.value = {
-        opId: 'op-recovered-3ds',
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        authenticationState: 'failed_retryable',
-        errorMessage: 'Challenge was closed',
-        canRetryAuthentication: false,
-        isAuthenticating: false
-      }
+      Object.assign(useBillingOperationStore(), {
+        subscriptionActionOperation: {
+          opId: 'op-recovered-3ds',
+          status: 'pending',
+          workspaceId: 'workspace-1',
+          authenticationState: 'failed_retryable',
+          errorMessage: 'Challenge was closed',
+          canRetryAuthentication: false,
+          isAuthenticating: false
+        }
+      })
 
       const checkout = await setup()
 
@@ -2774,11 +2717,13 @@ describe('useSubscriptionCheckout', () => {
     })
 
     it('surfaces an operation that needs reconciliation', async () => {
-      mockSubscriptionActionOperation.value = {
-        opId: 'op-reconciliation',
-        status: 'reconciliation_needed',
-        workspaceId: 'workspace-1'
-      }
+      Object.assign(useBillingOperationStore(), {
+        subscriptionActionOperation: {
+          opId: 'op-reconciliation',
+          status: 'reconciliation_needed',
+          workspaceId: 'workspace-1'
+        }
+      })
 
       const checkout = await setup()
 
@@ -2817,13 +2762,19 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-pending'
       })
-      mockGetOperation.mockImplementation((opId) =>
-        opId === 'op-pending'
-          ? { status: 'pending', workspaceId: 'workspace-1' }
-          : undefined
+      vi.mocked(useBillingOperationStore().getOperation).mockImplementation(
+        (opId) =>
+          opId === 'op-pending'
+            ? billingOperation({
+                status: 'pending',
+                workspaceId: 'workspace-1'
+              })
+            : undefined
       )
-      let resolveOperation!: (operation: { status: 'failed' }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -2831,12 +2782,14 @@ describe('useSubscriptionCheckout', () => {
       )
 
       const payment = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      await vi.waitFor(() =>
+        expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      )
       checkout.handleBackToPricing()
 
       expect(checkout.checkoutStep.value).toBe('preview')
 
-      resolveOperation({ status: 'failed' })
+      resolveOperation(billingOperation({ status: 'failed' }))
       await payment
     })
 
@@ -2857,16 +2810,17 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-pending'
       })
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        actionUrl: 'https://verify.example/sensitive-token'
-      })
-      let resolveOperation!: (operation: {
-        status: 'succeeded'
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({
+          status: 'pending',
+          workspaceId: 'workspace-1',
+          actionUrl: 'https://verify.example/sensitive-token'
+        })
+      )
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -2878,15 +2832,19 @@ describe('useSubscriptionCheckout', () => {
         expect(checkout.activeCheckoutActionUrl.value).not.toBeNull()
       )
 
-      mockSetActiveWorkspaceId('workspace-2')
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       expect(checkout.activeCheckoutActionUrl.value).toBeNull()
       expect(checkout.isPolling.value).toBe(false)
 
-      resolveOperation({
-        status: 'succeeded',
-        workspaceId: 'workspace-1'
-      })
+      resolveOperation(
+        billingOperation({
+          status: 'succeeded',
+          workspaceId: 'workspace-1'
+        })
+      )
       await payment
 
       expect(checkout.checkoutStep.value).not.toBe('success')
@@ -2894,7 +2852,7 @@ describe('useSubscriptionCheckout', () => {
   })
 
   describe('busy continuity through checkout', () => {
-    async function startPendingCheckout(operation: Record<string, unknown>) {
+    async function startPendingCheckout(operation: Partial<BillingOperation>) {
       const checkout = await setupWithApprovedPreview()
       checkout.checkoutStep.value = 'preview'
       checkout.selectedTierKey.value = 'standard'
@@ -2902,21 +2860,22 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-busy'
       })
-      mockGetOperation.mockImplementation((opId) =>
-        opId === 'op-busy' ? operation : undefined
+      vi.mocked(useBillingOperationStore().getOperation).mockImplementation(
+        (opId) => (opId === 'op-busy' ? billingOperation(operation) : undefined)
       )
-      let resolveOperation!: (operation: {
-        status: string
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
           })
       )
       const payment = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      await vi.waitFor(() =>
+        expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      )
       return { checkout, payment, finish: () => resolveOperation }
     }
 
@@ -2930,7 +2889,9 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.isPolling.value).toBe(true)
 
-      finish()({ status: 'failed', workspaceId: 'workspace-1' })
+      finish()(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
     })
 
@@ -2944,7 +2905,9 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.isPolling.value).toBe(false)
 
-      finish()({ status: 'failed', workspaceId: 'workspace-1' })
+      finish()(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
     })
 
@@ -2957,7 +2920,9 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.isPolling.value).toBe(true)
       expect(checkout.checkoutStep.value).toBe('preview')
 
-      finish()({ status: 'succeeded', workspaceId: 'workspace-1' })
+      finish()(
+        billingOperation({ status: 'succeeded', workspaceId: 'workspace-1' })
+      )
       await payment
       expect(checkout.checkoutStep.value).toBe('success')
     })
@@ -3038,7 +3003,7 @@ describe('useSubscriptionCheckout', () => {
     })
 
     it('skips begin_checkout when no user id is available', async () => {
-      mockUserId.value = null
+      Object.assign(useAuthStore(), { userId: null })
       const checkout = await setupWithApprovedPreview('subscribe_to_run')
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -3052,7 +3017,7 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
-      mockUserId.value = 'user-1'
+      Object.assign(useAuthStore(), { userId: 'user-1' })
     })
 
     it('fires begin_checkout carrying the payment intent source', async () => {
@@ -3114,7 +3079,7 @@ describe('useSubscriptionCheckout', () => {
           detail: 'subscription.preview.paymentPopupBlocked'
         })
       )
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-blocked',
         'subscription',
         expect.any(Object),
@@ -3136,7 +3101,7 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(openSpy).not.toHaveBeenCalled()
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
@@ -3155,15 +3120,19 @@ describe('useSubscriptionCheckout', () => {
         billing_op_id: 'op-async-1',
         payment_method_url: 'https://stripe.com/pay'
       })
-      mockStartOperation.mockResolvedValueOnce({
-        status: 'succeeded',
-        workspaceId: 'workspace-1'
-      })
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockResolvedValueOnce(
+        billingOperation({
+          status: 'succeeded',
+          workspaceId: 'workspace-1'
+        })
+      )
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
       await checkout.handleAddCreditCard()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-async-1',
         'subscription',
         {
@@ -3190,11 +3159,17 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-async-2'
       })
-      mockStartOperation.mockResolvedValueOnce({ status: 'failed' })
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockResolvedValueOnce(
+        billingOperation({
+          status: 'failed'
+        })
+      )
 
       await checkout.handleAddCreditCard()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-async-2',
         'subscription',
         {
@@ -3218,11 +3193,10 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-alipay'
       })
-      let resolveOperation!: (operation: {
-        status: 'failed'
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -3247,7 +3221,9 @@ describe('useSubscriptionCheckout', () => {
         })
       })
 
-      resolveOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      resolveOperation(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
 
       expect(
@@ -3264,11 +3240,10 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-legacy-alipay'
       })
-      let resolveOperation!: (operation: {
-        status: 'failed'
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -3296,7 +3271,9 @@ describe('useSubscriptionCheckout', () => {
         })
       })
 
-      resolveOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      resolveOperation(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
 
       expect(
@@ -4085,3 +4062,10 @@ describe('useSubscriptionCheckout', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -1,3 +1,6 @@
+import { billingOperation } from './billingOperationTestUtils'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
@@ -27,11 +30,8 @@ const mockBillingPlans = vi.hoisted(() => ({
 }))
 
 const mockShow = vi.hoisted(() => vi.fn())
-const mockStartOperation = vi.hoisted(() => vi.fn())
-const mockGetOperation = vi.hoisted(() => vi.fn())
-const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
+
 const mockReportError = vi.hoisted(() => vi.fn())
-const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
 // const is in its temporal dead zone when the hoisted factory runs under
@@ -71,31 +71,9 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({
-      getOperation: mockGetOperation,
-      startOperation: mockStartOperation
-    })
-  })
-)
-
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspace() {
-        return { id: mockActiveWorkspaceId.value }
-      },
-      setWorkspaceBillingRail: mockSetWorkspaceBillingRail
-    })
-  })
-)
 
 const mockTrackBillingEvent = vi.hoisted(() => vi.fn())
 
@@ -181,9 +159,27 @@ const subscribeResponses = [
   }
 ] satisfies SubscribeResponse[]
 
+beforeEach(() => {
+  vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(undefined)
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation()
+  )
+})
+
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), {
+    activeWorkspace: { id: 'workspace-1' }
+  })
+  vi.mocked(useTeamWorkspaceStore().setWorkspaceBillingRail).mockImplementation(
+    () => {}
+  )
+})
+
 describe('useWorkspaceBilling', () => {
   beforeEach(() => {
-    mockActiveWorkspaceId.value = 'workspace-1'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1' }
+    })
     mockBillingPlans.plans.value = []
     mockBillingPlans.currentPlanSlug.value = null
     mockBillingPlans.error.value = null
@@ -284,10 +280,9 @@ describe('useWorkspaceBilling', () => {
       })
       expect(billing.canAccessSubscriptionFeatures.value).toBe(true)
       expect(billing.isFreeTier.value).toBe(false)
-      expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
-        'workspace-1',
-        'stripe'
-      )
+      expect(
+        useTeamWorkspaceStore().setWorkspaceBillingRail
+      ).toHaveBeenCalledWith('workspace-1', 'stripe')
     })
 
     it('maps a scheduled plan change into subscription info', async () => {
@@ -325,7 +320,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-recovered',
         'subscription',
         undefined,
@@ -348,7 +343,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-sub',
         'subscription',
         undefined,
@@ -370,7 +365,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-topup',
         'topup',
         undefined,
@@ -399,7 +394,7 @@ describe('useWorkspaceBilling', () => {
       )
       // Recovery is preserved deliberately: without it the customer has no way
       // back to the payment page, while a wrong panel clears on reload.
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-future',
         'subscription',
         undefined,
@@ -413,16 +408,16 @@ describe('useWorkspaceBilling', () => {
         billing_status: 'pending_payment',
         pending_billing_op_id: 'op-recovered'
       } satisfies BillingStatusResponse)
-      mockGetOperation
+      vi.mocked(useBillingOperationStore().getOperation)
         .mockReturnValueOnce(undefined)
-        .mockReturnValue({ status: 'pending' })
+        .mockReturnValue(billingOperation({ status: 'pending' }))
 
       const billing = setupBilling()
       await billing.fetchStatus()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledOnce()
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-recovered',
         'subscription',
         undefined,
@@ -436,7 +431,9 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
 
       const fetch = billing.fetchStatus()
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: { id: 'workspace-2' }
+      })
       status.resolve({
         ...activeStatus,
         billing_status: 'pending_payment',
@@ -445,7 +442,7 @@ describe('useWorkspaceBilling', () => {
       })
       await fetch
 
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
       expect(billing.subscription.value).toBeNull()
     })
 
@@ -469,7 +466,9 @@ describe('useWorkspaceBilling', () => {
       await billing.fetchStatus()
 
       expect(billing.isFreeTier.value).toBe(true)
-      expect(mockSetWorkspaceBillingRail).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().setWorkspaceBillingRail
+      ).not.toHaveBeenCalled()
     })
 
     it('sets error and rethrows when fetchStatus fails', async () => {
@@ -903,13 +902,13 @@ describe('useWorkspaceBilling', () => {
         errorMessage: string | null
       }> = {}
     ) {
-      return {
+      return billingOperation({
         opId: 'op-cancel',
         type: 'cancel' as const,
         status: overrides.status ?? ('succeeded' as const),
         errorMessage: overrides.errorMessage ?? null,
         startedAt: 0
-      }
+      })
     }
 
     it('drives the shared billing operation poller with a cancel op', async () => {
@@ -917,14 +916,20 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-cancel',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(operation())
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation()
+      )
 
       const billing = setupBilling()
       await billing.cancelSubscription()
 
-      expect(mockStartOperation).toHaveBeenCalledWith('op-cancel', 'cancel', {
-        attemptStartedAt: expect.any(Number)
-      })
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+        'op-cancel',
+        'cancel',
+        {
+          attemptStartedAt: expect.any(Number)
+        }
+      )
       expect(billing.error.value).toBeNull()
     })
 
@@ -933,8 +938,11 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-fail',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
-        operation({ status: 'failed', errorMessage: 'processor rejected' })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation({
+          status: 'failed',
+          errorMessage: 'processor rejected'
+        })
       )
 
       const billing = setupBilling()
@@ -950,7 +958,7 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-timeout',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
         operation({
           status: 'timeout',
           errorMessage: 'billingOperation.cancelTimeout'
@@ -969,7 +977,7 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-noerr',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
         operation({ status: 'failed', errorMessage: null })
       )
 
@@ -989,7 +997,7 @@ describe('useWorkspaceBilling', () => {
 
       await expect(billing.cancelSubscription()).rejects.toThrow('API down')
       expect(billing.error.value).toBe('API down')
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
     })
 
     it('fires a started event before the cancel API call resolves', async () => {
@@ -997,7 +1005,9 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-cancel',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(operation())
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation()
+      )
 
       const billing = setupBilling()
       await billing.cancelSubscription()
@@ -1048,8 +1058,11 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-fail',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
-        operation({ status: 'failed', errorMessage: 'processor rejected' })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation({
+          status: 'failed',
+          errorMessage: 'processor rejected'
+        })
       )
 
       const billing = setupBilling()
@@ -1093,7 +1106,7 @@ describe('useWorkspaceBilling', () => {
       // shows — the point of resyncing rather than reporting a failure.
       expect(billing.subscription.value?.endDate).toBe('2026-06-01T00:00:00Z')
       expect(billing.subscription.value?.tier).toBe('CREATOR')
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
       expect(billing.isLoading.value).toBe(false)
       expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ stage: 'failed' })
@@ -1189,18 +1202,20 @@ describe('useWorkspaceBilling', () => {
       })
       mockWorkspaceApi.getBillingStatus.mockResolvedValue(activeStatus)
       mockWorkspaceApi.getBillingBalance.mockResolvedValue(positiveBalance)
-      mockStartOperation.mockResolvedValue({
-        opId: 'op-resub-pending',
-        type: 'subscription',
-        status: 'succeeded',
-        errorMessage: null,
-        startedAt: 0
-      })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        billingOperation({
+          opId: 'op-resub-pending',
+          type: 'subscription',
+          status: 'succeeded',
+          errorMessage: null,
+          startedAt: 0
+        })
+      )
 
       const billing = setupBilling()
       await billing.resubscribe()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-resub-pending',
         'subscription'
       )
@@ -1214,13 +1229,15 @@ describe('useWorkspaceBilling', () => {
       })
       mockWorkspaceApi.getBillingStatus.mockResolvedValue(activeStatus)
       mockWorkspaceApi.getBillingBalance.mockResolvedValue(positiveBalance)
-      mockStartOperation.mockResolvedValue({
-        opId: 'op-resub-failed',
-        type: 'subscription',
-        status: 'failed',
-        errorMessage: 'card declined',
-        startedAt: 0
-      })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        billingOperation({
+          opId: 'op-resub-failed',
+          type: 'subscription',
+          status: 'failed',
+          errorMessage: 'card declined',
+          startedAt: 0
+        })
+      )
 
       const billing = setupBilling()
 

--- a/src/platform/workspace/composables/useWorkspaceSwitch.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceSwitch.test.ts
@@ -1,41 +1,26 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
-import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 
-const mockSwitchWorkspace = vi.hoisted(() => vi.fn())
-const mockWorkspaceStore = vi.hoisted(() => ({
-  store: null as {
-    activeWorkspace: WorkspaceWithRole | null
-    switchWorkspace: typeof mockSwitchWorkspace
-  } | null
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { reactive, ref } = await import('vue')
-    mockWorkspaceStore.store = reactive({
-      activeWorkspace: ref<WorkspaceWithRole | null>(null),
-      switchWorkspace: mockSwitchWorkspace
-    })
-    return { useTeamWorkspaceStore: () => mockWorkspaceStore.store }
-  }
-)
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().switchWorkspace).mockResolvedValue(
+    undefined
+  )
+})
 
 describe('useWorkspaceSwitch', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
-    if (!mockWorkspaceStore.store) throw new Error('workspace store not ready')
-    mockWorkspaceStore.store.activeWorkspace = {
-      id: 'workspace-1',
-      name: 'Test Workspace',
-      type: 'personal',
-      role: 'owner',
-      created_at: '2026-01-01T00:00:00Z',
-      joined_at: '2026-01-01T00:00:00Z'
-    }
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: {
+        id: 'workspace-1',
+        name: 'Test Workspace',
+        type: 'personal',
+        role: 'owner',
+        created_at: '2026-01-01T00:00:00Z',
+        joined_at: '2026-01-01T00:00:00Z'
+      }
+    })
   })
 
   describe('switchWorkspace', () => {
@@ -45,21 +30,27 @@ describe('useWorkspaceSwitch', () => {
       const result = await switchWorkspace('workspace-1')
 
       expect(result).toBe(true)
-      expect(mockSwitchWorkspace).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().switchWorkspace).not.toHaveBeenCalled()
     })
 
     it('switches directly to the new workspace', async () => {
-      mockSwitchWorkspace.mockResolvedValue(undefined)
+      vi.mocked(useTeamWorkspaceStore().switchWorkspace).mockResolvedValue(
+        undefined
+      )
       const { switchWorkspace } = useWorkspaceSwitch()
 
       const result = await switchWorkspace('workspace-2')
 
       expect(result).toBe(true)
-      expect(mockSwitchWorkspace).toHaveBeenCalledWith('workspace-2')
+      expect(useTeamWorkspaceStore().switchWorkspace).toHaveBeenCalledWith(
+        'workspace-2'
+      )
     })
 
     it('returns false if switchWorkspace throws an error', async () => {
-      mockSwitchWorkspace.mockRejectedValue(new Error('Switch failed'))
+      vi.mocked(useTeamWorkspaceStore().switchWorkspace).mockRejectedValue(
+        new Error('Switch failed')
+      )
       const { switchWorkspace } = useWorkspaceSwitch()
 
       const result = await switchWorkspace('workspace-2')

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -1,15 +1,10 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { computed, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 
-const mockStore = vi.hoisted(() => ({
-  activeWorkspace: null as WorkspaceWithRole | null,
-  isCurrentUserOriginalOwner: false,
-  originalOwnerId: null as string | null,
-  ensureMembersLoaded: vi.fn()
-}))
-const mockIsCloud = ref(true)
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanReactivate = ref(false)
 const mockCanSubscribeSelfServe = ref(true)
@@ -18,30 +13,6 @@ const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockBillingControlEnabled = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspace() {
-        return mockStore.activeWorkspace
-      },
-      get isInPersonalWorkspace() {
-        return mockStore.activeWorkspace?.type === 'personal'
-      },
-      get isWorkspaceSubscribed() {
-        return false
-      },
-      get isCurrentUserOriginalOwner() {
-        return mockStore.isCurrentUserOriginalOwner
-      },
-      get originalOwnerId() {
-        return mockStore.originalOwnerId
-      },
-      ensureMembersLoaded: mockStore.ensureMembersLoaded
-    })
-  })
-)
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -125,10 +96,9 @@ async function loadComposable() {
 }
 
 function resetStore() {
-  mockStore.activeWorkspace = null
-  mockStore.isCurrentUserOriginalOwner = false
-  mockStore.originalOwnerId = null
-  mockStore.ensureMembersLoaded.mockReset()
+  Object.assign(useTeamWorkspaceStore(), { activeWorkspace: null })
+  Object.assign(useTeamWorkspaceStore(), { isCurrentUserOriginalOwner: false })
+  Object.assign(useTeamWorkspaceStore(), { originalOwnerId: null })
   mockIsActiveSubscription.value = false
   mockIsCancelled.value = false
   mockIsTeamPlan.value = false
@@ -139,6 +109,12 @@ function resetStore() {
   mockCanSubscribeSelfServe.value = true
   mockSnapshotAuthoritative.value = true
 }
+
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().ensureMembersLoaded).mockResolvedValue(
+    undefined
+  )
+})
 
 describe('useWorkspaceUI', () => {
   beforeEach(() => {
@@ -171,7 +147,9 @@ describe('useWorkspaceUI', () => {
 
   describe('personal workspace', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
     })
 
     it('grants billing access with personal workspace visibility', async () => {
@@ -190,7 +168,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('gives a Team-plan member only member actions', async () => {
-      mockStore.activeWorkspace = personalMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalMemberWorkspace
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
@@ -210,7 +190,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('withholds leave from a Personal-plan member', async () => {
-      mockStore.activeWorkspace = personalMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalMemberWorkspace
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
@@ -227,7 +209,9 @@ describe('useWorkspaceUI', () => {
 
     it('lets a promoted owner leave while using a Team plan', async () => {
       mockIsTeamPlan.value = true
-      mockStore.originalOwnerId = 'original-owner'
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'original-owner'
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
@@ -236,8 +220,12 @@ describe('useWorkspaceUI', () => {
 
     it('keeps the original creator from leaving while using a Team plan', async () => {
       mockIsTeamPlan.value = true
-      mockStore.originalOwnerId = 'current-user'
-      mockStore.isCurrentUserOriginalOwner = true
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'current-user'
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
@@ -271,7 +259,9 @@ describe('useWorkspaceUI', () => {
 
   describe('team workspace as owner', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
     })
 
     it('grants full management permissions', async () => {
@@ -323,7 +313,9 @@ describe('useWorkspaceUI', () => {
 
   describe('team workspace as member', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = teamMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamMemberWorkspace
+      })
       mockIsTeamPlan.value = true
     })
 
@@ -368,7 +360,9 @@ describe('useWorkspaceUI', () => {
 
   describe('original-owner permissions', () => {
     it('uses the canonical store signal for personal workspaces', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
       const ui = await loadComposable()
 
       expect(ui.isOriginalOwner.value).toBe(false)
@@ -376,9 +370,15 @@ describe('useWorkspaceUI', () => {
     })
 
     it('allows an original owner to downgrade', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
-      mockStore.originalOwnerId = 'current-user'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'current-user'
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
@@ -388,7 +388,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('allows an additional workspace owner to leave before creator identity resolves', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
@@ -398,8 +400,12 @@ describe('useWorkspaceUI', () => {
 
   describe('subscription lifecycle', () => {
     it('grants lifecycle and downgrade to the original owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
@@ -408,8 +414,12 @@ describe('useWorkspaceUI', () => {
     })
 
     it('withholds downgrade from an original owner on a Personal plan', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canManageSubscription).toBe(true)
@@ -417,9 +427,15 @@ describe('useWorkspaceUI', () => {
     })
 
     it('grants lifecycle but withholds downgrade from a promoted owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = false
-      mockStore.originalOwnerId = 'original-owner'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: false
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'original-owner'
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
@@ -429,7 +445,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('withholds lifecycle from members', async () => {
-      mockStore.activeWorkspace = teamMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamMemberWorkspace
+      })
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
       expect(ui.permissions.value.canDowngradeToPersonal).toBe(false)
@@ -438,27 +456,35 @@ describe('useWorkspaceUI', () => {
 
   describe('original-owner data loading', () => {
     it('loads members for a team owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       await loadComposable()
-      expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().ensureMembersLoaded).toHaveBeenCalled()
     })
 
     it('loads members for a personal owner', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
       await loadComposable()
-      expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().ensureMembersLoaded).toHaveBeenCalled()
     })
 
     it('does not load members for a member', async () => {
-      mockStore.activeWorkspace = personalMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalMemberWorkspace
+      })
       await loadComposable()
-      expect(mockStore.ensureMembersLoaded).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().ensureMembersLoaded).not.toHaveBeenCalled()
     })
   })
 
   describe('cancelled Team plan', () => {
     it('uses plan identity instead of workspace type', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
       mockIsTeamPlan.value = true
       mockIsCancelled.value = true
       const ui = await loadComposable()
@@ -468,7 +494,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('ignores a cancelled non-Team plan in a team workspace', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       mockIsTeamPlan.value = false
       mockIsCancelled.value = true
       const ui = await loadComposable()
@@ -480,7 +508,9 @@ describe('useWorkspaceUI', () => {
 
   describe('shared instance', () => {
     it('returns the same composable state for multiple callers within a test', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       const first = await loadComposable()
       const second = await loadComposable()
 
@@ -490,7 +520,9 @@ describe('useWorkspaceUI', () => {
   })
   describe('canReactivatePlan', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
     })
 
     it('uses the server capability on the consolidated rail', async () => {
@@ -527,7 +559,9 @@ describe('useWorkspaceUI', () => {
 
   describe('canOpenPricingSurface', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
     })
 
     it('closes the catalog when the server resolves a sales-managed plan', async () => {
@@ -573,7 +607,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('keeps the catalog closed for a non-owner with no readable snapshot', async () => {
-      mockStore.activeWorkspace = teamMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamMemberWorkspace
+      })
       mockSnapshotAuthoritative.value = false
       mockCanSubscribeSelfServe.value = false
 
@@ -583,3 +619,10 @@ describe('useWorkspaceUI', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1,5 +1,7 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
 
@@ -46,16 +48,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-const mockToastAdd = vi.fn()
-const mockToastRemove = vi.fn()
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd,
-    remove: mockToastRemove
-  })
-}))
-
 vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   workspaceApi: {
     getBillingOpStatus: vi.fn()
@@ -76,14 +68,6 @@ vi.mock(import('@/platform/settings/composables/useSettingsDialog'), () => ({
   })
 }))
 
-const mockCloseDialog = vi.fn()
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
-
 const mockTrackBillingEvent = vi.fn()
 const mockTrackMonthlySubscriptionSucceeded = vi.fn()
 
@@ -94,29 +78,26 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-const mockUpdateActiveWorkspace = vi.fn()
-const mockActiveWorkspaceId = ref('workspace-1')
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      updateActiveWorkspace: mockUpdateActiveWorkspace
-    })
-  })
-)
-
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingOperationStore } from './billingOperationStore'
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => {})
+  vi.mocked(useToastStore().remove).mockImplementation(() => {})
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().updateActiveWorkspace).mockImplementation(
+    () => {}
+  )
+})
+
 describe('billingOperationStore', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
-    mockActiveWorkspaceId.value = 'workspace-1'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
     mockFeatureFlags.embeddedCheckoutEnabled = true
     vi.stubEnv('VITE_STRIPE_PUBLISHABLE_KEY', 'pk_test_3ds')
     mockHandleNextAction.mockResolvedValue({})
@@ -230,7 +211,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'info',
         summary: 'billingOperation.subscriptionProcessing',
         group: 'billing-operation'
@@ -249,7 +230,7 @@ describe('billingOperationStore', () => {
         suppressProcessingToast: true
       })
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('shows immediate processing toast for topup operations', () => {
@@ -262,7 +243,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'topup')
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'info',
         summary: 'billingOperation.topupProcessing',
         group: 'billing-operation'
@@ -378,7 +359,7 @@ describe('billingOperationStore', () => {
       expect(mockFetchStatus).not.toHaveBeenCalled()
       expect(mockFetchBalance).not.toHaveBeenCalled()
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'billingOperation.subscriptionSuccess',
         life: 5000
@@ -398,7 +379,7 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockCloseDialog).not.toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalledWith({
         key: 'subscription-required'
       })
       expect(mockSettingsDialogShow).not.toHaveBeenCalled()
@@ -416,7 +397,9 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'top-up-credits' })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: 'top-up-credits'
+      })
       expect(mockSettingsDialogShow).toHaveBeenCalledWith('workspace')
     })
 
@@ -644,7 +627,7 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'billingOperation.topupSuccess',
         life: 5000
@@ -717,11 +700,11 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
 
-      const receivedToast = mockToastAdd.mock.calls[0][0]
+      const receivedToast = vi.mocked(useToastStore().add).mock.calls[0][0]
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastRemove).toHaveBeenCalledWith(receivedToast)
+      expect(useToastStore().remove).toHaveBeenCalledWith(receivedToast)
     })
   })
 
@@ -746,7 +729,7 @@ describe('billingOperationStore', () => {
       )
       expect(store.hasPendingOperations).toBe(false)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.subscriptionFailed',
         detail: 'billingOperation.subscriptionFailedDetail',
@@ -801,7 +784,7 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(store.getOperation('op-1')?.status).toBe('failed')
-      expect(mockToastAdd).not.toHaveBeenCalledWith(
+      expect(useToastStore().add).not.toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
@@ -918,7 +901,7 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.topupFailed',
         detail: undefined,
@@ -1015,7 +998,7 @@ describe('billingOperationStore', () => {
         await vi.advanceTimersByTimeAsync(0)
 
         expect(store.getOperation('op-1')?.errorMessage).toBe(detail)
-        expect(mockToastAdd).toHaveBeenCalledWith({
+        expect(useToastStore().add).toHaveBeenCalledWith({
           severity: 'error',
           summary,
           detail,
@@ -1807,7 +1790,9 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 8001)
 
@@ -1862,7 +1847,7 @@ describe('billingOperationStore', () => {
       expect(operation?.status).toBe('timeout')
       expect(store.hasPendingOperations).toBe(false)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.subscriptionTimeout'
       })
@@ -1933,7 +1918,9 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(30_000)
       expect((await terminal).status).toBe('succeeded')
       expect(store.getOperation('op-1')?.actionUrl).toBeNull()
-      expect(JSON.stringify(mockToastAdd.mock.calls)).not.toContain(actionUrl)
+      expect(
+        JSON.stringify(vi.mocked(useToastStore().add).mock.calls)
+      ).not.toContain(actionUrl)
       expect(JSON.stringify(mockTrackBillingEvent.mock.calls)).not.toContain(
         actionUrl
       )
@@ -1955,12 +1942,12 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.subscriptionProcessing',
         group: 'billing-operation'
       }
-      expect(mockToastAdd).toHaveBeenCalledWith(processingToast)
+      expect(useToastStore().add).toHaveBeenCalledWith(processingToast)
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastRemove).toHaveBeenCalledWith(processingToast)
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().remove).toHaveBeenCalledWith(processingToast)
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'warn',
         summary: 'billingOperation.subscriptionActionRequired',
         group: 'billing-operation'
@@ -1982,12 +1969,12 @@ describe('billingOperationStore', () => {
         'https://verify.example/sensitive-token'
       )
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'warn',
         summary: 'billingOperation.topupActionRequired',
         group: 'billing-operation'
       })
-      expect(mockToastAdd).not.toHaveBeenCalledWith(
+      expect(useToastStore().add).not.toHaveBeenCalledWith(
         expect.objectContaining({
           summary: 'billingOperation.topupProcessing'
         })
@@ -2017,14 +2004,14 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.subscriptionActionRequired',
         group: 'billing-operation'
       }
-      expect(mockToastAdd).toHaveBeenCalledWith(actionRequiredToast)
+      expect(useToastStore().add).toHaveBeenCalledWith(actionRequiredToast)
 
       // The verification action is gone, so the prompt pointing at it must go
       // too rather than asking for something the customer can no longer do.
       await vi.advanceTimersByTimeAsync(30_000)
 
-      expect(mockToastRemove).toHaveBeenCalledWith(actionRequiredToast)
-      expect(mockToastAdd).toHaveBeenLastCalledWith({
+      expect(useToastStore().remove).toHaveBeenCalledWith(actionRequiredToast)
+      expect(useToastStore().add).toHaveBeenLastCalledWith({
         severity: 'info',
         summary: 'billingOperation.subscriptionProcessing',
         group: 'billing-operation'
@@ -2044,10 +2031,12 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       const actionRequiredAdds = () =>
-        mockToastAdd.mock.calls.filter(
-          (call) =>
-            call[0]?.summary === 'billingOperation.subscriptionActionRequired'
-        ).length
+        vi
+          .mocked(useToastStore().add)
+          .mock.calls.filter(
+            (call) =>
+              call[0].summary === 'billingOperation.subscriptionActionRequired'
+          ).length
 
       expect(actionRequiredAdds()).toBe(1)
 
@@ -2140,7 +2129,9 @@ describe('billingOperationStore', () => {
       expect(store.topupActionOperation?.actionUrl).toBe(actionUrl)
       expect(store.isAddingCredits).toBe(true)
 
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       expect(store.topupActionOperation).toBeUndefined()
       expect(store.isAddingCredits).toBe(false)
@@ -2162,7 +2153,9 @@ describe('billingOperationStore', () => {
       expect(store.subscriptionActionOperation?.actionUrl).toBe(actionUrl)
       expect(store.isSettingUp).toBe(true)
 
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       expect(store.subscriptionActionOperation).toBeUndefined()
       expect(store.isSettingUp).toBe(false)
@@ -2180,7 +2173,9 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       resolveStatus({
         id: 'op-1',
@@ -2216,7 +2211,7 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(121_000)
       await vi.runAllTimersAsync()
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.topupTimeout'
       })
@@ -2241,7 +2236,7 @@ describe('billingOperationStore', () => {
         actionUrl,
         authenticationRequiredSeen: true
       })
-      expect(mockToastAdd).not.toHaveBeenCalledWith({
+      expect(useToastStore().add).not.toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.topupTimeout'
       })
@@ -2259,7 +2254,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'cancel')
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('resolves with the succeeded operation and refreshes status', async () => {
@@ -2277,7 +2272,9 @@ describe('billingOperationStore', () => {
 
       expect(operation.status).toBe('succeeded')
       expect(mockFetchStatus).toHaveBeenCalled()
-      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
+      expect(
+        useTeamWorkspaceStore().updateActiveWorkspace
+      ).toHaveBeenCalledWith({
         isSubscribed: false
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
@@ -2321,7 +2318,7 @@ describe('billingOperationStore', () => {
       await terminal
 
       expect(mockSettingsDialogShow).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('resolves with a failed operation and default message, no toast', async () => {
@@ -2339,8 +2336,10 @@ describe('billingOperationStore', () => {
 
       expect(operation.status).toBe('failed')
       expect(operation.errorMessage).toBe('billingOperation.cancelFailed')
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().updateActiveWorkspace
+      ).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: 'operation',
@@ -2373,8 +2372,10 @@ describe('billingOperationStore', () => {
 
       expect(operation.status).toBe('timeout')
       expect(operation.errorMessage).toBe('billingOperation.cancelTimeout')
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().updateActiveWorkspace
+      ).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: 'operation',
@@ -2471,7 +2472,7 @@ describe('billingOperationStore', () => {
       expect(store.getOperation('op-1')?.status).toBe('pending')
       expect(store.hasPendingOperations).toBe(true)
       expect(resolved).toBe(false)
-      expect(mockToastAdd).not.toHaveBeenCalledWith(
+      expect(useToastStore().add).not.toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
     })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,23 +9,6 @@ import type {
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
-
-const mockTeamWorkspaceStore = vi.hoisted(() => ({
-  store: null as null | {
-    activeWorkspace: null | { id: string; type: 'personal' | 'team' }
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mockTeamWorkspaceStore.store = reactive({ activeWorkspace: null })
-    return {
-      useTeamWorkspaceStore: () => mockTeamWorkspaceStore.store
-    }
-  }
-)
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
@@ -62,9 +46,7 @@ const providers: PartnerProvider[] = [
 ]
 
 function activateWorkspace(id: string, type: 'personal' | 'team' = 'team') {
-  if (!mockTeamWorkspaceStore.store)
-    throw new Error('Workspace store not ready')
-  mockTeamWorkspaceStore.store.activeWorkspace = { id, type }
+  Object.assign(useTeamWorkspaceStore(), { activeWorkspace: { id, type } })
 }
 
 async function createLoadedStore() {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -1,3 +1,4 @@
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
@@ -7,34 +8,6 @@ import { sortWorkspaces, useTeamWorkspaceStore } from './teamWorkspaceStore'
 const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock(import('@/platform/distribution/types'), () => mockDistributionTypes)
-
-// Mock workspaceAuthStore
-const mockWorkspaceAuthStore = vi.hoisted(() => ({
-  currentWorkspace: null as {
-    id: string
-    name: string
-    type: 'personal' | 'team'
-    role: 'owner' | 'member'
-  } | null,
-  workspaceToken: null as string | null,
-  isLoading: false,
-  error: null as Error | null,
-  isAuthenticated: false,
-  init: vi.fn(),
-  destroy: vi.fn(),
-  initializeFromSession: vi.fn(),
-  switchWorkspace: vi.fn(),
-  refreshToken: vi.fn(),
-  getWorkspaceAuthHeader: vi.fn(),
-  clearWorkspaceContext: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => mockWorkspaceAuthStore
-  })
-)
 
 const mockClearWorkflowRestoreState = vi.hoisted(() => vi.fn())
 const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
@@ -161,12 +134,37 @@ function expectCleanupBeforeContextAndReload(): void {
   expect(
     mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
   ).toBeLessThan(
-    mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+    vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+      .invocationCallOrder[0]
   )
   expect(
-    mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+    vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+      .invocationCallOrder[0]
   ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
 }
+
+beforeEach(() => {
+  Object.assign(useWorkspaceAuthStore(), { currentWorkspace: null })
+  Object.assign(useWorkspaceAuthStore(), { workspaceToken: null })
+  Object.assign(useWorkspaceAuthStore(), { isLoading: false })
+  Object.assign(useWorkspaceAuthStore(), { error: null })
+  Object.assign(useWorkspaceAuthStore(), { isAuthenticated: false })
+  vi.mocked(useWorkspaceAuthStore().init).mockImplementation(() => {})
+  vi.mocked(useWorkspaceAuthStore().destroy).mockImplementation(() => {})
+  vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+    false
+  )
+  vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useWorkspaceAuthStore().refreshToken).mockResolvedValue(undefined)
+  vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+    null
+  )
+  vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockImplementation(
+    () => {}
+  )
+})
 
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
@@ -177,13 +175,17 @@ describe('useTeamWorkspaceStore', () => {
     mockCurrentUser.isApiKeyLogin.value = false
 
     // Reset workspaceAuthStore mock state
-    mockWorkspaceAuthStore.currentWorkspace = null
-    mockWorkspaceAuthStore.workspaceToken = null
-    mockWorkspaceAuthStore.isLoading = false
-    mockWorkspaceAuthStore.error = null
-    mockWorkspaceAuthStore.isAuthenticated = false
-    mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(false)
-    mockWorkspaceAuthStore.switchWorkspace.mockResolvedValue(undefined)
+    Object.assign(useWorkspaceAuthStore(), { currentWorkspace: null })
+    Object.assign(useWorkspaceAuthStore(), { workspaceToken: null })
+    Object.assign(useWorkspaceAuthStore(), { isLoading: false })
+    Object.assign(useWorkspaceAuthStore(), { error: null })
+    Object.assign(useWorkspaceAuthStore(), { isAuthenticated: false })
+    vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+      false
+    )
+    vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockResolvedValue(
+      undefined
+    )
     mockEnsureSessionCookie.mockResolvedValue(undefined)
 
     // Default mock responses
@@ -231,28 +233,36 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.initState).toBe('ready')
       expect(store.workspaces).toHaveLength(2)
       expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledWith(
         mockPersonalWorkspace.id
       )
     })
 
     it('restores workspace from session if valid', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
       expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
-      expect(mockWorkspaceAuthStore.switchWorkspace).not.toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().switchWorkspace).not.toHaveBeenCalled()
     })
 
     it('clears transient restore state before falling back from a missing session workspace', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = {
-        ...mockTeamWorkspace,
-        id: 'missing-workspace'
-      }
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: {
+          ...mockTeamWorkspace,
+          id: 'missing-workspace'
+        }
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -261,9 +271,10 @@ describe('useTeamWorkspaceStore', () => {
       expect(
         mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
       ).toBeLessThan(
-        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
       )
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledWith(
         mockPersonalWorkspace.id
       )
     })
@@ -420,8 +431,8 @@ describe('useTeamWorkspaceStore', () => {
         expect.objectContaining({ id: mockMemberWorkspace.id })
       ])
       expect(store.activeWorkspaceId).toBe(mockMemberWorkspace.id)
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledOnce()
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledOnce()
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledWith(
         mockMemberWorkspace.id
       )
     })
@@ -438,7 +449,7 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('does not activate a workspace when token exchange fails', async () => {
-      mockWorkspaceAuthStore.switchWorkspace.mockRejectedValue(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockRejectedValue(
         new Error('Token exchange failed')
       )
 
@@ -484,7 +495,7 @@ describe('useTeamWorkspaceStore', () => {
       ])
       expect(store.activeWorkspaceId).toBe('ws-api-key')
       expect(mockWorkspaceApi.list).not.toHaveBeenCalled()
-      expect(mockWorkspaceAuthStore.switchWorkspace).not.toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().switchWorkspace).not.toHaveBeenCalled()
       expect(mockEnsureSessionCookie).not.toHaveBeenCalled()
     })
 
@@ -560,26 +571,30 @@ describe('useTeamWorkspaceStore', () => {
       await store.switchWorkspace(mockTeamWorkspace.id)
 
       expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledOnce()
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expect(
         mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
       ).toBeLessThan(
-        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
       )
       expect(
-        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
       ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
     })
 
     it('switches local billing context without touching workflow state', async () => {
       mockDistributionTypes.isCloud = false
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementation(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementation(
         async (workspaceId: string) => {
           const workspace = [mockPersonalWorkspace, mockTeamWorkspace].find(
             ({ id }) => id === workspaceId
           )
-          mockWorkspaceAuthStore.currentWorkspace = workspace ?? null
+          Object.assign(useWorkspaceAuthStore(), {
+            currentWorkspace: workspace ?? null
+          })
         }
       )
       const store = useTeamWorkspaceStore()
@@ -589,13 +604,13 @@ describe('useTeamWorkspaceStore', () => {
 
       await store.switchWorkspace(mockTeamWorkspace.id)
 
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenLastCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenLastCalledWith(
         mockTeamWorkspace.id
       )
       expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
       expect(mockPrepareWorkflowWorkspaceTransition).not.toHaveBeenCalled()
       expect(
-        mockWorkspaceAuthStore.clearWorkspaceContext
+        useWorkspaceAuthStore().clearWorkspaceContext
       ).not.toHaveBeenCalled()
       expect(mockReload).not.toHaveBeenCalled()
       expect(store.isSwitching).toBe(false)
@@ -612,11 +627,13 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
 
       let finishSwitch: () => void = () => {}
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = () => {
-              mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+              Object.assign(useWorkspaceAuthStore(), {
+                currentWorkspace: mockTeamWorkspace
+              })
               resolve()
             }
           })
@@ -642,11 +659,13 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
 
       let finishSwitch: () => void = () => {}
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = () => {
-              mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+              Object.assign(useWorkspaceAuthStore(), {
+                currentWorkspace: mockTeamWorkspace
+              })
               resolve()
             }
           })
@@ -676,7 +695,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
 
       let finishSwitch: () => void = () => {}
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = resolve
@@ -696,7 +715,7 @@ describe('useTeamWorkspaceStore', () => {
       mockDistributionTypes.isCloud = false
       const store = useTeamWorkspaceStore()
       await store.initialize()
-      mockWorkspaceAuthStore.switchWorkspace.mockRejectedValueOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockRejectedValueOnce(
         new Error('Token exchange failed')
       )
 
@@ -803,8 +822,10 @@ describe('useTeamWorkspaceStore', () => {
     ])(
       'reloads $reloads time(s) when the active $type workspace is revoked',
       async ({ workspace, reloads }) => {
-        mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-        mockWorkspaceAuthStore.currentWorkspace = workspace
+        vi.mocked(
+          useWorkspaceAuthStore().initializeFromSession
+        ).mockReturnValue(true)
+        Object.assign(useWorkspaceAuthStore(), { currentWorkspace: workspace })
         const store = useTeamWorkspaceStore()
         await store.initialize()
 
@@ -836,8 +857,12 @@ describe('useTeamWorkspaceStore', () => {
 
     it('falls back locally without clearing workflow state or reloading', async () => {
       mockDistributionTypes.isCloud = false
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
@@ -877,7 +902,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.workspaces).toContainEqual(
         expect.objectContaining({ id: newWorkspace.id })
       )
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expectCleanupBeforeContextAndReload()
     })
@@ -938,8 +963,12 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('deletes active workspace and reloads to personal', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -949,7 +978,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.deleteWorkspace()
 
       expect(mockWorkspaceApi.delete).toHaveBeenCalledWith(mockTeamWorkspace.id)
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expectCleanupBeforeContextAndReload()
     })
@@ -999,8 +1028,12 @@ describe('useTeamWorkspaceStore', () => {
 
   describe('leaveWorkspace', () => {
     it('leaves workspace and reloads to personal', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockMemberWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockMemberWorkspace
+      })
       mockWorkspaceApi.list.mockResolvedValue({
         workspaces: [mockPersonalWorkspace, mockMemberWorkspace]
       })
@@ -1012,7 +1045,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.leaveWorkspace()
 
       expect(mockWorkspaceApi.leave).toHaveBeenCalled()
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID,
         mockPersonalWorkspace.id
@@ -1029,7 +1062,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.leaveWorkspace()
 
       expect(mockWorkspaceApi.leave).toHaveBeenCalled()
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockLocalStorage.setItem).not.toHaveBeenCalled()
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
         WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID
@@ -1050,8 +1083,12 @@ describe('useTeamWorkspaceStore', () => {
 
   describe('computed properties', () => {
     it('activeWorkspace returns correct workspace', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1076,8 +1113,12 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('isInPersonalWorkspace returns false when in team', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1154,8 +1195,12 @@ describe('useTeamWorkspaceStore', () => {
         members: mockMembers,
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1232,8 +1277,12 @@ describe('useTeamWorkspaceStore', () => {
         members: mockMembers,
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1280,8 +1329,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'owner',
         is_original_owner: true
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1314,8 +1367,12 @@ describe('useTeamWorkspaceStore', () => {
         pagination: { offset: 0, limit: 50, total: 1 }
       })
       mockWorkspaceApi.updateMemberRole.mockRejectedValue(new Error('boom'))
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1389,8 +1446,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'member',
         is_original_owner: true
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1427,8 +1488,12 @@ describe('useTeamWorkspaceStore', () => {
         ],
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1468,8 +1533,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'member',
         is_original_owner: false
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1512,8 +1581,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'owner',
         is_original_owner: false
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1547,8 +1620,12 @@ describe('useTeamWorkspaceStore', () => {
     }
 
     async function activateTeamWorkspace() {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
       const store = useTeamWorkspaceStore()
       await store.initialize()
       return store
@@ -1633,8 +1710,12 @@ describe('useTeamWorkspaceStore', () => {
         members,
         pagination: { offset: 0, limit: 50, total: members.length }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1706,8 +1787,12 @@ describe('useTeamWorkspaceStore', () => {
 
     it('fails closed when members are not loaded', async () => {
       mockCurrentUser.userEmail.value = 'owner@test.com'
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1727,8 +1812,12 @@ describe('useTeamWorkspaceStore', () => {
         members: [ownerSelf],
         pagination: { offset: 0, limit: 50, total: 1 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1764,8 +1853,12 @@ describe('useTeamWorkspaceStore', () => {
         }
       ]
       mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1786,8 +1879,12 @@ describe('useTeamWorkspaceStore', () => {
         expires_at: '2024-01-08T00:00:00Z'
       }
       mockWorkspaceApi.createInvite.mockResolvedValue(newInvite)
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1821,8 +1918,12 @@ describe('useTeamWorkspaceStore', () => {
         }
       ]
       mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1853,8 +1954,12 @@ describe('useTeamWorkspaceStore', () => {
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1886,8 +1991,12 @@ describe('useTeamWorkspaceStore', () => {
         ]
       })
       mockWorkspaceApi.resendInvite.mockRejectedValue(error)
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1915,8 +2024,12 @@ describe('useTeamWorkspaceStore', () => {
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1937,8 +2050,12 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('resendInvite throws for an unknown invite id', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1974,7 +2091,7 @@ describe('useTeamWorkspaceStore', () => {
 
       store.destroy()
 
-      expect(mockWorkspaceAuthStore.destroy).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().destroy).toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -1,3 +1,6 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { storeToRefs } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -12,45 +15,15 @@ import {
 } from '@/platform/workflow/persistence/base/storageKeys'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 
-const mockGetIdToken = vi.fn()
-const mockNotifyTokenRefreshed = vi.fn()
 const mockTrackUnifiedAuthRefresh = vi.fn()
-const mockToastAdd = vi.fn()
+
 const mockEnsureSessionCookie = vi.fn()
-const mockCurrentUser = vi.hoisted((): { value: { uid: string } | null } => ({
-  value: null
-}))
-const mockForgetRevokedActiveWorkspace = vi.fn()
+
 const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
 const mockReload = vi.fn()
 const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
-const mockTeamWorkspaceState = vi.hoisted(() => ({
-  activeWorkspaceId: null as string | null
-}))
 
 vi.mock(import('@/platform/distribution/types'), () => mockDistributionTypes)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    getIdToken: mockGetIdToken,
-    notifyTokenRefreshed: mockNotifyTokenRefreshed,
-    get currentUser() {
-      return mockCurrentUser.value
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      forgetRevokedActiveWorkspace: mockForgetRevokedActiveWorkspace,
-      get activeWorkspaceId() {
-        return mockTeamWorkspaceState.activeWorkspaceId
-      }
-    })
-  })
-)
 
 vi.mock(import('@/platform/workflow/persistence/base/storageIO'), () => ({
   prepareWorkflowWorkspaceTransition: mockPrepareWorkflowWorkspaceTransition
@@ -68,16 +41,10 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd
-  })
-}))
-
-vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: {
+vi.mock(import('@/scripts/api'), async (importOriginal) => ({
+  api: Object.assign((await importOriginal()).api, {
     apiURL: (route: string) => `https://api.example.com/api${route}`
-  }
+  })
 }))
 
 vi.mock(import('@/platform/workspace/api/workspaceApiUrl'), () => ({
@@ -123,17 +90,29 @@ function expectedExpiresAtMs(expiresAt: string): string {
   return new Date(expiresAt).getTime().toString()
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => {})
+})
+
+beforeEach(() => {
+  vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
+  vi.mocked(useAuthStore().notifyTokenRefreshed).mockImplementation(() => {})
+  vi.mocked(
+    useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+  ).mockReturnValue(false)
+})
+
 describe('useWorkspaceAuthStore', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
-    mockTeamWorkspaceState.activeWorkspaceId = null
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
     vi.stubGlobal('location', {
       reload: mockReload,
       origin: 'http://localhost'
     })
     vi.useFakeTimers({ shouldAdvanceTime: false })
     mockUnifiedCloudAuthEnabled.value = false
-    mockCurrentUser.value = { uid: 'user-a' }
+    Object.assign(useAuthStore(), { currentUser: { uid: 'user-a' } })
     mockEnsureSessionCookie.mockResolvedValue(undefined)
   })
 
@@ -192,7 +171,7 @@ describe('useWorkspaceAuthStore', () => {
         futureExpiry.toString()
       )
       sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, 'user-a')
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
 
       const store = useWorkspaceAuthStore()
 
@@ -296,7 +275,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('switchWorkspace', () => {
     it('successfully exchanges Firebase token for workspace token', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -323,7 +304,9 @@ describe('useWorkspaceAuthStore', () => {
           confirmSession = resolve
         })
       )
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -358,7 +341,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('discards a token exchange that resolves after the user changes', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-a')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue('firebase-token-a')
       let resolveResponse: (value: unknown) => void = () => {}
       vi.stubGlobal(
         'fetch',
@@ -371,7 +354,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       const switchPromise = store.switchWorkspace('workspace-123')
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
       resolveResponse({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -384,7 +367,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('stores workspace data in sessionStorage', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -412,7 +397,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('replaces the workspace token when the same user switches workspaces', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -456,7 +443,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('sets isLoading to true during operation', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveResponse: (value: unknown) => void
       const responsePromise = new Promise((resolve) => {
         resolveResponse = resolve
@@ -479,7 +468,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('keeps isLoading true until overlapping switches settle', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveFirstSwitch: (value: unknown) => void = () => {}
       let resolveSecondSwitch: (value: unknown) => void = () => {}
       const firstSwitchResponse = new Promise((resolve) => {
@@ -524,7 +515,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code NOT_AUTHENTICATED when Firebase token unavailable', async () => {
-      mockGetIdToken.mockResolvedValue(undefined)
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
 
       const store = useWorkspaceAuthStore()
       const { error } = storeToRefs(store)
@@ -538,7 +529,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code ACCESS_DENIED on 403 response', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -562,7 +555,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code WORKSPACE_NOT_FOUND on 404 response', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -588,7 +583,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code INVALID_FIREBASE_TOKEN on 401 response', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -614,7 +611,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code TOKEN_EXCHANGE_FAILED on other errors', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -640,7 +639,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('sends correct request to API', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -667,7 +668,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('clearWorkspaceContext', () => {
     it('clears all state refs', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -713,7 +716,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('prevents in-flight refreshes from restoring cleared state', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -771,7 +776,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('returns proper Authorization header when workspace token exists', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -793,7 +800,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('ensureWorkspaceAuthHeader', () => {
     it('returns the existing header without minting when the token is valid', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -811,7 +820,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('re-mints instead of returning a token owned by another user', async () => {
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-a')
         .mockResolvedValueOnce('firebase-token-b')
       const mockFetch = vi
@@ -832,7 +841,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.switchWorkspace('workspace-123')
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
 
       const header = await store.ensureWorkspaceAuthHeader('workspace-123')
 
@@ -841,7 +850,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('mints a token for the preferred workspace when none exists', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -858,7 +869,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('coalesces concurrent recovery onto a single mint', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -878,7 +891,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('awaits an in-flight switch instead of racing a second mint', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveResponse: (value: unknown) => void = () => {}
       const responsePromise = new Promise((resolve) => {
         resolveResponse = resolve
@@ -903,8 +918,8 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('does not give a previous user waiter the next user token', async () => {
-      mockGetIdToken.mockImplementation(() =>
-        Promise.resolve(`firebase-${mockCurrentUser.value?.uid}`)
+      vi.mocked(useAuthStore().getIdToken).mockImplementation(() =>
+        Promise.resolve(`firebase-${useAuthStore().currentUser?.uid}`)
       )
       let resolvePreviousResponse: (value: unknown) => void = () => {}
       const mockFetch = vi
@@ -928,7 +943,7 @@ describe('useWorkspaceAuthStore', () => {
       const previousHeader = store.ensureWorkspaceAuthHeader('workspace-123')
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
 
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
       store.clearWorkspaceContext()
       await store.switchWorkspace('workspace-123')
 
@@ -948,7 +963,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('returns null (never a downgrade) when recovery fails transiently', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -975,7 +992,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('tears down workspace context and surfaces a toast on a permanent recovery failure', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -999,11 +1018,13 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(token).toBeNull()
       expect(currentWorkspace.value).toBeNull()
-      expect(mockToastAdd).toHaveBeenCalledTimes(1)
+      expect(useToastStore().add).toHaveBeenCalledTimes(1)
     })
 
     it('backs off re-minting after a failed recovery instead of retrying every call', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 500,
@@ -1023,7 +1044,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('forgets the revoked active workspace on a permanent workspace-selection failure', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1040,13 +1063,15 @@ describe('useWorkspaceAuthStore', () => {
       const token = await store.ensureWorkspaceToken('workspace-123')
 
       expect(token).toBeNull()
-      expect(mockForgetRevokedActiveWorkspace).toHaveBeenCalledWith(
-        'workspace-123'
-      )
+      expect(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).toHaveBeenCalledWith('workspace-123')
     })
 
     it('does not forget the workspace when the failure is an auth error, not revocation', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1062,11 +1087,15 @@ describe('useWorkspaceAuthStore', () => {
       const token = await store.ensureWorkspaceToken('workspace-123')
 
       expect(token).toBeNull()
-      expect(mockForgetRevokedActiveWorkspace).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).not.toHaveBeenCalled()
     })
 
     it('preserves a valid context on a transient Firebase network failure while signed in', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1079,19 +1108,23 @@ describe('useWorkspaceAuthStore', () => {
       const { currentWorkspace } = storeToRefs(store)
       await store.switchWorkspace('workspace-123')
 
-      mockCurrentUser.value = { uid: 'user-a' }
-      mockGetIdToken.mockResolvedValue(undefined)
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-a' } })
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
 
       const token = await store.ensureWorkspaceToken('workspace-999')
 
       expect(token).toBeNull()
       expect(currentWorkspace.value?.id).toBe('workspace-123')
-      expect(mockToastAdd).not.toHaveBeenCalled()
-      expect(mockForgetRevokedActiveWorkspace).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).not.toHaveBeenCalled()
     })
 
     it('collapses a burst of waiters into a single mint after a shared in-flight switch rejects', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -1124,7 +1157,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('re-mints for the requested workspace rather than returning an in-flight switch to a different one', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockImplementation((_url, options) => {
         const { workspace_id: workspaceId } = JSON.parse(options.body)
         return Promise.resolve({
@@ -1151,12 +1186,18 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not restore a stale local selection after another switch completes', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceState.activeWorkspaceId = 'workspace-123'
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockImplementation((_url, options) => {
         const { workspace_id: workspaceId } = JSON.parse(options.body)
         if (workspaceId === 'workspace-other') {
-          mockTeamWorkspaceState.activeWorkspaceId = workspaceId
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: workspaceId
+          })
         }
         return Promise.resolve({
           ok: true,
@@ -1183,7 +1224,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('token refresh scheduling', () => {
     it('schedules token refresh 5 minutes before expiry', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const tokenResponseWithFutureExpiry = {
         ...mockTokenResponse,
@@ -1213,7 +1256,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('clears context when refresh fails with ACCESS_DENIED', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const tokenResponseWithFutureExpiry = {
         ...mockTokenResponse,
@@ -1241,7 +1286,9 @@ describe('useWorkspaceAuthStore', () => {
       mockPrepareWorkflowWorkspaceTransition.mockReturnValue(
         cancelWorkflowTransition
       )
-      mockForgetRevokedActiveWorkspace.mockImplementation(() => {
+      vi.mocked(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).mockImplementation(() => {
         workspaceWhenRevocationHandled = sessionStorage.getItem(
           WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
         )
@@ -1281,7 +1328,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('refreshes token for current workspace', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -1311,7 +1360,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('isAuthenticated computed', () => {
     it('returns true when both workspace and token are present', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1336,7 +1387,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('returns false when currentWorkspace is set but workspaceToken is null', async () => {
-      mockGetIdToken.mockResolvedValue(null)
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
 
       const store = useWorkspaceAuthStore()
       const { currentWorkspace, workspaceToken, isAuthenticated } =
@@ -1351,7 +1402,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('refreshToken retry/race paths', () => {
     it('ends an expired workspace session behind the workflow write barrier', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresAt = Date.now() + 3600 * 1000
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1395,7 +1448,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('retries up to 3 times with exponential backoff on TOKEN_EXCHANGE_FAILED, then preserves valid context', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       // Initial successful switchWorkspace establishes context.
       const mockFetch = vi.fn().mockResolvedValueOnce({
@@ -1490,7 +1545,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('clears context immediately on INVALID_FIREBASE_TOKEN without retrying', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -1526,7 +1583,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('keeps the old workspace refresh when a newer workspace switch fails', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1581,7 +1640,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('allows same-workspace switches to leave in-flight refreshes valid', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1642,7 +1703,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('the new workspace wins when the stale refresh resolves last', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1720,7 +1783,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('blocks a stale refresh that resolves after switch-away-and-back to same workspace', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1787,7 +1852,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('the new workspace keeps clean error state when a stale refresh fails last', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1836,7 +1903,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('persistToSession resilience', () => {
     it('updates store state even when sessionStorage.setItem throws', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1886,7 +1955,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('Zod validation on token response', () => {
     it('throws TOKEN_EXCHANGE_FAILED when the response is missing required fields', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1927,7 +1998,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('mintAtLogin is a no-op and returns false when the flag is OFF', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn()
       vi.stubGlobal('fetch', mockFetch)
 
@@ -1943,7 +2016,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('mints the personal default once into the dormant unifiedToken slot when flag ON', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -1972,7 +2047,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not re-mint when unifiedToken is already populated', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -1990,7 +2067,7 @@ describe('useWorkspaceAuthStore', () => {
 
     it('re-mints when the existing unified token belongs to another user', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-a')
         .mockResolvedValueOnce('firebase-token-b')
       const mockFetch = vi
@@ -2008,7 +2085,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
 
       const result = await store.mintAtLogin()
 
@@ -2019,7 +2096,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('arms a refresh at expires_at - buffer and re-mints from the parsed expiry (no hardcoded TTL)', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -2047,7 +2126,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not bump the rotation trigger on the initial login mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -2059,12 +2140,14 @@ describe('useWorkspaceAuthStore', () => {
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
 
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
     it('does not bump the rotation trigger on a workspace switch', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -2083,12 +2166,14 @@ describe('useWorkspaceAuthStore', () => {
       )
       expect(store.getUnifiedToken()).toBe('workspace-token-abc')
       expect(store.workspaceToken).toBeNull()
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
     it('scopes workflow persistence to each unified workspace', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const secondWorkspace = {
         ...mockWorkspaceWithRole,
         id: 'workspace-456'
@@ -2135,7 +2220,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not retry an old workspace request with a new workspace token', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2171,7 +2258,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not let an old workspace retry supersede a pending switch', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveWorkspaceB: (value: unknown) => void = () => {}
       const mockFetch = vi
         .fn()
@@ -2217,7 +2306,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('fails closed when switching workspaces fails', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2245,7 +2336,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('bumps the rotation trigger exactly once on a refresh re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       vi.stubGlobal(
         'fetch',
@@ -2265,12 +2358,14 @@ describe('useWorkspaceAuthStore', () => {
       const refreshDelay = expiresInMs - 5 * 60 * 1000
       await vi.advanceTimersByTimeAsync(refreshDelay)
 
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
     })
 
     it('bumps the rotation trigger on a successful reactive re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -2281,16 +2376,18 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
 
       await store.remintUnifiedOnce('unified-token-1')
 
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
     })
 
     it('remintUnifiedOnce re-mints once and, on a permanent failure, surfaces it and tears down without looping', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2318,7 +2415,7 @@ describe('useWorkspaceAuthStore', () => {
       // A permanent failure resolves to null (the caller surfaces its 401),
       // fires the error toast keyed to the 401 code, and clears the dead session.
       expect(result).toBeNull()
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'workspaceAuth.errors.invalidFirebaseToken'
@@ -2335,7 +2432,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('remintUnifiedOnce does not toast or clear the slot on a transient re-mint failure', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2359,13 +2458,15 @@ describe('useWorkspaceAuthStore', () => {
       const result = await store.remintUnifiedOnce('unified-token-1')
 
       expect(result).toBeNull()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 
     it('remintUnifiedOnce returns null without minting when the flag is OFF', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn()
       vi.stubGlobal('fetch', mockFetch)
 
@@ -2379,7 +2480,7 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not retry an old account request with the current account token', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-a')
         .mockResolvedValueOnce('firebase-token-b')
       const mockFetch = vi
@@ -2397,7 +2498,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
       await store.mintAtLogin()
 
       const result = await store.remintUnifiedOnce('unified-token-1')
@@ -2408,7 +2509,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('evicts an expired unified-token context past the grace window on the next mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const base = Date.now()
       const mockFetch = vi
         .fn()
@@ -2451,7 +2554,7 @@ describe('useWorkspaceAuthStore', () => {
 
     it('ignores a stale unified mint failure after account state is cleared', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-a')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue('firebase-token-a')
       let resolveResponse: (value: unknown) => void = () => {}
       vi.stubGlobal(
         'fetch',
@@ -2474,12 +2577,14 @@ describe('useWorkspaceAuthStore', () => {
 
       await expect(mintPromise).resolves.toBe(false)
       expect(store.unifiedToken).toBeNull()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('coalesces concurrent re-mints and returns the winning token to every caller', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -2517,7 +2622,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('reuses a same-user burst winner for a later stale 401', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2545,7 +2652,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('clears unifiedToken and stops the unified timer on clearWorkspaceContext', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -2569,7 +2678,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('is fully dormant under the flag OFF: no unified network, timer, or rotation', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn()
       vi.stubGlobal('fetch', mockFetch)
 
@@ -2582,7 +2693,7 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(mockFetch).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBeNull()
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
     it.for([
@@ -2605,7 +2716,9 @@ describe('useWorkspaceAuthStore', () => {
       'surfaces the $status permanent refresh error as a toast and clears the slot',
       async ({ status, statusText, detailKey }) => {
         mockUnifiedCloudAuthEnabled.value = true
-        mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+        vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+          'firebase-token-xyz'
+        )
         const expiresInMs = 3600 * 1000
         const mockFetch = vi
           .fn()
@@ -2634,7 +2747,7 @@ describe('useWorkspaceAuthStore', () => {
 
         await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
 
-        expect(mockToastAdd).toHaveBeenCalledWith(
+        expect(useToastStore().add).toHaveBeenCalledWith(
           expect.objectContaining({ severity: 'error', detail: detailKey })
         )
         expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
@@ -2649,9 +2762,9 @@ describe('useWorkspaceAuthStore', () => {
       mockUnifiedCloudAuthEnabled.value = true
       const expiresInMs = 3600 * 1000
       // Mint succeeds, then the Firebase identity is gone at refresh time.
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-xyz')
-        .mockResolvedValue(null)
+        .mockResolvedValue(undefined)
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -2670,7 +2783,7 @@ describe('useWorkspaceAuthStore', () => {
       await store.mintAtLogin()
       await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'workspaceAuth.errors.notAuthenticated'
@@ -2681,7 +2794,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not toast on a successful refresh re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       vi.stubGlobal(
         'fetch',
@@ -2699,12 +2814,14 @@ describe('useWorkspaceAuthStore', () => {
       await store.mintAtLogin()
       await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('does not toast on a transient refresh failure and keeps the slot', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi
         .fn()
@@ -2733,13 +2850,15 @@ describe('useWorkspaceAuthStore', () => {
       const refreshDelay = expiresInMs - 5 * 60 * 1000
       await vi.advanceTimersByTimeAsync(refreshDelay)
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 
     it('retries a transiently failed proactive refresh with backoff and rotates on success', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const okResponse = () => ({
         ok: true,
@@ -2769,7 +2888,7 @@ describe('useWorkspaceAuthStore', () => {
       const refreshDelay = expiresInMs - 5 * 60 * 1000
       await vi.advanceTimersByTimeAsync(refreshDelay)
       expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
       expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
         outcome: 'retry_scheduled',
         retry_count: 1
@@ -2778,7 +2897,7 @@ describe('useWorkspaceAuthStore', () => {
       await vi.advanceTimersByTimeAsync(5000)
 
       expect(mockFetch).toHaveBeenCalledTimes(3)
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
       expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
         outcome: 'succeeded'
       })
@@ -2791,7 +2910,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('bounds refresh retries and keeps the slot for reactive recovery', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi
         .fn()
@@ -2825,7 +2946,7 @@ describe('useWorkspaceAuthStore', () => {
       await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
       expect(mockFetch).toHaveBeenCalledTimes(5)
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
         outcome: 'retries_exhausted',
         retry_count: 3
@@ -2835,7 +2956,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('re-arms the retry when a swallowed mint failure resolves false (owner null mid-refresh)', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi.fn().mockImplementation(() =>
         Promise.resolve({
@@ -2857,22 +2980,24 @@ describe('useWorkspaceAuthStore', () => {
 
       // Firebase is re-initializing at refresh time: requestToken throws
       // NOT_AUTHENTICATED, which performUnifiedMint swallows to `false`.
-      mockCurrentUser.value = null
+      Object.assign(useAuthStore(), { currentUser: null })
       await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
       expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
 
-      mockCurrentUser.value = { uid: 'user-a' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-a' } })
       await vi.advanceTimersByTimeAsync(5000)
 
       expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 
     it('does not stomp a superseding workspace switch schedule with a stale-refresh retry', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const okResponse = (token: string) => ({
         ok: true,
@@ -2923,7 +3048,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('surfaces an error toast and resolves false when the login mint hits a permanent auth error', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 401,
@@ -2940,7 +3067,7 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(result).toBe(false)
       expect(unifiedToken.value).toBeNull()
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'workspaceAuth.errors.invalidFirebaseToken'
@@ -2950,7 +3077,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('never toasts from the unified lifecycle when the flag is OFF', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       // Even with a backend that would reject, the OFF lifecycle stays inert.
       vi.stubGlobal(
         'fetch',
@@ -2968,7 +3097,14 @@ describe('useWorkspaceAuthStore', () => {
       await store.remintUnifiedOnce('unified-token-1')
       await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -6,22 +6,6 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { app } from '@/scripts/app'
 
-// Mock stores
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => {
-  const getCanvas = vi.fn()
-  const setCursorStyle = vi.fn()
-  return {
-    useCanvasStore: vi.fn(() => ({
-      getCanvas,
-      setCursorStyle,
-      isReadOnly: false
-    }))
-  }
-})
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => {
-  const getFn = vi.fn()
-  return { useSettingStore: vi.fn(() => ({ get: getFn })) }
-})
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: {

--- a/src/renderer/core/layout/store/hitTargetAuthority.test.ts
+++ b/src/renderer/core/layout/store/hitTargetAuthority.test.ts
@@ -12,9 +12,6 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { toGroupId } from '@/types/groupId'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({})
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
+++ b/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
@@ -17,15 +17,9 @@ const { getNodeById } = vi.hoisted(() => ({
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: { getNodeById } } }
+  app: { canvas: { graph: { getNodeById } }, nodePreviewImages: {} }
 }))
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    getNodeImageUrls: () => undefined,
-    nodeOutputs: {},
-    nodePreviewImages: {}
-  })
-}))
+
 vi.mock(
   import('@/renderer/extensions/compositor/composables/useCompositorEditor'),
   () => ({

--- a/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
@@ -1,3 +1,5 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent } from 'vue'
@@ -12,17 +14,6 @@ import {
   setCompositorLayers
 } from './useCompositorLayers'
 
-const { showDialog, toastAdd } = vi.hoisted(() => ({
-  showDialog: vi.fn(),
-  toastAdd: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -53,6 +44,10 @@ afterEach(() => {
   for (const app of apps.splice(0)) app.unmount()
 })
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
 describe('useCompositorEditor', () => {
   const node = { id: toNodeId(1) } as unknown as LGraphNode
 
@@ -63,13 +58,13 @@ describe('useCompositorEditor', () => {
   it('shows a toast and keeps the dialog closed without cached layers', () => {
     renderCompositorEditor().openCompositorEditor(node)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'info',
         detail: 'compositor.runWorkflowFirst'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   it('shows a toast when layers are cached without a fingerprint', () => {
@@ -79,13 +74,13 @@ describe('useCompositorEditor', () => {
 
     renderCompositorEditor().openCompositorEditor(node)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'info',
         detail: 'compositor.runWorkflowFirst'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   it('opens the layer editor in compositor mode when layers are cached', () => {
@@ -97,8 +92,8 @@ describe('useCompositorEditor', () => {
 
     renderCompositorEditor().openCompositorEditor(node)
 
-    expect(toastAdd).not.toHaveBeenCalled()
-    expect(showDialog).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).toHaveBeenCalledWith(
       expect.objectContaining({
         key: 'global-layer-editor',
         props: { node, mode: 'compositor' }

--- a/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent, ref } from 'vue'
@@ -9,13 +10,13 @@ import { toNodeId } from '@/types/nodeId'
 
 import { useCompositorPsdDownload } from './useCompositorPsdDownload'
 
-const { buildSessionPsdBlob, downloadBlob, loadCompositorSession, toastAdd } =
-  vi.hoisted(() => ({
+const { buildSessionPsdBlob, downloadBlob, loadCompositorSession } = vi.hoisted(
+  () => ({
     buildSessionPsdBlob: vi.fn(async () => new Blob(['psd'])),
     downloadBlob: vi.fn(),
-    loadCompositorSession: vi.fn().mockResolvedValue(0),
-    toastAdd: vi.fn()
-  }))
+    loadCompositorSession: vi.fn().mockResolvedValue(0)
+  })
+)
 
 vi.mock(
   import('@/renderer/extensions/compositor/composables/compositorSession'),
@@ -31,9 +32,7 @@ vi.mock(
   })
 )
 vi.mock(import('@/base/common/downloadUtil'), () => ({ downloadBlob }))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -75,6 +74,10 @@ function makeSession(glOk = true) {
 
 const node = { id: toNodeId(5) } as unknown as LGraphNode
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
 describe('useCompositorPsdDownload', () => {
   beforeEach(() => {
     loadCompositorSession.mockResolvedValue(0)
@@ -100,7 +103,7 @@ describe('useCompositorPsdDownload', () => {
     )
     expect(session.dispose).toHaveBeenCalledTimes(1)
     expect(exporting.value).toBe(false)
-    expect(toastAdd).not.toHaveBeenCalled()
+    expect(vi.mocked(useToastStore().add)).not.toHaveBeenCalled()
   })
 
   it('reports an error and still disposes when WebGL is unavailable', async () => {
@@ -112,7 +115,7 @@ describe('useCompositorPsdDownload', () => {
     await downloadPsd(node)
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'layerEditor.webglUnavailable'
@@ -132,7 +135,7 @@ describe('useCompositorPsdDownload', () => {
 
     expect(buildSessionPsdBlob).not.toHaveBeenCalled()
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledTimes(1)
     expect(session.dispose).toHaveBeenCalledTimes(1)
   })
 
@@ -146,7 +149,7 @@ describe('useCompositorPsdDownload', () => {
     await downloadPsd(node)
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledTimes(1)
     expect(session.dispose).toHaveBeenCalledTimes(1)
     expect(exporting.value).toBe(false)
   })
@@ -159,7 +162,7 @@ describe('useCompositorPsdDownload', () => {
     await downloadPsd(node)
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledTimes(1)
     expect(exporting.value).toBe(false)
   })
 

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -1,6 +1,9 @@
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { getActivePinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -14,11 +17,8 @@ const mocks = vi.hoisted(() => ({
   dismiss: vi.fn(),
   beginTour: vi.fn(),
   loadTemplate: vi.fn(),
-  loadCatalog: vi.fn(),
-  isLoaded: true,
-  toastAdd: vi.fn(),
-  loadingTemplateId: { value: null as string | null },
-  catalog: [] as { name: string }[]
+
+  loadingTemplateId: { value: null as string | null }
 }))
 
 vi.mock<unknown>(import('./firstRunEntry'), () => ({
@@ -45,27 +45,6 @@ vi.mock<unknown>(
   }
 )
 
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
-  () => ({
-    useWorkflowTemplatesStore: () => ({
-      get isLoaded() {
-        return mocks.isLoaded
-      },
-      get enhancedTemplates() {
-        return mocks.catalog
-      },
-      loadWorkflowTemplates: mocks.loadCatalog,
-      getTemplateByName: (name: string) =>
-        mocks.catalog.find((template) => template.name === name)
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mocks.toastAdd })
-}))
-
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -82,8 +61,7 @@ async function renderScreen({
   stubFocusScope = false,
   withOpenDialog = false
 } = {}) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
   if (withOpenDialog) {
     useDialogStore().showDialog({ component: { template: '<div />' } })
   }
@@ -97,12 +75,26 @@ async function renderScreen({
   })
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+  vi.mocked(useWorkflowTemplatesStore().getTemplateByName).mockImplementation(
+    (name) =>
+      useWorkflowTemplatesStore().enhancedTemplates.find(
+        (template) => template.name === name
+      )
+  )
+})
+
 describe('GettingStartedScreen', () => {
   beforeEach(() => {
-    mocks.isLoaded = true
-    mocks.catalog = CURATED_TEMPLATE_IDS.map((name) => ({ name }))
+    useWorkflowTemplatesStore().isLoaded = true
+    Object.assign(useWorkflowTemplatesStore(), {
+      enhancedTemplates: CURATED_TEMPLATE_IDS.map((name) => ({ name }))
+    })
     mocks.loadTemplate.mockResolvedValue(true)
-    mocks.loadCatalog.mockResolvedValue(undefined)
+    vi.mocked(
+      useWorkflowTemplatesStore().loadWorkflowTemplates
+    ).mockResolvedValue(undefined)
     mocks.beginTour.mockResolvedValue(true)
     mocks.loadingTemplateId.value = null
   })
@@ -177,13 +169,15 @@ describe('GettingStartedScreen', () => {
 
   describe('grid', () => {
     it('fills from the catalog when no curated template survived a package skew', async () => {
-      mocks.catalog = [
-        { name: 'skew-a' },
-        { name: 'skew-b' },
-        { name: 'skew-c' },
-        { name: 'skew-d' },
-        { name: 'skew-e' }
-      ]
+      Object.assign(useWorkflowTemplatesStore(), {
+        enhancedTemplates: [
+          { name: 'skew-a' },
+          { name: 'skew-b' },
+          { name: 'skew-c' },
+          { name: 'skew-d' },
+          { name: 'skew-e' }
+        ]
+      })
 
       await renderScreen()
 
@@ -194,11 +188,13 @@ describe('GettingStartedScreen', () => {
     })
 
     it('keeps curated templates ahead of the ones it backfills', async () => {
-      mocks.catalog = [
-        { name: 'catalog-filler' },
-        { name: FALLBACK_TEMPLATE_IDS[0] },
-        { name: CURATED_TEMPLATE_IDS[1] }
-      ]
+      Object.assign(useWorkflowTemplatesStore(), {
+        enhancedTemplates: [
+          { name: 'catalog-filler' },
+          { name: FALLBACK_TEMPLATE_IDS[0] },
+          { name: CURATED_TEMPLATE_IDS[1] }
+        ]
+      })
 
       await renderScreen()
 
@@ -296,7 +292,9 @@ describe('GettingStartedScreen', () => {
 
       await pickFirstTemplate()
 
-      await waitFor(() => expect(mocks.toastAdd).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(vi.mocked(useToastStore().add)).toHaveBeenCalled()
+      )
       expect(
         mocks.dismiss,
         'A failed load must not dismiss the screen; the user would be left on a bare canvas'
@@ -305,7 +303,7 @@ describe('GettingStartedScreen', () => {
     })
 
     it('retries a catalog load that resolved without loading anything', async () => {
-      mocks.isLoaded = false
+      useWorkflowTemplatesStore().isLoaded = false
       await renderScreen()
 
       const retry = await screen.findByTestId(
@@ -315,14 +313,16 @@ describe('GettingStartedScreen', () => {
           timeout: 1000
         }
       )
-      mocks.loadCatalog.mockImplementation(() => {
-        mocks.isLoaded = true
+      vi.mocked(
+        useWorkflowTemplatesStore().loadWorkflowTemplates
+      ).mockImplementation(() => {
+        useWorkflowTemplatesStore().isLoaded = true
         return Promise.resolve(undefined)
       })
       await userEvent.click(retry)
 
       expect(
-        mocks.loadCatalog,
+        vi.mocked(useWorkflowTemplatesStore().loadWorkflowTemplates),
         'The store swallows fetch errors and resolves with isLoaded false, so a failed catalog must be detected without a rejection'
       ).toHaveBeenCalledTimes(2)
       await waitFor(() =>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -1,3 +1,6 @@
+import type * as VueUse from '@vueuse/core'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
@@ -9,9 +12,7 @@ const mocks = vi.hoisted(() => ({
   subscriptionEnabled: true,
   isNewUser: true as boolean | null,
   tourFlag: true,
-  execute: vi.fn(),
-  settings: {} as Record<string, unknown>,
-  setSetting: vi.fn(),
+
   beginTour: vi.fn()
 }))
 
@@ -35,7 +36,8 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   breakpointsTailwind: {},
   createSharedComposable: sharedComposable.create,
   useBreakpoints: () => ({
@@ -70,17 +72,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: mocks.execute })
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => mocks.settings[key],
-    set: mocks.setSetting
-  })
-}))
-
 vi.mock<unknown>(import('../tour/useFirstRunTourController'), () => ({
   useFirstRunTourController: () => ({ beginTour: mocks.beginTour })
 }))
@@ -89,6 +80,10 @@ import { useFirstRunEntry } from './firstRunEntry'
 
 type FirstRunEntry = ReturnType<typeof useFirstRunEntry>
 
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
+
 describe('useFirstRunEntry', () => {
   beforeEach(() => {
     mocks.isCloud = true
@@ -96,9 +91,9 @@ describe('useFirstRunEntry', () => {
     mocks.subscriptionEnabled = true
     mocks.isNewUser = true
     mocks.tourFlag = true
-    mocks.settings = {}
-    mocks.setSetting.mockImplementation((key: string, value: unknown) => {
-      mocks.settings[key] = value
+    useSettingStore().settingValues = {}
+    vi.mocked(useSettingStore().set).mockImplementation(async (key, value) => {
+      useSettingStore().settingValues[key] = value
     })
     sharedComposable.reset()
     // beginTour reports whether a tour actually started; default to the
@@ -125,7 +120,7 @@ describe('useFirstRunEntry', () => {
       await entry.handleStartupOutcome('fresh')
 
       expect(entry.gettingStartedVisible.value).toBe(true)
-      expect(mocks.execute).not.toHaveBeenCalled()
+      expect(useCommandStore().execute).not.toHaveBeenCalled()
     })
 
     it('shares first-run state across consumers during one boot', async () => {
@@ -149,7 +144,9 @@ describe('useFirstRunEntry', () => {
           entry.gettingStartedVisible.value,
           'A non-candidate must keep the existing template-browser flow'
         ).toBe(false)
-        expect(mocks.execute).toHaveBeenCalledWith('Comfy.BrowseTemplates')
+        expect(useCommandStore().execute).toHaveBeenCalledWith(
+          'Comfy.BrowseTemplates'
+        )
       }
     )
 
@@ -162,7 +159,7 @@ describe('useFirstRunEntry', () => {
         await entry.handleStartupOutcome('fresh')
 
         expect(
-          mocks.setSetting,
+          vi.mocked(useSettingStore().set),
           'Without this the browser reopens on every launch, forever'
         ).toHaveBeenCalledWith('Comfy.TutorialCompleted', true)
       }
@@ -177,7 +174,7 @@ describe('useFirstRunEntry', () => {
         await entry.handleStartupOutcome('fresh')
 
         expect(
-          mocks.setSetting,
+          vi.mocked(useSettingStore().set),
           'Comfy.TutorialCompleted is write-once and server-side; setting it here burns the tour for an account that was only ineligible this boot'
         ).not.toHaveBeenCalled()
       }
@@ -209,12 +206,12 @@ describe('useFirstRunEntry', () => {
       entry.gettingStartedVisible.value,
       'A share or template link is the user’s choice; onboarding must not cover it'
     ).toBe(false)
-    expect(mocks.execute).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
 
     await entry.handleUrlWorkflow('url-intent', 'image_z_image_turbo')
 
     expect(
-      mocks.setSetting,
+      vi.mocked(useSettingStore().set),
       'Without this the template browser reopens on every launch, as it did before this flow existed'
     ).toHaveBeenCalledWith('Comfy.TutorialCompleted', true)
   })
@@ -259,7 +256,7 @@ describe('useFirstRunEntry', () => {
         'the link is the user’s choice; onboarding must not cover it'
       ).toBe(false)
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'no tour ran, so the write-once flag that pays for one must stay unspent for the boot that can lift this'
       ).not.toHaveBeenCalled()
     }
@@ -275,7 +272,8 @@ describe('useFirstRunEntry', () => {
 
     mocks.isDesktopWidth = true
     // What `checkIsNewUser()` reads on the next launch.
-    mocks.isNewUser = !mocks.settings['Comfy.TutorialCompleted']
+    mocks.isNewUser =
+      !useSettingStore().settingValues['Comfy.TutorialCompleted']
     sharedComposable.reset()
     const laptop = useFirstRunEntry()
     await laptop.handleStartupOutcome('url-intent')
@@ -286,7 +284,7 @@ describe('useFirstRunEntry', () => {
       'opening a template link on a phone and returning on a laptop is ordinary behaviour'
     ).toHaveBeenCalledWith('image_z_image_turbo')
     expect(
-      mocks.settings['Comfy.TutorialCompleted'],
+      useSettingStore().settingValues['Comfy.TutorialCompleted'],
       'the flag is spent on the boot that finally delivered the tour, not before'
     ).toBe(true)
   })
@@ -301,7 +299,7 @@ describe('useFirstRunEntry', () => {
       'checkIsNewUser reads Comfy.TutorialCompleted, so a user who predates that setting looks new; only the outcome shows they had work to restore'
     ).toBe(false)
     expect(
-      mocks.execute,
+      useCommandStore().execute,
       'nor may the template browser cover their restored workflow'
     ).not.toHaveBeenCalled()
   })
@@ -331,8 +329,8 @@ describe('useFirstRunEntry', () => {
       expect(
         entry.gettingStartedVisible.value ||
           mocks.beginTour.mock.calls.length > 0 ||
-          mocks.setSetting.mock.calls.length > 0 ||
-          mocks.execute.mock.calls.length > 0,
+          vi.mocked(useSettingStore().set).mock.calls.length > 0 ||
+          vi.mocked(useCommandStore().execute).mock.calls.length > 0,
         'a startup that opened a blank canvas must offer onboarding, tour what the link loaded, record that it is done, or open the template browser; anything else strands the user with an empty screen'
       ).toBe(true)
     }
@@ -379,13 +377,13 @@ describe('useFirstRunEntry', () => {
     it('leaves the completion flag alone when the engine refused to start', async () => {
       const entry = useFirstRunEntry()
       await entry.handleStartupOutcome('url-intent')
-      mocks.setSetting.mockClear()
+      vi.mocked(useSettingStore().set).mockClear()
       mocks.beginTour.mockResolvedValue(false)
 
       await entry.handleUrlWorkflow('url-intent', 'image_z_image_turbo')
 
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'writing it here would mark onboarding done for a user whose tour never started, and postpone() exists to offer that user the tour again'
       ).not.toHaveBeenCalled()
     })
@@ -401,7 +399,7 @@ describe('useFirstRunEntry', () => {
         'there is no workflow on the canvas to tour'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'a dead link must not spend the one tour the account gets; the next boot has no URL to honour and offers Getting Started instead'
       ).not.toHaveBeenCalled()
     })
@@ -448,14 +446,14 @@ describe('useFirstRunEntry', () => {
   })
 
   it('leaves a completed user alone', async () => {
-    mocks.settings['Comfy.TutorialCompleted'] = true
+    useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
     const entry = useFirstRunEntry()
 
     await entry.handleStartupOutcome('restored')
 
     expect(entry.gettingStartedVisible.value).toBe(false)
-    expect(mocks.execute).not.toHaveBeenCalled()
-    expect(mocks.setSetting).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
+    expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalled()
   })
 
   it('keeps the screen up when eligibility changes underneath it', async () => {
@@ -477,14 +475,14 @@ describe('useFirstRunEntry', () => {
     await entry.handleStartupOutcome('fresh')
 
     expect(
-      mocks.setSetting,
+      vi.mocked(useSettingStore().set),
       'Showing the screen must not persist completion; the user has not chosen anything yet'
     ).not.toHaveBeenCalled()
 
     await entry.dismissGettingStarted()
 
     expect(entry.gettingStartedVisible.value).toBe(false)
-    expect(mocks.setSetting).toHaveBeenCalledWith(
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
       'Comfy.TutorialCompleted',
       true
     )

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -1,3 +1,5 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,7 +16,7 @@ const mocks = await vi.hoisted(async () => {
   return {
     nudgeArmed: ref(false),
     tourWasCompleted: ref(true),
-    openDialogs: ref<string[]>([]),
+
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
     }),
@@ -28,14 +30,6 @@ vi.mock<unknown>(import('../tour/useFirstRunTourController'), () => ({
     nudgeArmed: mocks.nudgeArmed,
     tourWasCompleted: mocks.tourWasCompleted,
     dismissNudge: mocks.dismissNudge
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    get dialogStack() {
-      return mocks.openDialogs.value
-    }
   })
 }))
 
@@ -70,7 +64,7 @@ describe('FirstRunTourNudge', () => {
   beforeEach(() => {
     mocks.nudgeArmed.value = false
     mocks.tourWasCompleted.value = true
-    mocks.openDialogs.value = []
+    useDialogStore().dialogStack = []
   })
 
   it('shows a nudge that came due before it mounted', async () => {
@@ -97,7 +91,7 @@ describe('FirstRunTourNudge', () => {
 
   it('waits out a dialog that is already open', async () => {
     mocks.nudgeArmed.value = true
-    mocks.openDialogs.value = ['some-dialog']
+    useDialogStore().dialogStack = [fromPartial({ key: 'some-dialog' })]
     renderNudge()
 
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
@@ -106,7 +100,7 @@ describe('FirstRunTourNudge', () => {
       'the nudge sits below the modal stack, so under a dialog it is invisible'
     ).toBeNull()
 
-    mocks.openDialogs.value = []
+    useDialogStore().dialogStack = []
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
     expect(
@@ -120,7 +114,7 @@ describe('FirstRunTourNudge', () => {
     renderNudge()
 
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS - 500)
-    mocks.openDialogs.value = ['some-dialog']
+    useDialogStore().dialogStack = [fromPartial({ key: 'some-dialog' })]
     await vi.advanceTimersByTimeAsync(500 + APPEAR_DELAY_MS)
 
     expect(
@@ -138,9 +132,9 @@ describe('FirstRunTourNudge', () => {
     renderNudge()
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
-    mocks.openDialogs.value = ['some-dialog']
+    useDialogStore().dialogStack = [fromPartial({ key: 'some-dialog' })]
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-    mocks.openDialogs.value = []
+    useDialogStore().dialogStack = []
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
     const shown = mocks.trackOnboardingTour.mock.calls.filter(

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
@@ -1,3 +1,5 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
@@ -24,19 +26,10 @@ function scaleFor(bounds: ReadOnlyRect, fill: number): number {
   )
 }
 
-const appState = vi.hoisted(() => ({ canvas: undefined as unknown }))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    get canvas() {
-      return appState.canvas
-    }
-  })
-}))
-
 const camera = {
   animateToBounds: vi.fn(),
   setDirty: vi.fn(),
-  ds: { fitToBounds: vi.fn(), offset: [0, 0], scale: 1 }
+  ds: { fitToBounds: vi.fn(), offset: [0, 0] as [number, number], scale: 1 }
 }
 
 let canvasRect = new DOMRect(0, 0, VIEWPORT.width, VIEWPORT.height)
@@ -48,11 +41,13 @@ function mountCanvas(): LGraphNode {
   node.size = [50, 60]
   graph.add(node)
   node.updateArea()
-  appState.canvas = {
+  useCanvasStore().canvas = fromPartial({
     ...camera,
     graph,
-    canvas: { getBoundingClientRect: () => canvasRect }
-  }
+    canvas: Object.assign(document.createElement('canvas'), {
+      getBoundingClientRect: () => canvasRect
+    })
+  })
   return node
 }
 
@@ -158,7 +153,7 @@ describe('frameNode', () => {
     camera.ds.fitToBounds.mockClear()
     camera.ds.offset = [0, 0]
     camera.ds.scale = 1
-    appState.canvas = undefined
+    useCanvasStore().canvas = null
   })
 
   it('skips the flight for a step already framed, as Back lands on', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as Litegraph from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 
 import { toNodeId } from '@/types/nodeId'
@@ -10,10 +13,7 @@ const { TITLE_HEIGHT } = vi.hoisted(() => ({ TITLE_HEIGHT: 30 }))
 
 const state = vi.hoisted(() => ({
   camera: null as Record<string, number> | null,
-  currentGraph: null as {
-    getNodeById: (id: unknown) => unknown
-    rootGraph: { id: ReturnType<typeof createUuidv4> }
-  } | null,
+
   collapsed: new Set<string>(),
   layout: null as { value: unknown } | null,
   layoutReads: vi.fn(),
@@ -22,18 +22,24 @@ const state = vi.hoisted(() => ({
 }))
 
 function graph(id: string) {
-  return {
+  return fromPartial<Litegraph.LGraph>({
     id,
     rootGraph: { id: createUuidv4() },
-    getNodeById: (nodeId: unknown) => ({
-      collapsed: state.collapsed.has(String(nodeId))
-    })
-  }
+    getNodeById: (nodeId: unknown) =>
+      fromPartial<Litegraph.LGraphNode>({
+        constructor: {},
+        collapsed: state.collapsed.has(String(nodeId))
+      })
+  })
 }
 
-vi.mock<unknown>(import('@/lib/litegraph/src/litegraph'), () => ({
-  LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
-}))
+vi.mock<unknown>(
+  import('@/lib/litegraph/src/litegraph'),
+  async (importOriginal) => ({
+    ...(await importOriginal<typeof Litegraph>()),
+    LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
+  })
+)
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
   async () => {
@@ -42,14 +48,7 @@ vi.mock<unknown>(
     return { useTransformState: () => ({ camera: state.camera }) }
   }
 )
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    canvas: { canvas: document.createElement('canvas') },
-    get currentGraph() {
-      return state.currentGraph
-    }
-  })
-}))
+
 vi.mock<unknown>(
   import('@/renderer/core/layout/store/layoutStore'),
   async () => {
@@ -84,9 +83,17 @@ function placeNode(bounds = { x: 100, y: 200, width: 80, height: 40 }) {
   state.layout!.value = { bounds }
 }
 
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({
+    graph: graph('root'),
+    canvas: document.createElement('canvas')
+  })
+  useCanvasStore().currentGraph = useCanvasStore().canvas!.graph
+})
+
 describe('canvasNodeTarget', () => {
   afterEach(() => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     state.collapsed.clear()
     state.canvasOffset = { left: 0, top: 0 }
     if (state.camera) Object.assign(state.camera, { x: 0, y: 0, z: 1 })
@@ -96,7 +103,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('releases what it watches when the tour drops it', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     const target = canvasNodeTarget(toNodeId(1))
     expect(state.releaseBounds).not.toHaveBeenCalled()
 
@@ -109,7 +116,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('places the rect over the node, title bar included', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode({ x: 100, y: 200, width: 80, height: 40 })
 
     expect(
@@ -119,7 +126,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('carries the node through pan and zoom', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode({ x: 100, y: 200, width: 80, height: 40 })
     Object.assign(state.camera!, { x: 10, y: 20, z: 2 })
     state.canvasOffset = { left: 5, top: 7 }
@@ -138,8 +145,8 @@ describe('canvasNodeTarget', () => {
   })
 
   it('withholds a rect until the node has a layout', () => {
-    state.currentGraph = graph('root')
-    const rootGraphId = state.currentGraph.rootGraph.id
+    useCanvasStore().currentGraph = graph('root')
+    const rootGraphId = useCanvasStore().currentGraph!.rootGraph.id
     const nodeId = toNodeId(6)
 
     expect(
@@ -150,12 +157,12 @@ describe('canvasNodeTarget', () => {
   })
 
   it('withholds a rect once the graph it resolved against is gone', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode()
     const target = canvasNodeTarget(toNodeId(6))
     expect(target.getRect()).not.toBeNull()
 
-    state.currentGraph = graph('another-workflow')
+    useCanvasStore().currentGraph = graph('another-workflow')
 
     expect(
       target.getRect(),
@@ -164,7 +171,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('withholds a rect for a collapsed node, which renders no widget', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode()
     state.collapsed.add('6')
 

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -1,48 +1,42 @@
+import { useExecutionStore } from '@/stores/executionStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useOnboardingTourStore } from '@/platform/onboarding/onboardingTourStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import type { DetachedWindowAPI } from 'happy-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 import type { EffectScope, Ref } from 'vue'
 
 import type { TourEnding } from '@/platform/onboarding/onboardingTourStore'
+import type { WorkflowExecutionStatus } from '@/stores/executionStore'
 import type {
   CoachStep,
   SpotlightStep
 } from '@/platform/onboarding/onboardingTours'
 import type { OnboardingTourSkipReason } from '@/platform/telemetry/types'
 
-const TOUR_WORKFLOW = { path: 'tour.json' }
-const OTHER_WORKFLOW = { path: 'other.json' }
+const TOUR_WORKFLOW = fromPartial<
+  NonNullable<ReturnType<typeof useWorkflowStore>['activeWorkflow']>
+>({ path: 'tour.json' })
+const OTHER_WORKFLOW = fromPartial<
+  NonNullable<ReturnType<typeof useWorkflowStore>['activeWorkflow']>
+>({ path: 'other.json' })
 const INTRO_PREVIEW_MS = 500
 const OFFLINE_GRACE_MS = 20_000
 const ACCEPT_DEADLINE_MS = 15_000
 
 const mocks = vi.hoisted(() => {
-  const queuedJobs: { value: Record<string, { workflow?: unknown }> } = {
-    value: {}
-  }
   return {
     canRunWorkflows: { value: true },
     showSubscriptionDialog: vi.fn(),
-    workflowStatus: { value: new Map<unknown, string>() },
-    executionErrors: { hasNodeError: false, hasPromptError: false },
-    activeWorkflow: { value: null as { path: string } | null },
-    queuedJobs,
-    linearMode: { value: false },
-    vueNodesEnabled: true,
-    setSetting: vi.fn(),
+    workflowStatus: { value: new Map<unknown, WorkflowExecutionStatus>() },
+
     steps: [] as CoachStep[],
     runState: { value: 'idle' } as Ref<string>,
-    releaseFirstRunTargets: vi.fn(),
-    engine: {
-      activeTour: null as string | null,
-      lastEnding: null as TourEnding | null,
-      step: null as CoachStep | null,
-      isLast: false,
-      startTour: vi.fn(),
-      next: vi.fn(),
-      skip: vi.fn(),
-      postpone: vi.fn()
-    }
+    releaseFirstRunTargets: vi.fn()
   }
 })
 
@@ -53,66 +47,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-// Each factory runs on the first dynamic import, which lands mid-test for
-// whichever test runs first. Seed the new ref from the holder so that test's
-// setup survives instead of being discarded.
-vi.mock<unknown>(import('@/stores/executionStore'), async () => {
-  const { shallowRef } = await import('vue')
-  mocks.workflowStatus = shallowRef(new Map(mocks.workflowStatus.value))
-  mocks.queuedJobs = shallowRef(mocks.queuedJobs.value)
-  return {
-    useExecutionStore: () => ({
-      getWorkflowStatus: (workflow: unknown) =>
-        mocks.workflowStatus.value.get(workflow),
-      get queuedJobs() {
-        return mocks.queuedJobs.value
-      }
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), async () => {
-  const { reactive } = await import('vue')
-  mocks.executionErrors = reactive({ ...mocks.executionErrors })
-  return { useExecutionErrorStore: () => mocks.executionErrors }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { shallowRef } = await import('vue')
-    mocks.activeWorkflow = shallowRef(mocks.activeWorkflow.value)
-    return {
-      useWorkflowStore: () => ({
-        get activeWorkflow() {
-          return mocks.activeWorkflow.value
-        }
-      })
-    }
-  }
-)
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), async () => {
-  const { shallowRef } = await import('vue')
-  mocks.linearMode = shallowRef(mocks.linearMode.value)
-  return {
-    useCanvasStore: () => ({
-      get linearMode() {
-        return mocks.linearMode.value
-      }
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => mocks.vueNodesEnabled,
-    // A spy, not a plain writer: a value that was flipped and put back reads
-    // the same as one that was never touched.
-    set: mocks.setSetting
-  })
-}))
-
 vi.mock<unknown>(import('./firstRunTourDefinition'), () => ({
   firstRunTourSteps: (_templateId: string, runState: Ref<string>) => {
     mocks.runState = runState
@@ -120,15 +54,6 @@ vi.mock<unknown>(import('./firstRunTourDefinition'), () => ({
   },
   releaseFirstRunTargets: mocks.releaseFirstRunTargets
 }))
-
-vi.mock<unknown>(
-  import('@/platform/onboarding/onboardingTourStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mocks.engine = reactive(mocks.engine)
-    return { useOnboardingTourStore: () => mocks.engine }
-  }
-)
 
 function runStep(): SpotlightStep {
   return {
@@ -146,7 +71,6 @@ let registeredTourHolds: () => boolean
 /** Scoped so each controller's document listener dies with its test. */
 async function freshController() {
   controllerScope?.stop()
-  vi.resetModules()
   controllerScope = effectScope()
   const tours = await import('@/platform/onboarding/onboardingTours')
   resolveRegisteredTour = async () => {
@@ -162,11 +86,11 @@ async function freshController() {
 /** A started tour sitting on its Run step, the state every run outcome acts on. */
 async function tourOnRunStep() {
   mocks.steps = [runStep()]
-  mocks.activeWorkflow.value = TOUR_WORKFLOW
-  mocks.engine.startTour.mockImplementation(async () => {
+  useWorkflowStore().activeWorkflow = TOUR_WORKFLOW
+  vi.mocked(useOnboardingTourStore().startTour).mockImplementation(async () => {
     await resolveRegisteredTour()
-    mocks.engine.activeTour = 'firstRun'
-    mocks.engine.step = runStep()
+    useOnboardingTourStore().activeTour = 'firstRun'
+    Object.assign(useOnboardingTourStore(), { step: runStep() })
     return true
   })
   const controller = await freshController()
@@ -179,9 +103,9 @@ async function tourOnRunStep() {
 
 /** The engine ending the tour and recording how, the way `finish()` leaves it. */
 function endTour(ending: TourEnding) {
-  mocks.engine.lastEnding = ending
-  mocks.engine.activeTour = null
-  mocks.engine.step = null
+  useOnboardingTourStore().lastEnding = ending
+  useOnboardingTourStore().activeTour = null
+  Object.assign(useOnboardingTourStore(), { step: null })
   return nextTick()
 }
 
@@ -208,30 +132,28 @@ const EVERY_ENDING: { named: string; ending: TourEnding }[] = [
 ]
 
 /** The queue storing a job, which is what acceptance actually looks like. */
-function acceptRun(workflow: unknown) {
-  mocks.queuedJobs.value = { 'job-1': { workflow } }
+function acceptRun(workflow: typeof TOUR_WORKFLOW) {
+  useExecutionStore().queuedJobs = { 'job-1': { workflow, nodes: {} } }
   return nextTick()
 }
 
 /** The queue letting a job go, which `resetExecutionState` does silently. */
 function removeRun() {
-  mocks.queuedJobs.value = {}
+  useExecutionStore().queuedJobs = {}
   return nextTick()
 }
 
-function finishRun(workflow: unknown, status: string) {
-  mocks.workflowStatus.value = new Map(mocks.workflowStatus.value).set(
-    workflow,
-    status
-  )
+function finishRun(
+  workflow: typeof TOUR_WORKFLOW,
+  status: WorkflowExecutionStatus
+) {
+  mocks.workflowStatus.value.set(workflow, status)
   return nextTick()
 }
 
 /** A user stop, which drops the status instead of reporting an outcome. */
 function dropRun(workflow: unknown) {
-  const next = new Map(mocks.workflowStatus.value)
-  next.delete(workflow)
-  mocks.workflowStatus.value = next
+  mocks.workflowStatus.value.delete(workflow)
   return nextTick()
 }
 
@@ -255,25 +177,43 @@ function mountRunButton(
   return button
 }
 
+beforeEach(() => {
+  Object.assign(useOnboardingTourStore(), {
+    activeTour:
+      ref<ReturnType<typeof useOnboardingTourStore>['activeTour']>(null),
+    lastEnding: ref<TourEnding | null>(null)
+  })
+  vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(true)
+  mocks.workflowStatus = ref(new Map())
+  vi.mocked(useExecutionStore().getWorkflowStatus).mockImplementation(
+    (workflow) => mocks.workflowStatus.value.get(workflow)
+  )
+  vi.mocked(useOnboardingTourStore().next).mockImplementation(() => undefined)
+  vi.mocked(useOnboardingTourStore().skip).mockImplementation(() => undefined)
+  vi.mocked(useOnboardingTourStore().postpone).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('useFirstRunTourController', () => {
   beforeEach(() => {
     mocks.canRunWorkflows = ref(true)
     mocks.workflowStatus.value = new Map()
-    mocks.queuedJobs.value = {}
-    mocks.executionErrors.hasNodeError = false
-    mocks.executionErrors.hasPromptError = false
-    mocks.activeWorkflow.value = null
-    mocks.linearMode.value = false
-    mocks.vueNodesEnabled = true
-    mocks.setSetting.mockImplementation((_key: string, value: boolean) => {
-      mocks.vueNodesEnabled = value
+    useExecutionStore().queuedJobs = {}
+    Object.assign(useExecutionErrorStore(), { hasNodeError: false })
+    Object.assign(useExecutionErrorStore(), { hasPromptError: false })
+    useWorkflowStore().activeWorkflow = null
+    useCanvasStore().linearMode = false
+    useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = true
+    vi.mocked(useSettingStore().set).mockImplementation(async (_key, value) => {
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = value
       return Promise.resolve()
     })
     mocks.steps = []
-    mocks.engine.activeTour = null
-    mocks.engine.lastEnding = null
-    mocks.engine.step = null
-    mocks.engine.isLast = false
+    useOnboardingTourStore().activeTour = null
+    useOnboardingTourStore().lastEnding = null
+    Object.assign(useOnboardingTourStore(), { step: null })
+    Object.assign(useOnboardingTourStore(), { isLast: false })
   })
 
   afterEach(() => {
@@ -284,9 +224,9 @@ describe('useFirstRunTourController', () => {
 
   describe('starting', () => {
     it('turns on the renderer whose nodes it spotlights', async () => {
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockResolvedValue(true)
+      vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(true)
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -294,15 +234,15 @@ describe('useFirstRunTourController', () => {
       await starting
 
       expect(
-        mocks.vueNodesEnabled,
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'a new user has no installed version, so Nodes 2.0 reads off and every step is blind'
       ).toBe(true)
     })
 
     it('hands back the renderer when the engine turns the start down', async () => {
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockResolvedValue(false)
+      vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(false)
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -310,15 +250,15 @@ describe('useFirstRunTourController', () => {
       await starting
 
       expect(
-        mocks.vueNodesEnabled,
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'a user who got no tour must not be left migrated by the one that never ran'
       ).toBe(false)
     })
 
     it('leaves a renderer the user already had switched on', async () => {
-      mocks.vueNodesEnabled = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = true
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockResolvedValue(false)
+      vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(false)
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -326,13 +266,13 @@ describe('useFirstRunTourController', () => {
       await starting
 
       expect(
-        mocks.vueNodesEnabled,
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'the tour only undoes the switch it threw itself'
       ).toBe(true)
     })
 
     it('starts nothing over a tour that is already running', async () => {
-      mocks.engine.activeTour = 'appMode'
+      useOnboardingTourStore().activeTour = 'appMode'
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -343,8 +283,12 @@ describe('useFirstRunTourController', () => {
         await starting,
         'the engine would refuse it anyway, so the side effects must not fire either'
       ).toBe(false)
-      expect(mocks.engine.startTour).not.toHaveBeenCalled()
-      expect(mocks.vueNodesEnabled).toBe(true)
+      expect(
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).not.toHaveBeenCalled()
+      expect(useSettingStore().settingValues['Comfy.VueNodes.Enabled']).toBe(
+        true
+      )
     })
 
     // Holds only ever end a tour that is already running, and only when they
@@ -352,8 +296,8 @@ describe('useFirstRunTourController', () => {
     // refused at the door. Asserted as "nothing opened" rather than as the
     // holds value: with no tour registered there is nothing to hold.
     it('refuses to open over the linear view, which hides the canvas', async () => {
-      mocks.linearMode.value = true
-      mocks.vueNodesEnabled = false
+      useCanvasStore().linearMode = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -365,18 +309,18 @@ describe('useFirstRunTourController', () => {
         '?template=X&mode=linear display:none-s the canvas, so every card would point at a node nobody can see'
       ).toBe(false)
       expect(
-        mocks.engine.startTour,
+        vi.mocked(useOnboardingTourStore().startTour),
         'the cards would sit over a hidden canvas until their targets timed out'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'a tour that never opened must not touch the renderer setting at all'
       ).not.toHaveBeenCalledWith('Comfy.VueNodes.Enabled', true)
     })
 
     it('refuses to open on a viewport below the desktop layout', async () => {
       setViewportWidth(500)
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -387,15 +331,17 @@ describe('useFirstRunTourController', () => {
         await starting,
         'the spotlights are placed against a desktop layout, so below md they point nowhere'
       ).toBe(false)
-      expect(mocks.engine.startTour).not.toHaveBeenCalled()
-      expect(mocks.setSetting).not.toHaveBeenCalledWith(
+      expect(
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).not.toHaveBeenCalled()
+      expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         true
       )
     })
 
     it('refuses to open when the canvas goes away during the intro preview', async () => {
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -404,16 +350,18 @@ describe('useFirstRunTourController', () => {
       // preview delay rather than while beginTour is still setting up. Only
       // the post-delay re-check can catch it from there.
       await vi.advanceTimersByTimeAsync(0)
-      mocks.linearMode.value = true
+      useCanvasStore().linearMode = true
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
 
       expect(
         await starting,
         'the holds watcher cannot catch this — there is no active tour to end yet'
       ).toBe(false)
-      expect(mocks.engine.startTour).not.toHaveBeenCalled()
       expect(
-        mocks.vueNodesEnabled,
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).not.toHaveBeenCalled()
+      expect(
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'the renderer switch thrown for a tour that never opened is handed back'
       ).toBe(false)
     })
@@ -425,20 +373,24 @@ describe('useFirstRunTourController', () => {
 
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS - 1)
       expect(
-        mocks.engine.startTour,
+        vi.mocked(useOnboardingTourStore().startTour),
         'a user who just picked a template deserves a look at it before the scrim'
       ).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(1)
-      expect(mocks.engine.startTour).toHaveBeenCalledWith('firstRun')
+      expect(
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).toHaveBeenCalledWith('firstRun')
     })
 
     it('hands back the canvas targets when the engine turns the start down', async () => {
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockImplementation(async () => {
-        await resolveRegisteredTour()
-        return false
-      })
+      vi.mocked(useOnboardingTourStore().startTour).mockImplementation(
+        async () => {
+          await resolveRegisteredTour()
+          return false
+        }
+      )
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -694,7 +646,7 @@ describe('useFirstRunTourController', () => {
       await acceptRun(TOUR_WORKFLOW)
       await finishRun(TOUR_WORKFLOW, 'running')
 
-      mocks.executionErrors.hasPromptError = true
+      Object.assign(useExecutionErrorStore(), { hasPromptError: true })
       await removeRun()
 
       expect(
@@ -711,7 +663,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', () => {}).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'a run takes minutes; a tour parked on a button the user already pressed reads as broken'
       ).toHaveBeenCalled()
       expect(mocks.runState.value).toBe('generating')
@@ -719,12 +671,12 @@ describe('useFirstRunTourController', () => {
 
     it('hands the last step to the engine like any other', async () => {
       await tourOnRunStep()
-      mocks.engine.isLast = true
+      Object.assign(useOnboardingTourStore(), { isLast: true })
 
       mountRunButton('queue-button', () => {}).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'ending a tour is the engine’s call; the button only reports the click'
       ).toHaveBeenCalled()
     })
@@ -733,7 +685,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       expect(registeredTourHolds()).toBe(true)
 
-      mocks.activeWorkflow.value = OTHER_WORKFLOW
+      useWorkflowStore().activeWorkflow = OTHER_WORKFLOW
       await nextTick()
 
       expect(
@@ -757,7 +709,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       expect(registeredTourHolds()).toBe(true)
 
-      mocks.linearMode.value = true
+      useCanvasStore().linearMode = true
       await nextTick()
 
       expect(
@@ -768,7 +720,7 @@ describe('useFirstRunTourController', () => {
 
     it('ignores a run that finished for another workflow', async () => {
       await tourOnRunStep()
-      mocks.activeWorkflow.value = OTHER_WORKFLOW
+      useWorkflowStore().activeWorkflow = OTHER_WORKFLOW
 
       await finishRun(OTHER_WORKFLOW, 'failed')
 
@@ -825,7 +777,7 @@ describe('useFirstRunTourController', () => {
       await finishRun(TOUR_WORKFLOW, 'completed')
       expect(mocks.runState.value).toBe('succeeded')
 
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       expect(
@@ -864,7 +816,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
 
-      mocks.executionErrors.hasNodeError = true
+      Object.assign(useExecutionErrorStore(), { hasNodeError: true })
       await nextTick()
 
       expect(
@@ -877,7 +829,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
 
-      mocks.executionErrors.hasPromptError = true
+      Object.assign(useExecutionErrorStore(), { hasPromptError: true })
       await nextTick()
 
       expect(
@@ -889,7 +841,7 @@ describe('useFirstRunTourController', () => {
     it('leaves errors alone until the tour has run something', async () => {
       await tourOnRunStep()
 
-      mocks.executionErrors.hasPromptError = true
+      Object.assign(useExecutionErrorStore(), { hasPromptError: true })
       await nextTick()
 
       expect(
@@ -907,7 +859,7 @@ describe('useFirstRunTourController', () => {
         'a nudge fighting a live tour for the screen helps nobody'
       ).toBe(false)
 
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       expect(controller.nudgeArmed.value).toBe(true)
@@ -918,7 +870,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', () => {}).click()
       await finishRun(TOUR_WORKFLOW, 'failed')
 
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       expect(
@@ -929,7 +881,7 @@ describe('useFirstRunTourController', () => {
 
     it('takes an armed nudge off the screen when a second tour starts', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
       expect(controller.nudgeArmed.value).toBe(true)
 
@@ -981,16 +933,18 @@ describe('useFirstRunTourController', () => {
 
     it('congratulates nobody when the tour never appeared', async () => {
       mocks.steps = []
-      mocks.activeWorkflow.value = TOUR_WORKFLOW
-      mocks.engine.startTour.mockImplementation(async () => {
-        await resolveRegisteredTour()
-        // The store requests the run, resolves no steps and returns to idle, so
-        // nothing ever calls `finish()` and no ending is recorded.
-        mocks.engine.activeTour = 'firstRun'
-        await nextTick()
-        mocks.engine.activeTour = null
-        return false
-      })
+      useWorkflowStore().activeWorkflow = TOUR_WORKFLOW
+      vi.mocked(useOnboardingTourStore().startTour).mockImplementation(
+        async () => {
+          await resolveRegisteredTour()
+          // The store requests the run, resolves no steps and returns to idle, so
+          // nothing ever calls `finish()` and no ending is recorded.
+          useOnboardingTourStore().activeTour = 'firstRun'
+          await nextTick()
+          useOnboardingTourStore().activeTour = null
+          return false
+        }
+      )
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -1010,7 +964,7 @@ describe('useFirstRunTourController', () => {
 
     it('stops offering the nudge once it is waved away', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       controller.dismissNudge()
@@ -1045,19 +999,21 @@ describe('useFirstRunTourController', () => {
         'opening it here too would replace the button reason with the tour own'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.engine.postpone,
+        vi.mocked(useOnboardingTourStore().postpone),
         'whoever subscribes off the back of this still has their first run ahead of them'
       ).toHaveBeenCalled()
-      expect(mocks.engine.skip).not.toHaveBeenCalled()
+      expect(vi.mocked(useOnboardingTourStore().skip)).not.toHaveBeenCalled()
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'nothing was queued, so there is no result to send the user to'
       ).not.toHaveBeenCalled()
     })
 
     it('keeps parking after the step renames its copy', async () => {
       await tourOnRunStep()
-      mocks.engine.step = { ...runStep(), name: 'run.cloud' }
+      Object.assign(useOnboardingTourStore(), {
+        step: { ...runStep(), name: 'run.cloud' }
+      })
       mocks.canRunWorkflows.value = false
       await nextTick()
       const underlyingHandler = vi.fn()
@@ -1065,19 +1021,21 @@ describe('useFirstRunTourController', () => {
       mountRunButton('subscribe-to-run-button', underlyingHandler).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'a translation key is copy, so renaming it must not walk the tour onto a run that never queued'
       ).not.toHaveBeenCalled()
-      expect(mocks.engine.postpone).toHaveBeenCalled()
+      expect(vi.mocked(useOnboardingTourStore().postpone)).toHaveBeenCalled()
     })
 
     it('leaves the Run button alone on a step the user can walk past', async () => {
       await tourOnRunStep()
-      mocks.engine.step = {
-        kind: 'spotlight',
-        name: 'result.image',
-        placement: 'auto'
-      }
+      Object.assign(useOnboardingTourStore(), {
+        step: {
+          kind: 'spotlight',
+          name: 'result.image',
+          placement: 'auto'
+        }
+      })
       await nextTick()
       const underlyingHandler = vi.fn()
 
@@ -1087,7 +1045,7 @@ describe('useFirstRunTourController', () => {
         underlyingHandler,
         'only the step whose sole way forward is running may intercept the run'
       ).toHaveBeenCalled()
-      expect(mocks.engine.next).not.toHaveBeenCalled()
+      expect(vi.mocked(useOnboardingTourStore().next)).not.toHaveBeenCalled()
     })
 
     it('lets a funded run through untouched', async () => {
@@ -1097,7 +1055,9 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', underlyingHandler).click()
 
       expect(underlyingHandler).toHaveBeenCalled()
-      expect(mocks.engine.postpone).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useOnboardingTourStore().postpone)
+      ).not.toHaveBeenCalled()
     })
 
     it('does not walk the tour on for a run it just refused', async () => {
@@ -1107,7 +1067,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('subscribe-to-run-button', () => {}).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'nothing was queued, so there is no result to send the user to'
       ).not.toHaveBeenCalled()
     })
@@ -1119,7 +1079,7 @@ describe('useFirstRunTourController', () => {
       await nextTick()
 
       expect(
-        mocks.engine.postpone,
+        vi.mocked(useOnboardingTourStore().postpone),
         'the paywall is keyed to the click, so an active tour survives losing eligibility'
       ).not.toHaveBeenCalled()
     })

--- a/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
+++ b/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
@@ -1,3 +1,7 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
 import { render, screen, within } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,14 +20,13 @@ const {
   loadCompositorSession,
   saveLayerState,
   savePreview,
-  session,
-  toastAdd
+  session
 } = vi.hoisted(() => ({
   afterChange: vi.fn(),
   autoSaveStop: vi.fn(),
   beforeChange: vi.fn(),
   loadCompositorSession: vi.fn().mockResolvedValue(0),
-  toastAdd: vi.fn(),
+
   saveLayerState: vi.fn(() => true),
   savePreview: vi.fn().mockResolvedValue(undefined),
   session: {
@@ -74,26 +77,13 @@ vi.mock(
     useCompositorAutoSave: vi.fn(() => ({ stop: autoSaveStop }))
   })
 )
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: { changeTracker: { afterChange, beforeChange } }
-    })
-  })
-)
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
+
 vi.mock(
   import('@/renderer/extensions/compositor/composables/compositorSession'),
   () => ({
     loadCompositorSession
   })
 )
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({ getNodeImageUrls: () => [] })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -138,6 +128,14 @@ function findRestoreButton() {
 async function waitForAutoSaveStart() {
   await vi.waitFor(() => expect(useCompositorAutoSave).toHaveBeenCalled())
 }
+
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { afterChange, beforeChange }
+  })
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+  vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([])
+})
 
 describe('LayerEditorContent', () => {
   beforeEach(() => {
@@ -224,7 +222,7 @@ describe('LayerEditorContent', () => {
     renderEditor('compositor')
 
     await vi.waitFor(() =>
-      expect(toastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'warn',
           detail: '2 layers failed to load'
@@ -237,13 +235,13 @@ describe('LayerEditorContent', () => {
   it('warns on close when edits could not be auto-saved', async () => {
     loadCompositorSession.mockResolvedValueOnce(2)
     const { unmount } = renderEditor('compositor')
-    await vi.waitFor(() => expect(toastAdd).toHaveBeenCalled())
+    await vi.waitFor(() => expect(useToastStore().add).toHaveBeenCalled())
     session.editor.history.canUndo.mockReturnValue(true)
 
     unmount()
 
     expect(saveLayerState).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(useToastStore().add).toHaveBeenCalledWith(
       expect.objectContaining({ detail: 'Failed to save composite' })
     )
   })
@@ -253,7 +251,7 @@ describe('LayerEditorContent', () => {
     renderEditor('compositor')
 
     await vi.waitFor(() =>
-      expect(toastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
     )

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
@@ -1,40 +1,37 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
 import { useLayerEditor } from './useLayerEditor'
 
-const { showDialog, getNodeImageUrls, toastAdd } = vi.hoisted(() => ({
-  showDialog: vi.fn(),
-  getNodeImageUrls: vi.fn(),
-  toastAdd: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({ getNodeImageUrls })
-}))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+  vi.mocked(useNodeOutputStore().getNodeImageUrls).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('useLayerEditor', () => {
   it('does nothing without a node', () => {
     useLayerEditor().openLayerEditor(null)
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   it('toasts instead of opening when the node has fewer than 2 output images', () => {
     const node = {} as LGraphNode
-    getNodeImageUrls.mockReturnValue(['only-one.png'])
+    vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([
+      'only-one.png'
+    ])
     useLayerEditor().openLayerEditor(node)
-    expect(showDialog).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'info',
         detail: 'layerEditor.needsTwoImages'
@@ -44,9 +41,12 @@ describe('useLayerEditor', () => {
 
   it('opens the layer editor dialog for a node with multiple images', () => {
     const node = {} as LGraphNode
-    getNodeImageUrls.mockReturnValue(['a.png', 'b.png'])
+    vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([
+      'a.png',
+      'b.png'
+    ])
     useLayerEditor().openLayerEditor(node)
-    expect(showDialog).toHaveBeenCalledWith(
+    expect(vi.mocked(useDialogStore().showDialog)).toHaveBeenCalledWith(
       expect.objectContaining({
         key: 'global-layer-editor',
         props: { node }

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent, ref } from 'vue'
@@ -17,17 +18,14 @@ import type {
 import { useLayerEditorExport } from './useLayerEditorExport'
 import type { LayerEditorSession } from './useLayerEditorSession'
 
-const { writePsd, downloadBlob, toastAdd } = vi.hoisted(() => ({
+const { writePsd, downloadBlob } = vi.hoisted(() => ({
   writePsd: vi.fn((_psd: unknown) => new ArrayBuffer(4)),
-  downloadBlob: vi.fn(),
-  toastAdd: vi.fn()
+  downloadBlob: vi.fn()
 }))
 
 vi.mock(import('ag-psd'), () => ({ writePsd }))
 vi.mock(import('@/base/common/downloadUtil'), () => ({ downloadBlob }))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -173,6 +171,10 @@ function makeSession(nodes: RasterData[], glOk = true): LayerEditorSession {
   } as unknown as LayerEditorSession
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
 describe('useLayerEditorExport', () => {
   it('writes a psd matching the layer tree and triggers a download', async () => {
     const session = makeSession([
@@ -206,7 +208,7 @@ describe('useLayerEditorExport', () => {
     expect(blob).toBeInstanceOf(Blob)
     expect(exporting.value).toBe(false)
     expect(session.requestRender).toHaveBeenCalled()
-    expect(toastAdd).not.toHaveBeenCalled()
+    expect(vi.mocked(useToastStore().add)).not.toHaveBeenCalled()
   })
 
   it('shows an error toast when writing fails', async () => {
@@ -219,7 +221,7 @@ describe('useLayerEditorExport', () => {
     await exportPsd()
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'layerEditor.exportPsdFailed'

--- a/src/renderer/extensions/linearMode/LinearWelcome.test.ts
+++ b/src/renderer/extensions/linearMode/LinearWelcome.test.ts
@@ -1,23 +1,10 @@
+import { useAppModeStore } from '@/stores/appModeStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import LinearWelcome from './LinearWelcome.vue'
-
-const { hasNodes, hasOutputs, enterBuilder } = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { ref } = require('vue')
-  return {
-    hasNodes: ref(false),
-    hasOutputs: ref(false),
-    enterBuilder: vi.fn()
-  }
-})
-
-vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ setMode: vi.fn() })
-}))
 
 vi.mock<unknown>(
   import('@/composables/useWorkflowTemplateSelectorDialog'),
@@ -26,39 +13,26 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    hasNodes,
-    hasOutputs,
-    enterBuilder
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: null
-    })
-  })
-)
-
 const i18n = createI18n({ legacy: false, locale: 'en', missingWarn: false })
 
 function renderComponent(
   opts: { hasNodes?: boolean; hasOutputs?: boolean } = {}
 ) {
-  hasNodes.value = opts.hasNodes ?? false
-  hasOutputs.value = opts.hasOutputs ?? false
+  Object.assign(useAppModeStore(), { hasNodes: opts.hasNodes ?? false })
+  Object.assign(useAppModeStore(), { hasOutputs: opts.hasOutputs ?? false })
   return render(LinearWelcome, {
     global: { plugins: [i18n] }
   })
 }
 
+beforeEach(() => {
+  vi.mocked(useAppModeStore().enterBuilder).mockImplementation(() => undefined)
+})
+
 describe('LinearWelcome', () => {
   beforeEach(() => {
-    hasNodes.value = false
-    hasOutputs.value = false
+    Object.assign(useAppModeStore(), { hasNodes: false })
+    Object.assign(useAppModeStore(), { hasOutputs: false })
   })
 
   it('shows empty workflow text when there are no nodes', () => {
@@ -83,6 +57,6 @@ describe('LinearWelcome', () => {
     const user = userEvent.setup()
     renderComponent({ hasNodes: true, hasOutputs: false })
     await user.click(screen.getByTestId('linear-welcome-build-app'))
-    expect(enterBuilder).toHaveBeenCalled()
+    expect(useAppModeStore().enterBuilder).toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/linearMode/OutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistory.test.ts
@@ -1,3 +1,7 @@
+import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useQueueStore } from '@/stores/queueStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import type { RenderResult } from '@testing-library/vue'
@@ -21,29 +25,13 @@ const mediaRef = ref<AssetItem[]>([])
 const hasMoreRef = ref(false)
 const loadMoreFn = vi.fn()
 
-const selectedIdRef = ref<string | null>(null)
-const activeWorkflowInProgressItemsRef = ref<InProgressItem[]>([])
-
-const activeWorkflowPathRef = ref<string | undefined>('workflows/test.json')
-const hasOutputsRef = ref(false)
-
-const runningTasksRef = ref<Array<{ jobId: string }>>([])
-const pendingTasksRef = ref<Array<{ jobId: string }>>([])
-
 const selectFirstHistoryFn = vi.fn(() => {
   const first = mediaRef.value.at(0)
-  selectedIdRef.value = first ? `history:${first.id}:0` : null
+  useLinearOutputStore().selectedId = first ? `history:${first.id}:0` : null
 })
 const mayBeActiveWorkflowPendingRef = ref(false)
 
 const allOutputsFn = vi.fn((): AugmentedResultItem[] => [])
-
-const selectFn = vi.fn((id: string | null) => {
-  selectedIdRef.value = id
-})
-const selectAsLatestFn = vi.fn((id: string | null) => {
-  selectedIdRef.value = id
-})
 
 vi.mock<unknown>(import('@/lib/litegraph/src/CanvasPointer'), () => ({
   CanvasPointer: class {
@@ -69,55 +57,6 @@ vi.mock(import('@/renderer/extensions/linearMode/useOutputHistory'), () => ({
       mayBeActiveWorkflowPendingRef as ComputedRef<boolean>,
     isWorkflowActive: computed(() => false),
     cancelActiveWorkflowJobs: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/extensions/linearMode/linearOutputStore'),
-  () => ({
-    useLinearOutputStore: () => ({
-      get activeWorkflowInProgressItems() {
-        return activeWorkflowInProgressItemsRef.value
-      },
-      get selectedId() {
-        return selectedIdRef.value
-      },
-      set selectedId(v: string | null) {
-        selectedIdRef.value = v
-      },
-      select: selectFn,
-      selectAsLatest: selectAsLatestFn
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return activeWorkflowPathRef.value
-          ? { path: activeWorkflowPathRef.value }
-          : undefined
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    hasOutputs: hasOutputsRef
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    get runningTasks() {
-      return runningTasksRef.value
-    },
-    get pendingTasks() {
-      return pendingTasksRef.value
-    }
   })
 }))
 
@@ -206,12 +145,14 @@ describe('OutputHistory', () => {
   beforeEach(() => {
     mediaRef.value = []
     hasMoreRef.value = false
-    selectedIdRef.value = null
-    activeWorkflowInProgressItemsRef.value = []
-    activeWorkflowPathRef.value = 'workflows/test.json'
-    hasOutputsRef.value = false
-    runningTasksRef.value = []
-    pendingTasksRef.value = []
+    useLinearOutputStore().selectedId = null
+    Object.assign(useLinearOutputStore(), { activeWorkflowInProgressItems: [] })
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/test.json'
+    })
+    Object.assign(useAppModeStore(), { hasOutputs: false })
+    useQueueStore().runningTasks = []
+    useQueueStore().pendingTasks = []
     mayBeActiveWorkflowPendingRef.value = false
     allOutputsFn.mockReturnValue([])
   })
@@ -254,11 +195,11 @@ describe('OutputHistory', () => {
     })
 
     it('renders queue badge when queueCount > 1 and has active content', async () => {
-      runningTasksRef.value = [{ jobId: 'j1' }]
-      pendingTasksRef.value = [{ jobId: 'j2' }]
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'j1' }])
+      useQueueStore().pendingTasks = fromPartial([{ jobId: 'j2' }])
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
@@ -274,9 +215,9 @@ describe('OutputHistory', () => {
     })
 
     it('renders preview item for skeleton in-progress items', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
@@ -286,9 +227,11 @@ describe('OutputHistory', () => {
 
     it('renders history item for image in-progress items with output prop', async () => {
       const output = makeResult('out.png')
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'image', { output })
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          makeInProgressItem('ip1', 'image', { output })
+        ]
+      })
 
       mountComponent()
       await nextTick()
@@ -299,9 +242,9 @@ describe('OutputHistory', () => {
     })
 
     it('renders both active and history content when both exist', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('a1.png')])
 
@@ -328,9 +271,13 @@ describe('OutputHistory', () => {
       await userEvent.click(items[0])
       await nextTick()
 
-      expect(selectedIdRef.value).toBe('history:a1:0')
-      expect(selectFn).toHaveBeenCalledWith('history:a1:0')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenCalledWith(
+        'history:a1:0'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('history:a1:0')
       expect(lastEmission(result)).toMatchObject({
         asset,
         output: expect.objectContaining({ filename: 'a1.png' }),
@@ -341,9 +288,9 @@ describe('OutputHistory', () => {
     })
 
     it('selects in-progress item on click', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
@@ -353,9 +300,13 @@ describe('OutputHistory', () => {
 
       vi.clearAllMocks()
       await userEvent.click(slots[0])
-      expect(selectedIdRef.value).toBe('slot:ip1')
-      expect(selectFn).toHaveBeenCalledWith('slot:ip1')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('slot:ip1')
+      expect(useLinearOutputStore().selectedId).toBe('slot:ip1')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenCalledWith(
+        'slot:ip1'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('slot:ip1')
     })
 
     it('marks unselected items with tabindex=-1', async () => {
@@ -363,7 +314,7 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
 
       mountComponent()
       await nextTick()
@@ -378,7 +329,7 @@ describe('OutputHistory', () => {
 
     it('selects pending slot on click', async () => {
       mayBeActiveWorkflowPendingRef.value = true
-      runningTasksRef.value = [{ jobId: 'j1' }]
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'j1' }])
 
       mountComponent()
       await nextTick()
@@ -386,13 +337,13 @@ describe('OutputHistory', () => {
       const pendingPreview = screen.getByTestId('output-preview-item')
 
       await userEvent.click(pendingPreview)
-      expect(selectedIdRef.value).toBe('slot:pending')
+      expect(useLinearOutputStore().selectedId).toBe('slot:pending')
     })
   })
 
   describe('emit updateSelection', () => {
     it('emits canShowPreview:true when no selection', async () => {
-      selectedIdRef.value = null
+      useLinearOutputStore().selectedId = null
 
       const result = mountComponent()
       await nextTick()
@@ -401,10 +352,10 @@ describe('OutputHistory', () => {
     })
 
     it('emits showSkeleton for in-progress skeleton item', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       const result = mountComponent()
       await nextTick()
@@ -417,12 +368,14 @@ describe('OutputHistory', () => {
     })
 
     it('emits latentPreviewUrl for in-progress latent item', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'latent', {
-          latentPreviewUrl: 'blob:preview'
-        })
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          makeInProgressItem('ip1', 'latent', {
+            latentPreviewUrl: 'blob:preview'
+          })
+        ]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       const result = mountComponent()
       await nextTick()
@@ -436,10 +389,12 @@ describe('OutputHistory', () => {
 
     it('emits output for in-progress image item', async () => {
       const output = makeResult('out.png')
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'image', { output })
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          makeInProgressItem('ip1', 'image', { output })
+        ]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       const result = mountComponent()
       await nextTick()
@@ -456,12 +411,12 @@ describe('OutputHistory', () => {
       const output = makeResult('a1.png')
       mediaRef.value = [asset]
       allOutputsFn.mockReturnValue([output])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       const rendered = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
       await nextTick()
 
@@ -478,12 +433,12 @@ describe('OutputHistory', () => {
       const secondOutput = makeResult('second.png')
       mediaRef.value = [asset]
       allOutputsFn.mockReturnValue([firstOutput, secondOutput])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       const result = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'history:a1:1'
+      useLinearOutputStore().selectedId = 'history:a1:1'
       await nextTick()
       await nextTick()
 
@@ -499,12 +454,12 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       const result = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'history:a2:0'
+      useLinearOutputStore().selectedId = 'history:a2:0'
       await nextTick()
       await nextTick()
 
@@ -513,12 +468,12 @@ describe('OutputHistory', () => {
 
     it('emits skeleton for pending slot selection', async () => {
       mayBeActiveWorkflowPendingRef.value = true
-      runningTasksRef.value = [{ jobId: 'j1' }]
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'j1' }])
 
       const result = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'slot:pending'
+      useLinearOutputStore().selectedId = 'slot:pending'
       await nextTick()
       await nextTick()
 
@@ -531,39 +486,43 @@ describe('OutputHistory', () => {
 
   describe('workflow tab switch', () => {
     it('selects first in-progress item on mount', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith('slot:ip1')
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith('slot:ip1')
     })
 
     it('selects first history when no in-progress but outputs exist', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('a1.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
 
       expect(selectFirstHistoryFn).toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('clears selection when no outputs and no in-progress', async () => {
       mountComponent()
       await nextTick()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith(null)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith(null)
     })
 
     it('reselects when workflow path changes after mount', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('a1.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
@@ -571,11 +530,13 @@ describe('OutputHistory', () => {
       vi.clearAllMocks()
 
       // Simulate workflow tab switch
-      activeWorkflowPathRef.value = 'workflows/other.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/other.json'
+      })
       await nextTick()
 
       expect(selectFirstHistoryFn).toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('does not reselect when path becomes falsy', async () => {
@@ -584,20 +545,22 @@ describe('OutputHistory', () => {
 
       vi.clearAllMocks()
 
-      activeWorkflowPathRef.value = undefined
+      useWorkflowStore().activeWorkflow = null
       await nextTick()
 
-      expect(selectAsLatestFn).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalled()
       expect(selectFirstHistoryFn).not.toHaveBeenCalled()
     })
   })
 
   describe('media change watcher', () => {
     it('does not reselect when selection is a slot item', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       mountComponent()
       await nextTick()
@@ -618,11 +581,11 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
 
       vi.clearAllMocks()
@@ -638,11 +601,11 @@ describe('OutputHistory', () => {
       const oldFirst = makeAsset('old-first')
       mediaRef.value = [oldFirst]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:old-first:0'
+      useLinearOutputStore().selectedId = 'history:old-first:0'
       await nextTick()
 
       vi.clearAllMocks()
@@ -651,7 +614,7 @@ describe('OutputHistory', () => {
       await nextTick()
 
       expect(selectFirstHistoryFn).toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:new-first:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:new-first:0')
     })
 
     it('keeps older history selection stable when new assets arrive', async () => {
@@ -659,11 +622,11 @@ describe('OutputHistory', () => {
       const selectedOlder = makeAsset('selected-older')
       mediaRef.value = [currentFirst, selectedOlder]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:selected-older:0'
+      useLinearOutputStore().selectedId = 'history:selected-older:0'
       await nextTick()
 
       vi.clearAllMocks()
@@ -672,7 +635,7 @@ describe('OutputHistory', () => {
       await nextTick()
 
       expect(selectFirstHistoryFn).not.toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:selected-older:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:selected-older:0')
     })
   })
 
@@ -688,63 +651,71 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
 
       // Set selection after mount (mount watcher may reset it)
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a2:0')
-      expect(selectFn).toHaveBeenLastCalledWith('history:a2:0')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('history:a2:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a2:0')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenLastCalledWith(
+        'history:a2:0'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('history:a2:0')
 
       pressKey('ArrowLeft')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
-      expect(selectFn).toHaveBeenLastCalledWith('history:a1:0')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenLastCalledWith(
+        'history:a1:0'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('history:a1:0')
 
       pressKey('ArrowDown')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a2:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a2:0')
 
       pressKey('ArrowUp')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('clamps to first and last items', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
 
       pressKey('ArrowLeft')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('ignores key events from input elements', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       vi.clearAllMocks()
       await nextTick()
 
@@ -758,14 +729,14 @@ describe('OutputHistory', () => {
       )
       await nextTick()
 
-      expect(selectFn).not.toHaveBeenCalled()
+      expect(vi.mocked(useLinearOutputStore().select)).not.toHaveBeenCalled()
       document.body.removeChild(input)
     })
 
     it('navigates across in-progress and history items', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
 
@@ -773,11 +744,11 @@ describe('OutputHistory', () => {
       await nextTick()
 
       // Mount watcher selects the in-progress item
-      expect(selectedIdRef.value).toBe('slot:ip1')
+      expect(useLinearOutputStore().selectedId).toBe('slot:ip1')
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('selects first item when no current selection', async () => {
@@ -786,12 +757,12 @@ describe('OutputHistory', () => {
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = null
+      useLinearOutputStore().selectedId = null
       await nextTick()
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
   })
 })

--- a/src/renderer/extensions/linearMode/OutputHistoryActiveQueueItem.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistoryActiveQueueItem.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { useCommandStore } from '@/stores/commandStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { render, screen } from '@testing-library/vue'
@@ -8,15 +7,8 @@ import { render, screen } from '@testing-library/vue'
 import OutputHistoryActiveQueueItem from './OutputHistoryActiveQueueItem.vue'
 
 const i18n = createI18n({ legacy: false, locale: 'en' })
-setActivePinia(createTestingPinia({ stubActions: false }))
 
 vi.mock(import('@/platform/assets/composables/media/assetMappers'))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: vi.fn()
-  })
-}))
 
 function renderComponent(queueCount: number) {
   return render(OutputHistoryActiveQueueItem, {
@@ -24,6 +16,10 @@ function renderComponent(queueCount: number) {
     global: { plugins: [i18n] }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
 
 describe('OutputHistoryActiveQueueItem', () => {
   it('hides badge when queueCount is 1', () => {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -1,15 +1,16 @@
+import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useJobPreviewStore } from '@/stores/jobPreviewStore'
+import { toNodeId } from '@/types/nodeId'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 
-const activeJobIdRef = ref<string | null>(null)
-const previewsRef = ref<Record<string, { url: string; nodeId?: string }>>({})
 const isAppModeRef = ref(true)
-const activeWorkflowPathRef = ref<string>('workflows/test-workflow.json')
-const jobIdToWorkflowPathRef = ref(new Map<string, string>())
-const selectedOutputsRef = ref<string[]>([])
 
 const { apiTarget } = vi.hoisted(() => ({
   apiTarget: new EventTarget()
@@ -19,45 +20,8 @@ vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
   useAppMode: () => ({
-    isAppMode: isAppModeRef
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    get selectedOutputs() {
-      return selectedOutputsRef.value
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    get activeJobId() {
-      return activeJobIdRef.value
-    },
-    get jobIdToSessionWorkflowPath() {
-      return jobIdToWorkflowPathRef.value
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return { path: activeWorkflowPathRef.value }
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/jobPreviewStore'), () => ({
-  useJobPreviewStore: () => ({
-    get nodePreviewsByPromptId() {
-      return previewsRef.value
-    }
+    isAppMode: isAppModeRef,
+    isBuilderMode: ref(false)
   })
 }))
 
@@ -68,9 +32,9 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 }))
 
 function setJobWorkflowPath(jobId: string, path: string) {
-  const next = new Map(jobIdToWorkflowPathRef.value)
+  const next = new Map(useExecutionStore().jobIdToSessionWorkflowPath)
   next.set(jobId, path)
-  jobIdToWorkflowPathRef.value = next
+  useExecutionStore().jobIdToSessionWorkflowPath = next
 }
 
 function makeExecutedDetail(
@@ -90,12 +54,14 @@ function makeExecutedDetail(
 
 describe('linearOutputStore', () => {
   beforeEach(() => {
-    activeJobIdRef.value = null
-    previewsRef.value = {}
+    useExecutionStore().activeJobId = null
+    useJobPreviewStore().clearAllPreviews()
     isAppModeRef.value = true
-    activeWorkflowPathRef.value = 'workflows/test-workflow.json'
-    jobIdToWorkflowPathRef.value = new Map()
-    selectedOutputsRef.value = []
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/test-workflow.json'
+    })
+    useExecutionStore().jobIdToSessionWorkflowPath = new Map()
+    useAppModeStore().selectedOutputs = []
   })
 
   it('creates a skeleton item when a job starts', () => {
@@ -346,16 +312,14 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     expect(store.inProgressItems).toHaveLength(1)
     expect(store.inProgressItems[0].state).toBe('skeleton')
 
     // Simulate jobPreviewStore update
-    previewsRef.value = {
-      'job-1': { url: 'blob:preview-1', nodeId: 'node-1' }
-    }
+    useJobPreviewStore().setPreviewUrl('job-1', 'blob:preview-1', 'node-1')
     await nextTick()
     vi.advanceTimersByTime(16)
 
@@ -368,14 +332,14 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
 
     // Direct transition: job-1 → job-2 (no null in between)
     setJobWorkflowPath('job-2', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-2'
+    useExecutionStore().activeJobId = 'job-2'
     await nextTick()
 
     // job-1 should have been completed
@@ -624,7 +588,7 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
@@ -632,7 +596,7 @@ describe('linearOutputStore', () => {
     // Switch away — job finishes while we're gone
     isAppModeRef.value = false
     await nextTick()
-    activeJobIdRef.value = null
+    useExecutionStore().activeJobId = null
     await nextTick()
 
     // Switch back — store should reconcile the stale tracked job
@@ -647,7 +611,7 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     // First node executes, consuming the skeleton
@@ -657,9 +621,11 @@ describe('linearOutputStore', () => {
     // Switch away — latent preview arrives for next node while gone
     isAppModeRef.value = false
     await nextTick()
-    previewsRef.value = {
-      'job-1': { url: 'blob:preview-while-away', nodeId: 'node-2' }
-    }
+    useJobPreviewStore().setPreviewUrl(
+      'job-1',
+      'blob:preview-while-away',
+      'node-2'
+    )
     await nextTick()
 
     // Switch back — should recover the latent preview
@@ -678,16 +644,22 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     // Job-1 submitted from workflow-a
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     setJobWorkflowPath('job-1', 'workflows/app-a.json')
     store.onJobStart('job-1')
 
     // User switches to workflow-b: job-1 should NOT appear
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
     expect(store.activeWorkflowInProgressItems).toHaveLength(0)
 
     // Back on workflow-a: job-1 should appear
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     expect(store.activeWorkflowInProgressItems).toHaveLength(1)
     expect(store.activeWorkflowInProgressItems[0].jobId).toBe('job-1')
   })
@@ -700,7 +672,9 @@ describe('linearOutputStore', () => {
     setJobWorkflowPath('job-2', 'workflows/app-a.json')
 
     // User switches to workflow-b before execution starts
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
 
     store.onJobStart('job-1')
     store.onJobStart('job-2')
@@ -709,7 +683,9 @@ describe('linearOutputStore', () => {
     expect(store.activeWorkflowInProgressItems).toHaveLength(0)
 
     // On workflow-a: both jobs should appear
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     expect(store.activeWorkflowInProgressItems).toHaveLength(2)
   })
 
@@ -717,14 +693,18 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     // Job-1 on workflow-a (dog)
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     setJobWorkflowPath('job-1', 'workflows/app-a.json')
     store.onJobStart('job-1')
     store.onLatentPreview('job-1', 'blob:dog')
     vi.advanceTimersByTime(16)
 
     // User switches to workflow-b, runs job-2
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
     setJobWorkflowPath('job-2', 'workflows/app-b.json')
 
     // Job-1 finishes, job-2 starts
@@ -741,7 +721,7 @@ describe('linearOutputStore', () => {
   })
 
   it('skips output items for nodes not in selectedOutputs', () => {
-    selectedOutputsRef.value = ['2']
+    useAppModeStore().selectedOutputs = [toNodeId('2')]
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
 
@@ -772,7 +752,9 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     // User is on workflow-b, following latest
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
     store.selectAsLatest('history:asset-b:0')
 
     // Job from workflow-a starts
@@ -786,7 +768,9 @@ describe('linearOutputStore', () => {
   it('auto-selects for jobs belonging to the active workflow', () => {
     const store = useLinearOutputStore()
 
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     store.selectAsLatest('history:asset-a:0')
 
     setJobWorkflowPath('job-1', 'workflows/app-a.json')
@@ -804,7 +788,7 @@ describe('linearOutputStore', () => {
     await nextTick()
 
     // Watcher-driven job start should be ignored
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     expect(store.inProgressItems).toHaveLength(0)
@@ -821,9 +805,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start job, produce 1 image + 1 latent
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -840,7 +826,9 @@ describe('linearOutputStore', () => {
       expect(latentsBefore).toHaveLength(1)
 
       // Switch to workflow B (graph mode)
-      activeWorkflowPathRef.value = 'workflows/graph-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/graph-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
 
@@ -853,7 +841,9 @@ describe('linearOutputStore', () => {
       )
 
       // Switch back to workflow A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = true
       await nextTick()
       vi.advanceTimersByTime(16)
@@ -869,9 +859,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start job, produce 1 image
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -880,19 +872,21 @@ describe('linearOutputStore', () => {
       ).toHaveLength(1)
 
       // Switch away
-      activeWorkflowPathRef.value = 'workflows/graph-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/graph-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
 
       // While away: node 2 executes (event missed — listener removed)
       // Node 3 starts sending latent previews (watcher guarded)
-      previewsRef.value = {
-        'job-a': { url: 'blob:node3-latent', nodeId: '3' }
-      }
+      useJobPreviewStore().setPreviewUrl('job-a', 'blob:node3-latent', '3')
       await nextTick()
 
       // Switch back
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = true
       await nextTick()
       vi.advanceTimersByTime(16)
@@ -913,21 +907,27 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start job
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Switch to workflow B
-      activeWorkflowPathRef.value = 'workflows/app-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-b.json'
+      })
 
       // Workflow A items should NOT appear for workflow B
       expect(store.activeWorkflowInProgressItems).toHaveLength(0)
 
       // Switch back to workflow A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
 
       // Workflow A items should reappear
       expect(store.activeWorkflowInProgressItems).toHaveLength(1)
@@ -939,25 +939,31 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start and partially generate
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Switch to workflow B (graph mode)
-      activeWorkflowPathRef.value = 'workflows/graph-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/graph-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
 
       // While away: job A finishes, job B starts
       setJobWorkflowPath('job-b', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-b'
+      useExecutionStore().activeJobId = 'job-b'
       await nextTick()
 
       // Switch back to workflow A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = true
       await nextTick()
 
@@ -971,9 +977,11 @@ describe('linearOutputStore', () => {
     it('handles job finishing while away with no new job', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -983,7 +991,7 @@ describe('linearOutputStore', () => {
       await nextTick()
 
       // Job finishes, no new job
-      activeJobIdRef.value = null
+      useExecutionStore().activeJobId = null
       await nextTick()
 
       // Switch back
@@ -1002,9 +1010,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: two images
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -1023,7 +1033,9 @@ describe('linearOutputStore', () => {
       ).toHaveLength(2)
 
       // Switch to workflow B (also app mode)
-      activeWorkflowPathRef.value = 'workflows/app-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-b.json'
+      })
 
       // Workflow B should see nothing from job-a
       expect(store.activeWorkflowInProgressItems).toHaveLength(0)
@@ -1037,9 +1049,11 @@ describe('linearOutputStore', () => {
     it('cleans up stale tracked job when leaving app mode after job finishes', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -1050,7 +1064,7 @@ describe('linearOutputStore', () => {
 
       // Now switch away — pendingResolve items stay (still-running case
       // doesn't apply, but items are kept for history absorption)
-      activeJobIdRef.value = null
+      useExecutionStore().activeJobId = null
       isAppModeRef.value = false
       await nextTick()
 
@@ -1084,16 +1098,18 @@ describe('linearOutputStore', () => {
     it('cleans up finished tracked job on exit when job ended while in app mode', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Job ends, new job starts — all while in app mode
       setJobWorkflowPath('job-b', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-b'
+      useExecutionStore().activeJobId = 'job-b'
       await nextTick()
 
       // job-a completed via activeJobId watcher, now pending resolve
@@ -1130,9 +1146,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Tab A: queue "cat"
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-cat', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-cat'
+      useExecutionStore().activeJobId = 'job-cat'
       await nextTick()
 
       store.onNodeExecuted(
@@ -1143,14 +1161,16 @@ describe('linearOutputStore', () => {
       expect(store.activeWorkflowInProgressItems[0].jobId).toBe('job-cat')
 
       // Switch to tab B (different workflow, also app mode): queue "dog"
-      activeWorkflowPathRef.value = 'workflows/app-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
       await nextTick()
 
       setJobWorkflowPath('job-dog', 'workflows/app-b.json')
-      activeJobIdRef.value = 'job-dog'
+      useExecutionStore().activeJobId = 'job-dog'
       await nextTick()
 
       // Tab B should see dog, not cat
@@ -1159,7 +1179,9 @@ describe('linearOutputStore', () => {
       ).toBe(true)
 
       // Switch back to tab A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
@@ -1177,9 +1199,7 @@ describe('linearOutputStore', () => {
       apiTarget.dispatchEvent(event)
 
       // Dog's latent preview also arrives
-      previewsRef.value = {
-        'job-dog': { url: 'blob:dog-latent', nodeId: '2' }
-      }
+      useJobPreviewStore().setPreviewUrl('job-dog', 'blob:dog-latent', '2')
       await nextTick()
       vi.advanceTimersByTime(16)
 
@@ -1201,13 +1221,17 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Run dog on dog tab
-      activeWorkflowPathRef.value = 'workflows/dog.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/dog.json'
+      })
       setJobWorkflowPath('job-dog', 'workflows/dog.json')
-      activeJobIdRef.value = 'job-dog'
+      useExecutionStore().activeJobId = 'job-dog'
       await nextTick()
 
       // Swap to cat tab, queue cat (dog still running)
-      activeWorkflowPathRef.value = 'workflows/cat.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/cat.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
@@ -1215,14 +1239,16 @@ describe('linearOutputStore', () => {
       setJobWorkflowPath('job-cat', 'workflows/cat.json')
 
       // Swap back to dog tab
-      activeWorkflowPathRef.value = 'workflows/dog.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/dog.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
       await nextTick()
 
       // Dog finishes, cat starts (activeJobId transitions on dog tab)
-      activeJobIdRef.value = 'job-cat'
+      useExecutionStore().activeJobId = 'job-cat'
       await nextTick()
 
       // Dog tab must NOT show cat's skeleton
@@ -1238,9 +1264,11 @@ describe('linearOutputStore', () => {
     it('processes new executed events after switching back', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -1273,7 +1301,7 @@ describe('linearOutputStore', () => {
       const store = useLinearOutputStore()
 
       // activeJobId set before path mapping exists (WebSocket race)
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       // No skeleton yet — path mapping is missing
@@ -1293,7 +1321,7 @@ describe('linearOutputStore', () => {
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
 
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
@@ -1314,7 +1342,7 @@ describe('linearOutputStore', () => {
 
       // Path mapping set before activeJobId (normal case, no race)
       setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       expect(store.inProgressItems).toHaveLength(1)
@@ -1330,11 +1358,11 @@ describe('linearOutputStore', () => {
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
 
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       // Job changes before path mapping arrives
-      activeJobIdRef.value = null
+      useExecutionStore().activeJobId = null
       await nextTick()
 
       setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
@@ -1348,7 +1376,7 @@ describe('linearOutputStore', () => {
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
 
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       // Path maps to a different workflow than the active one

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -1,29 +1,18 @@
+import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useQueueStore } from '@/stores/queueStore'
+import { useAssetsStore } from '@/stores/assetsStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, toValue, ref } from 'vue'
+import { nextTick, toValue } from 'vue'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import type { InProgressItem } from '@/renderer/extensions/linearMode/linearModeTypes'
 import { useOutputHistory } from '@/renderer/extensions/linearMode/useOutputHistory'
 import { useAppModeStore } from '@/stores/appModeStore'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 import { toNodeId } from '@/types/nodeId'
-
-const mediaRef = ref<AssetItem[]>([])
-const pendingResolveRef = ref(new Set<string>())
-const inProgressItemsRef = ref<InProgressItem[]>([])
-const activeWorkflowInProgressItemsRef = ref<InProgressItem[]>([])
-const selectedIdRef = ref<string | null>(null)
-const activeWorkflowPathRef = ref<string>('workflows/test.json')
-const jobIdToPathRef = ref(new Map<string, string>())
-const isActiveWorkflowRunningRef = ref(false)
-const runningTasksRef = ref<Array<{ jobId: string }>>([])
-const pendingTasksRef = ref<Array<{ jobId: string }>>([])
-
-const selectAsLatestFn = vi.fn()
-const resolveIfReadyFn = vi.fn()
-const resolvedOutputsCacheRef = new Map<string, AugmentedResultItem[]>()
 
 vi.mock(import('@/platform/assets/composables/media/assetMappers'), () => ({
   getAssetType: (tags?: string[]) =>
@@ -31,75 +20,6 @@ vi.mock(import('@/platform/assets/composables/media/assetMappers'), () => ({
   mapInputFileToAssetItem: vi.fn(),
   mapTaskOutputToAssetItem: vi.fn(),
   unflattenOutputAssets: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    outputAssets: {
-      hasMore: ref(false),
-      invalidate: vi.fn(),
-      isLoading: ref(false),
-      items: mediaRef,
-      loadMore: vi.fn(),
-      loadNew: vi.fn()
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/extensions/linearMode/linearOutputStore'),
-  () => ({
-    useLinearOutputStore: () => ({
-      get pendingResolve() {
-        return pendingResolveRef.value
-      },
-      get inProgressItems() {
-        return inProgressItemsRef.value
-      },
-      get activeWorkflowInProgressItems() {
-        return activeWorkflowInProgressItemsRef.value
-      },
-      get selectedId() {
-        return selectedIdRef.value
-      },
-      resolvedOutputsCache: resolvedOutputsCacheRef,
-      selectAsLatest: selectAsLatestFn,
-      resolveIfReady: resolveIfReadyFn
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return { path: activeWorkflowPathRef.value }
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    get jobIdToSessionWorkflowPath() {
-      return jobIdToPathRef.value
-    },
-    get isActiveWorkflowRunning() {
-      return isActiveWorkflowRunningRef.value
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    get runningTasks() {
-      return runningTasksRef.value
-    },
-    get pendingTasks() {
-      return pendingTasksRef.value
-    }
-  })
 }))
 
 const { jobDetailResults } = vi.hoisted(() => ({
@@ -146,29 +66,47 @@ function makeResult(
   }
 }
 
+beforeEach(() => {
+  useAssetsStore().outputAssets.hasMore = false
+  vi.spyOn(useAssetsStore().outputAssets, 'loadMore').mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useLinearOutputStore().selectAsLatest).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useLinearOutputStore().resolveIfReady).mockImplementation(
+    () => undefined
+  )
+})
+
 describe(useOutputHistory, () => {
   beforeEach(() => {
-    mediaRef.value = []
-    pendingResolveRef.value = new Set()
-    inProgressItemsRef.value = []
-    activeWorkflowInProgressItemsRef.value = []
-    selectedIdRef.value = null
-    activeWorkflowPathRef.value = 'workflows/test.json'
-    jobIdToPathRef.value = new Map()
-    isActiveWorkflowRunningRef.value = false
-    runningTasksRef.value = []
-    pendingTasksRef.value = []
-    resolvedOutputsCacheRef.clear()
+    useAssetsStore().outputAssets.items = []
+    useLinearOutputStore().pendingResolve = new Set()
+    useLinearOutputStore().inProgressItems = []
+    Object.assign(useLinearOutputStore(), { activeWorkflowInProgressItems: [] })
+    useLinearOutputStore().selectedId = null
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/test.json'
+    })
+    useExecutionStore().jobIdToSessionWorkflowPath = new Map()
+    Object.assign(useExecutionStore(), { isActiveWorkflowRunning: false })
+    useQueueStore().runningTasks = []
+    useQueueStore().pendingTasks = []
+    useLinearOutputStore().resolvedOutputsCache.clear()
     jobDetailResults.clear()
   })
 
   describe('sessionMedia filtering', () => {
     it('filters assets to match active workflow path', () => {
-      jobIdToPathRef.value = new Map([
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
         ['job-1', 'workflows/test.json'],
         ['job-2', 'workflows/other.json']
       ])
-      mediaRef.value = [makeAsset('a1', 'job-1'), makeAsset('a2', 'job-2')]
+      useAssetsStore().outputAssets.items = [
+        makeAsset('a1', 'job-1'),
+        makeAsset('a2', 'job-2')
+      ]
 
       const { outputs } = useOutputHistory()
 
@@ -177,9 +115,11 @@ describe(useOutputHistory, () => {
     })
 
     it('returns empty when no workflow is active', () => {
-      activeWorkflowPathRef.value = ''
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      mediaRef.value = [makeAsset('a1', 'job-1')]
+      useWorkflowStore().activeWorkflow = fromPartial({ path: '' })
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useAssetsStore().outputAssets.items = [makeAsset('a1', 'job-1')]
 
       const { outputs } = useOutputHistory()
 
@@ -187,19 +127,26 @@ describe(useOutputHistory, () => {
     })
 
     it('updates when active workflow changes', async () => {
-      jobIdToPathRef.value = new Map([
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
         ['job-1', 'workflows/a.json'],
         ['job-2', 'workflows/b.json']
       ])
-      mediaRef.value = [makeAsset('a1', 'job-1'), makeAsset('a2', 'job-2')]
+      useAssetsStore().outputAssets.items = [
+        makeAsset('a1', 'job-1'),
+        makeAsset('a2', 'job-2')
+      ]
 
-      activeWorkflowPathRef.value = 'workflows/a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/a.json'
+      })
       const { outputs } = useOutputHistory()
 
       expect(toValue(outputs.items)).toHaveLength(1)
       expect(toValue(outputs.items)[0].id).toBe('a1')
 
-      activeWorkflowPathRef.value = 'workflows/b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/b.json'
+      })
       await nextTick()
 
       expect(toValue(outputs.items)).toHaveLength(1)
@@ -287,8 +234,8 @@ describe(useOutputHistory, () => {
 
     it('returns in-progress outputs for pending resolve jobs', () => {
       useAppModeStore().selectedOutputs.push(toNodeId('1'))
-      pendingResolveRef.value = new Set(['job-1'])
-      inProgressItemsRef.value = [
+      useLinearOutputStore().pendingResolve = new Set(['job-1'])
+      useLinearOutputStore().inProgressItems = [
         {
           id: 'item-1',
           jobId: 'job-1',
@@ -348,16 +295,22 @@ describe(useOutputHistory, () => {
         allOutputs: results,
         outputCount: 1
       })
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      pendingResolveRef.value = new Set(['job-1'])
-      mediaRef.value = [asset]
-      selectedIdRef.value = null
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useLinearOutputStore().pendingResolve = new Set(['job-1'])
+      useAssetsStore().outputAssets.items = [asset]
+      useLinearOutputStore().selectedId = null
 
       useOutputHistory()
       await nextTick()
 
-      expect(resolveIfReadyFn).toHaveBeenCalledWith('job-1', true)
-      expect(selectAsLatestFn).toHaveBeenCalledWith('history:a1:0')
+      expect(
+        vi.mocked(useLinearOutputStore().resolveIfReady)
+      ).toHaveBeenCalledWith('job-1', true)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith('history:a1:0')
     })
 
     it('does not select first history when a selection exists', async () => {
@@ -367,45 +320,59 @@ describe(useOutputHistory, () => {
         allOutputs: results,
         outputCount: 1
       })
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      pendingResolveRef.value = new Set(['job-1'])
-      mediaRef.value = [asset]
-      selectedIdRef.value = 'history:existing:0'
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useLinearOutputStore().pendingResolve = new Set(['job-1'])
+      useAssetsStore().outputAssets.items = [asset]
+      useLinearOutputStore().selectedId = 'history:existing:0'
 
       useOutputHistory()
       await nextTick()
 
-      expect(resolveIfReadyFn).toHaveBeenCalledWith('job-1', true)
-      expect(selectAsLatestFn).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useLinearOutputStore().resolveIfReady)
+      ).toHaveBeenCalledWith('job-1', true)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalled()
     })
 
     it('skips jobs with no matching asset in media', async () => {
-      pendingResolveRef.value = new Set(['job-missing'])
-      mediaRef.value = []
+      useLinearOutputStore().pendingResolve = new Set(['job-missing'])
+      useAssetsStore().outputAssets.items = []
 
       useOutputHistory()
       await nextTick()
 
-      expect(resolveIfReadyFn).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useLinearOutputStore().resolveIfReady)
+      ).not.toHaveBeenCalled()
     })
   })
 
   describe('selectFirstHistory', () => {
     it('selects first media item', () => {
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      mediaRef.value = [makeAsset('a1', 'job-1')]
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useAssetsStore().outputAssets.items = [makeAsset('a1', 'job-1')]
 
       const { selectFirstHistory } = useOutputHistory()
       selectFirstHistory()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith('history:a1:0')
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith('history:a1:0')
     })
 
     it('selects null when no media', () => {
       const { selectFirstHistory } = useOutputHistory()
       selectFirstHistory()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith(null)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith(null)
     })
   })
 
@@ -416,43 +383,53 @@ describe(useOutputHistory, () => {
     })
 
     it('returns false when there are active in-progress items', () => {
-      activeWorkflowInProgressItemsRef.value = [
-        { id: 'item-1', jobId: 'job-1', state: 'skeleton' }
-      ]
-      runningTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          { id: 'item-1', jobId: 'job-1', state: 'skeleton' }
+        ]
+      })
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)
     })
 
     it('returns true when a running task matches the active workflow', () => {
-      runningTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(true)
     })
 
     it('returns false when only pending tasks exist', () => {
-      pendingTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
+      useQueueStore().pendingTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)
     })
 
     it('returns false when tasks belong to another workflow', () => {
-      runningTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/other.json']])
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/other.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)
     })
 
     it('returns false when no workflow path is set', () => {
-      activeWorkflowPathRef.value = ''
-      runningTasksRef.value = [{ jobId: 'job-1' }]
+      useWorkflowStore().activeWorkflow = fromPartial({ path: '' })
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)

--- a/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
@@ -1,3 +1,6 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 /**
  * Lifecycle tests for the minimap's change-detection interval, run against the
  * real `useIntervalFn` with fake timers. The main useMinimap test file mocks
@@ -6,6 +9,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
+import type {
+  LGraph,
+  LGraphNode,
+  LGraphCanvas
+} from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
 
 import {
   createMockCanvas2DContext,
@@ -13,24 +22,26 @@ import {
   createMockMinimapCanvas
 } from '@/utils/__tests__/litegraphTestUtils'
 
-const mockNodes = [
+const mockNodes = fromPartial<LGraphNode[]>([
   {
-    id: 'node1',
+    constructor: {},
+    id: toNodeId('node1'),
     pos: [0, 0],
     size: [100, 50],
     renderingSize: [100, 50],
     outputs: []
   },
   {
-    id: 'node2',
+    constructor: {},
+    id: toNodeId('node2'),
     pos: [200, 100],
     size: [150, 75],
     renderingSize: [150, 75],
     outputs: []
   }
-]
+])
 
-const mockGraph = {
+const mockGraph = fromPartial<LGraph>({
   id: 'root',
   rootGraph: { id: 'root' },
   _groups: [],
@@ -38,38 +49,25 @@ const mockGraph = {
   links: createMockLinks([]),
   getNodeById: vi.fn((id: string) => mockNodes.find((n) => n.id === id)),
   setDirtyCanvas: vi.fn(),
-  onNodeAdded: null,
-  onNodeRemoved: null,
-  onConnectionChange: null,
   events: {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   }
-}
+})
 
-const mockCanvas = {
+const canvasElement = document.createElement('canvas')
+canvasElement.width = 1000
+canvasElement.height = 800
+Object.defineProperties(canvasElement, {
+  clientWidth: { value: 1000 },
+  clientHeight: { value: 800 }
+})
+const mockCanvas = fromPartial<LGraphCanvas>({
   graph: mockGraph,
-  canvas: { width: 1000, height: 800, clientWidth: 1000, clientHeight: 800 },
+  canvas: canvasElement,
   ds: { scale: 1, offset: [0, 0] },
   setDirty: vi.fn()
-}
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => ({ canvas: mockCanvas }))
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn().mockReturnValue(true),
-    set: vi.fn().mockResolvedValue(undefined)
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({
-    completedActivePalette: { light_theme: false }
-  }))
-}))
+})
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -80,26 +78,24 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: mockGraph } }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({ activeSubgraph: null }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {},
-    nodeProgressStates: {}
-  }))
+  app: {
+    canvas: {
+      get graph() {
+        return mockGraph
+      }
+    }
+  }
 }))
 
 import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
 
 const POLL_MS = 100
+
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial(mockCanvas)
+  vi.mocked(useSettingStore().get).mockReturnValue(true)
+  vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+})
 
 describe('useMinimap change-detection interval', () => {
   let context: CanvasRenderingContext2D

--- a/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
@@ -1,11 +1,19 @@
+import type * as VueUse from '@vueuse/core'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useLinkStore } from '@/stores/linkStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, shallowRef } from 'vue'
+import { effectScope, nextTick, shallowRef } from 'vue'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+import type { LinkTopology } from '@/types/linkTopology'
 
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { MinimapDataSource } from '@/renderer/extensions/minimap/data/MinimapDataSource'
-import type { NodeProgressState } from '@/schemas/apiSchema'
 import { createMockCanvas2DContext } from '@/utils/__tests__/litegraphTestUtils'
 
 interface HarnessCounters {
@@ -31,9 +39,7 @@ interface HarnessCounters {
 
 const {
   counters,
-  defaultSettingStore,
-  mockCanvasStore,
-  progressStates,
+
   linkTopologies,
   apiListeners,
   pollControl
@@ -58,20 +64,12 @@ const {
     pollPauses: 0,
     pollResumes: 0
   }
-  const progressStates: Record<string, NodeProgressState> = {}
-  const canvasStore = (canvas: unknown) => ({ canvas })
   return {
     counters,
-    defaultSettingStore: {
-      visible: true,
-      get: vi.fn(() => true),
-      set: vi.fn().mockResolvedValue(undefined)
-    },
-    mockCanvasStore: canvasStore(null),
-    progressStates,
+
     linkTopologies: [] as Array<{
-      originNodeId: string
-      targetNodeId: string
+      originNodeId: NodeId
+      targetNodeId: NodeId
       originSlot: number
       targetSlot: number
     }>,
@@ -80,7 +78,8 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useDocumentVisibility: () => ({ value: 'visible' }),
   useIntervalFn: (callback: () => void) => {
     counters.pollRegistrations++
@@ -104,51 +103,6 @@ vi.mock<unknown>(import('@vueuse/core'), () => ({
     counters.throttleCallbacks++
     callback()
   }
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => defaultSettingStore.visible,
-    set: defaultSettingStore.set
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ activeSubgraph: null })
-  })
-)
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => mockCanvasStore
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    nodeProgressStates: progressStates,
-    nodeLocationProgressStates: progressStates
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/linkStore'), () => ({
-  useLinkStore: () => ({
-    graphTopologies: () => {
-      counters.topologyReads++
-      return (function* () {
-        for (const topology of linkTopologies) {
-          counters.topologyEntries++
-          yield topology
-        }
-      })()
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: { light_theme: false }
-  })
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -239,8 +193,8 @@ function createGraph(graphSize: number, edgeCount: number) {
     0,
     linkTopologies.length,
     ...Array.from({ length: edgeCount }, (_, index) => ({
-      originNodeId: '1',
-      targetNodeId: String((index % graphSize) + 1),
+      originNodeId: toNodeId('1'),
+      targetNodeId: toNodeId(String((index % graphSize) + 1)),
       originSlot: index,
       targetSlot: index
     }))
@@ -271,8 +225,9 @@ async function runCell(
 ): Promise<MatrixResult> {
   resetCounters()
   apiListeners.clear()
-  for (const key of Object.keys(progressStates)) delete progressStates[key]
-  progressStates['1'] = {
+  for (const key of Object.keys(useExecutionStore().nodeProgressStates))
+    delete useExecutionStore().nodeProgressStates[key]
+  useExecutionStore().nodeProgressStates['1'] = {
     state: 'running',
     value: 1,
     max: 2,
@@ -293,28 +248,38 @@ async function runCell(
     height: 200,
     getContext: (kind: string) => (kind === '2d' ? context : null)
   } as unknown as HTMLCanvasElement
-  mockCanvasStore.canvas = {
+  const graphCanvasElement = document.createElement('canvas')
+  graphCanvasElement.width = 1000
+  graphCanvasElement.height = 800
+  Object.defineProperties(graphCanvasElement, {
+    clientWidth: { value: 1000 },
+    clientHeight: { value: 800 }
+  })
+  useCanvasStore().canvas = fromPartial({
     graph,
-    canvas: {
-      width: 1000,
-      height: 800,
-      clientWidth: 1000,
-      clientHeight: 800
-    },
+    canvas: graphCanvasElement,
     ds: { scale: 1, offset: [0, 0] },
     setDirty: () => counters.dirtyRequests++
-  }
-  defaultSettingStore.visible = visible
+  })
+  useSettingStore().settingValues['Comfy.Minimap.Visible'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.ShowLinks'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.ShowGroups'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.NodeColors'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.RenderBypassState'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.RenderErrorState'] = visible
 
   const getNodes = vi.spyOn(MinimapDataSource.prototype, 'getNodes')
   const getLinks = vi.spyOn(MinimapDataSource.prototype, 'getLinks')
   const getBounds = vi.spyOn(MinimapDataSource.prototype, 'getBounds')
-  const minimap = useMinimap({
-    canvasRefMaybe: shallowRef(canvasElement),
-    containerRefMaybe: shallowRef({
-      getBoundingClientRect: () => new DOMRect(0, 0, 250, 200)
-    } as HTMLDivElement)
-  })
+  const scope = effectScope()
+  const minimap = scope.run(() =>
+    useMinimap({
+      canvasRefMaybe: shallowRef(canvasElement),
+      containerRefMaybe: shallowRef({
+        getBoundingClientRect: () => new DOMRect(0, 0, 250, 200)
+      } as HTMLDivElement)
+    })
+  )!
   await minimap.init()
   await nextTick()
   await nextTick()
@@ -338,10 +303,12 @@ async function runCell(
   getBounds.mockClear()
 
   if (operation === 'equal-progress') {
-    progressStates['1'] = { ...progressStates['1'] }
+    useExecutionStore().nodeProgressStates['1'] = {
+      ...useExecutionStore().nodeProgressStates['1']
+    }
   } else if (operation === 'changed-progress') {
-    progressStates['1'] = {
-      ...progressStates['1'],
+    useExecutionStore().nodeProgressStates['1'] = {
+      ...useExecutionStore().nodeProgressStates['1'],
       state: 'finished'
     }
   } else if (operation === 'geometry') {
@@ -358,8 +325,8 @@ async function runCell(
       target_slot: 0
     })
     linkTopologies.push({
-      originNodeId: '1',
-      targetNodeId: String(Math.min(2, graphSize)),
+      originNodeId: toNodeId('1'),
+      targetNodeId: toNodeId(String(Math.min(2, graphSize))),
       originSlot: 0,
       targetSlot: 0
     })
@@ -382,6 +349,7 @@ async function runCell(
     ...counters
   }
   minimap.destroy()
+  scope.stop()
   result.pollRegistrations = lifecycleAtInit.pollRegistrations
   result.listenersAdded = lifecycleAtInit.listenersAdded
   result.listenersRemoved = counters.listenersRemoved
@@ -392,6 +360,20 @@ async function runCell(
   getBounds.mockRestore()
   return result
 }
+
+beforeEach(() => {
+  Object.assign(useExecutionStore(), {
+    nodeLocationProgressStates: useExecutionStore().nodeProgressStates
+  })
+  vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+  vi.mocked(useLinkStore().graphTopologies).mockImplementation(function* () {
+    counters.topologyReads++
+    for (const topology of linkTopologies) {
+      counters.topologyEntries++
+      yield fromPartial<LinkTopology>(topology)
+    }
+  })
+})
 
 describe('minimap progress performance baseline', () => {
   beforeEach(() => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -1,10 +1,12 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import type * as VueUse from '@vueuse/core'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref, shallowRef } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import { useLinkStore } from '@/stores/linkStore'
 import { toLinkId } from '@/types/linkId'
@@ -93,8 +95,10 @@ const mockIntervalResume = vi.fn()
 const rafCallbacks: Record<string, () => void> = {}
 let rafCallbackId = 0
 
-vi.mock<unknown>(import('@vueuse/core'), () => {
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
+  const { ref } = await import('vue')
   return {
+    ...(await importOriginal<typeof VueUse>()),
     useDocumentVisibility: vi.fn(() => ref('visible')),
     useRafFn: vi.fn((callback, options) => {
       const id = rafCallbackId++
@@ -217,35 +221,6 @@ const setupMocks = () => {
 
 setupMocks()
 
-const defaultCanvasStore: {
-  canvas: MockCanvas | null
-  getCanvas: () => MockCanvas | null
-} = {
-  canvas: moduleMockCanvas,
-  getCanvas: () => defaultCanvasStore.canvas
-}
-
-const defaultSettingStore = {
-  get: vi.fn().mockReturnValue(true),
-  set: vi.fn().mockResolvedValue(undefined)
-}
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => defaultCanvasStore)
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => defaultSettingStore)
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({
-    completedActivePalette: {
-      light_theme: false
-    }
-  }))
-}))
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     addEventListener: vi.fn(),
@@ -257,24 +232,11 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: {
-      graph: moduleMockGraph
+      get graph() {
+        return moduleMockGraph
+      }
     }
   }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      activeSubgraph: null
-    }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {}
-  }))
 }))
 
 import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
@@ -299,7 +261,6 @@ describe('useMinimap', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     registerMockLink(1, 'node2')
 
     mockContext2D = createMockCanvas2DContext()
@@ -388,10 +349,18 @@ describe('useMinimap', () => {
       setDirty: vi.fn()
     }
 
-    defaultCanvasStore.canvas = moduleMockCanvas
+    const element = document.createElement('canvas')
+    element.width = 1000
+    element.height = 800
+    Object.defineProperties(element, {
+      clientWidth: { value: 1000, writable: true },
+      clientHeight: { value: 800, writable: true }
+    })
+    moduleMockCanvas.canvas = element
+    useCanvasStore().canvas = moduleMockCanvas as unknown as LGraphCanvas
 
-    defaultSettingStore.get = vi.fn().mockReturnValue(true)
-    defaultSettingStore.set = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useSettingStore().get).mockReturnValue(true)
+    vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
 
     Object.defineProperty(window, 'devicePixelRatio', {
       writable: true,
@@ -405,8 +374,8 @@ describe('useMinimap', () => {
 
   describe('initialization', () => {
     it('should initialize with default values', () => {
-      const originalCanvas = defaultCanvasStore.canvas
-      defaultCanvasStore.canvas = null
+      const originalCanvas = useCanvasStore().canvas
+      useCanvasStore().canvas = null
 
       const minimap = useMinimap()
 
@@ -415,7 +384,7 @@ describe('useMinimap', () => {
       expect(minimap.visible.value).toBe(true)
       expect(minimap.initialized.value).toBe(false)
 
-      defaultCanvasStore.canvas = originalCanvas
+      useCanvasStore().canvas = originalCanvas
     })
 
     it('should initialize minimap when canvas is available', async () => {
@@ -424,7 +393,7 @@ describe('useMinimap', () => {
       await minimap.init()
 
       expect(minimap.initialized.value).toBe(true)
-      expect(defaultSettingStore.get).toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().get)).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible'
       )
       expect(api.addEventListener).toHaveBeenCalledWith(
@@ -438,8 +407,8 @@ describe('useMinimap', () => {
     })
 
     it('should not initialize without canvas and graph', async () => {
-      const originalCanvas = defaultCanvasStore.canvas
-      defaultCanvasStore.canvas = null
+      const originalCanvas = useCanvasStore().canvas
+      useCanvasStore().canvas = null
 
       const minimap = useMinimap()
       await minimap.init()
@@ -447,7 +416,7 @@ describe('useMinimap', () => {
       expect(minimap.initialized.value).toBe(false)
       expect(api.addEventListener).not.toHaveBeenCalled()
 
-      defaultCanvasStore.canvas = originalCanvas
+      useCanvasStore().canvas = originalCanvas
     })
 
     it('should setup event listeners on graph', async () => {
@@ -461,7 +430,7 @@ describe('useMinimap', () => {
     })
 
     it('should handle visibility from settings', async () => {
-      defaultSettingStore.get.mockReturnValue(false)
+      vi.mocked(useSettingStore().get).mockReturnValue(false)
       const minimap = await createAndInitializeMinimap()
 
       await minimap.init()
@@ -521,7 +490,7 @@ describe('useMinimap', () => {
       await minimap.toggle()
 
       expect(minimap.visible.value).toBe(!initialVisibility)
-      expect(defaultSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible',
         !initialVisibility
       )
@@ -529,7 +498,7 @@ describe('useMinimap', () => {
       await minimap.toggle()
 
       expect(minimap.visible.value).toBe(initialVisibility)
-      expect(defaultSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible',
         initialVisibility
       )
@@ -587,8 +556,8 @@ describe('useMinimap', () => {
       if (!renderingOccurred) {
         console.log('Minimap visible:', minimap.visible.value)
         console.log('Minimap initialized:', minimap.initialized.value)
-        console.log('Canvas exists:', !!defaultCanvasStore.canvas)
-        console.log('Graph exists:', !!defaultCanvasStore.canvas?.graph)
+        console.log('Canvas exists:', !!useCanvasStore().canvas)
+        console.log('Graph exists:', !!useCanvasStore().canvas?.graph)
         console.log(
           'clearRect calls:',
           vi.mocked(mockContext2D.clearRect).mock.calls.length

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -1,3 +1,5 @@
+import type * as VueUse from '@vueuse/core'
+import { useExecutionStore } from '@/stores/executionStore'
 import { useThrottleFn } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -20,18 +22,9 @@ import {
   createMockLinks
 } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useThrottleFn: vi.fn((fn) => fn)
-}))
-
-const { mockProgressStates } = vi.hoisted(() => ({
-  mockProgressStates: {} as Record<string, { state: string }>
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeProgressStates: mockProgressStates
-  }))
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -61,8 +54,8 @@ describe('useMinimapGraph', () => {
     })
 
     onGraphChangedMock = vi.fn()
-    for (const key of Object.keys(mockProgressStates)) {
-      delete mockProgressStates[key]
+    for (const key of Object.keys(useExecutionStore().nodeProgressStates)) {
+      delete useExecutionStore().nodeProgressStates[key]
     }
   })
 
@@ -500,11 +493,23 @@ describe('useMinimapGraph', () => {
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
 
-    mockProgressStates['1'] = { state: 'running' }
+    useExecutionStore().nodeProgressStates['1'] = {
+      state: 'running',
+      value: 1,
+      max: 2,
+      node_id: '1',
+      prompt_id: 'job-1'
+    }
     expect(graphManager.checkForChanges()).toBe(true)
     expect(graphManager.checkForChanges()).toBe(false)
 
-    mockProgressStates['1'] = { state: 'finished' }
+    useExecutionStore().nodeProgressStates['1'] = {
+      state: 'finished',
+      value: 2,
+      max: 2,
+      node_id: '1',
+      prompt_id: 'job-1'
+    }
     expect(graphManager.checkForChanges()).toBe(true)
   })
 

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
@@ -1,36 +1,22 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useMinimapSettings } from '@/renderer/extensions/minimap/composables/useMinimapSettings'
 
-type MockSettingStore = ReturnType<typeof useSettingStore>
-
-const mockUseColorPaletteStore = vi.hoisted(() => vi.fn())
-
-vi.mock(import('@/platform/settings/settingStore'))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: mockUseColorPaletteStore
-}))
+beforeEach(() => {
+  useSettingStore().settingValues = {
+    'Comfy.Minimap.NodeColors': true,
+    'Comfy.Minimap.ShowLinks': false,
+    'Comfy.Minimap.ShowGroups': true,
+    'Comfy.Minimap.RenderBypassState': false,
+    'Comfy.Minimap.RenderErrorState': true
+  }
+})
 
 describe('useMinimapSettings', () => {
   it('should return all minimap settings as computed refs', () => {
-    const mockSettingStore = {
-      get: vi.fn((key: string) => {
-        const settings: Record<string, unknown> = {
-          'Comfy.Minimap.NodeColors': true,
-          'Comfy.Minimap.ShowLinks': false,
-          'Comfy.Minimap.ShowGroups': true,
-          'Comfy.Minimap.RenderBypassState': false,
-          'Comfy.Minimap.RenderErrorState': true
-        }
-        return settings[key]
-      })
-    }
-
-    vi.mocked(useSettingStore).mockReturnValue(
-      mockSettingStore as Partial<MockSettingStore> as MockSettingStore
-    )
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',
@@ -58,10 +44,7 @@ describe('useMinimapSettings', () => {
       }
     }
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      get: vi.fn()
-    } as Partial<MockSettingStore> as MockSettingStore)
-    mockUseColorPaletteStore.mockReturnValue(mockColorPaletteStore)
+    Object.assign(useColorPaletteStore(), mockColorPaletteStore)
 
     const settings = useMinimapSettings()
     const styles = settings.containerStyles.value
@@ -82,10 +65,7 @@ describe('useMinimapSettings', () => {
       }
     }
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      get: vi.fn()
-    } as Partial<MockSettingStore> as MockSettingStore)
-    mockUseColorPaletteStore.mockReturnValue(mockColorPaletteStore)
+    Object.assign(useColorPaletteStore(), mockColorPaletteStore)
 
     const settings = useMinimapSettings()
     const styles = settings.containerStyles.value
@@ -106,10 +86,7 @@ describe('useMinimapSettings', () => {
       }
     }
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      get: vi.fn()
-    } as Partial<MockSettingStore> as MockSettingStore)
-    mockUseColorPaletteStore.mockReturnValue(mockColorPaletteStore)
+    Object.assign(useColorPaletteStore(), mockColorPaletteStore)
 
     const settings = useMinimapSettings()
     const styles = settings.panelStyles.value
@@ -121,17 +98,7 @@ describe('useMinimapSettings', () => {
   })
 
   it('should create computed properties that call the store getter', () => {
-    const mockGet = vi.fn((key: string) => {
-      if (key === 'Comfy.Minimap.NodeColors') return true
-      if (key === 'Comfy.Minimap.ShowLinks') return false
-      return true
-    })
-    const mockSettingStore = { get: mockGet }
-
-    vi.mocked(useSettingStore).mockReturnValue(
-      mockSettingStore as Partial<MockSettingStore> as MockSettingStore
-    )
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',
@@ -147,7 +114,11 @@ describe('useMinimapSettings', () => {
     expect(settings.showLinks.value).toBe(false)
 
     // Verify the store getter was called with the correct keys
-    expect(mockGet).toHaveBeenCalledWith('Comfy.Minimap.NodeColors')
-    expect(mockGet).toHaveBeenCalledWith('Comfy.Minimap.ShowLinks')
+    expect(useSettingStore().get).toHaveBeenCalledWith(
+      'Comfy.Minimap.NodeColors'
+    )
+    expect(useSettingStore().get).toHaveBeenCalledWith(
+      'Comfy.Minimap.ShowLinks'
+    )
   })
 })

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
@@ -12,16 +12,11 @@ import {
 import { useMinimapViewport } from '@/renderer/extensions/minimap/composables/useMinimapViewport'
 import type { MinimapCanvas } from '@/renderer/extensions/minimap/types'
 
-vi.mock(import('@vueuse/core'))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn()
+vi.mock(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRafFn: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {}
-  }))
-}))
 vi.mock(import('@/renderer/core/spatial/boundsCalculator'), () => ({
   calculateNodeBounds: vi.fn(),
   calculateMinimapScale: vi.fn(),

--- a/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
+++ b/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
@@ -1,7 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
+import { useExecutionStore } from '@/stores/executionStore'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type {
@@ -19,12 +18,6 @@ import {
   createMockLGraph,
   createMockLGraphNode
 } from '@/utils/__tests__/litegraphTestUtils'
-
-const useExecutionStore = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore
-}))
 
 const ROOT_GRAPH_ID = '00000000-0000-0000-0000-000000000001'
 const SUBGRAPH_ID = '00000000-0000-0000-0000-000000000002'
@@ -67,8 +60,7 @@ function rootGraph(
 
 describe('MinimapDataSource', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    useExecutionStore.mockReturnValue({ nodeLocationProgressStates: {} })
+    Object.assign(useExecutionStore(), { nodeLocationProgressStates: {} })
   })
 
   it('uses graph position and rendered size', () => {
@@ -89,7 +81,7 @@ describe('MinimapDataSource', () => {
       rootGraph: rootGraph(),
       _nodes: [node]
     })
-    useExecutionStore.mockReturnValue({
+    Object.assign(useExecutionStore(), {
       nodeLocationProgressStates: {
         [createNodeLocatorId(SUBGRAPH_ID, node.id)]: { state: 'running' }
       }

--- a/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
+++ b/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
@@ -1,5 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -18,19 +17,8 @@ import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
 
-const mockUseColorPaletteStore = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: mockUseColorPaletteStore
-}))
-
 vi.mock(import('@/utils/colorUtil'), () => ({
   adjustColor: vi.fn((color: string) => color + '_adjusted')
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {}
-  }))
 }))
 
 const GRAPH_ID: UUID = 'renderer-graph'
@@ -45,8 +33,6 @@ describe('minimapCanvasRenderer', () => {
   let mockGraph: LGraph
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-
     mockContext = {
       clearRect: vi.fn(),
       fillRect: vi.fn(),
@@ -95,7 +81,7 @@ describe('minimapCanvasRenderer', () => {
       getNodeById: vi.fn()
     })
 
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',
@@ -309,7 +295,7 @@ describe('minimapCanvasRenderer', () => {
   })
 
   it('should handle light theme colors', () => {
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.test.ts
@@ -1,16 +1,14 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import { useWidgetStore } from '@/stores/widgetStore'
+
 import { render, screen } from '@testing-library/vue'
 import { computed } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WidgetGridItem } from '@/renderer/extensions/vueNodes/types/widgetGrid'
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import LGraphNodePreview from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
 import { fromPartial } from '@total-typescript/shoehorn'
-
-vi.mock<unknown>(import('@/stores/widgetStore'), () => ({
-  useWidgetStore: () => ({ inputIsWidget: () => true })
-}))
 
 const WidgetGridProbe = {
   props: ['processedWidgets'],
@@ -50,7 +48,7 @@ function renderedWidgets(
   render(LGraphNodePreview, {
     props: { nodeDef: def, ...props },
     global: {
-      plugins: [createTestingPinia({ stubActions: false })],
+      plugins: [getActivePinia()!],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -70,12 +68,16 @@ function renderedComboWidget(
   return renderedWidgets(nodeDef, props).find((w) => w.name === 'ckpt_name')
 }
 
+beforeEach(() => {
+  vi.mocked(useWidgetStore().inputIsWidget).mockReturnValue(true)
+})
+
 describe('LGraphNodePreview', () => {
   it('does not synchronize preview geometry with the canvas layout', () => {
     render(LGraphNodePreview, {
       props: { nodeDef },
       global: {
-        plugins: [createTestingPinia({ stubActions: false })],
+        plugins: [getActivePinia()!],
         stubs: {
           NodeHeader: true,
           NodeSlots: {

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,9 +1,9 @@
+import { getActivePinia } from 'pinia'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeState } from '@/types/nodeState'
 import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
@@ -16,12 +16,6 @@ import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-test'
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    rootGraphId: GRAPH_ID
-  })
-}))
 
 const WidgetStub = {
   name: 'WidgetStub',
@@ -85,8 +79,7 @@ function renderComponent({
   widgetIds?: readonly WidgetId[]
   setupStores?: () => void
 }) {
-  const pinia = createTestingPinia({ stubActions: false })
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
   setupStores?.()
 
   return render(NodeWidgets, {
@@ -106,6 +99,10 @@ function renderComponent({
     }
   })
 }
+
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
+})
 
 describe('NodeWidgets', () => {
   describe('node-type prop passing', () => {

--- a/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.test.ts
@@ -1,46 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, effectScope } from 'vue'
 
-import type {
-  LGraph,
-  LGraphCanvas,
-  LGraphNode
-} from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
-import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables/useNodeEventHandlers'
+import { useNodeEventHandlers as createNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables/useNodeEventHandlers'
 import { toNodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 const ROOT_GRAPH_ID = vi.hoisted<UUID>(() => 'root-graph')
-const canvasSelectedItems = vi.hoisted(() => [] as Array<{ id?: string }>)
-const graphNode = vi.hoisted(() => ({
-  id: 'node-1',
+
+const graphNode = createMockLGraphNode({
+  id: toNodeId('node-1'),
   selected: false,
   flags: { pinned: false }
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => {
-  const canvas: Partial<LGraphCanvas> = {
-    select: vi.fn(),
-    deselect: vi.fn(),
-    deselectAll: vi.fn()
-  }
-  const updateSelectedItems = vi.fn()
-  const currentGraph: Partial<LGraph> = {
-    getNodeById: vi.fn(() => graphNode as Partial<LGraphNode> as LGraphNode)
-  }
-  const canvasStoreInstance = {
-    canvas: canvas as LGraphCanvas,
-    currentGraph: currentGraph as LGraph,
-    updateSelectedItems,
-    selectedItems: canvasSelectedItems,
-    rootGraphId: ROOT_GRAPH_ID
-  }
-  return {
-    useCanvasStore: vi.fn(() => canvasStoreInstance)
-  }
 })
 
 vi.mock<unknown>(
@@ -64,14 +39,40 @@ vi.mock<unknown>(
   }
 )
 
+let scope: ReturnType<typeof effectScope>
+
+function useNodeEventHandlers() {
+  return scope.run(createNodeEventHandlers)!
+}
+
+afterEach(() => scope.stop())
+
+beforeEach(() => {
+  const store = useCanvasStore()
+  const graph = fromPartial<NonNullable<typeof store.currentGraph>>({
+    getNodeById: vi.fn(() => graphNode)
+  })
+  store.canvas = fromPartial({
+    graph,
+    canvas: document.createElement('canvas'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    deselectAll: vi.fn()
+  })
+  store.currentGraph = graph
+  Object.assign(store, { rootGraphId: ROOT_GRAPH_ID })
+  vi.mocked(store.updateSelectedItems).mockImplementation(() => undefined)
+  scope = effectScope()
+})
+
 describe('useNodeEventHandlers', () => {
-  const mockNode = graphNode as Partial<LGraphNode> as LGraphNode
+  const mockNode = graphNode
   const mockLayoutMutations = useLayoutMutations(LayoutSource.Vue)
 
   const testNodeId = toNodeId('node-1')
 
   beforeEach(async () => {
-    canvasSelectedItems.length = 0
+    useCanvasStore().selectedItems.length = 0
   })
 
   describe('handleNodeSelect', () => {
@@ -206,7 +207,10 @@ describe('useNodeEventHandlers', () => {
       const { canvas } = useCanvasStore()
 
       mockNode.selected = true
-      canvasSelectedItems.push({ id: 'node-1' }, { id: 'node-2' })
+      useCanvasStore().selectedItems.push(
+        createMockLGraphNode({ id: toNodeId('node-1') }),
+        createMockLGraphNode({ id: toNodeId('node-2') })
+      )
 
       const event = new PointerEvent('pointerdown', {
         bubbles: true,
@@ -277,7 +281,10 @@ describe('useNodeEventHandlers', () => {
       const { canvas, updateSelectedItems } = useCanvasStore()
 
       mockNode.selected = true
-      canvasSelectedItems.push({ id: 'node-1' }, { id: 'node-2' })
+      useCanvasStore().selectedItems.push(
+        createMockLGraphNode({ id: toNodeId('node-1') }),
+        createMockLGraphNode({ id: toNodeId('node-2') })
+      )
 
       toggleNodeSelectionAfterPointerUp(testNodeId, false)
 
@@ -291,7 +298,9 @@ describe('useNodeEventHandlers', () => {
       const { canvas, updateSelectedItems } = useCanvasStore()
 
       mockNode.selected = true
-      canvasSelectedItems.push({ id: 'node-1' })
+      useCanvasStore().selectedItems.push(
+        createMockLGraphNode({ id: toNodeId('node-1') })
+      )
 
       toggleNodeSelectionAfterPointerUp(testNodeId, false)
 

--- a/src/renderer/extensions/vueNodes/composables/useNodeZIndex.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeZIndex.test.ts
@@ -1,6 +1,8 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
@@ -12,16 +14,14 @@ vi.mock(import('@/renderer/core/layout/operations/layoutMutations'), () => ({
   useLayoutMutations: vi.fn()
 }))
 
-const CURRENT_GRAPH = fromPartial({ id: createUuidv4() })
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ currentGraph: CURRENT_GRAPH })
-}))
+const CURRENT_GRAPH = fromPartial<LGraph>({ id: createUuidv4() })
 
 const mockedUseLayoutMutations = vi.mocked(useLayoutMutations)
 
 describe('useNodeZIndex', () => {
   it('scopes the mutation to the viewed root graph, attributed to Vue', () => {
     const mockSetNodeOrder = vi.fn()
+    useCanvasStore().currentGraph = CURRENT_GRAPH
 
     mockedUseLayoutMutations.mockReturnValue(
       fromPartial({

--- a/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
@@ -1,5 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -15,11 +14,6 @@ import { toNodeId } from '@/types/nodeId'
 import { NodeBadgeMode } from '@/types/nodeSource'
 
 const NODE_ID = toNodeId(5)
-
-const settings = vi.hoisted(() => new Map<string, unknown>())
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => settings.get(key) })
-}))
 
 const getNodeDisplayPrice = vi.fn(() => '$0.05 x 3 Runs')
 vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
@@ -77,15 +71,13 @@ function nodeData(type: string): NodeState {
 
 describe('usePartitionedBadges', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    settings.clear()
-    settings.set('Comfy.NodeBadge.NodeIdBadgeMode', NodeBadgeMode.ShowAll)
-    settings.set(
-      'Comfy.NodeBadge.NodeLifeCycleBadgeMode',
+    useSettingStore().settingValues['Comfy.NodeBadge.NodeIdBadgeMode'] =
       NodeBadgeMode.ShowAll
-    )
-    settings.set('Comfy.NodeBadge.NodeSourceBadgeMode', NodeBadgeMode.ShowAll)
-    settings.set('Comfy.NodeBadge.ShowApiPricing', true)
+    useSettingStore().settingValues['Comfy.NodeBadge.NodeLifeCycleBadgeMode'] =
+      NodeBadgeMode.ShowAll
+    useSettingStore().settingValues['Comfy.NodeBadge.NodeSourceBadgeMode'] =
+      NodeBadgeMode.ShowAll
+    useSettingStore().settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
   })
 
   it('partitions derived rows into core chips and pricing entries', () => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -1,6 +1,5 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { TooltipOptions } from 'primevue'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
@@ -32,12 +31,6 @@ import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-test'
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    rootGraphId: GRAPH_ID
-  })
-}))
 
 function createMockWidget(
   overrides: Partial<IBaseWidget> & { widgetId?: WidgetId } = {}
@@ -146,10 +139,12 @@ function processWidgets({
   })
 }
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
+})
+
 describe('widget slot ownership', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   it('does not assign a non-widget input socket to a same-named custom widget', () => {
     const { graph, node } = createGraphWithNode([])
@@ -171,9 +166,7 @@ describe('widget slot ownership', () => {
 })
 
 describe('widget visibility', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   function visibilityOf(
     options: IBaseWidget['options'],
@@ -279,9 +272,7 @@ describe('widget visibility', () => {
 })
 
 describe('widget error state', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   function processWidgetNamed(name: string) {
     const id = widgetId(GRAPH_ID, toNodeId(1), name)
@@ -326,7 +317,6 @@ describe('promoted subgraph widgets', () => {
   const SOURCE_EXECUTION_ID = createNodeExecutionId([HOST_ID, INTERIOR_ID])
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     resetSubgraphFixtureState()
   })
 
@@ -605,9 +595,7 @@ describe('computeProcessedWidgets', () => {
 describe('createWidgetUpdateHandler (via computeProcessedWidgets)', () => {
   const NODE_ID = toNodeId(1)
 
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   function processUpdateWidgets(widgets: IBaseWidget[]) {
     const { graph } = createGraphWithNode(widgets, NODE_ID)
@@ -687,9 +675,7 @@ describe('createWidgetUpdateHandler (via computeProcessedWidgets)', () => {
 })
 
 describe('live widget update handler', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   it('forwards null (not undefined) to both the live widget value and callback', () => {
     const callback = vi.fn()

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { computeProcessedWidgets } from '@/renderer/extensions/vueNodes/composables/useProcessedWidgets'
@@ -9,10 +8,6 @@ import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-widget-rename'
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ rootGraphId: GRAPH_ID })
-}))
 
 const noopUi = {
   getTooltipConfig: () => ({}),
@@ -51,10 +46,12 @@ function renderedWidgetNames(graph: LGraph, node: LGraphNode): string[] {
   }).map((w) => w.simplified.name)
 }
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
+})
+
 describe('widget rename after registration (#15600)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   it('control: a widget that is never renamed renders', () => {
     const { graph, node } = setup('Original')

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import type * as VueUse from '@vueuse/core'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { toNodeId } from '@/types/nodeId'
@@ -58,10 +57,6 @@ vi.mock<unknown>(import('@/renderer/core/canvas/useAutoPan'), () => ({
       capturedAutoPan.current = this
     }
   }
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ isReadOnly: false })
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
@@ -206,7 +201,8 @@ vi.mock(import('@/renderer/core/canvas/links/linkDropOrchestrator'), () => ({
   resolveNodeSurfaceSlotCandidate: () => null
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useEventListener: (event: string, handler: (...args: unknown[]) => void) => {
     capturedHandlers[event] = handler
     return vi.fn()
@@ -217,10 +213,6 @@ vi.mock<unknown>(import('@vueuse/core'), () => ({
 vi.mock<unknown>(import('@/lib/litegraph/src/LLink'), () => ({
   LLink: { getReroutes: () => [] },
   slotFloatingLinks: () => []
-}))
-
-vi.mock<unknown>(import('@/lib/litegraph/src/types/globalEnums'), () => ({
-  LinkDirection: { LEFT: 0, RIGHT: 1, NONE: -1 }
 }))
 
 vi.mock<unknown>(import('@/utils/rafBatch'), () => ({
@@ -264,7 +256,6 @@ function startDrag() {
 
 describe('useSlotLinkInteraction auto-pan', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     capturedOnPan.current = null
     capturedAutoPan.current = null
     for (const k of Object.keys(capturedHandlers)) {

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -1,5 +1,9 @@
+import type * as VueUse from '@vueuse/core'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
+import type { ComfyApp } from '@/scripts/app'
 
 import { render, screen } from '@testing-library/vue'
 
@@ -48,8 +52,6 @@ const testState = vi.hoisted(() => {
   const contentSizes = new Map<string, { width: number; height: number }>()
 
   return {
-    linearMode: false,
-    rootGraphId: ROOT_GRAPH_ID,
     visibility: null as { value: 'visible' | 'hidden' } | null,
     nodeLayouts: new Map<NodeId, NodeLayout>(),
     contentSizes,
@@ -67,22 +69,23 @@ const testState = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('@vueuse/core'), () => ({
-  useDocumentVisibility: () => {
-    const visibility = ref<'visible' | 'hidden'>('visible')
-    testState.visibility = visibility
-    return visibility
-  },
-  createSharedComposable: <T>(fn: T) => fn
-}))
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({ canvas: {}, nodePreviewImages: {} }) }
+})
 
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    linearMode: testState.linearMode,
-    rootGraphId: testState.rootGraphId,
-    canvas: { setDirty: testState.setDirty }
-  })
-}))
+vi.mock(import('@vueuse/core'), async (importOriginal) => {
+  const { ref } = await import('vue')
+  return {
+    ...(await importOriginal<typeof VueUse>()),
+    useDocumentVisibility: () => {
+      const visibility = ref<'visible' | 'hidden'>('visible')
+      testState.visibility = visibility
+      return visibility
+    },
+    createSharedComposable: <T>(fn: T) => fn
+  }
+})
 
 vi.mock<unknown>(
   import('@/composables/element/useCanvasPositionConversion'),
@@ -188,10 +191,14 @@ function seedNodeLayout(options: {
   })
 }
 
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({ setDirty: testState.setDirty })
+})
+
 describe('useVueNodeResizeTracking', () => {
   beforeEach(() => {
-    testState.linearMode = false
-    testState.rootGraphId = ROOT_GRAPH_ID
+    useCanvasStore().linearMode = false
+    Object.assign(useCanvasStore(), { rootGraphId: ROOT_GRAPH_ID })
     if (testState.visibility) testState.visibility.value = 'visible'
     testState.nodeLayouts.clear()
     testState.contentSizes.clear()
@@ -227,7 +234,7 @@ describe('useVueNodeResizeTracking', () => {
 
     resizeObserverState.callback?.([entry], createObserverMock())
     vi.clearAllMocks()
-    testState.rootGraphId = SECOND_GRAPH_ID
+    Object.assign(useCanvasStore(), { rootGraphId: SECOND_GRAPH_ID })
 
     resizeObserverState.callback?.([entry], createObserverMock())
 
@@ -288,7 +295,7 @@ describe('useVueNodeResizeTracking', () => {
     })
     resizeObserverState.callback?.([entry], createObserverMock())
 
-    expect(testState.rootGraphId).toBe(ROOT_GRAPH_ID)
+    expect(useCanvasStore().rootGraphId).toBe(ROOT_GRAPH_ID)
     expect(testState.reportContentSize).toHaveBeenCalledWith(
       ROOT_GRAPH_ID,
       subgraphNodeId,

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -1,32 +1,19 @@
 import type { MockInstance } from 'vitest'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { MIN_NODE_WIDTH } from '@/renderer/core/layout/transform/graphRenderTransform'
 
+import { useNodeResize } from './useNodeResize'
 import type { ResizeCallbackPayload } from './useNodeResize'
 
 type ResizeCallback = (
   payload: ResizeCallbackPayload,
   element: HTMLElement
 ) => void
-
-// Capture pointermove/pointerup handlers registered via useEventListener
-const eventHandlers = vi.hoisted(() => ({
-  pointermove: null as ((e: PointerEvent) => void) | null,
-  pointerup: null as ((e: PointerEvent) => void) | null
-}))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useEventListener: vi.fn(
-    (eventName: string, handler: (...args: unknown[]) => void) => {
-      if (eventName === 'pointermove' || eventName === 'pointerup') {
-        eventHandlers[eventName] = handler
-      }
-      return vi.fn()
-    }
-  )
-}))
 
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
@@ -66,10 +53,6 @@ vi.mock(
     })
   })
 )
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ rootGraphId: 'root-graph' })
-}))
 
 vi.mock<unknown>(import('@/renderer/core/layout/store/layoutStore'), () => ({
   layoutStore: {
@@ -157,7 +140,7 @@ function simulateMove(
     clientX: startX + deltaX,
     clientY: startY + deltaY
   })
-  eventHandlers.pointermove?.(moveEvent)
+  window.dispatchEvent(new PointerEvent('pointermove', moveEvent))
 }
 
 describe('useNodeResize', () => {
@@ -165,9 +148,14 @@ describe('useNodeResize', () => {
   let nodeElement: HTMLElement
   let handle: HTMLElement
 
-  beforeEach(async () => {
-    eventHandlers.pointermove = null
-    eventHandlers.pointerup = null
+  afterEach(() => {
+    window.dispatchEvent(new PointerEvent('pointercancel'))
+  })
+
+  beforeEach(() => {
+    useCanvasStore().currentGraph = fromPartial<LGraph>({
+      rootGraph: { id: 'root-graph' }
+    })
     snapState.shouldSnap = false
     snapState.applySnapToPosition = (pos) => pos
     snapState.applySnapToSize = (size) => size
@@ -176,8 +164,6 @@ describe('useNodeResize', () => {
     nodeElement = createMockNodeElement()
     handle = createMockHandle(nodeElement)
 
-    // Need fresh import after mocks are set up
-    const { useNodeResize } = await import('./useNodeResize')
     const { startResize } = useNodeResize(callback)
 
     // Store startResize for access in tests
@@ -325,12 +311,9 @@ describe('useNodeResize', () => {
 
     async function setupDynamic(getMinContentHeight: () => number) {
       vi.clearAllMocks()
-      eventHandlers.pointermove = null
-      eventHandlers.pointerup = null
       const cb = vi.fn<ResizeCallback>()
       const el = makeReflowingElement(300, 400, getMinContentHeight)
       const h = createMockHandle(el)
-      const { useNodeResize } = await import('./useNodeResize')
       const { startResize } = useNodeResize(cb)
       return { cb, el, handle: h, startResize }
     }
@@ -396,7 +379,7 @@ describe('useNodeResize', () => {
       const callsBeforeUp = cb.mock.calls.length
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      eventHandlers.pointerup?.(upEvent)
+      window.dispatchEvent(new PointerEvent('pointerup', upEvent))
 
       // Subsequent moves should be ignored after cleanup
       simulateMove(40, 40)
@@ -413,7 +396,9 @@ describe('useNodeResize', () => {
       simulateMove(10, 10)
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      expect(() => eventHandlers.pointerup?.(upEvent)).not.toThrow()
+      expect(() =>
+        window.dispatchEvent(new PointerEvent('pointerup', upEvent))
+      ).not.toThrow()
 
       // Further moves are ignored — cleanup still ran.
       const callsAfterUp = cb.mock.calls.length
@@ -496,7 +481,6 @@ describe('useNodeResize', () => {
       })()
       const cb = vi.fn<ResizeCallback>()
       const h = createMockHandle(breakpointAwareElement)
-      const { useNodeResize } = await import('./useNodeResize')
       const { startResize } = useNodeResize(cb)
 
       // Start at width=300 (still narrow side, but the breakpoint logic

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -1,14 +1,12 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import type * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
-import type { Ref } from 'vue'
 
 import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import type { NodeLayout } from '@/renderer/core/layout/types'
 import { toNodeId } from '@/types/nodeId'
-import type { NodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
 
 // TODO: Simplify test setup — use real layoutStore + createTestingPinia instead
@@ -17,8 +15,6 @@ const ROOT_GRAPH_ID = vi.hoisted<UUID>(() => 'root-graph')
 
 const testState = vi.hoisted(() => {
   return {
-    selectedNodeIds: null as unknown as Ref<Set<NodeId>>,
-    selectedItems: null as unknown as Ref<unknown[]>,
     nodeLayouts: new Map<string, Pick<NodeLayout, 'position' | 'size'>>(),
     mutationFns: {
       moveNode: vi.fn(),
@@ -55,26 +51,6 @@ vi.mock<unknown>(import('@/renderer/core/canvas/useAutoPan'), () => ({
       testState.capturedAutoPanInstance.current = this
     }
   }
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    rootGraphId: ROOT_GRAPH_ID,
-    selectedNodeIds: testState.selectedNodeIds,
-    selectedItems: testState.selectedItems,
-    canvas: {
-      ds: testState.mockDs,
-      auto_pan_speed: 10,
-      canvas: {
-        getBoundingClientRect: () => ({
-          left: 0,
-          top: 0,
-          right: 800,
-          bottom: 600
-        })
-      }
-    }
-  })
 }))
 
 vi.mock<unknown>(
@@ -138,8 +114,8 @@ function pointerEvent(clientX: number, clientY: number): PointerEvent {
 }
 
 beforeEach(() => {
-  testState.selectedNodeIds = ref(new Set<NodeId>())
-  testState.selectedItems = ref<unknown[]>([])
+  Object.assign(useCanvasStore(), { selectedNodeIds: new Set() })
+  useCanvasStore().selectedItems = []
   testState.nodeLayouts.clear()
   testState.nodeSnap.shouldSnap.mockReturnValue(false)
   testState.nodeSnap.applySnapToPosition.mockImplementation(
@@ -158,9 +134,20 @@ beforeEach(() => {
   vi.stubGlobal('cancelAnimationFrame', testState.cancelAnimationFrame)
 })
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: ROOT_GRAPH_ID })
+  useCanvasStore().canvas = fromPartial({
+    ds: testState.mockDs,
+    auto_pan_speed: 10,
+    canvas: { getBoundingClientRect: () => new DOMRect(0, 0, 800, 600) }
+  })
+})
+
 describe('useNodeDrag', () => {
   it('batches multi-node drag updates into one mutation call per frame', () => {
-    testState.selectedNodeIds.value = new Set([node1, toNodeId('2')])
+    Object.assign(useCanvasStore(), {
+      selectedNodeIds: new Set([node1, toNodeId('2')])
+    })
     testState.nodeLayouts.set('1', {
       position: { x: 100, y: 100 },
       size: { width: 200, height: 120 }
@@ -188,7 +175,7 @@ describe('useNodeDrag', () => {
   })
 
   it('uses the same batched mutation path for single-node drags', () => {
-    testState.selectedNodeIds.value = new Set([node1])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
     testState.nodeLayouts.set('1', {
       position: { x: 50, y: 80 },
       size: { width: 180, height: 110 }
@@ -213,8 +200,8 @@ describe('useNodeDrag', () => {
     selectedNode.pos = [300, 400]
     const selectedGroup = new LGraphGroup('selected')
     selectedGroup.pos = [500, 600]
-    testState.selectedNodeIds.value = new Set([node1])
-    testState.selectedItems.value = [selectedNode, selectedGroup]
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
+    useCanvasStore().selectedItems = [selectedNode, selectedGroup]
     testState.nodeLayouts.set('1', {
       position: { x: 100, y: 100 },
       size: { width: 200, height: 120 }
@@ -231,7 +218,7 @@ describe('useNodeDrag', () => {
   })
 
   it('cancels pending RAF and applies snap updates on endDrag', () => {
-    testState.selectedNodeIds.value = new Set([node1])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
     testState.nodeLayouts.set('1', {
       position: { x: 50, y: 80 },
       size: { width: 180, height: 110 }
@@ -271,8 +258,8 @@ describe('useNodeDrag', () => {
 
 describe('useNodeDrag auto-pan', () => {
   beforeEach(() => {
-    testState.selectedNodeIds = ref(new Set([node1]))
-    testState.selectedItems = ref<unknown[]>([])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
+    useCanvasStore().selectedItems = []
     testState.nodeLayouts.clear()
     testState.nodeLayouts.set('1', {
       position: { x: 100, y: 200 },
@@ -323,7 +310,9 @@ describe('useNodeDrag auto-pan', () => {
   })
 
   it('moves all selected nodes when auto-pan fires', () => {
-    testState.selectedNodeIds.value = new Set([node1, toNodeId('2')])
+    Object.assign(useCanvasStore(), {
+      selectedNodeIds: new Set([node1, toNodeId('2')])
+    })
     const drag = useNodeDrag()
 
     drag.startDrag(pointerEvent(750, 300), node1)
@@ -418,12 +407,12 @@ describe('useNodeDrag non-node positionables', () => {
         pos[1] += deltaY
       }
     }
-    testState.selectedItems.value = [group]
+    useCanvasStore().selectedItems = [fromPartial(group)]
     return group
   }
 
   function dragNodeBy(delta: number) {
-    testState.selectedNodeIds.value = new Set([node1])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
     testState.nodeLayouts.set('1', {
       position: { x: 0, y: 0 },
       size: { width: 100, height: 50 }

--- a/src/renderer/extensions/vueNodes/layout/useNodeLayout.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeLayout.test.ts
@@ -1,5 +1,6 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
@@ -32,16 +33,6 @@ function createNode(graphId: UUID, x: number): void {
   })
 }
 
-const state = vi.hoisted<{
-  canvasStore: { rootGraphId: UUID | undefined } | null
-}>(() => ({ canvasStore: null }))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), async () => {
-  const { reactive } = await import('vue')
-  state.canvasStore = reactive({ rootGraphId: undefined })
-  return { useCanvasStore: () => state.canvasStore }
-})
-
 const NodeLayoutHost = defineComponent({
   setup() {
     const { position } = useNodeLayout(NODE)
@@ -54,14 +45,14 @@ describe('useNodeLayout', () => {
     layoutStore.resetForTests()
     createNode(FIRST_WORKFLOW, 100)
     createNode(SECOND_WORKFLOW, 200)
-    state.canvasStore!.rootGraphId = FIRST_WORKFLOW
+    Object.assign(useCanvasStore(), { rootGraphId: FIRST_WORKFLOW })
   })
 
   it('follows layout changes when the workflow changes', async () => {
     const { container } = render(NodeLayoutHost)
     expect(container.textContent).toBe('100')
 
-    state.canvasStore!.rootGraphId = SECOND_WORKFLOW
+    Object.assign(useCanvasStore(), { rootGraphId: SECOND_WORKFLOW })
     await nextTick()
     expect(container.textContent).toBe('200')
 

--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
@@ -1,17 +1,12 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { ControlOptions } from '@/types/simplifiedWidget'
-
-const mockGet = vi.hoisted(() => vi.fn<(key: string) => string>())
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: mockGet })
-}))
 
 import ValueControlPopover from './ValueControlPopover.vue'
 
@@ -77,21 +72,25 @@ function renderPopover(modelValue: ControlOptions = 'randomize') {
 
 describe('ValueControlPopover', () => {
   beforeEach(() => {
-    mockGet.mockReturnValue('after')
+    useSettingStore().settingValues['Comfy.WidgetControlMode'] = 'after'
   })
 
   describe('Header text from setting store', () => {
     it('shows AFTER copy when Comfy.WidgetControlMode is "after"', () => {
       renderPopover()
-      expect(mockGet).toHaveBeenCalledWith('Comfy.WidgetControlMode')
+      expect(useSettingStore().get).toHaveBeenCalledWith(
+        'Comfy.WidgetControlMode'
+      )
       expect(screen.getByText('AFTER')).toBeInTheDocument()
       expect(screen.queryByText('BEFORE')).not.toBeInTheDocument()
     })
 
     it('shows BEFORE copy when Comfy.WidgetControlMode is "before"', () => {
-      mockGet.mockReturnValue('before')
+      useSettingStore().settingValues['Comfy.WidgetControlMode'] = 'before'
       renderPopover()
-      expect(mockGet).toHaveBeenCalledWith('Comfy.WidgetControlMode')
+      expect(useSettingStore().get).toHaveBeenCalledWith(
+        'Comfy.WidgetControlMode'
+      )
       expect(screen.getByText('BEFORE')).toBeInTheDocument()
       expect(screen.queryByText('AFTER')).not.toBeInTheDocument()
     })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
@@ -1,18 +1,8 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const canvasMocks = vi.hoisted(() => ({
-  canvas: {
-    graph: {
-      getNodeById: vi.fn((): unknown => null)
-    }
-  },
-  linearMode: false
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => canvasMocks
-}))
 
 const resolveMock = vi.hoisted(() => vi.fn())
 vi.mock(
@@ -32,6 +22,13 @@ import { toNodeId } from '@/types/nodeId'
 import WidgetDOM from './WidgetDOM.vue'
 import { createMockWidget } from './widgetTestUtils'
 
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({
+    canvas: document.createElement('canvas'),
+    graph: { getNodeById: vi.fn(() => null) }
+  })
+})
+
 describe('WidgetDOM', () => {
   beforeEach(() => {
     isDOMWidgetMock.mockReturnValue(true)
@@ -39,7 +36,9 @@ describe('WidgetDOM', () => {
 
   function mountWithWidget(domElement: HTMLElement | null) {
     if (domElement) {
-      canvasMocks.canvas.graph.getNodeById.mockReturnValue({ mock: true })
+      vi.mocked(
+        useCanvasStore().getCanvas().graph!.getNodeById
+      ).mockReturnValue(new LGraphNode('test'))
       resolveMock.mockReturnValue({
         node: { mock: true },
         widget: { element: domElement, name: 'dom' }
@@ -69,7 +68,9 @@ describe('WidgetDOM', () => {
   })
 
   it('renders an empty container when no host node is found', () => {
-    canvasMocks.canvas.graph.getNodeById.mockReturnValue(null)
+    vi.mocked(useCanvasStore().getCanvas().graph!.getNodeById).mockReturnValue(
+      null
+    )
     resolveMock.mockReturnValue(undefined)
 
     const { container } = render(WidgetDOM, {
@@ -94,7 +95,9 @@ describe('WidgetDOM', () => {
     const hosted = document.createElement('div')
     hosted.setAttribute('data-testid', 'hosted-dom')
 
-    canvasMocks.canvas.graph.getNodeById.mockReturnValue({ mock: true })
+    vi.mocked(useCanvasStore().getCanvas().graph!.getNodeById).mockReturnValue(
+      new LGraphNode('test')
+    )
     resolveMock.mockReturnValue({
       node: { mock: true },
       widget: { element: hosted, name: 'dom' }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -1,6 +1,7 @@
+import { getActivePinia } from 'pinia'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { computed, nextTick, ref } from 'vue'
@@ -16,19 +17,6 @@ import { createMockWidget } from './widgetTestUtils'
 
 const mockCheckState = vi.hoisted(() => vi.fn())
 const mockAssetsData = vi.hoisted(() => ({ items: [] as AssetItem[] }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: {
-          checkState: mockCheckState
-        }
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/api'))
 
@@ -120,6 +108,12 @@ const i18n = createI18n({
   messages: { en: {} }
 })
 
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { checkState: mockCheckState }
+  })
+})
+
 describe('WidgetSelectDropdown', () => {
   beforeEach(() => {
     mockMediaAssets.media.value = []
@@ -144,7 +138,7 @@ describe('WidgetSelectDropdown', () => {
         ...extraProps
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia(), i18n]
+        plugins: [PrimeVue, getActivePinia()!, i18n]
       }
     })
   }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
@@ -1,11 +1,13 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { getActivePinia } from 'pinia'
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
 import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { NodeOutputWith, ResultItem } from '@/schemas/apiSchema'
@@ -13,6 +15,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { widgetId } from '@/types/widgetId'
 
@@ -20,7 +23,7 @@ import WidgetTextPreview from './WidgetTextPreview.vue'
 
 const GRAPH_ID = 'graph-1'
 const NODE_ID = toNodeId('7')
-const LOCATOR = 'loc-1'
+const LOCATOR = createNodeLocatorId(null, NODE_ID)
 
 // jsdom does not implement ResizeObserver (happy-dom does); stub it before
 // component modules construct their module-level observer at import time.
@@ -49,13 +52,6 @@ vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   resolveNode: () => ({})
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ nodeToNodeLocatorId: () => LOCATOR })
-  })
-)
-
 interface SavedFile {
   filename: string
   subfolder?: string
@@ -81,8 +77,7 @@ function renderPreview(
   text: string,
   opts: { markdown?: boolean; file?: SavedFile } = {}
 ) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   const canvasStore = useCanvasStore()
   canvasStore.canvas = fromPartial({ graph: { rootGraph: { id: GRAPH_ID } } })
@@ -113,6 +108,10 @@ function renderPreview(
     global: { plugins: [pinia, createTestI18n()] }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().nodeToNodeLocatorId).mockReturnValue(LOCATOR)
+})
 
 describe('WidgetTextPreview', () => {
   it('renders plaintext in a textarea by default', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
@@ -1,6 +1,8 @@
+import { getActivePinia } from 'pinia'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia } from 'pinia'
+
 import PrimeVue from 'primevue/config'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -15,12 +17,6 @@ function createItem(id: string, name: string): FormDropdownItem {
 }
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    addAlert: vi.fn()
-  })
-}))
 
 const transformState = vi.hoisted(() => ({ camera: { x: 0, y: 0, z: 1 } }))
 
@@ -116,7 +112,7 @@ function mountDropdown(
       'onUpdate:isOpen': options.onUpdateIsOpen
     },
     global: {
-      plugins: [PrimeVue, i18n, createPinia()],
+      plugins: [PrimeVue, i18n, getActivePinia()!],
       stubs: {
         FormDropdownInput: MockFormDropdownInput,
         Popover: MockPopover,
@@ -146,6 +142,10 @@ async function openDropdown(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Open' }))
   await flushPromises()
 }
+
+beforeEach(() => {
+  vi.mocked(useToastStore().addAlert).mockImplementation(() => undefined)
+})
 
 describe('FormDropdown', () => {
   beforeEach(() => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
@@ -1,3 +1,5 @@
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -5,25 +7,6 @@ import { useAssetWidgetData } from '@/renderer/extensions/vueNodes/widgets/compo
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
-}))
-
-const mockUpdateModelsForNodeType = vi.fn()
-const mockGetCategoryForNodeType = vi.fn()
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    getAssets: () => [],
-    isModelLoading: () => false,
-    getError: () => undefined,
-    hasAssetKey: () => false,
-    updateModelsForNodeType: mockUpdateModelsForNodeType
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getCategoryForNodeType: mockGetCategoryForNodeType
-  })
 }))
 
 describe('useAssetWidgetData (desktop/isCloud=false)', () => {
@@ -35,7 +18,7 @@ describe('useAssetWidgetData (desktop/isCloud=false)', () => {
     expect(assets.value).toEqual([])
     expect(isLoading.value).toBe(false)
     expect(error.value).toBeNull()
-    expect(mockUpdateModelsForNodeType).not.toHaveBeenCalled()
-    expect(mockGetCategoryForNodeType).not.toHaveBeenCalled()
+    expect(useAssetsStore().updateModelsForNodeType).not.toHaveBeenCalled()
+    expect(useModelToNodeStore().getCategoryForNodeType).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
@@ -1,3 +1,5 @@
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,24 +16,21 @@ const mockAssetsByKey = new Map<string, AssetItem[]>()
 const mockLoadingByKey = new Map<string, boolean>()
 const mockErrorByKey = new Map<string, Error | undefined>()
 const mockInitializedKeys = new Set<string>()
-const mockUpdateModelsForNodeType = vi.fn()
-const mockGetCategoryForNodeType = vi.fn()
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    getAssets: (key: string) => mockAssetsByKey.get(key) ?? [],
-    isModelLoading: (key: string) => mockLoadingByKey.get(key) ?? false,
-    getError: (key: string) => mockErrorByKey.get(key),
-    hasAssetKey: (key: string) => mockInitializedKeys.has(key),
-    updateModelsForNodeType: mockUpdateModelsForNodeType
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getCategoryForNodeType: mockGetCategoryForNodeType
-  })
-}))
+beforeEach(() => {
+  vi.mocked(useAssetsStore().getAssets).mockImplementation(
+    (key) => mockAssetsByKey.get(key) ?? []
+  )
+  vi.mocked(useAssetsStore().isModelLoading).mockImplementation(
+    (key) => mockLoadingByKey.get(key) ?? false
+  )
+  vi.mocked(useAssetsStore().getError).mockImplementation((key) =>
+    mockErrorByKey.get(key)
+  )
+  vi.mocked(useAssetsStore().hasAssetKey).mockImplementation((key) =>
+    mockInitializedKeys.has(key)
+  )
+})
 
 describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   beforeEach(() => {
@@ -39,12 +38,12 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
     mockLoadingByKey.clear()
     mockErrorByKey.clear()
     mockInitializedKeys.clear()
-    mockGetCategoryForNodeType.mockReturnValue(undefined)
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+      undefined
+    )
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (): Promise<AssetItem[]> => {
-        return []
-      }
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockResolvedValue(
+      undefined
     )
   })
 
@@ -75,14 +74,15 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       createMockAsset('asset-2', 'Model B', 'model_b.safetensors', '/preview/2')
     ]
 
-    mockGetCategoryForNodeType.mockReturnValue('checkpoints')
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+      'checkpoints'
+    )
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (_nodeType: string): Promise<AssetItem[]> => {
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+      async (_nodeType: string) => {
         mockInitializedKeys.add(_nodeType)
         mockAssetsByKey.set(_nodeType, mockAssets)
         mockLoadingByKey.set(_nodeType, false)
-        return mockAssets
       }
     )
 
@@ -92,9 +92,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
     await nextTick()
     await vi.waitFor(() => !isLoading.value)
 
-    expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith(
-      'CheckpointLoaderSimple'
-    )
+    expect(
+      vi.mocked(useAssetsStore().updateModelsForNodeType)
+    ).toHaveBeenCalledWith('CheckpointLoaderSimple')
     expect(category.value).toBe('checkpoints')
     expect(assets.value).toEqual(mockAssets)
     expect(assets.value).toHaveLength(2)
@@ -106,13 +106,12 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   it('handles API errors gracefully', async () => {
     const mockError = new Error('Network error')
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (_nodeType: string): Promise<AssetItem[]> => {
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+      async (_nodeType: string) => {
         mockInitializedKeys.add(_nodeType)
         mockErrorByKey.set(_nodeType, mockError)
         mockAssetsByKey.set(_nodeType, [])
         mockLoadingByKey.set(_nodeType, false)
-        return []
       }
     )
 
@@ -127,14 +126,15 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   })
 
   it('returns empty for unknown node type', async () => {
-    mockGetCategoryForNodeType.mockReturnValue(undefined)
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+      undefined
+    )
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (_nodeType: string): Promise<AssetItem[]> => {
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+      async (_nodeType: string) => {
         mockInitializedKeys.add(_nodeType)
         mockAssetsByKey.set(_nodeType, [])
         mockLoadingByKey.set(_nodeType, false)
-        return []
       }
     )
 
@@ -153,13 +153,14 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
         createMockAsset('asset-1', 'Model A', 'model_a.safetensors')
       ]
 
-      mockGetCategoryForNodeType.mockReturnValue('checkpoints')
-      mockUpdateModelsForNodeType.mockImplementation(
-        async (_nodeType: string): Promise<AssetItem[]> => {
+      vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+        'checkpoints'
+      )
+      vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+        async (_nodeType: string) => {
           mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
-          return mockAssets
         }
       )
 
@@ -170,9 +171,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       await nextTick()
       await vi.waitFor(() => !isLoading.value)
 
-      expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith(
-        'CheckpointLoaderSimple'
-      )
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).toHaveBeenCalledWith('CheckpointLoaderSimple')
       expect(category.value).toBe('checkpoints')
       expect(assets.value).toEqual(mockAssets)
     })
@@ -182,13 +183,14 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
         createMockAsset('asset-1', 'Model A', 'model_a.safetensors')
       ]
 
-      mockGetCategoryForNodeType.mockReturnValue('loras')
-      mockUpdateModelsForNodeType.mockImplementation(
-        async (_nodeType: string): Promise<AssetItem[]> => {
+      vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+        'loras'
+      )
+      vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+        async (_nodeType: string) => {
           mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
-          return mockAssets
         }
       )
 
@@ -200,7 +202,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       await nextTick()
       await vi.waitFor(() => !isLoading.value)
 
-      expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith('LoraLoader')
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).toHaveBeenCalledWith('LoraLoader')
       expect(category.value).toBe('loras')
       expect(assets.value).toEqual(mockAssets)
     })
@@ -210,13 +214,14 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
         createMockAsset('asset-1', 'Model A', 'model_a.safetensors')
       ]
 
-      mockGetCategoryForNodeType.mockReturnValue('checkpoints')
-      mockUpdateModelsForNodeType.mockImplementation(
-        async (_nodeType: string): Promise<AssetItem[]> => {
+      vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+        'checkpoints'
+      )
+      vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+        async (_nodeType: string) => {
           mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
-          return mockAssets
         }
       )
 
@@ -226,9 +231,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       await nextTick()
       await vi.waitFor(() => !isLoading.value)
 
-      expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith(
-        'CheckpointLoaderSimple'
-      )
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).toHaveBeenCalledWith('CheckpointLoaderSimple')
       expect(category.value).toBe('checkpoints')
       expect(assets.value).toEqual(mockAssets)
     })
@@ -239,7 +244,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
       await nextTick()
 
-      expect(mockUpdateModelsForNodeType).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).not.toHaveBeenCalled()
       expect(category.value).toBeUndefined()
       expect(assets.value).toEqual([])
       expect(isLoading.value).toBe(false)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -1,4 +1,7 @@
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -24,49 +27,31 @@ function createMockAssetItem(overrides: Partial<AssetItem> = {}): AssetItem {
 }
 
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
-const mockLoadMore = vi.hoisted(() =>
-  vi.fn(() => {
-    mockAssetsStoreState.inputAssets.hasMore = false
-    return Promise.resolve()
-  })
-)
-const mockGetInputName = vi.hoisted(() => vi.fn((hash: string) => hash))
-const mockGetAssets = vi.hoisted(() => vi.fn(() => [] as AssetItem[]))
-const mockAssetsStoreState = vi.hoisted(() => ({
-  inputAssets: {
-    items: [] as AssetItem[],
-    isLoading: false,
-    hasMore: false,
-    loadMore: mockLoadMore
-  }
-}))
 
 vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidgets: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal()),
   get isCloud() {
     return mockDistributionState.isCloud
   }
 }))
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: vi.fn(() => ({
-    get inputAssets() {
-      return mockAssetsStoreState.inputAssets
-    },
-    getInputName: mockGetInputName,
-    getAssets: mockGetAssets
-  }))
-}))
-
-const mockSettingStoreGet = vi.fn(() => false)
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: mockSettingStoreGet
-  }))
-}))
+vi.mock(import('@/composables/useFeatureFlags'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useFeatureFlags: () => {
+      const featureFlags = actual.useFeatureFlags()
+      return {
+        ...featureFlags,
+        flags: { ...featureFlags.flags, assetsEnabled: false }
+      }
+    }
+  }
+})
 
 vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) =>
@@ -141,17 +126,27 @@ function createMockInputSpec(overrides: Partial<InputSpec> = {}): InputSpec {
   return inputSpec
 }
 
+beforeEach(() => {
+  vi.spyOn(useAssetsStore().inputAssets, 'loadMore').mockImplementation(
+    async () => {
+      useAssetsStore().inputAssets.hasMore = false
+    }
+  )
+})
+
 describe('useComboWidget', () => {
   beforeEach(() => {
-    mockSettingStoreGet.mockReturnValue(false)
-    mockGetInputName.mockImplementation((hash: string) => hash)
-    mockGetAssets.mockImplementation(() => [])
+    vi.mocked(useSettingStore().get).mockReturnValue(false)
+    vi.mocked(useAssetsStore().getInputName).mockImplementation(
+      (hash: string) => hash
+    )
+    vi.mocked(useAssetsStore().getAssets).mockImplementation(() => [])
     vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false)
     vi.mocked(assetService.shouldUseAssetBrowser).mockReturnValue(false)
     mockDistributionState.isCloud = false
-    mockAssetsStoreState.inputAssets.items = []
-    mockAssetsStoreState.inputAssets.isLoading = false
-    mockAssetsStoreState.inputAssets.hasMore = false
+    useAssetsStore().inputAssets.items = []
+    useAssetsStore().inputAssets.isLoading = false
+    useAssetsStore().inputAssets.hasMore = false
   })
 
   it('should handle undefined spec', () => {
@@ -177,7 +172,7 @@ describe('useComboWidget', () => {
 
   it('should create normal combo widget when asset API is disabled', () => {
     mockDistributionState.isCloud = true
-    mockSettingStoreGet.mockReturnValue(false)
+    vi.mocked(useSettingStore().get).mockReturnValue(false)
     vi.mocked(assetService.shouldUseAssetBrowser).mockReturnValue(false)
 
     const constructor = useComboWidget()
@@ -235,7 +230,7 @@ describe('useComboWidget', () => {
     }
 
     it('should create asset browser widget when API enabled', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'cloud_model.safetensors' })
       ])
 
@@ -256,7 +251,7 @@ describe('useComboWidget', () => {
     })
 
     it('should use first cloud asset as default instead of server combo options', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'cloud_model.safetensors' })
       ])
 
@@ -268,7 +263,7 @@ describe('useComboWidget', () => {
     })
 
     it('should fallback to assets[0] when inputSpec.default not in cloud assets', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'cloud_model.safetensors' })
       ])
 
@@ -280,7 +275,7 @@ describe('useComboWidget', () => {
     })
 
     it('should prefer inputSpec.default when it exists in cloud assets', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'other_model.safetensors' }),
         createMockAssetItem({ name: 'fallback.safetensors' })
       ])
@@ -294,7 +289,7 @@ describe('useComboWidget', () => {
     })
 
     it('should create asset browser widget when default value provided without options', () => {
-      mockGetAssets.mockReturnValue([])
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([])
 
       const { mockNode } = setupCloudAssetWidget({
         // Note: no options array provided
@@ -305,7 +300,7 @@ describe('useComboWidget', () => {
     })
 
     it('should fallback to placeholder when cloud assets not loaded', () => {
-      mockGetAssets.mockReturnValue([])
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([])
 
       const { mockNode } = setupCloudAssetWidget({
         options: ['local_model.safetensors']
@@ -375,7 +370,7 @@ describe('useComboWidget', () => {
       inputAssets: AssetItem[] = []
     ) {
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = inputAssets
+      useAssetsStore().inputAssets.items = inputAssets
 
       const constructor = useComboWidget()
       const mockNode = createMockNode(scenario.nodeClass)
@@ -636,7 +631,9 @@ describe('useComboWidget', () => {
 
     it("should format option labels using store's getInputName function", () => {
       const scenario = cloudInputScenarios[0]
-      mockGetInputName.mockReturnValue('Beautiful Sunset.png')
+      vi.mocked(useAssetsStore().getInputName).mockReturnValue(
+        'Beautiful Sunset.png'
+      )
 
       const { mockNode } = setupCloudInputMappingWidget(
         scenario,
@@ -659,7 +656,9 @@ describe('useComboWidget', () => {
       }
 
       const result = options.getOptionLabel(scenario.assetHash)
-      expect(mockGetInputName).toHaveBeenCalledWith(scenario.assetHash)
+      expect(vi.mocked(useAssetsStore().getInputName)).toHaveBeenCalledWith(
+        scenario.assetHash
+      )
       expect(result).toBe('Beautiful Sunset.png')
     })
 
@@ -748,9 +747,9 @@ describe('useComboWidget', () => {
     it('should trigger lazy load for cloud input nodes', () => {
       const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = []
-      mockAssetsStoreState.inputAssets.isLoading = false
-      mockAssetsStoreState.inputAssets.hasMore = true
+      useAssetsStore().inputAssets.items = []
+      useAssetsStore().inputAssets.isLoading = false
+      useAssetsStore().inputAssets.hasMore = true
 
       const constructor = useComboWidget()
       const mockWidget = createMockWidget({ type: 'combo' })
@@ -763,24 +762,29 @@ describe('useComboWidget', () => {
 
       constructor(mockNode, inputSpec)
 
-      expect(mockLoadMore).toHaveBeenCalledTimes(1)
+      expect(
+        vi.mocked(useAssetsStore().inputAssets.loadMore)
+      ).toHaveBeenCalledTimes(1)
     })
 
     it('should keep empty cloud input value after lazy-loaded inputs resolve a default', async () => {
       const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = []
-      mockAssetsStoreState.inputAssets.isLoading = false
-      mockAssetsStoreState.inputAssets.hasMore = true
-      mockLoadMore.mockImplementationOnce(async () => {
-        mockAssetsStoreState.inputAssets.items = [
-          createMockAssetItem({
-            name: scenario.assetName,
-            hash: scenario.assetHash
-          })
-        ]
-        mockAssetsStoreState.inputAssets.hasMore = false
-      })
+      await nextTick()
+      useAssetsStore().inputAssets.items = []
+      useAssetsStore().inputAssets.isLoading = false
+      useAssetsStore().inputAssets.hasMore = true
+      vi.spyOn(useAssetsStore().inputAssets, 'loadMore').mockImplementationOnce(
+        async () => {
+          useAssetsStore().inputAssets.items = [
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+          useAssetsStore().inputAssets.hasMore = false
+        }
+      )
 
       const constructor = useComboWidget()
       const mockNode = createMockNode(scenario.nodeClass)
@@ -791,11 +795,14 @@ describe('useComboWidget', () => {
 
       const widget = constructor(mockNode, inputSpec)
 
-      expect(mockLoadMore).toHaveBeenCalledTimes(1)
+      expect(
+        vi.mocked(useAssetsStore().inputAssets.loadMore)
+      ).toHaveBeenCalledTimes(1)
       expect(getInputWidgetDefault(mockNode)).toBe('')
       expect(widget.value).toBe('')
 
-      await mockLoadMore.mock.results[0]?.value
+      await vi.mocked(useAssetsStore().inputAssets.loadMore).mock.results[0]
+        ?.value
 
       expect(getInputWidgetValues(mockNode)).toEqual([scenario.assetHash])
       expect(widget.value).toBe('')
@@ -804,14 +811,14 @@ describe('useComboWidget', () => {
     it('should not trigger lazy load if assets already loaded', () => {
       const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = [
+      useAssetsStore().inputAssets.items = [
         createMockAssetItem({
           id: 'asset-123',
           name: scenario.assetName,
           hash: scenario.assetHash
         })
       ]
-      mockAssetsStoreState.inputAssets.isLoading = false
+      useAssetsStore().inputAssets.isLoading = false
 
       const constructor = useComboWidget()
       const mockWidget = createMockWidget({ type: 'combo' })
@@ -824,7 +831,9 @@ describe('useComboWidget', () => {
 
       constructor(mockNode, inputSpec)
 
-      expect(mockLoadMore).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useAssetsStore().inputAssets.loadMore)
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useFloatWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useFloatWidget.test.ts
@@ -7,12 +7,6 @@ vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidgets: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    settings: {}
-  })
-}))
-
 const { onFloatValueChange } = _for_testing
 
 describe('useFloatWidget', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -1,3 +1,5 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -6,25 +8,11 @@ import type { CanvasPointer, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { BaseWidget } from '@/lib/litegraph/src/widgets/BaseWidget'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 
-const mockSettingStore = vi.hoisted(() => ({
-  get: vi.fn(() => false)
-}))
-
 const mockCanvas = vi.hoisted(() => ({
   graph_mouse: [0, 0] as [number, number],
   pointer_is_down: false,
   canvas: { style: { cursor: '' } },
   setDirty: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => mockSettingStore
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    getCanvas: () => mockCanvas
-  })
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
@@ -130,10 +118,14 @@ const defaultInputSpec = fromPartial<InputSpec>({
   type: 'CUSTOM'
 })
 
+beforeEach(() => {
+  vi.mocked(useCanvasStore().getCanvas).mockReturnValue(fromPartial(mockCanvas))
+})
+
 describe('useImagePreviewWidget', () => {
   beforeEach(() => {
     // clearAllMocks does not reset mockReturnValue — restore defaults explicitly
-    mockSettingStore.get.mockReturnValue(false)
+    useSettingStore().settingValues['Comfy.Node.AllowImageSizeDraw'] = false
     vi.mocked(is_all_same_aspect_ratio).mockReturnValue(true)
     mockCanvas.graph_mouse = [0, 0]
     mockCanvas.pointer_is_down = false
@@ -351,7 +343,7 @@ describe('useImagePreviewWidget', () => {
 
   describe('drawWidget — image size text', () => {
     it('draws image size text when setting is enabled', () => {
-      mockSettingStore.get.mockReturnValue(true)
+      useSettingStore().settingValues['Comfy.Node.AllowImageSizeDraw'] = true
 
       const constructor = useImagePreviewWidget()
       const img = createMockImage(512, 768)
@@ -375,7 +367,7 @@ describe('useImagePreviewWidget', () => {
     })
 
     it('does not draw image size text when setting is disabled', () => {
-      mockSettingStore.get.mockReturnValue(false)
+      useSettingStore().settingValues['Comfy.Node.AllowImageSizeDraw'] = false
 
       const constructor = useImagePreviewWidget()
       const img = createMockImage(512, 768)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
@@ -1,3 +1,5 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -18,21 +20,9 @@ type CapturedImageUploadOptions = {
 const mocks = vi.hoisted(() => ({
   capturedUploadOptions: undefined as CapturedImageUploadOptions | undefined,
   openFileSelection: vi.fn(),
-  setNodeOutputs: vi.fn(),
   showPreview: vi.fn(),
   captureCanvasState: vi.fn()
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: { captureCanvasState: mocks.captureCanvasState }
-      }
-    })
-  })
-)
 
 vi.mock(import('@/composables/node/useNodeImage'), () => ({
   useNodeImage: () => ({ showPreview: mocks.showPreview }),
@@ -51,12 +41,6 @@ vi.mock<unknown>(import('@/composables/node/useNodeImageUpload'), () => ({
 
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    setNodeOutputs: mocks.setNodeOutputs
-  })
 }))
 
 vi.mock(import('@/utils/litegraphUtil'), () => ({
@@ -116,6 +100,15 @@ const outputFolderCases: {
   }
 ]
 
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { captureCanvasState: mocks.captureCanvasState }
+  })
+  vi.mocked(useNodeOutputStore().setNodeOutputs).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('useImageUploadWidget', () => {
   beforeEach(() => {
     mocks.capturedUploadOptions = undefined
@@ -131,9 +124,13 @@ describe('useImageUploadWidget', () => {
     mocks.capturedUploadOptions?.onUploadComplete(['uploaded.png'])
 
     expect(fileComboWidget.value).toBe('uploaded.png')
-    expect(mocks.setNodeOutputs).toHaveBeenCalledWith(node, 'uploaded.png', {
-      isAnimated: false
-    })
+    expect(useNodeOutputStore().setNodeOutputs).toHaveBeenCalledWith(
+      node,
+      'uploaded.png',
+      {
+        isAnimated: false
+      }
+    )
     expect(onWidgetChanged).toHaveBeenCalledWith(
       'image',
       'uploaded.png',
@@ -150,9 +147,13 @@ describe('useImageUploadWidget', () => {
     construct(node)
     frame.mock.calls[0][0]()
 
-    expect(mocks.setNodeOutputs).toHaveBeenCalledWith(node, 'beach.jpg', {
-      isAnimated: false
-    })
+    expect(useNodeOutputStore().setNodeOutputs).toHaveBeenCalledWith(
+      node,
+      'beach.jpg',
+      {
+        isAnimated: false
+      }
+    )
   })
 
   it('does not preview a combo whose value is still unset', () => {
@@ -164,7 +165,7 @@ describe('useImageUploadWidget', () => {
     construct(node)
     frame.mock.calls[0][0]()
 
-    expect(mocks.setNodeOutputs).not.toHaveBeenCalled()
+    expect(useNodeOutputStore().setNodeOutputs).not.toHaveBeenCalled()
     expect(mocks.showPreview).toHaveBeenCalled()
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts
@@ -11,12 +11,6 @@ vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidget: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn(() => false)
-  })
-}))
-
 const { onValueChange } = _for_testing
 
 describe('useIntWidget', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
@@ -17,9 +17,6 @@ const { canvasMock } = vi.hoisted(() => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { id: 'root' }, canvas: canvasMock }
 }))
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => ({ getWidget: () => undefined })
-}))
 
 function createMarkdownWidget(node: LGraphNode, defaultValue = '') {
   const inputSpec: InputSpec = {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -1,5 +1,6 @@
+import { useAuthStore } from '@/stores/authStore'
 import axios from 'axios'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
@@ -19,13 +20,22 @@ function createMockWidget(overrides: Partial<IWidget> = {}): IWidget {
 
 const mockCloudAuth = vi.hoisted(() => ({
   isCloud: false,
-  authHeader: null as { Authorization: string } | null
+  authHeader: null as { Authorization: `Bearer ${string}` } | null
 }))
 
-vi.mock<unknown>(import('axios'), () => ({
-  default: {
-    get: vi.fn()
+vi.mock(import('axios'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    default: Object.assign(actual.default, { get: vi.fn() })
   }
+})
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
 }))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
@@ -33,22 +43,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
     return mockCloudAuth.isCloud
   }
 }))
-
-vi.mock<unknown>(import('@/stores/authStore'), async () => {
-  return {
-    useAuthStore: vi.fn(() => ({
-      getAuthHeader: vi.fn(() => Promise.resolve(mockCloudAuth.authHeader))
-    }))
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), async () => {
-  return {
-    useSettingStore: () => ({
-      settings: {}
-    })
-  }
-})
 
 const FIRST_BACKOFF = 1000 // backoff is 1s on first retry
 const DEFAULT_VALUE = 'Loading...'
@@ -100,6 +94,12 @@ async function getResolvedValue(hook: ReturnType<typeof useRemoteWidget>) {
   await responsePromise
   return hook.getCachedValue()
 }
+
+beforeEach(() => {
+  vi.mocked(useAuthStore().getAuthHeader).mockImplementation(
+    async () => mockCloudAuth.authHeader
+  )
+})
 
 describe('useRemoteWidget', () => {
   describe('initialization', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
@@ -1,3 +1,5 @@
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
 import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -18,34 +20,6 @@ const { canvasMock } = vi.hoisted(() => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { id: 'root' }, canvas: canvasMock }
 }))
-const { widgetStoreMock } = vi.hoisted(() => {
-  const map = new Map<
-    string,
-    { type: string; value: unknown; options: unknown }
-  >()
-  return {
-    widgetStoreMock: {
-      map,
-      getWidget: (id: string) => map.get(id),
-      registerWidget: (
-        id: string,
-        init: { type: string; value: unknown; options: unknown }
-      ) => {
-        const existing = map.get(id)
-        if (existing) return existing
-        const state = { ...init }
-        map.set(id, state)
-        return state
-      }
-    }
-  }
-})
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => widgetStoreMock
-}))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => false })
-}))
 
 function createStringWidget(node: LGraphNode) {
   const inputSpec: InputSpec = {
@@ -63,7 +37,6 @@ function createStringWidget(node: LGraphNode) {
 describe('useStringWidget (multiline)', () => {
   function setup() {
     vi.clearAllMocks()
-    widgetStoreMock.map.clear()
     const node = createMockDOMWidgetNode()
     const widget = createStringWidget(node)
     const callback = vi.fn<(value: string) => void>()
@@ -87,7 +60,7 @@ describe('useStringWidget (multiline)', () => {
     }
     options.setValue('from-execution')
 
-    const entries = [...widgetStoreMock.map.values()]
+    const entries = useWidgetValueStore().getNodeWidgets('root', toNodeId(1))
     expect(entries.some((s) => s.value === 'from-execution')).toBe(true)
     expect(entries.every((s) => s.type === 'customtext')).toBe(true)
   })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetRenderer.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetRenderer.test.ts
@@ -1,6 +1,4 @@
-import { setActivePinia } from 'pinia'
-import { createTestingPinia } from '@pinia/testing'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   getComponent,
@@ -19,23 +17,7 @@ const {
   WidgetToggleSwitch
 } = FOR_TESTING
 
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: vi.fn(() => ({
-    historyTasks: []
-  }))
-}))
-
-// Mock the settings store for components that might use it
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn(() => 'before')
-  })
-}))
-
 describe('widgetRegistry', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia())
-  })
   describe('getComponent', () => {
     // Test number type mappings
     describe('number types', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -1,6 +1,7 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { computed, ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { FormDropdownItem } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions'
@@ -8,19 +9,6 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: {
-          captureCanvasState: mockCaptureCanvasState
-        }
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/api'))
 
@@ -32,6 +20,12 @@ function createItems(...names: string[]): FormDropdownItem[] {
     preview_url: ''
   }))
 }
+
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { captureCanvasState: mockCaptureCanvasState }
+  })
+})
 
 describe('useWidgetSelectActions', () => {
   describe('updateSelectedItems', () => {

--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -1,6 +1,8 @@
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, shallowRef } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { createMockDOMWidgetNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
@@ -9,6 +11,7 @@ import { DEBOUNCE_MS } from '@/renderer/glsl/glslPreviewUtils'
 import { useGLSLPreview } from '@/renderer/glsl/useGLSLPreview'
 import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 /**
  * Guards the writer/reader store contract behind the GLSL live preview: the
@@ -45,32 +48,8 @@ vi.mock<unknown>(import('@/renderer/glsl/useGLSLRenderer'), () => ({
   useGLSLRenderer: (_config?: GLSLRendererConfig) => mockRenderer.create()
 }))
 
-const nodeOutputs = reactive<Record<string, unknown>>({})
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    setNodePreviewsByNodeId: vi.fn(),
-    setNodePreviewsByLocatorId: vi.fn(),
-    revokePreviewsByLocatorId: vi.fn(),
-    nodeOutputs
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeIdToNodeLocatorId: (id: string | number) => String(id),
-      nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { rootGraph: { id: 'root', _nodes: [] } }
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => false })
+  app: { rootGraph: { id: 'root', _nodes: [] }, nodePreviewImages: {} }
 }))
 
 function seedShaderThroughWidget(nodeId: number, value: string): void {
@@ -102,15 +81,34 @@ function createGLSLNode(nodeId: number): LGraphNode {
   })
 }
 
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().nodeIdToNodeLocatorId).mockImplementation((id) =>
+    createNodeLocatorId(null, id)
+  )
+  vi.mocked(useWorkflowStore().nodeToNodeLocatorId).mockImplementation((node) =>
+    createNodeLocatorId(null, node.id)
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByNodeId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().revokePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('GLSL live preview reads the shader written by the customtext widget', () => {
   beforeEach(() => {
-    for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
+    for (const key of Object.keys(useNodeOutputStore().nodeOutputs))
+      delete useNodeOutputStore().nodeOutputs[key]
   })
 
   it('compiles the shader value written through the widget store path', async () => {
     const nodeId = 1
     seedShaderThroughWidget(nodeId, SHADER)
-    nodeOutputs[String(nodeId)] = {
+    useNodeOutputStore().nodeOutputs[String(nodeId)] = {
       images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
     }
 

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -1,6 +1,8 @@
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref, shallowRef } from 'vue'
+import { nextTick, ref, shallowRef } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -8,10 +10,7 @@ import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
 import { useGLSLPreview } from '@/renderer/glsl/useGLSLPreview'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { widgetId } from '@/types/widgetId'
-
-type WidgetValueStoreStub = {
-  _widgetMap: Map<string, { value: unknown }>
-}
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 const mockRendererFactory = vi.hoisted(() => {
   const init = vi.fn(() => true)
@@ -70,41 +69,6 @@ vi.mock<unknown>(import('@/renderer/glsl/useGLSLRenderer'), () => ({
     mockRendererFactory.create(config)
 }))
 
-const mockSetNodePreviewsByNodeId = vi.fn()
-const mockRevokePreviewsByLocatorId = vi.fn()
-const mockNodeOutputs = reactive<Record<string, unknown>>({})
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    setNodePreviewsByNodeId: mockSetNodePreviewsByNodeId,
-    setNodePreviewsByLocatorId: vi.fn(),
-    revokePreviewsByLocatorId: mockRevokePreviewsByLocatorId,
-    getNodeImageUrls: vi.fn(() => undefined),
-    nodeOutputs: mockNodeOutputs
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => {
-  const widgetMap = new Map<string, { value: unknown }>()
-  const getWidget = vi.fn((id: string) => widgetMap.get(id))
-  return {
-    useWidgetValueStore: () => ({
-      getWidget,
-      _widgetMap: widgetMap
-    })
-  }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeIdToNodeLocatorId: (id: string | number) => String(id),
-      nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
-    })
-  })
-)
-
 vi.mock(import('@/utils/objectUrlUtil'), () => ({
   createSharedObjectUrl: () => 'blob:test',
   releaseSharedObjectUrl: vi.fn()
@@ -134,6 +98,25 @@ function ensureImageBitmap(global: { ImageBitmap?: typeof ImageBitmap }): void {
   global.ImageBitmap ??= class ImageBitmap {} as unknown as typeof ImageBitmap
 }
 
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().nodeIdToNodeLocatorId).mockImplementation((id) =>
+    createNodeLocatorId(null, id)
+  )
+  vi.mocked(useWorkflowStore().nodeToNodeLocatorId).mockImplementation((node) =>
+    createNodeLocatorId(null, node.id)
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByNodeId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().revokePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue(undefined)
+})
+
 describe('useGLSLPreview', () => {
   beforeEach(() => {
     mockRendererFactory.lastConfig.value = undefined
@@ -150,14 +133,16 @@ describe('useGLSLPreview', () => {
 
   it('does not activate before first execution', () => {
     const node = createMockNode()
-    Object.keys(mockNodeOutputs).forEach((k) => delete mockNodeOutputs[k])
+    Object.keys(useNodeOutputStore().nodeOutputs).forEach(
+      (k) => delete useNodeOutputStore().nodeOutputs[k]
+    )
     const { isActive } = useGLSLPreview(wrapNode(node))
     expect(isActive.value).toBe(false)
   })
 
   it('activates for GLSLShader nodes with execution output', () => {
     const node = createMockNode()
-    mockNodeOutputs['1'] = {
+    useNodeOutputStore().nodeOutputs['1'] = {
       images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
     }
     const { isActive } = useGLSLPreview(wrapNode(node))
@@ -183,17 +168,13 @@ describe('useGLSLPreview', () => {
 
   describe('autogrow config extraction', () => {
     async function triggerRender(node: LGraphNode) {
-      mockNodeOutputs[String(node.id)] = {
+      useNodeOutputStore().nodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.set(
+      const store = useWidgetValueStore()
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'fragment_shader'),
-        {
-          value: 'void main() {}'
-        }
+        { type: 'customtext', options: {}, value: 'void main() {}' }
       )
 
       const nodeRef = shallowRef<LGraphNode | null>(null)
@@ -242,17 +223,13 @@ describe('useGLSLPreview', () => {
 
   describe('render pipeline', () => {
     async function setupAndRender(node: LGraphNode) {
-      mockNodeOutputs[String(node.id)] = {
+      useNodeOutputStore().nodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.set(
+      const store = useWidgetValueStore()
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'fragment_shader'),
-        {
-          value: 'void main() {}'
-        }
+        { type: 'customtext', options: {}, value: 'void main() {}' }
       )
 
       const nodeRef = shallowRef<LGraphNode | null>(null)
@@ -292,9 +269,9 @@ describe('useGLSLPreview', () => {
       expect(mockRendererFactory.init).toHaveBeenCalledTimes(1)
 
       mockRendererFactory.isContextLost.mockReturnValueOnce(true)
-      delete mockNodeOutputs['1']
+      delete useNodeOutputStore().nodeOutputs['1']
       await nextTick()
-      mockNodeOutputs['1'] = {
+      useNodeOutputStore().nodeOutputs['1'] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
       await nextTick()
@@ -344,14 +321,12 @@ describe('useGLSLPreview', () => {
         ],
         getInputNode: vi.fn((slot: number) => fromAny(slot === 0 ? up0 : up1))
       })
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.set(
+      const store = useWidgetValueStore()
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'fragment_shader'),
-        { value: 'void main() {}' }
+        { type: 'customtext', options: {}, value: 'void main() {}' }
       )
-      mockNodeOutputs['1'] = {
+      useNodeOutputStore().nodeOutputs['1'] = {
         images: [{ filename: 'a.png', subfolder: '', type: 'temp' }]
       }
 
@@ -367,9 +342,9 @@ describe('useGLSLPreview', () => {
 
       up0.imgs = []
       vi.clearAllMocks()
-      delete mockNodeOutputs['1']
+      delete useNodeOutputStore().nodeOutputs['1']
       await nextTick()
-      mockNodeOutputs['1'] = {
+      useNodeOutputStore().nodeOutputs['1'] = {
         images: [{ filename: 'a.png', subfolder: '', type: 'temp' }]
       }
       await nextTick()
@@ -401,7 +376,9 @@ describe('useGLSLPreview', () => {
       for (let i = 0; i < 5; i++) await nextTick()
 
       expect(hideExecutedOutput.value).toBe(false)
-      expect(mockRevokePreviewsByLocatorId).toHaveBeenCalledWith('1')
+      expect(
+        useNodeOutputStore().revokePreviewsByLocatorId
+      ).toHaveBeenCalledWith('1')
       expect(mockRendererFactory.compileFragment).not.toHaveBeenCalled()
     })
 
@@ -426,13 +403,9 @@ describe('useGLSLPreview', () => {
 
     it('skips render when shader source is unavailable', async () => {
       const node = createMockNode()
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.delete(
-        widgetId('test-graph-id', node.id, 'fragment_shader')
-      )
-      mockNodeOutputs[String(node.id)] = {
+      const store = useWidgetValueStore()
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'fragment_shader'))
+      useNodeOutputStore().nodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
 
@@ -447,53 +420,45 @@ describe('useGLSLPreview', () => {
     })
 
     it('uses custom resolution when size_mode is custom', async () => {
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
+      const store = useWidgetValueStore()
 
       const node = createMockNode()
-      store._widgetMap.set(widgetId('test-graph-id', node.id, 'size_mode'), {
+      store.registerWidget(widgetId('test-graph-id', node.id, 'size_mode'), {
+        type: 'customtext',
+        options: {},
         value: 'custom'
       })
-      store._widgetMap.set(
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'size_mode.width'),
-        {
-          value: 800
-        }
+        { type: 'customtext', options: {}, value: 800 }
       )
-      store._widgetMap.set(
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'size_mode.height'),
-        {
-          value: 600
-        }
+        { type: 'customtext', options: {}, value: 600 }
       )
       await setupAndRender(node)
 
       expect(mockRendererFactory.setResolution).toHaveBeenCalledWith(800, 600)
 
-      store._widgetMap.delete(widgetId('test-graph-id', node.id, 'size_mode'))
-      store._widgetMap.delete(
-        widgetId('test-graph-id', node.id, 'size_mode.width')
-      )
-      store._widgetMap.delete(
-        widgetId('test-graph-id', node.id, 'size_mode.height')
-      )
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode'))
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode.width'))
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode.height'))
     })
 
     it('uses default resolution when size_mode is not custom', async () => {
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
+      const store = useWidgetValueStore()
 
       const node = createMockNode()
-      store._widgetMap.set(widgetId('test-graph-id', node.id, 'size_mode'), {
+      store.registerWidget(widgetId('test-graph-id', node.id, 'size_mode'), {
+        type: 'customtext',
+        options: {},
         value: 'from_input'
       })
       await setupAndRender(node)
 
       expect(mockRendererFactory.setResolution).toHaveBeenCalledWith(512, 512)
 
-      store._widgetMap.delete(widgetId('test-graph-id', node.id, 'size_mode'))
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode'))
     })
 
     it('disposes renderer and cancels debounce on cleanup', async () => {

--- a/src/scripts/api.socketReset.test.ts
+++ b/src/scripts/api.socketReset.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock(import('firebase/auth'))
 
 let currentToken: string | undefined = 'token-a'
 // When set, each getAuthToken() call parks until released, capturing the token
@@ -15,18 +18,6 @@ const releaseNextToken = async () => {
 }
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
-
-vi.mock('@/stores/authStore', () => ({
-  useAuthStore: () => ({
-    getAuthToken: () => {
-      if (!deferTokenFetch) return Promise.resolve(currentToken)
-      const captured = currentToken
-      return new Promise<string | undefined>((resolve) => {
-        pendingTokenReleases.push(() => resolve(captured))
-      })
-    }
-  })
-}))
 
 class FakeWebSocket {
   static readonly OPEN = 1
@@ -68,6 +59,13 @@ describe('ComfyApi realtime socket reset', () => {
     pendingTokenReleases = []
     vi.stubGlobal('WebSocket', FakeWebSocket)
     api.socket = null
+    vi.mocked(useAuthStore().getAuthToken).mockImplementation(() => {
+      if (!deferTokenFetch) return Promise.resolve(currentToken)
+      const captured = currentToken
+      return new Promise<string | undefined>((resolve) => {
+        pendingTokenReleases.push(() => resolve(captured))
+      })
+    })
   })
 
   afterEach(() => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1,4 +1,15 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAuthStore } from '@/stores/authStore'
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { ref } from 'vue'
+
+vi.mock(import('@vueuse/router'), () => ({ useRouteHash: () => ref('') }))
 
 import type { CurveData } from '@/components/curve/types'
 import { t } from '@/i18n'
@@ -59,71 +70,17 @@ import type { importA1111 } from './pnginfo'
 
 type WorkflowService = ReturnType<typeof useWorkflowService>
 
+vi.mock(import('firebase/auth'))
+
 const {
-  mockApiKeyAuthStore,
-  mockAuthStore,
-  mockSettingStore,
-  mockToastStore,
   mockExtensionService,
-  mockNodeOutputStore,
-  mockSubgraphNavigationStore,
-  mockTeamWorkspaceStore,
-  mockWorkspaceWorkflow,
   mockRefreshMissingModelPipeline,
   mockImportA1111,
   mockWorkflowService
 } = vi.hoisted(() => ({
-  mockApiKeyAuthStore: {
-    getApiKey: vi.fn(),
-    isAuthenticated: false
-  },
-  mockAuthStore: {
-    getWorkspaceAuthToken: vi.fn(),
-    currentUser: null as { uid: string } | null
-  },
-  mockSettingStore: {
-    get: vi.fn()
-  },
-  mockToastStore: {
-    addAlert: vi.fn(),
-    add: vi.fn(),
-    remove: vi.fn()
-  },
   mockExtensionService: {
     invokeExtensions: vi.fn(),
     invokeExtensionsAsync: vi.fn()
-  },
-  mockNodeOutputStore: {
-    refreshNodeOutputs: vi.fn(),
-    replaceOutputsFromLegacy: vi.fn(),
-    setOutputFromLegacy: vi.fn(),
-    removeOutputFromLegacy: vi.fn(),
-    resetAllOutputsAndPreviews: vi.fn(),
-    snapshotOutputs: vi.fn(),
-    restoreOutputs: vi.fn(),
-    stashPreviewsForWorkflow: vi.fn(),
-    restorePreviewsForWorkflow: vi.fn(),
-    discardPreviewsForWorkflow: vi.fn()
-  },
-  mockSubgraphNavigationStore: {
-    saveCurrentViewport: vi.fn(),
-    updateHash: vi.fn(),
-    exportState: vi.fn(() => []),
-    restoreState: vi.fn()
-  },
-  mockTeamWorkspaceStore: {
-    activeWorkspaceId: 'workspace-a' as string | null,
-    workspaceTransitionGeneration: 0,
-    waitForWorkspaceSwitch: vi.fn(() => Promise.resolve())
-  },
-  mockWorkspaceWorkflow: {
-    activeWorkflow: null as ComfyWorkflow | null,
-    createNewTemporary: vi.fn(),
-    openWorkflow: vi.fn(),
-    getWorkflowByPath: vi.fn<(path: string) => ComfyWorkflow | null>(
-      () => null
-    ),
-    isActive: vi.fn<(workflow: ComfyWorkflow) => boolean>(() => false)
   },
   mockRefreshMissingModelPipeline: vi.fn(),
   mockImportA1111: vi.fn<typeof importA1111>(),
@@ -140,22 +97,6 @@ vi.mock('@/utils/litegraphUtil', () => ({
   isVideoNode: vi.fn(),
   isAudioNode: vi.fn(),
   executeWidgetsCallback: vi.fn()
-}))
-
-vi.mock('@/stores/apiKeyAuthStore', () => ({
-  useApiKeyAuthStore: vi.fn(() => mockApiKeyAuthStore)
-}))
-
-vi.mock('@/stores/authStore', () => ({
-  useAuthStore: vi.fn(() => mockAuthStore)
-}))
-
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: vi.fn(() => mockTeamWorkspaceStore)
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: vi.fn(() => mockSettingStore)
 }))
 
 vi.mock('@/composables/usePaste', () => ({
@@ -193,26 +134,8 @@ vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
   }
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: vi.fn(() => mockToastStore)
-}))
-
 vi.mock('@/services/extensionService', () => ({
   useExtensionService: vi.fn(() => mockExtensionService)
-}))
-
-vi.mock('@/stores/nodeOutputStore', () => ({
-  useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
-}))
-
-vi.mock('@/stores/subgraphNavigationStore', () => ({
-  useSubgraphNavigationStore: vi.fn(() => mockSubgraphNavigationStore)
-}))
-
-vi.mock('@/stores/workspaceStore', () => ({
-  useWorkspaceStore: vi.fn(() => ({
-    workflow: mockWorkspaceWorkflow
-  }))
 }))
 
 vi.mock('@/platform/missingModel/missingModelPipeline', () => ({
@@ -300,31 +223,51 @@ describe('ComfyApp', () => {
     app = new ComfyApp()
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas
-    mockWorkspaceWorkflow.activeWorkflow = null
+    useWorkflowStore().activeWorkflow = null
     const temporaryWorkflow = new ComfyWorkflow({
       path: 'workflows/temporary.json',
       modified: 0,
       size: 0
     })
-    mockWorkspaceWorkflow.createNewTemporary.mockReturnValue(temporaryWorkflow)
-    mockWorkspaceWorkflow.openWorkflow.mockImplementation(async (workflow) => {
-      mockWorkspaceWorkflow.activeWorkflow = workflow
-      return workflow
+    vi.mocked(useWorkflowStore().createNewTemporary).mockReturnValue(
+      temporaryWorkflow
+    )
+    vi.mocked(useWorkflowStore().openWorkflow).mockImplementation(
+      async (workflow) => {
+        useWorkflowStore().activeWorkflow = markLoaded(workflow)
+        return markLoaded(workflow)
+      }
+    )
+    vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(null)
+    Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+    useAuthStore().currentUser = null
+    vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValue(
+      'workspace-token'
+    )
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: 'workspace-a',
+      workspaceTransitionGeneration: 0
     })
-    mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
-    mockApiKeyAuthStore.isAuthenticated = false
-    mockAuthStore.currentUser = null
-    mockAuthStore.getWorkspaceAuthToken.mockResolvedValue('workspace-token')
-    mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-    mockTeamWorkspaceStore.workspaceTransitionGeneration = 0
-    mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockResolvedValue()
+    vi.mocked(
+      useTeamWorkspaceStore().waitForWorkspaceSwitch
+    ).mockResolvedValue()
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
     vi.mocked(extractFilesFromDragEvent).mockResolvedValue([])
     mockImportA1111.mockResolvedValue('imported')
     mockWorkflowService.afterLoadNewGraph.mockResolvedValue()
-    mockSettingStore.get.mockImplementation((key: string) =>
-      key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] = true
+    vi.mocked(useWorkflowStore().getWorkflowByPath).mockReturnValue(null)
+    vi.mocked(useWorkflowStore().isActive).mockReturnValue(false)
+    vi.mocked(useSubgraphNavigationStore().updateHash).mockResolvedValue(
+      undefined
+    )
+    vi.mocked(
+      useSubgraphNavigationStore().saveCurrentViewport
+    ).mockImplementation(() => {})
+    vi.mocked(useSubgraphNavigationStore().exportState).mockReturnValue([])
+    vi.mocked(useSubgraphNavigationStore().restoreState).mockImplementation(
+      () => {}
     )
   })
 
@@ -338,7 +281,7 @@ describe('ComfyApp', () => {
       })
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(false)
-      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+      expect(useSubgraphNavigationStore().updateHash).toHaveBeenCalledWith(
         'workflow-load',
         42
       )
@@ -350,7 +293,7 @@ describe('ComfyApp', () => {
       await app.loadGraphData(createWorkflowGraphData())
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(true)
-      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+      expect(useSubgraphNavigationStore().updateHash).toHaveBeenCalledWith(
         'workflow-load',
         undefined
       )
@@ -382,7 +325,7 @@ describe('ComfyApp', () => {
 
       expect(showDialog).toHaveBeenCalledOnce()
       // The finally still repairs the URL even on the handled-failure path.
-      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+      expect(useSubgraphNavigationStore().updateHash).toHaveBeenCalledWith(
         'workflow-load',
         7
       )
@@ -445,22 +388,24 @@ describe('ComfyApp', () => {
       app.vueAppReady = true
       const nodeCount = 50
       const storedOutputs = new Map<string, NodeExecutionOutput>()
-      mockNodeOutputStore.setOutputFromLegacy.mockImplementation((id, output) =>
-        storedOutputs.set(id, output)
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockImplementation(
+        (id, output) => storedOutputs.set(id, output)
       )
 
       for (let i = 0; i < nodeCount; i++) {
-        mockNodeOutputStore.setOutputFromLegacy.mockClear()
+        vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
         app.nodeOutputs[String(i)] = { images: [{ filename: `${i}.png` }] }
-        expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
-        expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+        expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledOnce()
+        expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
           String(i),
-          { images: [{ filename: `${i}.png` }] }
+          {
+            images: [{ filename: `${i}.png` }]
+          }
         )
       }
 
       expect(
-        mockNodeOutputStore.replaceOutputsFromLegacy
+        useNodeOutputStore().replaceOutputsFromLegacy
       ).not.toHaveBeenCalled()
 
       expect(storedOutputs.size).toBe(nodeCount)
@@ -476,12 +421,12 @@ describe('ComfyApp', () => {
       const output = { images: [{ filename: 'legacy.png' }] }
 
       app.nodeOutputs['1'] = output
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         output
       )
       delete app.nodeOutputs['1']
-      expect(mockNodeOutputStore.removeOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().removeOutputFromLegacy).toHaveBeenCalledWith(
         '1'
       )
     })
@@ -489,18 +434,18 @@ describe('ComfyApp', () => {
     it('commits nested legacy output mutations to the output store', () => {
       app.vueAppReady = true
       app.nodeOutputs['1'] = { images: [{ filename: 'first.png' }] }
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
 
       const output = app.nodeOutputs['1']
       output.images = [{ filename: 'second.png' }]
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         { images: [{ filename: 'second.png' }] }
       )
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
       const images = output.images
       images?.push({ filename: 'third.png' })
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         {
           images: [{ filename: 'second.png' }, { filename: 'third.png' }]
@@ -509,11 +454,11 @@ describe('ComfyApp', () => {
       expect(app.nodeOutputs['1']).toBe(output)
       expect(output.images).toBe(images)
 
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
       const image = images?.[0]
       if (!image) throw new Error('Expected a legacy output image')
       image.filename = 'mutated.png'
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         {
           images: [{ filename: 'mutated.png' }, { filename: 'third.png' }]
@@ -529,12 +474,12 @@ describe('ComfyApp', () => {
       app.nodeOutputs['2'] = shared
       void app.nodeOutputs['1']
       const second = app.nodeOutputs['2']
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
 
       second.images = [{ filename: 'second.png' }]
 
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledOnce()
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '2',
         shared
       )
@@ -543,13 +488,13 @@ describe('ComfyApp', () => {
     it('commits only the changed entry after whole-record assignment', () => {
       app.vueAppReady = true
       app.nodeOutputs = { '1': { images: [{ filename: 'first.png' }] } }
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
 
       const second = { images: [{ filename: 'second.png' }] }
       app.nodeOutputs['2'] = second
 
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledOnce()
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '2',
         second
       )
@@ -566,7 +511,7 @@ describe('ComfyApp', () => {
       const graph = new LGraph()
       Reflect.set(app, 'rootGraphInternal', graph)
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
-      mockWorkspaceWorkflow.activeWorkflow = workflow
+      useWorkflowStore().activeWorkflow = markLoaded(workflow)
       vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
         output: {},
         workflow: createWorkflowGraphData()
@@ -577,7 +522,7 @@ describe('ComfyApp', () => {
     it('waits for workspace authentication before submitting the prompt', async () => {
       prepareEmptyPromptQueue()
       let resolveToken: (token: string) => void = () => {}
-      mockAuthStore.getWorkspaceAuthToken.mockReturnValueOnce(
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockReturnValueOnce(
         new Promise((resolve) => {
           resolveToken = resolve
         })
@@ -591,7 +536,7 @@ describe('ComfyApp', () => {
 
       const submission = app.queuePrompt(0)
       await vi.waitFor(() =>
-        expect(mockAuthStore.getWorkspaceAuthToken).toHaveBeenCalledOnce()
+        expect(useAuthStore().getWorkspaceAuthToken).toHaveBeenCalledOnce()
       )
       expect(queuePrompt).not.toHaveBeenCalled()
 
@@ -603,16 +548,20 @@ describe('ComfyApp', () => {
     it('waits for a workspace switch before selecting the billing context', async () => {
       prepareEmptyPromptQueue()
       let finishSwitch: () => void = () => {}
-      mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockImplementationOnce(
+      vi.mocked(
+        useTeamWorkspaceStore().waitForWorkspaceSwitch
+      ).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = () => {
-              mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+              Object.assign(useTeamWorkspaceStore(), {
+                activeWorkspaceId: 'workspace-b'
+              })
               resolve()
             }
           })
       )
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
         'workspace-token-b'
       )
       const queuePrompt = vi
@@ -625,32 +574,32 @@ describe('ComfyApp', () => {
       const submission = app.queuePrompt(0)
       await vi.waitFor(() =>
         expect(
-          mockTeamWorkspaceStore.waitForWorkspaceSwitch
+          useTeamWorkspaceStore().waitForWorkspaceSwitch
         ).toHaveBeenCalledOnce()
       )
 
-      expect(mockAuthStore.getWorkspaceAuthToken).not.toHaveBeenCalled()
+      expect(useAuthStore().getWorkspaceAuthToken).not.toHaveBeenCalled()
       expect(app.graphToPrompt).not.toHaveBeenCalled()
       expect(queuePrompt).not.toHaveBeenCalled()
 
       finishSwitch()
       await expect(submission).resolves.toBe(true)
 
-      expect(mockAuthStore.getWorkspaceAuthToken).toHaveBeenCalledOnce()
+      expect(useAuthStore().getWorkspaceAuthToken).toHaveBeenCalledOnce()
       expect(queuePrompt).toHaveBeenCalledOnce()
     })
 
     it('does not submit when an in-progress workspace switch fails', async () => {
       prepareEmptyPromptQueue()
-      mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockRejectedValueOnce(
-        new Error('Token exchange failed')
-      )
+      vi.mocked(
+        useTeamWorkspaceStore().waitForWorkspaceSwitch
+      ).mockRejectedValueOnce(new Error('Token exchange failed'))
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
       await expect(app.queuePrompt(0)).resolves.toBe(false)
 
-      expect(mockAuthStore.getWorkspaceAuthToken).not.toHaveBeenCalled()
+      expect(useAuthStore().getWorkspaceAuthToken).not.toHaveBeenCalled()
       expect(app.graphToPrompt).not.toHaveBeenCalled()
       expect(queuePrompt).not.toHaveBeenCalled()
       expect(showDialog).toHaveBeenCalledOnce()
@@ -660,11 +609,17 @@ describe('ComfyApp', () => {
       'uses a workspace initialized while local authentication is pending',
       async () => {
         prepareEmptyPromptQueue()
-        mockTeamWorkspaceStore.activeWorkspaceId = null
-        mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
-          mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-          return 'workspace-token'
+        Object.assign(useTeamWorkspaceStore(), {
+          activeWorkspaceId: null
         })
+        vi.mocked(useAuthStore().getWorkspaceAuthToken).mockImplementationOnce(
+          async () => {
+            Object.assign(useTeamWorkspaceStore(), {
+              activeWorkspaceId: 'workspace-a'
+            })
+            return 'workspace-token'
+          }
+        )
         const queuePrompt = vi
           .spyOn(api, 'queuePrompt')
           .mockImplementation(() => {
@@ -682,11 +637,17 @@ describe('ComfyApp', () => {
       'does not submit when a cloud workspace appears during authentication',
       async () => {
         prepareEmptyPromptQueue()
-        mockTeamWorkspaceStore.activeWorkspaceId = null
-        mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
-          mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-          return 'firebase-token'
+        Object.assign(useTeamWorkspaceStore(), {
+          activeWorkspaceId: null
         })
+        vi.mocked(useAuthStore().getWorkspaceAuthToken).mockImplementationOnce(
+          async () => {
+            Object.assign(useTeamWorkspaceStore(), {
+              activeWorkspaceId: 'workspace-a'
+            })
+            return 'firebase-token'
+          }
+        )
         const queuePrompt = vi.spyOn(api, 'queuePrompt')
         const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -699,10 +660,14 @@ describe('ComfyApp', () => {
 
     it('does not submit when the workspace changes during authentication', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
-        mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
-        return 'workspace-token-a'
-      })
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockImplementationOnce(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-b'
+          })
+          return 'workspace-token-a'
+        }
+      )
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -730,7 +695,9 @@ describe('ComfyApp', () => {
 
       const submission = app.queuePrompt(0)
       await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-b'
+      })
       finishPromptBuild()
 
       await expect(submission).resolves.toBe(false)
@@ -740,8 +707,10 @@ describe('ComfyApp', () => {
 
     it('does not fall back to an API key when workspace authentication fails', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
-      mockApiKeyAuthStore.getApiKey.mockReturnValueOnce('api-key')
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
+        undefined
+      )
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValueOnce('api-key')
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -752,10 +721,14 @@ describe('ComfyApp', () => {
 
     it('does not accept the API key when a Firebase session lost its workspace token', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.currentUser = { uid: 'firebase-user' }
-      mockApiKeyAuthStore.isAuthenticated = true
-      mockApiKeyAuthStore.getApiKey.mockReturnValue('api-key')
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
+      useAuthStore().currentUser = fromPartial({
+        uid: 'firebase-user'
+      })
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue('api-key')
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
+        undefined
+      )
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -766,9 +739,13 @@ describe('ComfyApp', () => {
 
     it('submits with the validated API key when the key session has a workspace', async () => {
       prepareEmptyPromptQueue()
-      mockApiKeyAuthStore.isAuthenticated = true
-      mockApiKeyAuthStore.getApiKey.mockReturnValue('comfyui-valid-key')
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'comfyui-valid-key'
+      )
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
+        undefined
+      )
       const queuePrompt = vi
         .spyOn(api, 'queuePrompt')
         .mockImplementation(() => {
@@ -782,7 +759,7 @@ describe('ComfyApp', () => {
 
     it('does not submit after switching away and back to the same workspace', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
         'workspace-token'
       )
       let finishPromptBuild: () => void = () => {}
@@ -801,10 +778,14 @@ describe('ComfyApp', () => {
 
       const submission = app.queuePrompt(0)
       await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
-      mockTeamWorkspaceStore.workspaceTransitionGeneration++
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-      mockTeamWorkspaceStore.workspaceTransitionGeneration++
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-b',
+        workspaceTransitionGeneration: 1
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-a',
+        workspaceTransitionGeneration: 2
+      })
       finishPromptBuild()
 
       await expect(submission).resolves.toBe(false)
@@ -870,7 +851,7 @@ describe('ComfyApp', () => {
       }
       Reflect.set(app, 'rootGraphInternal', graph)
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
-      mockWorkspaceWorkflow.activeWorkflow = workflow
+      useWorkflowStore().activeWorkflow = markLoaded(workflow)
       vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
         output: promptOutput,
         workflow: createWorkflowGraphData()
@@ -942,7 +923,7 @@ describe('ComfyApp', () => {
 
     it('attributes a queued job to the mode used when submission started', async () => {
       prepareEmptyPromptQueue()
-      const workflow = mockWorkspaceWorkflow.activeWorkflow
+      const workflow = useWorkflowStore().activeWorkflow
       if (!workflow) throw new Error('Expected an active workflow')
       workflow.activeMode = 'graph'
 
@@ -1794,7 +1775,7 @@ describe('ComfyApp', () => {
         { deferWarnings: true }
       )
 
-      const deferredWorkflow = mockWorkspaceWorkflow.activeWorkflow
+      const deferredWorkflow = useWorkflowStore().activeWorkflow
       expect(missingNodesStore.missingNodesError).toBeNull()
       expect(deferredWorkflow?.pendingWarnings?.missingNodeTypes).toEqual([
         expect.objectContaining({ type: 'UninstalledDeferredNode' })
@@ -2030,23 +2011,13 @@ describe('ComfyApp', () => {
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
       singletonApp.canvas = mockCanvas
       Reflect.set(mockCanvas, 'ds', { scale: 1, offset: [0, 0] })
-      mockWorkspaceWorkflow.createNewTemporary.mockImplementation(
-        workflowStore.createNewTemporary
-      )
-      mockWorkspaceWorkflow.getWorkflowByPath.mockImplementation(
-        workflowStore.getWorkflowByPath
-      )
-      mockWorkspaceWorkflow.isActive.mockImplementation(workflowStore.isActive)
-      mockWorkspaceWorkflow.openWorkflow.mockImplementation(
-        async (workflow) => {
-          const loadedWorkflow = await workflowStore.openWorkflow(workflow)
-          mockWorkspaceWorkflow.activeWorkflow = loadedWorkflow
-          return loadedWorkflow
-        }
-      )
+      vi.mocked(workflowStore.createNewTemporary).mockRestore()
+      vi.mocked(workflowStore.getWorkflowByPath).mockRestore()
+      vi.mocked(workflowStore.isActive).mockRestore()
+      vi.mocked(workflowStore.openWorkflow).mockRestore()
 
       await app.loadApiJson({}, 'api-a')
-      const importedA = mockWorkspaceWorkflow.activeWorkflow
+      const importedA = useWorkflowStore().activeWorkflow
       const importedAId = importedA?.activeState?.id
       if (!importedA || !importedAId) {
         throw new Error('Expected the first imported workflow to have an id')
@@ -2058,7 +2029,7 @@ describe('ComfyApp', () => {
       executionErrorStore.recordNodeErrors(failedKSamplerErrors)
 
       await app.loadApiJson({}, 'api-b')
-      const importedBId = mockWorkspaceWorkflow.activeWorkflow?.activeState?.id
+      const importedBId = useWorkflowStore().activeWorkflow?.activeState?.id
       expect(importedBId).not.toBe(zeroUuid)
       expect(importedBId).not.toBe(importedAId)
       expect(executionErrorStore.lastNodeErrors).toBeNull()
@@ -2080,7 +2051,7 @@ describe('ComfyApp', () => {
           size: -1
         })
       )
-      mockWorkspaceWorkflow.createNewTemporary.mockImplementation(
+      vi.mocked(useWorkflowStore().createNewTemporary).mockImplementation(
         (_path, workflowData) => {
           if (workflowData) {
             importedWorkflow.changeTracker.activeState = workflowData
@@ -2088,18 +2059,18 @@ describe('ComfyApp', () => {
           return importedWorkflow
         }
       )
-      mockWorkspaceWorkflow.getWorkflowByPath.mockImplementation(
-        () => mockWorkspaceWorkflow.activeWorkflow
+      vi.mocked(useWorkflowStore().getWorkflowByPath).mockImplementation(
+        () => useWorkflowStore().activeWorkflow
       )
-      mockWorkspaceWorkflow.isActive.mockImplementation(
-        (workflow) => mockWorkspaceWorkflow.activeWorkflow === workflow
+      vi.mocked(useWorkflowStore().isActive).mockImplementation(
+        (workflow) => useWorkflowStore().activeWorkflow === workflow
       )
 
       await app.loadApiJson({}, 'repeat')
-      const activeWorkflow = mockWorkspaceWorkflow.activeWorkflow
+      const activeWorkflow = useWorkflowStore().activeWorkflow
       await app.loadApiJson({}, 'repeat')
 
-      expect(mockWorkspaceWorkflow.activeWorkflow).toBe(activeWorkflow)
+      expect(useWorkflowStore().activeWorkflow).toBe(activeWorkflow)
     })
   })
 
@@ -2110,14 +2081,14 @@ describe('ComfyApp', () => {
 
       await app.refreshComboInNodes()
 
-      expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'info' })
       )
-      expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'success' })
       )
-      expect(mockToastStore.remove).toHaveBeenCalledWith(
-        mockToastStore.add.mock.calls[0][0]
+      expect(useToastStore().remove).toHaveBeenCalledWith(
+        vi.mocked(useToastStore().add).mock.calls[0][0]
       )
     })
 
@@ -2128,11 +2099,11 @@ describe('ComfyApp', () => {
 
       await expect(app.refreshComboInNodes()).rejects.toThrow(error)
 
-      expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
-      expect(mockToastStore.remove).toHaveBeenCalledWith(
-        mockToastStore.add.mock.calls[0][0]
+      expect(useToastStore().remove).toHaveBeenCalledWith(
+        vi.mocked(useToastStore().add).mock.calls[0][0]
       )
     })
   })
@@ -2622,8 +2593,8 @@ describe('ComfyApp', () => {
 
       await app.handleFile(createTestFile('broken.json', 'application/json'))
 
-      expect(mockToastStore.addAlert).toHaveBeenCalledTimes(1)
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+      expect(useToastStore().addAlert).toHaveBeenCalledTimes(1)
+      expect(useToastStore().addAlert).toHaveBeenCalledWith(
         'Unable to find workflow in broken.json'
       )
       consoleError.mockRestore()
@@ -2668,8 +2639,8 @@ describe('ComfyApp', () => {
         parameters,
         expect.any(Function)
       )
-      expect(mockToastStore[testCase.toastMethod]).toHaveBeenCalledOnce()
-      expect(mockToastStore[testCase.toastMethod]).toHaveBeenCalledWith(
+      expect(useToastStore()[testCase.toastMethod]).toHaveBeenCalledOnce()
+      expect(useToastStore()[testCase.toastMethod]).toHaveBeenCalledWith(
         testCase.expectedToast
       )
       if (testCase.outcome === 'imported-without-embeddings') {
@@ -2754,7 +2725,7 @@ describe('ComfyApp', () => {
       outgoingWorkflow.pendingWarnings = {
         missingNodeTypes: ['OutgoingMissingNode']
       }
-      mockWorkspaceWorkflow.activeWorkflow = outgoingWorkflow
+      useWorkflowStore().activeWorkflow = markLoaded(outgoingWorkflow)
       const realWorkflowStore = useWorkflowStore()
       realWorkflowStore.activeWorkflow = markLoaded(outgoingWorkflow)
       const missingNodesStore = useMissingNodesErrorStore()
@@ -2778,12 +2749,12 @@ describe('ComfyApp', () => {
       const openWorkflowGate = new Promise<void>((resolve) => {
         releaseOpenWorkflow = resolve
       })
-      mockWorkspaceWorkflow.openWorkflow.mockImplementation(
+      vi.mocked(useWorkflowStore().openWorkflow).mockImplementation(
         async (workflow: ComfyWorkflow) => {
           await openWorkflowGate
-          mockWorkspaceWorkflow.activeWorkflow = workflow
+          useWorkflowStore().activeWorkflow = markLoaded(workflow)
           realWorkflowStore.activeWorkflow = markLoaded(workflow)
-          return workflow
+          return markLoaded(workflow)
         }
       )
 
@@ -2792,7 +2763,7 @@ describe('ComfyApp', () => {
 
         document.dispatchEvent(new DragEvent('drop'))
         await vi.waitFor(() => {
-          expect(mockWorkspaceWorkflow.openWorkflow).toHaveBeenCalledOnce()
+          expect(useWorkflowStore().openWorkflow).toHaveBeenCalledOnce()
         })
 
         expect(adjustMouseEvent).toHaveBeenCalledTimes(1)
@@ -2801,9 +2772,7 @@ describe('ComfyApp', () => {
 
         releaseOpenWorkflow()
         await vi.waitFor(() => {
-          expect(mockWorkspaceWorkflow.activeWorkflow).not.toBe(
-            outgoingWorkflow
-          )
+          expect(useWorkflowStore().activeWorkflow).not.toBe(outgoingWorkflow)
         })
         await vi.waitFor(() => {
           expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1,4 +1,11 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { markRaw, ref } from 'vue'
+
+vi.mock(import('@vueuse/router'), () => ({ useRouteHash: () => ref('') }))
 
 import {
   createNestedSubgraphs,
@@ -19,23 +26,10 @@ vi.mock('@/base/assert', () => ({
   assert: mockAssert
 }))
 
-const mockNodeOutputStore = vi.hoisted(() => ({
-  snapshotOutputs: vi.fn(() => ({})),
-  restoreOutputs: vi.fn()
-}))
-
-const mockSubgraphNavigationStore = vi.hoisted(() => ({
-  exportState: vi.fn(() => []),
-  restoreState: vi.fn()
-}))
-
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: null as { changeTracker: unknown } | null,
-  getWorkflowByPath: vi.fn()
-}))
-
 vi.mock('@/scripts/app', () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     graph: {},
     rootGraph: {
       serialize: vi.fn(() => ({
@@ -66,19 +60,6 @@ vi.mock('@/scripts/api', () => ({
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   }
-}))
-
-vi.mock('@/stores/nodeOutputStore', () => ({
-  useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
-}))
-
-vi.mock('@/stores/subgraphNavigationStore', () => ({
-  useSubgraphNavigationStore: vi.fn(() => mockSubgraphNavigationStore)
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  ComfyWorkflow: class {},
-  useWorkflowStore: vi.fn(() => mockWorkflowStore)
 }))
 
 import { app } from '@/scripts/app'
@@ -121,8 +102,10 @@ function createTracker(initialState?: ComfyWorkflowJSON): ChangeTracker {
   const workflow = {
     path: `/test/workflow-${++workflowPathCounter}.json`
   } as never
-  const tracker = new ChangeTracker(workflow, state)
-  mockWorkflowStore.activeWorkflow = { changeTracker: tracker }
+  const tracker = markRaw(new ChangeTracker(workflow, state))
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: tracker
+  })
   return tracker
 }
 
@@ -219,12 +202,16 @@ describe('ChangeTracker', () => {
     nodeIdCounter = 0
     ChangeTracker.isLoadingGraph = false
     ChangeTracker.resetCheckStateWarningForTest()
-    mockWorkflowStore.activeWorkflow = null
-    mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
+    useWorkflowStore().activeWorkflow = null
+    vi.mocked(useWorkflowStore().getWorkflowByPath).mockReturnValue(null)
     mockCanvasState(createState())
     useQueueSettingsStore().mode = 'change'
     app.ui.autoQueueEnabled = false
     app.ui.autoQueueMode = 'instant'
+    vi.mocked(useSubgraphNavigationStore().exportState).mockReturnValue([])
+    vi.mocked(useSubgraphNavigationStore().restoreState).mockImplementation(
+      () => {}
+    )
   })
 
   describe('captureCanvasState', () => {
@@ -270,7 +257,9 @@ describe('ChangeTracker', () => {
 
       it('is a no-op and calls assert when called on inactive tracker', () => {
         const tracker = createTracker()
-        mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+        useWorkflowStore().activeWorkflow = fromPartial({
+          changeTracker: {}
+        })
 
         tracker.captureCanvasState()
 
@@ -452,7 +441,9 @@ describe('ChangeTracker', () => {
         {
           name: 'tracker becomes inactive',
           blockSquash: () => {
-            mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+            useWorkflowStore().activeWorkflow = fromPartial({
+              changeTracker: {}
+            })
           }
         },
         {
@@ -1186,8 +1177,8 @@ describe('ChangeTracker', () => {
       tracker.deactivate()
 
       expect(tracker.activeState).toEqual(changed)
-      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
-      expect(mockSubgraphNavigationStore.exportState).toHaveBeenCalled()
+      expect(useNodeOutputStore().snapshotOutputs).toHaveBeenCalled()
+      expect(useSubgraphNavigationStore().exportState).toHaveBeenCalled()
     })
 
     it('skips captureCanvasState but still calls store during undo/redo', () => {
@@ -1197,17 +1188,19 @@ describe('ChangeTracker', () => {
       tracker.deactivate()
 
       expect(app.rootGraph.serialize).not.toHaveBeenCalled()
-      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
+      expect(useNodeOutputStore().snapshotOutputs).toHaveBeenCalled()
     })
 
     it('is a full no-op and calls assert when called on inactive tracker', () => {
       const tracker = createTracker()
-      mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        changeTracker: {}
+      })
 
       tracker.deactivate()
 
       expect(app.rootGraph.serialize).not.toHaveBeenCalled()
-      expect(mockNodeOutputStore.snapshotOutputs).not.toHaveBeenCalled()
+      expect(useNodeOutputStore().snapshotOutputs).not.toHaveBeenCalled()
       expect(mockAssert).toHaveBeenCalledWith(
         false,
         'ChangeTracker.deactivate() called on inactive tracker'
@@ -1229,7 +1222,9 @@ describe('ChangeTracker', () => {
     it('is a no-op when tracker is inactive', () => {
       const tracker = createTracker()
       const original = tracker.activeState
-      mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        changeTracker: {}
+      })
 
       tracker.prepareForSave()
 

--- a/src/scripts/domWidget.test.ts
+++ b/src/scripts/domWidget.test.ts
@@ -3,12 +3,6 @@ import { describe, expect, test, vi } from 'vitest'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { ComponentWidgetImpl, DOMWidgetImpl } from '@/scripts/domWidget'
 
-vi.mock('@/stores/domWidgetStore', () => ({
-  useDomWidgetStore: () => ({
-    unregisterWidget: vi.fn()
-  })
-}))
-
 vi.mock('@/utils/formatUtil', () => ({
   generateUUID: () => 'test-uuid'
 }))

--- a/src/services/audioService.test.ts
+++ b/src/services/audioService.test.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAudioService } from '@/services/audioService'
@@ -10,10 +11,6 @@ const mockApi = vi.hoisted(() => ({
   fetchApi: vi.fn()
 }))
 
-const mockToastStore = vi.hoisted(() => ({
-  addAlert: vi.fn()
-}))
-
 vi.mock(import('extendable-media-recorder'), () => ({
   register: mockRegister
 }))
@@ -24,10 +21,6 @@ vi.mock(import('extendable-media-recorder-wav-encoder'), () => ({
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: mockApi
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => mockToastStore)
 }))
 
 describe('useAudioService', () => {
@@ -211,7 +204,7 @@ describe('useAudioService', () => {
         'Error uploading temp file: 500 - Internal Server Error'
       )
 
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+      expect(useToastStore().addAlert).toHaveBeenCalledWith(
         'Error uploading temp file: 500 - Internal Server Error'
       )
     })
@@ -242,11 +235,11 @@ describe('useAudioService', () => {
           `Error uploading temp file: ${testCase.status} - ${testCase.statusText}`
         )
 
-        expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        expect(useToastStore().addAlert).toHaveBeenCalledWith(
           `Error uploading temp file: ${testCase.status} - ${testCase.statusText}`
         )
 
-        mockToastStore.addAlert.mockClear()
+        vi.mocked(useToastStore().addAlert).mockClear()
       }
     })
 

--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -1,20 +1,19 @@
+import { useAuthStore } from '@/stores/authStore'
 import axios from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock(import('firebase/auth'))
 
 import {
   EventType,
   useCustomerEventsService
 } from '@/services/customerEventsService'
+import type { AuthHeader } from '@/types/authTypes'
 
 // Hoist the mocks to avoid hoisting issues
 const mockAxiosInstance = vi.hoisted(() => ({
   get: vi.fn(),
   interceptors: { response: { use: vi.fn() } }
-}))
-
-const mockAuthStore = vi.hoisted(() => ({
-  getUserAuthHeader: vi.fn(),
-  currentUserIdentity: vi.fn()
 }))
 
 const mockI18n = vi.hoisted(() => ({
@@ -27,10 +26,6 @@ vi.mock<unknown>(import('axios'), () => ({
     create: vi.fn(() => mockAxiosInstance),
     isAxiosError: vi.fn()
   }
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => mockAuthStore)
 }))
 
 vi.mock(import('@/i18n'), () => ({
@@ -46,9 +41,8 @@ describe('useCustomerEventsService', () => {
   let service: ReturnType<typeof useCustomerEventsService>
 
   const mockAuthHeaders = {
-    Authorization: 'Bearer mock-token',
-    'Content-Type': 'application/json'
-  }
+    Authorization: 'Bearer mock-token'
+  } satisfies AuthHeader
 
   const mockEventsResponse = {
     events: [
@@ -81,8 +75,10 @@ describe('useCustomerEventsService', () => {
   }
 
   beforeEach(() => {
-    mockAuthStore.getUserAuthHeader.mockResolvedValue(mockAuthHeaders)
-    mockAuthStore.currentUserIdentity.mockReturnValue('api-key-a')
+    vi.mocked(useAuthStore().getUserAuthHeader).mockResolvedValue(
+      mockAuthHeaders
+    )
+    vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-a')
     mockI18n.d.mockImplementation((date, options) => {
       // Mock i18n date formatting
       if (options?.month === 'short') {
@@ -119,7 +115,7 @@ describe('useCustomerEventsService', () => {
         limit: 10
       })
 
-      expect(mockAuthStore.getUserAuthHeader).toHaveBeenCalled()
+      expect(useAuthStore().getUserAuthHeader).toHaveBeenCalled()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/customers/events', {
         params: { page: 1, limit: 10 },
         headers: mockAuthHeaders
@@ -142,7 +138,7 @@ describe('useCustomerEventsService', () => {
     })
 
     it('should return null when auth headers are missing', async () => {
-      mockAuthStore.getUserAuthHeader.mockResolvedValue(null)
+      vi.mocked(useAuthStore().getUserAuthHeader).mockResolvedValue(null)
 
       const result = await service.getMyEvents()
 
@@ -164,7 +160,7 @@ describe('useCustomerEventsService', () => {
 
       const request = service.getMyEvents()
       await eventsRequestStarted
-      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-b')
       resolveEvents({ data: mockEventsResponse })
 
       await expect(request).resolves.toBeNull()
@@ -184,7 +180,7 @@ describe('useCustomerEventsService', () => {
 
       const request = service.getMyEvents()
       await eventsRequestStarted
-      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-b')
       rejectEvents({
         response: { status: 400, data: { message: 'account A backend error' } }
       })
@@ -195,8 +191,12 @@ describe('useCustomerEventsService', () => {
     })
 
     it('ignores a stale auth preflight once a newer request begins', async () => {
-      let resolveStaleHeader!: (value: unknown) => void
-      mockAuthStore.getUserAuthHeader.mockImplementationOnce(
+      let resolveStaleHeader!: (
+        value: Awaited<
+          ReturnType<ReturnType<typeof useAuthStore>['getUserAuthHeader']>
+        >
+      ) => void
+      vi.mocked(useAuthStore().getUserAuthHeader).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveStaleHeader = resolve
@@ -204,7 +204,7 @@ describe('useCustomerEventsService', () => {
       )
       const staleRequest = service.getMyEvents()
 
-      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-b')
       const activeRequestStarted = new Promise<void>((requestStarted) => {
         mockAxiosInstance.get.mockImplementation(() => {
           requestStarted()

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -1,21 +1,18 @@
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Component } from 'vue'
+import type DowngradeContent from '@/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.vue'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useDialogStore } from '@/stores/dialogStore'
 /**
  * showDowngradeToPersonalDialog must refresh members before the no-members
  * fast path and stay non-dismissable (ESC derives from `closable` in
  * dialogStore); fast-path failures must toast.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
-const showDialog = vi.hoisted(() => vi.fn())
-const closeDialog = vi.hoisted(() => vi.fn())
-const isDialogOpen = vi.hoisted(() => vi.fn())
-const updateDialog = vi.hoisted(() => vi.fn())
-const toastAdd = vi.hoisted(() => vi.fn())
 const refreshMembers = vi.hoisted(() => vi.fn())
 const previewDowngrade = vi.hoisted(() => vi.fn())
 const downgradeToPersonal = vi.hoisted(() => vi.fn())
 const hasOtherMembers = vi.hoisted(() => ({ value: false }))
-const openDialogKeys = ref<string[]>([])
 
 const {
   ReactivationConfirmationRequiredError,
@@ -37,15 +34,6 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    showDialog,
-    closeDialog,
-    isDialogOpen,
-    updateDialog
-  })
-}))
-
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
@@ -64,10 +52,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     isFreeTier: { value: false },
     type: { value: 'legacy' }
   })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
 }))
 
 vi.mock<unknown>(
@@ -94,7 +78,6 @@ import { useDialogService } from '@/services/dialogService'
 describe('showDowngradeToPersonalDialog', () => {
   beforeEach(() => {
     hasOtherMembers.value = false
-    openDialogKeys.value = []
     refreshMembers.mockResolvedValue(undefined)
     previewDowngrade.mockResolvedValue({
       preview: {
@@ -105,17 +88,6 @@ describe('showDowngradeToPersonalDialog', () => {
       requiresReactivationConfirmation: false
     })
     downgradeToPersonal.mockResolvedValue(undefined)
-    isDialogOpen.mockImplementation((key: string) =>
-      openDialogKeys.value.includes(key)
-    )
-    showDialog.mockImplementation(({ key }: { key: string }) => {
-      openDialogKeys.value = [...openDialogKeys.value, key]
-    })
-    closeDialog.mockImplementation(({ key }: { key: string }) => {
-      openDialogKeys.value = openDialogKeys.value.filter(
-        (openKey) => openKey !== key
-      )
-    })
   })
 
   const options = { planName: 'Standard', planSlug: 'standard-monthly' }
@@ -135,7 +107,9 @@ describe('showDowngradeToPersonalDialog', () => {
 
     expect(calls).toEqual(['refresh', 'downgrade'])
     expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly')
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
   })
 
   it('returns the downgrade result from the no-members fast path', async () => {
@@ -155,19 +129,29 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
 
     expect(downgradeToPersonal).not.toHaveBeenCalled()
-    expect(closeDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
     expect(args.key).toBe('downgrade-remove-members')
     expect(args.props.requiresRemoval).toBe(true)
     expect(args.props.requiresReactivation).toBe(false)
-    expect(args.dialogComponentProps.closable).toBe(false)
-    expect(args.dialogComponentProps.dismissableMask).toBe(false)
+    expect(args.dialogComponentProps?.closable).toBe(false)
+    expect(args.dialogComponentProps?.dismissableMask).toBe(false)
 
+    assert(args.dialogComponentProps?.onClose)
     args.dialogComponentProps.onClose()
     await expect(resultPromise).resolves.toBeNull()
   })
@@ -185,14 +169,24 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
 
     expect(downgradeToPersonal).not.toHaveBeenCalled()
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
     expect(args.props.requiresRemoval).toBe(false)
     expect(args.props.requiresReactivation).toBe(true)
     expect(args.props.chargeCents).toBe(1500)
 
+    assert(args.dialogComponentProps?.onClose)
     args.dialogComponentProps.onClose()
     await resultPromise
   })
@@ -207,9 +201,19 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
 
+    assert(typeof args.props.onConfirm === 'function')
     await args.props.onConfirm('standard-monthly', false)
 
     expect(downgradeToPersonal).toHaveBeenCalledWith(
@@ -233,9 +237,19 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
 
+    assert(typeof args.props.onConfirm === 'function')
     await args.props.onConfirm('standard-monthly', true)
 
     expect(downgradeToPersonal).toHaveBeenCalledWith(
@@ -270,8 +284,18 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
+    assert(typeof args.props.onConfirm === 'function')
     expect(args.props.requiresReactivation).toBe(false)
     expect(args.props.chargeCents).toBe(0)
 
@@ -279,7 +303,7 @@ describe('showDowngradeToPersonalDialog', () => {
       args.props.onConfirm('standard-monthly', false)
     ).rejects.toThrow(ReactivationConfirmationRequiredError)
 
-    expect(updateDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledWith({
       key: 'downgrade-remove-members',
       contentProps: { requiresReactivation: true, chargeCents: 1500 }
     })
@@ -323,15 +347,25 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
+    assert(typeof args.props.onConfirm === 'function')
     expect(args.props.chargeCents).toBe(1500)
 
     await expect(
       args.props.onConfirm('standard-monthly', true)
     ).rejects.toThrow(ReactivationAmountChangedError)
 
-    expect(updateDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledWith({
       key: 'downgrade-remove-members',
       contentProps: { requiresReactivation: true, chargeCents: 2000 }
     })
@@ -358,9 +392,15 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
 
-    openDialogKeys.value = []
+    useDialogStore().dialogStack = []
 
     await expect(resultPromise).resolves.toBeNull()
   })
@@ -370,13 +410,15 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await useDialogService().showDowngradeToPersonalDialog(options)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'Outstanding balance'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
   })
 
   it('toasts and aborts when the member refresh fails', async () => {
@@ -385,10 +427,12 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await useDialogService().showDowngradeToPersonalDialog(options)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error', detail: 'network' })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
     expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 
@@ -397,13 +441,15 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await useDialogService().showDowngradeToPersonalDialog(options)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'Outstanding balance'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
     expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 })

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -3,13 +3,7 @@
  * Reka-migrated dialog, the dialog stack item must carry `renderer: 'reka'`.
  * Catches accidental reverts of the Reka renderer flip.
  */
-import { describe, expect, it, vi } from 'vitest'
-
-const showDialog = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
@@ -44,20 +38,29 @@ vi.mock<unknown>(
 )
 
 import { useDialogService } from '@/services/dialogService'
+import { useDialogStore } from '@/stores/dialogStore'
 
 describe('dialogService Reka renderer opt-in', () => {
+  let showDialog: ReturnType<
+    typeof vi.mocked<ReturnType<typeof useDialogStore>['showDialog']>
+  >
+
+  beforeEach(() => {
+    showDialog = vi.mocked(useDialogStore().showDialog)
+  })
+
   it("prompt() sets renderer 'reka' and size 'md'", () => {
     void useDialogService().prompt({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('md')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('md')
   })
 
   it("confirm() sets renderer 'reka' and size 'md'", () => {
     void useDialogService().confirm({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('md')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('md')
   })
 
   it('confirm() opens under its own stack key when the caller passes one', () => {
@@ -77,9 +80,9 @@ describe('dialogService Reka renderer opt-in', () => {
   it("showBillingComingSoonDialog() sets renderer 'reka', size 'sm', and 360px contentClass", () => {
     useDialogService().showBillingComingSoonDialog()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('sm')
-    expect(args.dialogComponentProps.contentClass).toBe('max-w-[360px]')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('sm')
+    expect(args.dialogComponentProps?.contentClass).toBe('max-w-[360px]')
   })
 
   it("showExecutionErrorDialog() sets renderer 'reka' and size 'lg'", () => {
@@ -91,25 +94,25 @@ describe('dialogService Reka renderer opt-in', () => {
       traceback: ['line 1', 'line 2']
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('lg')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('lg')
   })
 
   it("showErrorDialog() sets renderer 'reka' and size 'lg'", () => {
     useDialogService().showErrorDialog(new Error('boom'))
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('lg')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('lg')
   })
 
   it("showTopUpCreditsDialog() sets renderer 'reka' with a transparent shrink-wrapped chrome", async () => {
     await useDialogService().showTopUpCreditsDialog()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.pt).toBeUndefined()
-    expect(args.dialogComponentProps.contentClass).toContain('w-fit')
-    expect(args.dialogComponentProps.contentClass).toContain('bg-transparent')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.headless).toBe(true)
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
+    expect(args.dialogComponentProps?.contentClass).toContain('w-fit')
+    expect(args.dialogComponentProps?.contentClass).toContain('bg-transparent')
   })
 
   it("showLayoutDialog() defaults to renderer 'reka' headless without pt", () => {
@@ -120,9 +123,9 @@ describe('dialogService Reka renderer opt-in', () => {
       props: {}
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.pt).toBeUndefined()
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.headless).toBe(true)
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
   })
 
   it('showLayoutDialog() lets callers override the defaults', () => {
@@ -134,9 +137,9 @@ describe('dialogService Reka renderer opt-in', () => {
       dialogComponentProps: { closable: false, contentClass: 'w-170' }
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.closable).toBe(false)
-    expect(args.dialogComponentProps.contentClass).toBe('w-170')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.closable).toBe(false)
+    expect(args.dialogComponentProps?.contentClass).toBe('w-170')
   })
 
   it("showSmallLayoutDialog() sets renderer 'reka' with zeroed section padding", () => {
@@ -146,11 +149,11 @@ describe('dialogService Reka renderer opt-in', () => {
       component: Component
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.pt).toBeUndefined()
-    expect(args.dialogComponentProps.contentClass).toContain('w-fit')
-    expect(args.dialogComponentProps.headerClass).toBe('p-0')
-    expect(args.dialogComponentProps.bodyClass).toBe('p-0 overflow-y-hidden')
-    expect(args.dialogComponentProps.footerClass).toBe('p-0')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
+    expect(args.dialogComponentProps?.contentClass).toContain('w-fit')
+    expect(args.dialogComponentProps?.headerClass).toBe('p-0')
+    expect(args.dialogComponentProps?.bodyClass).toBe('p-0 overflow-y-hidden')
+    expect(args.dialogComponentProps?.footerClass).toBe('p-0')
   })
 })

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -1,21 +1,16 @@
+import { useDialogStore } from '@/stores/dialogStore'
 /**
  * showTopUpCreditsDialog routes the paired server capabilities to purchase,
  * subscription, or read-only contact-admin UI.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const showDialog = vi.hoisted(() => vi.fn())
-const closeDialog = vi.hoisted(() => vi.fn())
 const state = vi.hoisted(() => ({
   type: 'workspace' as 'workspace' | 'legacy',
   canTopUp: true,
   canSubscribeSelfServe: false,
   isReady: true,
   initialize: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog, closeDialog })
 }))
 
 vi.mock(import('@/i18n'), () => ({
@@ -64,10 +59,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: vi.fn() })
-}))
-
 const showSubscriptionDialog = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(
@@ -94,7 +85,7 @@ describe('showTopUpCreditsDialog', () => {
       isInsufficientCredits: true
     })
 
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('top-up-credits')
     expect(state.initialize).not.toHaveBeenCalled()
   })
@@ -107,15 +98,17 @@ describe('showTopUpCreditsDialog', () => {
       isInsufficientCredits: true
     })
 
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('insufficient-credits-member')
     // The member notice draws its own header + close button, so it must open
     // headless or Reka wraps it in duplicate chrome.
-    expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.headless).toBe(true)
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
 
-    args.props.onClose()
-    expect(closeDialog).toHaveBeenCalledWith({
+    const props = args.props
+    assert(props && 'onClose' in props && typeof props.onClose === 'function')
+    props.onClose()
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'insufficient-credits-member'
     })
   })
@@ -126,7 +119,7 @@ describe('showTopUpCreditsDialog', () => {
 
     await useDialogService().showTopUpCreditsDialog()
 
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('top-up-credits')
   })
 
@@ -136,7 +129,7 @@ describe('showTopUpCreditsDialog', () => {
 
     await useDialogService().showTopUpCreditsDialog()
 
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
     expect(showSubscriptionDialog).not.toHaveBeenCalled()
   })
 
@@ -154,7 +147,7 @@ describe('showTopUpCreditsDialog', () => {
     })
 
     expect(state.initialize).toHaveBeenCalledOnce()
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('top-up-credits')
   })
 
@@ -165,7 +158,7 @@ describe('showTopUpCreditsDialog', () => {
     await useDialogService().showTopUpCreditsDialog()
 
     expect(state.initialize).toHaveBeenCalledOnce()
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
     expect(showSubscriptionDialog).not.toHaveBeenCalled()
   })
 
@@ -178,7 +171,7 @@ describe('showTopUpCreditsDialog', () => {
     expect(showSubscriptionDialog).toHaveBeenCalledWith({
       reason: 'top_up_blocked'
     })
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   describe('non-cloud distribution', () => {
@@ -191,7 +184,7 @@ describe('showTopUpCreditsDialog', () => {
       await useDialogService().showTopUpCreditsDialog()
 
       expect(showSubscriptionDialog).not.toHaveBeenCalled()
-      const [args] = showDialog.mock.calls[0]
+      const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
       expect(args.key).toBe('top-up-credits')
     })
   })

--- a/src/services/hdrViewerService.test.ts
+++ b/src/services/hdrViewerService.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { showDialog } = vi.hoisted(() => ({ showDialog: vi.fn() }))
+import { useDialogStore } from '@/stores/dialogStore'
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
 vi.mock(import('@/i18n'), () => ({ t: (key: string) => key }))
 
 import { openHdrViewer } from './hdrViewerService'
 
 describe('openHdrViewer', () => {
   it('opens a full-screen dialog with the full-resolution url and filename title', () => {
+    const showDialog = vi.mocked(useDialogStore().showDialog)
     openHdrViewer('/api/view?filename=out.exr&preview=webp;75&rand=1')
 
     expect(showDialog).toHaveBeenCalledOnce()
     const options = showDialog.mock.calls[0][0]
     expect(options.key).toBe('hdr-viewer')
     expect(options.title).toBe('out.exr')
-    expect(options.props.imageUrl).toBe('/api/view?filename=out.exr&rand=1')
-    expect(options.dialogComponentProps.size).toBe('full')
+    expect(options.props).toMatchObject({
+      imageUrl: '/api/view?filename=out.exr&rand=1'
+    })
+    expect(options.dialogComponentProps?.size).toBe('full')
   })
 })

--- a/src/services/providers/registrySearchProvider.test.ts
+++ b/src/services/providers/registrySearchProvider.test.ts
@@ -1,42 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
 
 import { useComfyRegistrySearchProvider } from '@/services/providers/registrySearchProvider'
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
 
-// Mock the store
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: vi.fn()
-}))
-
 describe('useComfyRegistrySearchProvider', () => {
-  const mockSearchCall = vi.fn()
-  const mockSearchClear = vi.fn()
-  const mockListAllPacksCall = vi.fn()
-  const mockListAllPacksClear = vi.fn()
-
-  const createMockStore = (
-    params: Partial<ReturnType<typeof useComfyRegistryStore>> = {}
-  ) => {
-    return {
-      search: {
-        call: mockSearchCall,
-        clear: mockSearchClear,
-        cancel: vi.fn()
-      },
-      listAllPacks: {
-        call: mockListAllPacksCall,
-        clear: mockListAllPacksClear,
-        cancel: vi.fn()
-      },
-      ...params
-    } as Partial<ReturnType<typeof useComfyRegistryStore>> as ReturnType<
-      typeof useComfyRegistryStore
-    >
-  }
+  let mockSearchCall: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['search']['call']
+  >
+  let mockSearchClear: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['search']['clear']
+  >
+  let mockListAllPacksCall: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['listAllPacks']['call']
+  >
+  let mockListAllPacksClear: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['listAllPacks']['clear']
+  >
 
   beforeEach(() => {
-    // Setup store mock
-    vi.mocked(useComfyRegistryStore).mockReturnValue(createMockStore())
+    const store = useComfyRegistryStore()
+    mockSearchCall = vi.spyOn(store.search, 'call').mockResolvedValue(null)
+    mockSearchClear = vi.spyOn(store.search, 'clear')
+    mockListAllPacksCall = vi
+      .spyOn(store.listAllPacks, 'call')
+      .mockResolvedValue(null)
+    mockListAllPacksClear = vi.spyOn(store.listAllPacks, 'clear')
   })
 
   describe('searchPacks', () => {

--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
 
 const mockLocalStorage = vi.hoisted(() => ({
   getItem: vi.fn(),
@@ -7,42 +10,36 @@ const mockLocalStorage = vi.hoisted(() => ({
   clear: vi.fn()
 }))
 
-const mockSettingStore = vi.hoisted(() => ({
-  settingValues: {} as Record<string, unknown>,
-  get: vi.fn(),
-  set: vi.fn()
-}))
-
 Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
   writable: true
 })
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => mockSettingStore
-}))
-
 import { useNewUserService } from '@/services/useNewUserService'
 
 describe('useNewUserService', () => {
   let service: ReturnType<typeof useNewUserService>
+  let scope: ReturnType<typeof effectScope>
 
   beforeEach(() => {
-    mockSettingStore.settingValues = {}
+    vi.spyOn(api, 'storeSetting').mockResolvedValue(new Response())
+    useSettingStore().settingValues = {}
 
-    service = useNewUserService()
+    scope = effectScope()
+    scope.run(() => {
+      service = useNewUserService()
+    })
     service.reset()
 
     mockLocalStorage.getItem.mockReturnValue(null)
   })
 
+  afterEach(() => scope.stop())
+
   describe('checkIsNewUser logic', () => {
     it('should identify new user when all conditions are met', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -51,12 +48,11 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when settings exist but TutorialCompleted is undefined', async () => {
-      mockSettingStore.settingValues = { 'some.setting': 'value' }
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark'
+      }
 
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
 
       mockLocalStorage.getItem.mockReturnValue(null)
 
@@ -66,11 +62,10 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when tutorial is completed', async () => {
-      mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': true }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.TutorialCompleted': true
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -79,11 +74,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when workflow exists', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'workflow') return 'some-workflow'
         return null
@@ -95,11 +87,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when previous workflow exists', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.PreviousWorkflow') return 'some-previous-workflow'
         return null
@@ -111,8 +100,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when V1 draft store keys exist', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.Drafts') return '{}'
         return null
@@ -124,8 +113,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when V1 draft order key exists', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftOrder') return '[]'
         return null
@@ -137,8 +126,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when V2 draft index has entries', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftIndex.v2:personal')
           return '{"v":2,"updatedAt":1,"order":["abc"],"entries":{"abc":{"path":"workflows/Untitled.json","name":"Untitled","isTemporary":true,"updatedAt":1}}}'
@@ -151,8 +140,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when V2 draft index exists but is empty', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftIndex.v2:personal')
           return '{"v":2,"updatedAt":1,"order":[],"entries":{}}'
@@ -165,8 +154,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when V2 draft index is malformed', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftIndex.v2:personal') return 'not json'
         return null
@@ -178,11 +167,10 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when tutorial is explicitly false', async () => {
-      mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': false }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return false
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.TutorialCompleted': false
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = false
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -191,14 +179,11 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when has both settings and tutorial completed', async () => {
-      mockSettingStore.settingValues = {
-        'some.setting': 'value',
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark',
         'Comfy.TutorialCompleted': true
       }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -207,11 +192,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when only one condition fails', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'workflow') return 'some-workflow'
         if (key === 'Comfy.PreviousWorkflow') return null
@@ -228,11 +210,8 @@ describe('useNewUserService', () => {
     it('should execute callback immediately if new user is already determined', async () => {
       const mockCallback = vi.fn().mockResolvedValue(undefined)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -258,11 +237,8 @@ describe('useNewUserService', () => {
         .mockRejectedValue(new Error('Callback error'))
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -279,32 +255,28 @@ describe('useNewUserService', () => {
 
   describe('initializeIfNewUser', () => {
     it('should set installed version for new users', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
 
-      expect(mockSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.InstalledVersion',
         '1.24.0'
       )
     })
 
     it('should not set installed version for existing users', async () => {
-      mockSettingStore.settingValues = { 'some.setting': 'value' }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark'
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
 
-      expect(mockSettingStore.set).not.toHaveBeenCalled()
+      expect(useSettingStore().set).not.toHaveBeenCalled()
     })
 
     it('should execute pending callbacks for new users', async () => {
@@ -314,11 +286,8 @@ describe('useNewUserService', () => {
       await service.registerInitCallback(mockCallback1)
       await service.registerInitCallback(mockCallback2)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -332,11 +301,10 @@ describe('useNewUserService', () => {
 
       await service.registerInitCallback(mockCallback)
 
-      mockSettingStore.settingValues = { 'some.setting': 'value' }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark'
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -350,11 +318,8 @@ describe('useNewUserService', () => {
 
       await service.registerInitCallback(mockCallback)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -367,26 +332,20 @@ describe('useNewUserService', () => {
     })
 
     it('should not reinitialize if already determined', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
-      expect(mockSettingStore.set).toHaveBeenCalledTimes(1)
+      expect(useSettingStore().set).toHaveBeenCalledTimes(1)
 
       await service.initializeIfNewUser()
-      expect(mockSettingStore.set).toHaveBeenCalledTimes(1)
+      expect(useSettingStore().set).toHaveBeenCalledTimes(1)
     })
 
     it('should correctly determine new user status', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       expect(service.isNewUser()).toBeNull()
@@ -395,7 +354,7 @@ describe('useNewUserService', () => {
 
       expect(service.isNewUser()).toBe(true)
 
-      expect(mockSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.InstalledVersion',
         expect.any(String)
       )
@@ -408,8 +367,8 @@ describe('useNewUserService', () => {
     })
 
     it('should return cached result after determination', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -420,11 +379,10 @@ describe('useNewUserService', () => {
 
   describe('edge cases', () => {
     it('should handle settingStore.get returning false as not completed', async () => {
-      mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': false }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return false
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.TutorialCompleted': false
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = false
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -436,11 +394,8 @@ describe('useNewUserService', () => {
       const mockCallback1 = vi.fn().mockResolvedValue(undefined)
       const mockCallback2 = vi.fn().mockResolvedValue(undefined)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -458,11 +413,8 @@ describe('useNewUserService', () => {
       const service1 = useNewUserService()
       const service2 = useNewUserService()
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service1.initializeIfNewUser()
@@ -481,11 +433,8 @@ describe('useNewUserService', () => {
       await service1.registerInitCallback(mockCallback1)
       await service2.registerInitCallback(mockCallback2)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service1.initializeIfNewUser()

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -1,3 +1,6 @@
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
 import type { Mock } from 'vitest'
@@ -18,52 +21,6 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
   }
 }))
 
-const mockWorkspaceAuthHeader = vi.fn().mockReturnValue(null)
-const mockGetWorkspaceToken = vi.fn().mockReturnValue(undefined)
-const mockEnsureWorkspaceAuthHeader = vi.fn()
-const mockEnsureWorkspaceToken = vi.fn()
-const mockClearWorkspaceContext = vi.fn()
-const mockMintAtLogin = vi.fn().mockResolvedValue(false)
-let mockUnifiedToken: string | null = null
-const mockResetForIdentityChange = vi.fn()
-const mockInitializeWorkspaces = vi.fn().mockResolvedValue(undefined)
-let mockActiveWorkspaceId: string | null = null
-let mockTeamWorkspaceInitState = 'ready'
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({
-      getWorkspaceAuthHeader: mockWorkspaceAuthHeader,
-      getWorkspaceToken: mockGetWorkspaceToken,
-      ensureWorkspaceAuthHeader: mockEnsureWorkspaceAuthHeader,
-      ensureWorkspaceToken: mockEnsureWorkspaceToken,
-      getUnifiedToken: () => mockUnifiedToken ?? undefined,
-      clearWorkspaceContext: mockClearWorkspaceContext,
-      mintAtLogin: mockMintAtLogin,
-      get unifiedToken() {
-        return mockUnifiedToken
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId
-      },
-      get initState() {
-        return mockTeamWorkspaceInitState
-      },
-      initialize: mockInitializeWorkspaces,
-      resetForIdentityChange: mockResetForIdentityChange
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: mockFeatureFlags
@@ -80,27 +37,8 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackAuth: vi.fn() })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: vi.fn() })
-}))
-
 vi.mock(import('@/services/dialogService'))
 vi.mock(import('@/platform/distribution/types'), () => mockDistributionTypes)
-
-const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
-const mockApiKeyState = { isAuthenticated: false }
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => ({
-    getAuthHeader: mockApiKeyGetAuthHeader,
-    getApiKey: vi.fn(),
-    currentUser: null,
-    get isAuthenticated() {
-      return mockApiKeyState.isAuthenticated
-    },
-    storeApiKey: vi.fn(),
-    clearStoredApiKey: vi.fn()
-  })
-}))
 
 type MockUser = Omit<User, 'getIdToken'> & { getIdToken: Mock }
 
@@ -119,23 +57,9 @@ describe('auth token priority chain', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
     mockFeatureFlags.unifiedCloudAuthEnabled = false
-    mockUnifiedToken = null
-    mockActiveWorkspaceId = null
-    mockTeamWorkspaceInitState = 'ready'
-    mockWorkspaceAuthHeader.mockReturnValue(null)
-    mockGetWorkspaceToken.mockReturnValue(undefined)
-    mockEnsureWorkspaceAuthHeader.mockResolvedValue(null)
-    mockEnsureWorkspaceToken.mockResolvedValue(null)
-    mockMintAtLogin.mockResolvedValue(false)
-    mockInitializeWorkspaces.mockResolvedValue(undefined)
-    mockApiKeyGetAuthHeader.mockReturnValue(null)
-    mockApiKeyState.isAuthenticated = false
-    mockUser.getIdToken.mockResolvedValue('firebase-token')
-
     vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(
       mockAuth as unknown as ReturnType<typeof vuefire.useFirebaseAuth>
     )
-
     vi.mocked(firebaseAuth.onAuthStateChanged).mockImplementation(
       (_, callback) => {
         authStateCallback = callback as (user: User | null) => void
@@ -143,15 +67,45 @@ describe('auth token priority chain', () => {
         return vi.fn()
       }
     )
-
     store = useAuthStore()
+    useWorkspaceAuthStore().unifiedToken = null
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
+    useTeamWorkspaceStore().initState = 'ready'
+    vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+      null
+    )
+    vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+      undefined
+    )
+    vi.mocked(
+      useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+    ).mockResolvedValue(null)
+    vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+      null
+    )
+    vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(false)
+    vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockImplementation(
+      () => {}
+    )
+    vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockImplementation(
+      () => useWorkspaceAuthStore().unifiedToken ?? undefined
+    )
+    vi.mocked(
+      useTeamWorkspaceStore().resetForIdentityChange
+    ).mockImplementation(() => {})
+    vi.mocked(useTeamWorkspaceStore().initialize).mockResolvedValue(undefined)
+    vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
+    Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+    mockUser.getIdToken.mockResolvedValue('firebase-token')
   })
 
   describe('getAuthHeader priority', () => {
     it('returns workspace auth header when workspace is active', async () => {
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
-      })
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        {
+          Authorization: 'Bearer workspace-token'
+        }
+      )
 
       const header = await store.getAuthHeader()
 
@@ -161,7 +115,9 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace is not active but user is authenticated', async () => {
-      mockWorkspaceAuthHeader.mockReturnValue(null)
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        null
+      )
 
       const header = await store.getAuthHeader()
 
@@ -172,9 +128,11 @@ describe('auth token priority chain', () => {
 
     it('ignores workspace auth header outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
-      })
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        {
+          Authorization: 'Bearer workspace-token'
+        }
+      )
 
       const header = await store.getAuthHeader()
 
@@ -185,20 +143,28 @@ describe('auth token priority chain', () => {
 
     it('keeps generic authentication user-scoped outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(
+        useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+      ).mockResolvedValue({
         Authorization: 'Bearer workspace-token'
       })
 
       const header = await store.getAuthHeader()
 
-      expect(mockEnsureWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceAuthHeader)
+      ).not.toHaveBeenCalled()
       expect(header).toEqual({ Authorization: 'Bearer firebase-token' })
     })
 
     it('returns API key when neither workspace nor Firebase are available', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-key'
+      })
 
       const header = await store.getAuthHeader()
 
@@ -216,7 +182,9 @@ describe('auth token priority chain', () => {
 
   describe('getAuthToken priority', () => {
     it('returns workspace token when workspace is active', async () => {
-      mockGetWorkspaceToken.mockReturnValue('workspace-raw-token')
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+        'workspace-raw-token'
+      )
 
       const token = await store.getAuthToken()
 
@@ -224,7 +192,9 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace token is not available', async () => {
-      mockGetWorkspaceToken.mockReturnValue(undefined)
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+        undefined
+      )
 
       const token = await store.getAuthToken()
 
@@ -233,12 +203,18 @@ describe('auth token priority chain', () => {
 
     it('keeps generic tokens user-scoped outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       const token = await store.getAuthToken()
 
-      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).not.toHaveBeenCalled()
       expect(token).toBe('firebase-token')
     })
   })
@@ -247,25 +223,39 @@ describe('auth token priority chain', () => {
     it('sends the stored API key for workspace calls in an API-key session', async () => {
       mockDistributionTypes.isCloud = false
       authStateCallback(null)
-      mockApiKeyState.isAuthenticated = true
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'comfyui-test' })
-      mockActiveWorkspaceId = 'workspace-123'
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'comfyui-test'
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
 
       await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
         'X-API-KEY': 'comfyui-test'
       })
-      expect(mockEnsureWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceAuthHeader)
+      ).not.toHaveBeenCalled()
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBeUndefined()
-      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).not.toHaveBeenCalled()
     })
 
     it('prefers the Firebase session over a stored API key for workspace calls', async () => {
       mockDistributionTypes.isCloud = false
-      mockApiKeyState.isAuthenticated = true
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'comfyui-test' })
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'comfyui-test'
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(
+        useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+      ).mockResolvedValue({
         Authorization: 'Bearer workspace-token'
       })
 
@@ -276,11 +266,17 @@ describe('auth token priority chain', () => {
 
     it('uses selected workspace authentication outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(
+        useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+      ).mockResolvedValue({
         Authorization: 'Bearer workspace-token'
       })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
         Authorization: 'Bearer workspace-token'
@@ -288,20 +284,28 @@ describe('auth token priority chain', () => {
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
       )
-      expect(mockEnsureWorkspaceAuthHeader).toHaveBeenCalledWith(
-        'workspace-123'
-      )
-      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceAuthHeader)
+      ).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).toHaveBeenCalledWith('workspace-123')
     })
 
     it('waits for workspace initialization before queue authentication', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'uninitialized'
-      mockInitializeWorkspaces.mockImplementation(async () => {
-        mockActiveWorkspaceId = 'workspace-123'
-        mockTeamWorkspaceInitState = 'ready'
-      })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      useTeamWorkspaceStore().initState = 'uninitialized'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-123'
+          })
+          useTeamWorkspaceStore().initState = 'ready'
+        }
+      )
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
         Authorization: 'Bearer firebase-token'
@@ -309,18 +313,28 @@ describe('auth token priority chain', () => {
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
       )
-      expect(mockInitializeWorkspaces).toHaveBeenCalledOnce()
-      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useTeamWorkspaceStore().initialize)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).toHaveBeenCalledWith('workspace-123')
     })
 
     it('waits for an in-flight workspace selection before queue authentication', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'loading'
-      mockInitializeWorkspaces.mockImplementation(async () => {
-        mockActiveWorkspaceId = 'workspace-123'
-        mockTeamWorkspaceInitState = 'ready'
-      })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      useTeamWorkspaceStore().initState = 'loading'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-123'
+          })
+          useTeamWorkspaceStore().initState = 'ready'
+        }
+      )
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
@@ -330,48 +344,66 @@ describe('auth token priority chain', () => {
 
     it('fails queue authentication closed after workspace initialization errors', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'uninitialized'
-      mockInitializeWorkspaces.mockRejectedValue(new Error('Network error'))
+      useTeamWorkspaceStore().initState = 'uninitialized'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockRejectedValue(
+        new Error('Network error')
+      )
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBeUndefined()
       expect(mockUser.getIdToken).not.toHaveBeenCalled()
-      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).not.toHaveBeenCalled()
     })
 
     it('retries queue authentication after a previous initialization error', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'error'
-      mockInitializeWorkspaces.mockImplementation(async () => {
-        mockActiveWorkspaceId = 'workspace-123'
-        mockTeamWorkspaceInitState = 'ready'
-      })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      useTeamWorkspaceStore().initState = 'error'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-123'
+          })
+          useTeamWorkspaceStore().initState = 'ready'
+        }
+      )
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
       )
-      expect(mockInitializeWorkspaces).toHaveBeenCalledOnce()
-      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useTeamWorkspaceStore().initialize)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).toHaveBeenCalledWith('workspace-123')
     })
   })
 
   describe('unified login mint wiring', () => {
     it('mints the unified Cloud JWT when a cloud user signs in', () => {
       // beforeEach signs in mockUser via the onAuthStateChanged callback.
-      expect(mockMintAtLogin).toHaveBeenCalled()
+      expect(vi.mocked(useWorkspaceAuthStore().mintAtLogin)).toHaveBeenCalled()
     })
 
     it('does not mint on sign-out', () => {
-      mockMintAtLogin.mockClear()
+      vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockClear()
       authStateCallback(null)
-      expect(mockMintAtLogin).not.toHaveBeenCalled()
-      expect(mockClearWorkspaceContext).toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().mintAtLogin)
+      ).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext)
+      ).toHaveBeenCalled()
     })
 
     it('clears account-scoped state before minting for a different user', () => {
-      mockClearWorkspaceContext.mockClear()
-      mockResetForIdentityChange.mockClear()
-      mockMintAtLogin.mockClear()
+      vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockClear()
+      vi.mocked(useTeamWorkspaceStore().resetForIdentityChange).mockClear()
+      vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockClear()
       const nextUser = {
         ...mockUser,
         uid: 'different-user-id',
@@ -380,22 +412,36 @@ describe('auth token priority chain', () => {
 
       authStateCallback(nextUser)
 
-      expect(mockClearWorkspaceContext).toHaveBeenCalledOnce()
-      expect(mockResetForIdentityChange).toHaveBeenCalledOnce()
-      expect(mockMintAtLogin).toHaveBeenCalledOnce()
       expect(
-        mockClearWorkspaceContext.mock.invocationCallOrder[0]
-      ).toBeLessThan(mockMintAtLogin.mock.invocationCallOrder[0])
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useTeamWorkspaceStore().resetForIdentityChange)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().mintAtLogin)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
+      ).toBeLessThan(
+        vi.mocked(useWorkspaceAuthStore().mintAtLogin).mock
+          .invocationCallOrder[0]
+      )
     })
 
     it('keeps account-scoped state for a repeated callback with the same uid', () => {
-      mockClearWorkspaceContext.mockClear()
-      mockResetForIdentityChange.mockClear()
+      vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockClear()
+      vi.mocked(useTeamWorkspaceStore().resetForIdentityChange).mockClear()
 
       authStateCallback({ ...mockUser })
 
-      expect(mockClearWorkspaceContext).not.toHaveBeenCalled()
-      expect(mockResetForIdentityChange).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext)
+      ).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useTeamWorkspaceStore().resetForIdentityChange)
+      ).not.toHaveBeenCalled()
     })
   })
 
@@ -405,35 +451,49 @@ describe('auth token priority chain', () => {
     })
 
     it('getAuthHeader returns only the unified Cloud JWT, never Firebase or API key', async () => {
-      mockUnifiedToken = 'unified-jwt'
+      useWorkspaceAuthStore().unifiedToken = 'unified-jwt'
       // Even with the legacy sources available, the unified branch wins.
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        {
+          Authorization: 'Bearer workspace-token'
+        }
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-key'
       })
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
 
       const header = await store.getAuthHeader()
 
       expect(header).toEqual({ Authorization: 'Bearer unified-jwt' })
-      expect(mockWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader)
+      ).not.toHaveBeenCalled()
       expect(mockUser.getIdToken).not.toHaveBeenCalled()
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
     })
 
     it('getAuthHeader returns null when the unified token is empty and does not fall back', async () => {
-      mockUnifiedToken = null
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
+      useWorkspaceAuthStore().unifiedToken = null
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-key'
+      })
 
       const header = await store.getAuthHeader()
 
       expect(header).toBeNull()
       expect(mockUser.getIdToken).not.toHaveBeenCalled()
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
     })
 
     it('getAuthToken returns the unified Cloud JWT, never the Firebase token', async () => {
-      mockUnifiedToken = 'unified-jwt'
-      mockGetWorkspaceToken.mockReturnValue('workspace-raw-token')
+      useWorkspaceAuthStore().unifiedToken = 'unified-jwt'
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+        'workspace-raw-token'
+      )
 
       const token = await store.getAuthToken()
 
@@ -442,7 +502,7 @@ describe('auth token priority chain', () => {
     })
 
     it('getAuthToken returns undefined when the unified token is empty and does not fall back', async () => {
-      mockUnifiedToken = null
+      useWorkspaceAuthStore().unifiedToken = null
 
       const token = await store.getAuthToken()
 

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -1,32 +1,12 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useDialogStore } from '@/stores/dialogStore'
+import { api } from '@/scripts/api'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
-
-const dialogStack = vi.hoisted(() => [] as unknown[])
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ dialogStack })
-}))
-
-const settings = vi.hoisted(() => {
-  const values = new Map<string, unknown>()
-  return {
-    values,
-    get: (key: string) => values.get(key),
-    set: vi.fn((key: string, value: unknown) => {
-      values.set(key, value)
-      return Promise.resolve()
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settings
-}))
 
 /**
  * Real nodes carry `pos`/`size`; `boundingRect` is litegraph-renderer cache that
@@ -64,10 +44,7 @@ function stubCanvas(nodes: unknown[], selected: unknown[] = []) {
 describe('agentNodeSelectionStore', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    dialogStack.length = 0
-    settings.values.clear()
-    settings.set.mockClear()
-    setActivePinia(createPinia())
+    vi.spyOn(api, 'storeSetting').mockResolvedValue(new Response())
   })
 
   afterEach(() => {
@@ -93,20 +70,20 @@ describe('agentNodeSelectionStore', () => {
   // Flipping the setting rather than overriding the minimap is what keeps the
   // user's own toggle working while they pick.
   it('turns a visible minimap off on entry and back on when leaving', async () => {
-    settings.values.set('Comfy.Minimap.Visible', true)
+    useSettingStore().settingValues['Comfy.Minimap.Visible'] = true
     const store = useAgentNodeSelectionStore()
 
     store.enter()
     await nextTick()
-    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(false)
+    expect(useSettingStore().get('Comfy.Minimap.Visible')).toBe(false)
 
     store.exit()
     await nextTick()
-    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(true)
+    expect(useSettingStore().get('Comfy.Minimap.Visible')).toBe(true)
   })
 
   it('leaves the minimap setting alone when it was already off', async () => {
-    settings.values.set('Comfy.Minimap.Visible', false)
+    useSettingStore().settingValues['Comfy.Minimap.Visible'] = false
     const store = useAgentNodeSelectionStore()
 
     store.enter()
@@ -114,8 +91,8 @@ describe('agentNodeSelectionStore', () => {
     store.exit()
     await nextTick()
 
-    expect(settings.set).not.toHaveBeenCalled()
-    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(false)
+    expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalled()
+    expect(useSettingStore().get('Comfy.Minimap.Visible')).toBe(false)
   })
 
   it('clears the canvas selection on exit', () => {
@@ -234,11 +211,12 @@ describe('agentNodeSelectionStore', () => {
     store.enter()
     await nextTick()
 
-    dialogStack.push({})
+    useDialogStore().showDialog({ key: 'test', component: {} })
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     expect(store.isActive).toBe(true)
 
-    dialogStack.length = 0
+    useDialogStore().dialogStack.length = 0
+    await nextTick()
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     expect(store.isActive).toBe(false)
   })

--- a/src/stores/apiKeyAuthStore.integration.test.ts
+++ b/src/stores/apiKeyAuthStore.integration.test.ts
@@ -1,7 +1,6 @@
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
-import { disposePinia, getActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
@@ -26,28 +25,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
     flags: { unifiedCloudAuthEnabled: false }
   })
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({
-      clearWorkspaceContext: vi.fn(),
-      getWorkspaceAuthHeader: vi.fn().mockReturnValue(null),
-      getUnifiedToken: vi.fn().mockReturnValue(undefined),
-      mintAtLogin: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      activeWorkspaceId: null,
-      resetForIdentityChange: vi.fn()
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackAuth: vi.fn() })
@@ -77,11 +54,6 @@ describe('API key authentication initialization', () => {
       }
     )
     vi.mocked(firebaseAuth.onIdTokenChanged).mockReturnValue(vi.fn())
-  })
-
-  afterEach(() => {
-    const pinia = getActivePinia()
-    if (pinia) disposePinia(pinia)
   })
 
   const customerResponse = (id: string) => ({

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -1,3 +1,6 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { api } from '@/scripts/api'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -60,36 +63,8 @@ vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
   resolveNode: mockResolveNode
 }))
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => ({ read_only: false })
-    })
-  })
-)
-
 vi.mock(import('@/components/builder/useEmptyWorkflowDialog'), () => ({
   useEmptyWorkflowDialog: () => mockEmptyWorkflowDialog
-}))
-
-const mockSettings = vi.hoisted(() => {
-  const store: Record<string, unknown> = {}
-  return {
-    store,
-    get: vi.fn((key: string) => store[key] ?? false),
-    set: vi.fn(async (key: string, value: unknown) => {
-      store[key] = value
-    }),
-    reset() {
-      for (const key of Object.keys(store)) delete store[key]
-    }
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => mockSettings
 }))
 
 import { useAppModeStore } from './appModeStore'
@@ -168,7 +143,10 @@ describe('appModeStore', () => {
     vi.mocked(app.rootGraph).extra = {}
     ChangeTracker.isLoadingGraph = false
     mockResolveNode.mockReturnValue(undefined)
-    mockSettings.reset()
+    vi.spyOn(api, 'storeSetting').mockResolvedValue(new Response())
+    vi.mocked(useCanvasStore().getCanvas).mockReturnValue(
+      fromPartial({ read_only: false })
+    )
     vi.mocked(app.rootGraph).nodes = [{ id: toNodeId(1) } as LGraphNode]
     workflowStore = useWorkflowStore()
     store = useAppModeStore()
@@ -928,34 +906,36 @@ describe('appModeStore', () => {
 
   describe('autoEnableVueNodes', () => {
     it('enables Vue nodes when entering select mode with them disabled', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
       await nextTick()
 
-      expect(mockSettings.set).toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         true
       )
     })
 
     it('does not enable Vue nodes when already enabled', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = true
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
       await nextTick()
 
-      expect(mockSettings.set).not.toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         expect.anything()
       )
     })
 
     it('shows popup when Vue nodes are switched on and not dismissed', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
-      mockSettings.store['Comfy.AppBuilder.VueNodeSwitchDismissed'] = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues[
+        'Comfy.AppBuilder.VueNodeSwitchDismissed'
+      ] = false
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
@@ -965,8 +945,10 @@ describe('appModeStore', () => {
     })
 
     it('does not show popup when previously dismissed', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
-      mockSettings.store['Comfy.AppBuilder.VueNodeSwitchDismissed'] = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues[
+        'Comfy.AppBuilder.VueNodeSwitchDismissed'
+      ] = true
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
@@ -976,14 +958,14 @@ describe('appModeStore', () => {
     })
 
     it('does not enable Vue nodes when entering builder:arrange', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       workflowStore.activeWorkflow = createBuilderWorkflowWithOutputs('app')
 
       store.enterBuilder()
       await nextTick()
 
       expect(workflowStore.activeWorkflow.activeMode).toBe('builder:arrange')
-      expect(mockSettings.set).not.toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         expect.anything()
       )

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -3,11 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, watch } from 'vue'
 
 import { useAssetsStore } from '@/stores/assetsStore'
+import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 import type {
   AssetItem,
   AssetResponse
 } from '@/platform/assets/schemas/assetSchema'
-import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { assetService } from '@/platform/assets/services/assetService'
 
 // Mock the api module
@@ -44,116 +44,29 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-// Mock modelToNodeStore with proper node providers and category lookups
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getAllNodeProviders: vi.fn((category: string) => {
-      const providers: Record<
-        string,
-        Array<{ nodeDef: { name: string }; key: string }>
-      > = {
-        checkpoints: [
-          { nodeDef: { name: 'CheckpointLoaderSimple' }, key: 'ckpt_name' },
-          { nodeDef: { name: 'ImageOnlyCheckpointLoader' }, key: 'ckpt_name' }
-        ],
-        loras: [
-          { nodeDef: { name: 'LoraLoader' }, key: 'lora_name' },
-          { nodeDef: { name: 'LoraLoaderModelOnly' }, key: 'lora_name' }
-        ],
-        vae: [{ nodeDef: { name: 'VAELoader' }, key: 'vae_name' }]
-      }
-      return providers[category] ?? []
-    }),
-    getCategoryForNodeType: vi.fn((nodeType: string) => {
-      const nodeToCategory: Record<string, string> = {
-        CheckpointLoaderSimple: 'checkpoints',
-        ImageOnlyCheckpointLoader: 'checkpoints',
-        LoraLoader: 'loras',
-        LoraLoaderModelOnly: 'loras',
-        VAELoader: 'vae'
-      }
-      return nodeToCategory[nodeType]
-    }),
-    getNodeProvider: vi.fn(),
-    registerDefaults: vi.fn()
-  })
-}))
-
-type MockOutput = {
-  supportsPreview: boolean
-  filename: string
-  subfolder: string
-  type: string
-  url: string
-}
-
-// Per-test override for mock outputs (defaults to single output)
-const mockOutputOverrides = vi.hoisted(() => ({
-  value: null as MockOutput[] | null
-}))
-
-// Mock TaskItemImpl
-const PREVIEWABLE_MEDIA_TYPES = new Set(['images', 'video', 'audio'])
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  TaskItemImpl: class {
-    public flatOutputs: Array<{
-      supportsPreview: boolean
-      filename: string
-      subfolder: string
-      type: string
-      url: string
-    }>
-    public previewOutput:
-      | {
-          supportsPreview: boolean
-          filename: string
-          subfolder: string
-          type: string
-          url: string
-        }
-      | undefined
-    public jobId: string
-    public outputsCount: number | null
-    public previewableOutputsCount: number | undefined
-
-    constructor(public job: JobListItem) {
-      this.jobId = job.id
-      this.outputsCount = job.outputs_count ?? null
-      this.previewableOutputsCount = job.previewable_outputs_count ?? undefined
-      if (mockOutputOverrides.value) {
-        this.flatOutputs = mockOutputOverrides.value
-        const previewable = mockOutputOverrides.value.filter(
-          (o) => o.supportsPreview
-        )
-        this.previewOutput =
-          previewable.findLast((o) => o.type === 'output') ?? previewable.at(-1)
-      } else {
-        const preview = job.preview_output
-        const isPreviewable =
-          !!preview?.filename && PREVIEWABLE_MEDIA_TYPES.has(preview.mediaType)
-        if (preview && isPreviewable) {
-          const item = {
-            supportsPreview: true,
-            filename: preview.filename!,
-            subfolder: preview.subfolder ?? '',
-            type: preview.type ?? 'output',
-            url: `http://test.com/${preview.filename}`
-          }
-          this.flatOutputs = [item]
-          this.previewOutput = item
-        } else {
-          this.flatOutputs = []
-          this.previewOutput = undefined
-        }
-      }
-    }
-
-    get previewableOutputs() {
-      return this.flatOutputs.filter((o) => o.supportsPreview)
-    }
-  }
-}))
+beforeEach(() => {
+  useNodeDefStore().nodeDefsByName = Object.fromEntries(
+    [
+      'CheckpointLoaderSimple',
+      'ImageOnlyCheckpointLoader',
+      'LoraLoader',
+      'LoraLoaderModelOnly',
+      'VAELoader'
+    ].map((name) => [
+      name,
+      new ComfyNodeDefImpl({
+        name,
+        display_name: name,
+        description: '',
+        input: {},
+        output: [],
+        category: 'loaders',
+        python_module: 'nodes',
+        output_node: false
+      })
+    ])
+  )
+})
 
 // Mock asset mappers - add unique timestamps
 vi.mock<unknown>(

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1,3 +1,5 @@
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { FirebaseError } from 'firebase/app'
 import type { User, UserCredential } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
@@ -40,18 +42,6 @@ const { mockFeatureFlags } = vi.hoisted(() => ({
 const { mockResetSocket } = vi.hoisted(() => ({
   mockResetSocket: vi.fn()
 }))
-
-const mockTeamWorkspaceStore = vi.hoisted(() => ({
-  activeWorkspaceId: null as string | null,
-  resetForIdentityChange: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => mockTeamWorkspaceStore
-  })
-)
 
 type MockUser = Omit<User, 'getIdToken' | 'delete'> & {
   getIdToken: Mock
@@ -132,18 +122,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
 }))
 
 // Mock apiKeyAuthStore
-const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
-const mockApiKeyGetApiKey = vi.fn()
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => ({
-    getAuthHeader: mockApiKeyGetAuthHeader,
-    getApiKey: mockApiKeyGetApiKey,
-    currentUser: null,
-    isAuthenticated: false,
-    storeApiKey: vi.fn(),
-    clearStoredApiKey: vi.fn()
-  })
-}))
 
 describe('useAuthStore', () => {
   let store: ReturnType<typeof useAuthStore>
@@ -217,10 +195,11 @@ describe('useAuthStore', () => {
     mockUser.getIdToken.mockResolvedValue('mock-id-token')
 
     // Default: no API key auth
-    mockApiKeyGetAuthHeader.mockReturnValue(null)
-    mockApiKeyGetApiKey.mockReturnValue(null)
-    mockTeamWorkspaceStore.activeWorkspaceId = null
-    mockTeamWorkspaceStore.resetForIdentityChange.mockReset()
+    vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
+    vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(null)
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: null
+    })
   })
 
   describe('token refresh events', () => {
@@ -333,8 +312,10 @@ describe('useAuthStore', () => {
   describe('user-scoped billing endpoints with API-key sessions', () => {
     beforeEach(() => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
-      mockApiKeyGetApiKey.mockReturnValue('test-api-key')
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-api-key'
+      })
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue('test-api-key')
     })
 
     it('fetchBalance sends the stored API key when no Firebase user exists', async () => {
@@ -350,7 +331,7 @@ describe('useAuthStore', () => {
     })
 
     it('fetchBalance throws userNotAuthenticated when neither credential exists', async () => {
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.fetchBalance()).rejects.toMatchObject({
         name: 'AuthStoreError',
@@ -368,7 +349,9 @@ describe('useAuthStore', () => {
       )
 
       const request = store.fetchBalance()
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
       resolveBalance({ ok: true, json: () => Promise.resolve({ balance: 7 }) })
 
       await expect(request).resolves.toBeNull()
@@ -388,7 +371,9 @@ describe('useAuthStore', () => {
           })
         })
       )
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
     })
 
     it('initiateCreditPurchase sends the stored API key when no Firebase user exists', async () => {
@@ -439,7 +424,7 @@ describe('useAuthStore', () => {
     })
 
     it('accessBillingPortal throws userNotAuthenticated when neither credential exists', async () => {
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.accessBillingPortal()).rejects.toMatchObject({
         name: 'AuthStoreError',
@@ -466,8 +451,10 @@ describe('useAuthStore', () => {
       const payload = { amount_micros: 5_000_000, currency: 'usd' }
 
       await store.initiateCreditPurchase(payload)
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       await store.initiateCreditPurchase(payload)
@@ -505,8 +492,10 @@ describe('useAuthStore', () => {
 
       const request = store.accessBillingPortal()
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreate(mockCreateCustomerResponse)
@@ -533,8 +522,10 @@ describe('useAuthStore', () => {
         currency: 'usd'
       })
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreate(mockCreateCustomerResponse)
@@ -565,8 +556,10 @@ describe('useAuthStore', () => {
 
       const request = store.accessBillingPortal()
       await billingRequestStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveBilling({
@@ -603,8 +596,10 @@ describe('useAuthStore', () => {
         currency: 'usd'
       })
       await creditRequestStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCredit({
@@ -635,8 +630,10 @@ describe('useAuthStore', () => {
 
       const request = store.createCustomer()
       await createRequestStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreate(mockCreateCustomerResponse)
@@ -669,8 +666,10 @@ describe('useAuthStore', () => {
 
       const request = store.accessBillingPortal()
       await bodyParsingStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolvePortalBody({ billing_portal_url: 'https://stripe.test/portal' })
@@ -708,8 +707,10 @@ describe('useAuthStore', () => {
         currency: 'usd'
       })
       await bodyParsingStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreditBody({ checkout_url: 'https://stripe.test/checkout' })
@@ -732,8 +733,10 @@ describe('useAuthStore', () => {
     }
 
     const switchToAnotherApiKey = () => {
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
     }
@@ -1184,7 +1187,9 @@ describe('useAuthStore', () => {
 
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       const ensureSpy = vi
         .spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader')
@@ -1199,7 +1204,9 @@ describe('useAuthStore', () => {
 
     it('fails closed (no personal Firebase downgrade) when recovery yields no token', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       vi.spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader').mockResolvedValue(
         null
@@ -1213,7 +1220,9 @@ describe('useAuthStore', () => {
 
     it('falls back to Firebase when workspace mode is not yet initialized', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = null
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: null
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       const ensureSpy = vi.spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader')
 
@@ -1227,7 +1236,9 @@ describe('useAuthStore', () => {
   describe('getAuthToken workspace recovery', () => {
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       const ensureSpy = vi
         .spyOn(workspaceAuth, 'ensureWorkspaceToken')
         .mockResolvedValue('recovered-ws-token')
@@ -1241,7 +1252,9 @@ describe('useAuthStore', () => {
 
     it('fails closed (no personal Firebase downgrade) when recovery yields no token', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       vi.spyOn(workspaceAuth, 'ensureWorkspaceToken').mockResolvedValue(null)
 
       const token = await store.getAuthToken()
@@ -1252,7 +1265,9 @@ describe('useAuthStore', () => {
 
     it('falls back to Firebase when workspace mode is not yet initialized', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = null
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: null
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceToken').mockReturnValue(undefined)
       const ensureSpy = vi.spyOn(workspaceAuth, 'ensureWorkspaceToken')
 
@@ -1619,7 +1634,7 @@ describe('useAuthStore', () => {
 
     it('throws AuthStoreError when not authenticated', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.getAuthHeaderOrThrow()).rejects.toMatchObject({
         name: 'AuthStoreError',
@@ -1662,7 +1677,9 @@ describe('useAuthStore', () => {
 
     it('should use API key auth when no Firebase user is present', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-api-key'
+      })
 
       const result = await store.createCustomer()
 
@@ -1695,16 +1712,20 @@ describe('useAuthStore', () => {
 
     it('should not fall back to API key when Firebase token retrieval fails', async () => {
       mockUser.getIdToken.mockResolvedValue(undefined)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-api-key'
+      })
 
       await expect(store.createCustomer()).rejects.toThrow()
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('should throw when no auth method is available', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.createCustomer()).rejects.toThrow()
       expect(mockFetch).not.toHaveBeenCalled()

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,7 +1,9 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useUserStore } from '@/stores/userStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { AxiosResponse } from 'axios'
 import { AxiosError } from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import { mergeCustomNodesI18n } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -10,59 +12,21 @@ import { api } from '@/scripts/api'
 
 import { useBootstrapStore } from './bootstrapStore'
 
-vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: {
+vi.mock(import('firebase/auth'))
+vi.mock(import('@/scripts/api'), async (importOriginal) => {
+  const actual = await importOriginal()
+  Object.assign(actual.api, {
     init: vi.fn().mockResolvedValue(undefined),
     getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
     getUserConfig: vi.fn().mockResolvedValue({})
-  }
-}))
-
-vi.mock(import('@/i18n'), () => ({
-  mergeCustomNodesI18n: vi.fn()
-}))
-
-const mockIsSettingsReady = ref(false)
-const mockSettingLoad = vi.hoisted(() => vi.fn(() => Promise.resolve()))
-const mockWorkflowLoad = vi.hoisted(() => vi.fn(() => Promise.resolve()))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    load: mockSettingLoad,
-    get isReady() {
-      return mockIsSettingsReady.value
-    },
-    isLoading: ref(false),
-    error: ref(undefined)
-  }))
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      loadWorkflows: mockWorkflowLoad,
-      syncWorkflows: vi.fn().mockResolvedValue(undefined)
-    }))
   })
-)
+  return actual
+})
 
-const mockNeedsLogin = ref(false)
-vi.mock<unknown>(import('@/stores/userStore'), () => ({
-  useUserStore: vi.fn(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin
-  }))
-}))
-
-const mockIsAuthInitialized = ref(false)
-const mockIsAuthAuthenticated = ref(false)
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated
-  }))
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  mergeCustomNodesI18n: vi.fn()
 }))
 
 const mockDistributionTypes = vi.hoisted(() => ({
@@ -87,16 +51,18 @@ function requestFailure(status: number) {
 
 describe('bootstrapStore', () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false
-    mockIsAuthInitialized.value = false
-    mockIsAuthAuthenticated.value = false
-    mockNeedsLogin.value = false
+    useSettingStore().isReady = false
+    useAuthStore().isInitialized = false
+    Object.assign(useAuthStore(), { isAuthenticated: false })
+    Object.assign(useUserStore(), { needsLogin: false })
     mockDistributionTypes.isCloud = false
-    mockSettingLoad.mockImplementation(() => {
-      mockIsSettingsReady.value = true
+    vi.mocked(useSettingStore().load).mockImplementation(() => {
+      useSettingStore().isReady = true
       return Promise.resolve()
     })
-    mockWorkflowLoad.mockResolvedValue(undefined)
+    vi.mocked(useWorkflowStore().loadWorkflows).mockResolvedValue(undefined)
+    vi.mocked(useWorkflowStore().syncWorkflows).mockResolvedValue(undefined)
+    vi.mocked(useUserStore().initialize).mockResolvedValue(undefined)
   })
 
   it('initializes with all flags false', () => {
@@ -118,8 +84,12 @@ describe('bootstrapStore', () => {
   })
 
   it('records both store phases when their loads reject', async () => {
-    mockSettingLoad.mockRejectedValueOnce(new Error('settings failed'))
-    mockWorkflowLoad.mockRejectedValueOnce(new Error('workflows failed'))
+    vi.mocked(useSettingStore().load).mockRejectedValueOnce(
+      new Error('settings failed')
+    )
+    vi.mocked(useWorkflowStore().loadWorkflows).mockRejectedValueOnce(
+      new Error('workflows failed')
+    )
     const milestone = vi.spyOn(bootstrapTracer, 'milestone')
     const previousPhaseCount = bootstrapTracer.summary().length
     const store = useBootstrapStore()
@@ -182,7 +152,7 @@ describe('bootstrapStore', () => {
       // Firebase resolves with no user (signed-out) — bootstrap must unblock.
       // Previously it also waited for isAuthenticated, which made every
       // signed-out load wait 35s and fire a false Sentry timeout.
-      mockIsAuthInitialized.value = true
+      useAuthStore().isInitialized = true
       await bootstrapPromise
 
       await vi.waitFor(() => {
@@ -203,7 +173,7 @@ describe('bootstrapStore', () => {
         expect(settingStore.isReady).toBe(false)
 
         // Firebase resolves during the retry backoff.
-        mockIsAuthInitialized.value = true
+        useAuthStore().isInitialized = true
         await vi.advanceTimersByTimeAsync(3_001)
         await bootstrapPromise
 

--- a/src/stores/commandStore.test.ts
+++ b/src/stores/commandStore.test.ts
@@ -17,12 +17,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/keybindings/keybindingStore'), () => ({
-  useKeybindingStore: () => ({
-    getKeybindingByCommandId: () => null
-  })
-}))
-
 describe('commandStore', () => {
   describe('registerCommand', () => {
     it('registers a command by id', () => {

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -1,6 +1,5 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromAny } from '@total-typescript/shoehorn'
-import { createTestingPinia } from '@pinia/testing'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
@@ -24,14 +23,6 @@ vi.mock(import('@/i18n'), () => ({
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
-}))
-
-const mockShowErrorsTab = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => mockShowErrorsTab.value)
-  }))
 }))
 
 vi.mock<unknown>(
@@ -624,7 +615,7 @@ describe('executionErrorStore — node error operations', () => {
 
 describe('surfaceMissingModels — silent option', () => {
   beforeEach(() => {
-    mockShowErrorsTab.value = true
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] = true
   })
 
   it('opens error overlay when silent is not specified and setting is enabled', () => {
@@ -691,7 +682,7 @@ describe('surfaceMissingModels — silent option', () => {
 
 describe('surfaceMissingMedia — silent option', () => {
   beforeEach(() => {
-    mockShowErrorsTab.value = true
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] = true
   })
 
   it('opens error overlay when silent is not specified and setting is enabled', () => {
@@ -821,8 +812,6 @@ describe('clearRunErrors', () => {
   let missingNodesStore: ReturnType<typeof useMissingNodesErrorStore>
 
   beforeEach(() => {
-    const pinia = createPinia()
-    setActivePinia(pinia)
     executionErrorStore = useExecutionErrorStore()
     missingNodesStore = useMissingNodesErrorStore()
   })
@@ -874,10 +863,6 @@ describe('clearRunErrors', () => {
 })
 
 describe('added-node error scan coordination', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('keeps overlapping scans isolated by graph until every scan finishes', () => {
     const store = useExecutionErrorStore()
     const graphA = createTestRootGraph()
@@ -914,10 +899,6 @@ describe('setActiveGraph', () => {
       'KSampler'
     )
   }
-
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
 
   it('keeps each graph run errors separate and restores them on return', () => {
     const store = useExecutionErrorStore()

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1,3 +1,6 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -6,30 +9,22 @@ import { api } from '@/scripts/api'
 import { MAX_PROGRESS_JOBS, useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
-import { createNodeLocatorId } from '@/types/nodeIdentification'
+import {
+  createNodeExecutionId,
+  createNodeLocatorId
+} from '@/types/nodeIdentification'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { NodeProgressState } from '@/schemas/apiSchema'
 
 const {
-  mockNodeIdToNodeLocatorId,
-  mockNodeLocatorIdToNodeExecutionId,
-  mockExecutionIdToCurrentId,
-  mockActiveWorkflow,
-  mockOpenWorkflows,
   mockShowTextPreview,
   mockTrackExecutionError,
   mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
   mockTrackSharedWorkflowRun
 } = await vi.hoisted(async () => {
-  const { shallowRef } = await import('vue')
   return {
-    mockNodeIdToNodeLocatorId: vi.fn(),
-    mockNodeLocatorIdToNodeExecutionId: vi.fn(),
-    mockExecutionIdToCurrentId: vi.fn(),
-    mockActiveWorkflow: shallowRef<{ path?: string } | null>(null),
-    mockOpenWorkflows: shallowRef<{ path: string }[]>([]),
     mockShowTextPreview: vi.fn(),
     mockTrackExecutionError: vi.fn(),
     mockTrackExecutionOutcome: vi.fn(),
@@ -57,25 +52,6 @@ beforeEach(() => {
 })
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { toNodeId } from '@/types/nodeId'
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      nodeIdToNodeLocatorId: mockNodeIdToNodeLocatorId,
-      nodeLocatorIdToNodeExecutionId: mockNodeLocatorIdToNodeExecutionId,
-      executionIdToCurrentId: mockExecutionIdToCurrentId,
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      },
-      get openWorkflows() {
-        return mockOpenWorkflows.value
-      },
-      isOpen: (workflow: { path?: string }) =>
-        mockOpenWorkflows.value.some((w) => w.path === workflow.path)
-    }))
-  })
-)
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: true
@@ -126,18 +102,6 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    revokePreviewsByExecutionId: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/jobPreviewStore'), () => ({
-  useJobPreviewStore: () => ({
-    clearPreview: vi.fn()
-  })
-}))
-
 // Mock the app import with proper implementation
 vi.mock<unknown>(import('@/scripts/app'), () => {
   const rootGraph = {
@@ -155,18 +119,19 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
 })
 
 beforeEach(() => {
-  mockActiveWorkflow.value = null
-  mockOpenWorkflows.value = []
+  useWorkflowStore().activeWorkflow = null
+  Object.assign(useWorkflowStore(), { openWorkflows: [] })
+  vi.mocked(useWorkflowStore().isOpen).mockImplementation((workflow) =>
+    useWorkflowStore().openWorkflows.some((open) => open.path === workflow.path)
+  )
 })
 
 function createQueuedWorkflow(path: string = 'workflows/test.json') {
-  return {
+  return fromPartial<LoadedComfyWorkflow>({
     activeState: { id: 'workflow-id' },
     initialState: { id: 'workflow-id' },
     path
-  } as Parameters<
-    ReturnType<typeof useExecutionStore>['storeJob']
-  >[0]['workflow']
+  })
 }
 
 function createPromptNode(title: string, classType: string) {
@@ -244,12 +209,19 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
         'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         toNodeId(456)
       )
-      const mockExecutionId = '123:456'
-      mockNodeLocatorIdToNodeExecutionId.mockReturnValue(mockExecutionId)
+      const mockExecutionId = createNodeExecutionId([
+        toNodeId(123),
+        toNodeId(456)
+      ])
+      vi.mocked(
+        useWorkflowStore().nodeLocatorIdToNodeExecutionId
+      ).mockReturnValue(mockExecutionId)
 
       const result = store.nodeLocatorIdToExecutionId(locatorId)
 
-      expect(mockNodeLocatorIdToNodeExecutionId).toHaveBeenCalledWith(locatorId)
+      expect(
+        vi.mocked(useWorkflowStore().nodeLocatorIdToNodeExecutionId)
+      ).toHaveBeenCalledWith(locatorId)
       expect(result).toBe(mockExecutionId)
     })
 
@@ -258,7 +230,9 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
         'unknown-subgraph-id',
         toNodeId(456)
       )
-      mockNodeLocatorIdToNodeExecutionId.mockReturnValue(null)
+      vi.mocked(
+        useWorkflowStore().nodeLocatorIdToNodeExecutionId
+      ).mockReturnValue(null)
 
       const result = store.nodeLocatorIdToExecutionId(locatorId)
 
@@ -619,7 +593,7 @@ describe('useExecutionStore - workflowStatus', () => {
 
   beforeEach(() => {
     apiEventHandlers.clear()
-    mockOpenWorkflows.value = [workflowA, workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowA, workflowB] })
     store = useExecutionStore()
     store.bindExecutionEvents()
   })
@@ -881,7 +855,7 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionSuccess('job-a')
     fireExecutionSuccess('job-b')
 
-    mockOpenWorkflows.value = [workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowB] })
     await nextTick()
 
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
@@ -894,7 +868,7 @@ describe('useExecutionStore - workflowStatus', () => {
     expect(store.getWorkflowStatus(workflowA)).toBe('running')
 
     // Close the tab while the job is still running.
-    mockOpenWorkflows.value = [workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowB] })
     await nextTick()
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
 
@@ -1072,7 +1046,7 @@ describe('useExecutionStore - background workflow error routing', () => {
 
   beforeEach(() => {
     apiEventHandlers.clear()
-    mockOpenWorkflows.value = [workflowA, workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowA, workflowB] })
     store = useExecutionStore()
     errorStore = useExecutionErrorStore()
     store.bindExecutionEvents()
@@ -1213,7 +1187,9 @@ describe('useExecutionStore - background workflow error routing', () => {
 
   it('buffers a mapped job with an ambiguous path until storeJob', () => {
     const duplicateWorkflow = makeWorkflow('/workflows/c.json', graphBId)
-    mockOpenWorkflows.value = [workflowA, workflowB, duplicateWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [workflowA, workflowB, duplicateWorkflow]
+    })
     store.registerJobWorkflowIdMapping('job-ambiguous', graphBId)
 
     fireExecutionError('job-ambiguous')
@@ -1334,13 +1310,17 @@ describe('useExecutionStore - progress_text startup guard', () => {
     useCanvasStore().canvas = {
       graph: { getNodeById: vi.fn() }
     } as unknown as LGraphCanvas
-    mockExecutionIdToCurrentId.mockReturnValue(undefined)
+    vi.mocked(useWorkflowStore().executionIdToCurrentId).mockReturnValue(
+      undefined
+    )
 
     expect(() =>
       fireProgressText({ nodeId: toNodeId('1:2'), text: 'warming up' })
     ).not.toThrow()
 
-    expect(mockExecutionIdToCurrentId).toHaveBeenCalledWith('1:2')
+    expect(
+      vi.mocked(useWorkflowStore().executionIdToCurrentId)
+    ).toHaveBeenCalledWith('1:2')
     expect(mockShowTextPreview).not.toHaveBeenCalled()
   })
 })
@@ -2267,10 +2247,10 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
   function storeVisibleJob(jobId: string) {
     const workflow = createQueuedWorkflow()
-    mockActiveWorkflow.value = workflow
-    mockOpenWorkflows.value = [workflow]
+    useWorkflowStore().activeWorkflow = workflow
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflow] })
     useExecutionErrorStore().setActiveGraph(
-      workflow.activeState!.id!,
+      workflow.activeState.id!,
       workflow.path
     )
     store.storeJob({

--- a/src/stores/jobPreviewStore.test.ts
+++ b/src/stores/jobPreviewStore.test.ts
@@ -1,19 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useJobPreviewStore } from '@/stores/jobPreviewStore'
 import { releaseSharedObjectUrl } from '@/utils/objectUrlUtil'
-
-const previewMethodRef = ref('latent2rgb')
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => {
-      if (key === 'Comfy.Execution.PreviewMethod') return previewMethodRef.value
-      return undefined
-    }
-  })
-}))
 
 vi.mock(import('@/utils/objectUrlUtil'), () => ({
   retainSharedObjectUrl: vi.fn(),
@@ -22,7 +11,8 @@ vi.mock(import('@/utils/objectUrlUtil'), () => ({
 
 describe('jobPreviewStore', () => {
   beforeEach(() => {
-    previewMethodRef.value = 'latent2rgb'
+    useSettingStore().settingValues['Comfy.Execution.PreviewMethod'] =
+      'latent2rgb'
   })
 
   it('stores preview with nodeId', () => {
@@ -89,7 +79,7 @@ describe('jobPreviewStore', () => {
   })
 
   it('ignores setPreviewUrl when previews are disabled', () => {
-    previewMethodRef.value = 'none'
+    useSettingStore().settingValues['Comfy.Execution.PreviewMethod'] = 'none'
     const store = useJobPreviewStore()
 
     store.setPreviewUrl('p1', 'blob:a', 'node-1')

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -3,15 +3,14 @@ import { nextTick } from 'vue'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
-
-const mockRemoveNodeOutputs = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({ removeNodeOutputs: mockRemoveNodeOutputs })
-}))
 
 const mockApp = vi.hoisted(() => ({
   isGraphReady: true,
+  nodePreviewImages: {},
+  nodeOutputs: {},
   rootGraph: { nodes: [], _nodes: [] } as unknown as LGraph
 }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({ app: mockApp }))
@@ -33,10 +32,6 @@ vi.mock(import('@/i18n'), () => ({
 
 vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: false }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({ get: vi.fn(() => false) }))
-}))
-
 vi.mock<unknown>(
   import('@/platform/missingModel/composables/useMissingModelInteractions'),
   () => ({ clearMissingModelState: vi.fn() })
@@ -57,6 +52,8 @@ describe('FE-230 regression — workflow-load missing-media flagging must not wi
   beforeEach(() => {
     mockApp.isGraphReady = true
     mockApp.rootGraph = { nodes: [], _nodes: [] } as unknown as LGraph
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] =
+      false
   })
 
   it('does not clear node.imgs when verification flags a Load Image as missing on workflow load (e.g. mask-editor saved value)', async () => {
@@ -80,6 +77,6 @@ describe('FE-230 regression — workflow-load missing-media flagging must not wi
     await nextTick()
 
     expect(node.imgs).toEqual([{ src: 'blob:mask-edited' }])
-    expect(mockRemoveNodeOutputs).not.toHaveBeenCalled()
+    expect(useNodeOutputStore().removeNodeOutputs).not.toHaveBeenCalled()
   })
 })

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -48,24 +48,8 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   }
 }))
 
-// Mock the settingStore
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn()
-}))
-
 function enableMocks(useAssetAPI = false) {
-  // Mock settingStore to return the useAssetAPI setting
-  const mockSettingStore = {
-    get: vi.fn().mockImplementation((key: string) => {
-      if (key === 'Comfy.Assets.UseAssetAPI') {
-        return useAssetAPI
-      }
-      return false
-    })
-  }
-  vi.mocked(useSettingStore, { partial: true }).mockReturnValue(
-    mockSettingStore
-  )
+  useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = useAssetAPI
 
   // Mock experimental API - returns objects with name and folders properties
   vi.mocked(api.getModels).mockResolvedValue([

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   ModelNodeProvider,
@@ -76,13 +74,11 @@ const mockNodeDefsByName = Object.fromEntries(
   MOCK_NODE_NAMES.map((name) => [name, createMockNodeDef(name)])
 )
 
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: vi.fn(() => ({
-    nodeDefsByName: mockNodeDefsByName
-  }))
-}))
-
 describe('useModelToNodeStore', () => {
+  beforeEach(() => {
+    useNodeDefStore().nodeDefsByName = mockNodeDefsByName
+  })
+
   describe('modelToNodeMap', () => {
     it('should initialize as empty', () => {
       const modelToNodeStore = useModelToNodeStore()
@@ -468,18 +464,10 @@ describe('useModelToNodeStore', () => {
     })
 
     it('should not register when nodeDefStore is empty', () => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: {}
-      })
+      useNodeDefStore().nodeDefsByName = {}
       const modelToNodeStore = useModelToNodeStore()
       modelToNodeStore.registerDefaults()
       expect(modelToNodeStore.getNodeProvider('checkpoints')).toBeUndefined()
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: mockNodeDefsByName
-      })
     })
   })
 
@@ -491,19 +479,11 @@ describe('useModelToNodeStore', () => {
     })
 
     it('should return empty Record when nodeDefStore is empty', () => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: {}
-      })
+      useNodeDefStore().nodeDefsByName = {}
       const modelToNodeStore = useModelToNodeStore()
 
       const result = modelToNodeStore.getRegisteredNodeTypes()
       expect(result).toStrictEqual({})
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: mockNodeDefsByName
-      })
     })
 
     it('should contain node types to resolve widget name', () => {

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -53,16 +53,6 @@ vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   executionIdToNodeLocatorId: vi.fn((_rootGraph: unknown, id: string) => id)
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
-      nodeToNodeLocatorId: vi.fn((node: { id: number }) => String(node.id))
-    }))
-  })
-)
-
 describe('nodeOutputStore setNodeOutputsByExecutionId with merge', () => {
   beforeEach(() => {
     app.nodeOutputs = {}

--- a/src/stores/nodeOutputStore.workflowSwitch.test.ts
+++ b/src/stores/nodeOutputStore.workflowSwitch.test.ts
@@ -1,4 +1,5 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -9,15 +10,6 @@ import { toNodeId } from '@/types/nodeId'
 const { WORKFLOW_A, WORKFLOW_B } = vi.hoisted(() => ({
   WORKFLOW_A: 'workflows/a.json',
   WORKFLOW_B: 'workflows/b.json'
-}))
-
-const mocks = vi.hoisted(() => ({
-  workflowStore: null as unknown as {
-    activeWorkflow: { path: string } | null
-    openWorkflows: { path: string }[]
-    nodeIdToNodeLocatorId: (id: string | number) => string
-    nodeToNodeLocatorId: (node: { id: string | number }) => string
-  }
 }))
 
 vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
@@ -40,20 +32,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mocks.workflowStore = reactive({
-      activeWorkflow: { path: WORKFLOW_A },
-      openWorkflows: [{ path: WORKFLOW_A }, { path: WORKFLOW_B }],
-      nodeIdToNodeLocatorId: (id: string | number) => String(id),
-      nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
-    })
-    return { useWorkflowStore: () => mocks.workflowStore }
-  }
-)
-
 const createMockNode = (id: number): LGraphNode =>
   fromAny<LGraphNode, unknown>({ id: toNodeId(id), type: 'KSampler' })
 
@@ -64,10 +42,10 @@ const createMockNode = (id: number): LGraphNode =>
  */
 function switchToWorkflow(path: string) {
   const store = useNodeOutputStore()
-  const leaving = mocks.workflowStore.activeWorkflow
+  const leaving = useWorkflowStore().activeWorkflow
   if (leaving) store.stashPreviewsForWorkflow(leaving.path)
   store.resetAllOutputsAndPreviews()
-  mocks.workflowStore.activeWorkflow = { path }
+  useWorkflowStore().activeWorkflow = fromPartial({ path })
   store.restorePreviewsForWorkflow(path)
 }
 
@@ -89,11 +67,10 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
       .mockImplementation(() => {})
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
-    mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
-    mocks.workflowStore.openWorkflows = [
-      { path: WORKFLOW_A },
-      { path: WORKFLOW_B }
-    ]
+    useWorkflowStore().activeWorkflow = fromPartial({ path: WORKFLOW_A })
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [{ path: WORKFLOW_A }, { path: WORKFLOW_B }]
+    })
   })
 
   it('keeps a finished run preview when the user switches tabs and comes back', () => {
@@ -157,7 +134,7 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     store.setNodePreviewsByNodeId(createMockNode(5).id, [previewUrl])
     switchToWorkflow(WORKFLOW_B)
 
-    mocks.workflowStore.openWorkflows = [{ path: WORKFLOW_B }]
+    Object.assign(useWorkflowStore(), { openWorkflows: [{ path: WORKFLOW_B }] })
     switchToWorkflow(WORKFLOW_B)
 
     expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
@@ -175,7 +152,7 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     // Back to A: a frame lands between app.clean() and afterLoadNewGraph().
     store.stashPreviewsForWorkflow(WORKFLOW_B)
     store.resetAllOutputsAndPreviews()
-    mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
+    useWorkflowStore().activeWorkflow = fromPartial({ path: WORKFLOW_A })
     store.setNodePreviewsByNodeId(node.id, [arrivedUrl])
     store.restorePreviewsForWorkflow(WORKFLOW_A)
 

--- a/src/stores/queueStore.loadWorkflow.test.ts
+++ b/src/stores/queueStore.loadWorkflow.test.ts
@@ -16,10 +16,6 @@ vi.mock<unknown>(import('@/services/extensionService'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: vi.fn(() => ({}))
-}))
-
 vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 const mockWorkflow: ComfyWorkflowJSON = {

--- a/src/stores/subgraphNavigationStore.navigateToHash.test.ts
+++ b/src/stores/subgraphNavigationStore.navigateToHash.test.ts
@@ -1,8 +1,8 @@
-import { createTestingPinia } from '@pinia/testing'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { disposePinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref, shallowRef } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
 import type * as VueRouter from 'vue-router'
 
@@ -17,11 +17,6 @@ const ids = vi.hoisted(() => ({
   deletedSubgraph: '22222222-2222-4222-8222-222222222222'
 }))
 
-const workflowStoreState = vi.hoisted(() => ({
-  openWorkflows: [] as unknown[],
-  activeSubgraph: undefined as unknown
-}))
-
 const routerMocks = vi.hoisted(() => ({
   push: vi.fn().mockResolvedValue(undefined),
   replace: vi.fn().mockResolvedValue(undefined),
@@ -29,7 +24,6 @@ const routerMocks = vi.hoisted(() => ({
 }))
 
 const routeHashRef = ref('')
-const currentGraphRef = shallowRef<LGraph | null>(null)
 
 vi.mock<unknown>(import('vue-router'), () => ({
   NavigationFailureType: { cancelled: 8, duplicated: 16 },
@@ -74,19 +68,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
   }
 })
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => app.canvas,
-      get currentGraph() {
-        return currentGraphRef.value
-      }
-    })
-  })
-)
-
 const reportErrorMock = vi.hoisted(() => vi.fn())
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
@@ -105,12 +86,6 @@ vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
   () => ({
     useWorkflowService: () => workflowServiceMocks
-  })
-)
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => workflowStoreState
   })
 )
 
@@ -141,18 +116,15 @@ async function flushHashWatcher() {
 }
 
 describe('useSubgraphNavigationStore - navigateToHash validation', () => {
-  let pinia: ReturnType<typeof createTestingPinia>
-
   beforeEach(() => {
-    pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(() => app.canvas)
     app.rootGraph.id = ids.root
     app.rootGraph.subgraphs.clear()
     app.canvas.subgraph = undefined
     app.canvas.graph = app.rootGraph
-    currentGraphRef.value = app.rootGraph
-    workflowStoreState.openWorkflows = []
-    workflowStoreState.activeSubgraph = undefined
+    useCanvasStore().currentGraph = app.rootGraph
+    Object.assign(useWorkflowStore(), { openWorkflows: [] })
+    useWorkflowStore().activeSubgraph = undefined
     routeHashRef.value = ''
     routerMocks.history.state = {}
     routerMocks.push.mockReset().mockImplementation(async (target) => {
@@ -162,8 +134,6 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       applyRouteTarget(target)
     })
   })
-
-  afterEach(() => disposePinia(pinia))
 
   it('navigates to a valid, existing subgraph hash', async () => {
     const subgraph = makeSubgraph(ids.validSubgraph)
@@ -293,7 +263,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const newRootId = '33333333-3333-4333-8333-333333333333'
     app.rootGraph.id = newRootId
     app.canvas.graph = app.rootGraph
-    currentGraphRef.value = app.rootGraph
+    useCanvasStore().currentGraph = app.rootGraph
     await navigationStore.updateHash('workflow-load', workflowNavigationId)
 
     resolveReplace?.()
@@ -307,15 +277,17 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
 
   it('redirects when a workflow load resolves but the subgraph is still missing', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'phantom-workflow.json',
-        activeState: {
-          id: ids.deletedSubgraph,
-          definitions: { subgraphs: [] }
-        }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'phantom-workflow.json',
+          activeState: {
+            id: ids.deletedSubgraph,
+            definitions: { subgraphs: [] }
+          }
+        })
+      ]
+    })
     useSubgraphNavigationStore()
 
     routeHashRef.value = `#${ids.deletedSubgraph}`
@@ -336,15 +308,17 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     workflowServiceMocks.openWorkflow.mockRejectedValueOnce(
       new Error('load failed')
     )
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'broken-workflow.json',
-        activeState: {
-          id: ids.deletedSubgraph,
-          definitions: { subgraphs: [] }
-        }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'broken-workflow.json',
+          activeState: {
+            id: ids.deletedSubgraph,
+            definitions: { subgraphs: [] }
+          }
+        })
+      ]
+    })
     useSubgraphNavigationStore()
 
     routeHashRef.value = `#${ids.deletedSubgraph}`
@@ -370,12 +344,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const secondGraph = makeSubgraph(secondId)
     let resolveOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'first-workflow.json',
-        activeState: { id: firstId, definitions: { subgraphs: [] } }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'first-workflow.json',
+          activeState: { id: firstId, definitions: { subgraphs: [] } }
+        })
+      ]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -407,12 +383,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const secondGraph = makeSubgraph(secondId)
     let resolveOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'first-workflow.json',
-        activeState: { id: firstId, definitions: { subgraphs: [] } }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'first-workflow.json',
+          activeState: { id: firstId, definitions: { subgraphs: [] } }
+        })
+      ]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -420,14 +398,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
             app.rootGraph.id = firstId
             app.rootGraph.subgraphs.set(secondId, secondGraph)
             app.canvas.graph = app.rootGraph
-            currentGraphRef.value = app.rootGraph
+            useCanvasStore().currentGraph = app.rootGraph
             resolve()
           }
         })
     )
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     routerMocks.push.mockImplementation(async (target) => {
       applyRouteTarget(target)
@@ -439,7 +417,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       expect(workflowServiceMocks.openWorkflow).toHaveBeenCalledOnce()
     )
     app.canvas.graph = secondGraph
-    currentGraphRef.value = secondGraph
+    useCanvasStore().currentGraph = secondGraph
     await nextTick()
     resolveOpen?.()
 
@@ -454,12 +432,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const outgoingSubgraph = makeSubgraph(ids.validSubgraph)
     let resolveOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'target-workflow.json',
-        activeState: { id: targetId, definitions: { subgraphs: [] } }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'target-workflow.json',
+          activeState: { id: targetId, definitions: { subgraphs: [] } }
+        })
+      ]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -471,10 +451,10 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     )
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     app.canvas.graph = outgoingSubgraph
-    currentGraphRef.value = outgoingSubgraph
+    useCanvasStore().currentGraph = outgoingSubgraph
     const navigationStore = useSubgraphNavigationStore()
 
     routeHashRef.value = `#${targetId}`
@@ -498,14 +478,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     routeHashRef.value = `#${subgraph.id}`
 
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
 
-    expect(workflowStoreState.activeSubgraph).toBe(subgraph)
+    expect(useWorkflowStore().activeSubgraph).toBe(subgraph)
   })
 
   it('uses the emitted graph during a synchronous graph-change event', async () => {
@@ -513,7 +493,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
 
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     app.canvas.graph = subgraph
     await flushHashWatcher()
 
@@ -532,10 +512,10 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
         definitions: { subgraphs: [{ id: targetSubgraph.id }] }
       }
     })
-    workflowStoreState.openWorkflows = [targetWorkflow]
+    Object.assign(useWorkflowStore(), { openWorkflows: [targetWorkflow] })
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     const navigationStore = useSubgraphNavigationStore()
     workflowServiceMocks.openWorkflow.mockImplementation(
@@ -577,11 +557,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
         definitions: { subgraphs: [{ id: targetSubgraph.id }] }
       }
     })
-    workflowStoreState.openWorkflows = [originalWorkflow]
+    Object.assign(useWorkflowStore(), { openWorkflows: [originalWorkflow] })
     app.rootGraph.subgraphs.set(targetSubgraph.id, targetSubgraph)
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     routeHashRef.value = `#${originalRootId}`
     const navigationStore = useSubgraphNavigationStore()
@@ -625,11 +605,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const subgraph = makeSubgraph(ids.validSubgraph)
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     app.canvas.graph = subgraph
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     routeHashRef.value = `#${subgraph.id}`
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
@@ -650,11 +630,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const subgraph = makeSubgraph(ids.validSubgraph)
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     app.canvas.graph = subgraph
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     routeHashRef.value = `#${subgraph.id}`
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
@@ -682,11 +662,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     })
     let resolveFirstPush: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [routeWorkflow]
+    Object.assign(useWorkflowStore(), { openWorkflows: [routeWorkflow] })
     workflowServiceMocks.openWorkflow.mockImplementation(async () => {
       app.rootGraph.id = routeId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
     })
     routerMocks.push
       .mockImplementationOnce((target) => {
@@ -702,14 +682,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     await navigationStore.updateHash()
 
     app.canvas.graph = firstGraph
-    currentGraphRef.value = firstGraph
+    useCanvasStore().currentGraph = firstGraph
     await vi.waitFor(() =>
       expect(routerMocks.push).toHaveBeenCalledWith(
         expect.objectContaining({ hash: `#${firstId}` })
       )
     )
     app.canvas.graph = secondGraph
-    currentGraphRef.value = secondGraph
+    useCanvasStore().currentGraph = secondGraph
     routeHashRef.value = `#${routeId}`
 
     await vi.waitFor(() =>
@@ -739,21 +719,23 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const secondRoot = fromPartial<LGraph>({ id: secondId })
     let resolveFirstOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [firstWorkflow, secondWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [firstWorkflow, secondWorkflow]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation((workflow) => {
       if (workflow === firstWorkflow) {
         return new Promise<void>((resolve) => {
           resolveFirstOpen = () => {
             app.rootGraph.id = firstId
             app.canvas.graph = app.rootGraph
-            currentGraphRef.value = app.rootGraph
+            useCanvasStore().currentGraph = app.rootGraph
             resolve()
           }
         })
       }
       app.rootGraph.id = secondId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
       return Promise.resolve()
     })
     routerMocks.push.mockImplementation(async (target) => {
@@ -769,7 +751,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       )
     )
     app.canvas.graph = secondRoot
-    currentGraphRef.value = secondRoot
+    useCanvasStore().currentGraph = secondRoot
     resolveFirstOpen?.()
 
     await vi.waitFor(() => {
@@ -795,7 +777,9 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     })
     let rejectFirstOpen: ((error: Error) => void) | undefined
 
-    workflowStoreState.openWorkflows = [firstWorkflow, secondWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [firstWorkflow, secondWorkflow]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation((workflow) => {
       if (workflow === firstWorkflow) {
         return new Promise<void>((_resolve, reject) => {
@@ -804,7 +788,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       }
       app.rootGraph.id = secondId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
       return Promise.resolve()
     })
     useSubgraphNavigationStore()
@@ -843,7 +827,9 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     })
     let resolveFirstOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [firstWorkflow, secondWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [firstWorkflow, secondWorkflow]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation((workflow) => {
       if (workflow === firstWorkflow) {
         return new Promise<void>((resolve) => {
@@ -852,7 +838,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       }
       app.rootGraph.id = secondId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
       return Promise.resolve()
     })
     useSubgraphNavigationStore()
@@ -888,7 +874,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     // Consume the initial-load swallow so the watcher publish is live.
     await store.updateHash('graph', undefined, app.rootGraph)
 
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     await vi.waitFor(() => {
       expect(routerMocks.push).toHaveBeenCalledWith(
         expect.objectContaining({ hash: `#${ids.validSubgraph}` })
@@ -931,7 +917,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
   it('ignores endWorkflowNavigation for a superseded intent id', async () => {
     app.rootGraph.id = ids.root
     app.canvas.graph = app.rootGraph
-    currentGraphRef.value = app.rootGraph
+    useCanvasStore().currentGraph = app.rootGraph
     routeHashRef.value = ''
     const store = useSubgraphNavigationStore()
 

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { disposePinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import type * as VueRouter from 'vue-router'
@@ -11,6 +9,7 @@ import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workfl
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { app } from '@/scripts/app'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 type MockSubgraph = Pick<Subgraph, 'id' | 'rootGraph' | '_nodes' | 'nodes'>
 
@@ -83,16 +82,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
   }
 })
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => app.canvas
-    })
-  })
-)
-
 vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   findSubgraphPathById: vi.fn()
 }))
@@ -114,11 +103,8 @@ vi.mock<unknown>(
 )
 
 describe('useSubgraphNavigationStore', () => {
-  let pinia: ReturnType<typeof createTestingPinia>
-
   beforeEach(() => {
-    pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(() => app.canvas)
     app.rootGraph.subgraphs.clear()
     app.rootGraph.id = 'current-root'
     app.canvas.graph = app.rootGraph
@@ -138,8 +124,6 @@ describe('useSubgraphNavigationStore', () => {
     })
     mockOpenWorkflow.mockReset()
   })
-
-  afterEach(() => disposePinia(pinia))
 
   it('should not clear navigation stack when workflow internal state changes', async () => {
     const navigationStore = useSubgraphNavigationStore()

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { nextTick } from 'vue'
 
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -53,15 +54,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
   }
 })
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => app.canvas
-    })
-  })
-)
 vi.mock(import('@vueuse/router'), () => ({ useRouteHash: vi.fn() }))
 
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
@@ -74,6 +66,7 @@ let rafCallbacks: FrameRequestCallback[] = []
 
 describe('useSubgraphNavigationStore - Viewport Persistence', () => {
   beforeEach(() => {
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(() => app.canvas)
     rafCallbacks = []
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       rafCallbacks.push(cb)

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -1,5 +1,8 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock(import('@vueuse/router'), () => ({ useRouteHash: () => ref('') }))
 
 import {
   createTestSubgraph,
@@ -14,6 +17,7 @@ import { app as comfyApp } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { BLUEPRINT_TYPE_PREFIX } from '@/utils/blueprintUtils'
 
 const mockDistributionTypes = vi.hoisted(() => ({
@@ -43,16 +47,6 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
     prompt: () => 'testname',
     confirm: () => true
   }))
-}))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => ({
-    getCanvas: () => comfyApp.canvas
-  }))
-}))
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => ({
-    beginWorkflowNavigation: () => 1
-  })
 }))
 
 // Mock comfyApp globally for the store setup
@@ -98,6 +92,9 @@ describe('useSubgraphStore', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = false
     mockDistributionTypes.isDesktop = false
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(
+      () => comfyApp.canvas
+    )
     store = useSubgraphStore()
   })
 

--- a/src/stores/workspace/bottomPanelStore.test.ts
+++ b/src/stores/workspace/bottomPanelStore.test.ts
@@ -40,12 +40,6 @@ vi.mock(import('@/composables/bottomPanelTabs/useTerminalTabs'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    registerCommand: vi.fn()
-  })
-}))
-
 const mockData = vi.hoisted(() => ({ isDesktop: false }))
 
 vi.mock(import('@/platform/distribution/types'), () => ({

--- a/src/stores/workspace/searchBoxStore.test.ts
+++ b/src/stores/workspace/searchBoxStore.test.ts
@@ -1,44 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useMouse } from '@vueuse/core'
+import { nextTick } from 'vue'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
-import type { useSettingStore } from '@/platform/settings/settingStore'
+import { LGraph, LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
-
-const { mockAdjustMouseEvent } = vi.hoisted(() => ({
-  mockAdjustMouseEvent: vi.fn((event: PointerEvent) => {
-    Object.assign(event, {
-      canvasX: 50,
-      canvasY: 75,
-      deltaX: 0,
-      deltaY: 0,
-      safeOffsetX: event.clientX,
-      safeOffsetY: event.clientY
-    })
-  })
-}))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useMouse: vi.fn(() => ({
-    x: { value: 100 },
-    y: { value: 200 }
-  }))
-}))
-
-const mockSettingStore = createMockSettingStore()
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => mockSettingStore)
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => ({ adjustMouseEvent: mockAdjustMouseEvent })
-    })
-  })
-)
+import { createMockMinimapCanvas } from '@/utils/__tests__/litegraphTestUtils'
 
 function createMockPopover(): Pick<
   InstanceType<typeof NodeSearchBoxPopover>,
@@ -47,18 +15,24 @@ function createMockPopover(): Pick<
   return { showSearchBox: vi.fn() }
 }
 
-function createMockSettingStore(): ReturnType<typeof useSettingStore> {
-  return {
-    get: vi.fn()
-  } as Partial<ReturnType<typeof useSettingStore>> as ReturnType<
-    typeof useSettingStore
-  >
-}
-
 describe('useSearchBoxStore', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      createMockMinimapCanvas().getContext
+    )
+    const canvas = new LGraphCanvas(
+      document.createElement('canvas'),
+      new LGraph(),
+      { skip_render: true }
+    )
+    canvas.ds.scale = 2
+    canvas.ds.offset = [0, 25]
+    useCanvasStore().canvas = canvas
+  })
+
   describe('when user has new search box enabled', () => {
     beforeEach(() => {
-      vi.mocked(mockSettingStore.get).mockReturnValue('default')
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl'] = 'default'
     })
 
     it('should show new search box is enabled', () => {
@@ -81,7 +55,8 @@ describe('useSearchBoxStore', () => {
 
   describe('when user has legacy search box enabled', () => {
     beforeEach(() => {
-      vi.mocked(mockSettingStore.get).mockReturnValue('litegraph (legacy)')
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl'] =
+        'litegraph (legacy)'
     })
 
     it('should show new search box is disabled', () => {
@@ -89,10 +64,18 @@ describe('useSearchBoxStore', () => {
       expect(store.newSearchBoxEnabled).toBe(false)
     })
 
-    it('should open legacy search box at mouse position when user presses shortcut', () => {
+    it('should open legacy search box at mouse position when user presses shortcut', async () => {
       const store = useSearchBoxStore()
       const mockPopover = createMockPopover()
       store.setPopoverRef(mockPopover)
+      const adjustMouseEvent = vi.spyOn(
+        useCanvasStore().getCanvas(),
+        'adjustMouseEvent'
+      )
+      window.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 100, clientY: 200 })
+      )
+      await nextTick()
 
       expect(vi.mocked(store.visible)).toBe(false)
 
@@ -108,8 +91,7 @@ describe('useSearchBoxStore', () => {
           canvasY: 75
         })
       )
-      expect(useMouse).toHaveBeenCalledWith({ type: 'client' })
-      expect(mockAdjustMouseEvent).toHaveBeenCalledOnce()
+      expect(adjustMouseEvent).toHaveBeenCalledOnce()
     })
 
     it('should do nothing when user presses shortcut but popover is not ready', () => {
@@ -124,7 +106,8 @@ describe('useSearchBoxStore', () => {
 
   describe('when user configures popover reference', () => {
     beforeEach(() => {
-      vi.mocked(mockSettingStore.get).mockReturnValue('litegraph (legacy)')
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl'] =
+        'litegraph (legacy)'
     })
 
     it('should enable legacy search when popover is set', () => {

--- a/src/stores/workspace/sidebarTabStore.test.ts
+++ b/src/stores/workspace/sidebarTabStore.test.ts
@@ -1,45 +1,12 @@
-import { nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
-const {
-  mockGetSetting,
-  mockRegisterCommand,
-  mockRegisterCommands,
-  mockBrowseModelAssets,
-  registeredCommands,
-  commandStoreCommands
-} = vi.hoisted(() => {
-  const registeredCommands: { id: string; function: () => unknown }[] = []
-  return {
-    mockGetSetting: vi.fn(),
-    mockRegisterCommand: vi.fn((command) => registeredCommands.push(command)),
-    mockRegisterCommands: vi.fn(),
-    mockBrowseModelAssets: vi.fn(),
-    registeredCommands,
-    commandStoreCommands: [] as { id: string; function: () => unknown }[]
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    registerCommand: mockRegisterCommand,
-    commands: commandStoreCommands
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/menuItemStore'), () => ({
-  useMenuItemStore: () => ({
-    registerCommands: mockRegisterCommands
-  })
-}))
+const mockBrowseModelAssets = vi.fn()
 
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key,
@@ -108,21 +75,18 @@ vi.mock(
 
 describe('useSidebarTabStore', () => {
   beforeEach(() => {
-    registeredCommands.length = 0
-    commandStoreCommands.length = 0
+    vi.mocked(useMenuItemStore().registerCommands).mockImplementation(() => {})
   })
 
   const toggleModelLibrary = async () => {
-    const toggleCommand = registeredCommands.find(
+    const toggleCommand = useCommandStore().commands.find(
       (command) => command.id === 'Workspace.ToggleSidebarTab.model-library'
     )
     await toggleCommand?.function()
   }
 
   it('registers the job history tab when QPO V2 is enabled', () => {
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? true : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
 
     const store = useSidebarTabStore()
     store.registerCoreSidebarTabs()
@@ -135,13 +99,11 @@ describe('useSidebarTabStore', () => {
       'workflows',
       'apps'
     ])
-    expect(mockRegisterCommand).toHaveBeenCalledTimes(6)
+    expect(useCommandStore().registerCommand).toHaveBeenCalledTimes(6)
   })
 
   it('does not register the job history tab when QPO V2 is disabled', () => {
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? false : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     const store = useSidebarTabStore()
     store.registerCoreSidebarTabs()
@@ -153,19 +115,16 @@ describe('useSidebarTabStore', () => {
       'workflows',
       'apps'
     ])
-    expect(mockRegisterCommand).toHaveBeenCalledTimes(5)
+    expect(useCommandStore().registerCommand).toHaveBeenCalledTimes(5)
   })
 
   it('prepends the job history tab when QPO V2 is toggled on', async () => {
-    const qpoV2Enabled = ref(false)
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? qpoV2Enabled.value : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     const store = useSidebarTabStore()
     store.registerCoreSidebarTabs()
 
-    qpoV2Enabled.value = true
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
     await nextTick()
 
     expect(store.sidebarTabs.map((tab) => tab.id)).toEqual([
@@ -176,15 +135,14 @@ describe('useSidebarTabStore', () => {
       'workflows',
       'apps'
     ])
-    expect(mockRegisterCommand).toHaveBeenCalledTimes(6)
+    expect(useCommandStore().registerCommand).toHaveBeenCalledTimes(6)
   })
 
   describe('model library view selection', () => {
     it('toggles the sidebar tab when the asset view is disabled', async () => {
-      mockGetSetting.mockImplementation((key: string) =>
-        key === 'Comfy.ModelLibrary.UseAssetBrowser' ? false : undefined
-      )
-      commandStoreCommands.push({
+      useSettingStore().settingValues['Comfy.ModelLibrary.UseAssetBrowser'] =
+        false
+      useCommandStore().registerCommand({
         id: 'Comfy.BrowseModelAssets',
         function: mockBrowseModelAssets
       })
@@ -199,13 +157,10 @@ describe('useSidebarTabStore', () => {
     })
 
     it('opens the asset browser when the browser and asset API are enabled', async () => {
-      mockGetSetting.mockImplementation((key: string) =>
-        key === 'Comfy.ModelLibrary.UseAssetBrowser' ||
-        key === 'Comfy.Assets.UseAssetAPI'
-          ? true
-          : undefined
-      )
-      commandStoreCommands.push({
+      useSettingStore().settingValues['Comfy.ModelLibrary.UseAssetBrowser'] =
+        true
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
+      useCommandStore().registerCommand({
         id: 'Comfy.BrowseModelAssets',
         function: mockBrowseModelAssets
       })
@@ -220,10 +175,10 @@ describe('useSidebarTabStore', () => {
     })
 
     it('falls back to the sidebar tree when the asset API is disabled', async () => {
-      mockGetSetting.mockImplementation((key: string) =>
-        key === 'Comfy.ModelLibrary.UseAssetBrowser' ? true : false
-      )
-      commandStoreCommands.push({
+      useSettingStore().settingValues['Comfy.ModelLibrary.UseAssetBrowser'] =
+        true
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = false
+      useCommandStore().registerCommand({
         id: 'Comfy.BrowseModelAssets',
         function: mockBrowseModelAssets
       })

--- a/src/systems/badgeSystem.pricing.test.ts
+++ b/src/systems/badgeSystem.pricing.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useLinkStore } from '@/stores/linkStore'
@@ -27,13 +26,6 @@ vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => {
   }
 })
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.NodeBadge.ShowApiPricing' ? true : undefined
-  })
-}))
-
 class ApiNode extends LGraphNode {
   static override nodeData = { name: 'ApiNode', api_node: true }
 }
@@ -46,7 +38,7 @@ function scopeOf(id: string) {
 
 describe('badge derivation pricing input connectivity', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
+    useSettingStore().settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
     displayPrice = '$disconnected'
     getNodeDisplayPrice.mockClear()
   })

--- a/src/systems/badgeSystem.subgraph.test.ts
+++ b/src/systems/badgeSystem.subgraph.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { nextTick } from 'vue'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -33,20 +32,13 @@ vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.NodeBadge.ShowApiPricing' ? true : undefined
-  })
-}))
-
 class ApiNode extends LGraphNode {
   static override nodeData = { name: 'ApiNode', api_node: true }
 }
 
 describe('badge derivation subgraph credits aggregation', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
+    useSettingStore().settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
     getNodeDisplayPrice.mockReset()
     getNodeDisplayPrice.mockImplementation(defaultDisplayPrice)
     pricingMocks.hasDynamicPricing.mockReset()

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -20,8 +18,6 @@ import {
   resolveNode
 } from './litegraphUtil'
 
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
 const mockBringNodeToFront = vi.fn()
 
 vi.mock(
@@ -31,10 +27,6 @@ vi.mock(
     useNodeZIndex: () => ({ bringNodeToFront: mockBringNodeToFront })
   })
 )
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert: vi.fn() })
-}))
 
 describe('resolveNode', () => {
   it('returns undefined when graph is null', () => {

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type * as VueUseCore from '@vueuse/core'
@@ -8,8 +7,39 @@ import { useReconnectQueueRefresh } from '@/composables/useReconnectQueueRefresh
 import { useReconnectingNotification } from '@/composables/useReconnectingNotification'
 import type * as DistributionTypes from '@/platform/distribution/types'
 import type * as I18nModule from '@/i18n'
+import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
-const apiMock = vi.hoisted(() => new EventTarget())
+beforeEach(() => {
+  vi.mocked(useVersionCompatibilityStore().initialize).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useExecutionStore().bindExecutionEvents).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useExecutionStore().unbindExecutionEvents).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useMenuItemStore().registerCoreMenuCommands).mockImplementation(
+    () => {}
+  )
+  vi.mocked(
+    useBottomPanelStore().registerCoreBottomPanelTabs
+  ).mockResolvedValue(undefined)
+  vi.mocked(useSidebarTabStore().registerCoreSidebarTabs).mockImplementation(
+    () => {}
+  )
+})
+
+const apiMock = vi.hoisted(() =>
+  Object.assign(new EventTarget(), {
+    getServerFeature: vi.fn((_name: string, fallback?: unknown) => fallback),
+    getSystemStats: vi.fn(async () => ({ system: {}, devices: [] }))
+  })
+)
 const distribution = vi.hoisted(
   (): {
     isCloud: typeof DistributionTypes.isCloud
@@ -21,6 +51,12 @@ const distribution = vi.hoisted(
 )
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiMock }))
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn(async () => {}),
+  onAuthStateChanged: vi.fn(() => () => {}),
+  onIdTokenChanged: vi.fn(() => () => {})
+}))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -74,9 +110,7 @@ vi.mock(import('@/i18n'), async (importOriginal) => {
   return { ...actual, loadLocale: vi.fn().mockResolvedValue(undefined) }
 })
 vi.mock(import('@/platform/distribution/types'), () => distribution)
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: vi.fn(() => undefined), set: vi.fn() })
-}))
+
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => undefined
 }))
@@ -86,22 +120,7 @@ vi.mock(
     useFrontendVersionMismatchWarning: vi.fn()
   })
 )
-vi.mock<unknown>(
-  import('@/platform/updates/common/versionCompatibilityStore'),
-  () => ({
-    useVersionCompatibilityStore: () => ({
-      initialize: vi.fn().mockResolvedValue(undefined)
-    })
-  })
-)
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), async () => {
-  const { defineStore } = await import('pinia')
-  return {
-    useCanvasStore: defineStore('canvas-test-stub', () => ({
-      linearMode: ref(false)
-    }))
-  }
-})
+
 vi.mock(import('@/services/autoQueueService'), () => ({
   setupAutoQueueHandler: vi.fn()
 }))
@@ -111,65 +130,7 @@ vi.mock<unknown>(import('@/platform/keybindings/keybindingService'), () => ({
     keybindHandler: vi.fn()
   })
 }))
-vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ isBuilderMode: ref(false) })
-}))
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({ updateHistory: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ registerCommands: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    bindExecutionEvents: vi.fn(),
-    unbindExecutionEvents: vi.fn(),
-    activeJobId: null,
-    clearActiveJobIfStale: vi.fn()
-  })
-}))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({ isAuthenticated: false })
-}))
-vi.mock<unknown>(import('@/stores/menuItemStore'), () => ({
-  useMenuItemStore: () => ({ registerCoreMenuCommands: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/modelStore'), () => ({
-  useModelStore: () => ({})
-}))
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({}),
-  useNodeFrequencyStore: () => ({})
-}))
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    update: vi.fn(),
-    runningTasks: [],
-    pendingTasks: [],
-    tasks: [],
-    maxHistoryItems: 64
-  }),
-  useQueuePendingTaskCountStore: () => ({ update: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/serverConfigStore'), () => ({
-  useServerConfigStore: () => ({})
-}))
-vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), () => ({
-  useBottomPanelStore: () => ({
-    registerCoreBottomPanelTabs: vi.fn().mockResolvedValue(undefined)
-  })
-}))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: { light_theme: true, colors: { comfy_base: {} } }
-  })
-}))
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => ({
-    registerCoreSidebarTabs: vi.fn(),
-    activeSidebarTabId: null
-  })
-}))
+
 vi.mock<unknown>(import('@/utils/envUtil'), () => ({
   electronAPI: () => ({
     changeTheme: vi.fn(),

--- a/src/views/LinearView.test.ts
+++ b/src/views/LinearView.test.ts
@@ -2,9 +2,21 @@ import { render, screen, within } from '@testing-library/vue'
 import type { DetachedWindowAPI } from 'happy-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import type { SidebarTabExtension } from '@/types/extensionTypes'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import LinearView from './LinearView.vue'
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn(async () => {}),
+  onAuthStateChanged: vi.fn(() => () => {}),
+  onIdTokenChanged: vi.fn(() => () => {})
+}))
 
 interface ViewState {
   sidebarLocation: 'left' | 'right'
@@ -13,49 +25,6 @@ interface ViewState {
   activeTab: SidebarTabExtension | null
   hasOutputs: boolean
 }
-
-const state = vi.hoisted<ViewState>(() => ({
-  sidebarLocation: 'left',
-  isBuilderMode: false,
-  isArrangeMode: false,
-  activeTab: null,
-  hasOutputs: false
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.Sidebar.Location' ? state.sidebarLocation : undefined
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    sidebarTab: {
-      get activeSidebarTab() {
-        return state.activeTab
-      }
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
-  const { computed } = await import('vue')
-  return {
-    useAppMode: () => ({
-      isBuilderMode: computed(() => state.isBuilderMode),
-      isArrangeMode: computed(() => state.isArrangeMode)
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { reactive, computed } = await import('vue')
-  return {
-    useAppModeStore: () =>
-      reactive({ hasOutputs: computed(() => state.hasOutputs) })
-  }
-})
 
 vi.mock(
   import('@/workbench/extensions/agent/composables/useAgentDockMount'),
@@ -114,7 +83,25 @@ const baseStubs = {
 }
 
 function renderView(overrides: Partial<ViewState> = {}) {
-  Object.assign(state, overrides)
+  const state: ViewState = {
+    sidebarLocation: 'left',
+    isBuilderMode: false,
+    isArrangeMode: false,
+    activeTab: null,
+    hasOutputs: false,
+    ...overrides
+  }
+  useWorkflowStore().activeWorkflow = createMockLoadedWorkflow({
+    activeMode: state.isArrangeMode
+      ? 'builder:arrange'
+      : state.isBuilderMode
+        ? 'builder:inputs'
+        : 'app'
+  })
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] =
+    state.sidebarLocation
+  Object.assign(useSidebarTabStore(), { activeSidebarTab: state.activeTab })
+  Object.assign(useAppModeStore(), { hasOutputs: state.hasOutputs })
   return render(LinearView, {
     global: { stubs: baseStubs }
   })
@@ -136,13 +123,6 @@ function expectRenderedBefore(first: HTMLElement, second: HTMLElement) {
 describe('LinearView', () => {
   beforeEach(() => {
     setViewport(DESKTOP_WIDTH)
-    Object.assign(state, {
-      sidebarLocation: 'left',
-      isBuilderMode: false,
-      isArrangeMode: false,
-      activeTab: null,
-      hasOutputs: false
-    } satisfies ViewState)
   })
 
   it('renders only the mobile display on small screens', () => {

--- a/src/views/UserSelectView.test.ts
+++ b/src/views/UserSelectView.test.ts
@@ -4,6 +4,8 @@ import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useUserStore } from '@/stores/userStore'
+
 import UserSelectView from './UserSelectView.vue'
 
 const i18n = createI18n({
@@ -17,15 +19,7 @@ vi.mock<unknown>(import('vue-router'), () => ({
   useRouter: () => ({ push: mockRouterPush })
 }))
 
-const userStoreMock = vi.hoisted(() => ({
-  users: [] as Array<{ userId: string; username: string }>,
-  initialize: vi.fn().mockResolvedValue(undefined),
-  createUser: vi.fn(),
-  login: vi.fn().mockResolvedValue(undefined)
-}))
-vi.mock<unknown>(import('@/stores/userStore'), () => ({
-  useUserStore: () => userStoreMock
-}))
+let userStoreMock: ReturnType<typeof useUserStore>
 
 vi.mock<unknown>(import('@/views/templates/BaseViewTemplate.vue'), () => ({
   default: {
@@ -43,7 +37,9 @@ const mountView = () =>
 
 describe('UserSelectView', () => {
   beforeEach(() => {
-    userStoreMock.users = []
+    userStoreMock = useUserStore()
+    vi.mocked(userStoreMock.initialize).mockResolvedValue(undefined)
+    vi.mocked(userStoreMock.login).mockResolvedValue(undefined)
   })
 
   it('initializes the user store on mount', async () => {
@@ -68,7 +64,7 @@ describe('UserSelectView', () => {
 
   it('creates a new user, logs in, and navigates home', async () => {
     const newUser = { userId: 'u1', username: 'bob' }
-    userStoreMock.createUser.mockResolvedValueOnce(newUser)
+    vi.mocked(userStoreMock.createUser).mockResolvedValueOnce(newUser)
     mountView()
 
     await userEvent.type(
@@ -85,7 +81,7 @@ describe('UserSelectView', () => {
   })
 
   it('shows an error when the entered username already exists', async () => {
-    userStoreMock.users = [{ userId: 'u1', username: 'bob' }]
+    Object.assign(userStoreMock, { users: [{ userId: 'u1', username: 'bob' }] })
     mountView()
 
     await userEvent.type(
@@ -99,7 +95,7 @@ describe('UserSelectView', () => {
   })
 
   it('surfaces createUser failures as a login error', async () => {
-    userStoreMock.createUser.mockRejectedValueOnce(new Error('boom'))
+    vi.mocked(userStoreMock.createUser).mockRejectedValueOnce(new Error('boom'))
     mountView()
 
     await userEvent.type(

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -8,14 +8,8 @@ import type {
 } from '@comfyorg/ingest-types'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createTestingPinia } from '@pinia/testing'
-import {
-  createPinia,
-  disposePinia,
-  getActivePinia,
-  setActivePinia
-} from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 
 // jsdom does not implement ResizeObserver (happy-dom does); stub it before the
@@ -29,6 +23,8 @@ vi.hoisted(() => {
 })
 
 import { i18n } from '@/i18n'
+import type { LGraphNode, Subgraph } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
 import { assetService } from '@/platform/assets/services/assetService'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
@@ -39,6 +35,16 @@ import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { getFilenameDetails } from '@/utils/formatUtil'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+// eslint-disable-next-line import-x/no-restricted-paths
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import {
+  createMockLoadedWorkflow,
+  createMockChangeTracker,
+  createMockLGraphNode
+} from '@/utils/__tests__/litegraphTestUtils'
 
 const getServerFeature = vi.hoisted(() =>
   vi.fn((_name: string, defaultValue?: unknown) => defaultValue)
@@ -106,9 +112,9 @@ const appMock = vi.hoisted(() => {
             nodes: unknown[]
             getNodeById: (id: string) => unknown | null
           }
-          selectedItems: Set<unknown>
+          selectedItems: Set<LGraphNode>
           selectItems: ReturnType<typeof vi.fn>
-          deselect: (node: unknown) => void
+          deselect: (node: LGraphNode) => void
           multi_select: boolean
           allow_dragnodes: boolean
           selectOnly: boolean
@@ -128,112 +134,9 @@ vi.mock<unknown>(
   })
 )
 
-type FakeTab = {
-  path: string
-  directory: string
-  filename: string
-  suffix?: string
-  isTemporary: boolean
-  isModified: boolean
-  activeState: ComfyWorkflowJSON | null
-  changeTracker?: {
-    prepareForSave: ReturnType<typeof vi.fn>
-  }
-  initialMode?: 'app' | 'graph'
-  activeMode?: 'builder:inputs'
-}
-const hostStores = vi.hoisted(() => ({
-  workflow: null as unknown as {
-    activeWorkflow: FakeTab | null
-    openWorkflows: FakeTab[]
-    tabs: Map<string, FakeTab>
-    openTabPaths: Set<string>
-    getWorkflowByPath: (path: string) => FakeTab | null
-    nodeToNodeLocatorId: (node: {
-      graph?: { id?: string }
-      id: string | number
-    }) => string
-  },
-  canvas: null as unknown as {
-    selectedItems: unknown[]
-    updateSelectedItems: () => void
-    currentGraph: unknown | null
-    canvas: unknown
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    const tabs = new Map<string, FakeTab>()
-    const openTabPaths = reactive(new Set<string>())
-    const store = reactive({
-      activeWorkflow: null as FakeTab | null,
-      get openWorkflows() {
-        return Array.from(openTabPaths).flatMap((path) => {
-          const tab = tabs.get(path)
-          return tab === undefined ? [] : [tab]
-        })
-      },
-      tabs,
-      openTabPaths,
-      getWorkflowByPath: (path: string) => tabs.get(path) ?? null,
-      nodeToNodeLocatorId: (node: {
-        graph?: { id?: string }
-        id: string | number
-      }) => (node.graph?.id ? `${node.graph.id}:${node.id}` : String(node.id)),
-      closeWorkflow: vi.fn(async (tab: FakeTab) => {
-        openTabPaths.delete(tab.path)
-        if (tab.isTemporary) tabs.delete(tab.path)
-      }),
-      createTemporary: (path?: string, data?: ComfyWorkflowJSON) => {
-        const requested = (path ?? 'Unsaved Workflow.json').replace(
-          /\.json$/,
-          ''
-        )
-        let stem = requested
-        let counter = 2
-        while (tabs.has(`workflows/${stem}.json`))
-          stem = `${requested} (${counter++})`
-        const tab: FakeTab = {
-          path: `workflows/${stem}.json`,
-          directory: 'workflows',
-          filename: stem,
-          isTemporary: true,
-          isModified: false,
-          activeState: data ?? null
-        }
-        tabs.set(tab.path, tab)
-        openTabPaths.add(tab.path)
-        return tab
-      }
-    })
-    hostStores.workflow = store
-    return { useWorkflowStore: () => store }
-  }
-)
-
-vi.mock<unknown>(
-  // eslint-disable-next-line import-x/no-restricted-paths
-  import('@/renderer/core/canvas/canvasStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    const updateSelectedItems = () => {
-      hostStores.canvas.selectedItems = [
-        ...(appMock.canvas?.selectedItems ?? [])
-      ]
-    }
-    const store = reactive({
-      selectedItems: [] as unknown[],
-      updateSelectedItems,
-      currentGraph: null,
-      canvas: undefined
-    })
-    hostStores.canvas = store
-    return { useCanvasStore: () => store }
-  }
-)
+let workflowStore: ReturnType<typeof useWorkflowStore>
+let canvasStore: ReturnType<typeof useCanvasStore>
+let executionErrors: Mocked<ReturnType<typeof useExecutionErrorStore>>
 
 const workflowService = vi.hoisted(() => ({
   saveWorkflow: vi.fn(async (tab: { isModified: boolean }) => {
@@ -245,16 +148,16 @@ const workflowService = vi.hoisted(() => ({
       tab: { path: string; isTemporary: boolean; isModified: boolean },
       _options?: { filename?: string }
     ) => {
-      tab.isTemporary = false
+      Object.assign(tab, { isTemporary: true })
       tab.isModified = false
       return true
     }
   ),
   openWorkflow: vi.fn(async (tab: { path: string }) => {
-    const known = hostStores.workflow.tabs.get(tab.path)
+    const known = workflowStore.getWorkflowByPath(tab.path)
     if (known) {
-      hostStores.workflow.openTabPaths.add(tab.path)
-      hostStores.workflow.activeWorkflow = known
+      workflowStore.openWorkflowsInBackground({ right: [tab.path] })
+      workflowStore.activeWorkflow = await known.load()
     }
   })
 }))
@@ -270,26 +173,6 @@ vi.mock<unknown>(import('@/utils/litegraphUtil'), async (importOriginal) => ({
   ...(await importOriginal<object>()),
   isLGraphNode: (item: unknown) =>
     (item as { isNodeFake?: boolean } | null)?.isNodeFake === true
-}))
-
-type MockPromptError = {
-  type: string
-  message: string
-  details: string
-}
-const executionErrors = vi.hoisted(() => {
-  const store = {
-    lastPromptError: null as MockPromptError | null,
-    recordPromptError(error: MockPromptError) {
-      store.lastPromptError = error
-    },
-    showErrorOverlay: vi.fn()
-  }
-  return store
-})
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
-  useExecutionErrorStore: () => executionErrors
 }))
 
 vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
@@ -403,6 +286,15 @@ import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTab
 import AgentPanelRoot from './AgentPanelRoot.vue'
 
 beforeEach(() => {
+  workflowStore = useWorkflowStore()
+  canvasStore = useCanvasStore()
+  executionErrors = vi.mocked(useExecutionErrorStore())
+  executionErrors.showErrorOverlay.mockImplementation(() => {})
+  vi.mocked(canvasStore.updateSelectedItems).mockImplementation(() => {
+    canvasStore.selectedItems = fromPartial([
+      ...(appMock.canvas?.selectedItems ?? [])
+    ])
+  })
   vi.useRealTimers()
   Element.prototype.scrollIntoView = vi.fn()
   URL.createObjectURL = vi.fn(() => 'blob:mock-url')
@@ -412,11 +304,10 @@ beforeEach(() => {
   getServerFeature.mockImplementation(
     (_name: string, defaultValue?: unknown) => defaultValue
   )
-  hostStores.workflow.tabs.clear()
-  hostStores.workflow.openTabPaths.clear()
-  hostStores.workflow.activeWorkflow = null
-  hostStores.canvas.selectedItems = []
-  hostStores.canvas.currentGraph = null
+
+  workflowStore.activeWorkflow = null
+  canvasStore.selectedItems = []
+  canvasStore.currentGraph = null
   appMock.graph.nodes = []
   appMock.graph.arrange.mockClear()
   Object.assign(appMock.rootGraph, { subgraphs: new Map() })
@@ -431,11 +322,6 @@ beforeEach(() => {
   paywallCapabilities.canSubscribeSelfServe = true
   paywallCapabilities.isReady = true
   paywallBilling.tier = 'STANDARD'
-})
-
-afterEach(() => {
-  const pinia = getActivePinia()
-  if (pinia) disposePinia(pinia)
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
@@ -498,27 +384,31 @@ async function renderAndSend(text: string): Promise<void> {
   await sendFromComposer(text)
 }
 
-function addTab(path: string, overrides: Partial<FakeTab> = {}): FakeTab {
+function addTab(
+  path: string,
+  overrides: Partial<LoadedComfyWorkflow> = {}
+): LoadedComfyWorkflow {
   const slash = path.lastIndexOf('/')
   const { filename, suffix } = getFilenameDetails(path.slice(slash + 1))
-  const tab: FakeTab = {
+  const tab = createMockLoadedWorkflow({
     path,
     directory: path.slice(0, slash),
     filename,
-    suffix: suffix ?? undefined,
+    suffix,
     isTemporary: false,
     isModified: false,
     activeState: null,
     ...overrides
-  }
-  hostStores.workflow.tabs.set(tab.path, tab)
-  hostStores.workflow.openTabPaths.add(tab.path)
+  })
+  tab.load = vi.fn(async () => tab)
+  tab.unload = vi.fn()
+  workflowStore.attachWorkflow(tab, workflowStore.openWorkflows.length)
+  workflowStore.openWorkflowsInBackground({ right: [tab.path] })
   return tab
 }
 
 describe('AgentPanelRoot paywall actions', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     ws.clear()
     openAccountPrecondition.mockClear()
   })
@@ -678,12 +568,10 @@ describe('AgentPanelRoot paywall actions', () => {
 
 describe('AgentPanelRoot session notices', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
   })
 
   it('surfaces a session error notice via the host error modal, not a toast', async () => {
-    executionErrors.lastPromptError = null
     executionErrors.showErrorOverlay.mockClear()
     vi.stubGlobal(
       'fetch',
@@ -750,26 +638,28 @@ async function openMentionPicker(): Promise<void> {
   await userEvent.type(screen.getByRole('textbox'), '@')
 }
 
-type SelectionTestNode = {
-  isNodeFake: true
-  id: number | string
-  title: string
-  boundingRect: object
-  graph?: { id?: string }
-}
-
 function setupNodeSelectionCanvas() {
   const focus = vi.fn()
-  const nodes: SelectionTestNode[] = [
-    { isNodeFake: true, id: 9, title: 'VAE Decode', boundingRect: {} },
-    { isNodeFake: true, id: 12, title: 'KSampler', boundingRect: {} }
+  const nodes: LGraphNode[] = [
+    createMockLGraphNode({
+      isNodeFake: true,
+      id: 9,
+      title: 'VAE Decode',
+      boundingRect: {}
+    }),
+    createMockLGraphNode({
+      isNodeFake: true,
+      id: 12,
+      title: 'KSampler',
+      boundingRect: {}
+    })
   ]
-  const selectedItems = new Set<unknown>()
-  const selectItems = vi.fn((items: unknown[], add = false) => {
+  const selectedItems = new Set<LGraphNode>()
+  const selectItems = vi.fn((items: LGraphNode[], add = false) => {
     if (!add) selectedItems.clear()
     for (const item of items) selectedItems.add(item)
   })
-  const deselect = vi.fn((node: unknown) => selectedItems.delete(node))
+  const deselect = vi.fn((node: LGraphNode) => selectedItems.delete(node))
   const deselectAll = vi.fn(() => selectedItems.clear())
   const graph = {
     nodes,
@@ -789,7 +679,7 @@ function setupNodeSelectionCanvas() {
     canvas: { focus }
   }
   appMock.canvas = canvas
-  hostStores.canvas.currentGraph = graph
+  canvasStore.currentGraph = fromPartial(graph)
   return {
     canvas,
     focus,
@@ -807,7 +697,11 @@ function nestSelectionCanvasInSubgraph(
   state: ReturnType<typeof setupNodeSelectionCanvas>
 ) {
   Object.assign(state.canvas.graph, { id: SUBGRAPH_UUID })
-  for (const node of state.nodes) node.graph = { id: SUBGRAPH_UUID }
+  for (const node of state.nodes)
+    node.graph = fromPartial<Subgraph>({
+      id: SUBGRAPH_UUID,
+      isRootGraph: false
+    })
   const subgraphNode = {
     id: 1,
     title: 'Subgraph',
@@ -823,7 +717,7 @@ function nestSelectionCanvasInSubgraph(
 
 function showRootGraph(
   state: ReturnType<typeof setupNodeSelectionCanvas>,
-  nodes: SelectionTestNode[] = []
+  nodes: LGraphNode[] = []
 ) {
   const graph = {
     nodes,
@@ -831,12 +725,12 @@ function showRootGraph(
       nodes.find((node) => String(node.id) === String(id)) ?? null
   }
   state.canvas.graph = graph
-  hostStores.canvas.currentGraph = graph
+  canvasStore.currentGraph = fromPartial(graph)
 }
 
 function renderCanvasNodeButtons(
-  nodes: SelectionTestNode[],
-  onClick: (node: SelectionTestNode) => void
+  nodes: LGraphNode[],
+  onClick: (node: LGraphNode) => void
 ): void {
   const CanvasNodes = defineComponent({
     setup: () => () =>
@@ -871,11 +765,11 @@ async function enterNodeSelectionMode(): Promise<void> {
 
 async function startVueNodeSelection() {
   const state = setupNodeSelectionCanvas()
-  const selectClickedNode = vi.fn((node: SelectionTestNode) => {
+  const selectClickedNode = vi.fn((node: LGraphNode) => {
     if (!state.canvas.multi_select) state.selectedItems.clear()
     if (state.selectedItems.has(node)) state.selectedItems.delete(node)
     else state.selectedItems.add(node)
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
   })
   const panel = render(AgentPanelRoot, { global: { plugins: [i18n] } })
   renderCanvasNodeButtons(state.nodes, selectClickedNode)
@@ -888,7 +782,7 @@ async function startVueNodeSelection() {
   await userEvent.click(buttons[0])
   await userEvent.click(buttons[1])
   expect(state.selectItems).not.toHaveBeenCalled()
-  expect(hostStores.canvas.selectedItems).toEqual(state.nodes)
+  expect(canvasStore.selectedItems).toEqual(state.nodes)
 
   return { ...state, buttons, selectClickedNode, unmount: panel.unmount }
 }
@@ -923,7 +817,6 @@ function stubUploadFetch(uploaded: string[] = []): string[] {
 
 describe('AgentPanelRoot attach flow', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
   })
 
@@ -1035,15 +928,9 @@ describe('AgentPanelRoot attach flow', () => {
 
   it('hides the assets entry in builder mode', async () => {
     stubUploadFetch()
-    hostStores.workflow.activeWorkflow = {
-      path: 'workflows/current.json',
-      directory: 'workflows',
-      filename: 'current',
-      isTemporary: false,
-      isModified: false,
-      activeState: null,
+    workflowStore.activeWorkflow = addTab('workflows/current.json', {
       activeMode: 'builder:inputs'
-    }
+    })
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
@@ -1565,7 +1452,6 @@ describe('AgentPanelRoot attach flow', () => {
   })
 
   it('removes the chip, revokes its preview, and raises the error modal when the upload fails', async () => {
-    executionErrors.lastPromptError = null
     executionErrors.showErrorOverlay.mockClear()
     const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     let failUpload: () => void = () => {}
@@ -1657,7 +1543,6 @@ describe('AgentPanelRoot attach flow', () => {
 
 describe('AgentPanelRoot canvas draft on send', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
   })
 
@@ -1680,18 +1565,11 @@ describe('AgentPanelRoot canvas draft on send', () => {
       links: []
     })
     const prepareForSave = vi.fn()
-    const activeWorkflow = {
-      path: 'workflows/video_minimax_h3_i2v.json',
-      directory: 'workflows',
-      filename: 'video_minimax_h3_i2v',
-      isTemporary: false,
-      isModified: false,
+    const activeWorkflow = addTab('workflows/video_minimax_h3_i2v.json', {
       activeState,
-      changeTracker: { prepareForSave }
-    }
-    hostStores.workflow.tabs.set(activeWorkflow.path, activeWorkflow)
-    hostStores.workflow.openTabPaths.add(activeWorkflow.path)
-    hostStores.workflow.activeWorkflow = activeWorkflow
+      changeTracker: createMockChangeTracker({ prepareForSave })
+    })
+    workflowStore.activeWorkflow = activeWorkflow
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
@@ -1717,7 +1595,7 @@ describe('AgentPanelRoot canvas draft on send', () => {
         return json(202, { thread_id: 'th-1', message_id: 'm-1' })
       })
     )
-    hostStores.workflow.activeWorkflow = null
+    workflowStore.activeWorkflow = null
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
@@ -1731,7 +1609,6 @@ describe('AgentPanelRoot canvas draft on send', () => {
 
 describe('AgentPanelRoot history', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
     localStorage.clear()
   })
@@ -1991,7 +1868,6 @@ describe('AgentPanelRoot history', () => {
   })
 
   it('surfaces a thread-list failure via the host error modal', async () => {
-    executionErrors.lastPromptError = null
     executionErrors.showErrorOverlay.mockClear()
     vi.stubGlobal(
       'fetch',
@@ -2037,7 +1913,6 @@ describe('AgentPanelRoot history', () => {
 
 describe('AgentPanelRoot transcript copy', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
     clipboard.copy.mockClear()
   })
@@ -2121,7 +1996,6 @@ describe('AgentPanelRoot transcript copy', () => {
 
 describe('AgentPanelRoot feedback capture', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
     telemetry.trackAgentMessageFeedback.mockClear()
   })
@@ -2163,7 +2037,6 @@ describe('AgentPanelRoot feedback capture', () => {
 
 describe('AgentPanelRoot lifecycle', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
   })
 
@@ -2227,7 +2100,6 @@ describe('AgentPanelRoot lifecycle', () => {
 
 describe('AgentPanelRoot greeting', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
   })
 
@@ -2240,7 +2112,6 @@ describe('AgentPanelRoot greeting', () => {
 
 describe('AgentPanelRoot a11y id guard', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
   })
 
@@ -2263,7 +2134,6 @@ describe('AgentPanelRoot a11y id guard', () => {
 
 describe('AgentPanelRoot workflow binding', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     ws.clear()
     useAgentPanelStore().enabled = true
     vi.mocked(app.loadGraphData).mockClear()
@@ -2273,19 +2143,13 @@ describe('AgentPanelRoot workflow binding', () => {
     executionErrors.showErrorOverlay.mockClear()
   })
 
-  function makeTab(id?: string): FakeTab {
-    const tab: FakeTab = {
-      path: 'workflows/current.json',
-      directory: 'workflows',
-      filename: 'current',
-      isTemporary: false,
-      isModified: false,
-      activeState:
-        id === undefined ? null : fromPartial<ComfyWorkflowJSON>({ id })
-    }
-    hostStores.workflow.tabs.set(tab.path, tab)
-    hostStores.workflow.openTabPaths.add(tab.path)
-    hostStores.workflow.activeWorkflow = tab
+  function makeTab(id?: string): LoadedComfyWorkflow {
+    const tab = addTab('workflows/current.json', {
+      ...(id === undefined
+        ? {}
+        : { activeState: fromPartial<ComfyWorkflowJSON>({ id }) })
+    })
+    workflowStore.activeWorkflow = tab
     if (id !== undefined) useAgentWorkflowTabBindingStore().bind(id, tab.path)
     return tab
   }
@@ -2332,7 +2196,7 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(await screen.findAllByText('current')).not.toHaveLength(0)
 
     const other = addTab('workflows/other.json')
-    hostStores.workflow.activeWorkflow = other
+    workflowStore.activeWorkflow = other
     expect(await screen.findAllByText('other')).not.toHaveLength(0)
     expect(screen.queryAllByText('current')).toHaveLength(0)
   })
@@ -2458,11 +2322,13 @@ describe('AgentPanelRoot workflow binding', () => {
     await vi.advanceTimersByTimeAsync(0)
     await vi.advanceTimersByTimeAsync(499)
     expect(activity.creatingTab).toBe(true)
-    expect(hostStores.workflow.tabs.get('workflows/Fresh.json')).toBeUndefined()
+    expect(workflowStore.getWorkflowByPath('workflows/Fresh.json')).toBeNull()
 
     await vi.advanceTimersByTimeAsync(1)
     expect(activity.creatingTab).toBe(false)
-    expect(hostStores.workflow.tabs.get('workflows/Fresh.json')).toBeDefined()
+    expect(
+      workflowStore.getWorkflowByPath('workflows/Fresh.json')
+    ).not.toBeNull()
   })
 
   it('lowers the creating flag when a newer focus event supersedes the fetch', async () => {
@@ -2499,7 +2365,7 @@ describe('AgentPanelRoot workflow binding', () => {
       expect(workflowService.openWorkflow).toHaveBeenCalledWith(bound)
     )
     expect(activity.creatingTab).toBe(false)
-    expect(hostStores.workflow.tabs.get('workflows/Fresh.json')).toBe(undefined)
+    expect(workflowStore.getWorkflowByPath('workflows/Fresh.json')).toBeNull()
   })
 
   it('pins the spinner to the tab that sent the turn, not the tab active at ack', async () => {
@@ -2509,7 +2375,7 @@ describe('AgentPanelRoot workflow binding', () => {
       'fetch',
       vi.fn(async (url: string) => {
         if (url.includes('/messages')) {
-          hostStores.workflow.activeWorkflow = other
+          workflowStore.activeWorkflow = other
           return json(202, ack('wf-42', 'm-1'))
         }
         if (url.includes('/agent/threads')) return json(200, agentThreadList())
@@ -2557,7 +2423,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     const other = addTab('workflows/other.json')
     useAgentWorkflowTabBindingStore().bind('wf-other', other.path)
-    hostStores.workflow.activeWorkflow = other
+    workflowStore.activeWorkflow = other
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string) => {
@@ -2600,7 +2466,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const scratch = addTab('workflows/scratch.json', {
       activeState: fromPartial<ComfyWorkflowJSON>({ id: 'local-scratch' })
     })
-    hostStores.workflow.activeWorkflow = scratch
+    workflowStore.activeWorkflow = scratch
     await sendFromComposer('second message')
 
     expect(bodies[1]).not.toHaveProperty('workflow_id')
@@ -2742,7 +2608,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await vi.waitFor(() =>
       expect(workflowService.openWorkflow).toHaveBeenCalled()
     )
-    const minted = hostStores.workflow.tabs.get('workflows/Video test.json')
+    const minted = workflowStore.getWorkflowByPath('workflows/Video test.json')
     expect(minted?.filename).toBe('Video test')
     // The host minted the doc server-side; the follower fills the canvas.
     // Nothing loads, saves, or adopts here.
@@ -2768,7 +2634,9 @@ describe('AgentPanelRoot workflow binding', () => {
       thread_id: 'th-1'
     })
     await vi.waitFor(() =>
-      expect(hostStores.workflow.tabs.get('workflows/a-b.json')).toBeDefined()
+      expect(
+        workflowStore.getWorkflowByPath('workflows/a-b.json')
+      ).not.toBeNull()
     )
 
     ws.emit('agent_active_tab', {
@@ -2778,8 +2646,8 @@ describe('AgentPanelRoot workflow binding', () => {
     })
     await vi.waitFor(() =>
       expect(
-        hostStores.workflow.tabs.get('workflows/Unsaved Workflow.json')
-      ).toBeDefined()
+        workflowStore.getWorkflowByPath('workflows/Unsaved Workflow.json')
+      ).not.toBeNull()
     )
   })
 
@@ -2796,8 +2664,8 @@ describe('AgentPanelRoot workflow binding', () => {
     })
     await vi.waitFor(() =>
       expect(
-        hostStores.workflow.tabs.get('workflows/hidden.json')
-      ).toBeDefined()
+        workflowStore.getWorkflowByPath('workflows/hidden.json')
+      ).not.toBeNull()
     )
   })
 
@@ -2810,14 +2678,14 @@ describe('AgentPanelRoot workflow binding', () => {
     ws.emit('agent_active_tab', { workflow_id: 'wf-a', thread_id: 'th-1' })
     await vi.waitFor(() =>
       expect(
-        hostStores.workflow.tabs.get('workflows/Unsaved Workflow.json')
-      ).toBeDefined()
+        workflowStore.getWorkflowByPath('workflows/Unsaved Workflow.json')
+      ).not.toBeNull()
     )
     ws.emit('agent_active_tab', { workflow_id: 'wf-b', thread_id: 'th-1' })
     await vi.waitFor(() =>
       expect(
-        hostStores.workflow.tabs.get('workflows/Unsaved Workflow (2).json')
-      ).toBeDefined()
+        workflowStore.getWorkflowByPath('workflows/Unsaved Workflow (2).json')
+      ).not.toBeNull()
     )
     expect(workflowService.saveWorkflowAs).not.toHaveBeenCalled()
 
@@ -2843,8 +2711,8 @@ describe('AgentPanelRoot workflow binding', () => {
         await new Promise<void>((resolve) => {
           resolveSlowOpen = resolve
         })
-        const known = hostStores.workflow.tabs.get(slow.path)
-        if (known) hostStores.workflow.activeWorkflow = known
+        const known = workflowStore.getWorkflowByPath(slow.path)
+        if (known) workflowStore.activeWorkflow = await known.load()
       }
     )
 
@@ -2860,19 +2728,19 @@ describe('AgentPanelRoot workflow binding', () => {
 
     await new Promise((resolve) => setTimeout(resolve))
     expect(workflowService.openWorkflow).toHaveBeenCalledTimes(1)
-    expect(hostStores.workflow.tabs.get('workflows/Quick tab.json')).toBe(
-      undefined
-    )
+    expect(
+      workflowStore.getWorkflowByPath('workflows/Quick tab.json')
+    ).toBeNull()
     resolveSlowOpen?.()
     await vi.waitFor(() =>
       expect(
-        hostStores.workflow.tabs.get('workflows/Quick tab.json')
-      ).toBeDefined()
+        workflowStore.getWorkflowByPath('workflows/Quick tab.json')
+      ).not.toBeNull()
     )
     await new Promise((resolve) => setTimeout(resolve))
 
-    expect(hostStores.workflow.activeWorkflow?.filename).toBe('Quick tab')
-    expect(tab).not.toBe(hostStores.workflow.activeWorkflow)
+    expect(workflowStore.activeWorkflow?.filename).toBe('Quick tab')
+    expect(tab).not.toBe(workflowStore.activeWorkflow)
   })
 
   it('a stale agent_active_tab resolving late cannot steal focus from the newest', async () => {
@@ -2904,15 +2772,15 @@ describe('AgentPanelRoot workflow binding', () => {
 
     await vi.waitFor(() =>
       expect(
-        hostStores.workflow.tabs.get('workflows/Fast tab.json')
-      ).toBeDefined()
+        workflowStore.getWorkflowByPath('workflows/Fast tab.json')
+      ).not.toBeNull()
     )
     await new Promise((resolve) => setTimeout(resolve))
 
     // The superseded activation closed its own minted tab and bound nothing.
-    expect(hostStores.workflow.tabs.get('workflows/Slow tab.json')).toBe(
-      undefined
-    )
+    expect(
+      workflowStore.getWorkflowByPath('workflows/Slow tab.json')
+    ).toBeNull()
     expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-slow')).toBe(
       undefined
     )
@@ -2937,11 +2805,13 @@ describe('AgentPanelRoot workflow binding', () => {
     })
 
     await vi.waitFor(() =>
-      expect(hostStores.workflow.tabs.get('workflows/B tab.json')).toBeDefined()
+      expect(
+        workflowStore.getWorkflowByPath('workflows/B tab.json')
+      ).not.toBeNull()
     )
     await new Promise((resolve) => setTimeout(resolve))
 
-    expect(hostStores.workflow.tabs.get('workflows/A tab.json')).toBe(undefined)
+    expect(workflowStore.getWorkflowByPath('workflows/A tab.json')).toBeNull()
     expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-b')).toBe(
       'workflows/B tab.json'
     )
@@ -3164,7 +3034,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const appTab = addTab('workflows/all-in-one-image-edit-models.app.json', {
       activeState
     })
-    hostStores.workflow.activeWorkflow = appTab
+    workflowStore.activeWorkflow = appTab
     useAgentConversationStore().setThreadId('th-two-node-workflow')
     const bodies = mockMessagesEndpoint('wf-all-in-one', [
       { id: 'wf-all-in-one', name: 'all-in-one-image-edit-models.app' }
@@ -3191,7 +3061,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('does not resolve temporary tabs through the cloud workflow index', async () => {
     const tab = makeTab()
-    tab.isTemporary = true
+    Object.assign(tab, { isTemporary: true })
     const bodies = mockMessagesEndpoint('wf-fresh', [
       { id: 'wf-cloud-current', name: 'current' }
     ])
@@ -3220,9 +3090,9 @@ describe('AgentPanelRoot workflow binding', () => {
     await vi.waitFor(() =>
       expect(workflowService.openWorkflow).toHaveBeenCalledWith(duck)
     )
-    expect(hostStores.workflow.tabs.get('workflows/duck (2).json')).toBe(
-      undefined
-    )
+    expect(
+      workflowStore.getWorkflowByPath('workflows/duck (2).json')
+    ).toBeNull()
     // Resolving by cloud name has to leave the binding behind, or the transcript
     // link renders nothing for the tab the user was just moved to.
     expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-cloud-duck')).toBe(
@@ -3286,7 +3156,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await screen.findByRole('button', { name: 'Send' })
 
     const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
-    hostStores.workflow.activeWorkflow = scratch
+    workflowStore.activeWorkflow = scratch
 
     await sendFromComposer('second message')
 
@@ -3305,7 +3175,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await screen.findByRole('button', { name: 'Send' })
 
     const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
-    hostStores.workflow.activeWorkflow = scratch
+    workflowStore.activeWorkflow = scratch
     await nextTick()
     socketSend.mockClear()
 
@@ -3329,7 +3199,7 @@ describe('AgentPanelRoot workflow binding', () => {
   it('does not bind an unsaved tab to a workflow that already has an open tab', async () => {
     addTab('workflows/current.json')
     const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
-    hostStores.workflow.activeWorkflow = scratch
+    workflowStore.activeWorkflow = scratch
     mockMessagesEndpoint('wf-42', [{ id: 'wf-42', name: 'current' }])
 
     await renderAndSend('first message')
@@ -3349,9 +3219,11 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('does not bind an unsaved tab to a workflow whose saved tab is closed', async () => {
     const saved = makeTab('wf-42')
-    hostStores.workflow.openTabPaths.delete(saved.path)
+    await workflowStore.closeWorkflow(
+      workflowStore.getWorkflowByPath(saved.path)!
+    )
     const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
-    hostStores.workflow.activeWorkflow = scratch
+    workflowStore.activeWorkflow = scratch
     mockMessagesEndpoint('wf-42')
 
     await renderAndSend('first message')
@@ -3483,7 +3355,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('binds a minted workflow to its unsaved tab and subscribes once', async () => {
     const tab = makeTab()
-    tab.isTemporary = true
+    Object.assign(tab, { isTemporary: true })
     mockMessagesEndpoint('wf-fresh')
 
     await renderAndSend('build a graph')
@@ -3506,13 +3378,13 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('does not subscribe a minted workflow after its tab is backgrounded', async () => {
     const origin = makeTab()
-    origin.isTemporary = true
+    Object.assign(origin, { isTemporary: true })
     const background = addTab('workflows/background.json')
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string, init?: RequestInit) => {
         if (url.includes('/messages') && init?.method === 'POST') {
-          hostStores.workflow.activeWorkflow = background
+          workflowStore.activeWorkflow = background
           return json(202, ack('wf-fresh', 'm-1'))
         }
         if (url.includes('/agent/threads'))
@@ -3583,8 +3455,10 @@ describe('AgentPanelRoot workflow binding', () => {
     await userEvent.type(screen.getByRole('textbox'), 'build a graph')
     await userEvent.click(screen.getByRole('button', { name: 'Send' }))
     await vi.waitFor(() => expect(workflowRequests).toBe(2))
-    hostStores.workflow.openTabPaths.delete(origin.path)
-    hostStores.workflow.activeWorkflow = replacement
+    await workflowStore.closeWorkflow(
+      workflowStore.getWorkflowByPath(origin.path)!
+    )
+    workflowStore.activeWorkflow = replacement
     releasePreparation()
 
     await vi.waitFor(() => expect(bodies).toHaveLength(1))
@@ -3663,7 +3537,7 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(state.deselect).toHaveBeenCalledWith(state.nodes[0])
     expect(focusNodeInstance).not.toHaveBeenCalled()
     expect([...state.selectedItems]).toEqual([state.nodes[1]])
-    expect(hostStores.canvas.selectedItems).toEqual([state.nodes[1]])
+    expect(canvasStore.selectedItems).toEqual([state.nodes[1]])
   })
 
   it('focuses the graph node when its reference chip is activated', async () => {
@@ -3710,14 +3584,14 @@ describe('AgentPanelRoot workflow binding', () => {
     const state = setupNodeSelectionCanvas()
     const subgraphNode = nestSelectionCanvasInSubgraph(state)
     const referencedNode = state.nodes[1]
-    referencedNode.id = 'shared'
+    referencedNode.id = toNodeId('shared')
     referencedNode.title = 'Subgraph twin'
-    const rootTwin: SelectionTestNode = {
+    const rootTwin: LGraphNode = createMockLGraphNode({
       isNodeFake: true,
       id: 'shared',
       title: 'Root twin',
       boundingRect: {}
-    }
+    })
     appMock.graph.nodes = [subgraphNode, rootTwin]
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
@@ -3728,7 +3602,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     showRootGraph(state, [rootTwin])
     state.selectedItems.add(rootTwin)
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     await nextTick()
 
     await userEvent.click(
@@ -3782,7 +3656,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     state.selectedItems.clear()
     state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     await nextTick()
 
     expect(screen.getByText('KSampler')).toBeInTheDocument()
@@ -3801,7 +3675,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await userEvent.click(await screen.findByText('KSampler'))
     state.selectedItems.clear()
     state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     state.selectItems.mockClear()
 
     await enterNodeSelectionMode()
@@ -3820,7 +3694,7 @@ describe('AgentPanelRoot workflow binding', () => {
     mockMessagesEndpoint('wf-42')
     const state = setupNodeSelectionCanvas()
     const subgraphNode = nestSelectionCanvasInSubgraph(state)
-    state.nodes[1].id = 'shared'
+    state.nodes[1].id = toNodeId('shared')
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
@@ -3828,17 +3702,17 @@ describe('AgentPanelRoot workflow binding', () => {
     await openMentionPicker()
     await userEvent.click(await screen.findByText('KSampler'))
 
-    const rootNode: SelectionTestNode = {
+    const rootNode: LGraphNode = createMockLGraphNode({
       isNodeFake: true,
       id: 'shared',
       title: 'Root node',
       boundingRect: {}
-    }
+    })
     appMock.graph.nodes = [subgraphNode, rootNode]
     showRootGraph(state, [rootNode])
     state.selectedItems.clear()
     state.selectedItems.add(rootNode)
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     state.selectItems.mockClear()
     await nextTick()
 
@@ -3855,14 +3729,14 @@ describe('AgentPanelRoot workflow binding', () => {
     const state = setupNodeSelectionCanvas()
     const subgraphNode = nestSelectionCanvasInSubgraph(state)
     const referencedNode = state.nodes[1]
-    referencedNode.id = 'shared'
+    referencedNode.id = toNodeId('shared')
     referencedNode.title = 'Subgraph twin'
-    const rootTwin: SelectionTestNode = {
+    const rootTwin: LGraphNode = createMockLGraphNode({
       isNodeFake: true,
       id: 'shared',
       title: 'Root twin',
       boundingRect: {}
-    }
+    })
     appMock.graph.nodes = [subgraphNode, rootTwin]
     const panelStore = useAgentPanelStore()
 
@@ -3942,9 +3816,9 @@ describe('AgentPanelRoot workflow binding', () => {
 
     ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
     await screen.findByRole('button', { name: 'Send' })
-    hostStores.canvas.selectedItems = [
-      { isNodeFake: true, id: 7, title: 'KSampler' }
-    ]
+    canvasStore.selectedItems = fromPartial([
+      createMockLGraphNode({ isNodeFake: true, id: 7, title: 'KSampler' })
+    ])
     await nextTick()
     expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
     await sendFromComposer('still no nodes')
@@ -3952,9 +3826,9 @@ describe('AgentPanelRoot workflow binding', () => {
 
     ws.emit('agent_message_done', { message_id: 'm-2', thread_id: 'th-1' })
     await screen.findByRole('button', { name: 'Send' })
-    hostStores.canvas.selectedItems = [
-      { isNodeFake: true, id: 8, title: 'VAEDecode' }
-    ]
+    canvasStore.selectedItems = fromPartial([
+      createMockLGraphNode({ isNodeFake: true, id: 8, title: 'VAEDecode' })
+    ])
     await nextTick()
     expect(screen.queryByText('VAEDecode')).not.toBeInTheDocument()
     await sendFromComposer('use the new selection')
@@ -3962,10 +3836,9 @@ describe('AgentPanelRoot workflow binding', () => {
   })
 
   it('stages the same node id in another unsaved workflow after a panel remount', async () => {
-    hostStores.workflow.activeWorkflow = addTab(
-      'workflows/Unsaved Workflow.json',
-      { isTemporary: true }
-    )
+    workflowStore.activeWorkflow = addTab('workflows/Unsaved Workflow.json', {
+      isTemporary: true
+    })
     const bodies = mockMessagesEndpoint('wf-42')
     const panelStore = useAgentPanelStore()
     appMock.graph.nodes = [{ id: 7, title: 'First KSampler' }]
@@ -3984,7 +3857,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await nextTick()
     first.unmount()
 
-    hostStores.workflow.activeWorkflow = addTab(
+    workflowStore.activeWorkflow = addTab(
       'workflows/Unsaved Workflow (2).json',
       { isTemporary: true }
     )
@@ -4002,10 +3875,10 @@ describe('AgentPanelRoot workflow binding', () => {
     makeTab()
     mockMessagesEndpoint('wf-42')
     const state = setupNodeSelectionCanvas()
-    const selectLegacyNode = (node: SelectionTestNode) => {
+    const selectLegacyNode = (node: LGraphNode) => {
       if (!state.canvas.multi_select) state.selectedItems.clear()
       state.selectedItems.add(node)
-      hostStores.canvas.updateSelectedItems()
+      canvasStore.updateSelectedItems()
     }
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     renderCanvasNodeButtons(state.nodes, selectLegacyNode)
@@ -4028,17 +3901,17 @@ describe('AgentPanelRoot workflow binding', () => {
     makeTab()
     mockMessagesEndpoint('wf-42')
     const state = setupNodeSelectionCanvas()
-    const thirdNode: SelectionTestNode = {
+    const thirdNode: LGraphNode = createMockLGraphNode({
       isNodeFake: true,
       id: 15,
       title: 'Save Image',
       boundingRect: {}
-    }
+    })
     state.nodes.push(thirdNode)
-    const toggleNode = (node: SelectionTestNode) => {
+    const toggleNode = (node: LGraphNode) => {
       if (state.selectedItems.has(node)) state.selectedItems.delete(node)
       else state.selectedItems.add(node)
-      hostStores.canvas.updateSelectedItems()
+      canvasStore.updateSelectedItems()
     }
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     renderCanvasNodeButtons(state.nodes, toggleNode)
@@ -4069,12 +3942,12 @@ describe('AgentPanelRoot workflow binding', () => {
 
     await enterNodeSelectionMode()
     state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     state.selectItems.mockClear()
 
     state.selectedItems.clear()
     state.selectedItems.add(state.nodes[1])
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     await nextTick()
 
     expect([...state.selectedItems]).toEqual([state.nodes[1]])
@@ -4130,12 +4003,12 @@ describe('AgentPanelRoot workflow binding', () => {
     mockMessagesEndpoint('wf-42')
     const selection = await startVueNodeSelection()
     const nextGraph = {
-      nodes: [] as SelectionTestNode[],
+      nodes: [] as LGraphNode[],
       getNodeById: () => null
     }
 
     selection.canvas.graph = nextGraph
-    hostStores.canvas.currentGraph = nextGraph
+    canvasStore.currentGraph = fromPartial(nextGraph)
     await nextTick()
 
     expect(selection.canvas.multi_select).toBe(false)
@@ -4148,7 +4021,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const selection = await startVueNodeSelection()
     useAgentNodeSelectionStore().beginWorkflowLoad()
 
-    hostStores.workflow.activeWorkflow = addTab('workflows/other.json')
+    workflowStore.activeWorkflow = addTab('workflows/other.json')
     await nextTick()
 
     expect(useAgentNodeSelectionStore().isActive).toBe(false)
@@ -4163,7 +4036,7 @@ describe('AgentPanelRoot workflow binding', () => {
     mockMessagesEndpoint('wf-42')
     const selection = await startVueNodeSelection()
 
-    const active = hostStores.workflow.activeWorkflow
+    const active = workflowStore.activeWorkflow
     if (!active) throw new Error('expected an active workflow')
     active.path = 'workflows/renamed.json'
     active.filename = 'renamed'
@@ -4178,12 +4051,12 @@ describe('AgentPanelRoot workflow binding', () => {
   it('keeps each workflow node selection separate after a graph load', async () => {
     makeTab()
     const selection = await startVueNodeSelection()
-    const secondNode = {
+    const secondNode = createMockLGraphNode({
       isNodeFake: true as const,
       id: 20,
       title: 'Save Image',
       boundingRect: {}
-    }
+    })
     const secondGraph = {
       nodes: [secondNode],
       getNodeById: (id: string | number) =>
@@ -4196,8 +4069,8 @@ describe('AgentPanelRoot workflow binding', () => {
     selection.canvas.graph = secondGraph
     selection.selectedItems.clear()
     selection.selectedItems.add(secondNode)
-    hostStores.canvas.currentGraph = secondGraph
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.currentGraph = fromPartial(secondGraph)
+    canvasStore.updateSelectedItems()
     await nextTick()
 
     expect(nodeSelectionStore.isLoadingWorkflow).toBe(false)
@@ -4213,7 +4086,7 @@ describe('AgentPanelRoot workflow binding', () => {
     nodeSelectionStore.beginWorkflowLoad()
     nodeSelectionStore.restoreNodeIds(['9'])
     state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
+    canvasStore.updateSelectedItems()
     useAgentPanelStore().isOpen = true
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -3,14 +3,14 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@/i18n'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import type { ReplyAsset } from '../../../utils/replyAssets'
 import ReplyAssetGroup from './ReplyAssetGroup.vue'
 
-const showDialog = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
+let showDialog: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useDialogStore>['showDialog']>
+>
 
 const isAssetPreviewSupported = vi.hoisted(() => vi.fn(() => false))
 const findServerPreviewUrl = vi.hoisted(() =>
@@ -81,7 +81,7 @@ const toggle = () =>
 
 describe('ReplyAssetGroup', () => {
   beforeEach(() => {
-    showDialog.mockClear()
+    showDialog = vi.mocked(useDialogStore().showDialog)
     isAssetPreviewSupported.mockReset().mockReturnValue(false)
     findServerPreviewUrl.mockReset().mockResolvedValue(null)
     findOutputAsset.mockReset().mockResolvedValue(undefined)
@@ -226,7 +226,9 @@ describe('ReplyAssetGroup', () => {
 
     findServerPreviewUrl.mockResolvedValue('https://x/mesh_preview.png')
     const dialog = showDialog.mock.calls.at(-1)?.[0]
-    dialog.dialogComponentProps.onClose()
+    const onClose = dialog?.dialogComponentProps?.onClose
+    expect(onClose).toBeTypeOf('function')
+    onClose!()
 
     const thumb = await screen.findByRole('img', { name: 'mesh.glb' })
     expect(thumb).toHaveAttribute('src', 'https://x/mesh_preview.png')

--- a/src/workbench/extensions/agent/components/agent/message/TabLinkCard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/TabLinkCard.test.ts
@@ -1,28 +1,30 @@
 // @vitest-environment jsdom
 import userEvent from '@testing-library/user-event'
 import { render, screen, within } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import TabLinkCard from './TabLinkCard.vue'
 import { AgentTargetNavigationError } from '../../../services/agent/targetAwareAgentNavigation'
 
-interface FakeTab {
-  path: string
-  filename: string
-  activeState?: { nodes: unknown[] }
-}
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
 
 const mocks = vi.hoisted(() => ({
   api: new EventTarget(),
-  activeWorkflow: undefined as FakeTab | undefined,
   openWorkflow: vi.fn(),
   navigate: vi.fn(),
-  reportError: vi.fn(),
-  openWorkflows: [] as unknown[]
+  reportError: vi.fn()
 }))
 
 vi.mock(import('../../../composables/agent/useAgentTargetNavigation'), () => ({
@@ -42,20 +44,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get openWorkflows() {
-        return mocks.openWorkflows
-      },
-      get activeWorkflow() {
-        return mocks.activeWorkflow
-      }
-    })
-  })
-)
-
 const { useAgentWorkflowTabBindingStore } =
   await import('../../../stores/agent/agentWorkflowTabBindingStore')
 const { useAgentPanelStore } =
@@ -68,24 +56,30 @@ function mount(workflowId: string, name?: string) {
   })
 }
 
-function openTabs(...tabs: FakeTab[]): void {
-  mocks.openWorkflows = tabs
+function openTabs(...tabs: LoadedComfyWorkflow[]): void {
+  for (const tab of tabs) {
+    useWorkflowStore().attachWorkflow(
+      tab,
+      useWorkflowStore().openWorkflows.length
+    )
+  }
 }
 
 describe('TabLinkCard', () => {
   beforeEach(() => {
     localStorage.clear()
-    setActivePinia(createPinia())
     mocks.openWorkflow.mockClear()
     mocks.navigate.mockClear()
     mocks.reportError.mockClear()
-    mocks.activeWorkflow = undefined
     openTabs()
     useAgentPanelStore().enabled = true
   })
 
   it('T-14 / PM-676 / FE-1310 renders the backend tab name and focuses its workflow on click', async () => {
-    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    const tab = createMockLoadedWorkflow({
+      path: 'flows/portrait.json',
+      filename: 'portrait'
+    })
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
 
@@ -99,7 +93,10 @@ describe('TabLinkCard', () => {
   })
 
   it('falls back to the local tab name when no backend name is present', () => {
-    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    const tab = createMockLoadedWorkflow({
+      path: 'flows/portrait.json',
+      filename: 'portrait'
+    })
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
 
@@ -109,11 +106,11 @@ describe('TabLinkCard', () => {
   })
 
   it('renders one action with media, title and node-count content, then navigation affordance', () => {
-    const tab = {
+    const tab = createMockLoadedWorkflow({
       path: 'flows/portrait.json',
       filename: 'portrait',
       activeState: { nodes: [{}, {}] }
-    }
+    })
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
 
@@ -134,13 +131,13 @@ describe('TabLinkCard', () => {
   })
 
   it('keeps the active workflow node count current and accessible', async () => {
-    const tab = {
+    const tab = createMockLoadedWorkflow({
       path: 'flows/portrait.json',
       filename: 'portrait',
       activeState: { nodes: [{}] }
-    }
+    })
     openTabs(tab)
-    mocks.activeWorkflow = tab
+    useWorkflowStore().activeWorkflow = tab
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
 
     mount('wf-1')
@@ -156,18 +153,18 @@ describe('TabLinkCard', () => {
   })
 
   it('ignores graph changes while the linked workflow is inactive', async () => {
-    const linkedTab = {
+    const linkedTab = createMockLoadedWorkflow({
       path: 'flows/portrait.json',
       filename: 'portrait',
       activeState: { nodes: [{}] }
-    }
-    const activeTab = {
+    })
+    const activeTab = createMockLoadedWorkflow({
       path: 'flows/landscape.json',
       filename: 'landscape',
       activeState: { nodes: [{}, {}] }
-    }
+    })
     openTabs(linkedTab, activeTab)
-    mocks.activeWorkflow = activeTab
+    useWorkflowStore().activeWorkflow = activeTab
     useAgentWorkflowTabBindingStore().bind('wf-1', linkedTab.path)
 
     mount('wf-1')
@@ -182,13 +179,13 @@ describe('TabLinkCard', () => {
 
   it('removes its graph listener when unmounted', () => {
     const removeListener = vi.spyOn(mocks.api, 'removeEventListener')
-    const tab = {
+    const tab = createMockLoadedWorkflow({
       path: 'flows/portrait.json',
       filename: 'portrait',
       activeState: { nodes: [{}] }
-    }
+    })
     openTabs(tab)
-    mocks.activeWorkflow = tab
+    useWorkflowStore().activeWorkflow = tab
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
 
     const view = mount('wf-1')
@@ -207,7 +204,10 @@ describe('TabLinkCard', () => {
   })
 
   it('renders no reference and performs no action while the flag is off', () => {
-    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    const tab = createMockLoadedWorkflow({
+      path: 'flows/portrait.json',
+      filename: 'portrait'
+    })
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
     useAgentPanelStore().enabled = false
@@ -219,7 +219,10 @@ describe('TabLinkCard', () => {
   })
 
   it('navigates an explicit node reference through its target workflow', async () => {
-    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    const tab = createMockLoadedWorkflow({
+      path: 'flows/portrait.json',
+      filename: 'portrait'
+    })
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
 
@@ -241,7 +244,10 @@ describe('TabLinkCard', () => {
   })
 
   it('shows recovery feedback when a node target is no longer available', async () => {
-    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    const tab = createMockLoadedWorkflow({
+      path: 'flows/portrait.json',
+      filename: 'portrait'
+    })
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
     mocks.navigate.mockRejectedValueOnce(
@@ -263,7 +269,10 @@ describe('TabLinkCard', () => {
   })
 
   it('reports unexpected navigation failures', async () => {
-    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    const tab = createMockLoadedWorkflow({
+      path: 'flows/portrait.json',
+      filename: 'portrait'
+    })
     const error = new Error('focus failed')
     openTabs(tab)
     useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -32,9 +32,6 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { serialize: () => ({ nodes: [], links: [] }) } }
 }))
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({ extensions: [] })
-}))
 
 const status: AgentCrdtStatus = {
   enabled: true,

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -17,9 +17,6 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { serialize: () => ({ nodes: [], links: [] }) } }
 }))
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({ extensions: [] })
-}))
 
 const { reportError } = vi.hoisted(() => ({ reportError: vi.fn() }))
 vi.mock(import('@/platform/telemetry/reportError'), () => ({ reportError }))

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useExtensionStore } from '@/stores/extensionStore'
 
 const { getSystemStats, getLogs, getSettings } = vi.hoisted(() => ({
   getSystemStats: vi.fn(),
@@ -19,9 +20,9 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({ extensions: [{ name: 'Comfy.TestExtension' }] })
-}))
+beforeEach(() => {
+  useExtensionStore().registerExtension({ name: 'Comfy.TestExtension' })
+})
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -6,7 +6,6 @@
  * the FE-1901 bounded subscribe retry, the FE-1902 sessionStorage rebind,
  * the frame-handler status surface, and total teardown.
  */
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref, shallowRef } from 'vue'
 import type { Ref } from 'vue'
@@ -132,12 +131,21 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiState.api }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { graph: null, canvas: null }
 }))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({ userId: 'user-1' })
-}))
 
 import { STALE_AFTER_MS, useAgentCrdtFollower } from './useAgentCrdtFollower'
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn(async () => {}),
+  onAuthStateChanged: vi.fn(() => () => {}),
+  onIdTokenChanged: vi.fn(() => () => {})
+}))
+
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-1' })
+})
 
 const graphMutations = {} as GraphMutations
 const DOC_ID_KEY = 'Comfy.Agent.CrdtDocId'
@@ -209,7 +217,6 @@ function dispatchFrame(type: string, detail: unknown): void {
 
 describe('useAgentCrdtFollower', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     sessionStorage.clear()
     bridgeState.current = null
     materializerState.reconcileAgentAdapters.mockReset().mockReturnValue([])

--- a/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.test.ts
+++ b/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.test.ts
@@ -1,40 +1,19 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import { registerWorkflowTabActivityTracker } from './workflowTabActivityTracker'
 
-type FakeTab = { path: string }
-
-const hostWorkflow = vi.hoisted(() => ({
-  store: null as unknown as {
-    activeWorkflow: FakeTab | null
-    openWorkflows: FakeTab[]
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    const store = reactive({
-      activeWorkflow: null as FakeTab | null,
-      openWorkflows: [] as FakeTab[]
-    })
-    hostWorkflow.store = store
-    return { useWorkflowStore: () => store }
-  }
-)
+let workflowStore: ReturnType<typeof useWorkflowStore>
 
 describe('registerWorkflowTabActivityTracker', () => {
   let stop: () => void
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-    hostWorkflow.store.activeWorkflow = null
-    hostWorkflow.store.openWorkflows = []
+    workflowStore = useWorkflowStore()
     stop = registerWorkflowTabActivityTracker(ref(true))
   })
 
@@ -46,7 +25,9 @@ describe('registerWorkflowTabActivityTracker', () => {
     const activity = useWorkflowTabActivityStore()
     activity.markModified('workflows/a.json')
 
-    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/a.json'
+    })
     await nextTick()
 
     expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(false)
@@ -54,15 +35,19 @@ describe('registerWorkflowTabActivityTracker', () => {
 
   it('prunes activity state when a tab closes, with no panel mounted', async () => {
     const activity = useWorkflowTabActivityStore()
-    hostWorkflow.store.openWorkflows = [
-      { path: 'workflows/a.json' },
-      { path: 'workflows/b.json' }
-    ]
+    const first = createMockLoadedWorkflow({ path: 'workflows/a.json' })
+    const second = createMockLoadedWorkflow({
+      path: 'workflows/b.json',
+      isTemporary: false,
+      unload: vi.fn()
+    })
+    workflowStore.attachWorkflow(first, 0)
+    workflowStore.attachWorkflow(second, 1)
     await nextTick()
     activity.setEditing('workflows/b.json')
     activity.markModified('workflows/b.json')
 
-    hostWorkflow.store.openWorkflows = [{ path: 'workflows/a.json' }]
+    await workflowStore.closeWorkflow(second)
     await nextTick()
 
     expect(activity.editingTabPath).toBeNull()
@@ -74,7 +59,9 @@ describe('registerWorkflowTabActivityTracker', () => {
     activity.markModified('workflows/a.json')
 
     stop()
-    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/a.json'
+    })
     await nextTick()
 
     expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(true)
@@ -90,7 +77,9 @@ describe('registerWorkflowTabActivityTracker', () => {
     await nextTick()
     stop()
     activity.markModified('workflows/a.json')
-    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/a.json'
+    })
     await nextTick()
 
     expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(true)
@@ -103,7 +92,9 @@ describe('registerWorkflowTabActivityTracker', () => {
     const activity = useWorkflowTabActivityStore()
     activity.markModified('workflows/a.json')
 
-    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/a.json'
+    })
     await nextTick()
 
     expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(true)
@@ -118,7 +109,9 @@ describe('registerWorkflowTabActivityTracker', () => {
     enabled.value = true
     await nextTick()
     activity.markModified('workflows/a.json')
-    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/a.json'
+    })
     await nextTick()
     expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(false)
 

--- a/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable testing-library/no-node-access */
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/prefer-user-event */
-import { createTestingPinia } from '@pinia/testing'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -11,6 +10,7 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 
 import PackVersionBadge from './PackVersionBadge.vue'
 
@@ -31,26 +31,13 @@ const mockNodePack = {
 }
 
 const mockInstalledPacks = {
-  'test-pack': { ver: '1.5.0' },
-  'installed-pack': { ver: '2.0.0' }
+  'test-pack': { ver: '1.5.0', cnr_id: 'test-pack', enabled: true },
+  'installed-pack': { ver: '2.0.0', cnr_id: 'installed-pack', enabled: true }
 }
 
-const mockIsPackEnabled = vi.fn(() => true)
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn(() => ({
-      installedPacks: mockInstalledPacks,
-      isPackInstalled: (id: string) =>
-        !!mockInstalledPacks[id as keyof typeof mockInstalledPacks],
-      isPackEnabled: mockIsPackEnabled,
-      getInstalledPackVersion: (id: string) =>
-        mockInstalledPacks[id as keyof typeof mockInstalledPacks]?.ver
-    }))
-  })
-)
+let mockIsPackEnabled: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['isPackEnabled']>
+>
 
 vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus'),
@@ -81,7 +68,11 @@ const PackVersionSelectorPopoverStub = {
 }
 
 describe('PackVersionBadge', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const store = useComfyManagerStore()
+    store.installedPacks = mockInstalledPacks
+    await nextTick()
+    mockIsPackEnabled = vi.mocked(store.isPackEnabled)
     mockIsPackEnabled.mockReturnValue(true)
   })
 
@@ -101,7 +92,7 @@ describe('PackVersionBadge', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
+        plugins: [PrimeVue, i18n],
         directives: {
           tooltip: Tooltip
         },

--- a/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
@@ -1,16 +1,19 @@
 import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
-import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import Listbox from 'primevue/listbox'
 import Select from 'primevue/select'
 import Tooltip from 'primevue/tooltip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import VerifiedIcon from '@/components/icons/VerifiedIcon.vue'
+import { api } from '@/scripts/api'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 
 import PackVersionSelectorPopover from './PackVersionSelectorPopover.vue'
 
@@ -50,10 +53,13 @@ const mockNodePack = {
 
 // Create mock functions
 const mockGetPackVersions = vi.fn()
-const mockInstallPack = vi.fn().mockResolvedValue(undefined)
+let mockInstallPack: MockInstance<
+  ReturnType<typeof useComfyManagerStore>['installPack']['call']
+>
 const mockCheckNodeCompatibility = vi.fn()
-const mockIsPackInstalled = vi.fn(() => false)
-const mockGetInstalledPackVersion = vi.fn(() => undefined)
+let mockIsPackInstalled: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['isPackInstalled']>
+>
 
 // Mock the registry service
 vi.mock<unknown>(import('@/services/comfyRegistryService'), () => ({
@@ -61,22 +67,6 @@ vi.mock<unknown>(import('@/services/comfyRegistryService'), () => ({
     getPackVersions: mockGetPackVersions
   }))
 }))
-
-// Mock the manager store
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn(() => ({
-      installPack: {
-        call: mockInstallPack,
-        clear: vi.fn()
-      },
-      isPackInstalled: mockIsPackInstalled,
-      getInstalledPackVersion: mockGetInstalledPackVersion
-    }))
-  })
-)
 
 // Mock the conflict detection composable
 vi.mock<unknown>(
@@ -96,12 +86,18 @@ const waitForPromises = async () => {
 
 describe('PackVersionSelectorPopover', () => {
   beforeEach(() => {
+    vi.spyOn(api, 'getSystemStats').mockResolvedValue(
+      fromPartial({ system: { os: 'linux', argv: [] }, devices: [] })
+    )
+    const store = useComfyManagerStore()
+    vi.mocked(store.getInstalledPackVersion).mockReturnValue('')
+    mockInstallPack = vi.spyOn(store.installPack, 'call')
+    mockIsPackInstalled = vi.mocked(store.isPackInstalled)
     mockInstallPack.mockReset().mockResolvedValue(undefined)
     mockCheckNodeCompatibility
       .mockReset()
       .mockReturnValue({ hasConflict: false, conflicts: [] })
     mockIsPackInstalled.mockReset().mockReturnValue(false)
-    mockGetInstalledPackVersion.mockReset().mockReturnValue(undefined)
   })
 
   function renderComponent({
@@ -127,7 +123,7 @@ describe('PackVersionSelectorPopover', () => {
         ...(onSubmit ? { onSubmit } : {})
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
+        plugins: [PrimeVue, i18n],
         components: { Listbox, VerifiedIcon, Select },
         directives: { tooltip: Tooltip }
       }

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -1,4 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -8,10 +7,12 @@ import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores/conflictDetectionStore'
 
 import PackEnableToggle from './PackEnableToggle.vue'
 
-vi.mock(import('es-toolkit/compat'), () => ({
+vi.mock(import('es-toolkit/compat'), async (importOriginal) => ({
+  ...(await importOriginal()),
   debounce: <T extends (...args: unknown[]) => unknown>(fn: T) => fn
 }))
 
@@ -71,38 +72,33 @@ const mockNodePack = {
   }
 }
 
-const mockIsPackEnabled = vi.fn()
-const mockEnablePack = vi.fn().mockResolvedValue(undefined)
-const mockDisablePack = vi.fn().mockResolvedValue(undefined)
-const mockGetConflictsForPackageByID = vi.fn()
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn(() => ({
-      isPackEnabled: mockIsPackEnabled,
-      enablePack: mockEnablePack,
-      disablePack: mockDisablePack,
-      installedPacks: {}
-    }))
-  })
-)
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/conflictDetectionStore'),
-
-  () => ({
-    useConflictDetectionStore: vi.fn(() => ({
-      getConflictsForPackageByID: mockGetConflictsForPackageByID
-    }))
-  })
-)
+let mockIsPackEnabled: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['isPackEnabled']>
+>
+let mockEnablePack: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['enablePack']>
+>
+let mockDisablePack: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['disablePack']>
+>
+let mockGetConflictsForPackageByID: ReturnType<
+  typeof vi.mocked<
+    ReturnType<typeof useConflictDetectionStore>['getConflictsForPackageByID']
+  >
+>
 
 describe('PackEnableToggle', () => {
   const user = userEvent.setup()
 
   beforeEach(() => {
+    const store = useComfyManagerStore()
+    mockIsPackEnabled = vi.mocked(store.isPackEnabled)
+    mockEnablePack = vi.mocked(store.enablePack)
+    mockDisablePack = vi.mocked(store.disablePack)
+    mockGetConflictsForPackageByID = vi.fn()
+    Object.assign(useConflictDetectionStore(), {
+      getConflictsForPackageByID: mockGetConflictsForPackageByID
+    })
     mockEnablePack.mockReset().mockResolvedValue(undefined)
     mockDisablePack.mockReset().mockResolvedValue(undefined)
     mockGetConflictsForPackageByID.mockReset().mockReturnValue(undefined)
@@ -114,7 +110,7 @@ describe('PackEnableToggle', () => {
     installedPacks = {}
   }: {
     props?: Record<string, unknown>
-    installedPacks?: Record<string, unknown>
+    installedPacks?: ReturnType<typeof useComfyManagerStore>['installedPacks']
   } = {}) {
     const i18n = createI18n({
       legacy: false,
@@ -122,14 +118,7 @@ describe('PackEnableToggle', () => {
       messages: { en: enMessages }
     })
 
-    vi.mocked(useComfyManagerStore).mockReturnValue({
-      isPackEnabled: mockIsPackEnabled,
-      enablePack: mockEnablePack,
-      disablePack: mockDisablePack,
-      installedPacks
-    } as Partial<ReturnType<typeof useComfyManagerStore>> as ReturnType<
-      typeof useComfyManagerStore
-    >)
+    useComfyManagerStore().installedPacks = installedPacks
 
     return render(PackEnableToggle, {
       props: {
@@ -137,7 +126,7 @@ describe('PackEnableToggle', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n]
+        plugins: [PrimeVue, i18n]
       }
     })
   }
@@ -273,7 +262,7 @@ describe('PackEnableToggle', () => {
     })
 
     it('should not show warning icon when package has no conflicts', () => {
-      mockGetConflictsForPackageByID.mockReturnValue(null)
+      mockGetConflictsForPackageByID.mockReturnValue(undefined)
 
       mockIsPackEnabled.mockReturnValue(true)
       const { container } = renderComponent()

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
@@ -1,51 +1,17 @@
-import { createTestingPinia } from '@pinia/testing'
 import ProgressSpinner from 'primevue/progressspinner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { render, screen } from '@testing-library/vue'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import PackCard from '@/workbench/extensions/manager/components/manager/packCard/PackCard.vue'
 import type {
   MergedNodePack,
   RegistryPack
 } from '@/workbench/extensions/manager/types/comfyManagerTypes'
-
-const storageMap = vi.hoisted(() => new Map<string, unknown>())
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn(() => ({
-      isPackInstalled: vi.fn(() => false),
-      isPackEnabled: vi.fn(() => true),
-      isPackInstalling: vi.fn(() => false),
-      installedPacksIds: []
-    }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({
-    completedActivePalette: { light_theme: true }
-  }))
-}))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  whenever: vi.fn(),
-  useStorage: vi.fn((key: string, defaultValue: unknown) => {
-    if (!storageMap.has(key)) storageMap.set(key, defaultValue)
-    return storageMap.get(key)
-  }),
-  createSharedComposable: vi.fn((fn) => {
-    let cached: ReturnType<typeof fn>
-    return (...args: Parameters<typeof fn>) => (cached ??= fn(...args))
-  }),
-  useDocumentVisibility: vi.fn(() => ref<'visible' | 'hidden'>('visible'))
-}))
 
 vi.mock<unknown>(import('@/config'), () => ({
   default: {
@@ -53,18 +19,32 @@ vi.mock<unknown>(import('@/config'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: vi.fn(() => ({
-    systemStats: {
-      system: { os: 'Darwin' },
-      devices: [{ type: 'mps', name: 'Metal' }]
-    }
-  }))
-}))
-
 describe('PackCard', () => {
   beforeEach(() => {
-    storageMap.clear()
+    useSystemStatsStore().systemStats = {
+      system: {
+        os: 'Darwin',
+        ram_total: 0,
+        ram_free: 0,
+        comfyui_version: '0.3.41',
+        python_version: '3.11',
+        pytorch_version: '2.1',
+        embedded_python: false,
+        argv: []
+      },
+      devices: [
+        {
+          type: 'mps',
+          name: 'Metal',
+          index: 0,
+          vram_total: 0,
+          vram_free: 0,
+          torch_vram_total: 0,
+          torch_vram_free: 0
+        }
+      ]
+    }
+    useColorPaletteStore().activePaletteId = 'light'
   })
 
   function renderComponent(props: {
@@ -80,7 +60,7 @@ describe('PackCard', () => {
     return render(PackCard, {
       props,
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [i18n],
         components: {
           ProgressSpinner
         },

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/vue'
-import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 import { IsInstallingKey } from '@/workbench/extensions/manager/types/comfyManagerTypes'
 
 import PackCardFooter from './PackCardFooter.vue'
@@ -28,18 +28,13 @@ vi.mock<unknown>(
 )
 
 // Mock composables
-const mockIsPackInstalled = vi.fn()
+let mockIsPackInstalled: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['isPackInstalled']>
+>
+beforeEach(() => {
+  mockIsPackInstalled = vi.mocked(useComfyManagerStore().isPackInstalled)
+})
 const mockCheckNodeCompatibility = vi.fn()
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn(() => ({
-      isPackInstalled: mockIsPackInstalled
-    }))
-  })
-)
 
 vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useConflictDetection'),
@@ -71,7 +66,7 @@ describe('PackCardFooter', () => {
         ...props
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia({ stubActions: false }), i18n],
+        plugins: [PrimeVue, i18n],
         provide: {
           [IsInstallingKey]: ref(false)
         }

--- a/src/workbench/extensions/manager/composables/nodePack/useMissingNodes.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/useMissingNodes.test.ts
@@ -25,27 +25,6 @@ vi.mock(
   })
 )
 
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn()
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      activeWorkflow: null
-    }))
-  })
-)
-
 const mockApp: { rootGraph?: Partial<LGraph> } = vi.hoisted(() => ({}))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
@@ -57,8 +36,6 @@ vi.mock(import('@/utils/graphTraversalUtil'), () => ({
 }))
 
 const mockUseWorkflowPacks = vi.mocked(useWorkflowPacks)
-const mockUseComfyManagerStore = vi.mocked(useComfyManagerStore)
-const mockUseNodeDefStore = vi.mocked(useNodeDefStore)
 const mockCollectAllNodes = vi.mocked(collectAllNodes)
 
 describe('useMissingNodes', () => {
@@ -81,17 +58,14 @@ describe('useMissingNodes', () => {
   ]
 
   const mockStartFetchWorkflowPacks = vi.fn()
-  const mockIsPackInstalled = vi.fn()
+  let mockIsPackInstalled: ReturnType<
+    typeof vi.mocked<ReturnType<typeof useComfyManagerStore>['isPackInstalled']>
+  >
 
   beforeEach(() => {
+    mockIsPackInstalled = vi.mocked(useComfyManagerStore().isPackInstalled)
     // Default setup: pack-3 is installed, others are not
-    mockIsPackInstalled.mockImplementation((id: string) => id === 'pack-3')
-
-    mockUseComfyManagerStore.mockReturnValue({
-      isPackInstalled: mockIsPackInstalled
-    } as Partial<ReturnType<typeof useComfyManagerStore>> as ReturnType<
-      typeof useComfyManagerStore
-    >)
+    mockIsPackInstalled.mockImplementation((id) => id === 'pack-3')
 
     mockUseWorkflowPacks.mockReturnValue({
       workflowPacks: ref([]),
@@ -102,13 +76,6 @@ describe('useMissingNodes', () => {
       isReady: ref(false),
       filterWorkflowPack: vi.fn()
     })
-
-    // Reset node def store mock
-    mockUseNodeDefStore.mockReturnValue({
-      nodeDefsByName: {}
-    } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-      typeof useNodeDefStore
-    >)
 
     // Reset app.rootGraph.nodes
     mockApp.rootGraph = { nodes: [] }
@@ -405,13 +372,9 @@ describe('useMissingNodes', () => {
       const namedNode = {
         name: 'RegisteredNode'
       } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {
-          RegisteredNode: namedNode
-        }
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {
+        RegisteredNode: namedNode
+      }
 
       const { missingCoreNodes } = useMissingNodes()
 
@@ -429,11 +392,7 @@ describe('useMissingNodes', () => {
       // Mock collectAllNodes to return these nodes
       mockCollectAllNodes.mockReturnValue([node120, node130, nodeNoVer])
 
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {}
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {}
 
       const { missingCoreNodes } = useMissingNodes()
 
@@ -449,11 +408,7 @@ describe('useMissingNodes', () => {
       // Mock collectAllNodes to return only the filtered nodes (core nodes only)
       mockCollectAllNodes.mockReturnValue([coreNode])
 
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {}
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {}
 
       const { missingCoreNodes } = useMissingNodes()
 
@@ -466,18 +421,14 @@ describe('useMissingNodes', () => {
       // Mock collectAllNodes to return empty array (no missing nodes after filtering)
       mockCollectAllNodes.mockReturnValue([])
 
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {
-          RegisteredNode1: {
-            name: 'RegisteredNode1'
-          } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl,
-          RegisteredNode2: {
-            name: 'RegisteredNode2'
-          } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
-        }
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {
+        RegisteredNode1: {
+          name: 'RegisteredNode1'
+        } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl,
+        RegisteredNode2: {
+          name: 'RegisteredNode2'
+        } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
+      }
 
       const { missingCoreNodes } = useMissingNodes()
 
@@ -526,11 +477,7 @@ describe('useMissingNodes', () => {
       ])
 
       // Mock none of the nodes as registered
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {}
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {}
 
       const { missingCoreNodes } = useMissingNodes()
 
@@ -566,15 +513,11 @@ describe('useMissingNodes', () => {
       const mockGraph = { nodes: [], subgraphs: new Map() }
       mockApp.rootGraph = mockGraph
 
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {
-          RegisteredCore: {
-            name: 'RegisteredCore'
-          } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
-        }
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {
+        RegisteredCore: {
+          name: 'RegisteredCore'
+        } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
+      }
 
       let capturedFilterFunction: ((node: LGraphNode) => boolean) | undefined
 
@@ -666,15 +609,11 @@ describe('useMissingNodes', () => {
 
       mockApp.rootGraph = mockMainGraph
 
-      mockUseNodeDefStore.mockReturnValue({
-        nodeDefsByName: {
-          SubgraphRegistered: {
-            name: 'SubgraphRegistered'
-          } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
-        }
-      } as Partial<ReturnType<typeof useNodeDefStore>> as ReturnType<
-        typeof useNodeDefStore
-      >)
+      useNodeDefStore().nodeDefsByName = {
+        SubgraphRegistered: {
+          name: 'SubgraphRegistered'
+        } as Partial<ComfyNodeDefImpl> as ComfyNodeDefImpl
+      }
 
       const { missingCoreNodes } = useMissingNodes()
 

--- a/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.test.ts
@@ -5,22 +5,18 @@ import type { components } from '@/types/comfyRegistryTypes'
 import { usePackUpdateStatus } from '@/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn()
-  })
-)
-
 type NodePack = components['schemas']['Node']
 type ManagerStoreReturn = ReturnType<typeof useComfyManagerStore>
 
-const mockUseComfyManagerStore = vi.mocked(useComfyManagerStore)
-
-const mockIsPackInstalled = vi.fn()
-const mockIsPackEnabled = vi.fn()
-const mockGetInstalledPackVersion = vi.fn()
+let mockIsPackInstalled: ReturnType<
+  typeof vi.mocked<ManagerStoreReturn['isPackInstalled']>
+>
+let mockIsPackEnabled: ReturnType<
+  typeof vi.mocked<ManagerStoreReturn['isPackEnabled']>
+>
+let mockGetInstalledPackVersion: ReturnType<
+  typeof vi.mocked<ManagerStoreReturn['getInstalledPackVersion']>
+>
 
 function makePack(overrides: Partial<NodePack> = {}): NodePack {
   return {
@@ -32,14 +28,13 @@ function makePack(overrides: Partial<NodePack> = {}): NodePack {
 }
 
 beforeEach(() => {
+  const store = useComfyManagerStore()
+  mockIsPackInstalled = vi.mocked(store.isPackInstalled)
+  mockIsPackEnabled = vi.mocked(store.isPackEnabled)
+  mockGetInstalledPackVersion = vi.mocked(store.getInstalledPackVersion)
   mockIsPackInstalled.mockReturnValue(true)
   mockIsPackEnabled.mockReturnValue(true)
   mockGetInstalledPackVersion.mockReturnValue('1.0.0')
-  mockUseComfyManagerStore.mockReturnValue({
-    isPackInstalled: mockIsPackInstalled,
-    isPackEnabled: mockIsPackEnabled,
-    getInstalledPackVersion: mockGetInstalledPackVersion
-  } as Partial<ManagerStoreReturn> as ManagerStoreReturn)
 })
 
 describe('usePackUpdateStatus', () => {
@@ -62,7 +57,6 @@ describe('usePackUpdateStatus', () => {
 
   it('reports no update when the pack is not installed', () => {
     mockIsPackInstalled.mockReturnValue(false)
-    mockGetInstalledPackVersion.mockReturnValue(undefined)
 
     const { isUpdateAvailable } = usePackUpdateStatus(makePack())
 

--- a/src/workbench/extensions/manager/composables/nodePack/usePacksSelection.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePacksSelection.test.ts
@@ -1,21 +1,16 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import type { components } from '@/types/comfyRegistryTypes'
 import { usePacksSelection } from '@/workbench/extensions/manager/composables/nodePack/usePacksSelection'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 
-const { mockIsPackInstalled } = vi.hoisted(() => ({
-  mockIsPackInstalled: vi.fn<(packName: string | undefined) => boolean>()
-}))
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-  () => ({
-    useComfyManagerStore: () => ({
-      isPackInstalled: mockIsPackInstalled
-    })
-  })
-)
+let mockIsPackInstalled: ReturnType<
+  typeof useComfyManagerStore
+>['isPackInstalled']
+beforeEach(() => {
+  mockIsPackInstalled = useComfyManagerStore().isPackInstalled
+})
 
 type NodePack = components['schemas']['Node']
 

--- a/src/workbench/extensions/manager/composables/nodePack/useUpdateAvailableNodes.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/useUpdateAvailableNodes.test.ts
@@ -17,21 +17,12 @@ vi.mock(
   })
 )
 
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn()
-  })
-)
-
 vi.mock(import('semver'), () => ({
   compare: vi.fn(),
   valid: vi.fn()
 }))
 
 const mockUseInstalledPacks = vi.mocked(useInstalledPacks)
-const mockUseComfyManagerStore = vi.mocked(useComfyManagerStore)
 
 const mockSemverCompare = vi.mocked(compare)
 const mockSemverValid = vi.mocked(valid)
@@ -52,14 +43,6 @@ function createMockInstalledPacksReturn(
     filterInstalledPack: vi.fn(),
     ...overrides
   } as Partial<InstalledPacksReturn> as InstalledPacksReturn
-}
-
-function createMockManagerStoreReturn(
-  overrides: Partial<ManagerStoreReturn> = {}
-): ManagerStoreReturn {
-  return {
-    ...overrides
-  } as Partial<ManagerStoreReturn> as ManagerStoreReturn
 }
 
 function mountUpdateAvailableNodes() {
@@ -100,15 +83,24 @@ describe('useUpdateAvailableNodes', () => {
   ]
 
   const mockStartFetchInstalled = vi.fn()
-  const mockIsPackInstalled = vi.fn()
-  const mockGetInstalledPackVersion = vi.fn()
-  const mockIsPackEnabled = vi.fn()
+  let mockIsPackInstalled: ReturnType<
+    typeof vi.mocked<ManagerStoreReturn['isPackInstalled']>
+  >
+  let mockGetInstalledPackVersion: ReturnType<
+    typeof vi.mocked<ManagerStoreReturn['getInstalledPackVersion']>
+  >
+  let mockIsPackEnabled: ReturnType<
+    typeof vi.mocked<ManagerStoreReturn['isPackEnabled']>
+  >
 
   beforeEach(() => {
-    // Default setup
+    const store = useComfyManagerStore()
+    mockIsPackInstalled = vi.mocked(store.isPackInstalled)
+    mockGetInstalledPackVersion = vi.mocked(store.getInstalledPackVersion)
+    mockIsPackEnabled = vi.mocked(store.isPackEnabled)
     mockIsPackInstalled.mockReturnValue(true)
     mockIsPackEnabled.mockReturnValue(true) // Default: all packs are enabled
-    mockGetInstalledPackVersion.mockImplementation((id: string) => {
+    mockGetInstalledPackVersion.mockImplementation((id) => {
       switch (id) {
         case 'pack-1':
           return '1.0.0' // outdated
@@ -136,14 +128,6 @@ describe('useUpdateAvailableNodes', () => {
       if (latest === '1.0.0' && installed === '1.0.0') return 0 // up to date
       return 0
     })
-
-    mockUseComfyManagerStore.mockReturnValue(
-      createMockManagerStoreReturn({
-        isPackInstalled: mockIsPackInstalled,
-        getInstalledPackVersion: mockGetInstalledPackVersion,
-        isPackEnabled: mockIsPackEnabled
-      })
-    )
 
     mockUseInstalledPacks.mockReturnValue(
       createMockInstalledPacksReturn({
@@ -401,7 +385,7 @@ describe('useUpdateAvailableNodes', () => {
 
   describe('enabledUpdateAvailableNodePacks', () => {
     it('returns only enabled packs with updates', () => {
-      mockIsPackEnabled.mockImplementation((id: string) => {
+      mockIsPackEnabled.mockImplementation((id) => {
         // pack-1 is disabled
         return id !== 'pack-1'
       })
@@ -443,7 +427,7 @@ describe('useUpdateAvailableNodes', () => {
 
   describe('hasDisabledUpdatePacks', () => {
     it('returns true when there are disabled packs with updates', () => {
-      mockIsPackEnabled.mockImplementation((id: string) => {
+      mockIsPackEnabled.mockImplementation((id) => {
         // pack-1 is disabled
         return id !== 'pack-1'
       })
@@ -504,7 +488,7 @@ describe('useUpdateAvailableNodes', () => {
     })
 
     it('returns true when at least one enabled pack has updates', () => {
-      mockIsPackEnabled.mockImplementation((id: string) => {
+      mockIsPackEnabled.mockImplementation((id) => {
         // Only pack-1 is enabled
         return id === 'pack-1'
       })

--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 
@@ -12,19 +10,12 @@ import { useConflictDetection } from '@/workbench/extensions/manager/composables
 import { useComfyManagerService } from '@/workbench/extensions/manager/services/comfyManagerService'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores/conflictDetectionStore'
-import type { ConflictDetectionResult } from '@/workbench/extensions/manager/types/conflictDetectionTypes'
 import type * as ConflictUtils from '@/workbench/extensions/manager/utils/conflictUtils'
 import {
   checkAcceleratorCompatibility,
   checkOSCompatibility
 } from '@/workbench/extensions/manager/utils/systemCompatibility'
 import { checkVersionCompatibility } from '@/workbench/extensions/manager/utils/versionUtil'
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  until: vi.fn(() => ({
-    toBe: vi.fn(() => Promise.resolve())
-  }))
-}))
 
 // Mock dependencies
 vi.mock(
@@ -37,10 +28,6 @@ vi.mock(
 
 vi.mock(import('@/services/comfyRegistryService'), () => ({
   useComfyRegistryService: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: vi.fn()
 }))
 
 vi.mock(
@@ -93,22 +80,6 @@ vi.mock(
 )
 
 vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: vi.fn()
-  })
-)
-
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/conflictDetectionStore'),
-
-  () => ({
-    useConflictDetectionStore: vi.fn()
-  })
-)
-
-vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useManagerState'),
 
   () => ({
@@ -119,10 +90,9 @@ vi.mock<unknown>(
 )
 
 describe('useConflictDetection', () => {
-  let pinia: ReturnType<typeof createTestingPinia>
-
   const mockComfyManagerService = {
     getImportFailInfoBulk: vi.fn(),
+    listInstalledPacks: vi.fn(async () => ({})),
     isLoading: ref(false),
     error: ref<string | null>(null)
   } as Partial<ReturnType<typeof useComfyManagerService>> as ReturnType<
@@ -155,71 +125,35 @@ describe('useConflictDetection', () => {
     typeof useInstalledPacks
   >
 
-  const mockManagerStore = {
-    isPackEnabled: vi.fn()
-  } as Partial<ReturnType<typeof useComfyManagerStore>> as ReturnType<
-    typeof useComfyManagerStore
-  >
-
-  // Create refs that can be used to control computed properties
-  let mockConflictedPackages: ConflictDetectionResult[] = []
-
-  const mockConflictStore = {
-    get hasConflicts() {
-      return mockConflictedPackages.some((p) => p.has_conflict)
+  let mockManagerStore: ReturnType<typeof useComfyManagerStore>
+  let mockSystemStatsStore: ReturnType<typeof useSystemStatsStore>
+  const systemStats: NonNullable<
+    ReturnType<typeof useSystemStatsStore>['systemStats']
+  > = {
+    system: {
+      os: 'darwin', // sys.platform returns 'darwin' for macOS
+      ram_total: 17179869184,
+      ram_free: 8589934592,
+      comfyui_version: '0.3.41',
+      required_frontend_version: '1.24.0',
+      python_version:
+        '3.11.0 (main, Oct 13 2023, 09:34:16) [Clang 15.0.0 (clang-1500.0.40.1)]',
+      pytorch_version: '2.1.0',
+      embedded_python: false,
+      argv: ['--enable-manager']
     },
-    get conflictedPackages() {
-      return mockConflictedPackages
-    },
-    get bannedPackages() {
-      return mockConflictedPackages.filter((p) =>
-        p.conflicts.some((c) => c.type === 'banned')
-      )
-    },
-    get securityPendingPackages() {
-      return mockConflictedPackages.filter((p) =>
-        p.conflicts.some((c) => c.type === 'pending')
-      )
-    },
-    setConflictedPackages: vi.fn(),
-    clearConflicts: vi.fn()
-  } as Partial<ReturnType<typeof useConflictDetectionStore>> as ReturnType<
-    typeof useConflictDetectionStore
-  >
-
-  const mockIsInitialized = true
-  const mockSystemStatsStore = {
-    systemStats: {
-      system: {
-        os: 'darwin', // sys.platform returns 'darwin' for macOS
-        ram_total: 17179869184,
-        ram_free: 8589934592,
-        comfyui_version: '0.3.41',
-        required_frontend_version: '1.24.0',
-        python_version:
-          '3.11.0 (main, Oct 13 2023, 09:34:16) [Clang 15.0.0 (clang-1500.0.40.1)]',
-        pytorch_version: '2.1.0',
-        embedded_python: false,
-        argv: ['--enable-manager']
-      },
-      devices: [
-        {
-          name: 'Apple M1 Pro',
-          type: 'mps',
-          index: 0,
-          vram_total: 17179869184,
-          vram_free: 8589934592,
-          torch_vram_total: 17179869184,
-          torch_vram_free: 8589934592
-        }
-      ]
-    },
-    isInitialized: mockIsInitialized,
-
-    _customProperties: new Set<string>()
-  } as Partial<ReturnType<typeof useSystemStatsStore>> as ReturnType<
-    typeof useSystemStatsStore
-  >
+    devices: [
+      {
+        name: 'Apple M1 Pro',
+        type: 'mps',
+        index: 0,
+        vram_total: 17179869184,
+        vram_free: 8589934592,
+        torch_vram_total: 17179869184,
+        torch_vram_free: 8589934592
+      }
+    ]
+  }
 
   const mockAcknowledgment: ReturnType<typeof useConflictAcknowledgment> = {
     acknowledgmentState: computed(() => ({
@@ -236,17 +170,14 @@ describe('useConflictDetection', () => {
   }
 
   beforeEach(() => {
-    pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
-
     // Setup mocks
     vi.mocked(useComfyManagerService).mockReturnValue(mockComfyManagerService)
     vi.mocked(useComfyRegistryService).mockReturnValue(mockRegistryService)
-    vi.mocked(useSystemStatsStore).mockReturnValue(mockSystemStatsStore)
     vi.mocked(useConflictAcknowledgment).mockReturnValue(mockAcknowledgment)
     vi.mocked(useInstalledPacks).mockReturnValue(mockInstalledPacks)
-    vi.mocked(useComfyManagerStore).mockReturnValue(mockManagerStore)
-    vi.mocked(useConflictDetectionStore).mockReturnValue(mockConflictStore)
+    mockManagerStore = useComfyManagerStore()
+    mockSystemStatsStore = useSystemStatsStore()
+    mockSystemStatsStore.$patch({ systemStats, isInitialized: true })
 
     // Reset mock implementations
     vi.mocked(mockInstalledPacks.startFetchInstalled).mockResolvedValue(
@@ -262,8 +193,6 @@ describe('useConflictDetection', () => {
 
     // Reset the installedPacksWithVersions data
     mockInstalledPacksWithVersions.value = []
-    // Reset conflicted packages
-    mockConflictedPackages = []
   })
 
   describe('system environment collection', () => {
@@ -493,7 +422,8 @@ describe('useConflictDetection', () => {
 
   describe('computed properties', () => {
     it('should expose conflict status from store', () => {
-      mockConflictedPackages = [
+      const store = useConflictDetectionStore()
+      store.conflictedPackages = [
         {
           package_id: 'test',
           package_name: 'Test',
@@ -506,8 +436,8 @@ describe('useConflictDetection', () => {
       useConflictDetection()
 
       // The hasConflicts computed should be true since we have a conflict
-      expect(mockConflictedPackages).toHaveLength(1)
-      expect(mockConflictedPackages[0].has_conflict).toBe(true)
+      expect(store.conflictedPackages).toHaveLength(1)
+      expect(store.conflictedPackages[0].has_conflict).toBe(true)
     })
   })
 

--- a/src/workbench/extensions/manager/composables/useImportFailedDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useImportFailedDetection.test.ts
@@ -1,28 +1,26 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockedFunction } from 'vitest'
 import { computed, ref } from 'vue'
 
 import { useImportFailedDetection } from '@/workbench/extensions/manager/composables/useImportFailedDetection'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores/conflictDetectionStore'
 
-const mockIsPackInstalled = vi.fn()
-const mockGetConflictsForPackageByID = vi.fn()
+let mockIsPackInstalled: MockedFunction<
+  ReturnType<typeof useComfyManagerStore>['isPackInstalled']
+>
+let mockGetConflictsForPackageByID: MockedFunction<
+  ReturnType<typeof useConflictDetectionStore>['getConflictsForPackageByID']
+>
 const mockShow = vi.fn()
 
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-  () => ({
-    useComfyManagerStore: () => ({
-      isPackInstalled: mockIsPackInstalled
-    })
+beforeEach(() => {
+  mockIsPackInstalled = vi.mocked(useComfyManagerStore().isPackInstalled)
+  mockGetConflictsForPackageByID = vi.fn()
+  Object.assign(useConflictDetectionStore(), {
+    getConflictsForPackageByID: mockGetConflictsForPackageByID
   })
-)
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/conflictDetectionStore'),
-  () => ({
-    useConflictDetectionStore: () => ({
-      getConflictsForPackageByID: mockGetConflictsForPackageByID
-    })
-  })
-)
+})
 vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useImportFailedNodeDialog'),
   () => ({

--- a/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
@@ -4,14 +4,17 @@
  * max-width × 80vh, expanding at 3000px). Catches accidental reverts of the
  * Phase 4 renderer flip.
  */
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDialogStore } from '@/stores/dialogStore'
 
-const showDialog = vi.hoisted(() => vi.fn())
-const closeDialog = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog, closeDialog })
-}))
+let showDialog: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useDialogStore>['showDialog']>
+>
+let closeDialog: ReturnType<typeof useDialogStore>['closeDialog']
+beforeEach(() => {
+  showDialog = vi.mocked(useDialogStore().showDialog)
+  closeDialog = useDialogStore().closeDialog
+})
 
 import { ManagerTab } from '@/workbench/extensions/manager/types/comfyManagerTypes'
 import { useManagerDialog } from '@/workbench/extensions/manager/composables/useManagerDialog'
@@ -21,12 +24,12 @@ describe('useManagerDialog', () => {
     useManagerDialog().show()
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('global-manager')
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('full')
-    expect(args.dialogComponentProps.contentClass).toContain('max-w-[1724px]')
-    expect(args.dialogComponentProps.contentClass).toContain('h-[80vh]')
-    expect(args.dialogComponentProps.contentClass).toContain('max-h-[1026px]')
-    expect(args.dialogComponentProps.contentClass).toContain(
+    expect(args.dialogComponentProps!.renderer).toBe('reka')
+    expect(args.dialogComponentProps!.size).toBe('full')
+    expect(args.dialogComponentProps!.contentClass).toContain('max-w-[1724px]')
+    expect(args.dialogComponentProps!.contentClass).toContain('h-[80vh]')
+    expect(args.dialogComponentProps!.contentClass).toContain('max-h-[1026px]')
+    expect(args.dialogComponentProps!.contentClass).toContain(
       'min-[3000px]:max-w-[2200px]'
     )
   })
@@ -34,19 +37,19 @@ describe('useManagerDialog', () => {
   it('show() uses non-modal Reka so nested PrimeVue overlays keep focus and pointer events', () => {
     useManagerDialog().show()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.modal).toBe(false)
+    expect(args.dialogComponentProps!.modal).toBe(false)
   })
 
   it('show(initialTab) forwards initialTab to ManagerDialog props', () => {
     useManagerDialog().show(ManagerTab.UpdateAvailable)
     const [args] = showDialog.mock.calls[0]
-    expect(args.props.initialTab).toBe(ManagerTab.UpdateAvailable)
+    expect(args.props).toMatchObject({ initialTab: ManagerTab.UpdateAvailable })
   })
 
   it('show(initialTab, initialPackId) forwards initialPackId to ManagerDialog props', () => {
     useManagerDialog().show(ManagerTab.All, 'pack-123')
     const [args] = showDialog.mock.calls[0]
-    expect(args.props.initialPackId).toBe('pack-123')
+    expect(args.props).toMatchObject({ initialPackId: 'pack-123' })
   })
 
   it('hide() closes the global-manager dialog', () => {

--- a/src/workbench/extensions/manager/composables/useManagerState.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.test.ts
@@ -1,7 +1,7 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { api } from '@/scripts/api'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import {
@@ -39,21 +39,7 @@ vi.mock(import('@/platform/settings/composables/useSettingsDialog'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => ({
-    execute: vi.fn()
-  }))
-}))
-
-const { toastAddMock } = vi.hoisted(() => ({
-  toastAddMock: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({
-    add: toastAddMock
-  }))
-}))
+let toastAddMock: ReturnType<typeof useToastStore>['add']
 
 vi.mock(
   import('@/workbench/extensions/manager/composables/useManagerDialog'),
@@ -109,15 +95,8 @@ describe('useManagerState', () => {
   let systemStatsStore: ReturnType<typeof useSystemStatsStore>
 
   beforeEach(() => {
-    // Create a fresh testing pinia and activate it for each test
-    setActivePinia(
-      createTestingPinia({
-        stubActions: false,
-        createSpy: vi.fn
-      })
-    )
-
-    // Initialize stores
+    toastAddMock = useToastStore().add
+    vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
     systemStatsStore = useSystemStatsStore()
 
     // Reset all mocks

--- a/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDialogStore } from '@/stores/dialogStore'
 
-const showDialog = vi.hoisted(() => vi.fn())
-const closeDialog = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog, closeDialog })
-}))
+let showDialog: ReturnType<
+  typeof vi.mocked<ReturnType<typeof useDialogStore>['showDialog']>
+>
+let closeDialog: ReturnType<typeof useDialogStore>['closeDialog']
+beforeEach(() => {
+  showDialog = vi.mocked(useDialogStore().showDialog)
+  closeDialog = useDialogStore().closeDialog
+})
 
 import { useManagerSurveyDialog } from '@/workbench/extensions/manager/composables/useManagerSurveyDialog'
 
@@ -14,13 +17,17 @@ describe('useManagerSurveyDialog', () => {
     useManagerSurveyDialog().show()
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('global-manager-survey')
-    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
   })
 
   it('show() wires onClose to close the survey dialog', () => {
     useManagerSurveyDialog().show()
     const [args] = showDialog.mock.calls[0]
-    args.props.onClose()
+    const onClose =
+      args.props && 'onClose' in args.props ? args.props.onClose : undefined
+    expect(onClose).toBeTypeOf('function')
+    if (typeof onClose !== 'function') throw new Error('Missing survey onClose')
+    onClose()
     expect(closeDialog).toHaveBeenCalledWith({ key: 'global-manager-survey' })
   })
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Follow-up to #17218: use the global testing Pinia instead of module mocks for store composables.

## Changes

- Configure real store state and typed action spies across 388 existing test files.
- Dispose the active Pinia globally after each test to stop leaked store watchers.
- Add a rerunnable AST audit and lifecycle regression tests. Retain non-Pinia `layoutStore` mocks.

## Review Focus

Store actions remain real unless a test explicitly stubs them. Independent Vue effect scopes retain their own cleanup. No production behavior changes.

Validation: full unit suite passed with 1,521 files, 20,553 tests passed and 7 skipped; final targeted retests passed. Typecheck, scripts typecheck, lint, Knip, formatting, and diff checks passed. Audit reports zero Pinia store-module mock candidates.
