### PR TITLE
test: use global Pinia in component tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/LiteGraphCanvasSplitterOverlay.test.ts
+++ b/src/components/LiteGraphCanvasSplitterOverlay.test.ts
@@ -1,7 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import { readFileSync } from 'fs'
-import { setActivePinia } from 'pinia'
 import { resolve } from 'path'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -11,10 +10,8 @@ import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitter
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({ currentUser: null, loading: false }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 /**
  * Regression test: the graph-canvas-panel SplitterPanel must not clip
@@ -52,7 +49,7 @@ describe('LiteGraphCanvasSplitterOverlay', () => {
         'agent-panel': '<div data-testid="agent-panel-probe">docked panel</div>'
       },
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: { Splitter: true, SplitterPanel: true }
       }
     })
@@ -62,8 +59,7 @@ describe('LiteGraphCanvasSplitterOverlay', () => {
   })
 
   it('keeps tabs with the graph and Agent panel during graph node selection', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
     vi.mocked(useSettingStore().get).mockImplementation((id) => {
       if (id === 'Comfy.Sidebar.Location') return 'left'
       if (id === 'Comfy.UseNewMenu') return 'Top'

--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -1,26 +1,30 @@
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import type { MenuItem } from 'primevue/menuitem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick, onMounted, ref } from 'vue'
 import type { Component } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import TopMenuSection from '@/components/TopMenuSection.vue'
 import QueueNotificationBannerHost from '@/components/queue/QueueNotificationBannerHost.vue'
+import TopMenuSection from '@/components/TopMenuSection.vue'
 import type {
   JobListItem,
   JobStatus
 } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useReleaseStore } from '@/platform/updates/common/releaseStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
-import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const mockData = vi.hoisted(() => ({
   isLoggedIn: false,
@@ -38,12 +42,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false,
   isNightly: false
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/releaseStore'), () => ({
-  useReleaseStore: () => ({
-    shouldShowRedDot: computed(() => true)
-  })
 }))
 
 vi.mock<unknown>(
@@ -74,13 +72,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    currentUser: null,
-    loading: false
-  }))
-}))
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     menu: {
@@ -98,16 +89,17 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 }))
 
 type WrapperOptions = {
-  pinia?: ReturnType<typeof createTestingPinia>
+  pinia?: Pinia
   stubs?: Record<string, boolean | Component>
   attachTo?: HTMLElement
 }
 
 function createWrapper({
-  pinia = createTestingPinia({ createSpy: vi.fn }),
+  pinia = getActivePinia()!,
   stubs = {},
   attachTo
 }: WrapperOptions = {}) {
+  Object.assign(useReleaseStore(pinia), { shouldShowRedDot: true })
   const i18n = createI18n({
     legacy: false,
     locale: 'en',
@@ -208,7 +200,7 @@ describe('TopMenuSection', () => {
 
   describe('authentication state', () => {
     function createLegacyTabBarWrapper() {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       const settingStore = useSettingStore(pinia)
       vi.mocked(settingStore.get).mockImplementation((key) =>
         key === 'Comfy.UI.TabBarLayout' ? 'Legacy' : undefined
@@ -266,7 +258,7 @@ describe('TopMenuSection', () => {
   })
 
   it('keeps action bars mounted while hiding the error overlay in node selection mode', () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = getActivePinia()!
     useAgentNodeSelectionStore(pinia).isActionBarsHidden = true
 
     createWrapper({
@@ -299,7 +291,7 @@ describe('TopMenuSection', () => {
   })
 
   it('hides queue progress overlay when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -313,7 +305,7 @@ describe('TopMenuSection', () => {
   })
 
   it('toggles the queue progress overlay when QPO V2 is disabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? false : undefined
@@ -329,7 +321,7 @@ describe('TopMenuSection', () => {
   })
 
   it('opens the job history sidebar tab when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -343,7 +335,7 @@ describe('TopMenuSection', () => {
   })
 
   it('toggles the job history sidebar tab when QPO V2 is enabled', async () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined
@@ -361,7 +353,7 @@ describe('TopMenuSection', () => {
 
   describe('inline progress summary', () => {
     const configureSettings = (
-      pinia: ReturnType<typeof createTestingPinia>,
+      pinia: Pinia,
       qpoV2Enabled: boolean,
       showRunProgressBar = true
     ) => {
@@ -375,7 +367,7 @@ describe('TopMenuSection', () => {
     }
 
     it('renders inline progress summary when QPO V2 is enabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
 
       const { container } = createWrapper({ pinia })
@@ -388,7 +380,7 @@ describe('TopMenuSection', () => {
     })
 
     it('does not render inline progress summary when QPO V2 is disabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, false)
 
       const { container } = createWrapper({ pinia })
@@ -401,7 +393,7 @@ describe('TopMenuSection', () => {
     })
 
     it('does not render inline progress summary when run progress bar is disabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true, false)
 
       const { container } = createWrapper({ pinia })
@@ -417,7 +409,7 @@ describe('TopMenuSection', () => {
       localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
       const actionbarTarget = document.createElement('div')
       document.body.appendChild(actionbarTarget)
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
       const executionStore = useExecutionStore(pinia)
       executionStore.activeJobId = 'job-1'
@@ -445,10 +437,7 @@ describe('TopMenuSection', () => {
   })
 
   describe(QueueNotificationBannerHost, () => {
-    const configureSettings = (
-      pinia: ReturnType<typeof createTestingPinia>,
-      qpoV2Enabled: boolean
-    ) => {
+    const configureSettings = (pinia: Pinia, qpoV2Enabled: boolean) => {
       const settingStore = useSettingStore(pinia)
       vi.mocked(settingStore.get).mockImplementation((key) => {
         if (key === 'Comfy.Queue.QPOV2') return qpoV2Enabled
@@ -459,7 +448,7 @@ describe('TopMenuSection', () => {
     }
 
     it('renders queue notification banners when QPO V2 is enabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
 
       const { container } = createWrapper({ pinia })
@@ -472,7 +461,7 @@ describe('TopMenuSection', () => {
     })
 
     it('renders queue notification banners when QPO V2 is disabled', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, false)
 
       const { container } = createWrapper({ pinia })
@@ -485,7 +474,7 @@ describe('TopMenuSection', () => {
     })
 
     it('renders inline summary above banners when both are visible', async () => {
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
       const { container } = createWrapper({ pinia })
 
@@ -508,7 +497,7 @@ describe('TopMenuSection', () => {
       localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
       const actionbarTarget = document.createElement('div')
       document.body.appendChild(actionbarTarget)
-      const pinia = createTestingPinia({ createSpy: vi.fn })
+      const pinia = getActivePinia()!
       configureSettings(pinia, true)
       const executionStore = useExecutionStore(pinia)
       executionStore.activeJobId = 'job-1'
@@ -586,7 +575,7 @@ describe('TopMenuSection', () => {
     })
     vi.stubGlobal('cancelAnimationFrame', vi.fn())
 
-    const pinia = createTestingPinia({ createSpy: vi.fn })
+    const pinia = getActivePinia()!
     const settingStore = useSettingStore(pinia)
     vi.mocked(settingStore.get).mockImplementation((key) => {
       if (key === 'Comfy.UseNewMenu') return 'Top'

--- a/src/components/actionbar/BatchCountEdit.test.ts
+++ b/src/components/actionbar/BatchCountEdit.test.ts
@@ -1,21 +1,14 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useQueueSettingsStore } from '@/stores/queueSettingsStore'
 
 import BatchCountEdit from './BatchCountEdit.vue'
 
 const maxBatchCount = 16
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (settingId: string) =>
-      settingId === 'Comfy.QueueButton.BatchCountLimit' ? maxBatchCount : 1
-  })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -34,21 +27,15 @@ const i18n = createI18n({
 })
 
 function renderComponent(initialBatchCount = 1) {
-  const pinia = createTestingPinia({
-    createSpy: vi.fn,
-    stubActions: false,
-    initialState: {
-      queueSettingsStore: {
-        batchCount: initialBatchCount
-      }
-    }
-  })
+  useQueueSettingsStore().batchCount = initialBatchCount
+  useSettingStore().settingValues['Comfy.QueueButton.BatchCountLimit'] =
+    maxBatchCount
 
   const user = userEvent.setup()
 
   render(BatchCountEdit, {
     global: {
-      plugins: [pinia, i18n],
+      plugins: [i18n],
       directives: {
         tooltip: () => {}
       }

--- a/src/components/actionbar/ComfyActionbar.test.ts
+++ b/src/components/actionbar/ComfyActionbar.test.ts
@@ -1,31 +1,22 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 
 import ComfyActionbar from '@/components/actionbar/ComfyActionbar.vue'
 import { i18n } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 
-const configureSettings = (
-  pinia: ReturnType<typeof createTestingPinia>,
-  showRunProgressBar: boolean
-) => {
-  const settingStore = useSettingStore(pinia)
-  vi.mocked(settingStore.get).mockImplementation((key) => {
-    if (key === 'Comfy.UseNewMenu') return 'Top'
-    if (key === 'Comfy.Queue.QPOV2') return true
-    if (key === 'Comfy.Queue.ShowRunProgressBar') return showRunProgressBar
-    return undefined
-  })
-}
-
 const renderActionbar = (showRunProgressBar: boolean) => {
   const dockedProgressContainer = document.createElement('div')
   document.body.appendChild(dockedProgressContainer)
 
-  const pinia = createTestingPinia({ createSpy: vi.fn })
-  configureSettings(pinia, showRunProgressBar)
+  const pinia = getActivePinia()!
+  useSettingStore().settingValues = {
+    'Comfy.UseNewMenu': 'Top',
+    'Comfy.Queue.QPOV2': true,
+    'Comfy.Queue.ShowRunProgressBar': showRunProgressBar
+  }
 
   render(ComfyActionbar, {
     container: document.body.appendChild(document.createElement('div')),

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import type { BillingStatus } from '@/platform/workspace/api/workspaceApi'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import CloudRunButtonWrapper from './CloudRunButtonWrapper.vue'
 
@@ -18,9 +19,7 @@ const state = vi.hoisted(() => ({
   fetchStatus: vi.fn(),
   fetchBalance: vi.fn(),
   toastErrorHandler: vi.fn(),
-  showLayoutDialog: vi.fn(),
-  closeDialog: vi.fn(),
-  updateDialog: vi.fn()
+  showLayoutDialog: vi.fn()
 }))
 
 vi.mock<unknown>(
@@ -77,13 +76,6 @@ vi.mock<unknown>(
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showLayoutDialog: state.showLayoutDialog })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: state.closeDialog,
-    updateDialog: state.updateDialog
-  })
 }))
 
 vi.mock<unknown>(
@@ -328,7 +320,7 @@ describe('CloudRunButtonWrapper', () => {
     expect(dialogOptions.props.status).toBe('paused')
 
     await dialogOptions.props.onUpdatePayment()
-    expect(state.closeDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'subscription-paused'
     })
     expect(state.manageSubscription).toHaveBeenCalledOnce()
@@ -357,7 +349,7 @@ describe('CloudRunButtonWrapper', () => {
     await dialogOptions.props.onUpdatePayment()
 
     expect(state.toastErrorHandler).toHaveBeenCalledWith(error)
-    expect(state.closeDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
   })
 
   it('refreshes billing once on focus after returning from the portal', async () => {
@@ -419,7 +411,7 @@ describe('CloudRunButtonWrapper', () => {
 
     resolvePortal()
     await firstRequest
-    expect(state.updateDialog).toHaveBeenLastCalledWith({
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenLastCalledWith({
       key: 'subscription-paused',
       contentProps: { isUpdatingPayment: false }
     })
@@ -446,9 +438,9 @@ describe('CloudRunButtonWrapper', () => {
 
     resolvePortal()
     await portalRequest
-    expect(state.closeDialog).not.toHaveBeenCalled()
-    expect(state.updateDialog).toHaveBeenCalledTimes(1)
-    expect(state.updateDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledWith({
       key: 'subscription-paused',
       contentProps: { isUpdatingPayment: true }
     })
@@ -467,7 +459,7 @@ describe('CloudRunButtonWrapper', () => {
     expect(dialogOptions.props.canManage).toBe(false)
     expect(dialogOptions.props.status).toBe('paused')
     dialogOptions.props.onClose()
-    expect(state.closeDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'subscription-paused'
     })
     expect(state.manageSubscription).not.toHaveBeenCalled()

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
@@ -1,27 +1,29 @@
-import { createTestingPinia } from '@pinia/testing'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type {
-  JobListItem,
-  JobStatus
-} from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import type {
+  JobListItem,
+  JobStatus
+} from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useQueueSettingsStore } from '@/stores/queueSettingsStore'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
-import { render, screen } from '@testing-library/vue'
-import userEvent from '@testing-library/user-event'
 
 import ComfyQueueButton from './ComfyQueueButton.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
@@ -29,12 +31,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 
 vi.mock(import('@/platform/telemetry'), () => ({
   useTelemetry: () => null
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    shiftDown: false
-  })
 }))
 
 const BatchCountEditStub = {
@@ -151,10 +147,8 @@ const stubs = {
 function renderQueueButton(
   props: { paymentRecoveryLock?: 'owner' | 'member' } = {}
 ) {
-  const pinia = createTestingPinia({
-    createSpy: vi.fn,
-    stubActions: (actionName) => actionName !== 'recordPromptError'
-  })
+  const pinia = getActivePinia()!
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
   const user = userEvent.setup()
 
   const result = render(ComfyQueueButton, {

--- a/src/components/actionbar/PartnerNodesEducationCard.test.ts
+++ b/src/components/actionbar/PartnerNodesEducationCard.test.ts
@@ -1,7 +1,6 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -70,11 +69,9 @@ const copy = enMessages.partnerNodesEducation
 
 const CARD_TESTID = 'partner-nodes-education-card'
 
-let pinia: ReturnType<typeof createTestingPinia>
-
 function renderCard() {
   return render(PartnerNodesEducationCard, {
-    global: { plugins: [pinia, i18n] }
+    global: { plugins: [getActivePinia()!, i18n] }
   })
 }
 
@@ -90,8 +87,6 @@ function loadPaidTemplate(workflowKey: string) {
 
 describe('PartnerNodesEducationCard', () => {
   beforeEach(() => {
-    pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
     __setHasPartnerNodes(true)
     __setGate('none')
     showApiNodesSignInDialog.mockClear()

--- a/src/components/appMode/AppModeToolbar.test.ts
+++ b/src/components/appMode/AppModeToolbar.test.ts
@@ -1,30 +1,24 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useAppModeStore } from '@/stores/appModeStore'
 
 import AppModeToolbar from './AppModeToolbar.vue'
 
 const appModeState = vi.hoisted(() => ({
-  enableAppBuilder: true,
-  hasNodes: true
+  enableAppBuilder: true
 }))
-const enterBuilder = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ enableAppBuilder: appModeState.enableAppBuilder })
+  useAppMode: () => ({
+    enableAppBuilder: appModeState.enableAppBuilder,
+    isAppMode: { value: false },
+    isBuilderMode: { value: false },
+    isSelectMode: { value: false }
+  })
 }))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { computed, reactive } = await import('vue')
-  return {
-    useAppModeStore: () =>
-      reactive({
-        enterBuilder,
-        hasNodes: computed(() => appModeState.hasNodes)
-      })
-  }
-})
 
 const BUILD_AN_APP = 'Build an app'
 
@@ -54,7 +48,8 @@ function renderToolbar() {
 describe('AppModeToolbar', () => {
   beforeEach(() => {
     appModeState.enableAppBuilder = true
-    appModeState.hasNodes = true
+    Object.assign(useAppModeStore(), { hasNodes: true })
+    vi.mocked(useAppModeStore().enterBuilder).mockResolvedValue(undefined)
   })
 
   it('shows an enabled build button and enters the builder on click', async () => {
@@ -65,11 +60,11 @@ describe('AppModeToolbar', () => {
 
     await user.click(button)
 
-    expect(enterBuilder).toHaveBeenCalled()
+    expect(useAppModeStore().enterBuilder).toHaveBeenCalled()
   })
 
   it('disables the build button when there are no nodes', () => {
-    appModeState.hasNodes = false
+    Object.assign(useAppModeStore(), { hasNodes: false })
     renderToolbar()
 
     expect(screen.getByRole('button', { name: BUILD_AN_APP })).toBeDisabled()

--- a/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
+++ b/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useCommandStore } from '@/stores/commandStore'
 import type { ComfyCommandImpl } from '@/stores/commandStore'
+
+beforeEach(() => {
+  useCommandStore().registerCommands(mockCommands)
+})
 
 // Mock ShortcutsList component
 vi.mock<unknown>(
@@ -44,12 +49,6 @@ const mockCommands: ComfyCommandImpl[] = [
     keybinding: null
   }
 ]
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    commands: mockCommands
-  })
-}))
 
 describe('EssentialsPanel', () => {
   it('should render ShortcutsList with essentials commands', async () => {

--- a/src/components/bottomPanel/tabs/terminal/BaseTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/BaseTerminal.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
 /* eslint-disable testing-library/prefer-user-event */
-import { createTestingPinia } from '@pinia/testing'
 import { fireEvent, render, screen } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -93,12 +93,7 @@ function renderBaseTerminal(props: Record<string, unknown> = {}) {
   return render(BaseTerminal, {
     props,
     global: {
-      plugins: [
-        createTestingPinia({
-          createSpy: vi.fn
-        }),
-        i18n
-      ],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         Button: {
           template: '<button v-bind="$attrs"><slot /></button>',

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -1,10 +1,11 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import LogsTerminal from '@/components/bottomPanel/tabs/terminal/LogsTerminal.vue'
+import { useExecutionStore } from '@/stores/executionStore'
 
 const apiMock = vi.hoisted(
   () =>
@@ -74,14 +75,7 @@ const i18n = createI18n({
 const renderLogsTerminal = () =>
   render(LogsTerminal, {
     global: {
-      plugins: [
-        createTestingPinia({
-          createSpy: vi.fn,
-          stubActions: false,
-          initialState: { execution: { clientId: 'test-client' } }
-        }),
-        i18n
-      ]
+      plugins: [getActivePinia()!, i18n]
     }
   })
 
@@ -101,6 +95,7 @@ describe('LogsTerminal', () => {
   beforeEach(() => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     apiMock.clientId = 'test-client'
+    useExecutionStore().clientId = 'test-client'
   })
 
   it('loads logs and subscribes to streaming on mount', async () => {

--- a/src/components/breadcrumb/SubgraphBreadcrumb.test.ts
+++ b/src/components/breadcrumb/SubgraphBreadcrumb.test.ts
@@ -1,33 +1,11 @@
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import SubgraphBreadcrumb from './SubgraphBreadcrumb.vue'
-
-const canvasState = vi.hoisted(() => ({ linearMode: false }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ activeWorkflow: { filename: 'workflow.json' } })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => ({ navigationStack: [] })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: () => ({ isSubgraphBlueprint: () => false })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({ linearMode: canvasState.linearMode })
-  })
-)
 
 vi.mock<unknown>(import('@/composables/element/useOverflowObserver'), () => ({
   useOverflowObserver: () => ({
@@ -48,7 +26,10 @@ const i18n = createI18n({
 function renderBreadcrumb() {
   return render(SubgraphBreadcrumb, {
     global: {
-      plugins: [i18n],
+      plugins: [
+        i18n,
+        createRouter({ history: createMemoryHistory(), routes: [] })
+      ],
       directives: { tooltip: {} },
       stubs: {
         WorkflowActionsDropdown: { template: '<div data-testid="wad" />' },
@@ -62,7 +43,7 @@ function renderBreadcrumb() {
 
 describe('SubgraphBreadcrumb', () => {
   beforeEach(() => {
-    canvasState.linearMode = false
+    useCanvasStore().linearMode = false
   })
 
   it('renders the workflow actions dropdown when not in linear mode', () => {
@@ -71,7 +52,7 @@ describe('SubgraphBreadcrumb', () => {
   })
 
   it('hides the workflow actions dropdown in linear mode', () => {
-    canvasState.linearMode = true
+    useCanvasStore().linearMode = true
     renderBreadcrumb()
     expect(screen.queryByTestId('wad')).not.toBeInTheDocument()
   })

--- a/src/components/builder/BuilderFooterToolbar.test.ts
+++ b/src/components/builder/BuilderFooterToolbar.test.ts
@@ -1,15 +1,22 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import BuilderFooterToolbar from '@/components/builder/BuilderFooterToolbar.vue'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { toNodeId } from '@/types/nodeId'
 import type { AppMode } from '@/utils/appMode'
 
-import BuilderFooterToolbar from '@/components/builder/BuilderFooterToolbar.vue'
+beforeEach(() => {
+  vi.mocked(useAppModeStore().exitBuilder).mockImplementation(() => {})
+})
 
 const mockSetMode = vi.hoisted(() => vi.fn())
-const mockExitBuilder = vi.hoisted(() => vi.fn())
+
 const mockSave = vi.hoisted(() => vi.fn())
 const mockSaveAs = vi.hoisted(() => vi.fn())
 
@@ -21,46 +28,11 @@ vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
   useAppMode: () => ({
     mode: computed(() => mockState.mode),
     isBuilderMode: ref(true),
+    isAppMode: ref(false),
+    isSelectMode: ref(false),
     setMode: mockSetMode
   })
 }))
-
-const mockHasOutputs = ref(true)
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    exitBuilder: mockExitBuilder,
-    hasOutputs: mockHasOutputs,
-    $id: 'appMode'
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    dialogStack: []
-  })
-}))
-
-const mockActiveWorkflow = ref<{
-  isTemporary: boolean
-  initialMode?: string
-  isModified?: boolean
-  changeTracker?: { captureCanvasState: () => void }
-} | null>({
-  isTemporary: true,
-  initialMode: 'app'
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { extra: {} } }
@@ -102,8 +74,11 @@ const i18n = createI18n({
 describe('BuilderFooterToolbar', () => {
   beforeEach(() => {
     mockState.mode = 'builder:inputs'
-    mockHasOutputs.value = true
-    mockActiveWorkflow.value = { isTemporary: true, initialMode: 'app' }
+    useAppModeStore().selectedOutputs = [toNodeId('1')]
+    useWorkflowStore().activeWorkflow = fromPartial({
+      isTemporary: true,
+      initialMode: 'app'
+    })
   })
 
   function renderComponent() {
@@ -137,7 +112,7 @@ describe('BuilderFooterToolbar', () => {
 
   it('disables next on arrange step when no outputs', () => {
     mockState.mode = 'builder:arrange'
-    mockHasOutputs.value = false
+    useAppModeStore().selectedOutputs = []
     renderComponent()
     expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
   })
@@ -165,7 +140,7 @@ describe('BuilderFooterToolbar', () => {
   it('calls exitBuilder on exit button click', async () => {
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: /exit app builder/i }))
-    expect(mockExitBuilder).toHaveBeenCalledOnce()
+    expect(useAppModeStore().exitBuilder).toHaveBeenCalledOnce()
   })
 
   it('calls setMode app on view app click', async () => {
@@ -175,39 +150,45 @@ describe('BuilderFooterToolbar', () => {
   })
 
   it('shows "Save as" when workflow is temporary', () => {
-    mockActiveWorkflow.value = { isTemporary: true }
+    useWorkflowStore().activeWorkflow = fromPartial({ isTemporary: true })
     renderComponent()
     expect(screen.getByRole('button', { name: 'Save as' })).toBeDefined()
   })
 
   it('shows "Save" when workflow is saved', () => {
-    mockActiveWorkflow.value = { isTemporary: false }
+    useWorkflowStore().activeWorkflow = fromPartial({ isTemporary: false })
     renderComponent()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDefined()
   })
 
   it('calls saveAs when workflow is temporary', async () => {
-    mockActiveWorkflow.value = { isTemporary: true }
+    useWorkflowStore().activeWorkflow = fromPartial({ isTemporary: true })
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: 'Save as' }))
     expect(mockSaveAs).toHaveBeenCalledOnce()
   })
 
   it('calls save when workflow is saved and modified', async () => {
-    mockActiveWorkflow.value = { isTemporary: false, isModified: true }
+    useWorkflowStore().activeWorkflow = fromPartial({
+      isTemporary: false,
+      isModified: true
+    })
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: 'Save' }))
     expect(mockSave).toHaveBeenCalledOnce()
   })
 
   it('disables save button when workflow has no unsaved changes', () => {
-    mockActiveWorkflow.value = { isTemporary: false, isModified: false }
+    useWorkflowStore().activeWorkflow = fromPartial({
+      isTemporary: false,
+      isModified: false
+    })
     renderComponent()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
   it('does not call save when no outputs', async () => {
-    mockHasOutputs.value = false
+    useAppModeStore().selectedOutputs = []
     const { user } = renderComponent()
     await user.click(screen.getByRole('button', { name: 'Save as' }))
     expect(mockSave).not.toHaveBeenCalled()

--- a/src/components/builder/useBuilderSave.test.ts
+++ b/src/components/builder/useBuilderSave.test.ts
@@ -1,7 +1,17 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
 import { useBuilderSave } from './useBuilderSave'
+
+beforeEach(() => {
+  vi.mocked(useAppModeStore().exitBuilder).mockImplementation(() => {})
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
 
 const mockSetMode = vi.hoisted(() => vi.fn())
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
@@ -13,16 +23,15 @@ const mockSaveWorkflowAs = vi.hoisted(() =>
 )
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockShowConfirmDialog = vi.hoisted(() => vi.fn())
-const mockCloseDialog = vi.hoisted(() => vi.fn())
-const mockExitBuilder = vi.hoisted(() => vi.fn())
-
-const mockActiveWorkflow = ref<{
-  filename: string
-  initialMode?: string | null
-} | null>(null)
 
 vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ setMode: mockSetMode })
+  useAppMode: () => ({
+    setMode: mockSetMode,
+    mode: ref('builder:inputs'),
+    isAppMode: ref(false),
+    isBuilderMode: ref(true),
+    isSelectMode: ref(false)
+  })
 }))
 
 vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
@@ -46,27 +55,8 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showLayoutDialog: mockShowLayoutDialog })
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({ exitBuilder: mockExitBuilder })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
 }))
 
 vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
@@ -89,7 +79,7 @@ const SUCCESS_DIALOG_KEY = 'builder-save-success'
 
 describe('useBuilderSave', () => {
   beforeEach(() => {
-    mockActiveWorkflow.value = null
+    useWorkflowStore().activeWorkflow = null
   })
 
   describe('save()', () => {
@@ -102,7 +92,10 @@ describe('useBuilderSave', () => {
     })
 
     it('saves workflow directly without showing a dialog', async () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       mockSaveWorkflow.mockResolvedValueOnce(undefined)
       const { save } = useBuilderSave()
 
@@ -113,7 +106,10 @@ describe('useBuilderSave', () => {
     })
 
     it('toasts error on failure', async () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       const error = new Error('save failed')
       mockSaveWorkflow.mockRejectedValueOnce(error)
       const { save } = useBuilderSave()
@@ -125,7 +121,10 @@ describe('useBuilderSave', () => {
     })
 
     it('prevents concurrent saves', async () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       let resolveSave!: () => void
       mockSaveWorkflow.mockReturnValueOnce(
         new Promise<void>((r) => {
@@ -148,7 +147,7 @@ describe('useBuilderSave', () => {
 
   describe('saveAs()', () => {
     it('does nothing when there is no active workflow', () => {
-      mockActiveWorkflow.value = null
+      useWorkflowStore().activeWorkflow = null
       const { saveAs } = useBuilderSave()
 
       saveAs()
@@ -157,7 +156,10 @@ describe('useBuilderSave', () => {
     })
 
     it('opens save dialog with correct defaultFilename and defaultOpenAsApp', () => {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       const { saveAs } = useBuilderSave()
 
       saveAs()
@@ -172,10 +174,10 @@ describe('useBuilderSave', () => {
     })
 
     it('passes defaultOpenAsApp: false when initialMode is graph', () => {
-      mockActiveWorkflow.value = {
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'my-workflow',
         initialMode: 'graph'
-      }
+      })
       const { saveAs } = useBuilderSave()
 
       saveAs()
@@ -187,7 +189,10 @@ describe('useBuilderSave', () => {
 
   describe('save dialog callbacks', () => {
     function getSaveDialogProps() {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       const { saveAs } = useBuilderSave()
       saveAs()
       return mockShowLayoutDialog.mock.calls[0][0].props as {
@@ -203,7 +208,7 @@ describe('useBuilderSave', () => {
       await onSave('new-name', true)
 
       expect(mockSaveWorkflowAs).toHaveBeenCalledWith(
-        mockActiveWorkflow.value,
+        useWorkflowStore().activeWorkflow,
         {
           filename: 'new-name',
           isApp: true
@@ -221,7 +226,7 @@ describe('useBuilderSave', () => {
       await onSave('new-name', false)
 
       expect(mockSaveWorkflowAs).toHaveBeenCalledWith(
-        mockActiveWorkflow.value,
+        useWorkflowStore().activeWorkflow,
         {
           filename: 'new-name',
           isApp: false
@@ -239,7 +244,7 @@ describe('useBuilderSave', () => {
       await onSave('new-name', false)
 
       expect(mockTrackDefaultViewSet).not.toHaveBeenCalled()
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
     })
 
     it('onSave closes dialog and shows success dialog after successful save', async () => {
@@ -248,7 +253,9 @@ describe('useBuilderSave', () => {
 
       await onSave('new-name', true)
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SAVE_DIALOG_KEY })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SAVE_DIALOG_KEY
+      })
       expect(mockShowConfirmDialog).toHaveBeenCalledOnce()
       const successCall = mockShowConfirmDialog.mock.calls[0][0]
       expect(successCall.key).toBe(SUCCESS_DIALOG_KEY)
@@ -286,7 +293,9 @@ describe('useBuilderSave', () => {
       await onSave('new-name', false)
 
       expect(mockToastErrorHandler).toHaveBeenCalledWith(error)
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SAVE_DIALOG_KEY })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SAVE_DIALOG_KEY
+      })
     })
 
     it('prevents concurrent handleSaveAs calls', async () => {
@@ -310,7 +319,10 @@ describe('useBuilderSave', () => {
 
   describe('graph success dialog callbacks', () => {
     async function getGraphSuccessDialogProps() {
-      mockActiveWorkflow.value = { filename: 'my-workflow', initialMode: 'app' }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        filename: 'my-workflow',
+        initialMode: 'app'
+      })
       mockSaveWorkflowAs.mockResolvedValueOnce(true)
       const { saveAs } = useBuilderSave()
       saveAs()
@@ -329,8 +341,10 @@ describe('useBuilderSave', () => {
 
       onConfirm()
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SUCCESS_DIALOG_KEY })
-      expect(mockExitBuilder).toHaveBeenCalledOnce()
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SUCCESS_DIALOG_KEY
+      })
+      expect(useAppModeStore().exitBuilder).toHaveBeenCalledOnce()
     })
 
     it('onCancel closes dialog and switches to app mode', async () => {
@@ -338,7 +352,9 @@ describe('useBuilderSave', () => {
 
       onCancel()
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: SUCCESS_DIALOG_KEY })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: SUCCESS_DIALOG_KEY
+      })
       expect(mockTrackEnterLinear).toHaveBeenCalledWith({
         source: 'app_builder'
       })

--- a/src/components/common/CustomizationDialog.test.ts
+++ b/src/components/common/CustomizationDialog.test.ts
@@ -1,20 +1,21 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 
 import CustomizationDialog from './CustomizationDialog.vue'
 
+beforeEach(() => {
+  Object.assign(useNodeBookmarkStore(), {
+    defaultBookmarkIcon: DEFAULT_ICON,
+    defaultBookmarkColor: DEFAULT_COLOR
+  })
+})
+
 const DEFAULT_ICON = 'pi-bookmark-fill'
 const DEFAULT_COLOR = '#a1a1aa'
-
-vi.mock<unknown>(import('@/stores/nodeBookmarkStore'), () => ({
-  useNodeBookmarkStore: () => ({
-    defaultBookmarkIcon: DEFAULT_ICON,
-    defaultBookmarkColor: DEFAULT_COLOR,
-    bookmarksCustomization: {}
-  })
-}))
 
 vi.mock<unknown>(
   import('primevue/selectbutton'), // eslint-disable-line primevue-removal/no-imports

--- a/src/components/common/TreeExplorerTreeNode.test.ts
+++ b/src/components/common/TreeExplorerTreeNode.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import Badge from 'primevue/badge'
 import PrimeVue from 'primevue/config'
@@ -41,7 +41,7 @@ describe('TreeExplorerTreeNode', () => {
       props: { node: mockNode },
       global: {
         components: { EditableText, Badge },
-        plugins: [createTestingPinia(), i18n],
+        plugins: [getActivePinia()!, i18n],
         provide: {
           [InjectKeyHandleEditLabelFunction]: mockHandleEditLabel
         }
@@ -66,7 +66,7 @@ describe('TreeExplorerTreeNode', () => {
       },
       global: {
         components: { EditableText, Badge, InputText },
-        plugins: [createTestingPinia(), i18n, PrimeVue],
+        plugins: [getActivePinia()!, i18n, PrimeVue],
         provide: {
           [InjectKeyHandleEditLabelFunction]: mockHandleEditLabel
         }
@@ -89,7 +89,7 @@ describe('TreeExplorerTreeNode', () => {
       global: {
         components: { EditableText, Badge, InputText },
         provide: { [InjectKeyHandleEditLabelFunction]: handleEditLabelMock },
-        plugins: [createTestingPinia(), i18n, PrimeVue]
+        plugins: [getActivePinia()!, i18n, PrimeVue]
       }
     })
 

--- a/src/components/common/TreeExplorerV2Node.test.ts
+++ b/src/components/common/TreeExplorerV2Node.test.ts
@@ -1,45 +1,29 @@
-import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
 import type { FlattenedItem } from 'reka-ui'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { useSubgraphStore } from '@/stores/subgraphStore'
 import type { RenderedTreeExplorerNode } from '@/types/treeExplorerTypes'
 import { InjectKeyContextMenuNode } from '@/types/treeExplorerTypes'
 
 import TreeExplorerV2Node from './TreeExplorerV2Node.vue'
+
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+  vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(false)
+  vi.mocked(useSubgraphStore().deleteBlueprint).mockResolvedValue(undefined)
+})
 
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
   messages: { en: { g: { delete: 'Delete' } } }
 })
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn().mockReturnValue('left')
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/nodeBookmarkStore'), () => ({
-  useNodeBookmarkStore: () => ({
-    isBookmarked: vi.fn().mockReturnValue(false),
-    toggleBookmark: vi.fn()
-  })
-}))
-
-const mockDeleteBlueprint = vi.fn()
-const mockIsUserBlueprint = vi.fn().mockReturnValue(false)
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: () => ({
-    isUserBlueprint: mockIsUserBlueprint,
-    deleteBlueprint: mockDeleteBlueprint,
-    typePrefix: 'SubgraphBlueprint.'
-  })
-}))
 
 vi.mock<unknown>(import('@/components/node/NodePreviewCard.vue'), () => ({
   default: { template: '<div />' }
@@ -220,7 +204,7 @@ describe('TreeExplorerV2Node', () => {
 
   describe('blueprint actions', () => {
     it('shows delete button for user blueprints', () => {
-      mockIsUserBlueprint.mockReturnValue(true)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(true)
       renderComponent({
         item: createMockItem('node', {
           data: { name: 'SubgraphBlueprint.test' }
@@ -231,7 +215,7 @@ describe('TreeExplorerV2Node', () => {
     })
 
     it('hides delete button for non-blueprint nodes', () => {
-      mockIsUserBlueprint.mockReturnValue(false)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(false)
       renderComponent({
         item: createMockItem('node', {
           data: { name: 'KSampler' }
@@ -244,7 +228,7 @@ describe('TreeExplorerV2Node', () => {
     })
 
     it('always shows bookmark button', () => {
-      mockIsUserBlueprint.mockReturnValue(true)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(true)
       renderComponent({
         item: createMockItem('node', {
           data: { name: 'SubgraphBlueprint.test' }
@@ -258,7 +242,7 @@ describe('TreeExplorerV2Node', () => {
 
     it('calls deleteBlueprint when delete button is clicked', async () => {
       const user = userEvent.setup()
-      mockIsUserBlueprint.mockReturnValue(true)
+      vi.mocked(useSubgraphStore().isUserBlueprint).mockReturnValue(true)
       const nodeName = 'SubgraphBlueprint.test'
       renderComponent({
         item: createMockItem('node', {
@@ -269,7 +253,9 @@ describe('TreeExplorerV2Node', () => {
       const deleteButton = screen.getByRole('button', { name: 'Delete' })
       await user.click(deleteButton)
 
-      expect(mockDeleteBlueprint).toHaveBeenCalledWith(nodeName)
+      expect(
+        vi.mocked(useSubgraphStore().deleteBlueprint)
+      ).toHaveBeenCalledWith(nodeName)
     })
   })
 

--- a/src/components/common/UserCredit.test.ts
+++ b/src/components/common/UserCredit.test.ts
@@ -1,51 +1,22 @@
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createPinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useAuthStore } from '@/stores/authStore'
 
 import UserCredit from './UserCredit.vue'
-
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
-
-const mockBalance = vi.hoisted(() => ({
-  value: {
-    amount_micros: 100_000,
-    effective_balance_micros: 100_000,
-    currency: 'usd'
-  }
-}))
-
-const mockIsFetchingBalance = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    balance: mockBalance.value,
-    isFetchingBalance: mockIsFetchingBalance.value
-  }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 describe('UserCredit', () => {
   beforeEach(() => {
-    mockBalance.value = {
+    useAuthStore().balance = {
       amount_micros: 100_000,
       effective_balance_micros: 100_000,
       currency: 'usd'
     }
-    mockIsFetchingBalance.value = false
+    useAuthStore().isFetchingBalance = false
   })
 
   const renderComponent = (props = {}) => {
@@ -58,7 +29,7 @@ describe('UserCredit', () => {
     return render(UserCredit, {
       props,
       global: {
-        plugins: [i18n, createPinia()],
+        plugins: [i18n],
         stubs: {
           Skeleton: { template: '<div data-testid="skeleton" />' },
           Tag: true
@@ -69,7 +40,7 @@ describe('UserCredit', () => {
 
   describe('effective_balance_micros handling', () => {
     it('uses effective_balance_micros when present (positive balance)', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 200_000,
         effective_balance_micros: 150_000,
         currency: 'usd'
@@ -80,7 +51,7 @@ describe('UserCredit', () => {
     })
 
     it('uses effective_balance_micros when zero', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 100_000,
         effective_balance_micros: 0,
         currency: 'usd'
@@ -91,7 +62,7 @@ describe('UserCredit', () => {
     })
 
     it('uses effective_balance_micros when negative', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 0,
         effective_balance_micros: -50_000,
         currency: 'usd'
@@ -102,19 +73,19 @@ describe('UserCredit', () => {
     })
 
     it('falls back to amount_micros when effective_balance_micros is missing', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         amount_micros: 100_000,
         currency: 'usd'
-      } as typeof mockBalance.value
+      }
 
       renderComponent()
       expect(screen.getByText(/Credits/)).toBeInTheDocument()
     })
 
     it('falls back to 0 when both effective_balance_micros and amount_micros are missing', () => {
-      mockBalance.value = {
+      useAuthStore().balance = {
         currency: 'usd'
-      } as typeof mockBalance.value
+      } as ReturnType<typeof useAuthStore>['balance']
 
       renderComponent()
       expect(screen.getByText(/\b0\b/)).toBeInTheDocument()
@@ -123,7 +94,7 @@ describe('UserCredit', () => {
 
   describe('loading state', () => {
     it('shows skeleton when loading', () => {
-      mockIsFetchingBalance.value = true
+      useAuthStore().isFetchingBalance = true
 
       renderComponent()
       expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)

--- a/src/components/common/WorkflowActionsDropdown.test.ts
+++ b/src/components/common/WorkflowActionsDropdown.test.ts
@@ -1,43 +1,29 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type { ViewMode } from '@/utils/appMode'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 import WorkflowActionsDropdown from './WorkflowActionsDropdown.vue'
 
-const spies = vi.hoisted(() => ({
-  execute: vi.fn(),
-  trackUiButtonClicked: vi.fn(),
-  markAsSeen: vi.fn()
-}))
-
-const viewState = vi.hoisted(() => ({
-  viewMode: 'graph' as ViewMode,
-  displayViewMode: 'graph' as ViewMode
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { computed, reactive } = await import('vue')
-  return {
-    useAppModeStore: () =>
-      reactive({
-        viewMode: computed(() => viewState.viewMode),
-        displayViewMode: computed(() => viewState.displayViewMode)
-      })
-  }
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  useKeybindingStore().addDefaultKeybinding(
+    new KeybindingImpl({
+      commandId: 'Comfy.ToggleLinear',
+      combo: { key: 'l', ctrl: true }
+    })
+  )
 })
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: spies.execute, commands: [] })
-}))
-
-vi.mock<unknown>(import('@/platform/keybindings/keybindingStore'), () => ({
-  useKeybindingStore: () => ({
-    getKeybindingByCommandId: () => ({ combo: { toString: () => 'Ctrl+L' } })
-  })
+const spies = vi.hoisted(() => ({
+  trackUiButtonClicked: vi.fn(),
+  markAsSeen: vi.fn()
 }))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -96,8 +82,8 @@ function renderDropdown() {
 
 describe('WorkflowActionsDropdown', () => {
   beforeEach(() => {
-    viewState.viewMode = 'graph'
-    viewState.displayViewMode = 'graph'
+    Object.assign(useAppModeStore(), { viewMode: 'graph' })
+    useAppModeStore().displayViewMode = 'graph'
     // A prior test's segment switch arms the module-level focus handoff;
     // a throwaway mount consumes it so it cannot steal focus mid-test.
     renderDropdown().unmount()
@@ -123,8 +109,8 @@ describe('WorkflowActionsDropdown', () => {
   })
 
   it('flips the segment roles when app mode is active', () => {
-    viewState.viewMode = 'app'
-    viewState.displayViewMode = 'app'
+    Object.assign(useAppModeStore(), { viewMode: 'app' })
+    useAppModeStore().displayViewMode = 'app'
     renderDropdown()
 
     const active = screen.getByRole('button', { name: /workflow actions/ })
@@ -136,8 +122,8 @@ describe('WorkflowActionsDropdown', () => {
 
   it('derives the active segment from the real mode, not the lagged display mode', () => {
     // Mid-animation: the mode has flipped to app but the display still lags.
-    viewState.viewMode = 'app'
-    viewState.displayViewMode = 'graph'
+    Object.assign(useAppModeStore(), { viewMode: 'app' })
+    useAppModeStore().displayViewMode = 'graph'
     renderDropdown()
 
     const active = screen.getByRole('button', { name: /workflow actions/ })
@@ -163,9 +149,12 @@ describe('WorkflowActionsDropdown', () => {
 
     await user.click(screen.getByRole('button', { name: 'Enter app mode' }))
 
-    expect(spies.execute).toHaveBeenCalledWith('Comfy.ToggleLinear', {
-      metadata: { source: 'test' }
-    })
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.ToggleLinear',
+      {
+        metadata: { source: 'test' }
+      }
+    )
     // The switch must not also open the menu as a side effect.
     expect(
       screen.getByRole('button', { name: /workflow actions/ })
@@ -180,7 +169,7 @@ describe('WorkflowActionsDropdown', () => {
 
     await user.click(active)
 
-    expect(spies.execute).not.toHaveBeenCalled()
+    expect(vi.mocked(useCommandStore().execute)).not.toHaveBeenCalled()
     expect(active).toHaveAttribute('aria-expanded', 'true')
     expect(spies.markAsSeen).toHaveBeenCalled()
     expect(spies.trackUiButtonClicked).toHaveBeenCalledWith({
@@ -206,9 +195,12 @@ describe('WorkflowActionsDropdown', () => {
     inactive.focus()
     await user.keyboard('{Enter}')
 
-    expect(spies.execute).toHaveBeenCalledWith('Comfy.ToggleLinear', {
-      metadata: { source: 'test' }
-    })
+    expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+      'Comfy.ToggleLinear',
+      {
+        metadata: { source: 'test' }
+      }
+    )
     // The keydown must not reach the trigger and open the menu.
     expect(
       screen.getByRole('button', { name: /workflow actions/ })
@@ -239,7 +231,7 @@ describe('WorkflowActionsDropdown', () => {
     active.focus()
     await user.keyboard('{Enter}')
 
-    expect(spies.execute).not.toHaveBeenCalled()
+    expect(vi.mocked(useCommandStore().execute)).not.toHaveBeenCalled()
     expect(active).toHaveAttribute('aria-expanded', 'true')
   })
 
@@ -272,8 +264,8 @@ describe('WorkflowActionsDropdown', () => {
     // The mode flip unmounts this instance and mounts a fresh one in the
     // other mode's host.
     unmount()
-    viewState.viewMode = 'app'
-    viewState.displayViewMode = 'app'
+    Object.assign(useAppModeStore(), { viewMode: 'app' })
+    useAppModeStore().displayViewMode = 'app'
     renderDropdown()
     await nextTick()
 

--- a/src/components/curve/WidgetCurve.test.ts
+++ b/src/components/curve/WidgetCurve.test.ts
@@ -1,11 +1,15 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { toNodeId } from '@/types/nodeId'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import type { CurveData } from './types'
+import WidgetCurve from './WidgetCurve.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -35,17 +39,6 @@ vi.mock<unknown>(import('@/composables/useUpstreamValue'), async () => {
     singleValueExtractor: () => () => undefined
   }
 })
-
-const outputsHolder = vi.hoisted(() => ({
-  nodeOutputs: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => outputsHolder
-}))
-
-import WidgetCurve from './WidgetCurve.vue'
-import type { CurveData } from './types'
 
 const CurveEditorStub = defineComponent({
   name: 'CurveEditor',
@@ -144,7 +137,7 @@ function renderWidget(
 describe('WidgetCurve', () => {
   beforeEach(() => {
     upstreamHolder.ref = null
-    outputsHolder.nodeOutputs = {}
+    useNodeOutputStore().nodeOutputs = {}
   })
 
   describe('Point forwarding', () => {

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -6,28 +6,24 @@
  */
 import { describe, expect, it, vi } from 'vitest'
 
-const showDialog = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
-
 import ConfirmBody from '@/components/dialog/confirm/ConfirmBody.vue'
+import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 import ConfirmFooter from '@/components/dialog/confirm/ConfirmFooter.vue'
 import ConfirmHeader from '@/components/dialog/confirm/ConfirmHeader.vue'
-import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
+import { useDialogStore } from '@/stores/dialogStore'
 
 describe('showConfirmDialog Reka renderer opt-in', () => {
   it("sets renderer 'reka' with size 'md' and zeroed section padding", () => {
     showConfirmDialog()
 
-    const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('md')
-    expect(args.dialogComponentProps.headerClass).toBe('p-0 pr-3')
-    expect(args.dialogComponentProps.bodyClass).toBe('p-0')
-    expect(args.dialogComponentProps.footerClass).toBe('p-0')
-    expect(args.dialogComponentProps.pt).toBeUndefined()
+    const { showDialog } = useDialogStore()
+    const [args] = vi.mocked(showDialog).mock.calls[0]
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('md')
+    expect(args.dialogComponentProps?.headerClass).toBe('p-0 pr-3')
+    expect(args.dialogComponentProps?.bodyClass).toBe('p-0')
+    expect(args.dialogComponentProps?.footerClass).toBe('p-0')
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
   })
 
   it('forwards the confirm section components and caller props', () => {
@@ -38,7 +34,8 @@ describe('showConfirmDialog Reka renderer opt-in', () => {
       footerProps: { confirmText: 'Delete' }
     })
 
-    const [args] = showDialog.mock.calls[0]
+    const { showDialog } = useDialogStore()
+    const [args] = vi.mocked(showDialog).mock.calls[0]
     expect(args.key).toBe('confirm-test')
     expect(args.headerComponent).toBe(ConfirmHeader)
     expect(args.component).toBe(ConfirmBody)

--- a/src/components/dialog/content/ApiNodesSignInContent.test.ts
+++ b/src/components/dialog/content/ApiNodesSignInContent.test.ts
@@ -4,16 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 
 import ApiNodesSignInContent from './ApiNodesSignInContent.vue'
-
-const hoisted = vi.hoisted(() => ({
-  nodeDefsByName: {} as Record<string, { display_name?: string }>
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({ nodeDefsByName: hoisted.nodeDefsByName })
-}))
 
 const buildDocsUrl = vi.hoisted(() =>
   vi.fn((path: string) => `https://docs.comfy.org${path}`)
@@ -47,12 +40,19 @@ function renderContent(props: {
 
 describe('ApiNodesSignInContent', () => {
   beforeEach(() => {
-    hoisted.nodeDefsByName = {}
+    useNodeDefStore().nodeDefsByName = {}
   })
 
   it('lists partner nodes with display names, falling back to raw names', () => {
-    hoisted.nodeDefsByName = {
-      PartnerA: { display_name: 'Partner A' }
+    useNodeDefStore().nodeDefsByName = {
+      PartnerA: new ComfyNodeDefImpl({
+        name: 'PartnerA',
+        display_name: 'Partner A',
+        category: '',
+        python_module: '',
+        description: '',
+        output_node: false
+      })
     }
     renderContent({ apiNodeNames: ['PartnerA', 'UnknownNode'] })
 

--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
@@ -1,16 +1,17 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { AuthStoreError } from '@/stores/authStore'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import TopUpCreditsDialogContentLegacy from './TopUpCreditsDialogContentLegacy.vue'
 
 const mockPurchaseCreditsDirect = vi.fn()
 const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
-const mockCloseDialog = vi.fn()
+
 const mockTrackTopUpPurchase = vi.fn()
 const mockTrackBillingEvent = vi.fn()
 const mockIsSubscriptionEnabled = vi.fn(() => true)
@@ -47,10 +48,6 @@ vi.mock<unknown>(
     useSettingsDialog: () => ({ show: mockShowSettings })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -147,7 +144,7 @@ describe('TopUpCreditsDialogContentLegacy', () => {
     await clickBuyCredits()
 
     expect(mockPurchaseCreditsDirect).toHaveBeenCalledWith(50)
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalled()
     expect(mockShowSettings).toHaveBeenCalledWith('workspace')
     expect(mockClearPendingTopup).not.toHaveBeenCalled()
   })
@@ -158,7 +155,7 @@ describe('TopUpCreditsDialogContentLegacy', () => {
     await user.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(mockClearPendingTopup).toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalled()
   })
 
   it('shows Plan & Credits when no billing rail is active', async () => {

--- a/src/components/dialog/content/setting/CreditsPanel.test.ts
+++ b/src/components/dialog/content/setting/CreditsPanel.test.ts
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -49,10 +49,6 @@ vi.mock(
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackHelpResourceClicked: vi.fn() })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
 }))
 
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({

--- a/src/components/dialog/content/setting/SettingItem.test.ts
+++ b/src/components/dialog/content/setting/SettingItem.test.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue'
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Tag from 'primevue/tag'
 import Tooltip from 'primevue/tooltip'
@@ -37,7 +37,7 @@ describe('SettingItem', () => {
   function renderComponent(setting: SettingParams) {
     return render(SettingItem, {
       global: {
-        plugins: [PrimeVue, i18n, createPinia()],
+        plugins: [PrimeVue, i18n, getActivePinia()!],
         components: { Tag },
         stubs: {
           FormItem: FormItemStub,

--- a/src/components/dialog/content/setting/UsageLogsTable.test.ts
+++ b/src/components/dialog/content/setting/UsageLogsTable.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -95,11 +95,6 @@ const i18n = createI18n({
     }
   }
 })
-
-const globalConfig = {
-  plugins: [PrimeVue, i18n, createTestingPinia()],
-  directives: { tooltip: Tooltip }
-}
 
 async function flushMicrotasks() {
   await new Promise((resolve) => setTimeout(resolve, 0))
@@ -199,7 +194,12 @@ describe('UsageLogsTable', () => {
   })
 
   function renderComponent() {
-    return render(UsageLogsTable, { global: globalConfig })
+    return render(UsageLogsTable, {
+      global: {
+        plugins: [PrimeVue, i18n, getActivePinia()!],
+        directives: { tooltip: Tooltip }
+      }
+    })
   }
 
   async function renderLoaded() {

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -1,34 +1,19 @@
 import { Form } from '@primevue/forms'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import Button from '@/components/ui/button/Button.vue'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Message from 'primevue/message'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
+import { useAuthStore } from '@/stores/authStore'
 
 import ApiKeyForm from './ApiKeyForm.vue'
-
-const mockStoreApiKey = vi.fn()
-const mockLoadingRef = ref(false)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    get loading() {
-      return mockLoadingRef.value
-    }
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: vi.fn(() => ({
-    storeApiKey: mockStoreApiKey
-  }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const i18n = createI18n({
   legacy: false,
@@ -58,7 +43,7 @@ const i18n = createI18n({
 
 describe('ApiKeyForm', () => {
   beforeEach(() => {
-    mockLoadingRef.value = false
+    useAuthStore().loading = false
   })
 
   function renderComponent(props: Record<string, unknown> = {}) {
@@ -91,7 +76,7 @@ describe('ApiKeyForm', () => {
   })
 
   it('shows loading state when submitting', () => {
-    mockLoadingRef.value = true
+    useAuthStore().loading = true
     const { container } = renderComponent()
 
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access

--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -1,50 +1,27 @@
 import { Form } from '@primevue/forms'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import Button from '@/components/ui/button/Button.vue'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
 import ProgressSpinner from 'primevue/progressspinner'
 import ToastService from 'primevue/toastservice'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useAuthStore } from '@/stores/authStore'
 
 import SignInForm from './SignInForm.vue'
-
-// Mock firebase auth modules
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn(),
-  sendPasswordResetEmail: vi.fn()
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 // Mock the auth composables and stores
 const mockSendPasswordReset = vi.fn()
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: vi.fn(() => ({
     sendPasswordReset: mockSendPasswordReset
-  }))
-}))
-
-const mockLoadingRef = ref(false)
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    get loading() {
-      return mockLoadingRef.value
-    }
   }))
 }))
 
@@ -61,7 +38,7 @@ const loginButtonText = enMessages.auth.login.loginButton
 
 describe('SignInForm', () => {
   beforeEach(() => {
-    mockLoadingRef.value = false
+    useAuthStore().loading = false
   })
 
   function renderComponent(props: Record<string, unknown> = {}) {
@@ -141,7 +118,7 @@ describe('SignInForm', () => {
 
   describe('Loading State', () => {
     it('shows spinner when loading', () => {
-      mockLoadingRef.value = true
+      useAuthStore().loading = true
       renderComponent()
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument()

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -1,40 +1,20 @@
 import { Form, FormField } from '@primevue/forms'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import Button from '@/components/ui/button/Button.vue'
+import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
-import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import Button from '@/components/ui/button/Button.vue'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useAuthStore } from '@/stores/authStore'
 
 import SignUpForm from './SignUpForm.vue'
-
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
-
-const mockLoadingRef = ref(false)
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    get loading() {
-      return mockLoadingRef.value
-    }
-  }))
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const mockTurnstileEnabled = ref(false)
 const mockTurnstileToken = ref('')
@@ -101,7 +81,7 @@ function globalOptions() {
 describe('SignUpForm', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockLoadingRef.value = false
+    useAuthStore().loading = false
     mockTurnstileEnabled.value = false
     mockTurnstileToken.value = ''
     mockTurnstileUnavailable.value = false
@@ -224,7 +204,7 @@ describe('SignUpForm', () => {
       screen.getByRole('button', { name: signUpButton })
 
     it('keeps its accessible name and disables while loading', async () => {
-      mockLoadingRef.value = true
+      useAuthStore().loading = true
       renderComponent()
       await nextTick()
 
@@ -233,7 +213,7 @@ describe('SignUpForm', () => {
     })
 
     it('does not emit submit when clicked', async () => {
-      mockLoadingRef.value = true
+      useAuthStore().loading = true
       const { user, emitted } = renderComponent()
       await nextTick()
 

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -1,35 +1,23 @@
+import { render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import { render } from '@testing-library/vue'
-
 import type { TurnstileRenderOptions } from '@/composables/auth/turnstileScript'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
 import TurnstileWidget from './TurnstileWidget.vue'
 
-const { mockLoadTurnstile, mockGetSiteKey, mockLightTheme } = vi.hoisted(
-  () => ({
-    mockLoadTurnstile: vi.fn(),
-    mockGetSiteKey: vi.fn(() => 'site-key'),
-    mockLightTheme: { value: true }
-  })
-)
+const { mockLoadTurnstile, mockGetSiteKey } = vi.hoisted(() => ({
+  mockLoadTurnstile: vi.fn(),
+  mockGetSiteKey: vi.fn(() => 'site-key')
+}))
 
 vi.mock(import('@/composables/auth/turnstileScript'), () => ({
   loadTurnstile: mockLoadTurnstile
 }))
 vi.mock(import('@/config/turnstile'), () => ({
   getTurnstileSiteKey: mockGetSiteKey
-}))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: {
-      get light_theme() {
-        return mockLightTheme.value
-      }
-    }
-  })
 }))
 
 const i18n = createI18n({
@@ -98,7 +86,7 @@ const renderWidgetWithExpose = () => {
 describe('TurnstileWidget', () => {
   beforeEach(() => {
     mockGetSiteKey.mockReturnValue('site-key')
-    mockLightTheme.value = true
+    useColorPaletteStore().activePaletteId = 'light'
     delete window.turnstile
   })
 
@@ -120,7 +108,7 @@ describe('TurnstileWidget', () => {
   })
 
   it('uses the dark theme when the active palette is not light', async () => {
-    mockLightTheme.value = false
+    useColorPaletteStore().activePaletteId = 'dark'
     const { api, options } = fakeTurnstile()
     mockLoadTurnstile.mockResolvedValue(api)
 

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
@@ -1,10 +1,10 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
-import userEvent from '@testing-library/user-event'
-import { render, screen, waitFor } from '@testing-library/vue'
-
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useDialogStore } from '@/stores/dialogStore'
 
 import CancelSubscriptionDialogContent from './CancelSubscriptionDialogContent.vue'
 
@@ -50,7 +50,7 @@ const mockSubscription = vi.hoisted(() => ({
 
 const mockCancelSubscription = vi.hoisted(() => vi.fn())
 const mockFetchStatus = vi.hoisted(() => vi.fn())
-const mockCloseDialog = vi.hoisted(() => vi.fn())
+
 const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockTier = vi.hoisted(() => ({ value: 'STANDARD' as string | null }))
 const mockTrackCancellation = vi.hoisted(() => vi.fn())
@@ -105,12 +105,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackSubscriptionCancellation: mockTrackCancellation
   })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: vi.fn(() => ({
-    closeDialog: mockCloseDialog
-  }))
 }))
 
 vi.mock<unknown>(
@@ -192,7 +186,9 @@ describe('CancelSubscriptionDialogContent', () => {
         screen.getByRole('button', { name: /^cancel subscription$/i })
       )
 
-      await waitFor(() => expect(mockCloseDialog).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalled()
+      )
       unmount()
       expect(mockTrackCancellation).toHaveBeenCalledWith(
         'confirmed',
@@ -254,7 +250,7 @@ describe('CancelSubscriptionDialogContent', () => {
         screen.getByRole('button', { name: /keep subscription/i })
       )
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
         key: 'cancel-subscription'
       })
       unmount()
@@ -299,7 +295,7 @@ describe('CancelSubscriptionDialogContent', () => {
           })
         )
       )
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
     })
 
     it('closes the dialog and shows a success toast when cancellation succeeds', async () => {
@@ -312,7 +308,7 @@ describe('CancelSubscriptionDialogContent', () => {
       )
 
       await waitFor(() =>
-        expect(mockCloseDialog).toHaveBeenCalledWith({
+        expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
           key: 'cancel-subscription'
         })
       )
@@ -339,7 +335,7 @@ describe('CancelSubscriptionDialogContent', () => {
         expect.anything()
       )
       expect(mockToastAdd).not.toHaveBeenCalled()
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(vi.mocked(useDialogStore().closeDialog)).not.toHaveBeenCalled()
     })
 
     it('cancels off Cloud on the workspace permission, ignoring the Cloud-only capability', async () => {
@@ -392,7 +388,7 @@ describe('CancelSubscriptionDialogContent', () => {
           expect.objectContaining({ severity: 'success' })
         )
       )
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
         key: 'cancel-subscription'
       })
       expect(

--- a/src/components/error/ErrorOverlay.test.ts
+++ b/src/components/error/ErrorOverlay.test.ts
@@ -1,19 +1,20 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import ErrorOverlay from './ErrorOverlay.vue'
-import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import type { NodeError } from '@/schemas/apiSchema'
+import type { ErrorGroup } from '@/components/rightSidePanel/errors/types'
 import type {
   MissingPackGroup,
   SwapNodeGroup
 } from '@/components/rightSidePanel/errors/useErrorGroups'
-import type { ErrorGroup } from '@/components/rightSidePanel/errors/types'
 import type { MissingMediaGroup } from '@/platform/missingMedia/types'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type { NodeError } from '@/schemas/apiSchema'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+
+import ErrorOverlay from './ErrorOverlay.vue'
 
 const mockErrorGroups = vi.hoisted(() => ({
   allErrorGroups: { value: [] as ErrorGroup[] },
@@ -51,21 +52,6 @@ vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   getActiveGraphNodeIds: vi.fn(() => new Set()),
   getExecutionIdByNode: vi.fn(),
   getNodeByExecutionId: vi.fn()
-}))
-
-const mockOpenPanel = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), () => ({
-  useRightSidePanelStore: () => ({ openPanel: mockOpenPanel })
-}))
-
-const mockCanvasStore = vi.hoisted(() => ({
-  linearMode: false,
-  canvas: null,
-  currentGraph: null,
-  updateSelectedItems: vi.fn()
-}))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => mockCanvasStore
 }))
 
 function createTestI18n() {
@@ -106,12 +92,10 @@ function makeNodeError(messages: string[]): NodeError {
 }
 
 function renderOverlay(props: { appMode?: boolean } = {}) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
   return render(ErrorOverlay, {
     props,
     global: {
-      plugins: [pinia, createTestI18n()],
+      plugins: [createTestI18n()],
       stubs: {
         Button: {
           template: '<button v-bind="$attrs"><slot /></button>'
@@ -128,9 +112,9 @@ describe('ErrorOverlay', () => {
     mockErrorGroups.missingModelGroups.value = []
     mockErrorGroups.missingMediaGroups.value = []
     mockErrorGroups.swapNodeGroups.value = []
-    mockCanvasStore.linearMode = false
-    mockCanvasStore.canvas = null
-    mockCanvasStore.currentGraph = null
+    useCanvasStore().linearMode = false
+    useCanvasStore().canvas = null
+    useCanvasStore().currentGraph = null
   })
 
   it('renders a single overlay message without list markup', async () => {

--- a/src/components/error/useErrorOverlayState.test.ts
+++ b/src/components/error/useErrorOverlayState.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
@@ -82,8 +82,7 @@ function makeNodeError(messages: string[]): NodeError {
 }
 
 function mountOverlayState() {
-  const pinia = createPinia()
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   const Harness = defineComponent({
     setup() {

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -1,20 +1,25 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useReleaseStore } from '@/platform/updates/common/releaseStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 import HelpCenterMenuContent from './HelpCenterMenuContent.vue'
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  vi.mocked(useReleaseStore().fetchReleases).mockResolvedValue(undefined)
+})
 
 const distribution = vi.hoisted(() => ({
   isCloud: false,
   isDesktop: false,
   isNightly: false
 }))
-
-const commandStoreExecute = vi.hoisted(() => vi.fn())
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -39,31 +44,12 @@ vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => false
-  })
-}))
-
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackHelpResourceClicked: vi.fn(),
     trackHelpCenterOpened: vi.fn(),
     trackHelpCenterClosed: vi.fn()
   })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/releaseStore'), () => ({
-  useReleaseStore: () => ({
-    releases: [],
-    recentReleases: [],
-    isLoading: false,
-    fetchReleases: vi.fn().mockResolvedValue(undefined)
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: commandStoreExecute })
 }))
 
 vi.mock<unknown>(import('@/utils/envUtil'), () => ({
@@ -151,7 +137,7 @@ describe('HelpCenterMenuContent feedback item', () => {
       '_blank',
       'noopener,noreferrer'
     )
-    expect(commandStoreExecute).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
   })
 
   it('opens the Typeform survey tagged with help-center source on Nightly', async () => {
@@ -165,7 +151,7 @@ describe('HelpCenterMenuContent feedback item', () => {
       '_blank',
       'noopener,noreferrer'
     )
-    expect(commandStoreExecute).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
   })
 
   it('falls back to Comfy.ContactSupport on OSS builds', async () => {
@@ -174,7 +160,9 @@ describe('HelpCenterMenuContent feedback item', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).not.toHaveBeenCalled()
-    expect(commandStoreExecute).toHaveBeenCalledWith('Comfy.ContactSupport')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.ContactSupport'
+    )
   })
 })
 

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/components/queue/JobHistoryActionsMenu.test.ts
+++ b/src/components/queue/JobHistoryActionsMenu.test.ts
@@ -1,40 +1,18 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import JobHistoryActionsMenu from '@/components/queue/JobHistoryActionsMenu.vue'
 import { popoverCloseSpy } from '@/components/ui/__mocks__/popoverMockState'
 import { i18n } from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 vi.mock(import('@/components/ui/Popover.vue'))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
-
-const mockGetSetting = vi.fn<(key: string) => boolean | undefined>((key) =>
-  key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-    ? true
-    : undefined
-)
-const mockSetSetting = vi.fn()
-const mockSetMany = vi.fn()
-const mockSidebarTabStore = {
-  activeSidebarTabId: null as string | null
-}
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting,
-    set: mockSetSetting,
-    setMany: mockSetMany
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => mockSidebarTabStore
-}))
-
-import JobHistoryActionsMenu from '@/components/queue/JobHistoryActionsMenu.vue'
 
 const renderMenu = () =>
   render(JobHistoryActionsMenu, {
@@ -47,12 +25,15 @@ const renderMenu = () =>
 describe('JobHistoryActionsMenu', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    mockSidebarTabStore.activeSidebarTabId = null
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-        ? true
-        : undefined
-    )
+    useSidebarTabStore().activeSidebarTabId = null
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.Queue.QPOV2': true,
+        'Comfy.Queue.ShowRunProgressBar': true
+      }
+    })
+    vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+    vi.mocked(useSettingStore().setMany).mockResolvedValue(undefined)
   })
 
   it('toggles show run progress bar setting from the menu', async () => {
@@ -62,8 +43,8 @@ describe('JobHistoryActionsMenu', () => {
 
     await user.click(screen.getByTestId('show-run-progress-bar-action'))
 
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith(
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
       'Comfy.Queue.ShowRunProgressBar',
       false
     )
@@ -71,21 +52,20 @@ describe('JobHistoryActionsMenu', () => {
 
   it('opens docked job history sidebar when enabling from the menu', async () => {
     const user = userEvent.setup()
-    mockGetSetting.mockImplementation((key: string) => {
-      if (key === 'Comfy.Queue.QPOV2') return false
-      if (key === 'Comfy.Queue.ShowRunProgressBar') return true
-      return undefined
-    })
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     renderMenu()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith('Comfy.Queue.QPOV2', true)
-    expect(mockSetMany).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('job-history')
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
+      'Comfy.Queue.QPOV2',
+      true
+    )
+    expect(vi.mocked(useSettingStore().setMany)).not.toHaveBeenCalled()
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('job-history')
   })
 
   it('emits clear history from the menu', async () => {

--- a/src/components/queue/QueueOverlayHeader.test.ts
+++ b/src/components/queue/QueueOverlayHeader.test.ts
@@ -1,37 +1,16 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { popoverCloseSpy } from '@/components/ui/__mocks__/popoverMockState'
+import * as tooltipConfig from '@/composables/useTooltipConfig'
 import { i18n } from '@/i18n'
-
-vi.mock(import('@/components/ui/Popover.vue'))
-
-const mockGetSetting = vi.fn<(key: string) => boolean | undefined>((key) =>
-  key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-    ? true
-    : undefined
-)
-const mockSetSetting = vi.fn()
-const mockSetMany = vi.fn()
-const mockSidebarTabStore = {
-  activeSidebarTabId: null as string | null
-}
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting,
-    set: mockSetSetting,
-    setMany: mockSetMany
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => mockSidebarTabStore
-}))
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 import QueueOverlayHeader from './QueueOverlayHeader.vue'
-import * as tooltipConfig from '@/composables/useTooltipConfig'
+
+vi.mock(import('@/components/ui/Popover.vue'))
 
 const tooltipDirectiveStub = {
   mounted: vi.fn(),
@@ -54,12 +33,15 @@ const renderHeader = (props = {}) =>
 describe('QueueOverlayHeader', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    mockSidebarTabStore.activeSidebarTabId = null
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'
-        ? true
-        : undefined
-    )
+    useSidebarTabStore().activeSidebarTabId = null
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.Queue.QPOV2': true,
+        'Comfy.Queue.ShowRunProgressBar': true
+      }
+    })
+    vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+    vi.mocked(useSettingStore().setMany).mockResolvedValue(undefined)
   })
 
   it('renders header title', () => {
@@ -112,58 +94,64 @@ describe('QueueOverlayHeader', () => {
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetMany).toHaveBeenCalledTimes(1)
-    expect(mockSetMany).toHaveBeenCalledWith({
+    expect(vi.mocked(useSettingStore().setMany)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().setMany)).toHaveBeenCalledWith({
       'Comfy.Queue.QPOV2': false,
       'Comfy.Queue.History.Expanded': true
     })
-    expect(mockSetSetting).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe(null)
+    expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalled()
+    expect(useSidebarTabStore().activeSidebarTabId).toBe(null)
   })
 
   it('opens docked job history sidebar when enabling from the menu', async () => {
     const user = userEvent.setup()
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? false : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     renderHeader()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith('Comfy.Queue.QPOV2', true)
-    expect(mockSetMany).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('job-history')
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
+      'Comfy.Queue.QPOV2',
+      true
+    )
+    expect(vi.mocked(useSettingStore().setMany)).not.toHaveBeenCalled()
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('job-history')
   })
 
   it('keeps docked target open even when enabling persistence fails', async () => {
     const user = userEvent.setup()
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? false : undefined
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
+    vi.mocked(useSettingStore().set).mockRejectedValueOnce(
+      new Error('persistence failed')
     )
-    mockSetSetting.mockRejectedValueOnce(new Error('persistence failed'))
 
     renderHeader()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith('Comfy.Queue.QPOV2', true)
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('job-history')
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
+      'Comfy.Queue.QPOV2',
+      true
+    )
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('job-history')
   })
 
   it('closes the menu when disabling persistence fails', async () => {
     const user = userEvent.setup()
-    mockSetMany.mockRejectedValueOnce(new Error('persistence failed'))
+    vi.mocked(useSettingStore().setMany).mockRejectedValueOnce(
+      new Error('persistence failed')
+    )
 
     renderHeader()
 
     await user.click(screen.getByTestId('docked-job-history-action'))
 
     expect(popoverCloseSpy).toHaveBeenCalledTimes(1)
-    expect(mockSetMany).toHaveBeenCalledWith({
+    expect(vi.mocked(useSettingStore().setMany)).toHaveBeenCalledWith({
       'Comfy.Queue.QPOV2': false,
       'Comfy.Queue.History.Expanded': true
     })
@@ -176,8 +164,8 @@ describe('QueueOverlayHeader', () => {
 
     await user.click(screen.getByTestId('show-run-progress-bar-action'))
 
-    expect(mockSetSetting).toHaveBeenCalledTimes(1)
-    expect(mockSetSetting).toHaveBeenCalledWith(
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
       'Comfy.Queue.ShowRunProgressBar',
       false
     )

--- a/src/components/queue/QueueProgressOverlay.test.ts
+++ b/src/components/queue/QueueProgressOverlay.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -43,10 +43,7 @@ function renderComponent(
   runningTasks: TaskItemImpl[],
   pendingTasks: TaskItemImpl[]
 ) {
-  const pinia = createTestingPinia({
-    createSpy: vi.fn,
-    stubActions: false
-  })
+  const pinia = getActivePinia()!
   const queueStore = useQueueStore(pinia)
   const sidebarTabStore = useSidebarTabStore(pinia)
   queueStore.runningTasks = runningTasks

--- a/src/components/range/WidgetRange.test.ts
+++ b/src/components/range/WidgetRange.test.ts
@@ -1,7 +1,5 @@
-import { render, screen } from '@testing-library/vue'
-import { createNodeLocatorId } from '@/types/nodeIdentification'
-import { toNodeId } from '@/types/nodeId'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 
@@ -9,7 +7,12 @@ import type {
   IWidgetRangeOptions,
   RangeValue
 } from '@/lib/litegraph/src/types/widgets'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetRange from './WidgetRange.vue'
 
 const upstreamHolder = vi.hoisted(() => ({
   ref: null as { value: unknown } | null
@@ -25,16 +28,6 @@ vi.mock<unknown>(import('@/composables/useUpstreamValue'), async () => {
     singleValueExtractor: () => () => undefined
   }
 })
-
-const outputsHolder = vi.hoisted(() => ({
-  nodeOutputs: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => outputsHolder
-}))
-
-import WidgetRange from './WidgetRange.vue'
 
 const RangeEditorStub = defineComponent({
   name: 'RangeEditor',
@@ -96,7 +89,7 @@ function renderWidget(
 describe('WidgetRange', () => {
   beforeEach(() => {
     upstreamHolder.ref = null
-    outputsHolder.nodeOutputs = {}
+    useNodeOutputStore().nodeOutputs = {}
   })
 
   describe('Value pass-through', () => {
@@ -170,7 +163,7 @@ describe('WidgetRange', () => {
     })
 
     it('passes a histogram when node output has a matching histogram entry', () => {
-      outputsHolder.nodeOutputs = {
+      useNodeOutputStore().nodeOutputs = {
         loc1: { histogram_range_w: [1, 2, 3, 4] }
       }
       renderWidget(
@@ -185,7 +178,7 @@ describe('WidgetRange', () => {
     })
 
     it('treats an empty histogram array as null', () => {
-      outputsHolder.nodeOutputs = {
+      useNodeOutputStore().nodeOutputs = {
         loc1: { histogram_range_w: [] }
       }
       renderWidget(

--- a/src/components/rightSidePanel/RightSidePanel.test.ts
+++ b/src/components/rightSidePanel/RightSidePanel.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { markRaw, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -13,13 +12,14 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
-import { getExecutionIdByNode } from '@/utils/graphTraversalUtil'
 import { toNodeId } from '@/types/nodeId'
+import { getExecutionIdByNode } from '@/utils/graphTraversalUtil'
 
 const mockApp = vi.hoisted(() => ({
   isGraphReady: true,
@@ -34,19 +34,6 @@ vi.mock(import('@/composables/graph/useGraphHierarchy'), () => ({
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => undefined
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => {
-      if (key === 'Comfy.RightSidePanel.ShowErrorsTab') return true
-      if (key === 'Comfy.Sidebar.Location') return 'left'
-      if (key === 'Comfy.UseNewMenu') return 'Top'
-      if (key === 'Comfy.RightSidePanel.IsOpen') return true
-      return undefined
-    },
-    set: vi.fn()
-  })
 }))
 
 function createPanelI18n() {
@@ -75,9 +62,16 @@ function renderPanel(
     currentGraph: LGraph
     node: LGraphNode
   },
-  pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+  pinia = getActivePinia()!
 ) {
-  setActivePinia(pinia)
+  useSettingStore().$patch({
+    settingValues: {
+      'Comfy.RightSidePanel.ShowErrorsTab': true,
+      'Comfy.Sidebar.Location': 'left',
+      'Comfy.UseNewMenu': 'Top',
+      'Comfy.RightSidePanel.IsOpen': true
+    }
+  })
 
   const rootGraph = graphContext?.rootGraph ?? new LGraph()
   const currentGraph = graphContext?.currentGraph ?? rootGraph
@@ -181,8 +175,16 @@ describe('RightSidePanel active tab fallback', () => {
   })
 
   it('keeps errors active for a pending subgraph interior node scan', () => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
+
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.RightSidePanel.ShowErrorsTab': true,
+        'Comfy.Sidebar.Location': 'left',
+        'Comfy.UseNewMenu': 'Top',
+        'Comfy.RightSidePanel.IsOpen': true
+      }
+    })
     const subgraph = createTestSubgraph()
     const node = new LGraphNode('CheckpointLoaderSimple')
     node.id = toNodeId(7)
@@ -210,9 +212,16 @@ describe('RightSidePanel global parameters tab', () => {
 
   function renderWithNoSelection(
     activeWorkflowPath: string | null,
-    pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    pinia = getActivePinia()!
   ) {
-    setActivePinia(pinia)
+    useSettingStore().$patch({
+      settingValues: {
+        'Comfy.RightSidePanel.ShowErrorsTab': true,
+        'Comfy.Sidebar.Location': 'left',
+        'Comfy.UseNewMenu': 'Top',
+        'Comfy.RightSidePanel.IsOpen': true
+      }
+    })
     const onTabGlobalParametersSetup = vi.fn()
 
     const rootGraph = new LGraph()

--- a/src/components/rightSidePanel/errors/ErrorGroupList.test.ts
+++ b/src/components/rightSidePanel/errors/ErrorGroupList.test.ts
@@ -1,5 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import type { TestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
 import { render, screen, waitFor, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { fromPartial } from '@total-typescript/shoehorn'
@@ -80,20 +80,10 @@ function createNodeFixture(
   return node
 }
 
-const SAMPLER_NODE = createNodeFixture(
-  '1',
-  'SamplerNode',
-  ROOT_GRAPH,
-  SAMPLER_BOUNDS
-)
-const LOADER_NODE = createNodeFixture(
-  '2',
-  'LoaderNode',
-  ROOT_GRAPH,
-  LOADER_BOUNDS
-)
+let SAMPLER_NODE: LGraphNode
+let LOADER_NODE: LGraphNode
 
-function seedTwoErrorGroups(pinia: TestingPinia) {
+function seedTwoErrorGroups(pinia: Pinia) {
   const executionErrorStore = useExecutionErrorStore(pinia)
   executionErrorStore.recordNodeErrors({
     '1': {
@@ -122,7 +112,7 @@ function seedTwoErrorGroups(pinia: TestingPinia) {
   })
 }
 
-function renderList(pinia: TestingPinia) {
+function renderList(pinia: Pinia) {
   const user = userEvent.setup()
   render(ErrorGroupList, {
     global: {
@@ -137,11 +127,7 @@ function renderList(pinia: TestingPinia) {
   return { user }
 }
 
-function createPinia() {
-  return createTestingPinia({ createSpy: vi.fn, stubActions: false })
-}
-
-function createCanvasFixture(pinia: TestingPinia, graph = ROOT_GRAPH) {
+function createCanvasFixture(pinia: Pinia, graph = ROOT_GRAPH) {
   const canvasElement = document.createElement('canvas')
   canvasElement.width = 900
   canvasElement.height = 700
@@ -173,6 +159,18 @@ function isSectionExpanded(section: HTMLElement) {
 
 describe('ErrorGroupList selection emphasis', () => {
   beforeEach(() => {
+    SAMPLER_NODE = createNodeFixture(
+      '1',
+      'SamplerNode',
+      ROOT_GRAPH,
+      SAMPLER_BOUNDS
+    )
+    LOADER_NODE = createNodeFixture(
+      '2',
+      'LoaderNode',
+      ROOT_GRAPH,
+      LOADER_BOUNDS
+    )
     vi.mocked(isLGraphNode).mockReturnValue(true)
     vi.mocked(getNodeByExecutionId).mockImplementation((_, nodeId) =>
       nodeId === '1' ? SAMPLER_NODE : LOADER_NODE
@@ -184,7 +182,7 @@ describe('ErrorGroupList selection emphasis', () => {
   })
 
   it('expands matched groups, collapses others, and restores on deselect', async () => {
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
     renderList(pinia)
     const canvasStore = useCanvasStore(pinia)
@@ -208,7 +206,7 @@ describe('ErrorGroupList selection emphasis', () => {
   })
 
   it('expands only matched groups for a selection that predates mount', async () => {
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
     const canvasStore = useCanvasStore(pinia)
     canvasStore.selectedItems = [SAMPLER_NODE]
@@ -226,7 +224,7 @@ describe('ErrorGroupList selection emphasis', () => {
   })
 
   it('leaves manual collapse state alone for selections without errors', async () => {
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
     const { user } = renderList(pinia)
     const canvasStore = useCanvasStore(pinia)
@@ -252,7 +250,7 @@ describe('ErrorGroupList selection emphasis', () => {
   })
 
   it('always shows the strip: workflow summary by default, selection while emphasized', async () => {
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
     renderList(pinia)
     const canvasStore = useCanvasStore(pinia)
@@ -277,7 +275,7 @@ describe('ErrorGroupList selection emphasis', () => {
   })
 
   it('labels a missing-only selection as an issue', async () => {
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     useMissingModelStore(pinia).setMissingModels([
       {
         nodeId: '1',
@@ -312,7 +310,7 @@ describe('ErrorGroupList selection emphasis', () => {
           )
         : LOADER_NODE
     )
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
 
     renderList(pinia)
@@ -327,7 +325,7 @@ describe('ErrorGroupList selection emphasis', () => {
   })
 
   it('locates an execution error through the real root-graph focus path', async () => {
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
     const { user } = renderList(pinia)
     const canvas = createCanvasFixture(pinia, ROOT_GRAPH)
@@ -353,7 +351,7 @@ describe('ErrorGroupList selection emphasis', () => {
     vi.mocked(getNodeByExecutionId).mockImplementation((_, nodeId) =>
       nodeId === '2' ? subgraphLoaderNode : SAMPLER_NODE
     )
-    const pinia = createPinia()
+    const pinia = getActivePinia()!
     seedTwoErrorGroups(pinia)
     const { user } = renderList(pinia)
     const canvas = createCanvasFixture(pinia, ROOT_GRAPH)

--- a/src/components/rightSidePanel/errors/ErrorNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.test.ts
@@ -1,15 +1,19 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen, waitFor } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { resolveRunErrorMessage } from '@/platform/errorCatalog/errorMessageResolver'
+import { useCommandStore } from '@/stores/commandStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
+import { validationError } from '@/utils/__tests__/nodeErrorHelpers'
+
 import ErrorNodeCard from './ErrorNodeCard.vue'
 import type { ErrorCardData } from './types'
-import { resolveRunErrorMessage } from '@/platform/errorCatalog/errorMessageResolver'
-import { createNodeExecutionId } from '@/types/nodeIdentification'
-import { toNodeId } from '@/types/nodeId'
-import { validationError } from '@/utils/__tests__/nodeErrorHelpers'
 
 const mockGetLogs = vi.fn(() => Promise.resolve('mock server logs'))
 const mockSerialize = vi.fn(() => ({ nodes: [] }))
@@ -44,13 +48,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   }))
 }))
 
-const mockExecuteCommand = vi.fn()
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => ({
-    execute: mockExecuteCommand
-  }))
-}))
-
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   useExternalLink: vi.fn(() => ({
     staticUrls: {
@@ -66,6 +63,30 @@ describe('ErrorNodeCard.vue', () => {
     cardIdCounter = 0
     mockGetLogs.mockResolvedValue('mock server logs')
     mockGenerateErrorReport.mockReturnValue('# ComfyUI Error Report\n...')
+    vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+    useSystemStatsStore().systemStats = {
+      system: {
+        os: 'Linux',
+        python_version: '3.11.0',
+        embedded_python: false,
+        comfyui_version: '1.0.0',
+        pytorch_version: '2.1.0',
+        ram_total: 32000,
+        ram_free: 16000,
+        argv: ['--listen']
+      },
+      devices: [
+        {
+          name: 'NVIDIA RTX 4090',
+          type: 'cuda',
+          index: 0,
+          vram_total: 24000,
+          vram_free: 12000,
+          torch_vram_total: 24000,
+          torch_vram_free: 12000
+        }
+      ]
+    }
 
     i18n = createI18n({
       legacy: false,
@@ -95,47 +116,14 @@ describe('ErrorNodeCard.vue', () => {
     })
   })
 
-  function renderCard(
-    card: ErrorCardData,
-    options: { initialState?: Record<string, unknown> } = {}
-  ) {
+  function renderCard(card: ErrorCardData) {
     const user = userEvent.setup()
     const onCopyToClipboard = vi.fn()
     const onLocateNode = vi.fn()
     const { container } = render(ErrorNodeCard, {
       props: { card, onCopyToClipboard, onLocateNode },
       global: {
-        plugins: [
-          PrimeVue,
-          i18n,
-          createTestingPinia({
-            createSpy: vi.fn,
-            initialState: options.initialState ?? {
-              systemStats: {
-                systemStats: {
-                  system: {
-                    os: 'Linux',
-                    python_version: '3.11.0',
-                    embedded_python: false,
-                    comfyui_version: '1.0.0',
-                    pytorch_version: '2.1.0',
-                    argv: ['--listen']
-                  },
-                  devices: [
-                    {
-                      name: 'NVIDIA RTX 4090',
-                      type: 'cuda',
-                      vram_total: 24000,
-                      vram_free: 12000,
-                      torch_vram_total: 24000,
-                      torch_vram_free: 12000
-                    }
-                  ]
-                }
-              }
-            }
-          })
-        ],
+        plugins: [PrimeVue, i18n, getActivePinia()!],
         stubs: {
           TransitionCollapse: { template: '<div><slot /></div>' },
           Button: {
@@ -413,7 +401,9 @@ describe('ErrorNodeCard.vue', () => {
 
     await user.click(screen.getByRole('button', { name: /Get Help/ }))
 
-    expect(mockExecuteCommand).toHaveBeenCalledWith('Comfy.ContactSupport')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.ContactSupport'
+    )
     expect(mockTrackHelpResourceClicked).toHaveBeenCalledWith(
       expect.objectContaining({
         resource_type: 'help_feedback',
@@ -463,11 +453,8 @@ describe('ErrorNodeCard.vue', () => {
   })
 
   it('falls back to original details when systemStats is unavailable', async () => {
-    renderCard(makeRuntimeErrorCard(), {
-      initialState: {
-        systemStats: { systemStats: null }
-      }
-    })
+    useSystemStatsStore().systemStats = null
+    renderCard(makeRuntimeErrorCard())
 
     expect(screen.getByText(/Traceback line 1/)).toBeInTheDocument()
 

--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -1,10 +1,15 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { MissingPackGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
+import { api } from '@/scripts/api'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+
+import MissingNodeCard from './MissingNodeCard.vue'
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
 vi.mock(import('@/platform/distribution/types'), () => ({
@@ -15,9 +20,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 
 const mockMissingCoreNodes = vi.hoisted(() => ({
   value: {} as Record<string, { type: string }[]>
-}))
-const mockSystemStats = vi.hoisted(() => ({
-  value: null as { system?: { comfyui_version?: string } } | null
 }))
 
 vi.mock<unknown>(
@@ -34,14 +36,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: () => ({
-    get systemStats() {
-      return mockSystemStats.value
-    }
-  })
-}))
-
 const mockApplyChanges = vi.hoisted(() => vi.fn())
 const mockIsRestarting = vi.hoisted(() => ({ value: false }))
 vi.mock<unknown>(
@@ -57,24 +51,14 @@ vi.mock<unknown>(
   })
 )
 
-const mockIsPackInstalled = vi.hoisted(() => vi.fn(() => false))
-vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: () => ({
-      isPackInstalled: mockIsPackInstalled
-    })
-  })
-)
-
 const mockShouldShowManagerButtons = vi.hoisted(() => ({ value: false }))
 vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useManagerState'),
 
   () => ({
     useManagerState: () => ({
-      shouldShowManagerButtons: mockShouldShowManagerButtons
+      shouldShowManagerButtons: mockShouldShowManagerButtons,
+      isNewManagerUI: { value: false }
     })
   })
 )
@@ -92,8 +76,6 @@ vi.mock<unknown>(import('./MissingPackGroupRow.vue'), () => ({
     emits: ['locate-node', 'open-manager-info']
   }
 }))
-
-import MissingNodeCard from './MissingNodeCard.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -145,7 +127,7 @@ function renderCard(
       ...props
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      plugins: [i18n],
       stubs: {
         DotSpinner: { template: '<span role="status" aria-label="loading" />' }
       }
@@ -155,13 +137,18 @@ function renderCard(
 }
 
 describe('MissingNodeCard', () => {
-  beforeEach(() => {
-    mockIsPackInstalled.mockReturnValue(false)
+  beforeEach(async () => {
+    vi.spyOn(api, 'getSystemStats').mockResolvedValue(
+      fromPartial({ system: {}, devices: [] })
+    )
+    useSystemStatsStore()
+    await useSystemStatsStore().refetchSystemStats()
+    vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
     mockIsCloud.value = false
     mockShouldShowManagerButtons.value = false
     mockIsRestarting.value = false
     mockMissingCoreNodes.value = {}
-    mockSystemStats.value = null
+    useSystemStatsStore().systemStats = null
   })
 
   describe('Rendering & Props', () => {
@@ -216,21 +203,21 @@ describe('MissingNodeCard', () => {
 
     it('hides Apply Changes when manager enabled but no packs pending', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       renderCard()
       expect(screen.queryByText('Apply Changes')).not.toBeInTheDocument()
     })
 
     it('shows Apply Changes when at least one pack is pending restart', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       renderCard()
       expect(screen.getByText('Apply Changes')).toBeInTheDocument()
     })
 
     it('displays spinner during restart', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       mockIsRestarting.value = true
       renderCard()
       expect(screen.getByRole('status')).toBeInTheDocument()
@@ -238,7 +225,7 @@ describe('MissingNodeCard', () => {
 
     it('disables button during restart', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       mockIsRestarting.value = true
       renderCard()
       expect(
@@ -248,7 +235,7 @@ describe('MissingNodeCard', () => {
 
     it('calls applyChanges when Apply Changes button is clicked', async () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       const { user } = renderCard()
       await user.click(screen.getByRole('button', { name: /apply changes/i }))
       expect(mockApplyChanges).toHaveBeenCalledOnce()
@@ -266,7 +253,7 @@ describe('MissingNodeCard', () => {
           onLocateNode
         },
         global: {
-          plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+          plugins: [i18n],
           stubs: {
             DotSpinner: {
               template: '<span role="status" aria-label="loading" />'
@@ -288,7 +275,7 @@ describe('MissingNodeCard', () => {
           onOpenManagerInfo
         },
         global: {
-          plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+          plugins: [i18n],
           stubs: {
             DotSpinner: {
               template: '<span role="status" aria-label="loading" />'
@@ -311,7 +298,9 @@ describe('MissingNodeCard', () => {
       mockMissingCoreNodes.value = {
         '1.2.0': [{ type: 'TestNode' }]
       }
-      mockSystemStats.value = { system: { comfyui_version: '1.0.0' } }
+      useSystemStatsStore().$patch({
+        systemStats: { system: { comfyui_version: '1.0.0' } }
+      })
       const { container } = renderCard()
       expect(container.textContent).toContain('(current: 1.0.0)')
       expect(container.textContent).toContain('Requires ComfyUI 1.2.0:')

--- a/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
+++ b/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
@@ -1,16 +1,18 @@
-import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { MissingPackGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
+import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
+
+import MissingPackGroupRow from './MissingPackGroupRow.vue'
 
 const mockInstallAllPacks = vi.fn()
 const mockIsInstalling = ref(false)
-const mockIsPackInstalled = vi.fn(() => false)
+
 const mockShouldShowManagerButtons = { value: false }
 const mockOpenManager = vi.fn()
 const mockMissingNodePacks = ref<Array<{ id: string; name: string }>>([])
@@ -39,20 +41,11 @@ vi.mock<unknown>(
 )
 
 vi.mock<unknown>(
-  import('@/workbench/extensions/manager/stores/comfyManagerStore'),
-
-  () => ({
-    useComfyManagerStore: () => ({
-      isPackInstalled: mockIsPackInstalled
-    })
-  })
-)
-
-vi.mock<unknown>(
   import('@/workbench/extensions/manager/composables/useManagerState'),
 
   () => ({
     useManagerState: () => ({
+      isNewManagerUI: { value: false },
       shouldShowManagerButtons: mockShouldShowManagerButtons,
       openManager: mockOpenManager
     })
@@ -66,8 +59,6 @@ vi.mock<unknown>(
     ManagerTab: { Missing: 'missing', All: 'all' }
   })
 )
-
-import MissingPackGroupRow from './MissingPackGroupRow.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -128,7 +119,7 @@ function renderRow(
       ...props
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue, i18n],
+      plugins: [PrimeVue, i18n],
       stubs: {
         DotSpinner: {
           template: '<span role="status" aria-label="loading" />'
@@ -141,7 +132,7 @@ function renderRow(
 
 describe('MissingPackGroupRow', () => {
   beforeEach(() => {
-    mockIsPackInstalled.mockReturnValue(false)
+    vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
     mockShouldShowManagerButtons.value = false
     mockIsInstalling.value = false
     mockMissingNodePacks.value = []
@@ -355,7 +346,7 @@ describe('MissingPackGroupRow', () => {
 
     it('shows Search when packId exists but pack not in registry', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       mockMissingNodePacks.value = []
       renderRow()
       expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument()
@@ -363,7 +354,7 @@ describe('MissingPackGroupRow', () => {
 
     it('shows "Installed" state when pack is installed', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(true)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(true)
       mockMissingNodePacks.value = [{ id: 'my-pack', name: 'My Pack' }]
       renderRow()
       expect(screen.getByText('Installed')).toBeInTheDocument()
@@ -379,7 +370,7 @@ describe('MissingPackGroupRow', () => {
 
     it('shows install button when not installed and pack found', () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       mockMissingNodePacks.value = [{ id: 'my-pack', name: 'My Pack' }]
       renderRow()
       expect(
@@ -389,7 +380,7 @@ describe('MissingPackGroupRow', () => {
 
     it('calls installAllPacks when Install button is clicked', async () => {
       mockShouldShowManagerButtons.value = true
-      mockIsPackInstalled.mockReturnValue(false)
+      vi.mocked(useComfyManagerStore().isPackInstalled).mockReturnValue(false)
       mockMissingNodePacks.value = [{ id: 'my-pack', name: 'My Pack' }]
       const { user } = renderRow()
       await user.click(screen.getByRole('button', { name: 'Install' }))

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -1,7 +1,7 @@
-import { createTestingPinia } from '@pinia/testing'
-import type { TestingPinia } from '@pinia/testing'
-import { render, screen, within } from '@testing-library/vue'
+import { getActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
+import { render, screen, within } from '@testing-library/vue'
 import { fromAny } from '@total-typescript/shoehorn'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,20 +9,31 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import RightSidePanel from '@/components/rightSidePanel/RightSidePanel.vue'
-import { useSettingStore } from '@/platform/settings/settingStore'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
-import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { MissingNodeType } from '@/types/comfy'
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toNodeId } from '@/types/nodeId'
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
 
 import TabErrors from './TabErrors.vue'
+vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useComfyRegistryService: () => ({
+      ...actual.useComfyRegistryService(),
+      inferPackFromNodeName: vi.fn(async () => null),
+      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+    })
+  }
+})
 
 const { mockFocusNode, mockRefreshMissingModels } = vi.hoisted(() => ({
   mockFocusNode: vi.fn(),
@@ -62,17 +73,6 @@ vi.mock<unknown>(import('@/composables/canvas/useFocusNode'), () => ({
   useFocusNode: vi.fn(() => ({
     focusNode: mockFocusNode
   }))
-}))
-
-// Its pack lookup resolves after the test file ends, and the console.warn on a
-// rejection lands while the worker's rpc is closing - an unhandled error that
-// fails the whole run with every test green. Mocked as the sibling suites do.
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: () => ({
-    inferPackFromNodeName: vi.fn(),
-    // TabErrors mounts the node-pack tree, which cancels this on unmount.
-    getPacksByIds: { call: vi.fn().mockResolvedValue([]), cancel: vi.fn() }
-  })
 }))
 
 vi.mock(import('@/platform/missingModel/missingModelDownload'), () => ({
@@ -150,12 +150,9 @@ describe('TabErrors.vue', () => {
     })
   })
 
-  function renderComponent(seed?: (pinia: TestingPinia) => void) {
+  function renderComponent(seed?: (pinia: Pinia) => void) {
     const user = userEvent.setup()
-    const pinia = createTestingPinia({
-      createSpy: vi.fn,
-      stubActions: false
-    })
+    const pinia = getActivePinia()!
     seed?.(pinia)
     render(TabErrors, {
       global: {
@@ -174,11 +171,8 @@ describe('TabErrors.vue', () => {
     return { user }
   }
 
-  function renderRightSidePanel(seed: (pinia: TestingPinia) => void) {
-    const pinia = createTestingPinia({
-      createSpy: vi.fn,
-      stubActions: false
-    })
+  function renderRightSidePanel(seed: (pinia: Pinia) => void) {
+    const pinia = getActivePinia()!
     useSettingStore(pinia).settingValues['Comfy.RightSidePanel.ShowErrorsTab'] =
       true
     seed(pinia)

--- a/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
+++ b/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
@@ -1,8 +1,22 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { nextTick, ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import type { MissingNodeType } from '@/types/comfy'
+
+import { useErrorGroups } from './useErrorGroups'
+vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useComfyRegistryService: () => ({
+      ...actual.useComfyRegistryService(),
+      inferPackFromNodeName: vi.fn(async () => null),
+      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+    })
+  }
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -31,12 +45,6 @@ vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: () => ({
-    inferPackFromNodeName: vi.fn()
-  })
-}))
-
 vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: vi.fn(() => '')
 }))
@@ -44,9 +52,6 @@ vi.mock(import('@/utils/nodeTitleUtil'), () => ({
 vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   isLGraphNode: vi.fn(() => false)
 }))
-
-import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
-import { useErrorGroups } from './useErrorGroups'
 
 function makeMissingNodeType(
   type: string,

--- a/src/components/rightSidePanel/errors/useErrorActions.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorActions.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useCommandStore } from '@/stores/commandStore'
+
 import { useErrorActions } from './useErrorActions'
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
 
 const mocks = vi.hoisted(() => ({
   trackUiButtonClicked: vi.fn(),
   trackHelpResourceClicked: vi.fn(),
-  execute: vi.fn(),
   telemetry: null as {
     trackUiButtonClicked: ReturnType<typeof vi.fn>
     trackHelpResourceClicked: ReturnType<typeof vi.fn>
@@ -13,12 +18,6 @@ const mocks = vi.hoisted(() => ({
   staticUrls: {
     githubIssues: 'https://github.com/Comfy-Org/ComfyUI/issues'
   }
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: mocks.execute
-  })
 }))
 
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
@@ -79,26 +78,37 @@ describe('useErrorActions', () => {
   })
 
   describe('contactSupport', () => {
-    it('tracks the help resource click and executes the contact support command', () => {
-      mocks.execute.mockReturnValue('executed')
+    it('tracks the help resource click and executes the contact support command', async () => {
+      vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
       const { contactSupport } = useErrorActions()
 
-      const result = contactSupport()
+      const result = await contactSupport()
 
       expect(mocks.trackHelpResourceClicked).toHaveBeenCalledWith({
         resource_type: 'help_feedback',
         is_external: true,
         source: 'error_dialog'
       })
-      expect(mocks.execute).toHaveBeenCalledWith('Comfy.ContactSupport')
-      expect(result).toBe('executed')
+      expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+        'Comfy.ContactSupport'
+      )
+      expect(result).toBeUndefined()
     })
 
     it('returns the execute promise when the command is async', async () => {
-      mocks.execute.mockResolvedValue('done')
+      let resolve!: () => void
+      const promise = new Promise<void>((resolvePromise) => {
+        resolve = resolvePromise
+      })
+      vi.mocked(useCommandStore().execute).mockReturnValue(promise)
       const { contactSupport } = useErrorActions()
-
-      await expect(contactSupport()).resolves.toBe('done')
+      const settled = vi.fn()
+      const result = contactSupport().then(settled)
+      await Promise.resolve()
+      expect(settled).not.toHaveBeenCalled()
+      resolve()
+      await result
+      expect(settled).toHaveBeenCalledExactlyOnceWith(undefined)
     })
 
     it('still executes the command when telemetry is unavailable', () => {
@@ -108,7 +118,9 @@ describe('useErrorActions', () => {
       void contactSupport()
 
       expect(mocks.trackHelpResourceClicked).not.toHaveBeenCalled()
-      expect(mocks.execute).toHaveBeenCalledWith('Comfy.ContactSupport')
+      expect(vi.mocked(useCommandStore().execute)).toHaveBeenCalledWith(
+        'Comfy.ContactSupport'
+      )
     })
   })
 

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -1,10 +1,37 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
+import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { createBoundaryLinkedSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { MissingNodeType } from '@/types/comfy'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
 import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
+import {
+  getExecutionIdByNode,
+  getNodeByExecutionId
+} from '@/utils/graphTraversalUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
+
+import { useErrorGroups } from './useErrorGroups'
+
+vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useComfyRegistryService: () => ({
+      ...actual.useComfyRegistryService(),
+      inferPackFromNodeName: vi.fn(async () => null),
+      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+    })
+  }
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -109,12 +136,6 @@ vi.mock<unknown>(import('@/i18n'), () => {
   }
 })
 
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: () => ({
-    inferPackFromNodeName: vi.fn()
-  })
-}))
-
 vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: vi.fn(() => '')
 }))
@@ -129,21 +150,6 @@ vi.mock<unknown>(
     clearMissingModelState: vi.fn()
   })
 )
-
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
-import { isLGraphNode } from '@/utils/litegraphUtil'
-import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
-import { createBoundaryLinkedSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
-import {
-  getExecutionIdByNode,
-  getNodeByExecutionId
-} from '@/utils/graphTraversalUtil'
-import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { useErrorGroups } from './useErrorGroups'
-import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 
 function makeMissingNodeType(
   type: string,

--- a/src/components/rightSidePanel/errors/useErrorReport.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorReport.test.ts
@@ -1,3 +1,4 @@
+import { until } from '@vueuse/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -70,7 +71,7 @@ describe('useErrorReport', () => {
 
   beforeEach(async () => {
     const store = useSystemStatsStore()
-    await flushPromises()
+    await until(() => store.isInitialized).toBe(true)
     store.systemStats = null
     store.isLoading = false
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/components/rightSidePanel/errors/useErrorReport.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorReport.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
-import type { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
 
 import type { ErrorCardData } from './types'
-import { createNodeExecutionId } from '@/types/nodeIdentification'
 import { useErrorReport } from './useErrorReport'
-import { toNodeId } from '@/types/nodeId'
 
 async function flushPromises() {
   await new Promise((resolve) => setTimeout(resolve, 0))
@@ -18,22 +18,14 @@ const mocks = vi.hoisted(() => {
   return {
     getLogs: vi.fn(),
     serialize: vi.fn(),
-    refetchSystemStats: vi.fn(),
     generateErrorReport: vi.fn()
-  }
-})
-
-const storeState = vi.hoisted(() => {
-  // Plain objects wired up in beforeEach. Tests use setStoreState to swap values.
-  return {
-    systemStats: null,
-    isLoading: false
   }
 })
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
-    getLogs: mocks.getLogs
+    getLogs: mocks.getLogs,
+    getSystemStats: vi.fn(async () => sampleSystemStats)
   }
 }))
 
@@ -49,46 +41,6 @@ vi.mock(import('@/utils/errorReportUtil'), () => ({
   generateErrorReport: mocks.generateErrorReport
 }))
 
-vi.mock<unknown>(import('@/stores/systemStatsStore'), async () => {
-  const { ref: vueRef } = await import('vue')
-  const systemStatsRef = vueRef<unknown>(null)
-  const isLoadingRef = vueRef(false)
-
-  return {
-    useSystemStatsStore: () => ({
-      get systemStats() {
-        return systemStatsRef.value
-      },
-      set systemStats(value: unknown) {
-        systemStatsRef.value = value
-      },
-      get isLoading() {
-        return isLoadingRef.value
-      },
-      set isLoading(value: boolean) {
-        isLoadingRef.value = value
-      },
-      refetchSystemStats: mocks.refetchSystemStats,
-      __setSystemStats(value: unknown) {
-        systemStatsRef.value = value
-      },
-      __setIsLoading(value: boolean) {
-        isLoadingRef.value = value
-      }
-    })
-  }
-})
-
-type TestStore = ReturnType<typeof useSystemStatsStore> & {
-  __setSystemStats: (value: unknown) => void
-  __setIsLoading: (value: boolean) => void
-}
-
-async function getStore(): Promise<TestStore> {
-  const mod = await import('@/stores/systemStatsStore')
-  return mod.useSystemStatsStore() as unknown as TestStore
-}
-
 const sampleSystemStats = {
   system: {
     os: 'Linux',
@@ -96,7 +48,9 @@ const sampleSystemStats = {
     argv: [],
     python_version: '3.11',
     embedded_python: false,
-    pytorch_version: '2.3.0'
+    pytorch_version: '2.3.0',
+    ram_total: 16000000000,
+    ram_free: 8000000000
   },
   devices: []
 }
@@ -115,11 +69,10 @@ describe('useErrorReport', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(async () => {
-    storeState.systemStats = null
-    storeState.isLoading = false
-    const store = await getStore()
-    store.__setSystemStats(null)
-    store.__setIsLoading(false)
+    const store = useSystemStatsStore()
+    await flushPromises()
+    store.systemStats = null
+    store.isLoading = false
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -141,8 +94,8 @@ describe('useErrorReport', () => {
   })
 
   it('enriches each runtime error with a generated report when systemStats is present', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('server logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(
@@ -202,8 +155,8 @@ describe('useErrorReport', () => {
   })
 
   it('awaits the systemStats loading flag before proceeding', async () => {
-    const store = await getStore()
-    store.__setIsLoading(true)
+    const store = useSystemStatsStore()
+    store.isLoading = true
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockReturnValue('report')
@@ -218,8 +171,8 @@ describe('useErrorReport', () => {
     expect(mocks.getLogs).not.toHaveBeenCalled()
     expect(displayedDetailsMap.value).toEqual({ 0: 'trace' })
 
-    store.__setSystemStats(sampleSystemStats)
-    store.__setIsLoading(false)
+    store.systemStats = sampleSystemStats
+    store.isLoading = false
     await flushPromises()
 
     expect(mocks.getLogs).toHaveBeenCalledTimes(1)
@@ -227,10 +180,13 @@ describe('useErrorReport', () => {
   })
 
   it('calls refetchSystemStats when not loading and stats are missing', async () => {
-    const store = await getStore()
-    mocks.refetchSystemStats.mockImplementation(async () => {
-      store.__setSystemStats(sampleSystemStats)
-    })
+    const store = useSystemStatsStore()
+    vi.mocked(useSystemStatsStore().refetchSystemStats).mockImplementation(
+      async () => {
+        store.systemStats = sampleSystemStats
+        return sampleSystemStats
+      }
+    )
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockReturnValue('report')
@@ -242,12 +198,16 @@ describe('useErrorReport', () => {
     useErrorReport(card)
     await flushPromises()
 
-    expect(mocks.refetchSystemStats).toHaveBeenCalledTimes(1)
+    expect(
+      vi.mocked(useSystemStatsStore().refetchSystemStats)
+    ).toHaveBeenCalledTimes(1)
     expect(mocks.generateErrorReport).toHaveBeenCalledTimes(1)
   })
 
   it('returns early and warns when refetchSystemStats throws', async () => {
-    mocks.refetchSystemStats.mockRejectedValue(new Error('boom'))
+    vi.mocked(useSystemStatsStore().refetchSystemStats).mockRejectedValue(
+      new Error('boom')
+    )
     mocks.getLogs.mockResolvedValue('logs')
 
     const card = makeCard({
@@ -257,15 +217,17 @@ describe('useErrorReport', () => {
     useErrorReport(card)
     await flushPromises()
 
-    expect(mocks.refetchSystemStats).toHaveBeenCalledTimes(1)
+    expect(
+      vi.mocked(useSystemStatsStore().refetchSystemStats)
+    ).toHaveBeenCalledTimes(1)
     expect(mocks.getLogs).not.toHaveBeenCalled()
     expect(mocks.generateErrorReport).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalled()
   })
 
   it('returns early and warns when workflow serialization throws', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockImplementation(() => {
       throw new Error('serialize failed')
@@ -284,8 +246,8 @@ describe('useErrorReport', () => {
   })
 
   it('falls back to original error.details when generateErrorReport throws', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(() => {
@@ -306,8 +268,8 @@ describe('useErrorReport', () => {
   })
 
   it('re-enriches and clears stale enriched details when the card ref changes', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.getLogs.mockResolvedValue('logs')
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(
@@ -340,8 +302,8 @@ describe('useErrorReport', () => {
   })
 
   it('drops stale results when the card changes mid-flight', async () => {
-    const store = await getStore()
-    store.__setSystemStats(sampleSystemStats)
+    const store = useSystemStatsStore()
+    store.systemStats = sampleSystemStats
     mocks.serialize.mockReturnValue({ nodes: [] })
     mocks.generateErrorReport.mockImplementation(
       ({ exceptionMessage }: { exceptionMessage: string }) =>

--- a/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -13,41 +14,22 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { toNodeId } from '@/types/nodeId'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
 import { getExecutionIdByNode } from '@/utils/graphTraversalUtil'
 
 import SectionWidgets from './SectionWidgets.vue'
 
-const { mockGetInputSpecForWidget, mockTrackUiButtonClicked } = vi.hoisted(
-  () => ({
-    mockGetInputSpecForWidget: vi.fn(),
-    mockTrackUiButtonClicked: vi.fn()
-  })
-)
+const { mockTrackUiButtonClicked } = vi.hoisted(() => ({
+  mockTrackUiButtonClicked: vi.fn()
+}))
 
 const setDirty = vi.fn()
 const getNodeById = vi.fn()
 const animateToBounds = vi.fn()
-const selectedItems: unknown[] = []
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { setDirty, graph: { getNodeById }, animateToBounds },
-      selectedItems
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    getInputSpecForWidget: mockGetInputSpecForWidget
-  })
-}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -139,7 +121,11 @@ function createHostWithPromotedModel(): {
 
 describe('SectionWidgets', () => {
   beforeEach(() => {
-    selectedItems.length = 0
+    useCanvasStore().canvas = fromPartial({
+      setDirty,
+      graph: fromPartial({ getNodeById }),
+      animateToBounds
+    })
   })
 
   it('clears promoted widget validation by source and missing model by host', async () => {
@@ -262,7 +248,8 @@ describe('SectionWidgets', () => {
 
   it('tracks and resets all widgets when the Reset all button is clicked', async () => {
     const { node, widget } = createSimpleNodeWithWidget()
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: widget.name,
       type: 'COMBO',
       default: 'default_model.safetensors'
     })

--- a/src/components/rightSidePanel/parameters/TabGlobalParameters.test.ts
+++ b/src/components/rightSidePanel/parameters/TabGlobalParameters.test.ts
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import TabGlobalParameters from './TabGlobalParameters.vue'
@@ -27,10 +25,6 @@ function renderTab() {
 }
 
 describe('TabGlobalParameters', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('renders the shared search header', () => {
     renderTab()
 

--- a/src/components/rightSidePanel/parameters/TabNodes.test.ts
+++ b/src/components/rightSidePanel/parameters/TabNodes.test.ts
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import TabNodes from './TabNodes.vue'
@@ -35,10 +33,6 @@ function renderTab() {
 }
 
 describe('TabNodes', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('composes the shared search header with the collapse toggle in its slot', () => {
     renderTab()
 

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.test.ts
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.test.ts
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import TabNormalInputs from './TabNormalInputs.vue'
@@ -36,10 +34,6 @@ function renderTab() {
 }
 
 describe('TabNormalInputs', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('composes the shared search header with the collapse toggle in its slot', () => {
     renderTab()
 

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -1,58 +1,29 @@
-import { render, screen } from '@testing-library/vue'
-import { createTestingPinia } from '@pinia/testing'
 import userEvent from '@testing-library/user-event'
-import { fromAny } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial, fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Slots } from 'vue'
 import { h } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { promoteWidget } from '@/core/graph/subgraph/promotionUtils'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { useFavoritedWidgetsStore } from '@/stores/workspace/favoritedWidgetsStore'
 import { widgetId } from '@/types/widgetId'
+
 import WidgetActions from './WidgetActions.vue'
 
-const {
-  mockGetInputSpecForWidget,
-  mockIsFavorited,
-  mockToggleFavorite,
-  mockTrackWidgetFavoriteToggled
-} = vi.hoisted(() => ({
-  mockGetInputSpecForWidget: vi.fn(),
-  mockIsFavorited: vi.fn().mockReturnValue(false),
-  mockToggleFavorite: vi.fn(),
+const { mockTrackWidgetFavoriteToggled } = vi.hoisted(() => ({
   mockTrackWidgetFavoriteToggled: vi.fn()
 }))
 
 vi.mock(import('@/core/graph/subgraph/promotionUtils'), () => ({
   promoteWidget: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    getInputSpecForWidget: mockGetInputSpecForWidget
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { setDirty: vi.fn() }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/favoritedWidgetsStore'), () => ({
-  useFavoritedWidgetsStore: () => ({
-    isFavorited: mockIsFavorited,
-    toggleFavorite: mockToggleFavorite
-  })
 }))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -93,9 +64,13 @@ const i18n = createI18n({
 
 describe('WidgetActions', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    mockIsFavorited.mockReturnValue(false)
-    mockGetInputSpecForWidget.mockReturnValue({
+    useCanvasStore().canvas = fromPartial({ setDirty: vi.fn() })
+    vi.mocked(useFavoritedWidgetsStore().toggleFavorite).mockImplementation(
+      () => {}
+    )
+    vi.mocked(useFavoritedWidgetsStore().isFavorited).mockReturnValue(false)
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'INT',
       default: 42
     })
@@ -195,7 +170,8 @@ describe('WidgetActions', () => {
   })
 
   it('does not show reset button when no default value exists', () => {
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'CUSTOM'
     })
 
@@ -210,7 +186,8 @@ describe('WidgetActions', () => {
   })
 
   it('uses fallback default for INT type without explicit default', async () => {
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'INT'
     })
 
@@ -225,7 +202,8 @@ describe('WidgetActions', () => {
   })
 
   it('uses first option as default for combo without explicit default', async () => {
-    mockGetInputSpecForWidget.mockReturnValue({
+    vi.mocked(useNodeDefStore().getInputSpecForWidget).mockReturnValue({
+      name: 'test_widget',
       type: 'COMBO',
       options: ['option1', 'option2', 'option3']
     })
@@ -241,7 +219,7 @@ describe('WidgetActions', () => {
   })
 
   it('tracks widget favorite toggled with is_favorited true when favoriting', async () => {
-    mockIsFavorited.mockReturnValue(false)
+    vi.mocked(useFavoritedWidgetsStore().isFavorited).mockReturnValue(false)
 
     const widget = createMockWidget()
     const node = createMockNode()
@@ -257,14 +235,13 @@ describe('WidgetActions', () => {
       is_favorited: true,
       source: 'right_side_panel'
     })
-    expect(mockToggleFavorite).toHaveBeenCalledExactlyOnceWith(
-      node,
-      'test_widget'
-    )
+    expect(
+      vi.mocked(useFavoritedWidgetsStore().toggleFavorite)
+    ).toHaveBeenCalledExactlyOnceWith(node, 'test_widget')
   })
 
   it('tracks widget favorite toggled with is_favorited false when unfavoriting', async () => {
-    mockIsFavorited.mockReturnValue(true)
+    vi.mocked(useFavoritedWidgetsStore().isFavorited).mockReturnValue(true)
 
     const widget = createMockWidget()
     const node = createMockNode()
@@ -332,6 +309,8 @@ describe('WidgetActions', () => {
 
     await user.click(screen.getByRole('button', { name: /Favorite/ }))
 
-    expect(mockToggleFavorite).toHaveBeenCalledWith(node, 'test_widget')
+    expect(
+      vi.mocked(useFavoritedWidgetsStore().toggleFavorite)
+    ).toHaveBeenCalledWith(node, 'test_widget')
   })
 })

--- a/src/components/rightSidePanel/parameters/WidgetItem.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetItem.test.ts
@@ -1,51 +1,33 @@
 import { render } from '@testing-library/vue'
-import { fromAny } from '@total-typescript/shoehorn'
+import { fromPartial, fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLinkStore } from '@/stores/linkStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
-import { widgetId } from '@/types/widgetId'
-import WidgetItem from './WidgetItem.vue'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 
-const { mockGetInputSpecForWidget, StubWidgetComponent } = vi.hoisted(() => ({
-  mockGetInputSpecForWidget: vi.fn(),
+import WidgetItem from './WidgetItem.vue'
+
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({ setDirty: vi.fn() })
+})
+
+const { StubWidgetComponent } = vi.hoisted(() => ({
   StubWidgetComponent: {
     name: 'StubWidget',
     props: ['widget', 'modelValue', 'nodeId', 'nodeType'],
     template:
       '<div class="stub-widget" :data-widget-options="JSON.stringify(widget?.options)" :data-widget-type="widget?.type" :data-widget-name="widget?.name" :data-widget-value="String(widget?.value)" />'
   }
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    getInputSpecForWidget: mockGetInputSpecForWidget
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: { setDirty: vi.fn() }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/favoritedWidgetsStore'), () => ({
-  useFavoritedWidgetsStore: () => ({
-    isFavorited: vi.fn().mockReturnValue(false),
-    toggleFavorite: vi.fn()
-  })
 }))
 
 vi.mock(

--- a/src/components/rightSidePanel/shared.test.ts
+++ b/src/components/rightSidePanel/shared.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
 import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { Positionable } from '@/lib/litegraph/src/interfaces'
@@ -139,10 +137,6 @@ describe('searchWidgetsAndNodes', () => {
 })
 
 describe('computedSectionDataList', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function createWidget(
     name: string,
     options: IWidgetOptions = {}

--- a/src/components/searchbox/NodeSearchBoxPopover.test.ts
+++ b/src/components/searchbox/NodeSearchBoxPopover.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -6,8 +6,10 @@ import { computed, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { CORE_SETTINGS } from '@/platform/settings/constants/coreSettings'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { Settings } from '@/schemas/apiSchema'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import type { FuseFilter, FuseFilterWithValue } from '@/utils/fuseUtil'
 
 import NodeSearchBoxPopover from './NodeSearchBoxPopover.vue'
@@ -80,16 +82,11 @@ describe('NodeSearchBoxPopover', () => {
       template: '<div data-testid="search-content-v2"></div>'
     })
 
-    const pinia = createTestingPinia({
-      stubActions: false,
-      initialState: {
-        setting: {
-          settingValues: settings,
-          settingsById: coreSettingsById
-        },
-        searchBox: { visible: false }
-      }
-    })
+    const pinia = getActivePinia()!
+    const settingStore = useSettingStore()
+    settingStore.settingValues = settings
+    settingStore.settingsById = coreSettingsById
+    useSearchBoxStore().visible = false
 
     const result = render(NodeSearchBoxPopover, {
       global: {

--- a/src/components/searchbox/v2/NodeSearchCategorySidebar.test.ts
+++ b/src/components/searchbox/v2/NodeSearchCategorySidebar.test.ts
@@ -1,11 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import NodeSearchCategorySidebar from '@/components/searchbox/v2/NodeSearchCategorySidebar.vue'
 import {
   createMockNodeDef,
-  setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
@@ -18,10 +17,6 @@ type SidebarProps = Partial<{
 }>
 
 describe('NodeSearchCategorySidebar', () => {
-  beforeEach(() => {
-    setupTestPinia()
-  })
-
   function createRender(props: SidebarProps = {}) {
     const user = userEvent.setup()
     const onUpdateSelectedCategory = vi.fn<(value: string) => void>()

--- a/src/components/searchbox/v2/NodeSearchContent.test.ts
+++ b/src/components/searchbox/v2/NodeSearchContent.test.ts
@@ -6,7 +6,6 @@ import NodeSearchContent from '@/components/searchbox/v2/NodeSearchContent.vue'
 import {
   createMockNodeDef,
   setViewport,
-  setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
 
@@ -23,7 +22,6 @@ const MOBILE_VIEWPORT = { width: 360, height: 800 }
 describe('NodeSearchContent', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    setupTestPinia()
     setViewport(DESKTOP_VIEWPORT)
     const settings = useSettingStore()
     settings.settingValues['Comfy.NodeLibrary.Bookmarks.V2'] = []

--- a/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
@@ -6,7 +6,6 @@ import { nextTick } from 'vue'
 import NodeSearchFilterBar from '@/components/searchbox/v2/NodeSearchFilterBar.vue'
 import {
   createMockNodeDef,
-  setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -14,7 +13,6 @@ import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 describe(NodeSearchFilterBar, () => {
   beforeEach(() => {
-    setupTestPinia()
     const settings = useSettingStore()
     settings.settingValues['Comfy.NodeLibrary.Bookmarks.V2'] = []
     settings.settingValues['Comfy.NodeLibrary.BookmarksCustomization'] = {}

--- a/src/components/searchbox/v2/NodeSearchInput.test.ts
+++ b/src/components/searchbox/v2/NodeSearchInput.test.ts
@@ -1,12 +1,9 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
 
+import { testI18n } from '@/components/searchbox/v2/__test__/testUtils'
 import NodeSearchInput from '@/components/searchbox/v2/NodeSearchInput.vue'
-import {
-  setupTestPinia,
-  testI18n
-} from '@/components/searchbox/v2/__test__/testUtils'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type { FuseFilter, FuseFilterWithValue } from '@/utils/fuseUtil'
 
@@ -14,17 +11,6 @@ vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   getLinkTypeColor: vi.fn((type: string) =>
     type === 'IMAGE' ? '#64b5f6' : undefined
   )
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.NodeLibrary.Bookmarks.V2') return []
-      if (key === 'Comfy.NodeLibrary.BookmarksCustomization') return {}
-      return undefined
-    }),
-    set: vi.fn()
-  }))
 }))
 
 function createFilter(
@@ -41,10 +27,6 @@ function createFilter(
 }
 
 describe('NodeSearchInput', () => {
-  beforeEach(() => {
-    setupTestPinia()
-  })
-
   function createRender(
     props: Partial<{
       filters: FuseFilterWithValue<ComfyNodeDefImpl>[]

--- a/src/components/searchbox/v2/NodeSearchListItem.test.ts
+++ b/src/components/searchbox/v2/NodeSearchListItem.test.ts
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
 import NodeSearchListItem from '@/components/searchbox/v2/NodeSearchListItem.vue'
 import {
   createMockNodeDef,
-  setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -29,10 +28,6 @@ function renderItem(
 }
 
 describe('NodeSearchListItem', () => {
-  beforeEach(() => {
-    setupTestPinia()
-  })
-
   it('renders node names as text rather than HTML', () => {
     const displayName = '<img src=x onerror=alert(1)>Node'
     renderItem({

--- a/src/components/searchbox/v2/__test__/testUtils.ts
+++ b/src/components/searchbox/v2/__test__/testUtils.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import type { DetachedWindowAPI } from 'happy-dom'
-import { setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -25,10 +23,6 @@ export function createMockNodeDef(
     experimental: false,
     ...overrides
   })
-}
-
-export function setupTestPinia() {
-  setActivePinia(createTestingPinia({ stubActions: false }))
 }
 
 export const testI18n = createI18n({

--- a/src/components/sidebar/SideToolbar.test.ts
+++ b/src/components/sidebar/SideToolbar.test.ts
@@ -1,76 +1,42 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
-import SideToolbar from './SideToolbar.vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useUserStore } from '@/stores/userStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
+import type { SidebarTabExtension } from '@/types/extensionTypes'
 
-interface TestTab {
-  id: string
-  icon: string
-  tooltip: string
-  label: string
-  title: string
-}
+import SideToolbar from './SideToolbar.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
+
+beforeEach(() => {
+  useSettingStore().$patch({
+    settingValues: {
+      'Comfy.Sidebar.Size': 'normal',
+      'Comfy.Sidebar.Location': 'left'
+    }
+  })
+  useCommandStore().registerCommand({
+    id: 'Workspace.ToggleSidebarTab.assets',
+    function: spies.toggleAssets
+  })
+})
 
 const spies = vi.hoisted(() => ({
   trackUiButtonClicked: vi.fn(),
   toggleAssets: vi.fn()
 }))
 
-const state = vi.hoisted(() => ({
-  isMultiUserServer: false,
-  sidebarTabs: [] as TestTab[],
-  activeSidebarTab: null as { id: string } | null
-}))
-
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false,
   isDesktop: false,
   isNightly: false
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    getSidebarTabs: () => state.sidebarTabs,
-    sidebarTab: { activeSidebarTab: state.activeSidebarTab }
-  })
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => {
-      if (key === 'Comfy.Sidebar.Size') return 'large'
-      if (key === 'Comfy.Sidebar.Location') return 'left'
-      return 'floating'
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/userStore'), () => ({
-  useUserStore: () => ({ isMultiUserServer: state.isMultiUserServer })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    commands: [
-      { id: 'Workspace.ToggleSidebarTab.assets', function: spies.toggleAssets }
-    ]
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({ canvas: null })
-  })
-)
-
-vi.mock<unknown>(import('@/platform/keybindings/keybindingStore'), () => ({
-  useKeybindingStore: () => ({ getKeybindingByCommandId: () => undefined })
 }))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -109,7 +75,9 @@ function renderToolbar(props: SideToolbarProps = {}) {
   })
 }
 
-const assetsTab: TestTab = {
+const assetsTab: SidebarTabExtension = {
+  type: 'custom',
+  render: () => {},
   id: 'assets',
   icon: 'pi pi-image',
   tooltip: 'Assets',
@@ -117,7 +85,9 @@ const assetsTab: TestTab = {
   title: 'Assets'
 }
 
-const workflowsTab: TestTab = {
+const workflowsTab: SidebarTabExtension = {
+  type: 'custom',
+  render: () => {},
   id: 'workflows',
   icon: 'pi pi-folder',
   tooltip: 'Workflows',
@@ -127,9 +97,9 @@ const workflowsTab: TestTab = {
 
 describe('SideToolbar', () => {
   beforeEach(() => {
-    state.isMultiUserServer = false
-    state.sidebarTabs = [assetsTab, workflowsTab]
-    state.activeSidebarTab = null
+    Object.assign(useUserStore(), { isMultiUserServer: false })
+    useSidebarTabStore().sidebarTabs = [assetsTab, workflowsTab]
+    useSidebarTabStore().activeSidebarTabId = null
   })
 
   it('renders only the tabs listed in visibleTabIds', () => {
@@ -190,7 +160,7 @@ describe('SideToolbar', () => {
     expect(screen.queryByTestId('logout')).not.toBeInTheDocument()
     unmount()
 
-    state.isMultiUserServer = true
+    Object.assign(useUserStore(), { isMultiUserServer: true })
     renderToolbar()
     expect(screen.getByTestId('logout')).toBeInTheDocument()
   })

--- a/src/components/sidebar/SidebarHelpCenterIcon.test.ts
+++ b/src/components/sidebar/SidebarHelpCenterIcon.test.ts
@@ -1,9 +1,16 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+
 import SidebarHelpCenterIcon from './SidebarHelpCenterIcon.vue'
+
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+})
 
 const typeformState = vi.hoisted(() => ({
   typeformError: false,
@@ -11,8 +18,6 @@ const typeformState = vi.hoisted(() => ({
 }))
 
 const embedSpy = vi.hoisted(() => vi.fn())
-
-const canvasState = vi.hoisted(() => ({ linearMode: true }))
 
 const helpCenterSpies = vi.hoisted(() => ({ toggleHelpCenter: vi.fn() }))
 
@@ -40,22 +45,6 @@ vi.mock<unknown>(import('@/composables/useHelpCenter'), async () => {
     })
   }
 })
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => 'left' })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  async () => {
-    const { computed, reactive } = await import('vue')
-    return {
-      useCanvasStore: () =>
-        reactive({ linearMode: computed(() => canvasState.linearMode) })
-    }
-  }
-)
 
 const FEEDBACK_LOAD_ERROR =
   'Failed to load feedback form. Please try again later.'
@@ -96,7 +85,7 @@ describe('SidebarHelpCenterIcon', () => {
   beforeEach(() => {
     typeformState.typeformError = false
     typeformState.isValidTypeformId = true
-    canvasState.linearMode = true
+    useCanvasStore().linearMode = true
   })
 
   it('mounts the Typeform embed container wired to the feedback form', () => {
@@ -133,7 +122,7 @@ describe('SidebarHelpCenterIcon', () => {
   })
 
   it('shows the help center button instead of the feedback popover in graph mode', () => {
-    canvasState.linearMode = false
+    useCanvasStore().linearMode = false
     renderIcon()
 
     expect(
@@ -146,7 +135,7 @@ describe('SidebarHelpCenterIcon', () => {
   })
 
   it('toggles the help center on click in graph mode', async () => {
-    canvasState.linearMode = false
+    useCanvasStore().linearMode = false
     const { user } = renderIcon()
 
     await user.click(screen.getByRole('button', { name: 'Help Center' }))

--- a/src/components/sidebar/tabs/AppsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AppsSidebarTab.test.ts
@@ -1,46 +1,26 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import {
+  useWorkflowStore,
+  useWorkflowBookmarkStore
+} from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useCommandStore } from '@/stores/commandStore'
 
 import AppsSidebarTab from './AppsSidebarTab.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
-const execute = vi.hoisted(() => vi.fn())
-
-const workflowStoreState = vi.hoisted(() => ({
-  persistedWorkflows: [] as ComfyWorkflow[]
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { ComfyWorkflow } =
-      await import('@/platform/workflow/management/stores/comfyWorkflow')
-    return {
-      ComfyWorkflow,
-      useWorkflowStore: () => ({
-        get workflows() {
-          return workflowStoreState.persistedWorkflows
-        },
-        get persistedWorkflows() {
-          return workflowStoreState.persistedWorkflows
-        },
-        bookmarkedWorkflows: [],
-        openWorkflows: [],
-        activeWorkflow: undefined,
-        isSyncLoading: false,
-        syncWorkflows: vi.fn()
-      }),
-      useWorkflowBookmarkStore: () => ({ loadBookmarks: vi.fn() })
-    }
-  }
-)
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+  vi.mocked(useWorkflowStore().syncWorkflows).mockResolvedValue(undefined)
+  vi.mocked(useWorkflowBookmarkStore().loadBookmarks).mockResolvedValue(
+    undefined
+  )
+})
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -56,18 +36,10 @@ vi.mock(
   })
 )
 
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({ shiftDown: false })
-}))
-
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
   const { computed } = await import('vue')
   return { useAppMode: () => ({ isAppMode: computed(() => true) }) }
 })
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => undefined })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -152,7 +124,7 @@ function renderTabWithRealBase() {
 
 describe('AppsSidebarTab', () => {
   beforeEach(() => {
-    workflowStoreState.persistedWorkflows = []
+    Object.assign(useWorkflowStore(), { persistedWorkflows: [] })
   })
 
   it('shows the create action only when there are results', () => {
@@ -171,7 +143,9 @@ describe('AppsSidebarTab', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create' }))
 
-    expect(execute).toHaveBeenCalledWith('Comfy.NewBlankWorkflow')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.NewBlankWorkflow'
+    )
   })
 
   it('runs the new-workflow command from the empty-state action', async () => {
@@ -179,15 +153,19 @@ describe('AppsSidebarTab', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create app' }))
 
-    expect(execute).toHaveBeenCalledWith('Comfy.NewBlankWorkflow')
+    expect(useCommandStore().execute).toHaveBeenCalledWith(
+      'Comfy.NewBlankWorkflow'
+    )
   })
 
   describe('with the real workflows tab', () => {
     it('counts only app workflows as results', async () => {
-      workflowStoreState.persistedWorkflows = [
-        await makeWorkflow('workflows/my-app.app.json'),
-        await makeWorkflow('workflows/regular.json')
-      ]
+      Object.assign(useWorkflowStore(), {
+        persistedWorkflows: [
+          await makeWorkflow('workflows/my-app.app.json'),
+          await makeWorkflow('workflows/regular.json')
+        ]
+      })
 
       renderTabWithRealBase()
 
@@ -198,9 +176,9 @@ describe('AppsSidebarTab', () => {
     })
 
     it('shows the empty state when no app workflows exist', async () => {
-      workflowStoreState.persistedWorkflows = [
-        await makeWorkflow('workflows/regular.json')
-      ]
+      Object.assign(useWorkflowStore(), {
+        persistedWorkflows: [await makeWorkflow('workflows/regular.json')]
+      })
 
       renderTabWithRealBase()
 

--- a/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
@@ -1,8 +1,7 @@
-import { fromPartial } from '@total-typescript/shoehorn'
-
 import { render, fireEvent } from '@testing-library/vue'
-import { defineComponent } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -16,12 +15,6 @@ const i18n = createI18n({
   locale: 'en',
   messages: { en: enMessages }
 })
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    isAssetDeleting: () => false
-  })
-}))
 
 const VirtualGridStub = defineComponent({
   name: 'VirtualGrid',

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,12 +1,26 @@
-import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia } from 'pinia'
+import { render, screen, within } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
+import { useAssetsStore } from '@/stores/assetsStore'
 
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
+
+beforeEach(() => {
+  const store = useAssetsStore()
+  store.outputAssets = {
+    items: [],
+    hasMore: false,
+    isLoading: false,
+    loadMore: vi.fn(async () => {}),
+    loadNew: vi.fn(async () => {}),
+    invalidate: vi.fn(async () => {})
+  }
+  vi.spyOn(store.inputAssets, 'loadNew').mockResolvedValue(undefined)
+  vi.spyOn(store.inputAssets, 'loadMore').mockResolvedValue(undefined)
+})
 
 const folderAsset = vi.hoisted(() => ({
   id: 'multi-output',
@@ -21,42 +35,6 @@ const folderAsset = vi.hoisted(() => ({
     outputCount: 2
   }
 }))
-
-const outputAssetState = vi.hoisted(() => ({
-  items: [] as (typeof folderAsset)[],
-  hasMore: false
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), async () => {
-  const { ref } = await import('vue')
-
-  const store = {
-    outputAssets: {
-      get items() {
-        return outputAssetState.items
-      },
-      isLoading: ref(false),
-      get hasMore() {
-        return outputAssetState.hasMore
-      },
-      loadMore: vi.fn(),
-      loadNew: vi.fn(),
-      invalidate: vi.fn()
-    },
-    inputAssets: {
-      items: ref([]),
-      isLoading: ref(false),
-      hasMore: ref(false),
-      loadMore: vi.fn(),
-      loadNew: vi.fn(),
-      invalidate: vi.fn()
-    }
-  }
-
-  return {
-    useAssetsStore: () => store
-  }
-})
 
 vi.mock<unknown>(
   import('@/platform/assets/composables/useAssetGridSelection'),
@@ -163,7 +141,7 @@ const buttonStub = {
 function renderTab() {
   return render(AssetsSidebarTab, {
     global: {
-      plugins: [createPinia(), i18n],
+      plugins: [i18n],
       directives: {
         tooltip: {}
       },
@@ -184,13 +162,13 @@ function renderTab() {
 }
 
 beforeEach(() => {
-  outputAssetState.items = [folderAsset]
-  outputAssetState.hasMore = false
+  useAssetsStore().outputAssets.items = [folderAsset]
+  useAssetsStore().outputAssets.hasMore = false
 })
 
 it('keeps pagination mounted when more assets can be loaded', () => {
-  outputAssetState.items = []
-  outputAssetState.hasMore = true
+  useAssetsStore().outputAssets.items = []
+  useAssetsStore().outputAssets.hasMore = true
 
   renderTab()
 

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
@@ -1,16 +1,31 @@
-import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref, watchEffect } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { nextTick, reactive, ref, watchEffect } from 'vue'
+
+import BaseWorkflowsSidebarTab from '@/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import {
+  useWorkflowStore,
+  useWorkflowBookmarkStore
+} from '@/platform/workflow/management/stores/workflowStore'
 
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
 import { flattenTree } from '@/utils/treeUtil'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
-import BaseWorkflowsSidebarTab from '@/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue'
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Workflow.WorkflowTabsPosition'] =
+    'Sidebar'
+  vi.mocked(useWorkflowStore().syncWorkflows).mockResolvedValue(undefined)
+  vi.mocked(useWorkflowBookmarkStore().loadBookmarks).mockResolvedValue(
+    undefined
+  )
+})
 
 const {
   setSearchQuery,
@@ -20,24 +35,12 @@ const {
   resetCapturedSearchRoot,
   mockExpandNode,
   mockToggleNodeOnEvent,
-  mockLoadBookmarks,
   mockWorkflowService,
-  mockWorkflowStoreState,
   registerSearchHandlers
 } = vi.hoisted(() => {
   let updateQuery = (_query: string) => {}
   let triggerSearch = (_query: string) => {}
   let capturedSearchRoot: TreeExplorerNode<ComfyWorkflow> | null = null
-
-  const workflowStore = {
-    workflows: [] as ComfyWorkflow[],
-    persistedWorkflows: [] as ComfyWorkflow[],
-    bookmarkedWorkflows: [] as ComfyWorkflow[],
-    openWorkflows: [] as ComfyWorkflow[],
-    activeWorkflow: null as ComfyWorkflow | null,
-    isSyncLoading: false,
-    syncWorkflows: vi.fn().mockResolvedValue(undefined)
-  }
 
   return {
     setSearchQuery: (query: string) => {
@@ -55,7 +58,6 @@ const {
     },
     mockExpandNode: vi.fn(),
     mockToggleNodeOnEvent: vi.fn(),
-    mockLoadBookmarks: vi.fn().mockResolvedValue(undefined),
     mockWorkflowService: {
       openWorkflow: vi.fn().mockResolvedValue(undefined),
       closeWorkflow: vi.fn().mockResolvedValue(undefined),
@@ -64,7 +66,6 @@ const {
       insertWorkflow: vi.fn().mockResolvedValue(undefined),
       duplicateWorkflow: vi.fn().mockResolvedValue(undefined)
     },
-    mockWorkflowStoreState: workflowStore,
     registerSearchHandlers: (
       updateHandler: (query: string) => void,
       searchHandler: (query: string) => void
@@ -74,8 +75,6 @@ const {
     }
   }
 })
-
-const mockWorkflowStore = reactive(mockWorkflowStoreState)
 
 vi.mock<unknown>(
   import('@/components/common/NoResultsPlaceholder.vue'),
@@ -187,34 +186,10 @@ vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
   useAppMode: () => ({ isAppMode: ref(false) })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.Workflow.WorkflowTabsPosition') return 'Sidebar'
-      return undefined
-    })
-  })
-}))
-
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
   () => ({
     useWorkflowService: () => mockWorkflowService
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({ shiftDown: false })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => mockWorkflowStore,
-    useWorkflowBookmarkStore: () => ({ loadBookmarks: mockLoadBookmarks }),
-    ComfyWorkflow: class {
-      static basePath = 'workflows/'
-    }
   })
 )
 
@@ -248,12 +223,12 @@ describe('BaseWorkflowsSidebarTab', () => {
   beforeEach(() => {
     resetCapturedSearchRoot()
 
-    mockWorkflowStore.workflows = []
-    mockWorkflowStore.persistedWorkflows = []
-    mockWorkflowStore.bookmarkedWorkflows = []
-    mockWorkflowStore.openWorkflows = []
-    mockWorkflowStore.activeWorkflow = null
-    mockWorkflowStore.isSyncLoading = false
+    Object.assign(useWorkflowStore(), { workflows: [] })
+    Object.assign(useWorkflowStore(), { persistedWorkflows: [] })
+    Object.assign(useWorkflowStore(), { bookmarkedWorkflows: [] })
+    Object.assign(useWorkflowStore(), { openWorkflows: [] })
+    useWorkflowStore().activeWorkflow = null
+    useWorkflowStore().isSyncLoading = false
   })
 
   const renderComponent = () =>
@@ -264,16 +239,18 @@ describe('BaseWorkflowsSidebarTab', () => {
         dataTestid: 'workflows-sidebar'
       },
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [i18n],
         stubs: { teleport: true }
       }
     })
 
   it('returns an empty filtered workflow set when searchQuery is empty', async () => {
-    mockWorkflowStore.workflows = [
-      createMockWorkflow('workflows/test-alpha.json'),
-      createMockWorkflow('workflows/test-beta.json')
-    ]
+    Object.assign(useWorkflowStore(), {
+      workflows: [
+        createMockWorkflow('workflows/test-alpha.json'),
+        createMockWorkflow('workflows/test-beta.json')
+      ]
+    })
 
     renderComponent()
     emitSearch('alpha')
@@ -287,11 +264,13 @@ describe('BaseWorkflowsSidebarTab', () => {
   })
 
   it('filters workflows by case-insensitive path match', async () => {
-    mockWorkflowStore.workflows = [
-      createMockWorkflow('workflows/test-alpha.json'),
-      createMockWorkflow('workflows/other-workflow.json'),
-      createMockWorkflow('workflows/TEST-gamma.json')
-    ]
+    Object.assign(useWorkflowStore(), {
+      workflows: [
+        createMockWorkflow('workflows/test-alpha.json'),
+        createMockWorkflow('workflows/other-workflow.json'),
+        createMockWorkflow('workflows/TEST-gamma.json')
+      ]
+    })
 
     renderComponent()
 
@@ -312,15 +291,15 @@ describe('BaseWorkflowsSidebarTab', () => {
 
     await user.click(refreshButton)
 
-    expect(mockWorkflowStore.syncWorkflows).toHaveBeenCalledTimes(1)
+    expect(useWorkflowStore().syncWorkflows).toHaveBeenCalledTimes(1)
 
-    mockWorkflowStore.isSyncLoading = true
+    useWorkflowStore().isSyncLoading = true
     await nextTick()
 
     expect(refreshButton).toBeDisabled()
     expect(refreshButton).toHaveAttribute('aria-busy', 'true')
 
-    mockWorkflowStore.isSyncLoading = false
+    useWorkflowStore().isSyncLoading = false
     await nextTick()
 
     expect(refreshButton).toBeEnabled()
@@ -328,15 +307,17 @@ describe('BaseWorkflowsSidebarTab', () => {
 
     await user.click(refreshButton)
 
-    expect(mockWorkflowStore.syncWorkflows).toHaveBeenCalledTimes(2)
+    expect(useWorkflowStore().syncWorkflows).toHaveBeenCalledTimes(2)
   })
 
   it('reactively updates filtered workflows when a workflow is removed', async () => {
-    mockWorkflowStore.workflows = [
-      createMockWorkflow('workflows/test-alpha.json'),
-      createMockWorkflow('workflows/TEST-alpha-2.json'),
-      createMockWorkflow('workflows/test-beta.json')
-    ]
+    Object.assign(useWorkflowStore(), {
+      workflows: [
+        createMockWorkflow('workflows/test-alpha.json'),
+        createMockWorkflow('workflows/TEST-alpha-2.json'),
+        createMockWorkflow('workflows/test-beta.json')
+      ]
+    })
 
     renderComponent()
 
@@ -347,9 +328,11 @@ describe('BaseWorkflowsSidebarTab', () => {
       'workflows/test-alpha.json'
     ])
 
-    mockWorkflowStore.workflows = mockWorkflowStore.workflows.filter(
-      (workflow) => workflow.path !== 'workflows/TEST-alpha-2.json'
-    )
+    Object.assign(useWorkflowStore(), {
+      workflows: useWorkflowStore().workflows.filter(
+        (workflow) => workflow.path !== 'workflows/TEST-alpha-2.json'
+      )
+    })
     await nextTick()
 
     expect(getLeafPaths(getSearchRoot())).toEqual(['workflows/test-alpha.json'])

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
@@ -1,15 +1,29 @@
-import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { useModelStore } from '@/stores/modelStore'
 import type { ComfyModelDef } from '@/stores/modelStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
 
 import ModelLibrarySidebarTab from './ModelLibrarySidebarTab.vue'
+
+beforeEach(() => {
+  vi.mocked(useModelStore().loadModels).mockResolvedValue([])
+  vi.mocked(useModelStore().loadModelFolders).mockResolvedValue(true)
+  vi.mocked(useModelStore().getLoadedModelFolder).mockResolvedValue(null)
+  vi.mocked(useModelStore().refresh).mockResolvedValue(true)
+  vi.mocked(useModelStore().refreshModelFolder).mockResolvedValue(undefined)
+  useSettingStore().settingValues['Comfy.ModelLibrary.NameFormat'] = 'filename'
+})
 
 const {
   captureRoot,
@@ -18,13 +32,7 @@ const {
   captureExpandedKeys,
   getExpandedKeys,
   mockStartDrag,
-  mockGetNodeProvider,
-  mockToggleNodeOnEvent,
-  mockRefreshModelFolder,
-  mockLoadModels,
-  downloadStoreState,
-  settingState,
-  modelsState
+  mockToggleNodeOnEvent
 } = vi.hoisted(() => {
   let capturedRoot: TreeExplorerNode | null = null
   let capturedExpandedKeys: Record<string, boolean> = {}
@@ -41,30 +49,12 @@ const {
     },
     getExpandedKeys: () => capturedExpandedKeys,
     mockStartDrag: vi.fn(),
-    mockGetNodeProvider: vi.fn(),
-    mockToggleNodeOnEvent: vi.fn(),
-    mockRefreshModelFolder: vi.fn().mockResolvedValue(undefined),
-    mockLoadModels: vi.fn().mockResolvedValue([]),
-    downloadStoreState: { setLastCompleted: (_: unknown) => {} },
-    settingState: { useAssetAPI: false, autoLoadAll: false },
-    modelsState: {
-      push: (_: unknown) => {},
-      reset: () => {}
-    }
+    mockToggleNodeOnEvent: vi.fn()
   }
 })
 
 vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   useNodeDragToCanvas: () => ({ startDrag: mockStartDrag })
-}))
-
-const mockToastAdd = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mockToastAdd })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
 }))
 
 const mockModel = fromPartial<ComfyModelDef>({
@@ -75,65 +65,6 @@ const mockModel = fromPartial<ComfyModelDef>({
   directory: 'checkpoints',
   searchable: 'checkpoints/model.safetensors'
 })
-
-vi.mock<unknown>(import('@/stores/modelStore'), async () => {
-  const { reactive } = await import('vue')
-  const models = reactive<ComfyModelDef[]>([])
-  modelsState.push = (model: unknown) => {
-    models.push(model as ComfyModelDef)
-  }
-  modelsState.reset = () => {
-    models.splice(0, models.length, mockModel)
-  }
-  return {
-    ResourceState: {
-      Loading: 'loading',
-      Loaded: 'loaded'
-    },
-    useModelStore: () => ({
-      modelFolders: [],
-      visibleModelFolders: [],
-      models,
-      loadModels: mockLoadModels,
-      getLoadedModelFolder: vi.fn().mockResolvedValue(null),
-      loadModelFolders: vi.fn().mockResolvedValue([]),
-      refresh: vi.fn().mockResolvedValue(undefined),
-      refreshModelFolder: mockRefreshModelFolder
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/assetDownloadStore'), async () => {
-  const { ref } = await import('vue')
-  const lastCompletedDownload = ref<{
-    taskId: string
-    modelType: string
-    timestamp: number
-  } | null>(null)
-  downloadStoreState.setLastCompleted = (value) => {
-    lastCompletedDownload.value = value as typeof lastCompletedDownload.value
-  }
-  return {
-    useAssetDownloadStore: () => ({
-      get lastCompletedDownload() {
-        return lastCompletedDownload.value
-      }
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.ModelLibrary.NameFormat') return 'filename'
-      if (key === 'Comfy.Assets.UseAssetAPI') return settingState.useAssetAPI
-      if (key === 'Comfy.ModelLibrary.AutoLoadAll') {
-        return settingState.autoLoadAll
-      }
-      return false
-    })
-  })
-}))
 
 const mockExpandNode = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/composables/useTreeExpansion'), () => ({
@@ -231,16 +162,16 @@ const i18n = createI18n({
 describe('ModelLibrarySidebarTab', () => {
   beforeEach(() => {
     resetRoot()
-    downloadStoreState.setLastCompleted(null)
-    settingState.useAssetAPI = false
-    settingState.autoLoadAll = false
-    modelsState.reset()
+    useAssetDownloadStore().lastCompletedDownload = null
+    useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = false
+    useSettingStore().settingValues['Comfy.ModelLibrary.AutoLoadAll'] = false
+    Object.assign(useModelStore(), { models: [mockModel] })
   })
 
   function renderComponent() {
     return render(ModelLibrarySidebarTab, {
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [i18n],
         stubs: { teleport: true },
         directives: { tooltip: {} }
       }
@@ -253,9 +184,11 @@ describe('ModelLibrarySidebarTab', () => {
   })
 
   it('starts a ghost drag carrying the widget value to fill on placement', async () => {
-    const mockNodeDef = { name: 'CheckpointLoaderSimple' }
+    const mockNodeDef = fromPartial<ComfyNodeDefImpl>({
+      name: 'CheckpointLoaderSimple'
+    })
 
-    mockGetNodeProvider.mockReturnValue({
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
       nodeDef: mockNodeDef,
       key: 'ckpt_name'
     })
@@ -273,7 +206,9 @@ describe('ModelLibrarySidebarTab', () => {
     const mockEvent = new MouseEvent('click')
     await modelLeaf?.handleClick?.(mockEvent)
 
-    expect(mockGetNodeProvider).toHaveBeenCalledWith('checkpoints')
+    expect(
+      vi.mocked(useModelToNodeStore().getNodeProvider)
+    ).toHaveBeenCalledWith('checkpoints')
     expect(mockStartDrag).toHaveBeenCalledWith(mockNodeDef, {
       widgetValues: { ckpt_name: 'model.safetensors' },
       source: 'sidebar_drag'
@@ -297,23 +232,25 @@ describe('ModelLibrarySidebarTab', () => {
     renderComponent()
     await nextTick()
 
-    expect(mockRefreshModelFolder).not.toHaveBeenCalled()
+    expect(vi.mocked(useModelStore().refreshModelFolder)).not.toHaveBeenCalled()
 
-    downloadStoreState.setLastCompleted({
+    useAssetDownloadStore().lastCompletedDownload = {
       taskId: 'task-1',
       modelType: 'checkpoints',
       timestamp: Date.now()
-    })
+    }
     await nextTick()
 
-    expect(mockRefreshModelFolder).toHaveBeenCalledWith('checkpoints')
+    expect(vi.mocked(useModelStore().refreshModelFolder)).toHaveBeenCalledWith(
+      'checkpoints'
+    )
   })
 
   it('does not refresh when no download has completed', async () => {
     renderComponent()
     await nextTick()
 
-    expect(mockRefreshModelFolder).not.toHaveBeenCalled()
+    expect(vi.mocked(useModelStore().refreshModelFolder)).not.toHaveBeenCalled()
   })
 
   describe('search', () => {
@@ -325,7 +262,7 @@ describe('ModelLibrarySidebarTab', () => {
       await user.type(screen.getByTestId('search-input'), 'model')
       await nextTick()
 
-      expect(mockLoadModels).toHaveBeenCalled()
+      expect(vi.mocked(useModelStore().loadModels)).toHaveBeenCalled()
       const leafLabels = () => {
         const { children: folders = [] } = getRoot()
         return folders.flatMap(({ children: leaves = [] }) =>
@@ -335,16 +272,19 @@ describe('ModelLibrarySidebarTab', () => {
       expect(leafLabels()).toEqual(['model'])
 
       // A completed scan reloads the store while the search is still active.
-      modelsState.push(
-        fromPartial<ComfyModelDef>({
-          key: 'checkpoints/model-new.safetensors',
-          file_name: 'model-new.safetensors',
-          simplified_file_name: 'model-new',
-          title: 'Model New',
-          directory: 'checkpoints',
-          searchable: 'checkpoints/model-new.safetensors'
-        })
-      )
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          fromPartial<ComfyModelDef>({
+            key: 'checkpoints/model-new.safetensors',
+            file_name: 'model-new.safetensors',
+            simplified_file_name: 'model-new',
+            title: 'Model New',
+            directory: 'checkpoints',
+            searchable: 'checkpoints/model-new.safetensors'
+          })
+        ]
+      })
       await nextTick()
 
       expect(leafLabels()).toEqual(['model', 'model-new'])
@@ -381,16 +321,19 @@ describe('ModelLibrarySidebarTab', () => {
       renderComponent()
       await nextTick()
       for (let i = 0; i < 520; i++) {
-        modelsState.push(
-          fromPartial<ComfyModelDef>({
-            key: `checkpoints/bulk-${i}.safetensors`,
-            file_name: `bulk-${i}.safetensors`,
-            simplified_file_name: `bulk-${i}`,
-            title: `bulk-${i}`,
-            directory: 'checkpoints',
-            searchable: `checkpoints/bulk-${i}.safetensors`
-          })
-        )
+        Object.assign(useModelStore(), {
+          models: [
+            ...useModelStore().models,
+            fromPartial<ComfyModelDef>({
+              key: `checkpoints/bulk-${i}.safetensors`,
+              file_name: `bulk-${i}.safetensors`,
+              simplified_file_name: `bulk-${i}`,
+              title: `bulk-${i}`,
+              directory: 'checkpoints',
+              searchable: `checkpoints/bulk-${i}.safetensors`
+            })
+          ]
+        })
       }
 
       await user.type(screen.getByTestId('search-input'), 'bulk')
@@ -422,16 +365,19 @@ describe('ModelLibrarySidebarTab', () => {
 
       // A background reload adds another matching model to that folder; the
       // tree data updates but the manual collapse is preserved.
-      modelsState.push(
-        fromPartial<ComfyModelDef>({
-          key: 'checkpoints/model-late.safetensors',
-          file_name: 'model-late.safetensors',
-          simplified_file_name: 'model-late',
-          title: 'Model Late',
-          directory: 'checkpoints',
-          searchable: 'checkpoints/model-late.safetensors'
-        })
-      )
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          fromPartial<ComfyModelDef>({
+            key: 'checkpoints/model-late.safetensors',
+            file_name: 'model-late.safetensors',
+            simplified_file_name: 'model-late',
+            title: 'Model Late',
+            directory: 'checkpoints',
+            searchable: 'checkpoints/model-late.safetensors'
+          })
+        ]
+      })
       await nextTick()
       await nextTick()
 
@@ -453,16 +399,19 @@ describe('ModelLibrarySidebarTab', () => {
       // A scan completes mid-search and surfaces the first match; its
       // folder must render expanded or the result hides in a collapsed
       // node.
-      modelsState.push(
-        fromPartial<ComfyModelDef>({
-          key: 'checkpoints/zzz-model.safetensors',
-          file_name: 'zzz-model.safetensors',
-          simplified_file_name: 'zzz-model',
-          title: 'Zzz Model',
-          directory: 'checkpoints',
-          searchable: 'checkpoints/zzz-model.safetensors'
-        })
-      )
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          fromPartial<ComfyModelDef>({
+            key: 'checkpoints/zzz-model.safetensors',
+            file_name: 'zzz-model.safetensors',
+            simplified_file_name: 'zzz-model',
+            title: 'Zzz Model',
+            directory: 'checkpoints',
+            searchable: 'checkpoints/zzz-model.safetensors'
+          })
+        ]
+      })
       await nextTick()
       await nextTick()
 
@@ -473,14 +422,16 @@ describe('ModelLibrarySidebarTab', () => {
   describe('asset mode', () => {
     it('surfaces an error toast when the eager load fails on mount', async () => {
       const error = vi.spyOn(console, 'error').mockImplementation(() => {})
-      settingState.useAssetAPI = true
-      mockLoadModels.mockRejectedValueOnce(new Error('walk failed'))
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
+      vi.mocked(useModelStore().loadModels).mockRejectedValueOnce(
+        new Error('walk failed')
+      )
 
       renderComponent()
       await nextTick()
       await nextTick()
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'sideToolbar.modelLibraryLoadFailed'
@@ -490,13 +441,13 @@ describe('ModelLibrarySidebarTab', () => {
     })
 
     it('hides the load-all button and eager-loads models on mount', async () => {
-      settingState.useAssetAPI = true
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
       renderComponent()
       await nextTick()
 
       expect(screen.queryByLabelText('g.loadAllFolders')).toBeNull()
       expect(screen.getByLabelText('g.refresh')).toBeInTheDocument()
-      expect(mockLoadModels).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(useModelStore().loadModels)).toHaveBeenCalledTimes(1)
     })
 
     it('legacy mode keeps the load-all button and stays lazy by default', async () => {
@@ -504,15 +455,15 @@ describe('ModelLibrarySidebarTab', () => {
       await nextTick()
 
       expect(screen.getByLabelText('g.loadAllFolders')).toBeInTheDocument()
-      expect(mockLoadModels).not.toHaveBeenCalled()
+      expect(vi.mocked(useModelStore().loadModels)).not.toHaveBeenCalled()
     })
 
     it('legacy mode still honors AutoLoadAll', async () => {
-      settingState.autoLoadAll = true
+      useSettingStore().settingValues['Comfy.ModelLibrary.AutoLoadAll'] = true
       renderComponent()
       await nextTick()
 
-      expect(mockLoadModels).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(useModelStore().loadModels)).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -100,7 +100,7 @@ describe('NodeLibrarySidebarTabV2', () => {
   function renderComponent() {
     return render(NodeLibrarySidebarTabV2, {
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           teleport: true
         }

--- a/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
@@ -4,16 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { EssentialTile } from '@/constants/essentialsNodes'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 import EssentialNodeCard from './EssentialNodeCard.vue'
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn().mockReturnValue('left')
-  })
-}))
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] = 'left'
+})
 
 const { mockStartDrag, mockHandleNativeDrop } = vi.hoisted(() => ({
   mockStartDrag: vi.fn(),

--- a/src/components/sidebar/tabs/nodeLibrary/EssentialNodesPanel.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/EssentialNodesPanel.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { EssentialsMediaType } from '@/constants/essentialsNodes'
 import { i18n } from '@/i18n'
@@ -29,10 +27,6 @@ function createMediaFilters(
 }
 
 describe('EssentialNodesPanel', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia())
-  })
-
   function renderComponent({
     searchQuery = '',
     mediaFilters = createMediaFilters()

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
@@ -1,9 +1,10 @@
-import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type {
   TreeExplorerDragAndDropData,
@@ -13,11 +14,16 @@ import type {
 
 import NodeBookmarkTreeExplorer from './NodeBookmarkTreeExplorer.vue'
 
+beforeEach(() => {
+  Object.assign(useNodeBookmarkStore(), { bookmarkedRoot: mockBookmarkedRoot })
+  vi.mocked(useNodeBookmarkStore().addBookmark).mockResolvedValue(undefined)
+  vi.mocked(useNodeBookmarkStore().toggleBookmark).mockResolvedValue(undefined)
+  vi.mocked(useNodeBookmarkStore().deleteBookmarkFolder).mockResolvedValue(
+    undefined
+  )
+})
+
 const {
-  mockAddBookmark,
-  mockDeleteBookmarkFolder,
-  mockIsBookmarked,
-  mockToggleBookmark,
   mockAddNodeOnGraph,
   mockToggleNodeOnEvent,
   captureRoot,
@@ -26,10 +32,6 @@ const {
 } = vi.hoisted(() => {
   let capturedRoot: TreeExplorerNode | null = null
   return {
-    mockAddBookmark: vi.fn(),
-    mockDeleteBookmarkFolder: vi.fn(),
-    mockIsBookmarked: vi.fn().mockReturnValue(false),
-    mockToggleBookmark: vi.fn(),
     mockAddNodeOnGraph: vi.fn(),
     mockToggleNodeOnEvent: vi.fn(),
     captureRoot: (root: TreeExplorerNode) => {
@@ -79,23 +81,6 @@ const mockBookmarkedRoot: TreeNode = {
     }
   ]
 }
-
-vi.mock<unknown>(import('@/stores/nodeBookmarkStore'), () => ({
-  useNodeBookmarkStore: () => ({
-    bookmarks: [],
-    bookmarkedRoot: mockBookmarkedRoot,
-    isBookmarked: mockIsBookmarked,
-    toggleBookmark: mockToggleBookmark,
-    addBookmark: mockAddBookmark,
-    deleteBookmarkFolder: mockDeleteBookmarkFolder,
-    addNewBookmarkFolder: vi.fn(),
-    renameBookmarkFolder: vi.fn(),
-    bookmarksCustomization: {},
-    defaultBookmarkIcon: 'pi-bookmark-fill',
-    defaultBookmarkColor: '#a1a1aa',
-    updateCustomization: vi.fn()
-  })
-}))
 
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
@@ -153,7 +138,7 @@ const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
 
 describe('NodeBookmarkTreeExplorer', () => {
   beforeEach(() => {
-    mockIsBookmarked.mockReturnValue(false)
+    vi.mocked(useNodeBookmarkStore().isBookmarked).mockReturnValue(false)
     resetRoot()
   })
 
@@ -182,11 +167,11 @@ describe('NodeBookmarkTreeExplorer', () => {
         })
       )
 
-      expect(mockAddBookmark).toHaveBeenCalled()
+      expect(vi.mocked(useNodeBookmarkStore().addBookmark)).toHaveBeenCalled()
     })
 
     it('moves bookmark when a node is dragged onto a folder and is bookmarked', async () => {
-      mockIsBookmarked.mockReturnValue(true)
+      vi.mocked(useNodeBookmarkStore().isBookmarked).mockReturnValue(true)
       const root = await renderAndGetRoot()
       const folderNode = root.children?.[0]
 
@@ -197,8 +182,10 @@ describe('NodeBookmarkTreeExplorer', () => {
         })
       )
 
-      expect(mockToggleBookmark).toHaveBeenCalledWith(mockLeafNodeDef)
-      expect(mockAddBookmark).toHaveBeenCalled()
+      expect(
+        vi.mocked(useNodeBookmarkStore().toggleBookmark)
+      ).toHaveBeenCalledWith(mockLeafNodeDef)
+      expect(vi.mocked(useNodeBookmarkStore().addBookmark)).toHaveBeenCalled()
     })
 
     it('is a no-op when the dragged node carries no data', async () => {
@@ -212,7 +199,9 @@ describe('NodeBookmarkTreeExplorer', () => {
         })
       )
 
-      expect(mockAddBookmark).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useNodeBookmarkStore().addBookmark)
+      ).not.toHaveBeenCalled()
     })
   })
 
@@ -251,7 +240,9 @@ describe('NodeBookmarkTreeExplorer', () => {
         data: mockFolderNodeDef
       })
 
-      expect(mockDeleteBookmarkFolder).toHaveBeenCalledWith(mockFolderNodeDef)
+      expect(
+        vi.mocked(useNodeBookmarkStore().deleteBookmarkFolder)
+      ).toHaveBeenCalledWith(mockFolderNodeDef)
     })
 
     it('is a no-op when node data is missing', async () => {
@@ -260,7 +251,9 @@ describe('NodeBookmarkTreeExplorer', () => {
 
       await folderNode?.handleDelete?.call({ ...folderNode, data: undefined })
 
-      expect(mockDeleteBookmarkFolder).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useNodeBookmarkStore().deleteBookmarkFolder)
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -7,16 +7,6 @@ import { createI18n } from 'vue-i18n'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 
 import MediaLightbox from './MediaLightbox.vue'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => undefined })
-}))
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({
-    isExtensionInstalled: () => false,
-    isExtensionEnabled: () => false
-  })
-}))
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { cleanup, render } from '@testing-library/vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -24,7 +24,7 @@ vi.mock<unknown>(
 function renderToast() {
   return render(GlobalToast, {
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn })],
+      plugins: [getActivePinia()!],
       stubs: { Toast: true }
     }
   })

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -1,57 +1,17 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createPinia } from 'pinia'
 import { defineComponent, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import CurrentUserButton from './CurrentUserButton.vue'
-
-const mockTeamWorkspaceStore = vi.hoisted(() => ({
-  workspaceName: { value: '' },
-  initState: { value: 'idle' },
-  isInPersonalWorkspace: { value: false }
-}))
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
-
-// Mock all firebase modules
-vi.mock(import('firebase/app'), () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { defineStore } = await import('pinia')
-    const { computed } = await import('vue')
-
-    return {
-      useTeamWorkspaceStore: defineStore('teamWorkspace', () => ({
-        workspaceName: computed(
-          () => mockTeamWorkspaceStore.workspaceName.value
-        ),
-        initState: computed(() => mockTeamWorkspaceStore.initState.value),
-        isInPersonalWorkspace: computed(
-          () => mockTeamWorkspaceStore.isInPersonalWorkspace.value
-        ),
-        activeWorkspace: computed(() => null)
-      }))
-    }
-  }
-)
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -130,9 +90,9 @@ vi.mock(import('./CurrentUserPopoverLegacy.vue'), () => ({
 
 describe('CurrentUserButton', () => {
   beforeEach(() => {
-    mockTeamWorkspaceStore.workspaceName.value = ''
-    mockTeamWorkspaceStore.initState.value = 'idle'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: '' })
+    useTeamWorkspaceStore().initState = 'uninitialized'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     mockIsCloud.value = false
   })
 
@@ -146,7 +106,7 @@ describe('CurrentUserButton', () => {
 
     const result = render(CurrentUserButton, {
       global: {
-        plugins: [i18n, createPinia()],
+        plugins: [i18n],
         stubs: {
           CurrentUserPopoverWorkspace: CurrentUserPopoverWorkspaceStub,
           Popover: defineComponent({
@@ -187,11 +147,11 @@ describe('CurrentUserButton', () => {
     expect(screen.getByText('Popover Content')).toBeInTheDocument()
   })
 
-  it.for(['loading', 'error'])(
+  it.for(['loading', 'error'] as const)(
     'shows account actions while Cloud workspace initialization is %s',
     async (initState) => {
       mockIsCloud.value = true
-      mockTeamWorkspaceStore.initState.value = initState
+      useTeamWorkspaceStore().initState = initState
       const { user } = renderComponent()
 
       await user.click(screen.getByRole('button', { name: 'Current user' }))
@@ -214,8 +174,8 @@ describe('CurrentUserButton', () => {
 
   it('shows UserAvatar in personal workspace', () => {
     mockIsCloud.value = true
-    mockTeamWorkspaceStore.initState.value = 'ready'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = true
+    useTeamWorkspaceStore().initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
 
     renderComponent()
     expect(screen.getByText('Avatar')).toBeInTheDocument()
@@ -224,9 +184,9 @@ describe('CurrentUserButton', () => {
 
   it('shows WorkspaceProfilePic in team workspace', () => {
     mockIsCloud.value = true
-    mockTeamWorkspaceStore.initState.value = 'ready'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
-    mockTeamWorkspaceStore.workspaceName.value = 'My Team'
+    useTeamWorkspaceStore().initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: 'My Team' })
 
     renderComponent()
     expect(screen.getByText('WorkspaceProfilePic')).toBeInTheDocument()
@@ -234,9 +194,9 @@ describe('CurrentUserButton', () => {
   })
 
   it('shows WorkspaceProfilePic for an active local team workspace', () => {
-    mockTeamWorkspaceStore.initState.value = 'ready'
-    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
-    mockTeamWorkspaceStore.workspaceName.value = 'My Team'
+    useTeamWorkspaceStore().initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: 'My Team' })
 
     renderComponent()
 
@@ -245,7 +205,7 @@ describe('CurrentUserButton', () => {
   })
 
   it('shows workspace actions after local workspace initialization', async () => {
-    mockTeamWorkspaceStore.initState.value = 'ready'
+    useTeamWorkspaceStore().initState = 'ready'
     const { user } = renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Current user' }))

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,6 +8,7 @@ import { createI18n } from 'vue-i18n'
 import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
 import type { BalanceInfo, SubscriptionInfo } from '@/composables/billing/types'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import CurrentUserPopoverLegacy from './CurrentUserPopoverLegacy.vue'
 
@@ -148,17 +149,13 @@ describe('CurrentUserPopoverLegacy', () => {
     const onClose = vi.fn()
     const user = userEvent.setup()
 
+    if (teamWorkspaceState) {
+      useTeamWorkspaceStore().$patch(teamWorkspaceState)
+    }
+
     render(CurrentUserPopoverLegacy, {
       global: {
-        plugins: [
-          i18n,
-          createTestingPinia({
-            createSpy: vi.fn,
-            initialState: teamWorkspaceState
-              ? { teamWorkspace: teamWorkspaceState }
-              : {}
-          })
-        ],
+        plugins: [i18n, getActivePinia()!],
         stubs: {
           Divider: true
         }

--- a/src/components/topbar/TopbarSubscribeButton.test.ts
+++ b/src/components/topbar/TopbarSubscribeButton.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createPinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 
 import { render, screen } from '@testing-library/vue'
@@ -55,7 +55,7 @@ function renderComponent() {
 
   return render(TopbarSubscribeButton, {
     global: {
-      plugins: [i18n, createPinia()]
+      plugins: [i18n, getActivePinia()!]
     }
   })
 }

--- a/src/components/topbar/WorkflowTab.test.ts
+++ b/src/components/topbar/WorkflowTab.test.ts
@@ -1,46 +1,21 @@
-import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { markRaw, nextTick } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
-import type { ComponentProps } from 'vue-component-type-helpers'
-
-import type * as ExecutionStoreModule from '@/stores/executionStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
 import type { WorkflowExecutionStatus } from '@/stores/executionStore'
+import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
 
-const { mockWorkflowStatus, mockCloseWorkflow } = await vi.hoisted(async () => {
-  const { shallowRef } = await import('vue')
-  return {
-    mockWorkflowStatus: shallowRef<Map<object, WorkflowExecutionStatus>>(
-      new Map()
-    ),
-    mockCloseWorkflow: vi.fn().mockResolvedValue(true)
-  }
-})
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    currentUser: null,
-    isAuthenticated: false,
-    isInitialized: true
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), async (importOriginal) => {
-  const actual = await importOriginal<typeof ExecutionStoreModule>()
-  return {
-    WORKFLOW_STATUS_I18N_KEYS: actual.WORKFLOW_STATUS_I18N_KEYS,
-    useExecutionStore: () => ({
-      getWorkflowStatus(workflow: object | undefined | null) {
-        if (!workflow) return undefined
-        return mockWorkflowStatus.value.get(workflow)
-      }
-    })
-  }
-})
+import WorkflowTab from './WorkflowTab.vue'
+vi.mock(import('firebase/auth'))
+vi.mock(import('vuefire'), () => ({ useFirebaseAuth: vi.fn() }))
+const mockCloseWorkflow = vi.hoisted(() => vi.fn().mockResolvedValue(true))
 
 vi.mock(import('@/composables/usePragmaticDragAndDrop'), () => ({
   usePragmaticDraggable: vi.fn(),
@@ -82,10 +57,6 @@ vi.mock<unknown>(import('./WorkflowTabPopover.vue'), () => ({
     }
   }
 }))
-
-import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
-
-import WorkflowTab from './WorkflowTab.vue'
 
 type WorkflowTabProps = ComponentProps<typeof WorkflowTab>
 
@@ -145,24 +116,14 @@ function renderTab({
       ? workflowOption.workflow.path
       : '/workflows/other.json')
 
+  useWorkflowStore().activeWorkflow = fromPartial({
+    key: activeWorkflowKey,
+    path: resolvedActiveWorkflowPath
+  })
+  useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'off'
   return render(WorkflowTab, {
     global: {
-      plugins: [
-        createTestingPinia({
-          stubActions: false,
-          initialState: {
-            workspace: { shiftDown: false },
-            workflow: {
-              activeWorkflow: {
-                key: activeWorkflowKey,
-                path: resolvedActiveWorkflowPath
-              }
-            },
-            setting: { settingValues: { 'Comfy.Workflow.AutoSave': 'off' } }
-          }
-        }),
-        i18n
-      ],
+      plugins: [i18n],
       stubs: {
         WorkflowActionsList: true,
         Button: {
@@ -180,14 +141,14 @@ function renderTab({
 
 describe('WorkflowTab - workflow status indicator', () => {
   beforeEach(() => {
-    mockWorkflowStatus.value = new Map()
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue(undefined)
   })
 
   it.for(['running', 'completed', 'failed'] as const)(
     'labels the %s indicator with a translated status name',
     (status) => {
       const workflowOption = makeWorkflowOption()
-      mockWorkflowStatus.value = new Map([[workflowOption.workflow, status]])
+      vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue(status)
 
       renderTab({ workflowOption })
       expect(
@@ -198,7 +159,7 @@ describe('WorkflowTab - workflow status indicator', () => {
 
   it('does not badge the active tab with its own status', () => {
     const workflowOption = makeWorkflowOption()
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'running']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('running')
 
     renderTab({ workflowOption, activeWorkflowKey: 'test-key' })
     expect(screen.queryByRole('img')).toBeNull()
@@ -235,7 +196,7 @@ describe('WorkflowTab - workflow status indicator', () => {
 
   it('workflow status replaces the unsaved dot', () => {
     const workflowOption = makeWorkflowOption({ isPersisted: false })
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'running']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('running')
 
     renderTab({ workflowOption })
     expect(
@@ -247,7 +208,7 @@ describe('WorkflowTab - workflow status indicator', () => {
 
 describe('WorkflowTab - agent activity indicators', () => {
   beforeEach(() => {
-    mockWorkflowStatus.value = new Map()
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue(undefined)
   })
 
   it('T-17 / PM-658 / FE-1289 renders the active workflow tab loading state', async () => {
@@ -275,7 +236,7 @@ describe('WorkflowTab - agent activity indicators', () => {
 
   it('shows the unseen-changes dot ahead of non-failed execution status', async () => {
     const workflowOption = makeWorkflowOption()
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'running']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('running')
     renderTab({ workflowOption })
     useWorkflowTabActivityStore().markModified('/workflows/test.json')
     await nextTick()
@@ -291,7 +252,7 @@ describe('WorkflowTab - agent activity indicators', () => {
 
   it('a failed run outranks the unseen-changes dot', async () => {
     const workflowOption = makeWorkflowOption()
-    mockWorkflowStatus.value = new Map([[workflowOption.workflow, 'failed']])
+    vi.mocked(useExecutionStore().getWorkflowStatus).mockReturnValue('failed')
     renderTab({ workflowOption })
     useWorkflowTabActivityStore().markModified('/workflows/test.json')
     await nextTick()

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Supersedes the component-test migrations from #17222 and #17223 with real Pinia state and action spies.

## Changes

- 83 changed files: 79 component paths, including the searchbox helper, plus the four shared lifecycle files.
- Includes the shared Pinia disposal regression and singleton-reuse fixes. Each domain branch starts from the same prerequisite and targets main independently, so any domain can merge first.
- Enforcement and documentation remain deferred to #17223.

## Review Focus

- All 83 final blobs match the pinned migration source. No domain stacking or assertion weakening.
- Validation: 81 test files and 854 tests passed, including all changed tests and the three shared regressions. Typecheck, scoped ESLint, type-aware Oxlint, cleanup audit, format check, knip, and actual commit hooks passed.
