### PR TITLE
test: use global Pinia in graph and core tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useLinkPresentationStore } from '@/stores/linkPresentationStore'
@@ -44,7 +42,6 @@ describe('graphMutations', () => {
   const deleteLayouts = vi.fn()
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     createLayout.mockReset()
     deleteLayouts.mockReset()
   })

--- a/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
+++ b/src/core/graph/nodeShell/nodeShellLifecycle.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -15,10 +13,6 @@ import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 describe('node shell registration', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('remints a colliding node id and warns with both ids', () => {
     const graph = new LGraph()
     const first = new LGraphNode('first')
@@ -45,10 +39,6 @@ describe('node shell registration', () => {
 })
 
 describe('node shell teardown', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function addWidgetedNode(graph: LGraph | Subgraph): LGraphNode {
     const node = new LGraphNode('Node')
     node.addWidget('text', 'prompt', 'a value', () => {})

--- a/src/core/graph/nodeShell/nodeShellState.test.ts
+++ b/src/core/graph/nodeShell/nodeShellState.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { toRaw } from 'vue'
 
@@ -17,10 +15,6 @@ import { createUuidv4, zeroUuid } from '@/utils/uuid'
 import { createNodeShellState, unregisterNodeState } from './nodeShellState'
 
 describe('node shell state', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function addNodeToSubgraph() {
     const subgraph = createTestSubgraph()
     const node = new LGraphNode('Node')
@@ -110,7 +104,6 @@ describe('node shell state', () => {
 
 describe('node registration invariants', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.stubEnv('DEV', true)
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
@@ -25,13 +25,6 @@ import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/subgraph/resolveConcretePromotedWidget.test.ts
+++ b/src/core/graph/subgraph/resolveConcretePromotedWidget.test.ts
@@ -10,16 +10,6 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ widgetStates: new Map() })
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/subgraph/resolveSubgraphInputLink.test.ts
+++ b/src/core/graph/subgraph/resolveSubgraphInputLink.test.ts
@@ -11,16 +11,6 @@ import {
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ widgetStates: new Map() })
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/subgraph/resolveSubgraphInputTarget.test.ts
+++ b/src/core/graph/subgraph/resolveSubgraphInputTarget.test.ts
@@ -10,16 +10,6 @@ import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { toNodeId } from '@/types/nodeId'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ widgetStates: new Map() })
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -1,5 +1,3 @@
-import { setActivePinia } from 'pinia'
-import { createTestingPinia } from '@pinia/testing'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   addAutogrow,
@@ -9,13 +7,14 @@ import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
 
-setActivePinia(createTestingPinia({ stubActions: false }))
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 type TestAutogrowNode = LGraphNode & {
   comfyDynamic: { autogrow: Record<string, unknown> }
 }
 
-const { addNodeInput } = useLitegraphService()
+let addNodeInput: ReturnType<typeof useLitegraphService>['addNodeInput']
+beforeEach(() => {
+  ;({ addNodeInput } = useLitegraphService())
+})
 
 function nextTick() {
   return new Promise<void>((r) => requestAnimationFrame(() => r()))

--- a/src/core/graph/widgets/matchTypeConfiguring.test.ts
+++ b/src/core/graph/widgets/matchTypeConfiguring.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromAny } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { describe, expect, test } from 'vitest'
 import { effect, stop } from 'vue'
 
@@ -9,11 +7,8 @@ import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 
-setActivePinia(createTestingPinia({ stubActions: false }))
-
-const { addNodeInput } = useLitegraphService()
-
 function createMatchTypeNode(graph: LGraph) {
+  const { addNodeInput } = useLitegraphService()
   const node = new LGraphNode('switch')
   ;(node.constructor as { nodeData: unknown }).nodeData = {
     name: 'ComfySwitchAny',

--- a/src/core/graph/widgets/matchTypeFallback.test.ts
+++ b/src/core/graph/widgets/matchTypeFallback.test.ts
@@ -1,13 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import { useLitegraphService } from '@/services/litegraphService'
-
-setActivePinia(createTestingPinia())
 
 function testNode() {
   const node = new LGraphNode('test')

--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -1,31 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
 
 import type { ComfyExtension } from '@/types/comfy'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/agentPanelStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
+
+let agentStore: Mocked<ReturnType<typeof useAgentPanelStore>>
+let canvasStore: Mocked<ReturnType<typeof useCanvasStore>>
+let nodeSelectionStore: Mocked<ReturnType<typeof useAgentNodeSelectionStore>>
+let workflowStore: ReturnType<typeof useWorkflowStore>
 
 const mocks = vi.hoisted(() => ({
   capturedExtensions: [] as ComfyExtension[],
   notifyAfterGraphConfigure: vi.fn(),
   notifyBeforeGraphLoad: vi.fn(),
-  agentStore: { enabled: false, isOpen: true, close: vi.fn() },
-  canvasStore: { updateSelectedItems: vi.fn() },
   getNodeByLocatorId: vi.fn(),
   flagEnabled: undefined as boolean | undefined,
   flagListener: null as (() => void) | null,
-  nodeSelectionStore: {
-    beginWorkflowLoad: vi.fn(),
-    finishWorkflowLoad: vi.fn(),
-    isLoadingWorkflow: false,
-    nodeIds: vi.fn(() => [] as string[]),
-    restoreNodeIds: vi.fn(),
-    saveNodeIds: vi.fn()
-  },
-  registerTracker: vi.fn(() => () => {}),
-  workflowStore: {
-    activeWorkflow: { path: 'workflows/first.json' },
-    nodeToNodeLocatorId: vi.fn((node: { locatorId?: string; id: number }) =>
-      node.locatorId ? node.locatorId : String(node.id)
-    )
-  }
+  registerTracker: vi.fn(() => () => {})
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -41,28 +37,14 @@ vi.mock('@/workbench/extensions/agent/crdt/mintPortWiring', () => ({
   notifyMintPortsBeforeGraphLoad: mocks.notifyBeforeGraphLoad
 }))
 
-vi.mock('@/workbench/extensions/agent/stores/agent/agentPanelStore', () => ({
-  useAgentPanelStore: () => mocks.agentStore
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => mocks.workflowStore
-}))
-
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => mocks.canvasStore
-}))
-
-vi.mock('@/stores/agentNodeSelectionStore', () => ({
-  useAgentNodeSelectionStore: () => mocks.nodeSelectionStore
-}))
-
-vi.mock('@/utils/litegraphUtil', () => ({
-  isLGraphNode: (node: unknown): node is { id: number } =>
+vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  isLGraphNode: (node: unknown): node is LGraphNode =>
     typeof node === 'object' && node !== null && 'id' in node
 }))
 
-vi.mock('@/utils/graphTraversalUtil', () => ({
+vi.mock(import('@/utils/graphTraversalUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
   getNodeByLocatorId: mocks.getNodeByLocatorId
 }))
 
@@ -100,25 +82,33 @@ async function loadEntryAndSetup(): Promise<void> {
 
 describe('AgentPanel extension flag gate', () => {
   beforeEach(() => {
+    agentStore = vi.mocked(useAgentPanelStore())
+    canvasStore = vi.mocked(useCanvasStore())
+    nodeSelectionStore = vi.mocked(useAgentNodeSelectionStore())
+    workflowStore = useWorkflowStore()
+    canvasStore.updateSelectedItems.mockImplementation(() => {})
+    nodeSelectionStore.restoreNodeIds.mockImplementation(() => {})
     mocks.capturedExtensions.length = 0
     mocks.notifyAfterGraphConfigure.mockClear()
     mocks.notifyBeforeGraphLoad.mockClear()
-    mocks.agentStore.close.mockClear()
-    mocks.agentStore.enabled = false
-    mocks.agentStore.isOpen = true
+    agentStore.close.mockClear()
+    agentStore.enabled = false
+    agentStore.isOpen = true
     mocks.flagEnabled = undefined
     mocks.flagListener = null
     mocks.registerTracker.mockClear()
-    mocks.canvasStore.updateSelectedItems.mockClear()
+    canvasStore.updateSelectedItems.mockClear()
     mocks.getNodeByLocatorId.mockReset()
-    mocks.nodeSelectionStore.beginWorkflowLoad.mockClear()
-    mocks.nodeSelectionStore.finishWorkflowLoad.mockClear()
-    mocks.nodeSelectionStore.nodeIds.mockReset()
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue([])
-    mocks.nodeSelectionStore.restoreNodeIds.mockClear()
-    mocks.nodeSelectionStore.saveNodeIds.mockClear()
-    mocks.nodeSelectionStore.isLoadingWorkflow = false
-    mocks.workflowStore.activeWorkflow = { path: 'workflows/first.json' }
+    nodeSelectionStore.beginWorkflowLoad.mockClear()
+    nodeSelectionStore.finishWorkflowLoad.mockClear()
+    nodeSelectionStore.nodeIds.mockReset()
+    nodeSelectionStore.nodeIds.mockReturnValue([])
+    nodeSelectionStore.restoreNodeIds.mockClear()
+    nodeSelectionStore.saveNodeIds.mockClear()
+    nodeSelectionStore.isLoadingWorkflow = false
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/first.json'
+    })
     vi.resetModules()
   })
 
@@ -134,12 +124,12 @@ describe('AgentPanel extension flag gate', () => {
 
     await loadEntryAndSetup()
 
-    expect(mocks.agentStore.enabled).toBe(true)
+    expect(agentStore.enabled).toBe(true)
   })
 
   it('leaves the panel disabled while the flag is undefined', async () => {
     await loadEntryAndSetup()
-    expect(mocks.agentStore.enabled).toBe(false)
+    expect(agentStore.enabled).toBe(false)
   })
 
   it('registers the tab-activity tracker once at setup, not gated on the flag', async () => {
@@ -151,7 +141,7 @@ describe('AgentPanel extension flag gate', () => {
     await loadEntryAndSetup()
     mocks.flagEnabled = true
     mocks.flagListener!()
-    expect(mocks.agentStore.enabled).toBe(true)
+    expect(agentStore.enabled).toBe(true)
   })
 
   it('disables the panel without closing it when the flag flips back to false', async () => {
@@ -161,21 +151,21 @@ describe('AgentPanel extension flag gate', () => {
     mocks.flagEnabled = false
     mocks.flagListener!()
 
-    expect(mocks.agentStore.enabled).toBe(false)
-    expect(mocks.agentStore.close).not.toHaveBeenCalled()
-    expect(mocks.agentStore.isOpen).toBe(true)
+    expect(agentStore.enabled).toBe(false)
+    expect(agentStore.close).not.toHaveBeenCalled()
+    expect(agentStore.isOpen).toBe(true)
   })
 
   it('finishes a pending selection restore when the flag is disabled', async () => {
     await loadEntryAndSetup()
     mocks.flagEnabled = true
     mocks.flagListener!()
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.isLoadingWorkflow = true
 
     mocks.flagEnabled = false
     mocks.flagListener!()
 
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
   })
 
   it('restores each workflow reference after the shared graph load', async () => {
@@ -187,17 +177,19 @@ describe('AgentPanel extension flag gate', () => {
     const secondNode = { id: 12 }
     const rootGraph = {}
     const selectItems = vi.fn()
-    mocks.agentStore.enabled = true
+    agentStore.enabled = true
 
     extension!.beforeLoadGraph!({} as never)
 
     expect(mocks.notifyBeforeGraphLoad).toHaveBeenCalledOnce()
-    expect(mocks.nodeSelectionStore.beginWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.beginWorkflowLoad).toHaveBeenCalledOnce()
 
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue(['12'])
+    nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.nodeIds.mockReturnValue(['12'])
     mocks.getNodeByLocatorId.mockReturnValue(secondNode)
-    mocks.workflowStore.activeWorkflow = { path: 'workflows/second.json' }
+    workflowStore.activeWorkflow = createMockLoadedWorkflow({
+      path: 'workflows/second.json'
+    })
 
     extension!.afterLoadGraph!({
       rootGraph,
@@ -208,9 +200,9 @@ describe('AgentPanel extension flag gate', () => {
 
     expect(mocks.getNodeByLocatorId).toHaveBeenCalledWith(rootGraph, '12')
     expect(selectItems).toHaveBeenCalledWith([secondNode])
-    expect(mocks.nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith(['12'])
-    expect(mocks.canvasStore.updateSelectedItems).toHaveBeenCalledOnce()
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).not.toHaveBeenCalled()
+    expect(nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith(['12'])
+    expect(canvasStore.updateSelectedItems).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).not.toHaveBeenCalled()
   })
 
   it('closes the mint suppression bracket after graph configuration', async () => {
@@ -232,22 +224,23 @@ describe('AgentPanel extension flag gate', () => {
       (item) => item.name === 'Comfy.AgentPanel'
     )
     const locator = '12345678-1234-1234-1234-123456789abc:shared'
-    const subgraphNode = { id: 'shared', locatorId: locator }
+    const subgraphNode = {
+      id: 'shared',
+      graph: { id: '12345678-1234-1234-1234-123456789abc', isRootGraph: false }
+    }
     const rootGraph = {}
     const selectItems = vi.fn()
 
-    mocks.agentStore.enabled = true
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue([locator])
+    agentStore.enabled = true
+    nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.nodeIds.mockReturnValue([locator])
     mocks.getNodeByLocatorId.mockReturnValue(subgraphNode)
 
     extension!.afterLoadGraph!({ rootGraph, canvas: { selectItems } } as never)
 
     expect(mocks.getNodeByLocatorId).toHaveBeenCalledWith(rootGraph, locator)
     expect(selectItems).toHaveBeenCalledWith([subgraphNode])
-    expect(mocks.nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith([
-      locator
-    ])
+    expect(nodeSelectionStore.restoreNodeIds).toHaveBeenCalledWith([locator])
   })
 
   it('skips graph-load selection tracking while the panel is closed', async () => {
@@ -256,12 +249,12 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.agentStore.isOpen = false
+    agentStore.isOpen = false
 
     extension!.beforeLoadGraph!({} as never)
 
     expect(mocks.notifyBeforeGraphLoad).toHaveBeenCalledOnce()
-    expect(mocks.nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
+    expect(nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
   })
 
   it('finishes restoration when the panel closes during graph load', async () => {
@@ -270,14 +263,14 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.agentStore.isOpen = false
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
+    agentStore.isOpen = false
+    nodeSelectionStore.isLoadingWorkflow = true
 
     extension!.afterLoadGraph!({} as never)
 
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
     expect(mocks.getNodeByLocatorId).not.toHaveBeenCalled()
-    expect(mocks.canvasStore.updateSelectedItems).not.toHaveBeenCalled()
+    expect(canvasStore.updateSelectedItems).not.toHaveBeenCalled()
   })
 
   it('finishes restoration when graph configuration fails', async () => {
@@ -286,11 +279,11 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.isLoadingWorkflow = true
 
     extension!.onGraphLoadError!(new Error('bad workflow json'), {} as never)
 
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
   })
 
   it('finishes restoration when selection restoration throws', async () => {
@@ -299,10 +292,10 @@ describe('AgentPanel extension flag gate', () => {
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
-    mocks.agentStore.enabled = true
-    mocks.agentStore.isOpen = true
-    mocks.nodeSelectionStore.isLoadingWorkflow = true
-    mocks.nodeSelectionStore.nodeIds.mockReturnValue(['12'])
+    agentStore.enabled = true
+    agentStore.isOpen = true
+    nodeSelectionStore.isLoadingWorkflow = true
+    nodeSelectionStore.nodeIds.mockReturnValue(['12'])
     mocks.getNodeByLocatorId.mockImplementation(() => {
       throw new Error('selection restore failed')
     })
@@ -310,7 +303,7 @@ describe('AgentPanel extension flag gate', () => {
     expect(() =>
       extension!.afterLoadGraph!({ rootGraph: {} } as never)
     ).toThrow('selection restore failed')
-    expect(mocks.nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
+    expect(nodeSelectionStore.finishWorkflowLoad).toHaveBeenCalledOnce()
   })
 
   it('does not start selection restoration while the flag is disabled', async () => {
@@ -322,6 +315,6 @@ describe('AgentPanel extension flag gate', () => {
 
     extension!.beforeLoadGraph!({} as never)
 
-    expect(mocks.nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
+    expect(nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
   })
 })

--- a/src/extensions/core/agentPanelGateDependencyFailure.test.ts
+++ b/src/extensions/core/agentPanelGateDependencyFailure.test.ts
@@ -1,18 +1,13 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/agentPanelStore'
+import { registerAgentPanelExtension } from './agentPanel'
 
 const registered = vi.hoisted(() => ({
   setup: null as (() => Promise<void> | void) | null
 }))
 
 const reportErrorMock = vi.hoisted(() => vi.fn())
-const agentStore = vi.hoisted(() => ({
-  enabled: false,
-  gateSettled: false,
-  isOpen: false
-}))
 
 vi.mock('@/platform/telemetry/reportError', () => ({
   reportError: reportErrorMock
@@ -23,26 +18,6 @@ vi.mock('@/platform/telemetry/reportError', () => ({
 vi.mock('@/workbench/extensions/agent/utils/postHogFlagSource', () => {
   throw new Error('flag source chunk failed to load')
 })
-
-vi.mock('@/workbench/extensions/agent/stores/agent/agentPanelStore', () => ({
-  useAgentPanelStore: () => agentStore
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({ activeWorkflow: null })
-}))
-
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => ({ updateSelectedItems: vi.fn() })
-}))
-
-vi.mock('@/stores/agentNodeSelectionStore', () => ({
-  useAgentNodeSelectionStore: () => ({
-    isLoadingWorkflow: false,
-    beginWorkflowLoad: vi.fn(),
-    finishWorkflowLoad: vi.fn()
-  })
-}))
 
 vi.mock('@/utils/graphTraversalUtil', () => ({
   getNodeByLocatorId: vi.fn()
@@ -67,17 +42,14 @@ vi.mock('@/services/extensionService', () => ({
 
 describe('the agent panel gate under a dependency-chunk failure', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     reportErrorMock.mockClear()
-    agentStore.enabled = false
-    agentStore.gateSettled = false
+    useAgentPanelStore().enabled = false
+    useAgentPanelStore().gateSettled = false
   })
 
   it('settles fail-closed, reports, and resolves the setup promise', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.stubGlobal('__DISTRIBUTION__', 'cloud')
-    vi.resetModules()
-    const { registerAgentPanelExtension } = await import('./agentPanel')
     registerAgentPanelExtension()
 
     // The gate promise is HANDED BACK to the extension service - a

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -1,20 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ActionBarButton } from '@/types/comfy'
 
-const tabBarLayout = vi.hoisted(() => ({ value: 'Default' }))
 const registerExtension = vi.hoisted(() => vi.fn())
 const openFeedbackDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('@/i18n', () => ({
   t: (key: string) => key
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.UI.TabBarLayout' ? tabBarLayout.value : undefined
-  })
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -41,7 +34,7 @@ describe('cloudFeedbackTopbarButton', () => {
   }
 
   it('opens the feedback survey tagged with the action-bar source', async () => {
-    tabBarLayout.value = 'Legacy'
+    vi.mocked(useSettingStore().get).mockReturnValue('Legacy')
     await import('./cloudFeedbackTopbarButton')
 
     const buttons = getRegisteredButtons()
@@ -53,7 +46,7 @@ describe('cloudFeedbackTopbarButton', () => {
   })
 
   it('only registers the action bar button when the tab bar is Legacy', async () => {
-    tabBarLayout.value = 'Default'
+    vi.mocked(useSettingStore().get).mockReturnValue('Default')
     await import('./cloudFeedbackTopbarButton')
 
     expect(getRegisteredButtons()).toEqual([])

--- a/src/extensions/core/customWidgets.clone.test.ts
+++ b/src/extensions/core/customWidgets.clone.test.ts
@@ -1,13 +1,24 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
-import { useExtensionStore } from '@/stores/extensionStore'
 import type { ComfyExtension } from '@/types/comfy'
 
+const registeredExtensions = vi.hoisted((): ComfyExtension[] => [])
+vi.mock(import('@/scripts/app'), async (importOriginal) => {
+  const original = await importOriginal()
+  original.app.registerExtension = (extension) => {
+    registeredExtensions.push(extension)
+  }
+  return original
+})
+await import('./customWidgets')
+const extension = registeredExtensions.find(
+  (candidate) => candidate.name === 'Comfy.CustomWidgets'
+)
+if (!extension)
+  throw new Error('Comfy.CustomWidgets extension was not registered')
 const TEST_CUSTOM_COMBO_TYPE = 'test/CustomComboCopyPaste'
 
 class TestCustomComboNode extends LGraphNode {
@@ -27,24 +38,8 @@ function findWidget(node: LGraphNode, name: string) {
   return node.widgets?.find((widget) => widget.name === name)
 }
 
-function getCustomWidgetsExtension(): ComfyExtension {
-  const extension = useExtensionStore().extensions.find(
-    (candidate) => candidate.name === 'Comfy.CustomWidgets'
-  )
-
-  if (!extension) {
-    throw new Error('Comfy.CustomWidgets extension was not registered')
-  }
-
-  return extension
-}
-
 describe('CustomCombo copy/paste', () => {
   beforeAll(async () => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    await import('./customWidgets')
-
-    const extension = getCustomWidgetsExtension()
     await extension.beforeRegisterNodeDef?.(
       TestCustomComboNode,
       { name: 'CustomCombo' } as ComfyNodeDef,

--- a/src/extensions/core/customWidgets.subgraphPromotion.test.ts
+++ b/src/extensions/core/customWidgets.subgraphPromotion.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { promoteValueWidgetViaSubgraphInput } from '@/core/graph/subgraph/promotionUtils'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -11,11 +9,24 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
-import { useExtensionStore } from '@/stores/extensionStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { ComfyExtension } from '@/types/comfy'
 import { graphToPrompt } from '@/utils/executionUtil'
 
+const registeredExtensions = vi.hoisted((): ComfyExtension[] => [])
+vi.mock(import('@/scripts/app'), async (importOriginal) => {
+  const original = await importOriginal()
+  original.app.registerExtension = (extension) => {
+    registeredExtensions.push(extension)
+  }
+  return original
+})
+await import('./customWidgets')
+const extension = registeredExtensions.find(
+  (candidate) => candidate.name === 'Comfy.CustomWidgets'
+)
+if (!extension)
+  throw new Error('Comfy.CustomWidgets extension was not registered')
 // Regression coverage for https://github.com/Comfy-Org/ComfyUI/issues/15060
 // (FE-1456): once a Custom Combo node's `choice` widget is promoted through
 // a subgraph boundary (ADR-SUBGRAPH-PROMOTION-0009 link-only promotion), the hidden `index`
@@ -66,22 +77,8 @@ function findWidget(node: LGraphNode, name: string) {
   return node.widgets?.find((widget) => widget.name === name)
 }
 
-function getCustomWidgetsExtension(): ComfyExtension {
-  const extension = useExtensionStore().extensions.find(
-    (candidate) => candidate.name === 'Comfy.CustomWidgets'
-  )
-  if (!extension) {
-    throw new Error('Comfy.CustomWidgets extension was not registered')
-  }
-  return extension
-}
-
 describe('CustomCombo index widget after subgraph promotion', () => {
   beforeAll(async () => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    await import('./customWidgets')
-
-    const extension = getCustomWidgetsExtension()
     await extension.beforeRegisterNodeDef?.(
       TestCustomComboNode,
       { name: 'CustomCombo' } as ComfyNodeDef,

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { getActivePinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
 import { t } from '@/i18n'
@@ -240,8 +238,6 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
   it('removes a prior same-name group type before reporting missing nodes', async () => {
     const groupType = 'workflow>MyGroup'
     const missing: MissingNodeType[] = []
-    const previousPinia = getActivePinia()
-    setActivePinia(createTestingPinia({ stubActions: false }))
     extensionState.registerNodeDef.mockImplementation(
       async (typeName, nodeDef) => {
         class PreviousGroupNode extends LGraphNode {
@@ -282,7 +278,6 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
       ])
     } finally {
       extensionState.registerNodeDef.mockReset()
-      setActivePinia(previousPinia)
     }
   })
 
@@ -382,19 +377,12 @@ describe('group node extension beforeConfigureGraph', () => {
         expect.objectContaining({ nodeId: '8', type: 'workflow>MyGroup' })
       ])
 
-      const previousPinia = getActivePinia()
-      setActivePinia(createTestingPinia({ stubActions: false }))
-      try {
-        const store = useMissingNodesErrorStore()
-        store.setMissingNodeTypes(missingNodeTypes)
-        store.removeMissingNodesByNodeId('7')
-
-        expect(store.missingNodesError?.nodeTypes).toStrictEqual([
-          expect.objectContaining({ nodeId: '8', type: 'workflow>MyGroup' })
-        ])
-      } finally {
-        setActivePinia(previousPinia)
-      }
+      const store = useMissingNodesErrorStore()
+      store.setMissingNodeTypes(missingNodeTypes)
+      store.removeMissingNodesByNodeId('7')
+      expect(store.missingNodesError?.nodeTypes).toStrictEqual([
+        expect.objectContaining({ nodeId: '8', type: 'workflow>MyGroup' })
+      ])
     } finally {
       extensionState.rootGraph.nodes = []
     }

--- a/src/extensions/core/groupOptions.test.ts
+++ b/src/extensions/core/groupOptions.test.ts
@@ -12,6 +12,7 @@ import type {
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyExtension } from '@/types/comfy'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
@@ -21,10 +22,6 @@ const { registerExtension } = vi.hoisted(() => ({
 
 vi.mock('@/scripts/app', () => ({
   app: { registerExtension }
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: () => 10 })
 }))
 
 import '@/extensions/core/groupOptions'
@@ -83,6 +80,7 @@ const BASE_GROUP_ITEMS: (string | null)[] = [
 
 beforeEach(() => {
   graphChange.mockClear()
+  vi.mocked(useSettingStore().get).mockReturnValue(10)
 })
 
 describe('Comfy.GroupOptions canvas menu', () => {

--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CameraState } from '@/extensions/core/load3d/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { ComfyExtension } from '@/types/comfy'
 
@@ -12,7 +13,6 @@ const {
   configureMock,
   configureForSaveMeshMock,
   getLoad3dMock,
-  toastAddAlertMock,
   getNodeByLocatorIdMock,
   nodeToLoad3dMap
 } = vi.hoisted(() => ({
@@ -22,7 +22,6 @@ const {
   configureMock: vi.fn(),
   configureForSaveMeshMock: vi.fn(),
   getLoad3dMock: vi.fn(),
-  toastAddAlertMock: vi.fn(),
   getNodeByLocatorIdMock: vi.fn(),
   nodeToLoad3dMap: new Map<object, unknown>()
 }))
@@ -110,13 +109,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: toastAddAlertMock })
-}))
-
-vi.mock('@/stores/dialogStore', () => ({
-  useDialogStore: () => ({ showDialog: vi.fn() })
-}))
+let toastAddAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  toastAddAlertMock = useToastStore().addAlert
+})
 
 vi.mock('@/utils/litegraphUtil', () => ({
   isLoad3dNode: vi.fn(() => true)

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -15,14 +15,7 @@ import type {
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import type { Dictionary } from '@/lib/litegraph/src/interfaces'
 import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
-
-const { settingsGetMock } = vi.hoisted(() => ({
-  settingsGetMock: vi.fn()
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: settingsGetMock })
-}))
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -61,7 +54,7 @@ function createConfig(properties?: Dictionary<NodeProperty | undefined>) {
 }
 
 function stubSettings(values: Record<string, unknown>) {
-  settingsGetMock.mockImplementation((key: string) => values[key])
+  vi.mocked(useSettingStore().get).mockImplementation((key) => values[key])
 }
 
 const defaultGizmo: GizmoConfig = {
@@ -372,7 +365,7 @@ describe('Load3DConfiguration.loadSceneConfig', () => {
     })
 
     expect(createConfig(properties).loadSceneConfig()).toEqual(stored)
-    expect(settingsGetMock).not.toHaveBeenCalled()
+    expect(useSettingStore().get).not.toHaveBeenCalled()
   })
 
   it('falls back to settings and prepends # to the background color', () => {
@@ -401,7 +394,7 @@ describe('Load3DConfiguration.loadCameraConfig', () => {
     stubSettings({ 'Comfy.Load3D.CameraType': 'perspective' })
 
     expect(createConfig(properties).loadCameraConfig()).toEqual(stored)
-    expect(settingsGetMock).not.toHaveBeenCalled()
+    expect(useSettingStore().get).not.toHaveBeenCalled()
   })
 
   it('falls back to settings and a default fov of 35', () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useToastStore } from '@/platform/updates/common/toastStore'
+
 import type {
   EventManagerInterface,
   MaterialMode,
@@ -56,15 +58,13 @@ const {
   splatLoad,
   pointCloudLoad,
   fetchModelDataMock,
-  isGaussianSplatPLYMock,
-  addAlert
+  isGaussianSplatPLYMock
 } = vi.hoisted(() => ({
   meshLoad: vi.fn(),
   splatLoad: vi.fn(),
   pointCloudLoad: vi.fn(),
   fetchModelDataMock: vi.fn<() => Promise<ArrayBuffer>>(),
-  isGaussianSplatPLYMock: vi.fn<(b: ArrayBuffer) => Promise<boolean>>(),
-  addAlert: vi.fn()
+  isGaussianSplatPLYMock: vi.fn<(b: ArrayBuffer) => Promise<boolean>>()
 }))
 
 vi.mock('./MeshModelAdapter', () => ({
@@ -115,9 +115,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert })
-}))
+let addAlert: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  addAlert = useToastStore().addAlert
+})
 
 type LoaderManagerInternals = {
   pickAdapter(

--- a/src/extensions/core/load3d/ModelExporter.test.ts
+++ b/src/extensions/core/load3d/ModelExporter.test.ts
@@ -1,18 +1,18 @@
 import * as THREE from 'three'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import { ModelExporter } from './ModelExporter'
 
 const {
   downloadBlobMock,
-  addAlertMock,
   gltfParseMock,
   objParseMock,
   stlParseMock,
   fbxParseAsyncMock
 } = vi.hoisted(() => ({
   downloadBlobMock: vi.fn(),
-  addAlertMock: vi.fn(),
   gltfParseMock: vi.fn(),
   objParseMock: vi.fn(),
   stlParseMock: vi.fn(),
@@ -28,9 +28,10 @@ vi.mock('@/i18n', () => ({
     vars ? `${key}:${JSON.stringify(vars)}` : key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: addAlertMock })
-}))
+let addAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  addAlertMock = useToastStore().addAlert
+})
 
 vi.mock('three/examples/jsm/exporters/GLTFExporter', () => ({
   GLTFExporter: class {

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -1,15 +1,11 @@
 import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+
 import type { ModelLoadContext } from './ModelAdapter'
 import * as ModelAdapterModule from './ModelAdapter'
 import { PointCloudModelAdapter } from './PointCloudModelAdapter'
-
-const mockSettingGet = vi.fn<(key: string) => unknown>()
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: mockSettingGet })
-}))
 
 vi.mock('@/scripts/metadata/ply', () => ({
   isPLYAsciiFormat: vi.fn().mockReturnValue(false)
@@ -89,7 +85,7 @@ describe('PointCloudModelAdapter', () => {
 
   describe('load', () => {
     beforeEach(() => {
-      mockSettingGet.mockReturnValue('three')
+      vi.mocked(useSettingStore().get).mockReturnValue('three')
       vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(
         new ArrayBuffer(0)
       )

--- a/src/extensions/core/load3d/exportMenuHelper.test.ts
+++ b/src/extensions/core/load3d/exportMenuHelper.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type Load3d from './Load3d'
 import { createExportMenuItems } from './exportMenuHelper'
 
-const { contextMenuMock, addToastMock, addAlertMock } = vi.hoisted(() => ({
-  contextMenuMock: vi.fn(),
-  addToastMock: vi.fn(),
-  addAlertMock: vi.fn()
+const { contextMenuMock } = vi.hoisted(() => ({
+  contextMenuMock: vi.fn()
 }))
 
 vi.mock('@/i18n', () => ({
@@ -14,9 +14,12 @@ vi.mock('@/i18n', () => ({
     vars ? `${key}:${JSON.stringify(vars)}` : key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ add: addToastMock, addAlert: addAlertMock })
-}))
+let addToastMock: ReturnType<typeof useToastStore>['add']
+let addAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  addToastMock = useToastStore().add
+  addAlertMock = useToastStore().addAlert
+})
 
 vi.mock(import('@/lib/litegraph/src/litegraph'), async (importOriginal) => {
   const actual = await importOriginal()

--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -1,24 +1,26 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { ComfyExtension } from '@/types/comfy'
+import { useExtensionStore } from '@/stores/extensionStore'
 
-const { registerExtensionMock, enabledExtensionsGetter } = vi.hoisted(() => ({
-  registerExtensionMock: vi.fn(),
-  enabledExtensionsGetter: vi.fn(() => [] as ComfyExtension[])
+const { registerExtensionMock } = vi.hoisted(() => ({
+  registerExtensionMock: vi.fn()
 }))
+
+let enabledExtensionsGetter: MockInstance<() => ComfyExtension[]>
+beforeEach(() => {
+  enabledExtensionsGetter = vi.spyOn(
+    useExtensionStore(),
+    'enabledExtensions',
+    'get'
+  )
+})
 
 vi.mock('@/services/extensionService', () => ({
   useExtensionService: () => ({ registerExtension: registerExtensionMock })
-}))
-
-vi.mock('@/stores/extensionStore', () => ({
-  useExtensionStore: () => ({
-    get enabledExtensions() {
-      return enabledExtensionsGetter()
-    }
-  })
 }))
 
 vi.mock('@/scripts/app', () => ({

--- a/src/extensions/core/load3dPreviewExtensions.test.ts
+++ b/src/extensions/core/load3dPreviewExtensions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyExtension } from '@/types/comfy'
 
 const {
@@ -9,7 +10,6 @@ const {
   onLoad3dReadyMock,
   configureForSaveMeshMock,
   getLoad3dMock,
-  toastAddAlertMock,
   getNodeByLocatorIdMock,
   nodeToLoad3dMapMock
 } = vi.hoisted(() => ({
@@ -18,7 +18,6 @@ const {
   onLoad3dReadyMock: vi.fn(),
   configureForSaveMeshMock: vi.fn(),
   getLoad3dMock: vi.fn(),
-  toastAddAlertMock: vi.fn(),
   getNodeByLocatorIdMock: vi.fn(),
   nodeToLoad3dMapMock: new Map()
 }))
@@ -61,9 +60,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: toastAddAlertMock })
-}))
+let toastAddAlertMock: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  toastAddAlertMock = useToastStore().addAlert
+})
 
 type ExtCreated = ComfyExtension & {
   nodeCreated: (node: LGraphNode) => Promise<void>

--- a/src/extensions/core/saveImageExtraOutput.test.ts
+++ b/src/extensions/core/saveImageExtraOutput.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -62,8 +60,6 @@ async function createNodeWithFilenamePrefix(
 
 describe('Comfy.SaveImageExtraOutput', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-
     const graph = new LGraph()
     const sampler = new LGraphNode('Sampler')
     sampler.properties['Node name for S&R'] = 'Sampler'

--- a/src/extensions/core/textPreviewWidgets.test.ts
+++ b/src/extensions/core/textPreviewWidgets.test.ts
@@ -24,10 +24,6 @@ vi.mock(
   })
 )
 
-vi.mock('@/stores/widgetValueStore', () => ({
-  useWidgetValueStore: () => ({ getWidget: () => undefined })
-}))
-
 vi.mock('@/scripts/domWidget', () => ({
   ComponentWidgetImpl: class {
     name: string

--- a/src/extensions/core/uploadAudio.test.ts
+++ b/src/extensions/core/uploadAudio.test.ts
@@ -2,15 +2,14 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyExtension } from '@/types/comfy'
 
-const { mockAddAlert, mockApiURL, mockFetchApi, mockRegisterExtension } =
-  vi.hoisted(() => ({
-    mockAddAlert: vi.fn(),
-    mockApiURL: vi.fn((url: string) => `api:${url}`),
-    mockFetchApi: vi.fn(),
-    mockRegisterExtension: vi.fn()
-  }))
+const { mockApiURL, mockFetchApi, mockRegisterExtension } = vi.hoisted(() => ({
+  mockApiURL: vi.fn((url: string) => `api:${url}`),
+  mockFetchApi: vi.fn(),
+  mockRegisterExtension: vi.fn()
+}))
 
 let capturedDragDrop: ((files: File[]) => Promise<File[] | never[]>) | undefined
 let capturedFileSelect:
@@ -56,9 +55,10 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: () => ({ addAlert: mockAddAlert })
-}))
+let mockAddAlert: ReturnType<typeof useToastStore>['addAlert']
+beforeEach(() => {
+  mockAddAlert = useToastStore().addAlert
+})
 
 vi.mock('@/renderer/extensions/vueNodes/widgets/utils/audioUtils', () => ({
   getResourceURL: (subfolder = '', filename = '', type = 'input') =>
@@ -78,12 +78,6 @@ vi.mock('@/scripts/app', () => ({
     registerExtension: mockRegisterExtension,
     rootGraph: { id: 'root' }
   }
-}))
-
-vi.mock('@/stores/widgetValueStore', () => ({
-  useWidgetValueStore: () => ({
-    getWidget: vi.fn()
-  })
 }))
 
 vi.mock('@/utils/graphTraversalUtil', () => ({

--- a/src/extensions/core/widgetInputs.refreshCombo.test.ts
+++ b/src/extensions/core/widgetInputs.refreshCombo.test.ts
@@ -1,7 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LLink } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -122,10 +120,6 @@ function defsWithSpec(
 }
 
 describe('PrimitiveNode.refreshComboInNode', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it.each<[string, InputSpec]>([
     ['V1', [FRESH_OPTIONS, {}]],
     ['V2', ['COMBO', { options: FRESH_OPTIONS }]]

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -99,7 +97,6 @@ function widgetSlot(
 
 describe('PrimitiveNode', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.namedValuesRestore = false
   })
 
@@ -504,7 +501,6 @@ describe('convertToInput', () => {
 
 describe('setWidgetConfig', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     widgetInputsExtension.registerCustomNodes?.(app)
   })
 
@@ -574,10 +570,6 @@ describe('setWidgetConfig', () => {
 })
 
 describe('Comfy.WidgetInputs node-def hooks', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   describe('onGraphConfigured', () => {
     it('resolves GET_CONFIG from the node definition, chaining the original hook', async () => {
       const original = vi.fn()

--- a/src/extensions/core/widgetValuePropagation.test.ts
+++ b/src/extensions/core/widgetValuePropagation.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -83,10 +81,6 @@ function createSourceNode(options: {
 }
 
 describe('applyFirstWidgetValueToGraph', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('returns early when the source widget is missing', () => {
     const targetCallback = vi.fn()
     const targetWidget = createWidget('value', 'unchanged', targetCallback)

--- a/src/lib/litegraph/src/LGraph.deepCollision.test.ts
+++ b/src/lib/litegraph/src/LGraph.deepCollision.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { parseProxyWidgets } from '@/core/schemas/promotionSchema'
@@ -237,7 +235,6 @@ function scopesOf(graph: LGraph): { name: string; graph: LGraph | Subgraph }[] {
 }
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   LiteGraph.registerNodeType('dummy', DummyNode)
   vi.spyOn(console, 'warn').mockImplementation(() => {})
 })

--- a/src/lib/litegraph/src/LGraph.failedConfigure.test.ts
+++ b/src/lib/litegraph/src/LGraph.failedConfigure.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type {
@@ -65,7 +63,6 @@ class ThrowingNode extends LGraphNode {
 }
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   layoutStore.resetForTests()
   LiteGraph.registerNodeType('test/good', GoodNode)
   LiteGraph.registerNodeType('test/throwing', ThrowingNode)

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registerNodeState } from '@/core/graph/nodeShell/nodeShellState'
@@ -352,7 +350,6 @@ describe('normalizeConfiguredTopology', () => {
 
 describe('LGraph.configure input slot realignment (#3348)', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.registerNodeType('test/RealignSource', SourceNode)
     LiteGraph.registerNodeType('test/RealignTarget', ReorderTargetNode)
   })
@@ -588,7 +585,6 @@ function unmatchedInputLinkState(graph: LGraph) {
 
 describe('LGraph.configure realignment with an unmatched input name (#15581)', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.registerNodeType('test/RealignSource', SourceNode)
     LiteGraph.registerNodeType(
       'test/DroppedInputTarget',
@@ -637,10 +633,6 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
 })
 
 describe('realignInputLinkSlots with a rejected batch (#15581)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('atomically removes an unmatched blocker and moves links', () => {
     const graph = new LGraph()
     const source = new LGraphNode('Source')
@@ -696,10 +688,6 @@ describe('realignInputLinkSlots with a rejected batch (#15581)', () => {
 })
 
 describe('realignInputLinkSlots', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('rekeys a serialized link', () => {
     const graph = new LGraph()
     const source = new LGraphNode('Source')

--- a/src/lib/litegraph/src/LGraph.remintLinkRemap.test.ts
+++ b/src/lib/litegraph/src/LGraph.remintLinkRemap.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { registerNodeState } from '@/core/graph/nodeShell/nodeShellState'
@@ -131,7 +129,6 @@ function mergePayload(): SerialisableGraph {
 }
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   LiteGraph.registerNodeType('dummy', DummyNode)
 })
 

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe } from 'vitest'
 
 import {
@@ -21,7 +19,6 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 }))
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   mockReportError.mockClear()
 })
 

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -1,7 +1,5 @@
 import { toGroupId } from '@/types/groupId'
 import { graphScopeOf } from '@/types/graphScopeId'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createGraphMutations } from '@/core/graph/graphMutations'
@@ -67,7 +65,6 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 }))
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   LiteGraph.registerNodeType('dummy', DummyNode)
   mockReportError.mockClear()
 })
@@ -2306,10 +2303,6 @@ describe('deduplicateSubgraphNodeIds (via configure)', () => {
 })
 
 describe('Zero UUID handling in configure', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('rejects zeroUuid for root graphs and assigns a new ID', () => {
     const graph = new LGraph()
     const data = graph.serialize()

--- a/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
@@ -2,8 +2,6 @@ import {
   SUBGRAPH_INPUT_ID,
   SUBGRAPH_OUTPUT_ID
 } from '@/lib/litegraph/src/constants'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import {
   afterEach,
   beforeEach,
@@ -43,18 +41,9 @@ import { graphScopeOf } from '@/types/graphScopeId'
 import { toRerouteId } from '@/types/rerouteId'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function createSerialisedNode(
   id: number,

--- a/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeId } from '@/types/nodeId'
@@ -15,8 +13,6 @@ import {
   LGraphNode,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 const TEST_NODE_TYPE = 'test/CloneZIndex' as const
 

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -81,8 +79,6 @@ describe('drawConnections', () => {
   let canvasElement: HTMLCanvasElement
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-
     canvasElement = document.createElement('canvas')
     canvasElement.width = 800
     canvasElement.height = 600

--- a/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
@@ -1,14 +1,10 @@
 import userEvent from '@testing-library/user-event'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 vi.mock(import('@/renderer/core/layout/store/layoutStore'))
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function createGhostTestHarness() {
   const canvasElement = document.createElement('canvas')

--- a/src/lib/litegraph/src/LGraphCanvas.groupSelection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.groupSelection.test.ts
@@ -1,6 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
@@ -12,8 +10,6 @@ import {
 } from '@/lib/litegraph/src/litegraph'
 
 vi.mock(import('@/renderer/core/layout/store/layoutStore'))
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function createCanvas(graph: LGraph): LGraphCanvas {
   const el = document.createElement('canvas')

--- a/src/lib/litegraph/src/LGraphCanvas.invalidation.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.invalidation.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -107,7 +105,6 @@ describe('LGraphCanvas invalidation scheduling baseline', () => {
   let probe: InvalidationProbe
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     ;({ canvas, graph } = createCanvas())
     canvas.draw()
     probe = new InvalidationProbe(canvas)

--- a/src/lib/litegraph/src/LGraphCanvas.linkDragAutoPan.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.linkDragAutoPan.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -12,7 +10,6 @@ describe('LGraphCanvas link drag auto-pan', () => {
   let canvasElement: HTMLCanvasElement
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.useFakeTimers()
 
     canvasElement = document.createElement('canvas')

--- a/src/lib/litegraph/src/LGraphCanvas.onMenuAdd.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.onMenuAdd.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -62,7 +60,6 @@ describe('LGraphCanvas.onMenuAdd category sorting', () => {
   const capturedEntries: MenuEntry[][] = []
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     graph = new LGraph()
     canvas = createCanvas(graph)
     LGraphCanvas.active_canvas = canvas

--- a/src/lib/litegraph/src/LGraphCanvas.renderInfo.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.renderInfo.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -9,7 +7,6 @@ describe('LGraphCanvas.renderInfo', () => {
   let ctx: CanvasRenderingContext2D
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     const canvasElement = document.createElement('canvas')
     ctx = {
       save: vi.fn(),

--- a/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -21,8 +19,6 @@ vi.mock(
     getSlotLayoutAtPoint: vi.fn()
   })
 )
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('LGraphCanvas slot hit detection', () => {
   let graph: LGraph

--- a/src/lib/litegraph/src/LGraphCanvas.subgraphPasteDelete.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.subgraphPasteDelete.test.ts
@@ -41,13 +41,6 @@ import {
  * on host deletion — the delta is intended and called out inline.
  */
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/lib/litegraph/src/LGraphCanvas.titleButtons.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.titleButtons.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -16,7 +14,6 @@ describe('LGraphCanvas Title Button Rendering', () => {
   let node: LGraphNode
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     // Create a mock canvas element
     const canvasElement = document.createElement('canvas')
     ctx = {

--- a/src/lib/litegraph/src/LGraphGroup.test.ts
+++ b/src/lib/litegraph/src/LGraphGroup.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, vi } from 'vitest'
+import { afterEach, describe, expect, vi } from 'vitest'
 
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import {
@@ -43,8 +41,6 @@ function createMockContext() {
 }
 
 const graphCanvas = { editor_alpha: 1 } as Partial<LGraphCanvas> as LGraphCanvas
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('LGraphGroup', () => {
   test('serializes to the existing format', () => {

--- a/src/lib/litegraph/src/LGraphNode.geometry.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.geometry.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { Rect } from './interfaces'
@@ -11,7 +9,6 @@ import { toNodeId } from '@/types/nodeId'
 
 describe('layout geometry projection', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     layoutStore.resetForTests()
   })
 

--- a/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
 import { useNodeDataStore } from '@/stores/nodeDataStore'
@@ -15,10 +13,6 @@ import { NodeOutputSlot } from './node/NodeOutputSlot'
 import { createTestSubgraph } from './subgraph/__fixtures__/subgraphHelpers'
 
 describe('LGraphNode node-data adoption', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function addNodeToSubgraph() {
     const subgraph = createTestSubgraph()
     const node = new LGraphNode('Node')

--- a/src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
@@ -20,10 +18,6 @@ function expectOwnAccessor(node: object, key: string): void {
 }
 
 describe('LGraphNode own collection fields', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('exposes the collections to shell introspection on a bare node', () => {
     const node = new LGraphNode('Bare')
 

--- a/src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { LGraphEventMap } from './infrastructure/LGraphEventMap'
 import { LGraph, LGraphNode } from './litegraph'
@@ -29,10 +27,6 @@ function attachedNode() {
 }
 
 describe('LGraphNode shell-state change events', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('announces every tracked shell field with its before and after value', () => {
     const { graph, node } = attachedNode()
     const changes = observe(graph)
@@ -118,10 +112,6 @@ describe('LGraphNode shell-state change events', () => {
 })
 
 describe('LGraphNode flag serialization', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('serializes a set flag, including false, and omits an unset one', () => {
     const { node } = attachedNode()
 

--- a/src/lib/litegraph/src/LGraphNode.reactivity.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.reactivity.test.ts
@@ -1,15 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { computed, effect, nextTick, stop, watch } from 'vue'
 
 import { LGraph, LGraphNode } from './litegraph'
 import type { IBaseWidget } from './types/widgets'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
-
-beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
-})
 
 describe('_setConcreteSlots', () => {
   test('per-frame calls do not invalidate slot-array subscribers', async () => {

--- a/src/lib/litegraph/src/LGraphNode.stateProjection.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.stateProjection.test.ts
@@ -1,14 +1,8 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { LGraph, LGraphNode } from './litegraph'
 import { TitleMode } from './types/globalEnums'
 import { useNodeDataStore } from '@/stores/nodeDataStore'
-
-beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
-})
 
 describe('execution order projection', () => {
   test('writes attached node order to the canonical store', () => {

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest'
 
 import type {
@@ -880,10 +878,6 @@ describe('LGraphNode', () => {
 })
 
 describe('snapToGrid', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function addedNode(graph: LGraph) {
     const node = new LGraphNode('test')
     node.pos = [103, 97]

--- a/src/lib/litegraph/src/LLink.spreadCopy.test.ts
+++ b/src/lib/litegraph/src/LLink.spreadCopy.test.ts
@@ -1,7 +1,5 @@
 // oxlint-disable no-misused-spread -- spreading an LLink is what these tests reproduce
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { LLink } from '@/lib/litegraph/src/litegraph'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -46,10 +44,6 @@ function insertionScenario(consumerCount: number) {
 }
 
 describe('plain-object copies of LLink (uncovered)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('carries topology onto a spread copy of a link', () => {
     const { graph, link } = connectedPair(toRerouteId(7))
     const stored = graph.links[link.id]

--- a/src/lib/litegraph/src/LLink.store.test.ts
+++ b/src/lib/litegraph/src/LLink.store.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getActivePinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
 import { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
@@ -22,8 +21,6 @@ import {
 } from './subgraph/__fixtures__/subgraphHelpers'
 
 describe('LLink ↔ linkStore integration', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('preserves the id and reactive state of a registered link', () => {
     const graph = new LGraph()
     const link = new LLink(
@@ -67,9 +64,13 @@ describe('LLink ↔ linkStore integration', () => {
   })
 
   it('requires Pinia when constructing a root graph', () => {
+    const pinia = getActivePinia()
     setActivePinia(undefined)
-
-    expect(() => new LGraph()).toThrow()
+    try {
+      expect(() => new LGraph()).toThrow()
+    } finally {
+      setActivePinia(pinia)
+    }
   })
 
   it('does not add a link when topology registration is rejected', () => {

--- a/src/lib/litegraph/src/Reroute.store.test.ts
+++ b/src/lib/litegraph/src/Reroute.store.test.ts
@@ -1,14 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import {
-  assert,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  onTestFinished,
-  vi
-} from 'vitest'
+import { assert, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { computed } from 'vue'
 
 import {
@@ -41,8 +31,6 @@ function connectedGraph() {
 }
 
 describe('Reroute ↔ rerouteStore integration', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('createReroute registers the chain, removeReroute unregisters it', () => {
     const { graph, link } = connectedGraph()
     const store = useRerouteStore()
@@ -364,8 +352,6 @@ describe('Reroute ↔ rerouteStore integration', () => {
 })
 
 describe('Reroute position lives only in layoutStore', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('registers geometry after graph ownership', () => {
     const { graph, link } = connectedGraph()
 

--- a/src/lib/litegraph/src/canvas/FloatingRenderLink.test.ts
+++ b/src/lib/litegraph/src/canvas/FloatingRenderLink.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
 import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
@@ -11,8 +9,6 @@ import { toRerouteId } from '@/types/rerouteId'
 
 import { createTestSubgraph } from '../subgraph/__fixtures__/subgraphHelpers'
 import { FloatingRenderLink } from './FloatingRenderLink'
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function inputFloatingLink(targetId: number, targetSlot: number): LLink {
   return new LLink(

--- a/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
@@ -1,7 +1,5 @@
 // oxlint-disable no-empty-pattern
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { test as baseTest, beforeEach, describe, expect, vi } from 'vitest'
+import { test as baseTest, describe, expect, vi } from 'vitest'
 
 import type {
   MovingInputLink,
@@ -47,8 +45,6 @@ interface TestContext {
     slotType?: ISlotType
   ) => LLink
 }
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 const test = baseTest.extend<TestContext>({
   network: async ({}, use) => {

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -1,7 +1,5 @@
 // oxlint-disable no-empty-pattern
 // TODO: Fix these tests after migration
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, describe, expect, vi } from 'vitest'
 
 import type {
@@ -26,7 +24,6 @@ import {
 } from '@/utils/__tests__/litegraphTestUtils'
 
 interface TestContext {
-  pinia: undefined
   graph: LGraph
   connector: LinkConnector
   setConnectingLinks: (value: ConnectingLink[]) => void
@@ -39,14 +36,6 @@ interface TestContext {
 }
 
 const test = baseTest.extend<TestContext>({
-  pinia: [
-    async ({}, use) => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
-      await use(undefined)
-    },
-    { auto: true }
-  ],
-
   reroutesBeforeTest: async ({ reroutesComplexGraph }, use) => {
     await use([...reroutesComplexGraph.reroutes])
   },

--- a/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
@@ -1,6 +1,4 @@
 // TODO: Fix these tests after migration
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -33,7 +31,6 @@ describe('LinkConnector SubgraphInput connection validation', () => {
   const mockSetConnectingLinks = vi.fn()
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     connector = new LinkConnector(mockSetConnectingLinks)
   })
   describe('Link disconnection validation', () => {

--- a/src/lib/litegraph/src/extensionPersistence.test.ts
+++ b/src/lib/litegraph/src/extensionPersistence.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode, NodeInputSlot } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
@@ -17,10 +15,6 @@ function nodeWithNamespacedExtension(): ISerialisedNode {
     extensions: { myExt: { note: 'hello' } }
   }
 }
-
-beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
-})
 
 describe('LGraphNode.configure onConfigure hook isolation', () => {
   it('hands onConfigure a shallow copy, not the caller live serialized object', () => {

--- a/src/lib/litegraph/src/geometryApiContracts.test.ts
+++ b/src/lib/litegraph/src/geometryApiContracts.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   LGraph,
@@ -11,8 +9,6 @@ import {
 import { toRerouteId } from '@/types/rerouteId'
 
 describe('geometry API contracts', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('exposes entity-specific geometry write APIs', () => {
     const graph = new LGraph()
     const node = new LGraphNode('node')

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -1,6 +1,4 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -84,7 +82,6 @@ function linksIntoTargetSlot(
 
 describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.registerNodeType('test/DupTestNode', DupTestNode)
   })
 
@@ -150,7 +147,6 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
 
 describe('legacy mirror link creation (#15577 reachability)', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.registerNodeType('test/DupTestNode', DupTestNode)
   })
 

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -160,7 +160,6 @@ export { BaseWidget } from './widgets/BaseWidget'
 export { LegacyWidget } from './widgets/LegacyWidget'
 
 export { isComboWidget } from './widgets/widgetMap'
-/** @knipIgnoreUnusedButUsedByCustomNodes */
 export { isAssetWidget } from './widgets/widgetMap'
 // Additional test-specific exports
 export { LGraphButton } from './LGraphButton'

--- a/src/lib/litegraph/src/node/NodeInputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromAny } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LLink } from '@/lib/litegraph/src/LLink'
@@ -32,7 +30,6 @@ describe('NodeInputSlot', () => {
   const originalCallbacks = LiteGraph.onDeprecationWarning
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     onWarning.mockClear()
     LiteGraph.onDeprecationWarning = [onWarning]
     LiteGraph.alwaysRepeatWarnings = true
@@ -133,10 +130,6 @@ describe('NodeInputSlot', () => {
 })
 
 describe('NodeInputSlot.isConnected', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('reflects connect and disconnect', () => {
     const { target } = createConnectedPair()
     expect(inputSlot(target, 0)?.isConnected).toBe(true)

--- a/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromAny } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -24,7 +22,6 @@ describe('NodeOutputSlot deprecated links getter', () => {
   const onWarning = vi.fn()
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     onWarning.mockClear()
     LiteGraph.onDeprecationWarning = [onWarning]
     LiteGraph.alwaysRepeatWarnings = true

--- a/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
+++ b/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -103,7 +101,6 @@ function runMode(mode: CleanExtensionMode) {
 
 describe('clean extension compatibility fixture', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.onDeprecationWarning = []
   })
 

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -38,10 +36,6 @@ function fanOut(count: number) {
 }
 
 describe('legacy slot link compatibility', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('disconnects when legacy code assigns input.link = null', () => {
     const { source, target, link } = connectedPair()
 
@@ -106,10 +100,6 @@ describe('legacy slot link compatibility', () => {
 })
 
 describe('legacy slot link additions', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('ignores assigning a disconnected id to an input', () => {
     const { source, target } = connectedPair()
     const saved = target.inputs[0].link
@@ -186,10 +176,6 @@ function trimEmptyAutogrowSlots(node: LGraphNode) {
 }
 
 describe('comfyui-promptchain indexed slot replacement', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('keeps the link store correct when the pack replaces every slot', () => {
     const { graph, target } = autogrowChain(4, [0, 1, 2])
 

--- a/src/lib/litegraph/src/node/rgthreeLifecycleCompatFixture.test.ts
+++ b/src/lib/litegraph/src/node/rgthreeLifecycleCompatFixture.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -105,7 +103,6 @@ describe('rgthree clean-room lifecycle compatibility fixture', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.onDeprecationWarning = []
   })
 

--- a/src/lib/litegraph/src/node/slotEcosystemPatterns.test.ts
+++ b/src/lib/litegraph/src/node/slotEcosystemPatterns.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -34,10 +32,6 @@ function mockCanvasContext() {
 }
 
 describe('ecosystem slot patterns', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   describe('duck-typed slots wrapped by _setConcreteSlots', () => {
     it('renders a connected duck-typed input in collapsed mode', () => {
       const { source, target } = createSourceAndTarget()

--- a/src/lib/litegraph/src/node/slotLinks.test.ts
+++ b/src/lib/litegraph/src/node/slotLinks.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
@@ -35,8 +33,6 @@ function createConnectedGraph(targetCount: number) {
 }
 
 describe('slotLinks', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('reports presence, ids, and resolved links for an output slot', () => {
     const { graph, source } = createConnectedGraph(2)
 

--- a/src/lib/litegraph/src/node/slotMirrorNormalisationOnLoad.test.ts
+++ b/src/lib/litegraph/src/node/slotMirrorNormalisationOnLoad.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -121,7 +119,6 @@ function mirrors(graph: LGraph) {
 }
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   LiteGraph.registerNodeType('source', SourceNode)
   LiteGraph.registerNodeType('sink', SinkNode)
 })

--- a/src/lib/litegraph/src/node/slotUtils.test.ts
+++ b/src/lib/litegraph/src/node/slotUtils.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
@@ -31,8 +29,6 @@ function createConnectedGraph(linkIds: number[]) {
 }
 
 describe('outputAsSerialisable', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('serialises the links leaving the slot, ascending by id', () => {
     const { source } = createConnectedGraph([10, 2])
 

--- a/src/lib/litegraph/src/node/widgetsView.test.ts
+++ b/src/lib/litegraph/src/node/widgetsView.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -91,7 +89,6 @@ function storedValue(widget: IBaseWidget) {
 /** Node packs rebuild `node.widgets` by writing to the array directly. */
 describe('widgets view', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.vueNodesMode = false
   })
 

--- a/src/lib/litegraph/src/serialization.test.ts
+++ b/src/lib/litegraph/src/serialization.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from './litegraph'
@@ -15,7 +13,6 @@ class TestNode extends LGraphNode {
 
 describe('Serialization - Circular Reference Prevention', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     LiteGraph.registerNodeType('test/TestNode', TestNode)
   })
 

--- a/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import {
   assert,
   beforeEach,
@@ -30,7 +28,6 @@ import {
 } from './__fixtures__/subgraphHelpers'
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   resetSubgraphFixtureState()
 })
 

--- a/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
@@ -24,13 +24,6 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -43,13 +43,6 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphFixtures.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphFixtures.ts
@@ -6,9 +6,6 @@
  * in their test files. Each fixture provides a clean, pre-configured subgraph
  * setup for different testing scenarios.
  */
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-
 import type {
   LGraph,
   Subgraph,
@@ -19,9 +16,8 @@ import type {
 import { test as baseTest } from '../../__fixtures__/testExtensions'
 
 const test = baseTest.extend({
-  pinia: [
+  subgraphState: [
     async ({}, use) => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
       resetSubgraphFixtureState()
       await use(undefined)
     },

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.test.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { LiteGraph, SubgraphNode } from '@/lib/litegraph/src/litegraph'
@@ -51,7 +49,6 @@ describe('setupComplexPromotionFixture', () => {
 
 describe('enableSubgraphNodeCreation', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     resetSubgraphFixtureState()
   })
 

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -20,7 +18,6 @@ import {
 
 describe('subgraphUtils', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     resetSubgraphFixtureState()
   })
 

--- a/src/lib/litegraph/src/utils/collections.test.ts
+++ b/src/lib/litegraph/src/utils/collections.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -20,7 +18,6 @@ describe('getDraggedItems', () => {
   let selected: Set<Positionable>
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     graph = new LGraph()
 
     group = new LGraphGroup('TestGroup')

--- a/src/lib/litegraph/src/widgetConnectionSuppression.test.ts
+++ b/src/lib/litegraph/src/widgetConnectionSuppression.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -46,7 +44,6 @@ function createSourceNode(graph: LGraph) {
 
 describe('widget connection suppression', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     resetSubgraphFixtureState()
   })
 

--- a/src/lib/litegraph/src/widgetValueNullContract.test.ts
+++ b/src/lib/litegraph/src/widgetValueNullContract.test.ts
@@ -1,10 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { TWidgetValue } from '@/lib/litegraph/src/litegraph'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -49,7 +48,7 @@ function makeGraphWithWidget(value: TWidgetValue): {
 
 function roundTripGraphWithoutLiveWidgetState(graph: LGraph): LGraph {
   const text = JSON.stringify(graph.serialize())
-  setActivePinia(createTestingPinia({ stubActions: false }))
+  useWidgetValueStore().clearGraph(graph.id)
   const reloaded = new LGraph()
   reloaded.configure(JSON.parse(text))
   return reloaded
@@ -66,7 +65,6 @@ describe('widget value null contract', () => {
   const origNamedValuesRestore = LiteGraph.namedValuesRestore
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     registerNullContractNode()
   })
 

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -288,7 +288,6 @@ export function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
 
 /**
  * Type guard: Narrow **from {@link IBaseWidget}** to {@link IAssetWidget}.
- * @knipIgnoreUnusedButUsedByCustomNodes
  */
 export function isAssetWidget(widget: IBaseWidget): widget is IAssetWidget {
   return widget.type === 'asset'

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Replace the graph/core domain of #17222 plus local-instance removal from #17223 with global testing Pinia.

## Changes

- 93 files including the identical four-file shared lifecycle prerequisite. Targets main and can merge independently.
- Real store actions unless explicitly stubbed. Preserve scenario state and fixtures.
- Enforcement and documentation remain deferred to #17223.

## Review Focus

- All 89 domain paths are byte-identical to the corresponding files in [the immutable source](https://github.com/Comfy-Org/ComfyUI_frontend/commit/beb2e861ef0a168b0e0bd06edde4d80c050005c2).
- `pnpm test:unit` with all 86 changed domain test paths plus three shared tests: 89 files passed, 1,243 tests passed and one expected failure.
- Passed: `pnpm typecheck`, `pnpm typecheck:scripts`, scoped ESLint, type-aware Oxlint, cleanup audit, formatting, `pnpm knip`, and `git diff --check`. ESLint reports 69 warnings, zero errors.

<details>
<summary>Common lifecycle prerequisite</summary>

- `vitest.setup.ts`
- `scripts/testingPinia.test.ts`
- `src/components/node/NodePreview.test.ts`
- `src/renderer/extensions/vueNodes/components/LGraphNode.test.ts`

</details>
