### PR TITLE
test: use global Pinia in cloud and workspace tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -1,28 +1,13 @@
+import type * as DistributionModule from '@/platform/distribution/types'
 import { render } from '@testing-library/vue'
 import { useAsyncState } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import DesktopCloudNotificationController from './DesktopCloudNotificationController.vue'
 
-const settingState = {
-  shown: false
-}
-
-const settingStore = {
-  get error(): unknown {
-    return undefined
-  },
-  load: vi.fn<() => Promise<void>>(),
-  get: vi.fn((key: string) =>
-    key === 'Comfy.Desktop.CloudNotificationShown'
-      ? settingState.shown
-      : undefined
-  ),
-  set: vi.fn(async (_key: string, value: boolean) => {
-    settingState.shown = value
-  })
-}
+let settingStore: ReturnType<typeof useSettingStore>
 
 const dialogService = {
   showCloudNotification: vi.fn<() => Promise<void>>()
@@ -34,12 +19,9 @@ const electron = {
 
 const errorReporter = vi.hoisted(() => vi.fn())
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isDesktop: true
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settingStore
 }))
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
@@ -65,12 +47,16 @@ function createDeferred() {
 
 describe('DesktopCloudNotificationController', () => {
   beforeEach(() => {
-    settingState.shown = false
+    settingStore = useSettingStore()
+    useSettingStore().settingValues['Comfy.Desktop.CloudNotificationShown'] =
+      false
     electron.getPlatform.mockReturnValue('darwin')
-    settingStore.load.mockResolvedValue(undefined)
-    settingStore.set.mockImplementation(
+    vi.mocked(settingStore.load).mockResolvedValue(undefined)
+    vi.mocked(settingStore.set).mockImplementation(
       async (_key: string, value: boolean) => {
-        settingState.shown = value
+        useSettingStore().settingValues[
+          'Comfy.Desktop.CloudNotificationShown'
+        ] = value
       }
     )
     dialogService.showCloudNotification.mockResolvedValue(undefined)
@@ -78,12 +64,13 @@ describe('DesktopCloudNotificationController', () => {
 
   it('waits for settings to load before deciding whether to show the notification', async () => {
     const loadSettings = createDeferred()
-    settingStore.load.mockImplementation(() => loadSettings.promise)
+    vi.mocked(settingStore.load).mockImplementation(() => loadSettings.promise)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await nextTick()
 
-    settingState.shown = true
+    useSettingStore().settingValues['Comfy.Desktop.CloudNotificationShown'] =
+      true
     loadSettings.resolve()
 
     await vi.advanceTimersByTimeAsync(0)
@@ -96,7 +83,7 @@ describe('DesktopCloudNotificationController', () => {
 
   it('does not schedule or show the notification after unmounting before settings load resolves', async () => {
     const loadSettings = createDeferred()
-    settingStore.load.mockImplementation(() => loadSettings.promise)
+    vi.mocked(settingStore.load).mockImplementation(() => loadSettings.promise)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await nextTick()
@@ -126,7 +113,9 @@ describe('DesktopCloudNotificationController', () => {
       'Comfy.Desktop.CloudNotificationShown',
       true
     )
-    expect(settingStore.set.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      vi.mocked(settingStore.set).mock.invocationCallOrder[0]
+    ).toBeLessThan(
       dialogService.showCloudNotification.mock.invocationCallOrder[0]
     )
 
@@ -141,7 +130,7 @@ describe('DesktopCloudNotificationController', () => {
     const settingsLoad = useAsyncState(() => Promise.reject(error), undefined, {
       immediate: false
     })
-    settingStore.load.mockImplementation(async () => {
+    vi.mocked(settingStore.load).mockImplementation(async () => {
       await settingsLoad.execute()
     })
     vi.spyOn(settingStore, 'error', 'get').mockImplementation(
@@ -179,7 +168,7 @@ describe('DesktopCloudNotificationController', () => {
 
   it('reports an initial save failure, resets state, and never opens the dialog', async () => {
     const error = new Error('save failed')
-    settingStore.set.mockRejectedValueOnce(error)
+    vi.mocked(settingStore.set).mockRejectedValueOnce(error)
 
     const { unmount } = render(DesktopCloudNotificationController)
     await vi.advanceTimersByTimeAsync(2000)
@@ -255,11 +244,13 @@ describe('DesktopCloudNotificationController', () => {
       const initialError = new Error('initial failure')
       const resetError = new Error('reset failed')
       dialogService.showCloudNotification.mockRejectedValue(initialError)
-      settingStore.set.mockImplementation(
+      vi.mocked(settingStore.set).mockImplementation(
         async (_key: string, value: boolean) => {
           if (!value) throw resetError
           if (failure === 'save') throw initialError
-          settingState.shown = value
+          useSettingStore().settingValues[
+            'Comfy.Desktop.CloudNotificationShown'
+          ] = value
         }
       )
 

--- a/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
+++ b/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/stores/authStore'
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
@@ -7,15 +8,6 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
-
-const loading = vi.hoisted(() => ({ value: false }))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get loading() {
-      return loading.value
-    }
-  })
-}))
 
 const LOGIN_COPY = enMessages.auth.login
 
@@ -56,7 +48,7 @@ const submitButton = () =>
 
 beforeEach(() => {
   vi.useRealTimers()
-  loading.value = false
+  Object.assign(useAuthStore(), { loading: false })
 })
 
 describe('CloudSignInForm', () => {
@@ -177,7 +169,7 @@ describe('CloudSignInForm submit gating', () => {
 
 describe('CloudSignInForm in-flight state', () => {
   it('disables submit and marks it busy while an auth action runs', () => {
-    loading.value = true
+    Object.assign(useAuthStore(), { loading: true })
     renderRealForm()
 
     expect(submitButton()).toBeDisabled()
@@ -186,7 +178,7 @@ describe('CloudSignInForm in-flight state', () => {
 
   it('does not emit submit while loading', async () => {
     const user = userEvent.setup()
-    loading.value = true
+    Object.assign(useAuthStore(), { loading: true })
     const { emitted } = renderRealForm()
 
     await user.click(submitButton())
@@ -194,3 +186,10 @@ describe('CloudSignInForm in-flight state', () => {
     expect(emitted().submit).toBeUndefined()
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/onboarding/composables/usePostAuthRedirect.test.ts
+++ b/src/platform/cloud/onboarding/composables/usePostAuthRedirect.test.ts
@@ -1,3 +1,7 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -17,11 +21,6 @@ const resumeOAuthIfNeeded = vi.hoisted(() =>
 )
 vi.mock(import('@/platform/cloud/oauth/useOAuthPostLoginRedirect'), () => ({
   useOAuthPostLoginRedirect: () => ({ resumeOAuthIfNeeded })
-}))
-
-const toasts = vi.hoisted(() => ({ add: vi.fn() }))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => toasts
 }))
 
 const DEFAULT_REDIRECT = { name: 'cloud-user-check' }
@@ -70,7 +69,7 @@ describe('usePostAuthRedirect', () => {
 
     await onAuthSuccess()
 
-    expect(toasts.add).toHaveBeenCalledWith(
+    expect(useToastStore().add).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'success',
         summary: 'Login Completed'
@@ -140,7 +139,7 @@ describe('usePostAuthRedirect', () => {
     await onAuthSuccess()
 
     expect(
-      toasts.add,
+      useToastStore().add,
       'authError only renders in email-form mode, so a Google/GitHub user would see the failure nowhere at all'
     ).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -1,5 +1,8 @@
+import type * as I18nModule from '@/i18n'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { reactive } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
 
@@ -19,35 +22,19 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
 }))
 
 const mockToastAdd = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd
-  })
-}))
-
-interface MockAuthStore {
-  currentUser: {
-    uid: string
-    getIdToken: (forceRefresh?: boolean) => Promise<string>
-  } | null
-  getIdToken: () => Promise<string>
-}
 
 const mockUserGetIdToken = vi.hoisted(() => vi.fn())
 const mockStoreGetIdToken = vi.hoisted(() => vi.fn())
 
-// Reactive so the module's watcher on currentUser fires without a navigation.
-// The mock factory is cached across vi.resetModules(), so it reads a holder
-// refilled per test; watchers leaked by earlier module generations stay
-// subscribed to earlier stores and remain dormant.
-const authStoreHolder = vi.hoisted(() => ({
-  store: null as MockAuthStore | null
-}))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => authStoreHolder.store
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
 }))
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: (key: string) => key
 }))
 
@@ -66,7 +53,7 @@ const RETRY_DELAY_MS = 5_000
 
 const mockFetch = vi.fn()
 
-let mockAuthStore: MockAuthStore
+let mockAuthStore: ReturnType<typeof useAuthStore>
 
 function okResponse() {
   return new Response(JSON.stringify({ status: 'redeemed' }), { status: 200 })
@@ -76,7 +63,7 @@ function expectedFetchOptions(code: string) {
   return {
     method: 'POST',
     headers: {
-      Authorization: 'Bearer firebase-id-token',
+      Authorization: 'Bearer firebase-id-token' as const,
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({ code }),
@@ -125,6 +112,10 @@ async function setup(
   }
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+})
+
 describe('installDesktopLoginRedemption', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -132,14 +123,12 @@ describe('installDesktopLoginRedemption', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockConfirm.mockResolvedValue(true)
     mockUserGetIdToken.mockResolvedValue('firebase-id-token')
-    mockAuthStore = reactive({
-      currentUser: {
-        uid: 'user-1',
-        getIdToken: mockUserGetIdToken
-      },
-      getIdToken: mockStoreGetIdToken
+    mockAuthStore = useAuthStore()
+    mockAuthStore.currentUser = fromPartial({
+      uid: 'user-1',
+      getIdToken: mockUserGetIdToken
     })
-    authStoreHolder.store = mockAuthStore
+    vi.mocked(mockAuthStore.getIdToken).mockImplementation(mockStoreGetIdToken)
   })
 
   it('does nothing on navigation when no code is stashed', async () => {
@@ -267,10 +256,10 @@ describe('installDesktopLoginRedemption', () => {
     expect(mockConfirm).not.toHaveBeenCalled()
 
     // Signing in on the login page fires the auth watcher mid-handoff.
-    mockAuthStore.currentUser = {
+    mockAuthStore.currentUser = fromPartial({
       uid: 'user-1',
       getIdToken: mockUserGetIdToken
-    }
+    })
     await flushRedemption()
 
     expect(mockConfirm).not.toHaveBeenCalled()
@@ -501,10 +490,10 @@ describe('installDesktopLoginRedemption', () => {
 
     // A session appearing without any further navigation redeems via the
     // watcher.
-    mockAuthStore.currentUser = {
+    mockAuthStore.currentUser = fromPartial({
       uid: 'user-1',
       getIdToken: mockUserGetIdToken
-    }
+    })
 
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
     expect(mockFetch).toHaveBeenCalledWith(
@@ -575,10 +564,10 @@ describe('installDesktopLoginRedemption', () => {
 
     // The session changes to user-2 before the retry: user-1's approval must
     // not authorize redeeming with user-2's token.
-    mockAuthStore.currentUser = {
+    mockAuthStore.currentUser = fromPartial({
       uid: 'user-2',
       getIdToken: vi.fn().mockResolvedValue('second-user-token')
-    }
+    })
 
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(2))
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
@@ -586,7 +575,7 @@ describe('installDesktopLoginRedemption', () => {
       REDEEM_URL,
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'Bearer second-user-token'
+          Authorization: 'Bearer second-user-token' as const
         })
       })
     )
@@ -614,7 +603,7 @@ describe('installDesktopLoginRedemption', () => {
       uid: 'user-2',
       getIdToken: vi.fn().mockResolvedValue('second-user-token')
     }
-    mockAuthStore.currentUser = secondUser
+    mockAuthStore.currentUser = fromPartial(secondUser)
     await flushRedemption()
     approve(true)
     await flushRedemption()
@@ -625,7 +614,7 @@ describe('installDesktopLoginRedemption', () => {
       REDEEM_URL,
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'Bearer second-user-token'
+          Authorization: 'Bearer second-user-token' as const
         })
       })
     )

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -1,8 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, reactive, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import PricingTable from '@/platform/cloud/subscription/components/PricingTable.vue'
@@ -30,9 +31,9 @@ const mockAccessBillingPortal = vi.fn()
 const mockReportError = vi.fn()
 const mockTrackBeginCheckout = vi.fn()
 const mockTrackBillingEvent = vi.fn()
-const mockUserId = ref<string | undefined>('user-123')
+
 const mockGetAuthHeader = vi.fn(() =>
-  Promise.resolve({ Authorization: 'Bearer test-token' })
+  Promise.resolve({ Authorization: 'Bearer test-token' as const })
 )
 const mockGetCheckoutAttribution = vi.hoisted(() => vi.fn(() => ({})))
 const mockLocalStorage = vi.hoisted(() => {
@@ -114,23 +115,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () =>
-    reactive({
-      getFirebaseAuthHeader: mockGetAuthHeader,
-      fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
-        fetch(input, init),
-      userId: computed(() => mockUserId.value)
-    }),
-  AuthStoreError: class extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.status = status
-    }
-  }
-}))
-
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackBeginCheckout: mockTrackBeginCheckout,
@@ -145,7 +129,8 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: true
 }))
 
@@ -211,7 +196,7 @@ function renderComponent() {
       // verify checkout-failure telemetry; without an app-level errorHandler,
       // Vue's dev-mode default handler re-throws it as an unhandled rejection.
       config: { errorHandler: () => {} },
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      plugins: [i18n],
       components: {
         Button
       },
@@ -242,12 +227,22 @@ function renderComponent() {
 
 const onChooseTeamWorkspace = vi.fn()
 
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-123' })
+  vi.mocked(useAuthStore().getFirebaseAuthHeader).mockImplementation(
+    mockGetAuthHeader
+  )
+  vi.mocked(useAuthStore().fetchWithCustomerRecovery).mockImplementation(
+    (input, init) => fetch(input, init)
+  )
+})
+
 describe('PricingTable', () => {
   beforeEach(() => {
     mockCanAccessSubscriptionFeatures.value = false
     mockSubscriptionTier.value = null
     mockSubscriptionDuration.value = 'MONTHLY'
-    mockUserId.value = 'user-123'
+    Object.assign(useAuthStore(), { userId: 'user-123' })
     mockAccessBillingPortal.mockResolvedValue(true)
     mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
@@ -364,12 +359,12 @@ describe('PricingTable', () => {
     it('should use the latest userId value when it changes after mount', async () => {
       mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
-      mockUserId.value = 'user-early'
+      Object.assign(useAuthStore(), { userId: 'user-early' })
 
       renderComponent()
       await flushPromises()
 
-      mockUserId.value = 'user-late'
+      Object.assign(useAuthStore(), { userId: 'user-late' })
 
       const creatorButton = screen
         .getAllByRole('button')
@@ -567,3 +562,10 @@ describe('PricingTable', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
@@ -12,25 +15,25 @@ const {
   mockGetAuthHeader,
   mockGetCheckoutAttribution,
   mockTelemetry,
-  mockUserId,
+
   mockIsCloud,
-  mockAuthStoreInitialized,
+
   mockGetBillingStatus,
-  mockActiveWorkspaceId,
+
   mockSetWorkspaceBillingRail,
   mockLocalStorage
 } = vi.hoisted(() => ({
   mockIsLoggedIn: { value: false },
   mockIsCloud: { value: true },
-  mockAuthStoreInitialized: { value: true },
+
   mockGetBillingStatus: vi.fn(),
-  mockActiveWorkspaceId: { value: 'workspace-123' },
+
   mockSetWorkspaceBillingRail: vi.fn(),
   mockReportError: vi.fn(),
   mockAccessBillingPortal: vi.fn(),
   mockShowSubscriptionRequiredDialog: vi.fn(),
   mockGetAuthHeader: vi.fn(() =>
-    Promise.resolve({ Authorization: 'Bearer test-token' })
+    Promise.resolve({ Authorization: 'Bearer test-token' as const })
   ),
   mockGetCheckoutAttribution: vi.fn(() => ({
     im_ref: 'impact-click-001',
@@ -42,7 +45,7 @@ const {
     trackMonthlySubscriptionCancelled: vi.fn(),
     trackBillingEvent: vi.fn()
   },
-  mockUserId: { value: 'user-123' },
+
   mockLocalStorage: (() => {
     const store = new Map<string, string>()
 
@@ -131,7 +134,8 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   }))
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -150,41 +154,28 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      setWorkspaceBillingRail: mockSetWorkspaceBillingRail
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: vi.fn(() => ({
     showSubscriptionRequiredDialog: mockShowSubscriptionRequiredDialog
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    getFirebaseAuthHeader: mockGetAuthHeader,
-    fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
-      fetch(input, init),
-    get isInitialized() {
-      return mockAuthStoreInitialized.value
-    },
-    get userId() {
-      return mockUserId.value
-    }
-  })),
-  AuthStoreError: class extends Error {}
-}))
-
 // Mock fetch
 global.fetch = vi.fn()
+
+beforeEach(() => {
+  Object.assign(useAuthStore(), { isInitialized: true, userId: 'user-123' })
+  vi.mocked(useAuthStore().getFirebaseAuthHeader).mockImplementation(
+    mockGetAuthHeader
+  )
+  vi.mocked(useAuthStore().fetchWithCustomerRecovery).mockImplementation(
+    (input, init) => fetch(input, init)
+  )
+
+  vi.mocked(useTeamWorkspaceStore().setWorkspaceBillingRail).mockImplementation(
+    mockSetWorkspaceBillingRail
+  )
+})
 
 describe('useSubscription', () => {
   afterEach(() => {
@@ -202,10 +193,12 @@ describe('useSubscription', () => {
     mockLocalStorage.__reset()
     mockIsLoggedIn.value = false
     mockAccessBillingPortal.mockResolvedValue(true)
-    mockUserId.value = 'user-123'
+    Object.assign(useAuthStore(), { userId: 'user-123' })
     mockIsCloud.value = true
-    mockAuthStoreInitialized.value = true
-    mockActiveWorkspaceId.value = 'workspace-123'
+    Object.assign(useAuthStore(), { isInitialized: true })
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: 'workspace-123'
+    })
     mockGetBillingStatus.mockResolvedValue({
       is_active: false,
       has_funds: false,
@@ -387,8 +380,10 @@ describe('useSubscription', () => {
       const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
       const previousAccountRequest = fetchStatus()
 
-      mockUserId.value = 'user-456'
-      mockActiveWorkspaceId.value = 'workspace-456'
+      Object.assign(useAuthStore(), { userId: 'user-456' })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-456'
+      })
       const currentAccountRequest = fetchStatus()
       await currentAccountRequest
 
@@ -474,7 +469,7 @@ describe('useSubscription', () => {
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
-            Authorization: 'Bearer test-token',
+            Authorization: 'Bearer test-token' as const,
             'Content-Type': 'application/json'
           }),
           body: JSON.stringify({
@@ -786,7 +781,7 @@ describe('useSubscription', () => {
     })
 
     it('does not clear pending attempts before auth initialization resolves', async () => {
-      mockAuthStoreInitialized.value = false
+      Object.assign(useAuthStore(), { isInitialized: false })
       mockIsLoggedIn.value = false
 
       localStorage.setItem(
@@ -1032,3 +1027,10 @@ describe('useSubscription', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
@@ -1,3 +1,5 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
@@ -6,7 +8,9 @@ const mockBillingFetchBalance = vi.fn()
 const mockAuthFetchBalance = vi.fn()
 const mockFetchStatus = vi.fn()
 const mockShowTopUpCreditsDialog = vi.fn()
-const mockExecute = vi.fn()
+const mockExecute = vi.fn<ReturnType<typeof useCommandStore>['execute']>(
+  async () => undefined
+)
 const mockToastAdd = vi.fn()
 
 const { mockReportError } = vi.hoisted(() => ({
@@ -15,10 +19,6 @@ const { mockReportError } = vi.hoisted(() => ({
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mockToastAdd })
 }))
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
@@ -37,12 +37,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     showTopUpCreditsDialog: mockShowTopUpCreditsDialog
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: mockExecute
   })
 }))
 
@@ -74,10 +68,14 @@ Object.defineProperty(window, 'open', {
   value: mockOpen
 })
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+  vi.mocked(useCommandStore().execute).mockImplementation(mockExecute)
+})
+
 describe('useSubscriptionActions', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockReportError.mockReset()
   })
 
   describe('handleAddApiCredits', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -1,3 +1,8 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SubscriptionInfo } from '@/composables/billing/types'
@@ -17,7 +22,7 @@ const mockCloseDialog = vi.fn()
 const mockShowLayoutDialog = vi.fn()
 const mockShowTeamWorkspacesDialog = vi.fn()
 const mockTrackSubscription = vi.hoisted(() => vi.fn())
-const mockIsInPersonalWorkspace = vi.hoisted(() => ({ value: true }))
+
 const mockIsFreeTier = vi.hoisted(() => ({ value: false }))
 const mockTier = vi.hoisted(() => ({ value: 'FREE' as string | null }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
@@ -30,8 +35,7 @@ const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockCurrentPlanSlug = vi.hoisted(() => ({ value: null as string | null }))
 const mockCanManageSubscription = vi.hoisted(() => ({ value: true }))
 const mockEmbeddedCheckoutEnabled = vi.hoisted(() => ({ value: false }))
-const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
-const mockUserId = vi.hoisted(() => ({ value: 'user-1' as string | undefined }))
+
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockFetchPlans = vi.hoisted(() => vi.fn())
 const mockFetchStatus = vi.hoisted(() => vi.fn())
@@ -46,12 +50,6 @@ const mockSubscription = vi.hoisted(() => ({
 }))
 const mockSubscriptionStatus = vi.hoisted(() => ({
   value: null as BillingSubscriptionStatus | null
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
 }))
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
@@ -86,39 +84,11 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      get isInPersonalWorkspace() {
-        return mockIsInPersonalWorkspace.value
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({ startOperation: mockStartOperation })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get userId() {
-      return mockUserId.value
-    }
-  })
 }))
 
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
@@ -166,10 +136,19 @@ function expectRekaPricingDialogProps(
   expect(dialogComponentProps).not.toHaveProperty('pt')
 }
 
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-1' })
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(mockCloseDialog)
+
+  vi.mocked(useBillingOperationStore().startOperation).mockImplementation(
+    mockStartOperation
+  )
+})
+
 describe('useSubscriptionDialog', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsFreeTier.value = false
     mockTier.value = 'FREE'
     mockShouldUseWorkspaceBilling.value = false
@@ -179,8 +158,8 @@ describe('useSubscriptionDialog', () => {
     mockCurrentPlanSlug.value = null
     mockCanManageSubscription.value = true
     mockEmbeddedCheckoutEnabled.value = false
-    mockActiveWorkspaceId.value = 'workspace-1'
-    mockUserId.value = 'user-1'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
+    Object.assign(useAuthStore(), { userId: 'user-1' })
     mockStartOperation.mockResolvedValue({ status: 'succeeded' })
     mockFetchPlans.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
@@ -212,7 +191,7 @@ describe('useSubscriptionDialog', () => {
 
     it('does not wire onChooseTeam on the unified table (personal subscribes directly)', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -224,7 +203,7 @@ describe('useSubscriptionDialog', () => {
 
     it('sizes the unified pricing dialog via the Reka contentClass, not the ignored PrimeVue style', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -235,7 +214,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults to the personal tab in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -246,7 +225,7 @@ describe('useSubscriptionDialog', () => {
 
     it('opens the team tab when planMode is forced from a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockCurrentPlanSlug.value = 'creator-monthly'
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -273,7 +252,7 @@ describe('useSubscriptionDialog', () => {
 
     it('routes a personal deep link through the legacy Team downgrade flow', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
       const initialCheckout = {
@@ -290,7 +269,7 @@ describe('useSubscriptionDialog', () => {
 
     it('keeps a Team stop deep link table-only for a legacy Team plan', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -314,7 +293,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults to the team tab for a Team plan in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsTeamPlan.value = true
       mockCurrentPlanSlug.value = 'team_per_credit_monthly'
       const { showPricingTable } = useSubscriptionDialog()
@@ -327,7 +306,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults to the personal tab for a personal plan in a team workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockCurrentPlanSlug.value = 'creator-monthly'
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -339,7 +318,7 @@ describe('useSubscriptionDialog', () => {
 
     it('keeps personal checkout deep links table-only on the legacy billing flow', () => {
       mockShouldUseWorkspaceBilling.value = false
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable({
@@ -365,7 +344,7 @@ describe('useSubscriptionDialog', () => {
     it('uses the unified table when pricing is unified but billing remains legacy', () => {
       mockShouldUseWorkspaceBilling.value = false
       mockShouldUseUnifiedPricing.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable()
@@ -390,7 +369,7 @@ describe('useSubscriptionDialog', () => {
 
     it('routes an existing per-member (legacy) team subscriber to the old team table', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -408,7 +387,7 @@ describe('useSubscriptionDialog', () => {
 
     it('sizes the legacy workspace pricing dialog via Reka contentClass', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -423,7 +402,7 @@ describe('useSubscriptionDialog', () => {
 
     it('defaults an unsubscribed team workspace to the team tab', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockIsLegacyTeamPlan.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -435,7 +414,7 @@ describe('useSubscriptionDialog', () => {
 
     it('shows the read-only member dialog in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockCanManageSubscription.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -474,7 +453,7 @@ describe('useSubscriptionDialog', () => {
 
     it('does not track modal_opened for the inactive member dialog', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockCanManageSubscription.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -486,7 +465,7 @@ describe('useSubscriptionDialog', () => {
 
     it('shows the read-only member dialog for out-of-credits too, not the pricing table', () => {
       mockShouldUseWorkspaceBilling.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockCanManageSubscription.value = false
       const { showPricingTable } = useSubscriptionDialog()
 
@@ -512,7 +491,7 @@ describe('useSubscriptionDialog', () => {
   describe('show', () => {
     it('sends a free-tier personal user straight to the pricing table', () => {
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { show } = useSubscriptionDialog()
 
       show()
@@ -525,7 +504,7 @@ describe('useSubscriptionDialog', () => {
     it('checks workspace member permission before the personal free-tier path', () => {
       mockShouldUseWorkspaceBilling.value = true
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockCanManageSubscription.value = false
       const { show } = useSubscriptionDialog()
 
@@ -550,7 +529,7 @@ describe('useSubscriptionDialog', () => {
 
     it('falls back to the pricing table for a free-tier team workspace', () => {
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       const { show } = useSubscriptionDialog()
 
       show()
@@ -562,7 +541,7 @@ describe('useSubscriptionDialog', () => {
 
     it('tracks modal_opened with the reason for the free-tier dialog', () => {
       mockIsFreeTier.value = true
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       const { show } = useSubscriptionDialog()
 
       show({ reason: 'out_of_credits' })
@@ -635,7 +614,7 @@ describe('useSubscriptionDialog', () => {
 
     it('shows pricing table and clears intent when in team workspace', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
       mockShouldUseWorkspaceBilling.value = true
       mockCurrentPlanSlug.value = 'creator-monthly'
 
@@ -653,7 +632,7 @@ describe('useSubscriptionDialog', () => {
 
     it('clears intent but does not show pricing if still in personal workspace', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
       void resumePendingPricingFlow()
@@ -664,7 +643,7 @@ describe('useSubscriptionDialog', () => {
 
     it('consumes intent so second call is a no-op', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
-      mockIsInPersonalWorkspace.value = false
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
       void resumePendingPricingFlow()
@@ -930,3 +909,10 @@ describe('useSubscriptionDialog', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/launchCancellationFlow.test.ts
+++ b/src/platform/cloud/subscription/launchCancellationFlow.test.ts
@@ -1,3 +1,5 @@
+import type * as I18nModule from '@/i18n'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SubscriptionInfo } from '@/composables/billing/types'
@@ -30,7 +32,10 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock(import('@/i18n'), () => ({ t: (key: string) => key }))
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
+  t: (key: string) => key
+}))
 
 vi.mock(import('@/platform/cloud/churnkey/churnkeyClient'), () => ({
   prepareChurnkey: mocks.prepare
@@ -42,20 +47,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mocks.activeWorkspaceId
-      },
-      get activeWorkspaceBillingRail() {
-        return mocks.billingRail
-      }
-    })
-  })
-)
-
 import { launchCancellationFlow } from './launchCancellationFlow'
 
 function session(
@@ -63,6 +54,23 @@ function session(
 ): ChurnkeySession {
   return { show }
 }
+
+beforeEach(() => {
+  vi.spyOn(
+    useTeamWorkspaceStore(),
+    'activeWorkspaceId',
+    'get'
+  ).mockImplementation(() => {
+    return mocks.activeWorkspaceId
+  })
+  vi.spyOn(
+    useTeamWorkspaceStore(),
+    'activeWorkspaceBillingRail',
+    'get'
+  ).mockImplementation(() => {
+    return mocks.billingRail
+  })
+})
 
 describe('launchCancellationFlow', () => {
   beforeEach(() => {

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -1,5 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, reactive } from 'vue'
 
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { performSubscriptionCheckout } from './subscriptionCheckoutUtil'
@@ -7,7 +8,7 @@ import { performSubscriptionCheckout } from './subscriptionCheckoutUtil'
 const {
   mockTelemetry,
   mockGetAuthHeader,
-  mockUserId,
+
   mockIsCloud,
   mockGetCheckoutAttribution,
   mockLocalStorage
@@ -16,10 +17,10 @@ const {
     trackBeginCheckout: vi.fn(),
     trackBillingEvent: vi.fn()
   },
-  mockGetAuthHeader: vi.fn(() =>
-    Promise.resolve({ Authorization: 'Bearer test-token' })
-  ),
-  mockUserId: { value: 'user-123' },
+  mockGetAuthHeader: vi.fn<
+    ReturnType<typeof useAuthStore>['getFirebaseAuthHeader']
+  >(() => Promise.resolve({ Authorization: 'Bearer test-token' as const })),
+
   mockIsCloud: { value: true },
   mockGetCheckoutAttribution: vi.fn(() => ({
     ga_client_id: 'ga-client-id',
@@ -68,25 +69,8 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: vi.fn(() => mockTelemetry)
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() =>
-    reactive({
-      getFirebaseAuthHeader: mockGetAuthHeader,
-      fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
-        fetch(input, init),
-      userId: computed(() => mockUserId.value)
-    })
-  ),
-  AuthStoreError: class extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.status = status
-    }
-  }
-}))
-
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -118,11 +102,21 @@ function createDeferred<T>() {
   return { promise, resolve }
 }
 
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-123' })
+  vi.mocked(useAuthStore().getFirebaseAuthHeader).mockImplementation(
+    mockGetAuthHeader
+  )
+  vi.mocked(useAuthStore().fetchWithCustomerRecovery).mockImplementation(
+    (input, init) => fetch(input, init)
+  )
+})
+
 describe('performSubscriptionCheckout', () => {
   beforeEach(() => {
     setDistribution('cloud')
     mockIsCloud.value = true
-    mockUserId.value = 'user-123'
+    Object.assign(useAuthStore(), { userId: 'user-123' })
     mockLocalStorage.__reset()
   })
 
@@ -256,9 +250,14 @@ describe('performSubscriptionCheckout', () => {
   it('uses the latest userId when it changes after checkout starts', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window)
-    const authHeader = createDeferred<{ Authorization: string }>()
+    const authHeader =
+      createDeferred<
+        Awaited<
+          ReturnType<ReturnType<typeof useAuthStore>['getFirebaseAuthHeader']>
+        >
+      >()
 
-    mockUserId.value = 'user-early'
+    Object.assign(useAuthStore(), { userId: 'user-early' })
     mockGetAuthHeader.mockImplementationOnce(() => authHeader.promise)
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -267,8 +266,8 @@ describe('performSubscriptionCheckout', () => {
 
     const checkoutPromise = performSubscriptionCheckout('pro', 'yearly')
 
-    mockUserId.value = 'user-late'
-    authHeader.resolve({ Authorization: 'Bearer test-token' })
+    Object.assign(useAuthStore(), { userId: 'user-late' })
+    authHeader.resolve({ Authorization: 'Bearer test-token' as const })
 
     await checkoutPromise
 
@@ -336,3 +335,10 @@ describe('performSubscriptionCheckout', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -1,21 +1,21 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, reactive } from 'vue'
 
 const {
   mockIsCloud,
   mockSubscribe,
   mockTrackBeginCheckout,
-  mockTrackBillingEvent,
-  mockUserId
+  mockTrackBillingEvent
 } = vi.hoisted(() => ({
   mockIsCloud: { value: true },
   mockSubscribe: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
-  mockTrackBillingEvent: vi.fn(),
-  mockUserId: { value: 'user-1' }
+  mockTrackBillingEvent: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -42,17 +42,12 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     trackBillingEvent: mockTrackBillingEvent
   })
 }))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => reactive({ userId: computed(() => mockUserId.value) }),
-  AuthStoreError: class AuthStoreError extends Error {
-    constructor(message: string) {
-      super(message)
-      this.name = 'AuthStoreError'
-    }
-  }
-}))
 
 import { performTeamSubscriptionCheckout } from './teamSubscriptionCheckoutUtil'
+
+beforeEach(() => {
+  Object.assign(useAuthStore(), { userId: 'user-1' })
+})
 
 describe('performTeamSubscriptionCheckout', () => {
   let assignedHref: string | undefined
@@ -169,3 +164,10 @@ describe('performTeamSubscriptionCheckout', () => {
     expect(assignedHref).toBeUndefined()
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -5,20 +6,14 @@ import type {
   SavedPaymentMethod
 } from './workspaceApi'
 
-const {
-  mockAxiosInstance,
-  mockGetWorkspaceAuthHeaderOrThrow,
-  mockGetFirebaseAuthHeaderOrThrow
-} = vi.hoisted(() => ({
+const { mockAxiosInstance } = vi.hoisted(() => ({
   mockAxiosInstance: {
     get: vi.fn(),
     post: vi.fn(),
     patch: vi.fn(),
     delete: vi.fn(),
     interceptors: { response: { use: vi.fn() } }
-  },
-  mockGetWorkspaceAuthHeaderOrThrow: vi.fn(),
-  mockGetFirebaseAuthHeaderOrThrow: vi.fn()
+  }
 }))
 
 vi.mock<unknown>(import('axios'), () => ({
@@ -39,44 +34,45 @@ vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) => key)
 }))
 
-vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: {
+vi.mock(import('@/scripts/api'), async (importOriginal) => ({
+  api: Object.assign((await importOriginal()).api, {
     apiURL: vi.fn((path: string) => `/api${path}`)
-  }
+  })
 }))
 
 vi.mock(import('./workspaceApiUrl'), () => ({
   workspaceApiUrl: (path: string) => `/api${path}`
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    getWorkspaceAuthHeaderOrThrow: mockGetWorkspaceAuthHeaderOrThrow,
-    getFirebaseAuthHeaderOrThrow: mockGetFirebaseAuthHeaderOrThrow
-  })
-}))
-
 import { workspaceApi } from './workspaceApi'
 
-const AUTH_HEADER = { Authorization: 'Bearer test-token' }
+const AUTH_HEADER = { Authorization: 'Bearer test-token' } as const
 
 describe('workspaceApi', () => {
   beforeEach(() => {
-    mockGetWorkspaceAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
-    mockGetFirebaseAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
+    vi.mocked(useAuthStore().getWorkspaceAuthHeaderOrThrow).mockResolvedValue(
+      AUTH_HEADER
+    )
+    vi.mocked(useAuthStore().getFirebaseAuthHeaderOrThrow).mockResolvedValue(
+      AUTH_HEADER
+    )
   })
 
   describe('authentication', () => {
     it('propagates error when workspace authentication rejects', async () => {
       const authError = new Error('toastMessages.userNotAuthenticated')
-      mockGetWorkspaceAuthHeaderOrThrow.mockRejectedValue(authError)
+      vi.mocked(useAuthStore().getWorkspaceAuthHeaderOrThrow).mockRejectedValue(
+        authError
+      )
 
       await expect(workspaceApi.list()).rejects.toBe(authError)
     })
 
     it('propagates error when getFirebaseAuthHeaderOrThrow rejects', async () => {
       const authError = new Error('toastMessages.userNotAuthenticated')
-      mockGetFirebaseAuthHeaderOrThrow.mockRejectedValue(authError)
+      vi.mocked(useAuthStore().getFirebaseAuthHeaderOrThrow).mockRejectedValue(
+        authError
+      )
 
       await expect(workspaceApi.acceptInvite('token')).rejects.toBe(authError)
     })
@@ -340,8 +336,10 @@ describe('workspaceApi', () => {
 
       const result = await workspaceApi.acceptInvite('abc-token')
 
-      expect(mockGetFirebaseAuthHeaderOrThrow).toHaveBeenCalled()
-      expect(mockGetWorkspaceAuthHeaderOrThrow).not.toHaveBeenCalled()
+      expect(useAuthStore().getFirebaseAuthHeaderOrThrow).toHaveBeenCalled()
+      expect(
+        useAuthStore().getWorkspaceAuthHeaderOrThrow
+      ).not.toHaveBeenCalled()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/invites/abc-token/accept',
         null,
@@ -789,3 +787,10 @@ describe('workspaceApi', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -1,7 +1,10 @@
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -17,16 +20,7 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 
-const mockIsInitialized = ref(false)
-const mockCurrentUser = ref<object | null>(null)
 const mockLogout = vi.fn()
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    isInitialized: mockIsInitialized,
-    currentUser: mockCurrentUser
-  })
-}))
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: () => ({ logout: mockLogout })
@@ -63,52 +57,7 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-const mockMintAtLogin = vi.fn()
-const mockGetUnifiedToken = vi.fn()
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({
-      mintAtLogin: mockMintAtLogin,
-      getUnifiedToken: mockGetUnifiedToken
-    })
-  })
-)
-
-const mockWorkspaceStoreInitialize = vi.fn()
-const mockWorkspaceStoreReset = vi.fn()
 const mockBillingCapabilitiesInitialize = vi.hoisted(() => vi.fn())
-const mockWorkspaceStoreInitState = vi.hoisted(() => ({
-  value: 'uninitialized' as string
-}))
-const mockActiveWorkspaceId = vi.hoisted(() => ({
-  value: 'workspace-123' as string | null
-}))
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get initState() {
-        return mockWorkspaceStoreInitState.value
-      },
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      initialize: mockWorkspaceStoreInitialize,
-      resetForIdentityChange: mockWorkspaceStoreReset
-    })
-  })
-)
-
-const mockApiKeyAuthenticated = ref(false)
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => ({
-    get isAuthenticated() {
-      return mockApiKeyAuthenticated.value
-    },
-    getApiKey: () => (mockApiKeyAuthenticated.value ? 'comfyui-test-key' : null)
-  })
-}))
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useBillingCapabilities'),
@@ -126,27 +75,50 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
+beforeEach(() => {
+  vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(false)
+  vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockReturnValue(undefined)
+})
+
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().initialize).mockResolvedValue(undefined)
+  vi.mocked(useTeamWorkspaceStore().resetForIdentityChange).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useApiKeyAuthStore().getApiKey).mockImplementation(() =>
+    useApiKeyAuthStore().isAuthenticated ? 'comfyui-test-key' : null
+  )
+})
+
 describe('WorkspaceAuthGate', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockIsInitialized.value = false
-    mockCurrentUser.value = null
-    mockApiKeyAuthenticated.value = false
+    Object.assign(useAuthStore(), { isInitialized: false })
+    Object.assign(useAuthStore(), { currentUser: null })
+    Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
     mockUnifiedCloudAuthEnabled.value = false
     mockRemoteConfigState.value = 'authenticated'
     mockRemoteConfigErrorStatus.value = null
-    mockWorkspaceStoreInitState.value = 'uninitialized'
-    mockActiveWorkspaceId.value = 'workspace-123'
+    Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: 'workspace-123'
+    })
     mockRefreshRemoteConfig.mockResolvedValue(undefined)
     mockBillingCapabilitiesInitialize.mockResolvedValue(undefined)
-    mockWorkspaceStoreInitialize.mockImplementation(async () => {
-      mockWorkspaceStoreInitState.value = 'ready'
+    vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+      async () => {
+        Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
+      }
+    )
+    vi.mocked(
+      useTeamWorkspaceStore().resetForIdentityChange
+    ).mockImplementation(() => {
+      Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
     })
-    mockWorkspaceStoreReset.mockImplementation(() => {
-      mockWorkspaceStoreInitState.value = 'uninitialized'
-    })
-    mockMintAtLogin.mockResolvedValue(true)
-    mockGetUnifiedToken.mockReturnValue('cloud-jwt')
+    vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(true)
+    vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockReturnValue(
+      'cloud-jwt'
+    )
   })
 
   const i18n = createI18n({
@@ -176,41 +148,41 @@ describe('WorkspaceAuthGate', () => {
 
     it('initializes workspace context in the background for a signed-in user', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
 
       mountComponent()
       await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
       expect(mockBillingCapabilitiesInitialize).not.toHaveBeenCalled()
       expect(mockRefreshRemoteConfig).not.toHaveBeenCalled()
     })
 
     it('initializes workspace context after a mid-session sign-in', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { isInitialized: true })
 
       mountComponent()
       await flushPromises()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
 
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
     })
 
     it('deduplicates mount and auth-hydration initialization', async () => {
       mockIsCloud.value = false
 
       mountComponent()
-      mockCurrentUser.value = { uid: 'user-123' }
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
     })
 
     it('cancels pending initialization when unmounted', async () => {
@@ -218,71 +190,71 @@ describe('WorkspaceAuthGate', () => {
 
       const { unmount } = mountComponent()
       unmount()
-      mockCurrentUser.value = { uid: 'user-123' }
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('cancels pending initialization on logout', async () => {
       mockIsCloud.value = false
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
 
       mountComponent()
-      mockCurrentUser.value = null
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { currentUser: null })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('initializes workspace context after an API-key sign-in', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
+      Object.assign(useAuthStore(), { isInitialized: true })
 
       mountComponent()
       await flushPromises()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
 
-      mockApiKeyAuthenticated.value = true
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledOnce()
     })
 
     it('cancels pending initialization on API-key sign-out', async () => {
       mockIsCloud.value = false
-      mockApiKeyAuthenticated.value = true
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
 
       mountComponent()
-      mockApiKeyAuthenticated.value = false
-      mockIsInitialized.value = true
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+      Object.assign(useAuthStore(), { isInitialized: true })
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('resets workspace state when the session identity changes', async () => {
       mockIsCloud.value = false
-      mockIsInitialized.value = true
-      mockApiKeyAuthenticated.value = true
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
 
       mountComponent()
       await flushPromises()
 
-      mockApiKeyAuthenticated.value = false
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
       await flushPromises()
 
-      expect(mockWorkspaceStoreReset).toHaveBeenCalled()
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledTimes(2)
+      expect(useTeamWorkspaceStore().resetForIdentityChange).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledTimes(2)
     })
   })
 
   describe('cloud builds - unauthenticated user', () => {
     it('hides slot while waiting for Firebase auth', () => {
-      mockIsInitialized.value = false
+      Object.assign(useAuthStore(), { isInitialized: false })
 
       mountComponent()
 
@@ -290,13 +262,13 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('renders slot when Firebase initializes with no user', async () => {
-      mockIsInitialized.value = false
+      Object.assign(useAuthStore(), { isInitialized: false })
 
       mountComponent()
       expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
 
-      mockIsInitialized.value = true
-      mockCurrentUser.value = null
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: null })
       await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
@@ -317,8 +289,8 @@ describe('WorkspaceAuthGate', () => {
 
   describe('cloud builds - authenticated user', () => {
     beforeEach(() => {
-      mockIsInitialized.value = true
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
     })
 
     it('refreshes remote config with auth after Firebase init', async () => {
@@ -339,7 +311,7 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(mockMintAtLogin).toHaveBeenCalledOnce()
+      expect(useWorkspaceAuthStore().mintAtLogin).toHaveBeenCalledOnce()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
 
@@ -347,7 +319,7 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalled()
       expect(mockBillingCapabilitiesInitialize).toHaveBeenCalled()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
@@ -408,25 +380,25 @@ describe('WorkspaceAuthGate', () => {
       await flushPromises()
 
       expect(signal.aborted).toBe(true)
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
       expect(mockReportError).not.toHaveBeenCalled()
     })
 
     it('skips workspace init when store is already initialized', async () => {
-      mockWorkspaceStoreInitState.value = 'ready'
+      Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
 
       mountComponent()
       await flushPromises()
 
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
   })
 
   describe('error handling', () => {
     beforeEach(() => {
-      mockIsInitialized.value = true
-      mockCurrentUser.value = { uid: 'user-123' }
+      Object.assign(useAuthStore(), { isInitialized: true })
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-123' } })
     })
 
     it('shows a recoverable error when remote config refresh fails', async () => {
@@ -482,7 +454,7 @@ describe('WorkspaceAuthGate', () => {
       expect(
         screen.getByText("Couldn't load your workspace")
       ).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('requires sign out when authenticated config rejects the credential', async () => {
@@ -506,7 +478,7 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows a recoverable error when unified auth initialization fails', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockMintAtLogin.mockResolvedValue(false)
+      vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(false)
 
       mountComponent()
       await flushPromises()
@@ -514,11 +486,11 @@ describe('WorkspaceAuthGate', () => {
       expect(
         screen.getByText("Couldn't load your workspace")
       ).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
 
     it('shows a recoverable error when workspace store initialization fails', async () => {
-      mockWorkspaceStoreInitialize.mockRejectedValue(
+      vi.mocked(useTeamWorkspaceStore().initialize).mockRejectedValue(
         new Error('Workspace init failed')
       )
 
@@ -531,7 +503,7 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('requires sign out when no workspace is available', async () => {
-      mockWorkspaceStoreInitialize.mockRejectedValue(
+      vi.mocked(useTeamWorkspaceStore().initialize).mockRejectedValue(
         new Error('No workspaces available')
       )
 
@@ -548,7 +520,9 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows a recoverable error when workspace setup clears unified auth', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetUnifiedToken.mockReturnValue(undefined)
+      vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockReturnValue(
+        undefined
+      )
 
       mountComponent()
       await flushPromises()
@@ -559,7 +533,7 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error without a ready workspace context', async () => {
-      mockWorkspaceStoreInitState.value = 'loading'
+      Object.assign(useTeamWorkspaceStore(), { initState: 'loading' })
 
       mountComponent()
       await flushPromises()
@@ -571,13 +545,13 @@ describe('WorkspaceAuthGate', () => {
 
     it('renders the app after retrying a failed initialization', async () => {
       const user = userEvent.setup()
-      mockWorkspaceStoreInitialize
+      vi.mocked(useTeamWorkspaceStore().initialize)
         .mockImplementationOnce(async () => {
-          mockWorkspaceStoreInitState.value = 'error'
+          Object.assign(useTeamWorkspaceStore(), { initState: 'error' })
           throw new Error('Workspace init failed')
         })
         .mockImplementationOnce(async () => {
-          mockWorkspaceStoreInitState.value = 'ready'
+          Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
         })
 
       mountComponent()
@@ -586,7 +560,7 @@ describe('WorkspaceAuthGate', () => {
       await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledTimes(2)
+      expect(useTeamWorkspaceStore().initialize).toHaveBeenCalledTimes(2)
     })
 
     it('keeps the retry action named while retrying', async () => {
@@ -635,7 +609,14 @@ describe('WorkspaceAuthGate', () => {
 
       expect(retrySignal.aborted).toBe(true)
       expect(mockLogout).toHaveBeenCalledOnce()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().initialize).not.toHaveBeenCalled()
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -1,4 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { getActivePinia } from 'pinia'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -30,27 +31,6 @@ const state = vi.hoisted(() => ({
   showPricingTable: vi.fn(),
   showSettingsDialog: vi.fn()
 }))
-
-const workspaceStoreMock = vi.hoisted(() => ({
-  store: null as null | {
-    initState: string
-    workspaceName: string
-    isInPersonalWorkspace: boolean
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { reactive, ref } = await import('vue')
-    workspaceStoreMock.store = reactive({
-      initState: ref('ready'),
-      workspaceName: ref('Personal Workspace'),
-      isInPersonalWorkspace: ref(true)
-    })
-    return { useTeamWorkspaceStore: () => workspaceStoreMock.store }
-  }
-)
 
 vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   useCurrentUser: () => ({
@@ -173,19 +153,17 @@ function renderComponent(
   type: 'personal' | 'team' = 'personal',
   accountActionsOnly = false
 ) {
-  if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
-  workspaceStoreMock.store.workspaceName = `${type === 'personal' ? 'Personal' : 'Team'} Workspace`
-  workspaceStoreMock.store.isInPersonalWorkspace = type === 'personal'
+  useTeamWorkspaceStore().initState = 'ready'
+  Object.assign(useTeamWorkspaceStore(), {
+    workspaceName: `${type === 'personal' ? 'Personal' : 'Team'} Workspace`
+  })
+  Object.assign(useTeamWorkspaceStore(), {
+    isInPersonalWorkspace: type === 'personal'
+  })
   return render(CurrentUserPopoverWorkspace, {
     props: { accountActionsOnly },
     global: {
-      plugins: [
-        createTestingPinia({
-          createSpy: vi.fn
-        }),
-        PrimeVue,
-        i18n
-      ],
+      plugins: [getActivePinia()!, PrimeVue, i18n],
       directives: {
         tooltip: Tooltip
       },
@@ -376,9 +354,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       screen.queryByRole('button', { name: 'Subscribe' })
     ).not.toBeInTheDocument()
 
-    if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
-    workspaceStoreMock.store.workspaceName = 'Team Workspace'
-    workspaceStoreMock.store.isInPersonalWorkspace = false
+    Object.assign(useTeamWorkspaceStore(), { workspaceName: 'Team Workspace' })
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     await rerender({})
 
     expect(screen.getByTestId('workspace-switcher-trigger')).toHaveTextContent(

--- a/src/platform/workspace/components/InviteMembersForm.test.ts
+++ b/src/platform/workspace/components/InviteMembersForm.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,18 +9,12 @@ import InviteMembersForm from './InviteMembersForm.vue'
 import type { WorkspacePendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const {
-  mockCreateInvite,
-  mockFetchPendingInvites,
   mockFetchStatus,
-  mockPendingInvites,
   mockToastAdd,
   mockTrackInviteSent,
   mockTrackInviteFailed
 } = vi.hoisted(() => ({
-  mockCreateInvite: vi.fn(),
-  mockFetchPendingInvites: vi.fn(),
   mockFetchStatus: vi.fn(),
-  mockPendingInvites: { value: [] as WorkspacePendingInvite[] },
   mockToastAdd: vi.fn(),
   mockTrackInviteSent: vi.fn(),
   mockTrackInviteFailed: vi.fn()
@@ -28,21 +23,6 @@ const {
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({ fetchStatus: mockFetchStatus })
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      createInvite: mockCreateInvite as (
-        email: string
-      ) => Promise<WorkspacePendingInvite>,
-      fetchPendingInvites: mockFetchPendingInvites,
-      get pendingInvites() {
-        return [...mockPendingInvites.value]
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(
   import('primevue/usetoast'), // eslint-disable-line primevue-removal/no-imports
@@ -102,11 +82,13 @@ function submitButton() {
 describe('InviteMembersForm', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockPendingInvites.value = []
-    mockFetchPendingInvites.mockResolvedValue([...mockPendingInvites.value])
+    Object.assign(useTeamWorkspaceStore(), { pendingInvites: [] })
+    vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([
+      ...useTeamWorkspaceStore().pendingInvites
+    ])
     mockFetchStatus.mockResolvedValue(undefined)
-    mockCreateInvite.mockImplementation(async (email: string) =>
-      pendingInviteFor(email)
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => pendingInviteFor(email)
     )
   })
 
@@ -142,9 +124,11 @@ describe('InviteMembersForm', () => {
     await user.type(emailInput(), 'A@B.com C@D.com{Enter}')
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
-    expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
-    expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('a@b.com')
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('c@d.com')
     expect(mockTrackInviteSent).toHaveBeenCalledWith({
       source: 'post_upgrade_success',
       count: 2
@@ -170,8 +154,12 @@ describe('InviteMembersForm', () => {
 
   it('ignores stale cached invites when pending invites cannot be refreshed', async () => {
     const refreshError = new Error('pending invites failed')
-    mockPendingInvites.value.push(pendingInviteFor('stale@example.com'))
-    mockFetchPendingInvites.mockRejectedValueOnce(refreshError)
+    useTeamWorkspaceStore().pendingInvites.push(
+      pendingInviteFor('stale@example.com')
+    )
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockRejectedValueOnce(refreshError)
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { user, emitted } = renderForm()
 
@@ -194,7 +182,9 @@ describe('InviteMembersForm', () => {
     let resolvePendingInvites: (
       invites: WorkspacePendingInvite[]
     ) => void = () => {}
-    mockFetchPendingInvites.mockImplementationOnce(
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolvePendingInvites = resolve
@@ -210,24 +200,28 @@ describe('InviteMembersForm', () => {
     await waitFor(() =>
       expect(submitButton()).toHaveAttribute('aria-busy', 'false')
     )
-    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
   })
 
   it('keeps failed emails for retry and emits all invited emails after recovery', async () => {
     let shouldFail = true
-    mockCreateInvite.mockImplementation(async (email: string) => {
-      if (email === 'fail@x.com' && shouldFail) {
-        shouldFail = false
-        throw new Error('nope')
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => {
+        if (email === 'fail@x.com' && shouldFail) {
+          shouldFail = false
+          throw new Error('nope')
+        }
+        return pendingInviteFor(email)
       }
-      return pendingInviteFor(email)
-    })
+    )
     const { user, emitted } = renderForm()
 
     await user.type(emailInput(), 'ok@x.com fail@x.com{Enter}')
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(screen.getByText('fail@x.com')).toBeInTheDocument()
     expect(screen.queryByText('ok@x.com')).not.toBeInTheDocument()
     expect(mockToastAdd).toHaveBeenCalledWith(
@@ -241,7 +235,9 @@ describe('InviteMembersForm', () => {
 
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(3))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(3)
+    )
     expect(emitted().submitted).toEqual([[['ok@x.com', 'fail@x.com']]])
     expect(mockTrackInviteSent).toHaveBeenCalledTimes(2)
     expect(mockTrackInviteSent).toHaveBeenLastCalledWith({
@@ -251,13 +247,17 @@ describe('InviteMembersForm', () => {
   })
 
   it('keeps all chips, toasts, and emits nothing when every invite fails', async () => {
-    mockCreateInvite.mockRejectedValue(new Error('nope'))
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockRejectedValue(
+      new Error('nope')
+    )
     const { user, emitted } = renderForm()
 
     await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(screen.getByText('a@b.com')).toBeInTheDocument()
     expect(screen.getByText('c@d.com')).toBeInTheDocument()
     expect(mockToastAdd).toHaveBeenCalledWith(
@@ -295,8 +295,10 @@ describe('InviteMembersForm', () => {
 
   it('disables submit when every email has a pending invite', async () => {
     const pendingInvite = pendingInviteFor('ALREADY@EXAMPLE.COM')
-    mockPendingInvites.value.push(pendingInvite)
-    mockFetchPendingInvites.mockResolvedValueOnce([pendingInvite])
+    useTeamWorkspaceStore().pendingInvites.push(pendingInvite)
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockResolvedValueOnce([pendingInvite])
     const { user } = renderForm()
 
     await user.type(emailInput(), 'already@example.com{Enter}')
@@ -305,7 +307,7 @@ describe('InviteMembersForm', () => {
       screen.getByText('workspacePanel.inviteMemberDialog.pendingInviteSingle')
     ).toBeInTheDocument()
     expect(submitButton()).toBeDisabled()
-    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
   })
 
   it('skips pending invites and sends the rest of the batch', async () => {
@@ -313,8 +315,10 @@ describe('InviteMembersForm', () => {
       pendingInviteFor('first@example.com'),
       pendingInviteFor('second@example.com')
     ]
-    mockPendingInvites.value.push(...pendingInvites)
-    mockFetchPendingInvites.mockResolvedValueOnce(pendingInvites)
+    useTeamWorkspaceStore().pendingInvites.push(...pendingInvites)
+    vi.mocked(
+      useTeamWorkspaceStore().fetchPendingInvites
+    ).mockResolvedValueOnce(pendingInvites)
     const { user, emitted } = renderForm({ maxSeats: 3, occupiedSeats: 2 })
 
     await user.type(
@@ -329,8 +333,12 @@ describe('InviteMembersForm', () => {
 
     await user.click(submitButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledOnce())
-    expect(mockCreateInvite).toHaveBeenCalledWith('new@example.com')
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledOnce()
+    )
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith(
+      'new@example.com'
+    )
     expect(emitted().submitted).toEqual([[['new@example.com']]])
   })
 
@@ -354,7 +362,7 @@ describe('InviteMembersForm', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(emitted().cancel).toBeTruthy()
-    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
   })
 
   it('hides the built-in submit row when showSubmit is false', () => {

--- a/src/platform/workspace/components/PricingTableWorkspace.test.ts
+++ b/src/platform/workspace/components/PricingTableWorkspace.test.ts
@@ -1,3 +1,4 @@
+import { useCommandStore } from '@/stores/commandStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -42,10 +43,6 @@ function apiPlan(
   }
 }
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
-}))
-
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -75,6 +72,10 @@ function renderComponent() {
     }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
 
 describe('PricingTableWorkspace credit allotment copy', () => {
   beforeEach(() => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -1,8 +1,10 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import { toRef, computed, ref } from 'vue'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { BillingType, SubscriptionInfo } from '@/composables/billing/types'
@@ -18,12 +20,6 @@ import type {
 
 import SubscriptionPanelContentWorkspace from './SubscriptionPanelContentWorkspace.vue'
 
-const { mockIsSettingUp, mockSubscriptionActionOperation } = vi.hoisted(() => ({
-  mockIsSettingUp: { value: false },
-  mockSubscriptionActionOperation: {
-    value: undefined as { actionUrl: string } | undefined
-  }
-}))
 const mockDistributionState = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock<unknown>(import('@/composables/billing/useBillingRouting'), () => ({
@@ -89,8 +85,7 @@ function scheduledChange(
 }
 const mockHasSubscription = ref(true)
 const mockIsActiveSubscription = ref(true)
-const mockIsInPersonalWorkspace = ref(false)
-const mockIsWorkspaceSubscribed = ref(true)
+
 const mockCanManageSubscription = ref(true)
 const mockCanManageSubscriptionLifecycle = ref(true)
 const mockCanCancel = ref(true)
@@ -207,16 +202,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      isInPersonalWorkspace: mockIsInPersonalWorkspace,
-      isWorkspaceSubscribed: mockIsWorkspaceSubscribed
-    })
-  })
-)
-
 const mockIsTeamPlanCancelled = computed(
   () => mockHasTeamPlan.value && (mockSubscription.value?.isCancelled ?? false)
 )
@@ -243,7 +228,10 @@ vi.mock<unknown>(
       canReactivatePlan: mockCanReactivatePlan,
       canOpenPricingSurface: mockCanOpenPricingSurface,
       uiConfig: computed(() => mockUiConfig.value),
-      isInPersonalWorkspace: mockIsInPersonalWorkspace,
+      isInPersonalWorkspace: toRef(
+        useTeamWorkspaceStore(),
+        'isInPersonalWorkspace'
+      ),
       canAccessSubscriptionFeatures: computed(
         () => mockIsActiveSubscription.value
       ),
@@ -267,20 +255,6 @@ vi.mock<unknown>(
       canReactivate: mockCanReactivate,
       canChangeSeats: mockCanChangeSeats,
       canSubscribeSelfServe: mockCanSubscribeSelfServe
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({
-      get isSettingUp() {
-        return mockIsSettingUp.value
-      },
-      get subscriptionActionOperation() {
-        return mockSubscriptionActionOperation.value
-      }
     })
   })
 )
@@ -347,7 +321,7 @@ const DropdownMenuStub = {
 function renderComponent({ stubFooter = true } = {}) {
   return render(SubscriptionPanelContentWorkspace, {
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      plugins: [getActivePinia()!, i18n],
       directives: { tooltip: {} },
       stubs: {
         CreditsTile: CreditsTileStub,
@@ -373,8 +347,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockScheduledChange.value = null
     mockHasSubscription.value = true
     mockIsActiveSubscription.value = true
-    mockIsInPersonalWorkspace.value = false
-    mockIsWorkspaceSubscribed.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: true })
     mockCanManageSubscription.value = true
     mockCanManageSubscriptionLifecycle.value = true
     mockCanCancel.value = true
@@ -398,15 +372,19 @@ describe('SubscriptionPanelContentWorkspace', () => {
     }
     mockIsLoading.value = false
     mockError.value = null
-    mockIsSettingUp.value = false
-    mockSubscriptionActionOperation.value = undefined
+    Object.assign(useBillingOperationStore(), { isSettingUp: false })
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: undefined
+    })
   })
 
   it('keeps verification available in settings without exposing its URL', async () => {
     const actionUrl = 'https://verify.example/sensitive-token'
     const open = vi.spyOn(window, 'open').mockReturnValue({} as Window)
-    mockIsSettingUp.value = true
-    mockSubscriptionActionOperation.value = { actionUrl }
+    Object.assign(useBillingOperationStore(), { isSettingUp: true })
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: { actionUrl }
+    })
     const { container } = renderComponent()
 
     expect(open).not.toHaveBeenCalled()
@@ -422,13 +400,15 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('hides verification from users without billing permission', () => {
-    mockIsSettingUp.value = true
+    Object.assign(useBillingOperationStore(), { isSettingUp: true })
     mockCanManageSubscription.value = false
     mockCanChangeSeats.value = false
     mockCanSubscribeSelfServe.value = false
-    mockSubscriptionActionOperation.value = {
-      actionUrl: 'https://verify.example/sensitive-token'
-    }
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: {
+        actionUrl: 'https://verify.example/sensitive-token'
+      }
+    })
 
     renderComponent()
 
@@ -547,7 +527,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     })
 
     it('marks an ended Personal plan inactive when it cannot self-serve', () => {
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsActiveSubscription.value = false
       mockSubscriptionStatus.value = 'ended'
       mockBillingStatus.value = 'inactive'
@@ -729,7 +709,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('keeps a Personal workspace Team-plan member view read-only', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
     mockCanCancel.value = false
@@ -762,7 +742,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('uses Team-plan change copy in a Personal workspace', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     renderComponent()
 
     expect(
@@ -776,7 +756,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps billing access in the ended state for an inactive paid Personal workspace', async () => {
     const user = userEvent.setup()
     mockBillingType.value = 'legacy'
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsActiveSubscription.value = false
     mockBillingStatus.value = 'inactive'
     renderComponent()
@@ -818,7 +798,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it.for(['paid', 'payment_failed', 'paused'] as BillingStatus[])(
     'keeps billing access for a non-terminal %s personal plan',
     (billingStatus) => {
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsActiveSubscription.value = false
       mockBillingStatus.value = billingStatus
       renderComponent()
@@ -873,7 +853,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('drops the state card for an inactive ended subscription without a date', () => {
     mockSubscriptionStatus.value = 'ended'
     mockIsActiveSubscription.value = false
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockEndDate.value = null
     renderComponent()
 
@@ -891,7 +871,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockDistributionState.isCloud = false
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     renderComponent({ stubFooter: false })
 
     expect(
@@ -906,7 +886,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('renders an ended Team plan for its owner and routes reactivation to checkout', async () => {
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     const user = userEvent.setup()
     renderComponent()
 
@@ -961,7 +941,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps ended Team credits inactive when self-serve capabilities are unavailable', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockCanSubscribeSelfServe.value = false
     renderComponent()
 
@@ -1001,7 +981,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps a cancelled Personal plan in a Team workspace reactivatable', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockHasTeamPlan.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     renderComponent()
 
     expect(
@@ -1018,7 +998,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('hides Reactivate plan when the server denies reactivation to a client-side owner', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockHasTeamPlan.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockCanManageSubscriptionLifecycle.value = true
     mockCanReactivatePlan.value = false
     renderComponent()
@@ -1034,7 +1014,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('keeps Billing & invoices available to unsubscribed team owners', async () => {
     const user = userEvent.setup()
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     renderComponent()
 
@@ -1056,7 +1036,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('lets a never-subscribed team workspace top up on Local instead of upselling', () => {
     mockDistributionState.isCloud = false
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     renderComponent()
 
@@ -1099,7 +1079,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('hides Subscribe Now when the server denies self-serve to a client-side owner', () => {
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     mockCanManageSubscription.value = true
     mockCanSubscribeSelfServe.value = false
@@ -1112,7 +1092,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('shows the zero-state contact-owner view to unsubscribed members', () => {
     mockIsActiveSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockHasSubscription.value = false
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
@@ -1136,10 +1116,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('renders the Free plan header with Subscribe CTA for unsubscribed personal workspaces', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsActiveSubscription.value = false
     mockHasSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockUiConfig.value = personalUiConfig
     mockCanLeaveWorkspace.value = false
     renderComponent()
@@ -1173,10 +1153,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
       mockBillingType.value = 'legacy'
       mockBillingStatus.value = 'inactive'
       mockSubscriptionTier.value = tier
-      mockIsInPersonalWorkspace.value = true
+      Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
       mockIsActiveSubscription.value = false
       mockHasSubscription.value = hasSubscription
-      mockIsWorkspaceSubscribed.value = false
+      Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
       mockUiConfig.value = personalUiConfig
       mockCanLeaveWorkspace.value = false
       renderComponent()
@@ -1193,13 +1173,13 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('lets a Free personal workspace only rename itself (no Cancel or Delete)', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     // A Free personal workspace routes to legacy billing, where lifecycle
     // authorization stays on the client.
     mockShouldUseWorkspaceBilling.value = false
     mockIsActiveSubscription.value = false
     mockHasSubscription.value = false
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockUiConfig.value = personalUiConfig
     mockCanLeaveWorkspace.value = false
     renderComponent()
@@ -1218,10 +1198,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('offers a subscribed personal workspace Edit and Cancel without Delete', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     mockIsActiveSubscription.value = true
     mockHasSubscription.value = true
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
     mockUiConfig.value = personalUiConfig
     mockCanLeaveWorkspace.value = false
     renderComponent()
@@ -1262,7 +1242,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('shows the Team plan identity when a personal workspace holds a Team subscription', () => {
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     renderComponent()
 
     expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,7 +11,7 @@ const mockHandleSubscribeTeamClick = vi.fn()
 const mockHandleBackToPricing = vi.fn()
 const mockHandleSubscribeClick = vi.fn()
 const mockInvalidateQuote = vi.fn()
-const mockIsInPersonalWorkspace = ref(false)
+
 const mockCheckoutStep = ref('pricing')
 const mockPreviewVariant = ref<string | null>(null)
 const mockPreviewData = ref<Record<string, unknown> | null>(null)
@@ -53,17 +54,6 @@ vi.mock<unknown>(
       applyPromotionCode: vi.fn(),
       invalidateQuote: mockInvalidateQuote,
       handleResubscribe: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get isInPersonalWorkspace() {
-        return mockIsInPersonalWorkspace.value
-      }
     })
   })
 )
@@ -130,7 +120,7 @@ function renderComponent(props: Record<string, unknown> = {}) {
 
 describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
   beforeEach(() => {
-    mockIsInPersonalWorkspace.value = false
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     mockCheckoutStep.value = 'pricing'
     mockPreviewVariant.value = null
     mockPreviewData.value = null
@@ -197,7 +187,7 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
 
   it('advances to team checkout from a team workspace', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = false
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: false })
     renderComponent()
 
     await user.click(screen.getByTestId('subscribe-team-btn'))
@@ -209,7 +199,7 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
 
   it('advances to team checkout from a personal workspace (no reroute)', async () => {
     const user = userEvent.setup()
-    mockIsInPersonalWorkspace.value = true
+    Object.assign(useTeamWorkspaceStore(), { isInPersonalWorkspace: true })
     renderComponent()
 
     await user.click(screen.getByTestId('subscribe-team-btn'))

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -104,10 +104,7 @@ function renderComponent(
         : {})
     },
     global: {
-      plugins: [
-        createTestingPinia({ createSpy: vi.fn, stubActions: false }),
-        i18n
-      ],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         PricingTableWorkspace: PricingTableStub,
         SubscriptionAddPaymentPreviewWorkspace: AddPaymentPreviewStub,

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -1,3 +1,5 @@
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,6 +10,7 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import type { CreateTopupResponse } from '@/platform/workspace/api/workspaceApi'
+import { billingOperation } from '@/platform/workspace/composables/billingOperationTestUtils'
 
 import TopUpCreditsDialogContentWorkspace from './TopUpCreditsDialogContentWorkspace.vue'
 
@@ -21,19 +24,10 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 }))
 const mockTopup =
   vi.fn<(amountCents: number) => Promise<CreateTopupResponse | void>>()
-const mockStartOperation = vi.fn()
-const mockRetryPaymentAuthentication = vi.fn()
-const mockDismissOperation = vi.fn((opId: string) => {
-  if (mockBillingOperationState.topupActionOperation?.value?.opId === opId) {
-    mockBillingOperationState.topupActionOperation.value = undefined
-  }
-  if (mockBillingOperationState.isAddingCredits) {
-    mockBillingOperationState.isAddingCredits.value = false
-  }
-})
+
 const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
-const mockCloseDialog = vi.fn()
+
 const mockTrackTopUpPurchase = vi.fn()
 const mockTrackBillingEvent = vi.fn()
 const mockCanTopUp = vi.hoisted(() => ({
@@ -70,13 +64,6 @@ interface MockTopupOperation {
   isAuthenticating?: boolean
 }
 
-const mockBillingOperationState = vi.hoisted(() => ({
-  isAddingCredits: undefined as { value: boolean } | undefined,
-  topupActionOperation: undefined as
-    | { value: MockTopupOperation | undefined }
-    | undefined
-}))
-
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({
     fetchBalance: mockFetchBalance,
@@ -85,29 +72,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     topup: (amountCents: number) => mockTopup(amountCents)
   })
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  async () => {
-    const { ref } = await import('vue')
-    mockBillingOperationState.isAddingCredits = ref(false)
-    mockBillingOperationState.topupActionOperation = ref(undefined)
-    return {
-      useBillingOperationStore: () => ({
-        hasPendingOperations: true,
-        get isAddingCredits() {
-          return mockBillingOperationState.isAddingCredits?.value ?? false
-        },
-        get topupActionOperation() {
-          return mockBillingOperationState.topupActionOperation?.value
-        },
-        startOperation: mockStartOperation,
-        retryPaymentAuthentication: mockRetryPaymentAuthentication,
-        dismissOperation: mockDismissOperation
-      })
-    }
-  }
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useBillingCapabilities'),
@@ -126,10 +90,6 @@ vi.mock<unknown>(
     useSettingsDialog: () => ({ show: mockShowSettings })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
@@ -200,17 +160,11 @@ function setCanTopUp(canTopUp: boolean) {
 }
 
 function setIsAddingCredits(isAddingCredits: boolean) {
-  if (!mockBillingOperationState.isAddingCredits) {
-    throw new Error('Billing operation mock not initialized')
-  }
-  mockBillingOperationState.isAddingCredits.value = isAddingCredits
+  Object.assign(useBillingOperationStore(), { isAddingCredits })
 }
 
 function setTopupActionOperation(operation: MockTopupOperation | undefined) {
-  if (!mockBillingOperationState.topupActionOperation) {
-    throw new Error('Billing operation mock not initialized')
-  }
-  mockBillingOperationState.topupActionOperation.value = operation
+  Object.assign(useBillingOperationStore(), { topupActionOperation: operation })
 }
 
 function setHasSavedPaymentMethod(value: boolean | null) {
@@ -225,6 +179,29 @@ async function clickAddCredits() {
   await user.click(screen.getByRole('button', { name: 'Add credits' }))
 }
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
+beforeEach(() => {
+  Object.assign(useBillingOperationStore(), { hasPendingOperations: true })
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation({ type: 'topup' })
+  )
+  vi.mocked(
+    useBillingOperationStore().retryPaymentAuthentication
+  ).mockResolvedValue(false)
+  vi.mocked(useBillingOperationStore().dismissOperation).mockImplementation(
+    (opId) => {
+      const store = useBillingOperationStore()
+      if (store.topupActionOperation?.opId === opId) {
+        Object.assign(store, { topupActionOperation: undefined })
+      }
+      Object.assign(store, { isAddingCredits: false })
+    }
+  )
+})
+
 describe('TopUpCreditsDialogContentWorkspace', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
@@ -234,10 +211,12 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     mockFetchBalance.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
     setHasSavedPaymentMethod(true)
-    mockStartOperation.mockImplementation(() => {
-      setIsAddingCredits(true)
-      return new Promise(() => {})
-    })
+    vi.mocked(useBillingOperationStore().startOperation).mockImplementation(
+      () => {
+        setIsAddingCredits(true)
+        return new Promise(() => {})
+      }
+    )
   })
 
   it('fires a started event before the purchase resolves', async () => {
@@ -504,7 +483,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Complete verification' })
     )
-    expect(mockRetryPaymentAuthentication).toHaveBeenCalledWith('op-resume')
+    expect(
+      useBillingOperationStore().retryPaymentAuthentication
+    ).toHaveBeenCalledWith('op-resume')
   })
 
   it('reports a failed challenge without offering to resume it', async () => {
@@ -525,7 +506,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(
       screen.queryByRole('button', { name: 'Complete verification' })
     ).not.toBeInTheDocument()
-    expect(mockRetryPaymentAuthentication).not.toHaveBeenCalled()
+    expect(
+      useBillingOperationStore().retryPaymentAuthentication
+    ).not.toHaveBeenCalled()
   })
 
   it('lets the customer start over after a failed challenge', async () => {
@@ -548,7 +531,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Start over' }))
     await nextTick()
 
-    expect(mockDismissOperation).toHaveBeenCalledWith('op-1')
+    expect(useBillingOperationStore().dismissOperation).toHaveBeenCalledWith(
+      'op-1'
+    )
     expect(
       screen.queryByText('Your bank rejected the verification.')
     ).not.toBeInTheDocument()
@@ -584,10 +569,14 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
 
     expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
     expect(payButton).toBeDisabled()
-    expect(mockStartOperation).toHaveBeenCalledWith('op-1', 'topup', {
-      attemptStartedAt: expect.any(Number),
-      autoHandleRequiresAction: true
-    })
+    expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+      'op-1',
+      'topup',
+      {
+        attemptStartedAt: expect.any(Number),
+        autoHandleRequiresAction: true
+      }
+    )
 
     payButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(mockTopup).toHaveBeenCalledOnce()
@@ -596,7 +585,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
   it('unlocks payment and reports an operation start failure', async () => {
     const error = new Error('Operation unavailable')
     mockTopup.mockResolvedValue(topupResponse('pending'))
-    mockStartOperation.mockRejectedValue(error)
+    vi.mocked(useBillingOperationStore().startOperation).mockRejectedValue(
+      error
+    )
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     renderDialog()
@@ -656,7 +647,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(mockClearPendingTopup).toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('opens Credits settings after a completed local top-up', async () => {
@@ -697,10 +688,14 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await clickAddCredits()
     await userEvent.click(screen.getByRole('button', { name: 'Pay $50.00' }))
 
-    expect(mockStartOperation).toHaveBeenCalledWith('op-1', 'topup', {
-      attemptStartedAt: expect.any(Number),
-      autoHandleRequiresAction: true
-    })
+    expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+      'op-1',
+      'topup',
+      {
+        attemptStartedAt: expect.any(Number),
+        autoHandleRequiresAction: true
+      }
+    )
     expect(mockFetchBalance).not.toHaveBeenCalled()
     expect(mockFetchStatus).not.toHaveBeenCalled()
     expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
@@ -766,6 +761,6 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(mockTopup).not.toHaveBeenCalled()
     expect(mockTrackTopUpPurchase).not.toHaveBeenCalled()
     expect(mockToastAdd).not.toHaveBeenCalled()
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -11,6 +11,7 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import type { CreateTopupResponse } from '@/platform/workspace/api/workspaceApi'
 import { billingOperation } from '@/platform/workspace/composables/billingOperationTestUtils'
+import type { BillingOperation } from '@/platform/workspace/composables/billingOperationTestUtils'
 
 import TopUpCreditsDialogContentWorkspace from './TopUpCreditsDialogContentWorkspace.vue'
 
@@ -53,16 +54,6 @@ vi.mock<unknown>(
     }
   }
 )
-
-interface MockTopupOperation {
-  opId: string
-  status: 'pending' | 'reconciliation_needed'
-  actionUrl: string | null
-  authenticationState?: string
-  errorMessage?: string | null
-  canRetryAuthentication?: boolean
-  isAuthenticating?: boolean
-}
 
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({
@@ -163,8 +154,14 @@ function setIsAddingCredits(isAddingCredits: boolean) {
   Object.assign(useBillingOperationStore(), { isAddingCredits })
 }
 
-function setTopupActionOperation(operation: MockTopupOperation | undefined) {
-  Object.assign(useBillingOperationStore(), { topupActionOperation: operation })
+function setTopupActionOperation(
+  operation: Partial<BillingOperation> | undefined
+) {
+  Object.assign(useBillingOperationStore(), {
+    topupActionOperation: operation
+      ? billingOperation({ type: 'topup', ...operation })
+      : undefined
+  })
 }
 
 function setHasSavedPaymentMethod(value: boolean | null) {

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -1,7 +1,9 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import WorkspaceSwitcherPopover from './WorkspaceSwitcherPopover.vue'
 
@@ -51,7 +53,14 @@ const i18n = createI18n({
   }
 })
 
-function createWorkspaceState(overrides: Record<string, unknown>) {
+type WorkspaceState = ReturnType<
+  typeof useTeamWorkspaceStore
+>['workspaces'][number]
+
+function createWorkspaceState(
+  overrides: Pick<WorkspaceState, 'id' | 'name' | 'type' | 'role'> &
+    Partial<WorkspaceState>
+): WorkspaceState {
   return {
     created_at: '2026-01-01T00:00:00Z',
     joined_at: '2026-01-01T00:00:00Z',
@@ -67,37 +76,33 @@ function createWorkspaceState(overrides: Record<string, unknown>) {
 function renderComponent(
   overrides: {
     activeWorkspaceId?: string
-    workspaces?: Record<string, unknown>[]
+    workspaces?: WorkspaceState[]
   } = {}
 ) {
+  const store: ReturnType<typeof useTeamWorkspaceStore> & {
+    activeWorkspaceId: string | null
+  } = useTeamWorkspaceStore()
+  store.activeWorkspaceId = overrides.activeWorkspaceId ?? 'ws-personal'
+  store.$patch({
+    isFetchingWorkspaces: false,
+    workspaces: overrides.workspaces ?? [
+      createWorkspaceState({
+        id: 'ws-personal',
+        name: 'Personal Workspace',
+        type: 'personal',
+        role: 'owner'
+      }),
+      createWorkspaceState({
+        id: 'ws-team-long',
+        name: LONG_WORKSPACE_NAME,
+        type: 'team',
+        role: 'member'
+      })
+    ]
+  })
   return render(WorkspaceSwitcherPopover, {
     global: {
-      plugins: [
-        createTestingPinia({
-          createSpy: vi.fn,
-          initialState: {
-            teamWorkspace: {
-              activeWorkspaceId: overrides.activeWorkspaceId ?? 'ws-personal',
-              isFetchingWorkspaces: false,
-              workspaces: overrides.workspaces ?? [
-                createWorkspaceState({
-                  id: 'ws-personal',
-                  name: 'Personal Workspace',
-                  type: 'personal',
-                  role: 'owner'
-                }),
-                createWorkspaceState({
-                  id: 'ws-team-long',
-                  name: LONG_WORKSPACE_NAME,
-                  type: 'team',
-                  role: 'member'
-                })
-              ]
-            }
-          }
-        }),
-        i18n
-      ],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         WorkspaceProfilePic: true
       }

--- a/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.test.ts
@@ -1,3 +1,5 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,28 +9,7 @@ import ChangeMemberRoleDialogContent from './ChangeMemberRoleDialogContent.vue'
 
 import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
 
-const { mockChangeMemberRole, mockCloseDialog, mockToastAdd } = vi.hoisted(
-  () => ({
-    mockChangeMemberRole: vi.fn(),
-    mockCloseDialog: vi.fn(),
-    mockToastAdd: vi.fn()
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      changeMemberRole: mockChangeMemberRole
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
+const { mockToastAdd } = vi.hoisted(() => ({ mockToastAdd: vi.fn() }))
 
 vi.mock<unknown>(
   import('primevue/usetoast'), // eslint-disable-line primevue-removal/no-imports
@@ -56,9 +37,18 @@ function renderDialog(targetRole: WorkspaceRole) {
   return { ...result, user }
 }
 
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().changeMemberRole).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('ChangeMemberRoleDialogContent', () => {
   beforeEach(() => {
-    mockChangeMemberRole.mockResolvedValue(undefined)
+    vi.mocked(useTeamWorkspaceStore().changeMemberRole).mockResolvedValue(
+      undefined
+    )
   })
 
   it('shows promote copy and confirms with Make owner', async () => {
@@ -78,9 +68,12 @@ describe('ChangeMemberRoleDialogContent', () => {
       })
     )
 
-    expect(mockChangeMemberRole).toHaveBeenCalledWith('mem-1', 'owner')
+    expect(useTeamWorkspaceStore().changeMemberRole).toHaveBeenCalledWith(
+      'mem-1',
+      'owner'
+    )
     await waitFor(() =>
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'change-member-role'
       })
     )
@@ -105,11 +98,16 @@ describe('ChangeMemberRoleDialogContent', () => {
       })
     )
 
-    expect(mockChangeMemberRole).toHaveBeenCalledWith('mem-1', 'member')
+    expect(useTeamWorkspaceStore().changeMemberRole).toHaveBeenCalledWith(
+      'mem-1',
+      'member'
+    )
   })
 
   it('keeps the dialog open and toasts on failure', async () => {
-    mockChangeMemberRole.mockRejectedValue(new Error('boom'))
+    vi.mocked(useTeamWorkspaceStore().changeMemberRole).mockRejectedValue(
+      new Error('boom')
+    )
     const { user } = renderDialog('owner')
 
     await user.click(
@@ -123,7 +121,7 @@ describe('ChangeMemberRoleDialogContent', () => {
         expect.objectContaining({ severity: 'error' })
       )
     )
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
   })
 
   it('closes without changing the role on cancel', async () => {
@@ -131,7 +129,9 @@ describe('ChangeMemberRoleDialogContent', () => {
 
     await user.click(screen.getByRole('button', { name: 'g.cancel' }))
 
-    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'change-member-role' })
-    expect(mockChangeMemberRole).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+      key: 'change-member-role'
+    })
+    expect(useTeamWorkspaceStore().changeMemberRole).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
@@ -1,11 +1,11 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import DowngradeRemoveMembersDialogContent from './DowngradeRemoveMembersDialogContent.vue'
 
-const mockCloseDialog = vi.fn()
 const mockToastAdd = vi.fn()
 
 vi.mock<unknown>(
@@ -16,12 +16,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -71,6 +65,10 @@ const getChangePlanButton = () =>
   screen.getByRole('button', { name: 'Change plan' })
 const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' })
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('DowngradeRemoveMembersDialogContent', () => {
   it('disables Change plan until the exact phrase is typed', async () => {
     const { user } = mountComponent()
@@ -95,7 +93,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     await user.click(getChangePlanButton())
 
     expect(onConfirm).toHaveBeenCalledWith('founder-monthly', false)
-    expect(mockCloseDialog).toHaveBeenCalledWith({
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
   })
@@ -149,7 +147,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     await user.click(getCancelButton())
 
     expect(onConfirm).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalledWith({
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
   })
@@ -163,7 +161,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
     )
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
   })
 
   // Regression guard: a drift refresh (dialogService's onConfirm handler)

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
@@ -1,3 +1,5 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,9 +10,6 @@ import InviteMemberDialogContent from './InviteMemberDialogContent.vue'
 import type { WorkspacePendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const {
-  mockCreateInvite,
-  mockFetchPendingInvites,
-  mockCloseDialog,
   mockToastAdd,
   mockTrackInviteSent,
   mockTrackInviteFailed,
@@ -20,9 +19,6 @@ const {
 } = vi.hoisted(() => {
   const nullableNumber = (value: number | null) => ({ value })
   return {
-    mockCreateInvite: vi.fn(),
-    mockFetchPendingInvites: vi.fn(),
-    mockCloseDialog: vi.fn(),
     mockToastAdd: vi.fn(),
     mockTrackInviteSent: vi.fn(),
     mockTrackInviteFailed: vi.fn(),
@@ -40,27 +36,10 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      createInvite: mockCreateInvite,
-      fetchPendingInvites: mockFetchPendingInvites,
-      pendingInvites: []
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({
     trackWorkspaceInviteSent: mockTrackInviteSent,
     trackWorkspaceInviteFailed: mockTrackInviteFailed
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
   })
 }))
 
@@ -106,15 +85,20 @@ function inviteButton() {
   return screen.getByRole('button', { name: 'workspacePanel.invite' })
 }
 
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), { pendingInvites: [] })
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('InviteMemberDialogContent', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockFetchPendingInvites.mockResolvedValue([])
+    vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([])
     mockFetchStatus.mockResolvedValue(undefined)
     mockMaxSeats.value = 73
     mockOccupiedSeats.value = 0
-    mockCreateInvite.mockImplementation(async (email: string) =>
-      pendingInviteFor(email)
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => pendingInviteFor(email)
     )
   })
 
@@ -218,9 +202,9 @@ describe('InviteMemberDialogContent', () => {
         'workspacePanel.inviteMemberDialog.invitedMessage'
       )
     ).toBeInTheDocument()
-    expect(mockCreateInvite).toHaveBeenCalledTimes(2)
-    expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
-    expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('a@b.com')
+    expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledWith('c@d.com')
     expect(mockTrackInviteSent).toHaveBeenCalledWith({
       source: 'settings_members',
       count: 2
@@ -231,20 +215,26 @@ describe('InviteMemberDialogContent', () => {
       .find((button) => button.textContent.includes('g.close'))
     await user.click(closeButton!)
 
-    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'invite-member' })
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+      key: 'invite-member'
+    })
   })
 
   it('keeps only failed emails as chips and toasts on partial failure', async () => {
-    mockCreateInvite.mockImplementation(async (email: string) => {
-      if (email === 'fail@x.com') throw new Error('nope')
-      return pendingInviteFor(email)
-    })
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockImplementation(
+      async (email: string) => {
+        if (email === 'fail@x.com') throw new Error('nope')
+        return pendingInviteFor(email)
+      }
+    )
     const { user } = renderDialog()
 
     await user.type(emailInput(), 'ok@x.com,fail@x.com{Enter}')
     await user.click(inviteButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(screen.getByText('fail@x.com')).toBeInTheDocument()
     expect(screen.queryByText('ok@x.com')).not.toBeInTheDocument()
     expect(mockToastAdd).toHaveBeenCalledWith(
@@ -258,13 +248,17 @@ describe('InviteMemberDialogContent', () => {
   })
 
   it('stays on the form and keeps every chip when all invites fail', async () => {
-    mockCreateInvite.mockRejectedValue(new Error('nope'))
+    vi.mocked(useTeamWorkspaceStore().createInvite).mockRejectedValue(
+      new Error('nope')
+    )
     const { user } = renderDialog()
 
     await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
     await user.click(inviteButton())
 
-    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(useTeamWorkspaceStore().createInvite).toHaveBeenCalledTimes(2)
+    )
     expect(
       screen.queryByText('workspacePanel.inviteMemberDialog.invitedMessage')
     ).not.toBeInTheDocument()
@@ -282,7 +276,9 @@ describe('InviteMemberDialogContent', () => {
 
     await user.click(screen.getByRole('button', { name: 'g.cancel' }))
 
-    expect(mockCreateInvite).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'invite-member' })
+    expect(useTeamWorkspaceStore().createInvite).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+      key: 'invite-member'
+    })
   })
 })

--- a/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.test.ts
@@ -1,27 +1,15 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import SetMemberCreditLimitDialogContent from './SetMemberCreditLimitDialogContent.vue'
 
-const { mockSetMemberCreditLimit, mockCloseDialog } = vi.hoisted(() => ({
-  mockSetMemberCreditLimit: vi.fn(),
-  mockCloseDialog: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      setMemberCreditLimit: mockSetMemberCreditLimit
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
+let workspaceStore: ReturnType<typeof useTeamWorkspaceStore>
+let dialogStore: ReturnType<typeof useDialogStore>
 
 const i18n = createI18n({
   legacy: false,
@@ -68,6 +56,11 @@ function renderDialog(options: RenderDialogOptions = {}) {
 }
 
 describe('SetMemberCreditLimitDialogContent', () => {
+  beforeEach(() => {
+    workspaceStore = useTeamWorkspaceStore()
+    dialogStore = useDialogStore()
+  })
+
   it('updates an existing limit', async () => {
     const { user } = renderDialog()
     const input = screen.getByRole('textbox')
@@ -76,8 +69,11 @@ describe('SetMemberCreditLimitDialogContent', () => {
     await user.type(input, '2500')
     await user.click(screen.getByRole('button', { name: 'Update limit' }))
 
-    expect(mockSetMemberCreditLimit).toHaveBeenCalledWith('mem-1', 2500)
-    expect(mockCloseDialog).toHaveBeenCalledWith({
+    expect(workspaceStore.setMemberCreditLimit).toHaveBeenCalledWith(
+      'mem-1',
+      2500
+    )
+    expect(dialogStore.closeDialog).toHaveBeenCalledWith({
       key: 'set-member-credit-limit'
     })
   })
@@ -95,7 +91,10 @@ describe('SetMemberCreditLimitDialogContent', () => {
     const { user } = renderDialog()
     await user.click(screen.getByRole('radio', { name: 'No limit' }))
     await user.click(screen.getByRole('button', { name: 'Update limit' }))
-    expect(mockSetMemberCreditLimit).toHaveBeenCalledWith('mem-1', null)
+    expect(workspaceStore.setMemberCreditLimit).toHaveBeenCalledWith(
+      'mem-1',
+      null
+    )
   })
 
   it('supports keyboard navigation between limit modes', async () => {

--- a/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/TeamWorkspacesDialogContent.test.ts
@@ -1,6 +1,8 @@
+import type { Pinia } from 'pinia'
+import { getActivePinia } from 'pinia'
+import { useDialogStore } from '@/stores/dialogStore'
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,11 +16,10 @@ import TeamWorkspacesDialogContent from './TeamWorkspacesDialogContent.vue'
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-const mockCloseDialog = vi.fn()
 const mockToastAdd = vi.fn()
 const mockSwitchWorkspace = vi.fn()
 
-let pinia: ReturnType<typeof createTestingPinia>
+let pinia: Pinia
 let workspaceStore: ReturnType<typeof useTeamWorkspaceStore>
 
 vi.mock<unknown>(
@@ -29,12 +30,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
 
 vi.mock(import('@/platform/workspace/composables/useWorkspaceSwitch'), () => ({
   useWorkspaceSwitch: () => ({
@@ -134,10 +129,14 @@ function setOwnedWorkspaces() {
   ]
 }
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
 describe('TeamWorkspacesDialogContent', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    pinia = getActivePinia()!
     workspaceStore = useTeamWorkspaceStore(pinia)
     workspaceStore.workspaces = []
   })
@@ -190,7 +189,7 @@ describe('TeamWorkspacesDialogContent', () => {
       await flushPromises()
 
       expect(mockSwitchWorkspace).toHaveBeenCalledWith('ws-1')
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })
@@ -204,7 +203,7 @@ describe('TeamWorkspacesDialogContent', () => {
       await user.click(switchButton)
       await flushPromises()
 
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
@@ -287,7 +286,7 @@ describe('TeamWorkspacesDialogContent', () => {
 
       expect(workspaceStore.createWorkspace).toHaveBeenCalledWith('New Team')
       expect(onConfirm).toHaveBeenCalledWith('New Team')
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })
@@ -306,7 +305,7 @@ describe('TeamWorkspacesDialogContent', () => {
           detail: 'Limit reached'
         })
       )
-      expect(mockCloseDialog).not.toHaveBeenCalled()
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
     })
 
     it('shows separate toast when onConfirm fails but still closes dialog', async () => {
@@ -329,7 +328,7 @@ describe('TeamWorkspacesDialogContent', () => {
           detail: 'Setup failed'
         })
       )
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })
@@ -388,7 +387,7 @@ describe('TeamWorkspacesDialogContent', () => {
       const closeBtn = container.querySelector('header button')!
       await user.click(closeBtn)
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
         key: 'team-workspaces'
       })
     })

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -1,87 +1,40 @@
+import { getActivePinia } from 'pinia'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
-import type {
-  PartnerNodePolicy,
-  PartnerProvider
-} from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 
 import PartnerNodeAccessPanel from './PartnerNodeAccessPanel.vue'
 
-const {
-  mockCloseDialog,
-  mockGovernedWorkspaceId,
-  mockIsProviderEnabled,
-  mockIsSaving,
-  mockLoadPolicy,
-  mockNodeDefsByName,
-  mockPolicy,
-  mockProviders,
-  mockSetAllProvidersEnabled,
-  mockSetEnforcementEnabled,
-  mockSetProviderEnabled,
-  mockSetProvidersEnabled,
-  mockShowConfirmDialog,
-  mockStatus,
-  mockWorkspaceRole
-} = vi.hoisted(() => {
+const { mockShowConfirmDialog, mockWorkspaceRole } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
   const { ref } = require('vue') as typeof import('vue')
   return {
-    mockCloseDialog: vi.fn(),
-    mockGovernedWorkspaceId: ref('workspace-one'),
-    mockIsProviderEnabled: vi.fn(),
-    mockIsSaving: ref(false),
-    mockLoadPolicy: vi.fn(),
-    mockNodeDefsByName: ref<Record<string, ComfyNodeDefImpl>>({}),
-    mockPolicy: ref<PartnerNodePolicy | null>(null),
-    mockProviders: ref<PartnerProvider[]>([]),
-    mockSetAllProvidersEnabled: vi.fn(),
-    mockSetEnforcementEnabled: vi.fn(),
-    mockSetProviderEnabled: vi.fn(),
-    mockSetProvidersEnabled: vi.fn(),
     mockShowConfirmDialog: vi.fn(),
-    mockStatus: ref('configured'),
     mockWorkspaceRole: ref<'owner' | 'member'>('owner')
   }
 })
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/partnerNodeGovernanceStore'),
-  () => ({
-    usePartnerNodeGovernanceStore: () => ({
-      governedWorkspaceId: mockGovernedWorkspaceId,
-      policy: mockPolicy,
-      providers: mockProviders,
-      status: mockStatus,
-      isSaving: mockIsSaving,
-      isProviderEnabled: mockIsProviderEnabled,
-      loadPolicy: mockLoadPolicy,
-      setAllProvidersEnabled: mockSetAllProvidersEnabled,
-      setEnforcementEnabled: mockSetEnforcementEnabled,
-      setProviderEnabled: mockSetProviderEnabled,
-      setProvidersEnabled: mockSetProvidersEnabled
-    })
-  })
-)
 
 vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
   showConfirmDialog: mockShowConfirmDialog
 }))
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ closeDialog: mockCloseDialog })
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({ nodeDefsByName: mockNodeDefsByName })
-}))
+vi.mock(
+  import('@/platform/workspace/api/partnerNodePolicyApi'),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    getPartnerNodePolicy: vi.fn(() => new Promise<never>(() => {})),
+    getPartnerProviders: vi.fn(() => new Promise<never>(() => {}))
+  })
+)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -111,7 +64,7 @@ function nodeDef(
 
 function renderComponent() {
   return render(PartnerNodeAccessPanel, {
-    global: { plugins: [createPinia(), i18n], directives: { tooltip: {} } }
+    global: { plugins: [getActivePinia()!, i18n], directives: { tooltip: {} } }
   })
 }
 
@@ -120,7 +73,12 @@ function restrictPolicy(
     { providerId: 'openai', enabled: true }
   ]
 ) {
-  mockPolicy.value = { enforcementEnabled: true, providers: entries }
+  Object.assign(usePartnerNodeGovernanceStore(), {
+    policy: {
+      enforcementEnabled: true,
+      providers: entries
+    }
+  })
 }
 
 const allowAllSwitchName = 'Allow all partner models'
@@ -129,35 +87,80 @@ async function openBulkMenu(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Disable all' }))
 }
 
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
+beforeEach(async () => {
+  vi.mocked(usePartnerNodeGovernanceStore().isProviderEnabled).mockReturnValue(
+    false
+  )
+  vi.mocked(usePartnerNodeGovernanceStore().loadPolicy).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setAllProvidersEnabled
+  ).mockResolvedValue(undefined)
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setEnforcementEnabled
+  ).mockResolvedValue(undefined)
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setProviderEnabled
+  ).mockResolvedValue(undefined)
+  vi.mocked(
+    usePartnerNodeGovernanceStore().setProvidersEnabled
+  ).mockResolvedValue(undefined)
+  Object.assign(usePartnerNodeGovernanceStore(), {
+    governedWorkspaceId: 'workspace-one'
+  })
+  await nextTick()
+})
+
 describe('PartnerNodeAccessPanel', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mockGovernedWorkspaceId.value = 'workspace-one'
-    mockStatus.value = 'configured'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-one'
+    })
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'configured' })
     mockWorkspaceRole.value = 'owner'
-    mockIsSaving.value = false
-    mockPolicy.value = null
-    mockProviders.value = [
-      {
-        id: 'openai',
-        displayName: 'OpenAI (inc. Sora)',
-        nodeCategories: ['OpenAI', 'Sora']
-      },
-      {
-        id: 'route-only',
-        displayName: 'Route only',
-        nodeCategories: []
+    Object.assign(usePartnerNodeGovernanceStore(), { isSaving: false })
+    Object.assign(usePartnerNodeGovernanceStore(), { policy: null })
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        {
+          id: 'openai',
+          displayName: 'OpenAI (inc. Sora)',
+          nodeCategories: ['OpenAI', 'Sora']
+        },
+        {
+          id: 'route-only',
+          displayName: 'Route only',
+          nodeCategories: []
+        }
+      ]
+    })
+    Object.assign(useNodeDefStore(), {
+      nodeDefsByName: {
+        ImageNode: nodeDef('ImageNode', 'Create image', 'partner/image/OpenAI'),
+        VideoNode: nodeDef('VideoNode', 'Create video', 'partner/video/Sora')
       }
-    ]
-    mockNodeDefsByName.value = {
-      ImageNode: nodeDef('ImageNode', 'Create image', 'partner/image/OpenAI'),
-      VideoNode: nodeDef('VideoNode', 'Create video', 'partner/video/Sora')
-    }
-    mockIsProviderEnabled.mockReturnValue(true)
-    mockSetAllProvidersEnabled.mockResolvedValue(undefined)
-    mockSetEnforcementEnabled.mockResolvedValue(undefined)
-    mockSetProviderEnabled.mockResolvedValue(undefined)
-    mockSetProvidersEnabled.mockResolvedValue(undefined)
+    })
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(true)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).mockResolvedValue(undefined)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).mockResolvedValue(undefined)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setProviderEnabled
+    ).mockResolvedValue(undefined)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setProvidersEnabled
+    ).mockResolvedValue(undefined)
     mockShowConfirmDialog.mockReturnValue({ key: 'disable-all-dialog' })
   })
 
@@ -182,14 +185,16 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: true },
       { providerId: 'acme', enabled: true }
     ])
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
 
     const table = screen.getByRole('table', {
@@ -215,15 +220,17 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: true },
       { providerId: 'acme', enabled: true }
     ])
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
-    mockNodeDefsByName.value.AcmeNode = nodeDef(
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
+    useNodeDefStore().nodeDefsByName.AcmeNode = nodeDef(
       'AcmeNode',
       'Enhance image',
       'partner/image/Acme'
@@ -252,17 +259,19 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: false },
       { providerId: 'acme', enabled: true }
     ])
-    mockIsProviderEnabled.mockImplementation(
-      (providerId: string) => providerId !== 'openai'
-    )
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockImplementation((providerId: string) => providerId !== 'openai')
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
 
     const table = screen.getByRole('table', {
@@ -280,20 +289,22 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('searches both provider and model names', async () => {
     const user = userEvent.setup()
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
-    mockNodeDefsByName.value.AcmeNode = nodeDef(
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
+    useNodeDefStore().nodeDefsByName.AcmeNode = nodeDef(
       'AcmeNode',
       'Enhance image',
       'partner/image/Acme'
     )
-    mockNodeDefsByName.value.AcmeResize = nodeDef(
+    useNodeDefStore().nodeDefsByName.AcmeResize = nodeDef(
       'AcmeResize',
       'Resize video',
       'partner/video/Acme'
@@ -321,15 +332,17 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('keeps provider-name matches collapsed while searching', async () => {
     const user = userEvent.setup()
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
-    mockNodeDefsByName.value.AcmeNode = nodeDef(
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
+    useNodeDefStore().nodeDefsByName.AcmeNode = nodeDef(
       'AcmeNode',
       'Enhance image',
       'partner/image/Acme'
@@ -349,14 +362,16 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('keeps name-matched providers without loaded nodes', async () => {
     const user = userEvent.setup()
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
     const search = screen.getByRole('combobox', {
       name: 'Search providers and partner models...'
@@ -377,7 +392,9 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('shows stored disabled state while restricted', () => {
     restrictPolicy([{ providerId: 'openai', enabled: false }])
-    mockIsProviderEnabled.mockReturnValue(false)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(false)
     renderComponent()
 
     expect(
@@ -405,11 +422,15 @@ describe('PartnerNodeAccessPanel', () => {
   })
 
   it('hides provider controls while access is unrestricted', () => {
-    mockPolicy.value = {
-      enforcementEnabled: false,
-      providers: [{ providerId: 'openai', enabled: false }]
-    }
-    mockIsProviderEnabled.mockReturnValue(false)
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      policy: {
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: false }]
+      }
+    })
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(false)
     renderComponent()
 
     expect(
@@ -456,7 +477,9 @@ describe('PartnerNodeAccessPanel', () => {
   it('applies bulk enable to every provider from the menu', async () => {
     const user = userEvent.setup()
     restrictPolicy([{ providerId: 'openai', enabled: false }])
-    mockIsProviderEnabled.mockReturnValue(false)
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockReturnValue(false)
     renderComponent()
 
     await openBulkMenu(user)
@@ -464,7 +487,9 @@ describe('PartnerNodeAccessPanel', () => {
       screen.getByRole('menuitem', { name: 'Enable all 1 provider' })
     )
 
-    expect(mockSetProvidersEnabled).toHaveBeenCalledWith(['openai'], true)
+    expect(
+      usePartnerNodeGovernanceStore().setProvidersEnabled
+    ).toHaveBeenCalledWith(['openai'], true)
   })
 
   it('disables no-op bulk actions in the menu', async () => {
@@ -488,14 +513,16 @@ describe('PartnerNodeAccessPanel', () => {
       { providerId: 'openai', enabled: true },
       { providerId: 'acme', enabled: true }
     ])
-    mockProviders.value = [
-      ...mockProviders.value,
-      {
-        id: 'acme',
-        displayName: 'Acme',
-        nodeCategories: ['Acme']
-      }
-    ]
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      providers: [
+        ...usePartnerNodeGovernanceStore().providers,
+        {
+          id: 'acme',
+          displayName: 'Acme',
+          nodeCategories: ['Acme']
+        }
+      ]
+    })
     renderComponent()
 
     await user.type(
@@ -510,13 +537,17 @@ describe('PartnerNodeAccessPanel', () => {
     )
 
     expect(mockShowConfirmDialog).not.toHaveBeenCalled()
-    expect(mockSetProvidersEnabled).toHaveBeenCalledWith(['acme'], false)
+    expect(
+      usePartnerNodeGovernanceStore().setProvidersEnabled
+    ).toHaveBeenCalledWith(['acme'], false)
   })
 
   it('surfaces save failures', async () => {
     const user = userEvent.setup()
     restrictPolicy()
-    mockSetProviderEnabled.mockRejectedValueOnce(new Error('Save failed'))
+    vi.mocked(
+      usePartnerNodeGovernanceStore().setProviderEnabled
+    ).mockRejectedValueOnce(new Error('Save failed'))
     renderComponent()
 
     await user.click(
@@ -532,7 +563,7 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('locks provider controls while saving', () => {
     restrictPolicy()
-    mockIsSaving.value = true
+    Object.assign(usePartnerNodeGovernanceStore(), { isSaving: true })
     renderComponent()
 
     expect(
@@ -584,8 +615,10 @@ describe('PartnerNodeAccessPanel', () => {
     const options = mockShowConfirmDialog.mock.calls[0][0]
     expect(options.headerProps.title).toBe('Disable all providers?')
     await options.footerProps.onConfirm()
-    expect(mockSetAllProvidersEnabled).toHaveBeenCalledWith(false)
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).toHaveBeenCalledWith(false)
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('ignores a disable-all confirmation after the workspace changes', async () => {
@@ -598,11 +631,15 @@ describe('PartnerNodeAccessPanel', () => {
       screen.getByRole('menuitem', { name: 'Disable all 1 provider' })
     )
     const options = mockShowConfirmDialog.mock.calls[0][0]
-    mockGovernedWorkspaceId.value = 'workspace-two'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-two'
+    })
     await options.footerProps.onConfirm()
 
-    expect(mockSetAllProvidersEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('ignores a disable-all confirmation after the owner loses access', async () => {
@@ -618,8 +655,10 @@ describe('PartnerNodeAccessPanel', () => {
     mockWorkspaceRole.value = 'member'
     await options.footerProps.onConfirm()
 
-    expect(mockSetAllProvidersEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setAllProvidersEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('confirms before turning on restrictions', async () => {
@@ -631,7 +670,9 @@ describe('PartnerNodeAccessPanel', () => {
     const options = mockShowConfirmDialog.mock.calls[0][0]
     expect(options.headerProps.title).toBe('Restrict access to partner models?')
     await options.footerProps.onConfirm()
-    expect(mockSetEnforcementEnabled).toHaveBeenCalledWith(true)
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).toHaveBeenCalledWith(true)
   })
 
   it('ignores a restriction confirmation after the workspace changes', async () => {
@@ -640,33 +681,47 @@ describe('PartnerNodeAccessPanel', () => {
 
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
     const options = mockShowConfirmDialog.mock.calls[0][0]
-    mockGovernedWorkspaceId.value = 'workspace-two'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-two'
+    })
     await options.footerProps.onConfirm()
 
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('ignores a restriction confirmation after a workspace round trip', async () => {
     const user = userEvent.setup()
-    mockPolicy.value = {
-      enforcementEnabled: false,
-      providers: [{ providerId: 'openai', enabled: true }]
-    }
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      policy: {
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: true }]
+      }
+    })
     renderComponent()
 
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
     const options = mockShowConfirmDialog.mock.calls[0][0]
-    mockGovernedWorkspaceId.value = 'workspace-two'
-    mockPolicy.value = {
-      enforcementEnabled: false,
-      providers: [{ providerId: 'openai', enabled: false }]
-    }
-    mockGovernedWorkspaceId.value = 'workspace-one'
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-two'
+    })
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      policy: {
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: false }]
+      }
+    })
+    Object.assign(usePartnerNodeGovernanceStore(), {
+      governedWorkspaceId: 'workspace-one'
+    })
     await options.footerProps.onConfirm()
 
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
   })
 
   it('keeps the access toggle in place until the change is confirmed', async () => {
@@ -684,7 +739,9 @@ describe('PartnerNodeAccessPanel', () => {
     await nextTick()
 
     expect(toggle.getAttribute('aria-checked')).toBe('true')
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
   })
 
   it('toggles access mode from the keyboard', async () => {
@@ -700,7 +757,7 @@ describe('PartnerNodeAccessPanel', () => {
   it.for(['loading', 'error'] as const)(
     'locks the access toggle while policy status is %s',
     (status) => {
-      mockStatus.value = status
+      Object.assign(usePartnerNodeGovernanceStore(), { status: status })
       renderComponent()
 
       expect(
@@ -712,8 +769,8 @@ describe('PartnerNodeAccessPanel', () => {
   it.for(['ineligible', 'inactive'] as const)(
     'shows an unavailable state while policy status is %s',
     (status) => {
-      mockStatus.value = status
-      mockProviders.value = []
+      Object.assign(usePartnerNodeGovernanceStore(), { status: status })
+      Object.assign(usePartnerNodeGovernanceStore(), { providers: [] })
       renderComponent()
 
       expect(
@@ -726,7 +783,7 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('offers the enterprise dialog when the gated toggle is clicked', async () => {
     const user = userEvent.setup()
-    mockStatus.value = 'ineligible'
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'ineligible' })
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     renderComponent()
 
@@ -745,12 +802,12 @@ describe('PartnerNodeAccessPanel', () => {
       'https://comfy.org/cloud/enterprise/',
       '_blank'
     )
-    expect(mockCloseDialog).toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).toHaveBeenCalled()
     openSpy.mockRestore()
   })
 
   it('shows the enterprise upsell when the catalog loads but policy access is forbidden', () => {
-    mockStatus.value = 'ineligible'
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'ineligible' })
     renderComponent()
 
     expect(screen.getByText('Enterprise')).toBeTruthy()
@@ -773,9 +830,9 @@ describe('PartnerNodeAccessPanel', () => {
   it('confirms expanded access when a restricted provider is disabled', async () => {
     const user = userEvent.setup()
     restrictPolicy([{ providerId: 'openai', enabled: false }])
-    mockIsProviderEnabled.mockImplementation(
-      (providerId: string) => providerId !== 'openai'
-    )
+    vi.mocked(
+      usePartnerNodeGovernanceStore().isProviderEnabled
+    ).mockImplementation((providerId: string) => providerId !== 'openai')
     renderComponent()
 
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
@@ -785,7 +842,9 @@ describe('PartnerNodeAccessPanel', () => {
       'Allow access to all partner models?'
     )
     await options.footerProps.onConfirm()
-    expect(mockSetEnforcementEnabled).toHaveBeenCalledWith(false)
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).toHaveBeenCalledWith(false)
   })
 
   it('confirms before returning to unrestricted when every provider is enabled', async () => {
@@ -796,7 +855,9 @@ describe('PartnerNodeAccessPanel', () => {
     await user.click(screen.getByRole('switch', { name: allowAllSwitchName }))
 
     expect(mockShowConfirmDialog).toHaveBeenCalledOnce()
-    expect(mockSetEnforcementEnabled).not.toHaveBeenCalled()
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).not.toHaveBeenCalled()
     const options = mockShowConfirmDialog.mock.calls[0][0]
     expect(options.headerProps.title).toBe(
       'Allow access to all partner models?'
@@ -805,12 +866,14 @@ describe('PartnerNodeAccessPanel', () => {
       'Partner models from every provider will become available to every workspace member. This can take up to 10 minutes to apply across your workspace.'
     )
     await options.footerProps.onConfirm()
-    expect(mockSetEnforcementEnabled).toHaveBeenCalledWith(false)
+    expect(
+      usePartnerNodeGovernanceStore().setEnforcementEnabled
+    ).toHaveBeenCalledWith(false)
   })
 
   it('retries a failed load', async () => {
     const user = userEvent.setup()
-    mockStatus.value = 'error'
+    Object.assign(usePartnerNodeGovernanceStore(), { status: 'error' })
     renderComponent()
 
     expect(
@@ -818,6 +881,6 @@ describe('PartnerNodeAccessPanel', () => {
     ).toBeTruthy()
     await user.click(screen.getByRole('button', { name: 'Try again' }))
 
-    expect(mockLoadPolicy).toHaveBeenCalledOnce()
+    expect(usePartnerNodeGovernanceStore().loadPolicy).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMembersPanelContent.test.ts
@@ -2,22 +2,9 @@ import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
 import WorkspaceMembersPanelContent from './WorkspaceMembersPanelContent.vue'
-
-const { mockFetchMembers, mockFetchPendingInvites } = vi.hoisted(() => ({
-  mockFetchMembers: vi.fn(),
-  mockFetchPendingInvites: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      fetchMembers: mockFetchMembers,
-      fetchPendingInvites: mockFetchPendingInvites
-    })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -31,25 +18,32 @@ const stubs = {
 }
 
 describe('WorkspaceMembersPanelContent', () => {
+  let workspaceStore: ReturnType<typeof useTeamWorkspaceStore>
+
   beforeEach(() => {
-    mockFetchMembers.mockResolvedValue(undefined)
-    mockFetchPendingInvites.mockResolvedValue(undefined)
+    workspaceStore = useTeamWorkspaceStore()
+    vi.mocked(workspaceStore.fetchMembers).mockResolvedValue([])
+    vi.mocked(workspaceStore.fetchPendingInvites).mockResolvedValue([])
   })
 
   it('fetches members and pending invites on mount', () => {
     render(WorkspaceMembersPanelContent, { global: { stubs } })
-    expect(mockFetchMembers).toHaveBeenCalled()
-    expect(mockFetchPendingInvites).toHaveBeenCalled()
+    expect(workspaceStore.fetchMembers).toHaveBeenCalled()
+    expect(workspaceStore.fetchPendingInvites).toHaveBeenCalled()
   })
 
   it('settles rejected loading requests', async () => {
-    mockFetchMembers.mockRejectedValueOnce(new Error('members failed'))
-    mockFetchPendingInvites.mockRejectedValueOnce(new Error('invites failed'))
+    vi.mocked(workspaceStore.fetchMembers).mockRejectedValueOnce(
+      new Error('members failed')
+    )
+    vi.mocked(workspaceStore.fetchPendingInvites).mockRejectedValueOnce(
+      new Error('invites failed')
+    )
 
     render(WorkspaceMembersPanelContent, { global: { stubs } })
     await Promise.resolve()
 
-    expect(mockFetchMembers).toHaveBeenCalled()
-    expect(mockFetchPendingInvites).toHaveBeenCalled()
+    expect(workspaceStore.fetchMembers).toHaveBeenCalled()
+    expect(workspaceStore.fetchPendingInvites).toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -28,7 +29,6 @@ const personalConfig = {
 const mockUiConfig = ref<Record<string, unknown>>(ownerConfig)
 const mockCanLeaveWorkspace = ref(false)
 const mockCanManageSubscription = ref(true)
-const mockIsWorkspaceSubscribed = ref(false)
 
 const mockShowLeaveWorkspaceDialog = vi.fn()
 const mockShowDeleteWorkspaceDialog = vi.fn()
@@ -43,15 +43,6 @@ vi.mock<unknown>(
         canManageSubscription: mockCanManageSubscription.value
       })),
       uiConfig: mockUiConfig
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      isWorkspaceSubscribed: mockIsWorkspaceSubscribed
     })
   })
 )
@@ -91,7 +82,7 @@ describe('WorkspaceMenuButton', () => {
     mockUiConfig.value = ownerConfig
     mockCanLeaveWorkspace.value = false
     mockCanManageSubscription.value = true
-    mockIsWorkspaceSubscribed.value = false
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
   })
 
   it('lets a member leave and offers no destructive workspace actions', () => {
@@ -133,7 +124,7 @@ describe('WorkspaceMenuButton', () => {
   })
 
   it('disables Delete while the additional workspace is subscribed', () => {
-    mockIsWorkspaceSubscribed.value = true
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: true })
     renderComponent()
 
     expect(
@@ -187,7 +178,7 @@ describe('WorkspaceMenuButton', () => {
     const deleteWorkspace = screen.getByRole('button', {
       name: 'Delete Workspace'
     })
-    mockIsWorkspaceSubscribed.value = true
+    Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: true })
     deleteWorkspace.click()
 
     expect(mockShowDeleteWorkspaceDialog).not.toHaveBeenCalled()

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -1,4 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import type { Pinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -20,7 +21,7 @@ const { mockMaxSeats, mockIsPlanLoading } = vi.hoisted(() => {
   }
 })
 
-let pinia: ReturnType<typeof createTestingPinia>
+let pinia: Pinia
 let workspaceStore: ReturnType<typeof useTeamWorkspaceStore> & {
   activeWorkspaceId: string | null
 }
@@ -123,7 +124,7 @@ function renderComponent() {
 }
 
 beforeEach(() => {
-  pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+  pinia = getActivePinia()!
   workspaceStore = useTeamWorkspaceStore(pinia)
   vi.mocked(workspaceStore.fetchMembers).mockResolvedValue([])
   vi.mocked(workspaceStore.fetchPendingInvites).mockResolvedValue([])

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceSettingsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceSettingsPanelContent.test.ts
@@ -1,32 +1,14 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { defineComponent, h, onMounted, onUnmounted, ref } from 'vue'
 
 import WorkspaceSettingsPanelContent from './WorkspaceSettingsPanelContent.vue'
 
-const {
-  mockBannerMounted,
-  mockBannerUnmounted,
-  mockFetchMembers,
-  mockFetchPendingInvites
-} = vi.hoisted(() => ({
+const { mockBannerMounted, mockBannerUnmounted } = vi.hoisted(() => ({
   mockBannerMounted: vi.fn(),
-  mockBannerUnmounted: vi.fn(),
-  mockFetchMembers: vi.fn(),
-  mockFetchPendingInvites: vi.fn()
+  mockBannerUnmounted: vi.fn()
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () =>
-      reactive({
-        workspaceName: ref('Acme Team'),
-        fetchMembers: mockFetchMembers,
-        fetchPendingInvites: mockFetchPendingInvites
-      })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -51,10 +33,16 @@ const stubs = {
   WorkspaceProfilePic: { template: '<div />' }
 }
 
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), { workspaceName: 'Acme Team' })
+  vi.mocked(useTeamWorkspaceStore().fetchMembers).mockResolvedValue([])
+  vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([])
+})
+
 describe('WorkspaceSettingsPanelContent', () => {
   beforeEach(() => {
-    mockFetchMembers.mockResolvedValue(undefined)
-    mockFetchPendingInvites.mockResolvedValue(undefined)
+    vi.mocked(useTeamWorkspaceStore().fetchMembers).mockResolvedValue([])
+    vi.mocked(useTeamWorkspaceStore().fetchPendingInvites).mockResolvedValue([])
   })
 
   it('keeps the billing banner mounted while switching sections', async () => {
@@ -75,8 +63,8 @@ describe('WorkspaceSettingsPanelContent', () => {
 
     expect(screen.queryByTestId('plan-body')).not.toBeInTheDocument()
     expect(screen.getByTestId('members-body')).toBeInTheDocument()
-    expect(mockFetchMembers).toHaveBeenCalledTimes(1)
-    expect(mockFetchPendingInvites).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchMembers).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchPendingInvites).toHaveBeenCalledTimes(1)
     expect(mockBannerMounted).toHaveBeenCalledTimes(1)
     expect(mockBannerUnmounted).not.toHaveBeenCalled()
 
@@ -84,8 +72,8 @@ describe('WorkspaceSettingsPanelContent', () => {
 
     expect(screen.queryByTestId('members-body')).not.toBeInTheDocument()
     expect(screen.getByTestId('allowlist-body')).toBeInTheDocument()
-    expect(mockFetchMembers).toHaveBeenCalledTimes(1)
-    expect(mockFetchPendingInvites).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchMembers).toHaveBeenCalledTimes(1)
+    expect(useTeamWorkspaceStore().fetchPendingInvites).toHaveBeenCalledTimes(1)
     expect(mockBannerMounted).toHaveBeenCalledTimes(1)
     expect(mockBannerUnmounted).not.toHaveBeenCalled()
 

--- a/src/platform/workspace/composables/billingOperationTestUtils.ts
+++ b/src/platform/workspace/composables/billingOperationTestUtils.ts
@@ -1,0 +1,27 @@
+import type { useBillingOperationStore } from '../stores/billingOperationStore'
+
+export type BillingOperation = Awaited<
+  ReturnType<ReturnType<typeof useBillingOperationStore>['startOperation']>
+>
+
+export function billingOperation(
+  overrides: Partial<BillingOperation> = {}
+): BillingOperation {
+  return {
+    opId: 'op-test',
+    type: 'subscription',
+    status: 'pending',
+    errorMessage: null,
+    startedAt: 0,
+    operationStartedAt: 0,
+    actionUrl: null,
+    authenticationState: null,
+    isAuthenticating: false,
+    canRetryAuthentication: false,
+    authenticationRequiredSeen: false,
+    workspaceId: 'workspace-1',
+    autoHandleRequiresAction: false,
+    dismissed: false,
+    ...overrides
+  }
+}

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -1,8 +1,10 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import axios, { AxiosError, AxiosHeaders } from 'axios'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
@@ -12,11 +14,6 @@ import { useBillingCapabilities } from './useBillingCapabilities'
 const mockGetBillingCapabilities = vi.hoisted(() => vi.fn())
 const mockReportError = vi.hoisted(() => vi.fn())
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
-const mockScope = vi.hoisted(() => ({
-  workspaceId: 'workspace-1' as string | null,
-  authUid: 'firebase-user-1' as string | null,
-  role: 'owner' as 'owner' | 'member'
-}))
 
 vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   WorkspaceApiError: class WorkspaceApiError extends Error {
@@ -39,30 +36,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockScope.workspaceId
-      },
-      get activeWorkspace() {
-        return mockScope.workspaceId
-          ? { id: mockScope.workspaceId, role: mockScope.role }
-          : null
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get currentUser() {
-      return mockScope.authUid ? { uid: mockScope.authUid } : null
-    }
-  })
 }))
 
 function capabilitiesResponse(
@@ -175,15 +148,28 @@ function capabilityReadsThroughInterceptor() {
   }
 }
 
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), {
+    activeWorkspaceId: 'workspace-1',
+    activeWorkspace: { id: 'workspace-1', role: 'owner' }
+  })
+  Object.assign(useAuthStore(), {
+    userId: 'firebase-user-1',
+    currentUser: { uid: 'firebase-user-1' }
+  })
+})
+
 describe('useBillingCapabilities', () => {
   let scope: EffectScope
   let billingCapabilities: ReturnType<typeof useBillingCapabilities>
 
   beforeEach(() => {
     mockIsCloud.value = true
-    mockScope.workspaceId = 'workspace-1'
-    mockScope.authUid = 'firebase-user-1'
-    mockScope.role = 'owner'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
+    Object.assign(useAuthStore(), { userId: 'firebase-user-1' })
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1', role: 'owner' }
+    })
     scope = effectScope()
     billingCapabilities = scope.run(() => useBillingCapabilities())!
   })
@@ -293,7 +279,9 @@ describe('useBillingCapabilities', () => {
   })
 
   it('withholds top-up from members when the endpoint is unavailable', async () => {
-    mockScope.role = 'member'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1', role: 'member' }
+    })
     mockGetBillingCapabilities.mockRejectedValueOnce(new Error('unavailable'))
 
     await billingCapabilities.initialize()
@@ -369,8 +357,11 @@ describe('useBillingCapabilities', () => {
       .mockResolvedValueOnce(capabilitiesResponse(false, 'workspace-2', false))
 
     const firstInitialization = billingCapabilities.initialize()
-    mockScope.workspaceId = 'workspace-2'
-    await billingCapabilities.initialize()
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-2' })
+    await nextTick()
+    await vi.waitFor(() =>
+      expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
+    )
 
     resolveFirstRequest(capabilitiesResponse(true, 'workspace-1', true))
     await firstInitialization
@@ -392,7 +383,9 @@ describe('useBillingCapabilities', () => {
 
   it('preserves the local role gate for workspace members', async () => {
     mockIsCloud.value = false
-    mockScope.role = 'member'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1', role: 'member' }
+    })
 
     await billingCapabilities.initialize()
 
@@ -402,7 +395,7 @@ describe('useBillingCapabilities', () => {
   })
 
   it('does not enter pending state without an authenticated scope', async () => {
-    mockScope.workspaceId = null
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
 
     await billingCapabilities.initialize()
 
@@ -514,8 +507,11 @@ describe('useBillingCapabilities', () => {
       )
 
     await billingCapabilities.initialize()
-    mockScope.workspaceId = 'workspace-2'
-    await billingCapabilities.initialize()
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-2' })
+    await nextTick()
+    await vi.waitFor(() =>
+      expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
+    )
     expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
 
     await vi.advanceTimersByTimeAsync(60_000)
@@ -984,3 +980,10 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canTopUp.value).toBe(false)
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -165,11 +165,6 @@ describe('useBillingCapabilities', () => {
 
   beforeEach(() => {
     mockIsCloud.value = true
-    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
-    Object.assign(useAuthStore(), { userId: 'firebase-user-1' })
-    Object.assign(useTeamWorkspaceStore(), {
-      activeWorkspace: { id: 'workspace-1', role: 'owner' }
-    })
     scope = effectScope()
     billingCapabilities = scope.run(() => useBillingCapabilities())!
   })

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -1,4 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -7,6 +8,7 @@ import type { ListMembersParams } from '@/platform/workspace/api/workspaceApi'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
+import { billingOperation } from './billingOperationTestUtils'
 import {
   ReactivationConfirmationRequiredError,
   useDowngradeToPersonal
@@ -21,7 +23,7 @@ const mockFetchMembers =
 const mockSubscribe = vi.hoisted(() => vi.fn())
 const mockPreviewSubscribe = vi.hoisted(() => vi.fn())
 const mockFetchStatus = vi.hoisted(() => vi.fn())
-const mockStartOperation = vi.hoisted(() => vi.fn())
+
 const mockTrackBillingEvent = vi.hoisted(() => vi.fn())
 const mockPermissions = vi.hoisted(() => ({
   value: {
@@ -58,13 +60,6 @@ const mockMembers = {
     workspaceStore.activeWorkspaceId = 'workspace-one'
   }
 }
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({ startOperation: mockStartOperation })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
@@ -141,11 +136,17 @@ function teamWithOwnerAnd(...memberIds: string[]) {
   ]
 }
 
+beforeEach(() => {
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation()
+  )
+})
+
 describe('useDowngradeToPersonal', () => {
   let windowOpen: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+    const pinia = getActivePinia()!
     workspaceStore = useTeamWorkspaceStore(pinia)
     vi.mocked(workspaceStore.removeMember).mockImplementation(mockRemoveMember)
     vi.mocked(workspaceStore.fetchMembers).mockImplementation(mockFetchMembers)
@@ -603,18 +604,22 @@ describe('useDowngradeToPersonal', () => {
         'https://pay.test/method',
         '_blank'
       )
-      expect(mockStartOperation).toHaveBeenCalledWith('op-2', 'subscription', {
-        tier: undefined,
-        cycle: undefined,
-        checkoutType: 'change',
-        downgradeToPersonal: {
-          memberRemovalCount: 1,
-          memberRemovalFailures: 0,
-          targetTier: undefined,
-          startedAt: expect.any(Number)
-        },
-        attemptStartedAt: expect.any(Number)
-      })
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+        'op-2',
+        'subscription',
+        {
+          tier: undefined,
+          cycle: undefined,
+          checkoutType: 'change',
+          downgradeToPersonal: {
+            memberRemovalCount: 1,
+            memberRemovalFailures: 0,
+            targetTier: undefined,
+            startedAt: expect.any(Number)
+          },
+          attemptStartedAt: expect.any(Number)
+        }
+      )
     })
 
     it('falls back to the generic message when the transition is disallowed without a reason', async () => {
@@ -640,7 +645,7 @@ describe('useDowngradeToPersonal', () => {
       await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
         'subscription.downgrade.paymentPageBlocked'
       )
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
     })
 
     it('throws when a payment method is needed but no url is provided', async () => {
@@ -654,7 +659,7 @@ describe('useDowngradeToPersonal', () => {
       await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
         'subscription.downgrade.paymentMethodRequired'
       )
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
     })
 
     it('polls without opening a tab when the payment is pending', async () => {
@@ -668,18 +673,22 @@ describe('useDowngradeToPersonal', () => {
       await downgradeToPersonal('founder-monthly')
 
       expect(windowOpen).not.toHaveBeenCalled()
-      expect(mockStartOperation).toHaveBeenCalledWith('op-4', 'subscription', {
-        tier: undefined,
-        cycle: undefined,
-        checkoutType: 'change',
-        downgradeToPersonal: {
-          memberRemovalCount: 1,
-          memberRemovalFailures: 0,
-          targetTier: undefined,
-          startedAt: expect.any(Number)
-        },
-        attemptStartedAt: expect.any(Number)
-      })
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+        'op-4',
+        'subscription',
+        {
+          tier: undefined,
+          cycle: undefined,
+          checkoutType: 'change',
+          downgradeToPersonal: {
+            memberRemovalCount: 1,
+            memberRemovalFailures: 0,
+            targetTier: undefined,
+            startedAt: expect.any(Number)
+          },
+          attemptStartedAt: expect.any(Number)
+        }
+      )
       expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ stage: 'succeeded' })
       )

--- a/src/platform/workspace/composables/useInviteUrlLoader.test.ts
+++ b/src/platform/workspace/composables/useInviteUrlLoader.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent } from 'vue'
@@ -52,13 +53,6 @@ vi.mock<unknown>(
   })
 )
 
-const mockAcceptInvite = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('../stores/teamWorkspaceStore'), () => ({
-  useTeamWorkspaceStore: () => ({
-    acceptInvite: mockAcceptInvite
-  })
-}))
-
 const apps: App<Element>[] = []
 
 function useInviteUrlLoader(): ReturnType<typeof createInviteUrlLoader> {
@@ -110,7 +104,7 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().acceptInvite).not.toHaveBeenCalled()
       expect(mockToastAdd).not.toHaveBeenCalled()
       expect(mockRouterReplace).not.toHaveBeenCalled()
     })
@@ -120,7 +114,7 @@ describe('useInviteUrlLoader', () => {
       preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
         invite: 'preserved-token'
       })
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -134,12 +128,14 @@ describe('useInviteUrlLoader', () => {
       expect(mockRouterReplace).toHaveBeenCalledWith({
         query: { invite: 'preserved-token' }
       })
-      expect(mockAcceptInvite).toHaveBeenCalledWith('preserved-token')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'preserved-token'
+      )
     })
 
     it('accepts invite and shows success toast on success', async () => {
       mockRouteQuery.value = { invite: 'valid-token' }
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -147,7 +143,9 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).toHaveBeenCalledWith('valid-token')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'valid-token'
+      )
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'Invite Accepted',
@@ -163,12 +161,16 @@ describe('useInviteUrlLoader', () => {
 
     it('shows error toast when invite acceptance fails', async () => {
       mockRouteQuery.value = { invite: 'invalid-token' }
-      mockAcceptInvite.mockRejectedValue(new Error('Invalid invite'))
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockRejectedValue(
+        new Error('Invalid invite')
+      )
 
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).toHaveBeenCalledWith('invalid-token')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'invalid-token'
+      )
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'Failed to Accept Invite',
@@ -178,7 +180,7 @@ describe('useInviteUrlLoader', () => {
 
     it('cleans up URL after processing invite', async () => {
       mockRouteQuery.value = { invite: 'valid-token', other: 'param' }
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -194,7 +196,7 @@ describe('useInviteUrlLoader', () => {
 
     it('clears preserved query after processing', async () => {
       mockRouteQuery.value = { invite: 'valid-token' }
-      mockAcceptInvite.mockResolvedValue({
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockResolvedValue({
         workspaceId: 'ws-123',
         workspaceName: 'Test Workspace'
       })
@@ -209,7 +211,9 @@ describe('useInviteUrlLoader', () => {
 
     it('clears preserved query even on error', async () => {
       mockRouteQuery.value = { invite: 'invalid-token' }
-      mockAcceptInvite.mockRejectedValue(new Error('Invalid invite'))
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockRejectedValue(
+        new Error('Invalid invite')
+      )
 
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
@@ -221,13 +225,17 @@ describe('useInviteUrlLoader', () => {
 
     it('sends any token format to backend for validation', async () => {
       mockRouteQuery.value = { invite: 'any-token-format==' }
-      mockAcceptInvite.mockRejectedValue(new Error('Invalid token'))
+      vi.mocked(useTeamWorkspaceStore().acceptInvite).mockRejectedValue(
+        new Error('Invalid token')
+      )
 
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
       // Token is sent to backend, which validates and rejects
-      expect(mockAcceptInvite).toHaveBeenCalledWith('any-token-format==')
+      expect(useTeamWorkspaceStore().acceptInvite).toHaveBeenCalledWith(
+        'any-token-format=='
+      )
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'Failed to Accept Invite',
@@ -241,7 +249,7 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().acceptInvite).not.toHaveBeenCalled()
     })
 
     it('ignores non-string invite param', async () => {
@@ -252,7 +260,7 @@ describe('useInviteUrlLoader', () => {
       const { loadInviteFromUrl } = useInviteUrlLoader()
       await loadInviteFromUrl()
 
-      expect(mockAcceptInvite).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().acceptInvite).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, ref } from 'vue'
@@ -17,53 +17,6 @@ import {
   sortPendingInvites,
   useMembersPanel
 } from './useMembersPanel'
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { defineStore } = await import('pinia')
-    const { computed, ref } = await import('vue')
-    return {
-      useTeamWorkspaceStore: defineStore('teamWorkspace', () => {
-        const workspaces = ref<
-          Array<{
-            id: string
-            type: 'personal' | 'team'
-            members: WorkspaceMember[]
-            pendingInvites: WorkspacePendingInvite[]
-          }>
-        >([])
-        const activeWorkspaceId = ref<string | null>(null)
-        const activeWorkspace = computed(
-          () =>
-            workspaces.value.find(
-              (workspace) => workspace.id === activeWorkspaceId.value
-            ) ?? null
-        )
-        const members = computed(() => activeWorkspace.value?.members ?? [])
-        const pendingInvites = computed(
-          () => activeWorkspace.value?.pendingInvites ?? []
-        )
-        const originalOwnerId = computed(
-          () =>
-            members.value.find((member) => member.isOriginalOwner)?.id ?? null
-        )
-        return {
-          workspaces,
-          activeWorkspaceId,
-          activeWorkspace,
-          isInPersonalWorkspace: computed(
-            () => activeWorkspace.value?.type === 'personal'
-          ),
-          members,
-          pendingInvites,
-          originalOwnerId,
-          resendInvite: vi.fn()
-        }
-      })
-    }
-  }
-)
 
 function createMember(
   overrides: Partial<WorkspaceMember> = {}
@@ -528,8 +481,7 @@ describe('useMembersPanel', () => {
   let pinia: Pinia
 
   beforeEach(() => {
-    pinia = createPinia()
-    setActivePinia(pinia)
+    pinia = getActivePinia()!
     workspaceStore = useTeamWorkspaceStore(pinia)
     vi.spyOn(workspaceStore, 'resendInvite').mockImplementation(
       mockResendInvite

--- a/src/platform/workspace/composables/useResubscribe.test.ts
+++ b/src/platform/workspace/composables/useResubscribe.test.ts
@@ -74,17 +74,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock(import('@/stores/authStore'), () => ({
-  AuthStoreError: class AuthStoreError extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.name = 'AuthStoreError'
-      this.status = status
-    }
-  }
-}))
-
 vi.mock<unknown>(
   import('primevue/usetoast'), // eslint-disable-line primevue-removal/no-imports
   () => ({

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1,12 +1,9 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { billingOperation } from './billingOperationTestUtils'
+import type { BillingOperation } from './billingOperationTestUtils'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  computed,
-  createApp,
-  defineComponent,
-  effectScope,
-  reactive
-} from 'vue'
+import { computed, createApp, defineComponent, effectScope } from 'vue'
 import type { App } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -16,15 +13,9 @@ import type {
   Plan,
   PreviewSubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
-import type { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import { findPlanSlug } from './useSubscriptionCheckout'
-
-type SubscriptionActionOperation = NonNullable<
-  ReturnType<typeof useBillingOperationStore>['subscriptionActionOperation']
->
-type MockSubscriptionActionOperation = Partial<SubscriptionActionOperation> &
-  Pick<SubscriptionActionOperation, 'status' | 'workspaceId'>
 
 function makeStandardYearly(): Plan {
   return {
@@ -133,6 +124,13 @@ function makeReactivationAuthorityPreview({
   }
 }
 
+beforeEach(() => {
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation()
+  )
+  vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(undefined)
+})
+
 describe('findPlanSlug', () => {
   it('finds an annual plan by tier key and yearly billing cycle', () => {
     expect(findPlanSlug(allPlans(), 'standard', 'yearly')).toBe(
@@ -168,25 +166,18 @@ const {
   mockPlans,
   mockResubscribe,
   mockToastAdd,
-  mockStartOperation,
-  mockGetOperation,
-  mockSubscriptionActionOperation,
   mockListSavedPaymentMethods,
   mockTrackBeginCheckout,
   mockTrackBillingEvent,
   mockShowDowngradeToPersonalDialog,
-  mockUserId,
   mockIsTeamPlan,
   mockShouldUseWorkspaceBilling,
   mockIncompleteEmbeddedPreview,
-  mockSetActiveWorkspaceIdImpl,
-  mockSetActiveWorkspaceId,
   mockPermissions,
   mockCanReactivatePlan,
   mockCapabilities,
   mockSubscription
 } = vi.hoisted(() => {
-  const nullableString = (value: string | null) => ({ value })
   return {
     mockSubscribe: vi.fn(),
     mockPreviewSubscribe: vi.fn(),
@@ -200,27 +191,13 @@ const {
     mockPlans: { value: [] as Plan[] },
     mockResubscribe: vi.fn(),
     mockToastAdd: vi.fn(),
-    mockStartOperation: vi.fn(),
-    mockGetOperation: vi.fn(),
-    mockSubscriptionActionOperation: {
-      value: undefined as MockSubscriptionActionOperation | undefined
-    },
     mockListSavedPaymentMethods: vi.fn(),
     mockTrackBeginCheckout: vi.fn(),
     mockTrackBillingEvent: vi.fn(),
     mockShowDowngradeToPersonalDialog: vi.fn(),
-    mockUserId: nullableString('user-1'),
     mockIsTeamPlan: { value: false },
     mockShouldUseWorkspaceBilling: { value: true },
     mockIncompleteEmbeddedPreview: { value: false },
-    mockSetActiveWorkspaceIdImpl: {
-      value: undefined as ((workspaceId: string) => void) | undefined
-    },
-    mockSetActiveWorkspaceId: vi.fn<(workspaceId: string) => void>(
-      (workspaceId) => {
-        mockSetActiveWorkspaceIdImpl.value?.(workspaceId)
-      }
-    ),
     mockPermissions: {
       value: {
         canManageSubscription: true,
@@ -362,37 +339,6 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({
-      startOperation: mockStartOperation,
-      getOperation: mockGetOperation,
-      get subscriptionActionOperation() {
-        return mockSubscriptionActionOperation.value
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { ref } = await import('vue')
-    const activeWorkspaceId = ref('workspace-1')
-    mockSetActiveWorkspaceIdImpl.value = (workspaceId) => {
-      activeWorkspaceId.value = workspaceId
-    }
-    return {
-      useTeamWorkspaceStore: () => ({
-        get activeWorkspaceId() {
-          return activeWorkspaceId.value
-        }
-      })
-    }
-  }
-)
-
 vi.mock(import('@/config/comfyApi'), () => ({
   getComfyPlatformBaseUrl: () => 'https://platform.comfy.org'
 }))
@@ -418,18 +364,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => reactive({ userId: computed(() => mockUserId.value) }),
-  AuthStoreError: class AuthStoreError extends Error {
-    readonly status: number | undefined
-    constructor(message: string, status?: number) {
-      super(message)
-      this.name = 'AuthStoreError'
-      this.status = status
-    }
-  }
 }))
 
 describe('useSubscriptionCheckout', () => {
@@ -491,14 +425,15 @@ describe('useSubscriptionCheckout', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockSubscribe.mockReset()
     mockPreviewSubscribe.mockReset()
     mockFetchPlans.mockReset()
     mockFetchStatus.mockReset()
-    mockStartOperation.mockReset()
+    vi.mocked(useBillingOperationStore().startOperation).mockReset()
     mockListSavedPaymentMethods.mockReset()
-    mockSubscriptionActionOperation.value = undefined
+    Object.assign(useBillingOperationStore(), {
+      subscriptionActionOperation: undefined
+    })
     mockPlans.value = allPlans()
     mockFetchPlans.mockResolvedValue(undefined)
     mockPreviewSubscribe.mockResolvedValue({
@@ -507,14 +442,18 @@ describe('useSubscriptionCheckout', () => {
       is_immediate: true,
       requires_reactivation_confirmation: false
     })
-    mockStartOperation.mockResolvedValue({
-      status: 'succeeded',
-      workspaceId: 'workspace-1'
-    })
+    vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+      billingOperation({
+        status: 'succeeded',
+        workspaceId: 'workspace-1'
+      })
+    )
     mockListSavedPaymentMethods.mockResolvedValue([])
-    mockGetOperation.mockReturnValue(undefined)
+    vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+      undefined
+    )
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
-    mockUserId.value = 'user-1'
+    Object.assign(useAuthStore(), { userId: 'user-1' })
     mockIsTeamPlan.value = false
     mockOpen.mockReturnValue({})
     mockGetBillingStatus.mockResolvedValue({ billing_status: 'paid' })
@@ -529,7 +468,7 @@ describe('useSubscriptionCheckout', () => {
     vi.stubGlobal('open', mockOpen)
     mockShouldUseWorkspaceBilling.value = true
     mockIncompleteEmbeddedPreview.value = false
-    mockSetActiveWorkspaceId('workspace-1')
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
     mockPermissions.value = {
       canManageSubscription: true,
       canManageSubscriptionLifecycle: true,
@@ -2740,12 +2679,14 @@ describe('useSubscriptionCheckout', () => {
 
   describe('handleBackToPricing', () => {
     it('surfaces a subscription operation recovered from billing status', async () => {
-      mockSubscriptionActionOperation.value = {
-        opId: 'op-recovered-3ds',
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        actionUrl: 'https://verify.example/sensitive-token'
-      }
+      Object.assign(useBillingOperationStore(), {
+        subscriptionActionOperation: {
+          opId: 'op-recovered-3ds',
+          status: 'pending',
+          workspaceId: 'workspace-1',
+          actionUrl: 'https://verify.example/sensitive-token'
+        }
+      })
 
       const checkout = await setup()
 
@@ -2756,15 +2697,17 @@ describe('useSubscriptionCheckout', () => {
     })
 
     it('surfaces recovered failed authentication and releases the confirm action', async () => {
-      mockSubscriptionActionOperation.value = {
-        opId: 'op-recovered-3ds',
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        authenticationState: 'failed_retryable',
-        errorMessage: 'Challenge was closed',
-        canRetryAuthentication: false,
-        isAuthenticating: false
-      }
+      Object.assign(useBillingOperationStore(), {
+        subscriptionActionOperation: {
+          opId: 'op-recovered-3ds',
+          status: 'pending',
+          workspaceId: 'workspace-1',
+          authenticationState: 'failed_retryable',
+          errorMessage: 'Challenge was closed',
+          canRetryAuthentication: false,
+          isAuthenticating: false
+        }
+      })
 
       const checkout = await setup()
 
@@ -2774,11 +2717,13 @@ describe('useSubscriptionCheckout', () => {
     })
 
     it('surfaces an operation that needs reconciliation', async () => {
-      mockSubscriptionActionOperation.value = {
-        opId: 'op-reconciliation',
-        status: 'reconciliation_needed',
-        workspaceId: 'workspace-1'
-      }
+      Object.assign(useBillingOperationStore(), {
+        subscriptionActionOperation: {
+          opId: 'op-reconciliation',
+          status: 'reconciliation_needed',
+          workspaceId: 'workspace-1'
+        }
+      })
 
       const checkout = await setup()
 
@@ -2817,13 +2762,19 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-pending'
       })
-      mockGetOperation.mockImplementation((opId) =>
-        opId === 'op-pending'
-          ? { status: 'pending', workspaceId: 'workspace-1' }
-          : undefined
+      vi.mocked(useBillingOperationStore().getOperation).mockImplementation(
+        (opId) =>
+          opId === 'op-pending'
+            ? billingOperation({
+                status: 'pending',
+                workspaceId: 'workspace-1'
+              })
+            : undefined
       )
-      let resolveOperation!: (operation: { status: 'failed' }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -2831,12 +2782,14 @@ describe('useSubscriptionCheckout', () => {
       )
 
       const payment = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      await vi.waitFor(() =>
+        expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      )
       checkout.handleBackToPricing()
 
       expect(checkout.checkoutStep.value).toBe('preview')
 
-      resolveOperation({ status: 'failed' })
+      resolveOperation(billingOperation({ status: 'failed' }))
       await payment
     })
 
@@ -2857,16 +2810,17 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-pending'
       })
-      mockGetOperation.mockReturnValue({
-        status: 'pending',
-        workspaceId: 'workspace-1',
-        actionUrl: 'https://verify.example/sensitive-token'
-      })
-      let resolveOperation!: (operation: {
-        status: 'succeeded'
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(
+        billingOperation({
+          status: 'pending',
+          workspaceId: 'workspace-1',
+          actionUrl: 'https://verify.example/sensitive-token'
+        })
+      )
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -2878,15 +2832,19 @@ describe('useSubscriptionCheckout', () => {
         expect(checkout.activeCheckoutActionUrl.value).not.toBeNull()
       )
 
-      mockSetActiveWorkspaceId('workspace-2')
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       expect(checkout.activeCheckoutActionUrl.value).toBeNull()
       expect(checkout.isPolling.value).toBe(false)
 
-      resolveOperation({
-        status: 'succeeded',
-        workspaceId: 'workspace-1'
-      })
+      resolveOperation(
+        billingOperation({
+          status: 'succeeded',
+          workspaceId: 'workspace-1'
+        })
+      )
       await payment
 
       expect(checkout.checkoutStep.value).not.toBe('success')
@@ -2894,7 +2852,7 @@ describe('useSubscriptionCheckout', () => {
   })
 
   describe('busy continuity through checkout', () => {
-    async function startPendingCheckout(operation: Record<string, unknown>) {
+    async function startPendingCheckout(operation: Partial<BillingOperation>) {
       const checkout = await setupWithApprovedPreview()
       checkout.checkoutStep.value = 'preview'
       checkout.selectedTierKey.value = 'standard'
@@ -2902,21 +2860,22 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-busy'
       })
-      mockGetOperation.mockImplementation((opId) =>
-        opId === 'op-busy' ? operation : undefined
+      vi.mocked(useBillingOperationStore().getOperation).mockImplementation(
+        (opId) => (opId === 'op-busy' ? billingOperation(operation) : undefined)
       )
-      let resolveOperation!: (operation: {
-        status: string
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
           })
       )
       const payment = checkout.handleAddCreditCard()
-      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      await vi.waitFor(() =>
+        expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      )
       return { checkout, payment, finish: () => resolveOperation }
     }
 
@@ -2930,7 +2889,9 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.isPolling.value).toBe(true)
 
-      finish()({ status: 'failed', workspaceId: 'workspace-1' })
+      finish()(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
     })
 
@@ -2944,7 +2905,9 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.isPolling.value).toBe(false)
 
-      finish()({ status: 'failed', workspaceId: 'workspace-1' })
+      finish()(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
     })
 
@@ -2957,7 +2920,9 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.isPolling.value).toBe(true)
       expect(checkout.checkoutStep.value).toBe('preview')
 
-      finish()({ status: 'succeeded', workspaceId: 'workspace-1' })
+      finish()(
+        billingOperation({ status: 'succeeded', workspaceId: 'workspace-1' })
+      )
       await payment
       expect(checkout.checkoutStep.value).toBe('success')
     })
@@ -3038,7 +3003,7 @@ describe('useSubscriptionCheckout', () => {
     })
 
     it('skips begin_checkout when no user id is available', async () => {
-      mockUserId.value = null
+      Object.assign(useAuthStore(), { userId: null })
       const checkout = await setupWithApprovedPreview('subscribe_to_run')
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -3052,7 +3017,7 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
-      mockUserId.value = 'user-1'
+      Object.assign(useAuthStore(), { userId: 'user-1' })
     })
 
     it('fires begin_checkout carrying the payment intent source', async () => {
@@ -3114,7 +3079,7 @@ describe('useSubscriptionCheckout', () => {
           detail: 'subscription.preview.paymentPopupBlocked'
         })
       )
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-blocked',
         'subscription',
         expect.any(Object),
@@ -3136,7 +3101,7 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(openSpy).not.toHaveBeenCalled()
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
@@ -3155,15 +3120,19 @@ describe('useSubscriptionCheckout', () => {
         billing_op_id: 'op-async-1',
         payment_method_url: 'https://stripe.com/pay'
       })
-      mockStartOperation.mockResolvedValueOnce({
-        status: 'succeeded',
-        workspaceId: 'workspace-1'
-      })
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockResolvedValueOnce(
+        billingOperation({
+          status: 'succeeded',
+          workspaceId: 'workspace-1'
+        })
+      )
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
       await checkout.handleAddCreditCard()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-async-1',
         'subscription',
         {
@@ -3190,11 +3159,17 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-async-2'
       })
-      mockStartOperation.mockResolvedValueOnce({ status: 'failed' })
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockResolvedValueOnce(
+        billingOperation({
+          status: 'failed'
+        })
+      )
 
       await checkout.handleAddCreditCard()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-async-2',
         'subscription',
         {
@@ -3218,11 +3193,10 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-alipay'
       })
-      let resolveOperation!: (operation: {
-        status: 'failed'
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -3247,7 +3221,9 @@ describe('useSubscriptionCheckout', () => {
         })
       })
 
-      resolveOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      resolveOperation(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
 
       expect(
@@ -3264,11 +3240,10 @@ describe('useSubscriptionCheckout', () => {
         status: 'pending_payment',
         billing_op_id: 'op-legacy-alipay'
       })
-      let resolveOperation!: (operation: {
-        status: 'failed'
-        workspaceId: string
-      }) => void
-      mockStartOperation.mockImplementationOnce(
+      let resolveOperation!: (operation: BillingOperation) => void
+      vi.mocked(
+        useBillingOperationStore().startOperation
+      ).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveOperation = resolve
@@ -3296,7 +3271,9 @@ describe('useSubscriptionCheckout', () => {
         })
       })
 
-      resolveOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      resolveOperation(
+        billingOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      )
       await payment
 
       expect(
@@ -4085,3 +4062,10 @@ describe('useSubscriptionCheckout', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -1,3 +1,6 @@
+import { billingOperation } from './billingOperationTestUtils'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
@@ -27,11 +30,8 @@ const mockBillingPlans = vi.hoisted(() => ({
 }))
 
 const mockShow = vi.hoisted(() => vi.fn())
-const mockStartOperation = vi.hoisted(() => vi.fn())
-const mockGetOperation = vi.hoisted(() => vi.fn())
-const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
+
 const mockReportError = vi.hoisted(() => vi.fn())
-const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
 // const is in its temporal dead zone when the hoisted factory runs under
@@ -71,31 +71,9 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/billingOperationStore'),
-  () => ({
-    useBillingOperationStore: () => ({
-      getOperation: mockGetOperation,
-      startOperation: mockStartOperation
-    })
-  })
-)
-
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspace() {
-        return { id: mockActiveWorkspaceId.value }
-      },
-      setWorkspaceBillingRail: mockSetWorkspaceBillingRail
-    })
-  })
-)
 
 const mockTrackBillingEvent = vi.hoisted(() => vi.fn())
 
@@ -181,9 +159,27 @@ const subscribeResponses = [
   }
 ] satisfies SubscribeResponse[]
 
+beforeEach(() => {
+  vi.mocked(useBillingOperationStore().getOperation).mockReturnValue(undefined)
+  vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+    billingOperation()
+  )
+})
+
+beforeEach(() => {
+  Object.assign(useTeamWorkspaceStore(), {
+    activeWorkspace: { id: 'workspace-1' }
+  })
+  vi.mocked(useTeamWorkspaceStore().setWorkspaceBillingRail).mockImplementation(
+    () => {}
+  )
+})
+
 describe('useWorkspaceBilling', () => {
   beforeEach(() => {
-    mockActiveWorkspaceId.value = 'workspace-1'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: { id: 'workspace-1' }
+    })
     mockBillingPlans.plans.value = []
     mockBillingPlans.currentPlanSlug.value = null
     mockBillingPlans.error.value = null
@@ -284,10 +280,9 @@ describe('useWorkspaceBilling', () => {
       })
       expect(billing.canAccessSubscriptionFeatures.value).toBe(true)
       expect(billing.isFreeTier.value).toBe(false)
-      expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
-        'workspace-1',
-        'stripe'
-      )
+      expect(
+        useTeamWorkspaceStore().setWorkspaceBillingRail
+      ).toHaveBeenCalledWith('workspace-1', 'stripe')
     })
 
     it('maps a scheduled plan change into subscription info', async () => {
@@ -325,7 +320,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-recovered',
         'subscription',
         undefined,
@@ -348,7 +343,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-sub',
         'subscription',
         undefined,
@@ -370,7 +365,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-topup',
         'topup',
         undefined,
@@ -399,7 +394,7 @@ describe('useWorkspaceBilling', () => {
       )
       // Recovery is preserved deliberately: without it the customer has no way
       // back to the payment page, while a wrong panel clears on reload.
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-future',
         'subscription',
         undefined,
@@ -413,16 +408,16 @@ describe('useWorkspaceBilling', () => {
         billing_status: 'pending_payment',
         pending_billing_op_id: 'op-recovered'
       } satisfies BillingStatusResponse)
-      mockGetOperation
+      vi.mocked(useBillingOperationStore().getOperation)
         .mockReturnValueOnce(undefined)
-        .mockReturnValue({ status: 'pending' })
+        .mockReturnValue(billingOperation({ status: 'pending' }))
 
       const billing = setupBilling()
       await billing.fetchStatus()
       await billing.fetchStatus()
 
-      expect(mockStartOperation).toHaveBeenCalledOnce()
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledOnce()
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-recovered',
         'subscription',
         undefined,
@@ -436,7 +431,9 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
 
       const fetch = billing.fetchStatus()
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: { id: 'workspace-2' }
+      })
       status.resolve({
         ...activeStatus,
         billing_status: 'pending_payment',
@@ -445,7 +442,7 @@ describe('useWorkspaceBilling', () => {
       })
       await fetch
 
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
       expect(billing.subscription.value).toBeNull()
     })
 
@@ -469,7 +466,9 @@ describe('useWorkspaceBilling', () => {
       await billing.fetchStatus()
 
       expect(billing.isFreeTier.value).toBe(true)
-      expect(mockSetWorkspaceBillingRail).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().setWorkspaceBillingRail
+      ).not.toHaveBeenCalled()
     })
 
     it('sets error and rethrows when fetchStatus fails', async () => {
@@ -903,13 +902,13 @@ describe('useWorkspaceBilling', () => {
         errorMessage: string | null
       }> = {}
     ) {
-      return {
+      return billingOperation({
         opId: 'op-cancel',
         type: 'cancel' as const,
         status: overrides.status ?? ('succeeded' as const),
         errorMessage: overrides.errorMessage ?? null,
         startedAt: 0
-      }
+      })
     }
 
     it('drives the shared billing operation poller with a cancel op', async () => {
@@ -917,14 +916,20 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-cancel',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(operation())
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation()
+      )
 
       const billing = setupBilling()
       await billing.cancelSubscription()
 
-      expect(mockStartOperation).toHaveBeenCalledWith('op-cancel', 'cancel', {
-        attemptStartedAt: expect.any(Number)
-      })
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
+        'op-cancel',
+        'cancel',
+        {
+          attemptStartedAt: expect.any(Number)
+        }
+      )
       expect(billing.error.value).toBeNull()
     })
 
@@ -933,8 +938,11 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-fail',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
-        operation({ status: 'failed', errorMessage: 'processor rejected' })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation({
+          status: 'failed',
+          errorMessage: 'processor rejected'
+        })
       )
 
       const billing = setupBilling()
@@ -950,7 +958,7 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-timeout',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
         operation({
           status: 'timeout',
           errorMessage: 'billingOperation.cancelTimeout'
@@ -969,7 +977,7 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-noerr',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
         operation({ status: 'failed', errorMessage: null })
       )
 
@@ -989,7 +997,7 @@ describe('useWorkspaceBilling', () => {
 
       await expect(billing.cancelSubscription()).rejects.toThrow('API down')
       expect(billing.error.value).toBe('API down')
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
     })
 
     it('fires a started event before the cancel API call resolves', async () => {
@@ -997,7 +1005,9 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-cancel',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(operation())
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation()
+      )
 
       const billing = setupBilling()
       await billing.cancelSubscription()
@@ -1048,8 +1058,11 @@ describe('useWorkspaceBilling', () => {
         billing_op_id: 'op-fail',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockStartOperation.mockResolvedValue(
-        operation({ status: 'failed', errorMessage: 'processor rejected' })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        operation({
+          status: 'failed',
+          errorMessage: 'processor rejected'
+        })
       )
 
       const billing = setupBilling()
@@ -1093,7 +1106,7 @@ describe('useWorkspaceBilling', () => {
       // shows — the point of resyncing rather than reporting a failure.
       expect(billing.subscription.value?.endDate).toBe('2026-06-01T00:00:00Z')
       expect(billing.subscription.value?.tier).toBe('CREATOR')
-      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(useBillingOperationStore().startOperation).not.toHaveBeenCalled()
       expect(billing.isLoading.value).toBe(false)
       expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ stage: 'failed' })
@@ -1189,18 +1202,20 @@ describe('useWorkspaceBilling', () => {
       })
       mockWorkspaceApi.getBillingStatus.mockResolvedValue(activeStatus)
       mockWorkspaceApi.getBillingBalance.mockResolvedValue(positiveBalance)
-      mockStartOperation.mockResolvedValue({
-        opId: 'op-resub-pending',
-        type: 'subscription',
-        status: 'succeeded',
-        errorMessage: null,
-        startedAt: 0
-      })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        billingOperation({
+          opId: 'op-resub-pending',
+          type: 'subscription',
+          status: 'succeeded',
+          errorMessage: null,
+          startedAt: 0
+        })
+      )
 
       const billing = setupBilling()
       await billing.resubscribe()
 
-      expect(mockStartOperation).toHaveBeenCalledWith(
+      expect(useBillingOperationStore().startOperation).toHaveBeenCalledWith(
         'op-resub-pending',
         'subscription'
       )
@@ -1214,13 +1229,15 @@ describe('useWorkspaceBilling', () => {
       })
       mockWorkspaceApi.getBillingStatus.mockResolvedValue(activeStatus)
       mockWorkspaceApi.getBillingBalance.mockResolvedValue(positiveBalance)
-      mockStartOperation.mockResolvedValue({
-        opId: 'op-resub-failed',
-        type: 'subscription',
-        status: 'failed',
-        errorMessage: 'card declined',
-        startedAt: 0
-      })
+      vi.mocked(useBillingOperationStore().startOperation).mockResolvedValue(
+        billingOperation({
+          opId: 'op-resub-failed',
+          type: 'subscription',
+          status: 'failed',
+          errorMessage: 'card declined',
+          startedAt: 0
+        })
+      )
 
       const billing = setupBilling()
 

--- a/src/platform/workspace/composables/useWorkspaceSwitch.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceSwitch.test.ts
@@ -1,41 +1,26 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
-import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 
-const mockSwitchWorkspace = vi.hoisted(() => vi.fn())
-const mockWorkspaceStore = vi.hoisted(() => ({
-  store: null as {
-    activeWorkspace: WorkspaceWithRole | null
-    switchWorkspace: typeof mockSwitchWorkspace
-  } | null
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { reactive, ref } = await import('vue')
-    mockWorkspaceStore.store = reactive({
-      activeWorkspace: ref<WorkspaceWithRole | null>(null),
-      switchWorkspace: mockSwitchWorkspace
-    })
-    return { useTeamWorkspaceStore: () => mockWorkspaceStore.store }
-  }
-)
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().switchWorkspace).mockResolvedValue(
+    undefined
+  )
+})
 
 describe('useWorkspaceSwitch', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
-    if (!mockWorkspaceStore.store) throw new Error('workspace store not ready')
-    mockWorkspaceStore.store.activeWorkspace = {
-      id: 'workspace-1',
-      name: 'Test Workspace',
-      type: 'personal',
-      role: 'owner',
-      created_at: '2026-01-01T00:00:00Z',
-      joined_at: '2026-01-01T00:00:00Z'
-    }
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspace: {
+        id: 'workspace-1',
+        name: 'Test Workspace',
+        type: 'personal',
+        role: 'owner',
+        created_at: '2026-01-01T00:00:00Z',
+        joined_at: '2026-01-01T00:00:00Z'
+      }
+    })
   })
 
   describe('switchWorkspace', () => {
@@ -45,21 +30,27 @@ describe('useWorkspaceSwitch', () => {
       const result = await switchWorkspace('workspace-1')
 
       expect(result).toBe(true)
-      expect(mockSwitchWorkspace).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().switchWorkspace).not.toHaveBeenCalled()
     })
 
     it('switches directly to the new workspace', async () => {
-      mockSwitchWorkspace.mockResolvedValue(undefined)
+      vi.mocked(useTeamWorkspaceStore().switchWorkspace).mockResolvedValue(
+        undefined
+      )
       const { switchWorkspace } = useWorkspaceSwitch()
 
       const result = await switchWorkspace('workspace-2')
 
       expect(result).toBe(true)
-      expect(mockSwitchWorkspace).toHaveBeenCalledWith('workspace-2')
+      expect(useTeamWorkspaceStore().switchWorkspace).toHaveBeenCalledWith(
+        'workspace-2'
+      )
     })
 
     it('returns false if switchWorkspace throws an error', async () => {
-      mockSwitchWorkspace.mockRejectedValue(new Error('Switch failed'))
+      vi.mocked(useTeamWorkspaceStore().switchWorkspace).mockRejectedValue(
+        new Error('Switch failed')
+      )
       const { switchWorkspace } = useWorkspaceSwitch()
 
       const result = await switchWorkspace('workspace-2')

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -1,15 +1,10 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { computed, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 
-const mockStore = vi.hoisted(() => ({
-  activeWorkspace: null as WorkspaceWithRole | null,
-  isCurrentUserOriginalOwner: false,
-  originalOwnerId: null as string | null,
-  ensureMembersLoaded: vi.fn()
-}))
-const mockIsCloud = ref(true)
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanReactivate = ref(false)
 const mockCanSubscribeSelfServe = ref(true)
@@ -18,30 +13,6 @@ const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockBillingControlEnabled = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspace() {
-        return mockStore.activeWorkspace
-      },
-      get isInPersonalWorkspace() {
-        return mockStore.activeWorkspace?.type === 'personal'
-      },
-      get isWorkspaceSubscribed() {
-        return false
-      },
-      get isCurrentUserOriginalOwner() {
-        return mockStore.isCurrentUserOriginalOwner
-      },
-      get originalOwnerId() {
-        return mockStore.originalOwnerId
-      },
-      ensureMembersLoaded: mockStore.ensureMembersLoaded
-    })
-  })
-)
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -125,10 +96,9 @@ async function loadComposable() {
 }
 
 function resetStore() {
-  mockStore.activeWorkspace = null
-  mockStore.isCurrentUserOriginalOwner = false
-  mockStore.originalOwnerId = null
-  mockStore.ensureMembersLoaded.mockReset()
+  Object.assign(useTeamWorkspaceStore(), { activeWorkspace: null })
+  Object.assign(useTeamWorkspaceStore(), { isCurrentUserOriginalOwner: false })
+  Object.assign(useTeamWorkspaceStore(), { originalOwnerId: null })
   mockIsActiveSubscription.value = false
   mockIsCancelled.value = false
   mockIsTeamPlan.value = false
@@ -139,6 +109,12 @@ function resetStore() {
   mockCanSubscribeSelfServe.value = true
   mockSnapshotAuthoritative.value = true
 }
+
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().ensureMembersLoaded).mockResolvedValue(
+    undefined
+  )
+})
 
 describe('useWorkspaceUI', () => {
   beforeEach(() => {
@@ -171,7 +147,9 @@ describe('useWorkspaceUI', () => {
 
   describe('personal workspace', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
     })
 
     it('grants billing access with personal workspace visibility', async () => {
@@ -190,7 +168,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('gives a Team-plan member only member actions', async () => {
-      mockStore.activeWorkspace = personalMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalMemberWorkspace
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
@@ -210,7 +190,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('withholds leave from a Personal-plan member', async () => {
-      mockStore.activeWorkspace = personalMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalMemberWorkspace
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
@@ -227,7 +209,9 @@ describe('useWorkspaceUI', () => {
 
     it('lets a promoted owner leave while using a Team plan', async () => {
       mockIsTeamPlan.value = true
-      mockStore.originalOwnerId = 'original-owner'
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'original-owner'
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
@@ -236,8 +220,12 @@ describe('useWorkspaceUI', () => {
 
     it('keeps the original creator from leaving while using a Team plan', async () => {
       mockIsTeamPlan.value = true
-      mockStore.originalOwnerId = 'current-user'
-      mockStore.isCurrentUserOriginalOwner = true
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'current-user'
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
@@ -271,7 +259,9 @@ describe('useWorkspaceUI', () => {
 
   describe('team workspace as owner', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
     })
 
     it('grants full management permissions', async () => {
@@ -323,7 +313,9 @@ describe('useWorkspaceUI', () => {
 
   describe('team workspace as member', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = teamMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamMemberWorkspace
+      })
       mockIsTeamPlan.value = true
     })
 
@@ -368,7 +360,9 @@ describe('useWorkspaceUI', () => {
 
   describe('original-owner permissions', () => {
     it('uses the canonical store signal for personal workspaces', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
       const ui = await loadComposable()
 
       expect(ui.isOriginalOwner.value).toBe(false)
@@ -376,9 +370,15 @@ describe('useWorkspaceUI', () => {
     })
 
     it('allows an original owner to downgrade', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
-      mockStore.originalOwnerId = 'current-user'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'current-user'
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
@@ -388,7 +388,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('allows an additional workspace owner to leave before creator identity resolves', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
@@ -398,8 +400,12 @@ describe('useWorkspaceUI', () => {
 
   describe('subscription lifecycle', () => {
     it('grants lifecycle and downgrade to the original owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
@@ -408,8 +414,12 @@ describe('useWorkspaceUI', () => {
     })
 
     it('withholds downgrade from an original owner on a Personal plan', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: true
+      })
       const ui = await loadComposable()
 
       expect(ui.permissions.value.canManageSubscription).toBe(true)
@@ -417,9 +427,15 @@ describe('useWorkspaceUI', () => {
     })
 
     it('grants lifecycle but withholds downgrade from a promoted owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = false
-      mockStore.originalOwnerId = 'original-owner'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        isCurrentUserOriginalOwner: false
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        originalOwnerId: 'original-owner'
+      })
       mockIsTeamPlan.value = true
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
@@ -429,7 +445,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('withholds lifecycle from members', async () => {
-      mockStore.activeWorkspace = teamMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamMemberWorkspace
+      })
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
       expect(ui.permissions.value.canDowngradeToPersonal).toBe(false)
@@ -438,27 +456,35 @@ describe('useWorkspaceUI', () => {
 
   describe('original-owner data loading', () => {
     it('loads members for a team owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       await loadComposable()
-      expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().ensureMembersLoaded).toHaveBeenCalled()
     })
 
     it('loads members for a personal owner', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
       await loadComposable()
-      expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().ensureMembersLoaded).toHaveBeenCalled()
     })
 
     it('does not load members for a member', async () => {
-      mockStore.activeWorkspace = personalMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalMemberWorkspace
+      })
       await loadComposable()
-      expect(mockStore.ensureMembersLoaded).not.toHaveBeenCalled()
+      expect(useTeamWorkspaceStore().ensureMembersLoaded).not.toHaveBeenCalled()
     })
   })
 
   describe('cancelled Team plan', () => {
     it('uses plan identity instead of workspace type', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
       mockIsTeamPlan.value = true
       mockIsCancelled.value = true
       const ui = await loadComposable()
@@ -468,7 +494,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('ignores a cancelled non-Team plan in a team workspace', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       mockIsTeamPlan.value = false
       mockIsCancelled.value = true
       const ui = await loadComposable()
@@ -480,7 +508,9 @@ describe('useWorkspaceUI', () => {
 
   describe('shared instance', () => {
     it('returns the same composable state for multiple callers within a test', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamOwnerWorkspace
+      })
       const first = await loadComposable()
       const second = await loadComposable()
 
@@ -490,7 +520,9 @@ describe('useWorkspaceUI', () => {
   })
   describe('canReactivatePlan', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
     })
 
     it('uses the server capability on the consolidated rail', async () => {
@@ -527,7 +559,9 @@ describe('useWorkspaceUI', () => {
 
   describe('canOpenPricingSurface', () => {
     beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: personalWorkspace
+      })
     })
 
     it('closes the catalog when the server resolves a sales-managed plan', async () => {
@@ -573,7 +607,9 @@ describe('useWorkspaceUI', () => {
     })
 
     it('keeps the catalog closed for a non-owner with no readable snapshot', async () => {
-      mockStore.activeWorkspace = teamMemberWorkspace
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspace: teamMemberWorkspace
+      })
       mockSnapshotAuthoritative.value = false
       mockCanSubscribeSelfServe.value = false
 
@@ -583,3 +619,10 @@ describe('useWorkspaceUI', () => {
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1,5 +1,7 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
 
@@ -46,16 +48,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-const mockToastAdd = vi.fn()
-const mockToastRemove = vi.fn()
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd,
-    remove: mockToastRemove
-  })
-}))
-
 vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   workspaceApi: {
     getBillingOpStatus: vi.fn()
@@ -76,14 +68,6 @@ vi.mock(import('@/platform/settings/composables/useSettingsDialog'), () => ({
   })
 }))
 
-const mockCloseDialog = vi.fn()
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
-  })
-}))
-
 const mockTrackBillingEvent = vi.fn()
 const mockTrackMonthlySubscriptionSucceeded = vi.fn()
 
@@ -94,29 +78,26 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-const mockUpdateActiveWorkspace = vi.fn()
-const mockActiveWorkspaceId = ref('workspace-1')
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId.value
-      },
-      updateActiveWorkspace: mockUpdateActiveWorkspace
-    })
-  })
-)
-
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingOperationStore } from './billingOperationStore'
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => {})
+  vi.mocked(useToastStore().remove).mockImplementation(() => {})
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+})
+
+beforeEach(() => {
+  vi.mocked(useTeamWorkspaceStore().updateActiveWorkspace).mockImplementation(
+    () => {}
+  )
+})
+
 describe('billingOperationStore', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
-    mockActiveWorkspaceId.value = 'workspace-1'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-1' })
     mockFeatureFlags.embeddedCheckoutEnabled = true
     vi.stubEnv('VITE_STRIPE_PUBLISHABLE_KEY', 'pk_test_3ds')
     mockHandleNextAction.mockResolvedValue({})
@@ -230,7 +211,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'info',
         summary: 'billingOperation.subscriptionProcessing',
         group: 'billing-operation'
@@ -249,7 +230,7 @@ describe('billingOperationStore', () => {
         suppressProcessingToast: true
       })
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('shows immediate processing toast for topup operations', () => {
@@ -262,7 +243,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'topup')
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'info',
         summary: 'billingOperation.topupProcessing',
         group: 'billing-operation'
@@ -378,7 +359,7 @@ describe('billingOperationStore', () => {
       expect(mockFetchStatus).not.toHaveBeenCalled()
       expect(mockFetchBalance).not.toHaveBeenCalled()
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'billingOperation.subscriptionSuccess',
         life: 5000
@@ -398,7 +379,7 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockCloseDialog).not.toHaveBeenCalledWith({
+      expect(useDialogStore().closeDialog).not.toHaveBeenCalledWith({
         key: 'subscription-required'
       })
       expect(mockSettingsDialogShow).not.toHaveBeenCalled()
@@ -416,7 +397,9 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'top-up-credits' })
+      expect(useDialogStore().closeDialog).toHaveBeenCalledWith({
+        key: 'top-up-credits'
+      })
       expect(mockSettingsDialogShow).toHaveBeenCalledWith('workspace')
     })
 
@@ -644,7 +627,7 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'billingOperation.topupSuccess',
         life: 5000
@@ -717,11 +700,11 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
 
-      const receivedToast = mockToastAdd.mock.calls[0][0]
+      const receivedToast = vi.mocked(useToastStore().add).mock.calls[0][0]
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastRemove).toHaveBeenCalledWith(receivedToast)
+      expect(useToastStore().remove).toHaveBeenCalledWith(receivedToast)
     })
   })
 
@@ -746,7 +729,7 @@ describe('billingOperationStore', () => {
       )
       expect(store.hasPendingOperations).toBe(false)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.subscriptionFailed',
         detail: 'billingOperation.subscriptionFailedDetail',
@@ -801,7 +784,7 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(store.getOperation('op-1')?.status).toBe('failed')
-      expect(mockToastAdd).not.toHaveBeenCalledWith(
+      expect(useToastStore().add).not.toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
@@ -918,7 +901,7 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.topupFailed',
         detail: undefined,
@@ -1015,7 +998,7 @@ describe('billingOperationStore', () => {
         await vi.advanceTimersByTimeAsync(0)
 
         expect(store.getOperation('op-1')?.errorMessage).toBe(detail)
-        expect(mockToastAdd).toHaveBeenCalledWith({
+        expect(useToastStore().add).toHaveBeenCalledWith({
           severity: 'error',
           summary,
           detail,
@@ -1807,7 +1790,9 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 8001)
 
@@ -1862,7 +1847,7 @@ describe('billingOperationStore', () => {
       expect(operation?.status).toBe('timeout')
       expect(store.hasPendingOperations).toBe(false)
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.subscriptionTimeout'
       })
@@ -1933,7 +1918,9 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(30_000)
       expect((await terminal).status).toBe('succeeded')
       expect(store.getOperation('op-1')?.actionUrl).toBeNull()
-      expect(JSON.stringify(mockToastAdd.mock.calls)).not.toContain(actionUrl)
+      expect(
+        JSON.stringify(vi.mocked(useToastStore().add).mock.calls)
+      ).not.toContain(actionUrl)
       expect(JSON.stringify(mockTrackBillingEvent.mock.calls)).not.toContain(
         actionUrl
       )
@@ -1955,12 +1942,12 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.subscriptionProcessing',
         group: 'billing-operation'
       }
-      expect(mockToastAdd).toHaveBeenCalledWith(processingToast)
+      expect(useToastStore().add).toHaveBeenCalledWith(processingToast)
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockToastRemove).toHaveBeenCalledWith(processingToast)
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().remove).toHaveBeenCalledWith(processingToast)
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'warn',
         summary: 'billingOperation.subscriptionActionRequired',
         group: 'billing-operation'
@@ -1982,12 +1969,12 @@ describe('billingOperationStore', () => {
         'https://verify.example/sensitive-token'
       )
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'warn',
         summary: 'billingOperation.topupActionRequired',
         group: 'billing-operation'
       })
-      expect(mockToastAdd).not.toHaveBeenCalledWith(
+      expect(useToastStore().add).not.toHaveBeenCalledWith(
         expect.objectContaining({
           summary: 'billingOperation.topupProcessing'
         })
@@ -2017,14 +2004,14 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.subscriptionActionRequired',
         group: 'billing-operation'
       }
-      expect(mockToastAdd).toHaveBeenCalledWith(actionRequiredToast)
+      expect(useToastStore().add).toHaveBeenCalledWith(actionRequiredToast)
 
       // The verification action is gone, so the prompt pointing at it must go
       // too rather than asking for something the customer can no longer do.
       await vi.advanceTimersByTimeAsync(30_000)
 
-      expect(mockToastRemove).toHaveBeenCalledWith(actionRequiredToast)
-      expect(mockToastAdd).toHaveBeenLastCalledWith({
+      expect(useToastStore().remove).toHaveBeenCalledWith(actionRequiredToast)
+      expect(useToastStore().add).toHaveBeenLastCalledWith({
         severity: 'info',
         summary: 'billingOperation.subscriptionProcessing',
         group: 'billing-operation'
@@ -2044,10 +2031,12 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       const actionRequiredAdds = () =>
-        mockToastAdd.mock.calls.filter(
-          (call) =>
-            call[0]?.summary === 'billingOperation.subscriptionActionRequired'
-        ).length
+        vi
+          .mocked(useToastStore().add)
+          .mock.calls.filter(
+            (call) =>
+              call[0].summary === 'billingOperation.subscriptionActionRequired'
+          ).length
 
       expect(actionRequiredAdds()).toBe(1)
 
@@ -2140,7 +2129,9 @@ describe('billingOperationStore', () => {
       expect(store.topupActionOperation?.actionUrl).toBe(actionUrl)
       expect(store.isAddingCredits).toBe(true)
 
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       expect(store.topupActionOperation).toBeUndefined()
       expect(store.isAddingCredits).toBe(false)
@@ -2162,7 +2153,9 @@ describe('billingOperationStore', () => {
       expect(store.subscriptionActionOperation?.actionUrl).toBe(actionUrl)
       expect(store.isSettingUp).toBe(true)
 
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       expect(store.subscriptionActionOperation).toBeUndefined()
       expect(store.isSettingUp).toBe(false)
@@ -2180,7 +2173,9 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'subscription')
-      mockActiveWorkspaceId.value = 'workspace-2'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-2'
+      })
 
       resolveStatus({
         id: 'op-1',
@@ -2216,7 +2211,7 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(121_000)
       await vi.runAllTimersAsync()
 
-      expect(mockToastAdd).toHaveBeenCalledWith({
+      expect(useToastStore().add).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.topupTimeout'
       })
@@ -2241,7 +2236,7 @@ describe('billingOperationStore', () => {
         actionUrl,
         authenticationRequiredSeen: true
       })
-      expect(mockToastAdd).not.toHaveBeenCalledWith({
+      expect(useToastStore().add).not.toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.topupTimeout'
       })
@@ -2259,7 +2254,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'cancel')
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('resolves with the succeeded operation and refreshes status', async () => {
@@ -2277,7 +2272,9 @@ describe('billingOperationStore', () => {
 
       expect(operation.status).toBe('succeeded')
       expect(mockFetchStatus).toHaveBeenCalled()
-      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
+      expect(
+        useTeamWorkspaceStore().updateActiveWorkspace
+      ).toHaveBeenCalledWith({
         isSubscribed: false
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
@@ -2321,7 +2318,7 @@ describe('billingOperationStore', () => {
       await terminal
 
       expect(mockSettingsDialogShow).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('resolves with a failed operation and default message, no toast', async () => {
@@ -2339,8 +2336,10 @@ describe('billingOperationStore', () => {
 
       expect(operation.status).toBe('failed')
       expect(operation.errorMessage).toBe('billingOperation.cancelFailed')
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().updateActiveWorkspace
+      ).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: 'operation',
@@ -2373,8 +2372,10 @@ describe('billingOperationStore', () => {
 
       expect(operation.status).toBe('timeout')
       expect(operation.errorMessage).toBe('billingOperation.cancelTimeout')
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().updateActiveWorkspace
+      ).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: 'operation',
@@ -2471,7 +2472,7 @@ describe('billingOperationStore', () => {
       expect(store.getOperation('op-1')?.status).toBe('pending')
       expect(store.hasPendingOperations).toBe(true)
       expect(resolved).toBe(false)
-      expect(mockToastAdd).not.toHaveBeenCalledWith(
+      expect(useToastStore().add).not.toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
     })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -1,3 +1,4 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,23 +9,6 @@ import type {
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
-
-const mockTeamWorkspaceStore = vi.hoisted(() => ({
-  store: null as null | {
-    activeWorkspace: null | { id: string; type: 'personal' | 'team' }
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mockTeamWorkspaceStore.store = reactive({ activeWorkspace: null })
-    return {
-      useTeamWorkspaceStore: () => mockTeamWorkspaceStore.store
-    }
-  }
-)
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
@@ -62,9 +46,7 @@ const providers: PartnerProvider[] = [
 ]
 
 function activateWorkspace(id: string, type: 'personal' | 'team' = 'team') {
-  if (!mockTeamWorkspaceStore.store)
-    throw new Error('Workspace store not ready')
-  mockTeamWorkspaceStore.store.activeWorkspace = { id, type }
+  Object.assign(useTeamWorkspaceStore(), { activeWorkspace: { id, type } })
 }
 
 async function createLoadedStore() {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -1,3 +1,4 @@
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
@@ -7,34 +8,6 @@ import { sortWorkspaces, useTeamWorkspaceStore } from './teamWorkspaceStore'
 const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock(import('@/platform/distribution/types'), () => mockDistributionTypes)
-
-// Mock workspaceAuthStore
-const mockWorkspaceAuthStore = vi.hoisted(() => ({
-  currentWorkspace: null as {
-    id: string
-    name: string
-    type: 'personal' | 'team'
-    role: 'owner' | 'member'
-  } | null,
-  workspaceToken: null as string | null,
-  isLoading: false,
-  error: null as Error | null,
-  isAuthenticated: false,
-  init: vi.fn(),
-  destroy: vi.fn(),
-  initializeFromSession: vi.fn(),
-  switchWorkspace: vi.fn(),
-  refreshToken: vi.fn(),
-  getWorkspaceAuthHeader: vi.fn(),
-  clearWorkspaceContext: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => mockWorkspaceAuthStore
-  })
-)
 
 const mockClearWorkflowRestoreState = vi.hoisted(() => vi.fn())
 const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
@@ -161,12 +134,37 @@ function expectCleanupBeforeContextAndReload(): void {
   expect(
     mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
   ).toBeLessThan(
-    mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+    vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+      .invocationCallOrder[0]
   )
   expect(
-    mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+    vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+      .invocationCallOrder[0]
   ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
 }
+
+beforeEach(() => {
+  Object.assign(useWorkspaceAuthStore(), { currentWorkspace: null })
+  Object.assign(useWorkspaceAuthStore(), { workspaceToken: null })
+  Object.assign(useWorkspaceAuthStore(), { isLoading: false })
+  Object.assign(useWorkspaceAuthStore(), { error: null })
+  Object.assign(useWorkspaceAuthStore(), { isAuthenticated: false })
+  vi.mocked(useWorkspaceAuthStore().init).mockImplementation(() => {})
+  vi.mocked(useWorkspaceAuthStore().destroy).mockImplementation(() => {})
+  vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+    false
+  )
+  vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useWorkspaceAuthStore().refreshToken).mockResolvedValue(undefined)
+  vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+    null
+  )
+  vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockImplementation(
+    () => {}
+  )
+})
 
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
@@ -177,13 +175,17 @@ describe('useTeamWorkspaceStore', () => {
     mockCurrentUser.isApiKeyLogin.value = false
 
     // Reset workspaceAuthStore mock state
-    mockWorkspaceAuthStore.currentWorkspace = null
-    mockWorkspaceAuthStore.workspaceToken = null
-    mockWorkspaceAuthStore.isLoading = false
-    mockWorkspaceAuthStore.error = null
-    mockWorkspaceAuthStore.isAuthenticated = false
-    mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(false)
-    mockWorkspaceAuthStore.switchWorkspace.mockResolvedValue(undefined)
+    Object.assign(useWorkspaceAuthStore(), { currentWorkspace: null })
+    Object.assign(useWorkspaceAuthStore(), { workspaceToken: null })
+    Object.assign(useWorkspaceAuthStore(), { isLoading: false })
+    Object.assign(useWorkspaceAuthStore(), { error: null })
+    Object.assign(useWorkspaceAuthStore(), { isAuthenticated: false })
+    vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+      false
+    )
+    vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockResolvedValue(
+      undefined
+    )
     mockEnsureSessionCookie.mockResolvedValue(undefined)
 
     // Default mock responses
@@ -231,28 +233,36 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.initState).toBe('ready')
       expect(store.workspaces).toHaveLength(2)
       expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledWith(
         mockPersonalWorkspace.id
       )
     })
 
     it('restores workspace from session if valid', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
       expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
-      expect(mockWorkspaceAuthStore.switchWorkspace).not.toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().switchWorkspace).not.toHaveBeenCalled()
     })
 
     it('clears transient restore state before falling back from a missing session workspace', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = {
-        ...mockTeamWorkspace,
-        id: 'missing-workspace'
-      }
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: {
+          ...mockTeamWorkspace,
+          id: 'missing-workspace'
+        }
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -261,9 +271,10 @@ describe('useTeamWorkspaceStore', () => {
       expect(
         mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
       ).toBeLessThan(
-        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
       )
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledWith(
         mockPersonalWorkspace.id
       )
     })
@@ -420,8 +431,8 @@ describe('useTeamWorkspaceStore', () => {
         expect.objectContaining({ id: mockMemberWorkspace.id })
       ])
       expect(store.activeWorkspaceId).toBe(mockMemberWorkspace.id)
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledOnce()
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledOnce()
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenCalledWith(
         mockMemberWorkspace.id
       )
     })
@@ -438,7 +449,7 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('does not activate a workspace when token exchange fails', async () => {
-      mockWorkspaceAuthStore.switchWorkspace.mockRejectedValue(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockRejectedValue(
         new Error('Token exchange failed')
       )
 
@@ -484,7 +495,7 @@ describe('useTeamWorkspaceStore', () => {
       ])
       expect(store.activeWorkspaceId).toBe('ws-api-key')
       expect(mockWorkspaceApi.list).not.toHaveBeenCalled()
-      expect(mockWorkspaceAuthStore.switchWorkspace).not.toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().switchWorkspace).not.toHaveBeenCalled()
       expect(mockEnsureSessionCookie).not.toHaveBeenCalled()
     })
 
@@ -560,26 +571,30 @@ describe('useTeamWorkspaceStore', () => {
       await store.switchWorkspace(mockTeamWorkspace.id)
 
       expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledOnce()
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expect(
         mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
       ).toBeLessThan(
-        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
       )
       expect(
-        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
       ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
     })
 
     it('switches local billing context without touching workflow state', async () => {
       mockDistributionTypes.isCloud = false
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementation(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementation(
         async (workspaceId: string) => {
           const workspace = [mockPersonalWorkspace, mockTeamWorkspace].find(
             ({ id }) => id === workspaceId
           )
-          mockWorkspaceAuthStore.currentWorkspace = workspace ?? null
+          Object.assign(useWorkspaceAuthStore(), {
+            currentWorkspace: workspace ?? null
+          })
         }
       )
       const store = useTeamWorkspaceStore()
@@ -589,13 +604,13 @@ describe('useTeamWorkspaceStore', () => {
 
       await store.switchWorkspace(mockTeamWorkspace.id)
 
-      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenLastCalledWith(
+      expect(useWorkspaceAuthStore().switchWorkspace).toHaveBeenLastCalledWith(
         mockTeamWorkspace.id
       )
       expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
       expect(mockPrepareWorkflowWorkspaceTransition).not.toHaveBeenCalled()
       expect(
-        mockWorkspaceAuthStore.clearWorkspaceContext
+        useWorkspaceAuthStore().clearWorkspaceContext
       ).not.toHaveBeenCalled()
       expect(mockReload).not.toHaveBeenCalled()
       expect(store.isSwitching).toBe(false)
@@ -612,11 +627,13 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
 
       let finishSwitch: () => void = () => {}
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = () => {
-              mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+              Object.assign(useWorkspaceAuthStore(), {
+                currentWorkspace: mockTeamWorkspace
+              })
               resolve()
             }
           })
@@ -642,11 +659,13 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
 
       let finishSwitch: () => void = () => {}
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = () => {
-              mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+              Object.assign(useWorkspaceAuthStore(), {
+                currentWorkspace: mockTeamWorkspace
+              })
               resolve()
             }
           })
@@ -676,7 +695,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
 
       let finishSwitch: () => void = () => {}
-      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = resolve
@@ -696,7 +715,7 @@ describe('useTeamWorkspaceStore', () => {
       mockDistributionTypes.isCloud = false
       const store = useTeamWorkspaceStore()
       await store.initialize()
-      mockWorkspaceAuthStore.switchWorkspace.mockRejectedValueOnce(
+      vi.mocked(useWorkspaceAuthStore().switchWorkspace).mockRejectedValueOnce(
         new Error('Token exchange failed')
       )
 
@@ -803,8 +822,10 @@ describe('useTeamWorkspaceStore', () => {
     ])(
       'reloads $reloads time(s) when the active $type workspace is revoked',
       async ({ workspace, reloads }) => {
-        mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-        mockWorkspaceAuthStore.currentWorkspace = workspace
+        vi.mocked(
+          useWorkspaceAuthStore().initializeFromSession
+        ).mockReturnValue(true)
+        Object.assign(useWorkspaceAuthStore(), { currentWorkspace: workspace })
         const store = useTeamWorkspaceStore()
         await store.initialize()
 
@@ -836,8 +857,12 @@ describe('useTeamWorkspaceStore', () => {
 
     it('falls back locally without clearing workflow state or reloading', async () => {
       mockDistributionTypes.isCloud = false
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
@@ -877,7 +902,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.workspaces).toContainEqual(
         expect.objectContaining({ id: newWorkspace.id })
       )
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expectCleanupBeforeContextAndReload()
     })
@@ -938,8 +963,12 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('deletes active workspace and reloads to personal', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -949,7 +978,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.deleteWorkspace()
 
       expect(mockWorkspaceApi.delete).toHaveBeenCalledWith(mockTeamWorkspace.id)
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expectCleanupBeforeContextAndReload()
     })
@@ -999,8 +1028,12 @@ describe('useTeamWorkspaceStore', () => {
 
   describe('leaveWorkspace', () => {
     it('leaves workspace and reloads to personal', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockMemberWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockMemberWorkspace
+      })
       mockWorkspaceApi.list.mockResolvedValue({
         workspaces: [mockPersonalWorkspace, mockMemberWorkspace]
       })
@@ -1012,7 +1045,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.leaveWorkspace()
 
       expect(mockWorkspaceApi.leave).toHaveBeenCalled()
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID,
         mockPersonalWorkspace.id
@@ -1029,7 +1062,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.leaveWorkspace()
 
       expect(mockWorkspaceApi.leave).toHaveBeenCalled()
-      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().clearWorkspaceContext).toHaveBeenCalled()
       expect(mockLocalStorage.setItem).not.toHaveBeenCalled()
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
         WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID
@@ -1050,8 +1083,12 @@ describe('useTeamWorkspaceStore', () => {
 
   describe('computed properties', () => {
     it('activeWorkspace returns correct workspace', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1076,8 +1113,12 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('isInPersonalWorkspace returns false when in team', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1154,8 +1195,12 @@ describe('useTeamWorkspaceStore', () => {
         members: mockMembers,
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1232,8 +1277,12 @@ describe('useTeamWorkspaceStore', () => {
         members: mockMembers,
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1280,8 +1329,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'owner',
         is_original_owner: true
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1314,8 +1367,12 @@ describe('useTeamWorkspaceStore', () => {
         pagination: { offset: 0, limit: 50, total: 1 }
       })
       mockWorkspaceApi.updateMemberRole.mockRejectedValue(new Error('boom'))
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1389,8 +1446,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'member',
         is_original_owner: true
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1427,8 +1488,12 @@ describe('useTeamWorkspaceStore', () => {
         ],
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1468,8 +1533,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'member',
         is_original_owner: false
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1512,8 +1581,12 @@ describe('useTeamWorkspaceStore', () => {
         role: 'owner',
         is_original_owner: false
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1547,8 +1620,12 @@ describe('useTeamWorkspaceStore', () => {
     }
 
     async function activateTeamWorkspace() {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
       const store = useTeamWorkspaceStore()
       await store.initialize()
       return store
@@ -1633,8 +1710,12 @@ describe('useTeamWorkspaceStore', () => {
         members,
         pagination: { offset: 0, limit: 50, total: members.length }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1706,8 +1787,12 @@ describe('useTeamWorkspaceStore', () => {
 
     it('fails closed when members are not loaded', async () => {
       mockCurrentUser.userEmail.value = 'owner@test.com'
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1727,8 +1812,12 @@ describe('useTeamWorkspaceStore', () => {
         members: [ownerSelf],
         pagination: { offset: 0, limit: 50, total: 1 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1764,8 +1853,12 @@ describe('useTeamWorkspaceStore', () => {
         }
       ]
       mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1786,8 +1879,12 @@ describe('useTeamWorkspaceStore', () => {
         expires_at: '2024-01-08T00:00:00Z'
       }
       mockWorkspaceApi.createInvite.mockResolvedValue(newInvite)
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1821,8 +1918,12 @@ describe('useTeamWorkspaceStore', () => {
         }
       ]
       mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1853,8 +1954,12 @@ describe('useTeamWorkspaceStore', () => {
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1886,8 +1991,12 @@ describe('useTeamWorkspaceStore', () => {
         ]
       })
       mockWorkspaceApi.resendInvite.mockRejectedValue(error)
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1915,8 +2024,12 @@ describe('useTeamWorkspaceStore', () => {
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1937,8 +2050,12 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('resendInvite throws for an unknown invite id', async () => {
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      vi.mocked(useWorkspaceAuthStore().initializeFromSession).mockReturnValue(
+        true
+      )
+      Object.assign(useWorkspaceAuthStore(), {
+        currentWorkspace: mockTeamWorkspace
+      })
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -1974,7 +2091,7 @@ describe('useTeamWorkspaceStore', () => {
 
       store.destroy()
 
-      expect(mockWorkspaceAuthStore.destroy).toHaveBeenCalled()
+      expect(useWorkspaceAuthStore().destroy).toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -41,12 +41,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock(import('@/scripts/api'), async (importOriginal) => ({
-  api: Object.assign((await importOriginal()).api, {
-    apiURL: (route: string) => `https://api.example.com/api${route}`
-  })
-}))
-
 vi.mock(import('@/platform/workspace/api/workspaceApiUrl'), () => ({
   workspaceApiUrl: (route: string) => `https://api.example.com/api${route}`
 }))

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -1,3 +1,6 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { storeToRefs } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -12,45 +15,15 @@ import {
 } from '@/platform/workflow/persistence/base/storageKeys'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 
-const mockGetIdToken = vi.fn()
-const mockNotifyTokenRefreshed = vi.fn()
 const mockTrackUnifiedAuthRefresh = vi.fn()
-const mockToastAdd = vi.fn()
+
 const mockEnsureSessionCookie = vi.fn()
-const mockCurrentUser = vi.hoisted((): { value: { uid: string } | null } => ({
-  value: null
-}))
-const mockForgetRevokedActiveWorkspace = vi.fn()
+
 const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
 const mockReload = vi.fn()
 const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
-const mockTeamWorkspaceState = vi.hoisted(() => ({
-  activeWorkspaceId: null as string | null
-}))
 
 vi.mock(import('@/platform/distribution/types'), () => mockDistributionTypes)
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    getIdToken: mockGetIdToken,
-    notifyTokenRefreshed: mockNotifyTokenRefreshed,
-    get currentUser() {
-      return mockCurrentUser.value
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      forgetRevokedActiveWorkspace: mockForgetRevokedActiveWorkspace,
-      get activeWorkspaceId() {
-        return mockTeamWorkspaceState.activeWorkspaceId
-      }
-    })
-  })
-)
 
 vi.mock(import('@/platform/workflow/persistence/base/storageIO'), () => ({
   prepareWorkflowWorkspaceTransition: mockPrepareWorkflowWorkspaceTransition
@@ -68,16 +41,10 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd
-  })
-}))
-
-vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: {
+vi.mock(import('@/scripts/api'), async (importOriginal) => ({
+  api: Object.assign((await importOriginal()).api, {
     apiURL: (route: string) => `https://api.example.com/api${route}`
-  }
+  })
 }))
 
 vi.mock(import('@/platform/workspace/api/workspaceApiUrl'), () => ({
@@ -123,17 +90,29 @@ function expectedExpiresAtMs(expiresAt: string): string {
   return new Date(expiresAt).getTime().toString()
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => {})
+})
+
+beforeEach(() => {
+  vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
+  vi.mocked(useAuthStore().notifyTokenRefreshed).mockImplementation(() => {})
+  vi.mocked(
+    useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+  ).mockReturnValue(false)
+})
+
 describe('useWorkspaceAuthStore', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
-    mockTeamWorkspaceState.activeWorkspaceId = null
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
     vi.stubGlobal('location', {
       reload: mockReload,
       origin: 'http://localhost'
     })
     vi.useFakeTimers({ shouldAdvanceTime: false })
     mockUnifiedCloudAuthEnabled.value = false
-    mockCurrentUser.value = { uid: 'user-a' }
+    Object.assign(useAuthStore(), { currentUser: { uid: 'user-a' } })
     mockEnsureSessionCookie.mockResolvedValue(undefined)
   })
 
@@ -192,7 +171,7 @@ describe('useWorkspaceAuthStore', () => {
         futureExpiry.toString()
       )
       sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, 'user-a')
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
 
       const store = useWorkspaceAuthStore()
 
@@ -296,7 +275,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('switchWorkspace', () => {
     it('successfully exchanges Firebase token for workspace token', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -323,7 +304,9 @@ describe('useWorkspaceAuthStore', () => {
           confirmSession = resolve
         })
       )
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -358,7 +341,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('discards a token exchange that resolves after the user changes', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-a')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue('firebase-token-a')
       let resolveResponse: (value: unknown) => void = () => {}
       vi.stubGlobal(
         'fetch',
@@ -371,7 +354,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       const switchPromise = store.switchWorkspace('workspace-123')
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
       resolveResponse({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -384,7 +367,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('stores workspace data in sessionStorage', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -412,7 +397,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('replaces the workspace token when the same user switches workspaces', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -456,7 +443,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('sets isLoading to true during operation', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveResponse: (value: unknown) => void
       const responsePromise = new Promise((resolve) => {
         resolveResponse = resolve
@@ -479,7 +468,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('keeps isLoading true until overlapping switches settle', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveFirstSwitch: (value: unknown) => void = () => {}
       let resolveSecondSwitch: (value: unknown) => void = () => {}
       const firstSwitchResponse = new Promise((resolve) => {
@@ -524,7 +515,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code NOT_AUTHENTICATED when Firebase token unavailable', async () => {
-      mockGetIdToken.mockResolvedValue(undefined)
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
 
       const store = useWorkspaceAuthStore()
       const { error } = storeToRefs(store)
@@ -538,7 +529,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code ACCESS_DENIED on 403 response', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -562,7 +555,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code WORKSPACE_NOT_FOUND on 404 response', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -588,7 +583,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code INVALID_FIREBASE_TOKEN on 401 response', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -614,7 +611,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('throws WorkspaceAuthError with code TOKEN_EXCHANGE_FAILED on other errors', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -640,7 +639,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('sends correct request to API', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -667,7 +668,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('clearWorkspaceContext', () => {
     it('clears all state refs', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -713,7 +716,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('prevents in-flight refreshes from restoring cleared state', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -771,7 +776,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('returns proper Authorization header when workspace token exists', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -793,7 +800,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('ensureWorkspaceAuthHeader', () => {
     it('returns the existing header without minting when the token is valid', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -811,7 +820,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('re-mints instead of returning a token owned by another user', async () => {
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-a')
         .mockResolvedValueOnce('firebase-token-b')
       const mockFetch = vi
@@ -832,7 +841,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.switchWorkspace('workspace-123')
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
 
       const header = await store.ensureWorkspaceAuthHeader('workspace-123')
 
@@ -841,7 +850,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('mints a token for the preferred workspace when none exists', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -858,7 +869,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('coalesces concurrent recovery onto a single mint', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -878,7 +891,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('awaits an in-flight switch instead of racing a second mint', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveResponse: (value: unknown) => void = () => {}
       const responsePromise = new Promise((resolve) => {
         resolveResponse = resolve
@@ -903,8 +918,8 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('does not give a previous user waiter the next user token', async () => {
-      mockGetIdToken.mockImplementation(() =>
-        Promise.resolve(`firebase-${mockCurrentUser.value?.uid}`)
+      vi.mocked(useAuthStore().getIdToken).mockImplementation(() =>
+        Promise.resolve(`firebase-${useAuthStore().currentUser?.uid}`)
       )
       let resolvePreviousResponse: (value: unknown) => void = () => {}
       const mockFetch = vi
@@ -928,7 +943,7 @@ describe('useWorkspaceAuthStore', () => {
       const previousHeader = store.ensureWorkspaceAuthHeader('workspace-123')
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
 
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
       store.clearWorkspaceContext()
       await store.switchWorkspace('workspace-123')
 
@@ -948,7 +963,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('returns null (never a downgrade) when recovery fails transiently', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -975,7 +992,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('tears down workspace context and surfaces a toast on a permanent recovery failure', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -999,11 +1018,13 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(token).toBeNull()
       expect(currentWorkspace.value).toBeNull()
-      expect(mockToastAdd).toHaveBeenCalledTimes(1)
+      expect(useToastStore().add).toHaveBeenCalledTimes(1)
     })
 
     it('backs off re-minting after a failed recovery instead of retrying every call', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 500,
@@ -1023,7 +1044,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('forgets the revoked active workspace on a permanent workspace-selection failure', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1040,13 +1063,15 @@ describe('useWorkspaceAuthStore', () => {
       const token = await store.ensureWorkspaceToken('workspace-123')
 
       expect(token).toBeNull()
-      expect(mockForgetRevokedActiveWorkspace).toHaveBeenCalledWith(
-        'workspace-123'
-      )
+      expect(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).toHaveBeenCalledWith('workspace-123')
     })
 
     it('does not forget the workspace when the failure is an auth error, not revocation', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1062,11 +1087,15 @@ describe('useWorkspaceAuthStore', () => {
       const token = await store.ensureWorkspaceToken('workspace-123')
 
       expect(token).toBeNull()
-      expect(mockForgetRevokedActiveWorkspace).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).not.toHaveBeenCalled()
     })
 
     it('preserves a valid context on a transient Firebase network failure while signed in', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1079,19 +1108,23 @@ describe('useWorkspaceAuthStore', () => {
       const { currentWorkspace } = storeToRefs(store)
       await store.switchWorkspace('workspace-123')
 
-      mockCurrentUser.value = { uid: 'user-a' }
-      mockGetIdToken.mockResolvedValue(undefined)
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-a' } })
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
 
       const token = await store.ensureWorkspaceToken('workspace-999')
 
       expect(token).toBeNull()
       expect(currentWorkspace.value?.id).toBe('workspace-123')
-      expect(mockToastAdd).not.toHaveBeenCalled()
-      expect(mockForgetRevokedActiveWorkspace).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
+      expect(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).not.toHaveBeenCalled()
     })
 
     it('collapses a burst of waiters into a single mint after a shared in-flight switch rejects', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -1124,7 +1157,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('re-mints for the requested workspace rather than returning an in-flight switch to a different one', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockImplementation((_url, options) => {
         const { workspace_id: workspaceId } = JSON.parse(options.body)
         return Promise.resolve({
@@ -1151,12 +1186,18 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not restore a stale local selection after another switch completes', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceState.activeWorkspaceId = 'workspace-123'
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockImplementation((_url, options) => {
         const { workspace_id: workspaceId } = JSON.parse(options.body)
         if (workspaceId === 'workspace-other') {
-          mockTeamWorkspaceState.activeWorkspaceId = workspaceId
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: workspaceId
+          })
         }
         return Promise.resolve({
           ok: true,
@@ -1183,7 +1224,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('token refresh scheduling', () => {
     it('schedules token refresh 5 minutes before expiry', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const tokenResponseWithFutureExpiry = {
         ...mockTokenResponse,
@@ -1213,7 +1256,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('clears context when refresh fails with ACCESS_DENIED', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const tokenResponseWithFutureExpiry = {
         ...mockTokenResponse,
@@ -1241,7 +1286,9 @@ describe('useWorkspaceAuthStore', () => {
       mockPrepareWorkflowWorkspaceTransition.mockReturnValue(
         cancelWorkflowTransition
       )
-      mockForgetRevokedActiveWorkspace.mockImplementation(() => {
+      vi.mocked(
+        useTeamWorkspaceStore().forgetRevokedActiveWorkspace
+      ).mockImplementation(() => {
         workspaceWhenRevocationHandled = sessionStorage.getItem(
           WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
         )
@@ -1281,7 +1328,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('refreshes token for current workspace', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -1311,7 +1360,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('isAuthenticated computed', () => {
     it('returns true when both workspace and token are present', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1336,7 +1387,7 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('returns false when currentWorkspace is set but workspaceToken is null', async () => {
-      mockGetIdToken.mockResolvedValue(null)
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(undefined)
 
       const store = useWorkspaceAuthStore()
       const { currentWorkspace, workspaceToken, isAuthenticated } =
@@ -1351,7 +1402,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('refreshToken retry/race paths', () => {
     it('ends an expired workspace session behind the workflow write barrier', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresAt = Date.now() + 3600 * 1000
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1395,7 +1448,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('retries up to 3 times with exponential backoff on TOKEN_EXCHANGE_FAILED, then preserves valid context', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       // Initial successful switchWorkspace establishes context.
       const mockFetch = vi.fn().mockResolvedValueOnce({
@@ -1490,7 +1545,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('clears context immediately on INVALID_FIREBASE_TOKEN without retrying', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -1526,7 +1583,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('keeps the old workspace refresh when a newer workspace switch fails', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1581,7 +1640,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('allows same-workspace switches to leave in-flight refreshes valid', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1642,7 +1703,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('the new workspace wins when the stale refresh resolves last', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1720,7 +1783,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('blocks a stale refresh that resolves after switch-away-and-back to same workspace', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1787,7 +1852,9 @@ describe('useWorkspaceAuthStore', () => {
     })
 
     it('the new workspace keeps clean error state when a stale refresh fails last', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -1836,7 +1903,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('persistToSession resilience', () => {
     it('updates store state even when sessionStorage.setItem throws', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1886,7 +1955,9 @@ describe('useWorkspaceAuthStore', () => {
 
   describe('Zod validation on token response', () => {
     it('throws TOKEN_EXCHANGE_FAILED when the response is missing required fields', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -1927,7 +1998,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('mintAtLogin is a no-op and returns false when the flag is OFF', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn()
       vi.stubGlobal('fetch', mockFetch)
 
@@ -1943,7 +2016,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('mints the personal default once into the dormant unifiedToken slot when flag ON', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -1972,7 +2047,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not re-mint when unifiedToken is already populated', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -1990,7 +2067,7 @@ describe('useWorkspaceAuthStore', () => {
 
     it('re-mints when the existing unified token belongs to another user', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-a')
         .mockResolvedValueOnce('firebase-token-b')
       const mockFetch = vi
@@ -2008,7 +2085,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
 
       const result = await store.mintAtLogin()
 
@@ -2019,7 +2096,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('arms a refresh at expires_at - buffer and re-mints from the parsed expiry (no hardcoded TTL)', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -2047,7 +2126,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not bump the rotation trigger on the initial login mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -2059,12 +2140,14 @@ describe('useWorkspaceAuthStore', () => {
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
 
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
     it('does not bump the rotation trigger on a workspace switch', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(mockTokenResponse)
@@ -2083,12 +2166,14 @@ describe('useWorkspaceAuthStore', () => {
       )
       expect(store.getUnifiedToken()).toBe('workspace-token-abc')
       expect(store.workspaceToken).toBeNull()
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
     it('scopes workflow persistence to each unified workspace', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const secondWorkspace = {
         ...mockWorkspaceWithRole,
         id: 'workspace-456'
@@ -2135,7 +2220,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not retry an old workspace request with a new workspace token', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2171,7 +2258,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not let an old workspace retry supersede a pending switch', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       let resolveWorkspaceB: (value: unknown) => void = () => {}
       const mockFetch = vi
         .fn()
@@ -2217,7 +2306,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('fails closed when switching workspaces fails', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2245,7 +2336,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('bumps the rotation trigger exactly once on a refresh re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       vi.stubGlobal(
         'fetch',
@@ -2265,12 +2358,14 @@ describe('useWorkspaceAuthStore', () => {
       const refreshDelay = expiresInMs - 5 * 60 * 1000
       await vi.advanceTimersByTimeAsync(refreshDelay)
 
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
     })
 
     it('bumps the rotation trigger on a successful reactive re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -2281,16 +2376,18 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
 
       await store.remintUnifiedOnce('unified-token-1')
 
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
     })
 
     it('remintUnifiedOnce re-mints once and, on a permanent failure, surfaces it and tears down without looping', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2318,7 +2415,7 @@ describe('useWorkspaceAuthStore', () => {
       // A permanent failure resolves to null (the caller surfaces its 401),
       // fires the error toast keyed to the 401 code, and clears the dead session.
       expect(result).toBeNull()
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'workspaceAuth.errors.invalidFirebaseToken'
@@ -2335,7 +2432,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('remintUnifiedOnce does not toast or clear the slot on a transient re-mint failure', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2359,13 +2458,15 @@ describe('useWorkspaceAuthStore', () => {
       const result = await store.remintUnifiedOnce('unified-token-1')
 
       expect(result).toBeNull()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 
     it('remintUnifiedOnce returns null without minting when the flag is OFF', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn()
       vi.stubGlobal('fetch', mockFetch)
 
@@ -2379,7 +2480,7 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not retry an old account request with the current account token', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-a')
         .mockResolvedValueOnce('firebase-token-b')
       const mockFetch = vi
@@ -2397,7 +2498,7 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       await store.mintAtLogin()
-      mockCurrentUser.value = { uid: 'user-b' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-b' } })
       await store.mintAtLogin()
 
       const result = await store.remintUnifiedOnce('unified-token-1')
@@ -2408,7 +2509,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('evicts an expired unified-token context past the grace window on the next mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const base = Date.now()
       const mockFetch = vi
         .fn()
@@ -2451,7 +2554,7 @@ describe('useWorkspaceAuthStore', () => {
 
     it('ignores a stale unified mint failure after account state is cleared', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-a')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue('firebase-token-a')
       let resolveResponse: (value: unknown) => void = () => {}
       vi.stubGlobal(
         'fetch',
@@ -2474,12 +2577,14 @@ describe('useWorkspaceAuthStore', () => {
 
       await expect(mintPromise).resolves.toBe(false)
       expect(store.unifiedToken).toBeNull()
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('coalesces concurrent re-mints and returns the winning token to every caller', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -2517,7 +2622,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('reuses a same-user burst winner for a later stale 401', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2545,7 +2652,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('clears unifiedToken and stops the unified timer on clearWorkspaceContext', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
@@ -2569,7 +2678,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('is fully dormant under the flag OFF: no unified network, timer, or rotation', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn()
       vi.stubGlobal('fetch', mockFetch)
 
@@ -2582,7 +2693,7 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(mockFetch).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBeNull()
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
     it.for([
@@ -2605,7 +2716,9 @@ describe('useWorkspaceAuthStore', () => {
       'surfaces the $status permanent refresh error as a toast and clears the slot',
       async ({ status, statusText, detailKey }) => {
         mockUnifiedCloudAuthEnabled.value = true
-        mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+        vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+          'firebase-token-xyz'
+        )
         const expiresInMs = 3600 * 1000
         const mockFetch = vi
           .fn()
@@ -2634,7 +2747,7 @@ describe('useWorkspaceAuthStore', () => {
 
         await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
 
-        expect(mockToastAdd).toHaveBeenCalledWith(
+        expect(useToastStore().add).toHaveBeenCalledWith(
           expect.objectContaining({ severity: 'error', detail: detailKey })
         )
         expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
@@ -2649,9 +2762,9 @@ describe('useWorkspaceAuthStore', () => {
       mockUnifiedCloudAuthEnabled.value = true
       const expiresInMs = 3600 * 1000
       // Mint succeeds, then the Firebase identity is gone at refresh time.
-      mockGetIdToken
+      vi.mocked(useAuthStore().getIdToken)
         .mockResolvedValueOnce('firebase-token-xyz')
-        .mockResolvedValue(null)
+        .mockResolvedValue(undefined)
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -2670,7 +2783,7 @@ describe('useWorkspaceAuthStore', () => {
       await store.mintAtLogin()
       await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'workspaceAuth.errors.notAuthenticated'
@@ -2681,7 +2794,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('does not toast on a successful refresh re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       vi.stubGlobal(
         'fetch',
@@ -2699,12 +2814,14 @@ describe('useWorkspaceAuthStore', () => {
       await store.mintAtLogin()
       await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
 
     it('does not toast on a transient refresh failure and keeps the slot', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi
         .fn()
@@ -2733,13 +2850,15 @@ describe('useWorkspaceAuthStore', () => {
       const refreshDelay = expiresInMs - 5 * 60 * 1000
       await vi.advanceTimersByTimeAsync(refreshDelay)
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 
     it('retries a transiently failed proactive refresh with backoff and rotates on success', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const okResponse = () => ({
         ok: true,
@@ -2769,7 +2888,7 @@ describe('useWorkspaceAuthStore', () => {
       const refreshDelay = expiresInMs - 5 * 60 * 1000
       await vi.advanceTimersByTimeAsync(refreshDelay)
       expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(useAuthStore().notifyTokenRefreshed).not.toHaveBeenCalled()
       expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
         outcome: 'retry_scheduled',
         retry_count: 1
@@ -2778,7 +2897,7 @@ describe('useWorkspaceAuthStore', () => {
       await vi.advanceTimersByTimeAsync(5000)
 
       expect(mockFetch).toHaveBeenCalledTimes(3)
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
       expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
         outcome: 'succeeded'
       })
@@ -2791,7 +2910,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('bounds refresh retries and keeps the slot for reactive recovery', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi
         .fn()
@@ -2825,7 +2946,7 @@ describe('useWorkspaceAuthStore', () => {
       await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
       expect(mockFetch).toHaveBeenCalledTimes(5)
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
       expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
         outcome: 'retries_exhausted',
         retry_count: 3
@@ -2835,7 +2956,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('re-arms the retry when a swallowed mint failure resolves false (owner null mid-refresh)', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const mockFetch = vi.fn().mockImplementation(() =>
         Promise.resolve({
@@ -2857,22 +2980,24 @@ describe('useWorkspaceAuthStore', () => {
 
       // Firebase is re-initializing at refresh time: requestToken throws
       // NOT_AUTHENTICATED, which performUnifiedMint swallows to `false`.
-      mockCurrentUser.value = null
+      Object.assign(useAuthStore(), { currentUser: null })
       await vi.advanceTimersByTimeAsync(expiresInMs - 5 * 60 * 1000)
       expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
 
-      mockCurrentUser.value = { uid: 'user-a' }
+      Object.assign(useAuthStore(), { currentUser: { uid: 'user-a' } })
       await vi.advanceTimersByTimeAsync(5000)
 
       expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(useAuthStore().notifyTokenRefreshed).toHaveBeenCalledTimes(1)
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 
     it('does not stomp a superseding workspace switch schedule with a stale-refresh retry', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const expiresInMs = 3600 * 1000
       const okResponse = (token: string) => ({
         ok: true,
@@ -2923,7 +3048,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('surfaces an error toast and resolves false when the login mint hits a permanent auth error', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 401,
@@ -2940,7 +3067,7 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(result).toBe(false)
       expect(unifiedToken.value).toBeNull()
-      expect(mockToastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
           detail: 'workspaceAuth.errors.invalidFirebaseToken'
@@ -2950,7 +3077,9 @@ describe('useWorkspaceAuthStore', () => {
 
     it('never toasts from the unified lifecycle when the flag is OFF', async () => {
       mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
       // Even with a backend that would reject, the OFF lifecycle stays inert.
       vi.stubGlobal(
         'fetch',
@@ -2968,7 +3097,14 @@ describe('useWorkspaceAuthStore', () => {
       await store.remintUnifiedOnce('unified-token-1')
       await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
-      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(useToastStore().add).not.toHaveBeenCalled()
     })
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Use the global testing Pinia in cloud and workspace tests, replacing this domain's migration from #17222 and local-instance cleanup from #17223.

## Changes

- 49 files: 45 domain files plus the identical four-file shared lifecycle prerequisite.
- Includes the billing-operation helper and its consumers. Preserves real-store state/action setup and independent effect scopes.
- Independently targets main from the shared lifecycle prerequisite; no other domain branch is required. Rule enforcement and documentation remain deferred to #17223.

## Review Focus

- All 45 domain file blobs match the immutable source commit from #17223.
- Passed all 47 selected test files, 1,316 tests, including all three shared tests; helper excluded from test selection.
- Passed `pnpm typecheck`, `pnpm typecheck:scripts`, scoped ESLint, type-aware Oxlint, cleanup audit, formatting, `pnpm knip`, and `git diff --check`.
- Real commit hooks passed, including full lint and typecheck.
