### PR TITLE
fix(billing): keep the embedded chrome on the plan-change success step

### DIFF
--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -292,4 +292,32 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
       expect(mockHandleBackToPricing).toHaveBeenCalled()
     }
   )
+
+  it.for(['personal-new', 'personal-change', 'team-change'])(
+    'keeps the embedded chrome on the success step (%s)',
+    (variant) => {
+      vi.stubEnv('VITE_STRIPE_PUBLISHABLE_KEY', 'pk_test_example')
+      mockCheckoutStep.value = 'success'
+      mockPreviewVariant.value = variant
+
+      renderComponent()
+
+      expect(screen.getByTestId('checkout-dialog-shell')).toHaveClass(
+        'rounded-2xl',
+        'overflow-hidden'
+      )
+    }
+  )
+
+  it('renders the success step without the embedded chrome when the flag is off', () => {
+    vi.stubEnv('VITE_STRIPE_PUBLISHABLE_KEY', 'pk_test_example')
+    mockCheckoutStep.value = 'success'
+    mockPreviewVariant.value = 'personal-change'
+
+    renderComponent({ embeddedCheckoutEnabled: false })
+
+    expect(screen.getByTestId('checkout-dialog-shell')).not.toHaveClass(
+      'rounded-2xl'
+    )
+  })
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -319,5 +319,8 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
     expect(screen.getByTestId('checkout-dialog-shell')).not.toHaveClass(
       'rounded-2xl'
     )
+    expect(screen.getByTestId('checkout-dialog-shell')).not.toHaveClass(
+      'overflow-hidden'
+    )
   })
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="contentRoot"
+    data-testid="checkout-dialog-shell"
     :class="
       cn(
         'relative flex h-full flex-col gap-4 overflow-y-auto p-4 pt-6',
@@ -279,7 +280,9 @@ const isEmbeddedSuccessStep = computed(
     checkoutStep.value === 'success' &&
     stripePaymentElementEnabled &&
     (previewVariant.value === 'team-new' ||
-      previewVariant.value === 'personal-new')
+      previewVariant.value === 'personal-new' ||
+      previewVariant.value === 'team-change' ||
+      previewVariant.value === 'personal-change')
 )
 
 watch(checkoutStep, (step) => {


### PR DESCRIPTION
Closes FE-2144.

On a plan change with the embedded checkout enabled, the success step rendered in the legacy dialog treatment: the shell dropped its fixed height (`h-[min(740px,85vh)] … xl:w-[512px]`) so the dialog shrank mid-flow, and `dark-surface` was false so the plan summary card reverted to the bordered legacy style.

Root cause: `isEmbeddedSuccessStep` only admitted `team-new || personal-new`, while `isEmbeddedConfirmStep` also admits the `*-change` variants — the chrome fell away at the exact confirm → success transition. Success on a change variant is only reachable through the embedded confirm, so the two gates now share the same variant set.

Found during embedded-checkout QA on staging. The redundant success toast visible in the same repro is separate (FE-1981 / #16571).

## Tests

- Success step keeps the embedded chrome for `personal-new`, `personal-change`, and `team-change` (red on the change variants before the fix, verified).
- Flag off: success renders without the embedded chrome.
- Shell gets a `data-testid` to satisfy `testing-library/no-node-access`.