### PR TITLE
fix(pricing): make the yearly credit allotment atomic and cover its no-date arm

### DIFF
--- a/apps/website/src/components/pricing/PricingSection.test.ts
+++ b/apps/website/src/components/pricing/PricingSection.test.ts
@@ -56,20 +56,22 @@ describe('PricingSection credit allotment copy', () => {
 
   it('keeps every yearly figure at twelve times its monthly counterpart', () => {
     const annualPlans = pricingPlans.flatMap((plan) => {
-      const { creditsKey, yearlyCreditsKey, estimateKey, yearlyEstimateKey } =
-        plan
-      return creditsKey && yearlyCreditsKey && estimateKey && yearlyEstimateKey
-        ? [{ creditsKey, yearlyCreditsKey, estimateKey, yearlyEstimateKey }]
+      const { creditsKey, estimateKey, yearlyAllotment } = plan
+      return creditsKey && estimateKey && yearlyAllotment
+        ? [{ creditsKey, estimateKey, yearlyAllotment }]
         : []
     })
     expect(annualPlans.length).toBeGreaterThan(0)
+    expect(annualPlans).toHaveLength(
+      pricingPlans.filter((plan) => plan.yearlyAllotment).length
+    )
 
     for (const plan of annualPlans) {
       for (const locale of LOCALES) {
-        expect(firstNumber(plan.yearlyCreditsKey, locale)).toBe(
+        expect(firstNumber(plan.yearlyAllotment.creditsKey, locale)).toBe(
           firstNumber(plan.creditsKey, locale) * MONTHS_PER_YEAR
         )
-        expect(firstNumber(plan.yearlyEstimateKey, locale)).toBe(
+        expect(firstNumber(plan.yearlyAllotment.estimateKey, locale)).toBe(
           firstNumber(plan.estimateKey, locale) * MONTHS_PER_YEAR
         )
       }

--- a/apps/website/src/components/pricing/PricingSection.vue
+++ b/apps/website/src/components/pricing/PricingSection.vue
@@ -5,7 +5,11 @@ import { cn } from '@comfyorg/tailwind-utils'
 import { computed, ref, useSlots } from 'vue'
 
 import { pricingPlans } from '../../data/pricingPlans'
-import type { BillingCycle, PricingPlan } from '../../data/pricingPlans'
+import type {
+  BillingCycle,
+  PlanYearlyAllotment,
+  PricingPlan
+} from '../../data/pricingPlans'
 import { t } from '../../i18n/translations'
 import Badge from '../ui/badge/Badge.vue'
 import Button from '../ui/button/Button.vue'
@@ -55,23 +59,23 @@ function originalPriceFor(plan: PricingPlan): string | undefined {
     : undefined
 }
 
-function showsYearlyCredits(plan: PricingPlan): boolean {
-  return billingPeriod.value === 'yearly' && plan.yearlyCreditsKey !== undefined
+function yearlyAllotmentFor(
+  plan: PricingPlan
+): PlanYearlyAllotment | undefined {
+  return billingPeriod.value === 'yearly' ? plan.yearlyAllotment : undefined
 }
 
 function displayCreditsKey(plan: PricingPlan): TranslationKey | undefined {
-  return showsYearlyCredits(plan) ? plan.yearlyCreditsKey : plan.creditsKey
+  return yearlyAllotmentFor(plan)?.creditsKey ?? plan.creditsKey
 }
 
 function displayEstimateKey(plan: PricingPlan): TranslationKey | undefined {
-  return showsYearlyCredits(plan) && plan.yearlyEstimateKey
-    ? plan.yearlyEstimateKey
-    : plan.estimateKey
+  return yearlyAllotmentFor(plan)?.estimateKey ?? plan.estimateKey
 }
 
 function creditsLabelFor(plan: PricingPlan): string {
   return t(
-    showsYearlyCredits(plan)
+    yearlyAllotmentFor(plan)
       ? 'pricing.creditsLabelYearly'
       : 'pricing.creditsLabel',
     locale

--- a/apps/website/src/config/features.ts
+++ b/apps/website/src/config/features.ts
@@ -1,1 +1,1 @@
-export const SHOW_FREE_TIER = false
+export const SHOW_FREE_TIER: boolean = false

--- a/apps/website/src/data/pricingPlans.ts
+++ b/apps/website/src/data/pricingPlans.ts
@@ -18,6 +18,12 @@ export interface PlanFeatureGroup {
   features: PlanFeature[]
 }
 
+/** Atomic so a plan cannot show annual credits beside a monthly estimate. */
+export interface PlanYearlyAllotment {
+  creditsKey: TranslationKey
+  estimateKey: TranslationKey
+}
+
 export interface PricingPlan {
   id: string
   labelKey: TranslationKey
@@ -28,9 +34,8 @@ export interface PricingPlan {
   eduYearlyPriceKey?: TranslationKey
   eduYearlyTotalKey?: TranslationKey
   creditsKey?: TranslationKey
-  yearlyCreditsKey?: TranslationKey
   estimateKey?: TranslationKey
-  yearlyEstimateKey?: TranslationKey
+  yearlyAllotment?: PlanYearlyAllotment
   ctaKey: TranslationKey
   ctaHref: (cycle: BillingCycle) => string
   features: PlanFeature[]
@@ -74,9 +79,11 @@ const standardPricingPlans: PricingPlan[] = [
     eduYearlyPriceKey: 'pricing.plan.standard.eduYearlyPrice',
     eduYearlyTotalKey: 'pricing.plan.standard.eduYearlyTotal',
     creditsKey: 'pricing.plan.standard.credits',
-    yearlyCreditsKey: 'pricing.plan.standard.yearlyCredits',
     estimateKey: 'pricing.plan.standard.estimate',
-    yearlyEstimateKey: 'pricing.plan.standard.yearlyEstimate',
+    yearlyAllotment: {
+      creditsKey: 'pricing.plan.standard.yearlyCredits',
+      estimateKey: 'pricing.plan.standard.yearlyEstimate'
+    },
     ctaKey: 'pricing.plan.standard.cta',
     ctaHref: (cycle) => subscribeUrl('standard', cycle),
     features: [
@@ -96,9 +103,11 @@ const standardPricingPlans: PricingPlan[] = [
     eduYearlyPriceKey: 'pricing.plan.creator.eduYearlyPrice',
     eduYearlyTotalKey: 'pricing.plan.creator.eduYearlyTotal',
     creditsKey: 'pricing.plan.creator.credits',
-    yearlyCreditsKey: 'pricing.plan.creator.yearlyCredits',
     estimateKey: 'pricing.plan.creator.estimate',
-    yearlyEstimateKey: 'pricing.plan.creator.yearlyEstimate',
+    yearlyAllotment: {
+      creditsKey: 'pricing.plan.creator.yearlyCredits',
+      estimateKey: 'pricing.plan.creator.yearlyEstimate'
+    },
     ctaKey: 'pricing.plan.creator.cta',
     ctaHref: (cycle) => subscribeUrl('creator', cycle),
     features: [
@@ -119,9 +128,11 @@ const standardPricingPlans: PricingPlan[] = [
     eduYearlyPriceKey: 'pricing.plan.pro.eduYearlyPrice',
     eduYearlyTotalKey: 'pricing.plan.pro.eduYearlyTotal',
     creditsKey: 'pricing.plan.pro.credits',
-    yearlyCreditsKey: 'pricing.plan.pro.yearlyCredits',
     estimateKey: 'pricing.plan.pro.estimate',
-    yearlyEstimateKey: 'pricing.plan.pro.yearlyEstimate',
+    yearlyAllotment: {
+      creditsKey: 'pricing.plan.pro.yearlyCredits',
+      estimateKey: 'pricing.plan.pro.yearlyEstimate'
+    },
     ctaKey: 'pricing.plan.pro.cta',
     ctaHref: (cycle) => subscribeUrl('pro', cycle),
     features: [

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -317,6 +317,20 @@ describe('CreditsTile', () => {
     expect(container.textContent).not.toContain('Monthly credits are used up')
   })
 
+  it('keeps the depletion notice yearly when the renewal date is unusable', () => {
+    activeProSubscription()
+    state.subscription = { tier: 'PRO', duration: 'ANNUAL', renewalDate: null }
+    state.balance = {
+      amountMicros: 300,
+      cloudCreditBalanceMicros: 0,
+      prepaidBalanceMicros: 300
+    }
+    const { container } = renderTile()
+    expect(container.textContent).toContain('Yearly credits are used up')
+    expect(container.textContent).not.toContain('used up. Refills')
+    expect(container.textContent).not.toContain('Monthly credits are used up')
+  })
+
   it('hides the monthly usage bar on Local', () => {
     mockIsCloud.value = false
     activeProSubscription()

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -325,10 +325,10 @@ describe('CreditsTile', () => {
       cloudCreditBalanceMicros: 0,
       prepaidBalanceMicros: 300
     }
-    const { container } = renderTile()
-    expect(container.textContent).toContain('Yearly credits are used up')
-    expect(container.textContent).not.toContain('used up. Refills')
-    expect(container.textContent).not.toContain('Monthly credits are used up')
+    renderTile()
+    expect(screen.getByText('Yearly credits are used up')).toBeTruthy()
+    expect(screen.queryByText(/used up\. Refills/)).toBeNull()
+    expect(screen.queryByText('Monthly credits are used up')).toBeNull()
   })
 
   it('hides the monthly usage bar on Local', () => {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Follow-up to #16099, carrying the two P2 fixes from @DrJKL's post-merge review. Both were pushed to that branch after it had already been squash-merged, so they never reached `main` — this PR lands them.

## Annual credits and estimates are now atomic

`yearlyCreditsKey` and `yearlyEstimateKey` were independently optional, and `displayEstimateKey()` switched to the annual credit amount whenever `yearlyCreditsKey` existed, then silently fell back to the monthly `estimateKey`. A plan carrying only the first rendered an annual credit total beside a monthly video count.

Nothing caught it. Dropping Creator's `yearlyEstimateKey` leaves the entire website suite green, because `states the whole-year allotment on the yearly cycle` asserts Standard's `~4,560` but never Creator's `~8,040`, and the 12× invariant filters incomplete pairs out before checking.

`PlanYearlyAllotment` now carries both keys as required fields, so the mixed state fails to compile:

```
src/data/pricingPlans.ts(132,5): error TS2741: Property 'estimateKey' is missing in type
'{ creditsKey: "pricing.plan.pro.yearlyCredits"; }' but required in type 'PlanYearlyAllotment'
```

`PricingSection.vue` derives credits, estimate and the cadence label from a single `yearlyAllotmentFor(plan)` lookup, so they cannot drift — `creditsLabelFor` previously keyed off `yearlyCreditsKey` presence separately, which was a third way to disagree.

The invariant test also asserts its filtered list matches the number of plans declaring an allotment, so an incomplete plan fails loudly instead of being skipped:

```
AssertionError: expected [ { …(3) }, { …(3) } ] to have a length of 3 but got 2
```

Note the type guarantees the two keys are *selected* together, not that their content agrees — a plan pairing `yearlyCredits` with the monthly `estimate` key still compiles, and that residual case remains covered by the 12× cross-locale invariant.

## Annual no-date depletion branch is covered

The annual arm of the depletion notice could regress to `monthlyCreditsUsedUpTitleNoDate` without failing anything: every `duration: 'ANNUAL'` test used a valid `renewalDate`, and both dateless cases were monthly (one of them zeroing prepaid, so it landed in the out-of-credits branch instead).

The new test uses a depleted annual subscription with `renewalDate: null` and prepaid above zero. Regressing that arm to the monthly key fails it and nothing else — 1 failed, 39 passed.

Its middle assertion is `not.toContain('used up. Refills')` rather than a month name: pinning `Refills Feb` would still pass if the outer `hasRefillsDate` guard were removed, since that renders a dangling `Yearly credits are used up. Refills `, and a bare `Refills` can't be used because the usage bar legitimately renders `Refills next cycle`.

## Drive-by

`SHOW_FREE_TIER` is annotated `boolean`. Staging `pricingPlans.ts` makes the pre-commit `oxlint --type-aware` pass evaluate the pre-existing `SHOW_FREE_TIER ? … : …` export in that file and reject it as *"Unnecessary conditional, value is always falsy"*, because the flag was narrowed to the literal `false`. Annotating it keeps the flag flippable, which deleting the dead branch would not. Runtime behaviour is unchanged.

## Verification

`CreditsTile` 40 tests, website pricing + data 95 tests, `pnpm typecheck` 0 errors, `eslint` and `oxfmt` clean.

No rendered change: building the site before and after, the pricing page HTML is byte-identical in `en` and `zh-CN` once per-build nondeterminism is normalised, the sole delta being the island's asset content-hash — expected, since the component source changed.