### PR TITLE
test: enforce global testing Pinia with Oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -138,6 +138,15 @@
   },
   "overrides": [
     {
+      "files": [
+        "**/*.{test,spec}.{ts,tsx}",
+        "**/{__test__,__tests__,__fixtures__}/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "comfy/use-global-pinia": "error"
+      }
+    },
+    {
       "files": ["**/*.{stories,test,spec}.ts", "**/*.stories.vue"],
       "rules": {
         "no-console": "allow"

--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -7,26 +7,42 @@ globs:
 
 ## Setup
 
-Use `createTestingPinia` from `@pinia/testing`, not `createPinia`:
+`vitest.setup.ts` creates a fresh active testing Pinia before each test with
+`stubActions: false` and disposes the active Pinia afterward to stop store
+watchers. Use real store composables inside tests or `beforeEach`. Do not mock
+their modules, mock Pinia, or create another Pinia instance.
+
+Set scenario state on the store. Actions already have spies, but execute their
+implementations unless you stub them:
 
 ```typescript
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 
-describe('MyStore', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.useFakeTimers()
-  })
+import { useSettingStore } from '@/platform/settings/settingStore'
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
+beforeEach(() => {
+  const settings = useSettingStore()
+  settings.settingValues['Comfy.WorkflowActions.SeenItems'] = []
+  vi.mocked(settings.set).mockResolvedValue()
 })
 ```
 
-**Why `stubActions: false`?** By default, testing pinia stubs all actions. Set to `false` when testing actual store behavior.
+Stub actions only when the test needs to isolate their effects. Keep the action
+under test real. Use `vi.mocked(store.action)` to access `.mock` or configure
+return values without changing the store's types.
+
+For component tests, configure the same Pinia instance that the component uses.
+Pass `getActivePinia()!` from `pinia` to the mount's `global.plugins` when it
+needs injection. Set scenario state directly or with `store.$patch()` rather
+than creating a Pinia with `initialState`. Stub individual actions to isolate
+their effects; keep actions under test real.
+
+`pnpm lint` enforces `comfy/use-global-pinia` in `.test` and `.spec` files and
+in `__test__`, `__tests__`, and `__fixtures__` directories, including files
+covered by the separate Oxlint audit. It rejects Pinia factory imports,
+namespace access to factories, Pinia module mocks, and replacements of store
+composables. Non-Pinia modules such as `layoutStore` and spies on real store
+actions remain allowed. Only the global setup owns Pinia creation and disposal.
 
 ## Don't Mock `vue-i18n` — Use a Real Plugin
 

--- a/tools/oxlint-plugins/comfy.ts
+++ b/tools/oxlint-plugins/comfy.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module'
 
 import type { noComfyPageSetupCall as NoComfyPageSetupCall } from './comfyPageSetup'
 import type { noDuplicateIngestType as NoDuplicateIngestType } from './comfyIngestTypes'
+import type { useGlobalPinia as UseGlobalPinia } from './globalPinia'
 import type {
   noModuleScopeVitestMocks as NoModuleScopeVitestMocks,
   noPersistentLiteGraphRegistration as NoPersistentLiteGraphRegistration,
@@ -16,6 +17,9 @@ const { noComfyPageSetupCall } = requireFrom('./comfyPageSetup.ts') as {
 }
 const { noDuplicateIngestType } = requireFrom('./comfyIngestTypes.ts') as {
   noDuplicateIngestType: typeof NoDuplicateIngestType
+}
+const { useGlobalPinia } = requireFrom('./globalPinia.ts') as {
+  useGlobalPinia: typeof UseGlobalPinia
 }
 const {
   noModuleScopeVitestMocks,
@@ -41,6 +45,7 @@ export default {
     'no-persistent-litegraph-registration': noPersistentLiteGraphRegistration,
     'no-render-in-watch-effect': noRenderInWatchEffect,
     'no-redundant-litegraph-cleanup': noRedundantLiteGraphCleanup,
-    'no-redundant-vitest-cleanup': noRedundantVitestCleanup
+    'no-redundant-vitest-cleanup': noRedundantVitestCleanup,
+    'use-global-pinia': useGlobalPinia
   }
 }

--- a/tools/oxlint-plugins/globalPinia.test.ts
+++ b/tools/oxlint-plugins/globalPinia.test.ts
@@ -1,0 +1,198 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { RuleTester } from 'oxlint/plugins-dev'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { useGlobalPinia } from './globalPinia'
+
+RuleTester.describe = describe
+RuleTester.it = it
+
+const directory = mkdtempSync(path.join(tmpdir(), 'comfy-global-pinia-'))
+mkdirSync(path.join(directory, 'src'))
+writeFileSync(
+  path.join(directory, 'src/store.ts'),
+  `import { defineStore as define } from 'pinia'
+export const useExampleStore = define('example', () => ({}))
+export function helper() {}`
+)
+writeFileSync(
+  path.join(directory, 'src/namespaceStore.ts'),
+  `import * as pinia from 'pinia'
+export const useOtherStore = pinia.defineStore('other', () => ({}))`
+)
+writeFileSync(
+  path.join(directory, 'src/barrel.ts'),
+  `export { useExampleStore } from './store'`
+)
+writeFileSync(
+  path.join(directory, 'src/layoutStore.ts'),
+  `export const layoutStore = new Map()`
+)
+writeFileSync(
+  path.join(directory, 'src/notStore.ts'),
+  `const example = "defineStore('example', () => ({}))"`
+)
+writeFileSync(
+  path.join(directory, 'src/types.ts'),
+  `export type { Store } from 'pinia'`
+)
+writeFileSync(
+  path.join(directory, 'src/inlineTypes.ts'),
+  `export { type Store } from 'pinia'
+export function formatName() { return 'name' }`
+)
+writeFileSync(
+  path.join(directory, 'src/mixedExports.ts'),
+  `export { type Store, defineStore } from 'pinia'`
+)
+afterAll(() => rmSync(directory, { recursive: true, force: true }))
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } }
+})
+const filename = path.join(directory, 'src/example.test.ts')
+const invalid = (code: string, message: RegExp) => ({
+  code,
+  filename,
+  errors: [{ message }]
+})
+
+ruleTester.run('use-global-pinia', useGlobalPinia, {
+  valid: [
+    `import { getActivePinia, defineStore } from 'pinia'
+const store = defineStore('fixture', () => ({}))(getActivePinia())`,
+    {
+      filename,
+      code: `import { useExampleStore } from './store'
+vi.mocked(useExampleStore().save).mockResolvedValue()`
+    },
+    {
+      filename,
+      code: `vi.mock(import('./layoutStore'), () => ({}))`
+    },
+    {
+      filename,
+      code: `vi.mock('./notStore', () => ({}))`
+    },
+    {
+      filename,
+      code: `vi.mock('./types', () => ({}))`
+    },
+    {
+      filename,
+      code: `vi.mock('./inlineTypes', () => ({ formatName: () => 'mock' }))`
+    },
+    {
+      filename,
+      code: `function local(vi) { vi.mock('./store') }`
+    },
+    {
+      filename,
+      code: `import * as stores from './store'
+vi.spyOn(stores, 'helper')`
+    },
+    `const pinia = { createPinia() {} }; pinia.createPinia()`,
+    `const example = "vi.mock('pinia')"`
+  ],
+  invalid: [
+    invalid(`import { createPinia } from 'pinia'`, /global testing Pinia/),
+    invalid(
+      `import { createTestingPinia as create } from '@pinia/testing'`,
+      /global testing Pinia/
+    ),
+    invalid(
+      `import * as pinia from 'pinia'; pinia['createPinia']()`,
+      /global testing Pinia/
+    ),
+    invalid(
+      `const { createTestingPinia } = await import('@pinia/testing')`,
+      /global testing Pinia/
+    ),
+    invalid(`vi.mock('pinia')`, /Do not mock Pinia/),
+    invalid(`vi.doMock(import('@pinia/testing'))`, /Do not mock Pinia/),
+    invalid(`vi.mock(import('./store'), () => ({}))`, /Do not mock Pinia/),
+    invalid(
+      `vi.mock(import('@/platform/settings/settingStore'))`,
+      /Do not mock Pinia/
+    ),
+    invalid(`vi.doMock('./namespaceStore', () => ({}))`, /Do not mock Pinia/),
+    invalid(`vi.mock('./barrel', () => ({}))`, /Do not mock Pinia/),
+    invalid(`vi.mock('./mixedExports', () => ({}))`, /Do not mock Pinia/),
+    invalid(
+      `import { vi as testDouble } from 'vitest'
+testDouble.mock('./store')`,
+      /Do not mock Pinia/
+    ),
+    invalid(
+      `import * as vitest from 'vitest'
+vitest.vi.doMock(import('./store'))`,
+      /Do not mock Pinia/
+    ),
+    invalid(
+      `import { vitest } from 'vitest'
+vitest.mock('pinia')`,
+      /Do not mock Pinia/
+    ),
+    invalid(`vitest.mock('pinia')`, /Do not mock Pinia/),
+    invalid(
+      `import * as stores from './store'
+vi.spyOn(stores, 'useExampleStore')`,
+      /Do not mock Pinia/
+    ),
+    invalid(
+      `import { useExampleStore as useStore } from './store'
+vi.mocked(useStore).mockReturnValue({})`,
+      /Do not mock Pinia/
+    ),
+    invalid(
+      `import * as pinia from 'pinia'
+vi.spyOn(pinia, 'defineStore')`,
+      /Do not mock Pinia/
+    )
+  ]
+})
+
+it('enforces the rule through both repository lint configurations', () => {
+  const code = `import { createPinia } from 'pinia'
+createPinia()
+vi.mock('pinia')`
+  const testPath = path.join(directory, 'src/example.test.ts')
+  const appPath = path.join(directory, 'src/example.ts')
+  const ignoredTestPath = path.join(directory, 'src/scripts/ignored.test.ts')
+  const helperPaths = [
+    path.join(directory, 'src/__test__/testUtils.ts'),
+    path.join(directory, 'src/__tests__/helpers.ts'),
+    path.join(directory, 'src/__fixtures__/fixture.ts')
+  ]
+  for (const file of [testPath, appPath, ignoredTestPath, ...helperPaths]) {
+    mkdirSync(path.dirname(file), { recursive: true })
+    writeFileSync(file, code)
+  }
+
+  for (const [config, files] of [
+    ['.oxlintrc.json', [testPath, appPath, ...helperPaths]],
+    [
+      'tools/oxlint-plugins/vitestCleanup.config.json',
+      [ignoredTestPath, appPath, ...helperPaths]
+    ]
+  ] as const) {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.resolve('node_modules/oxlint/bin/oxlint'),
+        '--format=json',
+        '--config',
+        path.resolve(config),
+        ...files
+      ],
+      { encoding: 'utf8', windowsHide: true }
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(1)
+    expect(result.stdout.match(/comfy\(use-global-pinia\)/g)).toHaveLength(8)
+    expect(result.stdout).not.toContain('"filename": "src/example.ts"')
+  }
+})

--- a/tools/oxlint-plugins/globalPinia.ts
+++ b/tools/oxlint-plugins/globalPinia.ts
@@ -1,0 +1,263 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { RuleTester } from 'oxlint/plugins-dev'
+import * as ts from 'typescript'
+
+type Rule = Parameters<RuleTester['run']>[1]
+type Context = Parameters<Extract<Rule, { create: unknown }>['create']>[0]
+type Node = Parameters<Context['sourceCode']['getScope']>[0]
+
+const PINIA_MODULES = new Set(['pinia', '@pinia/testing'])
+const PINIA_FACTORIES = new Set(['createPinia', 'createTestingPinia'])
+const compilerOptions: ts.CompilerOptions = {
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  paths: { '@/*': [resolve(import.meta.dirname, '../../src/*')] }
+}
+
+function literal(node: Node | undefined): string | undefined {
+  if (node?.type === 'Literal' && typeof node.value === 'string') {
+    return node.value
+  }
+  if (node?.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis[0]?.value.cooked ?? undefined
+  }
+}
+
+function propertyName(node: Node): string | undefined {
+  return node.type === 'Identifier' ? node.name : literal(node)
+}
+
+function importedReference(
+  context: Context,
+  node: Node,
+  seen = new Set<Node>()
+): { source: string; path: string[] } | undefined {
+  if (seen.has(node)) return
+  seen.add(node)
+  if (node.type === 'AwaitExpression' || node.type === 'ChainExpression') {
+    return importedReference(
+      context,
+      node.type === 'AwaitExpression' ? node.argument : node.expression,
+      seen
+    )
+  }
+  if (node.type === 'ImportExpression') {
+    const source = literal(node.source)
+    if (source) return { source, path: [] }
+  }
+  if (node.type === 'MemberExpression') {
+    const base = importedReference(context, node.object, seen)
+    const name = node.computed
+      ? literal(node.property)
+      : propertyName(node.property)
+    if (base && name) return { ...base, path: [...base.path, name] }
+  }
+  if (node.type !== 'Identifier') return
+  let scope: ReturnType<Context['sourceCode']['getScope']> | null =
+    context.sourceCode.getScope(node)
+  while (scope) {
+    const variable = scope.set.get(node.name)
+    if (variable) {
+      for (const definition of variable.defs) {
+        if (
+          definition.type === 'ImportBinding' &&
+          definition.parent?.type === 'ImportDeclaration'
+        ) {
+          return {
+            source: definition.parent.source.value,
+            path:
+              definition.node.type === 'ImportSpecifier'
+                ? [propertyName(definition.node.imported) ?? '']
+                : []
+          }
+        }
+        if (
+          definition.node.type === 'VariableDeclarator' &&
+          definition.node.init
+        ) {
+          const base = importedReference(context, definition.node.init, seen)
+          if (definition.node.id.type !== 'ObjectPattern') return base
+          const property = definition.node.id.properties.find(
+            (property) =>
+              property.type === 'Property' &&
+              property.value.type === 'Identifier' &&
+              property.value.name === node.name
+          )
+          if (base && property?.type === 'Property') {
+            const name = propertyName(property.key)
+            if (name) return { ...base, path: [...base.path, name] }
+          }
+        }
+      }
+      if (variable.defs.length) return
+    }
+    scope = scope.upper
+  }
+  if (node.name === 'vi' || node.name === 'vitest') {
+    return { source: 'vitest', path: [node.name] }
+  }
+}
+
+export const useGlobalPinia: Rule = {
+  create(context) {
+    const modules = new Map<string, boolean>()
+    function isPiniaModule(
+      specifier: string,
+      importer = context.filename
+    ): boolean {
+      if (PINIA_MODULES.has(specifier)) return true
+      if (!specifier.startsWith('.') && !specifier.startsWith('@/'))
+        return false
+      const resolved = ts.resolveModuleName(
+        specifier,
+        importer,
+        compilerOptions,
+        ts.sys
+      ).resolvedModule?.resolvedFileName
+      if (!resolved) return false
+      const cached = modules.get(resolved)
+      if (cached !== undefined) return cached
+      modules.set(resolved, false)
+      const source = ts.createSourceFile(
+        resolved,
+        readFileSync(resolved, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true
+      )
+      const factories = new Set<string>()
+      const namespaces = new Set<string>()
+      for (const statement of source.statements) {
+        if (
+          !ts.isImportDeclaration(statement) ||
+          !ts.isStringLiteral(statement.moduleSpecifier) ||
+          statement.moduleSpecifier.text !== 'pinia'
+        )
+          continue
+        const bindings = statement.importClause?.namedBindings
+        if (bindings && ts.isNamespaceImport(bindings))
+          namespaces.add(bindings.name.text)
+        if (bindings && ts.isNamedImports(bindings)) {
+          for (const binding of bindings.elements) {
+            if ((binding.propertyName ?? binding.name).text === 'defineStore')
+              factories.add(binding.name.text)
+          }
+        }
+      }
+      function definesStore(node: ts.Node): boolean {
+        if (ts.isCallExpression(node)) {
+          const callee = node.expression
+          if (ts.isIdentifier(callee) && factories.has(callee.text)) return true
+          if (
+            ts.isPropertyAccessExpression(callee) &&
+            ts.isIdentifier(callee.expression) &&
+            namespaces.has(callee.expression.text) &&
+            callee.name.text === 'defineStore'
+          )
+            return true
+        }
+        return ts.forEachChild(node, definesStore) ?? false
+      }
+      const result =
+        definesStore(source) ||
+        source.statements.some(
+          (statement) =>
+            ts.isExportDeclaration(statement) &&
+            !statement.isTypeOnly &&
+            (!statement.exportClause ||
+              !ts.isNamedExports(statement.exportClause) ||
+              statement.exportClause.elements.some(
+                (specifier) => !specifier.isTypeOnly
+              )) &&
+            statement.moduleSpecifier &&
+            ts.isStringLiteral(statement.moduleSpecifier) &&
+            isPiniaModule(statement.moduleSpecifier.text, resolved)
+        )
+      modules.set(resolved, result)
+      return result
+    }
+
+    function reportCreation(node: Node) {
+      context.report({
+        node,
+        message:
+          'Use the global testing Pinia from vitest.setup.ts. Configure real store state and action spies instead of creating another Pinia.'
+      })
+    }
+    function reportMock(node: Node) {
+      context.report({
+        node,
+        message:
+          'Do not mock Pinia or store composables. Use the global testing Pinia and vi.mocked(store.action) for action stubs.'
+      })
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (!PINIA_MODULES.has(node.source.value) || node.importKind === 'type')
+          return
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.importKind !== 'type' &&
+            PINIA_FACTORIES.has(propertyName(specifier.imported) ?? '')
+          )
+            reportCreation(specifier)
+        }
+      },
+      MemberExpression(node) {
+        if (!PINIA_FACTORIES.has(propertyName(node.property) ?? '')) return
+        const reference = importedReference(context, node)
+        if (
+          reference &&
+          PINIA_MODULES.has(reference.source) &&
+          reference.path.length === 1 &&
+          PINIA_FACTORIES.has(reference.path[0])
+        )
+          reportCreation(node)
+      },
+      VariableDeclarator(node) {
+        if (node.id.type !== 'ObjectPattern' || !node.init) return
+        const reference = importedReference(context, node.init)
+        if (
+          !reference ||
+          !PINIA_MODULES.has(reference.source) ||
+          reference.path.length
+        )
+          return
+        for (const property of node.id.properties) {
+          if (
+            property.type === 'Property' &&
+            PINIA_FACTORIES.has(propertyName(property.key) ?? '')
+          )
+            reportCreation(property)
+        }
+      },
+      CallExpression(node) {
+        const reference = importedReference(context, node.callee)
+        if (
+          reference?.source !== 'vitest' ||
+          reference.path.length !== 2 ||
+          !['vi', 'vitest'].includes(reference.path[0])
+        )
+          return
+        const argument = node.arguments.at(0)
+        if (!argument) return
+        const method = reference.path[1]
+        if (method === 'mock' || method === 'doMock') {
+          const source = literal(
+            argument.type === 'ImportExpression' ? argument.source : argument
+          )
+          if (source && isPiniaModule(source)) reportMock(node)
+        }
+        if (method === 'spyOn' || method === 'mocked') {
+          const target = importedReference(context, argument)
+          if (!target || !isPiniaModule(target.source)) return
+          const name =
+            method === 'spyOn' ? literal(node.arguments[1]) : target.path.at(-1)
+          if (PINIA_MODULES.has(target.source) || name?.startsWith('use'))
+            reportMock(node)
+        }
+      }
+    }
+  }
+}

--- a/tools/oxlint-plugins/vitestCleanup.config.json
+++ b/tools/oxlint-plugins/vitestCleanup.config.json
@@ -7,6 +7,15 @@
   "overrides": [
     {
       "files": [
+        "**/*.{test,spec}.{ts,tsx}",
+        "**/{__test__,__tests__,__fixtures__}/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "comfy/use-global-pinia": "error"
+      }
+    },
+    {
+      "files": [
         "**/apps/**/*.test.{ts,tsx}",
         "**/packages/**/*.test.{ts,tsx}",
         "**/scripts/**/*.test.{ts,tsx}",


### PR DESCRIPTION
## Summary

Enforce the global testing Pinia convention now that all nine domain migration PRs have merged. This PR targets `main` and contains only the lint rule, its tests/configuration, and testing documentation.

## Changes

- Add `comfy/use-global-pinia` to reject local Pinia construction, Pinia/store-module mocks, and store-composable replacements in tests and test helpers.
- Enable it in both Oxlint configurations, including `__test__`, `__tests__`, and `__fixtures__` directories.
- Cover aliases, dynamic imports, store re-exports, inline type-only exports, and both actual CLI configurations. Preserve real-store action spies and non-Pinia `layoutStore` mocks.
- Document global setup ownership and per-test state/action configuration. No application-test migrations, production changes, or new dependencies.

## Review Focus

The rule identifies store modules through `defineStore` and runtime re-exports rather than filenames. Type-only exports must not classify a utility as a store module. Test helpers receive the same enforcement as test files.

The [migration index](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17222#pullrequestreview-5151092712) records the nine merged prerequisite PRs. The temporary integration branch is no longer this PR's base.

Local verification on the rebased branch: `pnpm test:unit tools/oxlint-plugins scripts/testingPinia.test.ts` passed 7 files / 75 tests; `pnpm lint`, `pnpm typecheck`, `pnpm typecheck:tools`, formatting, and `git diff --check` passed. Lint reports existing warnings in unchanged source files. Full application unit/E2E suites were not rerun locally for this enforcement-only update; new-head CI results are separate from the old-base checks.
