### PR TITLE
test: use global Pinia in state and service tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -25,13 +25,6 @@ vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
-vi.mock<unknown>(
-  import('@/platform/updates/common/toastStore'), // eslint-disable-line import-x/no-restricted-paths
-  () => ({
-    useToastStore: vi.fn(() => ({ addAlert: vi.fn() }))
-  })
-)
-
 let createObjectURLSpy: MockInstance<typeof URL.createObjectURL>
 let revokeObjectURLSpy: MockInstance<typeof URL.revokeObjectURL>
 

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/src/scripts/api.socketReset.test.ts
+++ b/src/scripts/api.socketReset.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock(import('firebase/auth'))
 
 let currentToken: string | undefined = 'token-a'
 // When set, each getAuthToken() call parks until released, capturing the token
@@ -15,18 +18,6 @@ const releaseNextToken = async () => {
 }
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
-
-vi.mock('@/stores/authStore', () => ({
-  useAuthStore: () => ({
-    getAuthToken: () => {
-      if (!deferTokenFetch) return Promise.resolve(currentToken)
-      const captured = currentToken
-      return new Promise<string | undefined>((resolve) => {
-        pendingTokenReleases.push(() => resolve(captured))
-      })
-    }
-  })
-}))
 
 class FakeWebSocket {
   static readonly OPEN = 1
@@ -68,6 +59,13 @@ describe('ComfyApi realtime socket reset', () => {
     pendingTokenReleases = []
     vi.stubGlobal('WebSocket', FakeWebSocket)
     api.socket = null
+    vi.mocked(useAuthStore().getAuthToken).mockImplementation(() => {
+      if (!deferTokenFetch) return Promise.resolve(currentToken)
+      const captured = currentToken
+      return new Promise<string | undefined>((resolve) => {
+        pendingTokenReleases.push(() => resolve(captured))
+      })
+    })
   })
 
   afterEach(() => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1,4 +1,15 @@
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAuthStore } from '@/stores/authStore'
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { ref } from 'vue'
+
+vi.mock(import('@vueuse/router'), () => ({ useRouteHash: () => ref('') }))
 
 import type { CurveData } from '@/components/curve/types'
 import { t } from '@/i18n'
@@ -59,71 +70,17 @@ import type { importA1111 } from './pnginfo'
 
 type WorkflowService = ReturnType<typeof useWorkflowService>
 
+vi.mock(import('firebase/auth'))
+
 const {
-  mockApiKeyAuthStore,
-  mockAuthStore,
-  mockSettingStore,
-  mockToastStore,
   mockExtensionService,
-  mockNodeOutputStore,
-  mockSubgraphNavigationStore,
-  mockTeamWorkspaceStore,
-  mockWorkspaceWorkflow,
   mockRefreshMissingModelPipeline,
   mockImportA1111,
   mockWorkflowService
 } = vi.hoisted(() => ({
-  mockApiKeyAuthStore: {
-    getApiKey: vi.fn(),
-    isAuthenticated: false
-  },
-  mockAuthStore: {
-    getWorkspaceAuthToken: vi.fn(),
-    currentUser: null as { uid: string } | null
-  },
-  mockSettingStore: {
-    get: vi.fn()
-  },
-  mockToastStore: {
-    addAlert: vi.fn(),
-    add: vi.fn(),
-    remove: vi.fn()
-  },
   mockExtensionService: {
     invokeExtensions: vi.fn(),
     invokeExtensionsAsync: vi.fn()
-  },
-  mockNodeOutputStore: {
-    refreshNodeOutputs: vi.fn(),
-    replaceOutputsFromLegacy: vi.fn(),
-    setOutputFromLegacy: vi.fn(),
-    removeOutputFromLegacy: vi.fn(),
-    resetAllOutputsAndPreviews: vi.fn(),
-    snapshotOutputs: vi.fn(),
-    restoreOutputs: vi.fn(),
-    stashPreviewsForWorkflow: vi.fn(),
-    restorePreviewsForWorkflow: vi.fn(),
-    discardPreviewsForWorkflow: vi.fn()
-  },
-  mockSubgraphNavigationStore: {
-    saveCurrentViewport: vi.fn(),
-    updateHash: vi.fn(),
-    exportState: vi.fn(() => []),
-    restoreState: vi.fn()
-  },
-  mockTeamWorkspaceStore: {
-    activeWorkspaceId: 'workspace-a' as string | null,
-    workspaceTransitionGeneration: 0,
-    waitForWorkspaceSwitch: vi.fn(() => Promise.resolve())
-  },
-  mockWorkspaceWorkflow: {
-    activeWorkflow: null as ComfyWorkflow | null,
-    createNewTemporary: vi.fn(),
-    openWorkflow: vi.fn(),
-    getWorkflowByPath: vi.fn<(path: string) => ComfyWorkflow | null>(
-      () => null
-    ),
-    isActive: vi.fn<(workflow: ComfyWorkflow) => boolean>(() => false)
   },
   mockRefreshMissingModelPipeline: vi.fn(),
   mockImportA1111: vi.fn<typeof importA1111>(),
@@ -140,22 +97,6 @@ vi.mock('@/utils/litegraphUtil', () => ({
   isVideoNode: vi.fn(),
   isAudioNode: vi.fn(),
   executeWidgetsCallback: vi.fn()
-}))
-
-vi.mock('@/stores/apiKeyAuthStore', () => ({
-  useApiKeyAuthStore: vi.fn(() => mockApiKeyAuthStore)
-}))
-
-vi.mock('@/stores/authStore', () => ({
-  useAuthStore: vi.fn(() => mockAuthStore)
-}))
-
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: vi.fn(() => mockTeamWorkspaceStore)
-}))
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: vi.fn(() => mockSettingStore)
 }))
 
 vi.mock('@/composables/usePaste', () => ({
@@ -193,26 +134,8 @@ vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
   }
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => ({
-  useToastStore: vi.fn(() => mockToastStore)
-}))
-
 vi.mock('@/services/extensionService', () => ({
   useExtensionService: vi.fn(() => mockExtensionService)
-}))
-
-vi.mock('@/stores/nodeOutputStore', () => ({
-  useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
-}))
-
-vi.mock('@/stores/subgraphNavigationStore', () => ({
-  useSubgraphNavigationStore: vi.fn(() => mockSubgraphNavigationStore)
-}))
-
-vi.mock('@/stores/workspaceStore', () => ({
-  useWorkspaceStore: vi.fn(() => ({
-    workflow: mockWorkspaceWorkflow
-  }))
 }))
 
 vi.mock('@/platform/missingModel/missingModelPipeline', () => ({
@@ -300,31 +223,51 @@ describe('ComfyApp', () => {
     app = new ComfyApp()
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas
-    mockWorkspaceWorkflow.activeWorkflow = null
+    useWorkflowStore().activeWorkflow = null
     const temporaryWorkflow = new ComfyWorkflow({
       path: 'workflows/temporary.json',
       modified: 0,
       size: 0
     })
-    mockWorkspaceWorkflow.createNewTemporary.mockReturnValue(temporaryWorkflow)
-    mockWorkspaceWorkflow.openWorkflow.mockImplementation(async (workflow) => {
-      mockWorkspaceWorkflow.activeWorkflow = workflow
-      return workflow
+    vi.mocked(useWorkflowStore().createNewTemporary).mockReturnValue(
+      temporaryWorkflow
+    )
+    vi.mocked(useWorkflowStore().openWorkflow).mockImplementation(
+      async (workflow) => {
+        useWorkflowStore().activeWorkflow = markLoaded(workflow)
+        return markLoaded(workflow)
+      }
+    )
+    vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(null)
+    Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+    useAuthStore().currentUser = null
+    vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValue(
+      'workspace-token'
+    )
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: 'workspace-a',
+      workspaceTransitionGeneration: 0
     })
-    mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
-    mockApiKeyAuthStore.isAuthenticated = false
-    mockAuthStore.currentUser = null
-    mockAuthStore.getWorkspaceAuthToken.mockResolvedValue('workspace-token')
-    mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-    mockTeamWorkspaceStore.workspaceTransitionGeneration = 0
-    mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockResolvedValue()
+    vi.mocked(
+      useTeamWorkspaceStore().waitForWorkspaceSwitch
+    ).mockResolvedValue()
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
     vi.mocked(extractFilesFromDragEvent).mockResolvedValue([])
     mockImportA1111.mockResolvedValue('imported')
     mockWorkflowService.afterLoadNewGraph.mockResolvedValue()
-    mockSettingStore.get.mockImplementation((key: string) =>
-      key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] = true
+    vi.mocked(useWorkflowStore().getWorkflowByPath).mockReturnValue(null)
+    vi.mocked(useWorkflowStore().isActive).mockReturnValue(false)
+    vi.mocked(useSubgraphNavigationStore().updateHash).mockResolvedValue(
+      undefined
+    )
+    vi.mocked(
+      useSubgraphNavigationStore().saveCurrentViewport
+    ).mockImplementation(() => {})
+    vi.mocked(useSubgraphNavigationStore().exportState).mockReturnValue([])
+    vi.mocked(useSubgraphNavigationStore().restoreState).mockImplementation(
+      () => {}
     )
   })
 
@@ -338,7 +281,7 @@ describe('ComfyApp', () => {
       })
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(false)
-      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+      expect(useSubgraphNavigationStore().updateHash).toHaveBeenCalledWith(
         'workflow-load',
         42
       )
@@ -350,7 +293,7 @@ describe('ComfyApp', () => {
       await app.loadGraphData(createWorkflowGraphData())
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(true)
-      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+      expect(useSubgraphNavigationStore().updateHash).toHaveBeenCalledWith(
         'workflow-load',
         undefined
       )
@@ -382,7 +325,7 @@ describe('ComfyApp', () => {
 
       expect(showDialog).toHaveBeenCalledOnce()
       // The finally still repairs the URL even on the handled-failure path.
-      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalledWith(
+      expect(useSubgraphNavigationStore().updateHash).toHaveBeenCalledWith(
         'workflow-load',
         7
       )
@@ -445,22 +388,24 @@ describe('ComfyApp', () => {
       app.vueAppReady = true
       const nodeCount = 50
       const storedOutputs = new Map<string, NodeExecutionOutput>()
-      mockNodeOutputStore.setOutputFromLegacy.mockImplementation((id, output) =>
-        storedOutputs.set(id, output)
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockImplementation(
+        (id, output) => storedOutputs.set(id, output)
       )
 
       for (let i = 0; i < nodeCount; i++) {
-        mockNodeOutputStore.setOutputFromLegacy.mockClear()
+        vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
         app.nodeOutputs[String(i)] = { images: [{ filename: `${i}.png` }] }
-        expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
-        expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+        expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledOnce()
+        expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
           String(i),
-          { images: [{ filename: `${i}.png` }] }
+          {
+            images: [{ filename: `${i}.png` }]
+          }
         )
       }
 
       expect(
-        mockNodeOutputStore.replaceOutputsFromLegacy
+        useNodeOutputStore().replaceOutputsFromLegacy
       ).not.toHaveBeenCalled()
 
       expect(storedOutputs.size).toBe(nodeCount)
@@ -476,12 +421,12 @@ describe('ComfyApp', () => {
       const output = { images: [{ filename: 'legacy.png' }] }
 
       app.nodeOutputs['1'] = output
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         output
       )
       delete app.nodeOutputs['1']
-      expect(mockNodeOutputStore.removeOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().removeOutputFromLegacy).toHaveBeenCalledWith(
         '1'
       )
     })
@@ -489,18 +434,18 @@ describe('ComfyApp', () => {
     it('commits nested legacy output mutations to the output store', () => {
       app.vueAppReady = true
       app.nodeOutputs['1'] = { images: [{ filename: 'first.png' }] }
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
 
       const output = app.nodeOutputs['1']
       output.images = [{ filename: 'second.png' }]
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         { images: [{ filename: 'second.png' }] }
       )
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
       const images = output.images
       images?.push({ filename: 'third.png' })
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         {
           images: [{ filename: 'second.png' }, { filename: 'third.png' }]
@@ -509,11 +454,11 @@ describe('ComfyApp', () => {
       expect(app.nodeOutputs['1']).toBe(output)
       expect(output.images).toBe(images)
 
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
       const image = images?.[0]
       if (!image) throw new Error('Expected a legacy output image')
       image.filename = 'mutated.png'
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '1',
         {
           images: [{ filename: 'mutated.png' }, { filename: 'third.png' }]
@@ -529,12 +474,12 @@ describe('ComfyApp', () => {
       app.nodeOutputs['2'] = shared
       void app.nodeOutputs['1']
       const second = app.nodeOutputs['2']
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
 
       second.images = [{ filename: 'second.png' }]
 
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledOnce()
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '2',
         shared
       )
@@ -543,13 +488,13 @@ describe('ComfyApp', () => {
     it('commits only the changed entry after whole-record assignment', () => {
       app.vueAppReady = true
       app.nodeOutputs = { '1': { images: [{ filename: 'first.png' }] } }
-      mockNodeOutputStore.setOutputFromLegacy.mockClear()
+      vi.mocked(useNodeOutputStore().setOutputFromLegacy).mockClear()
 
       const second = { images: [{ filename: 'second.png' }] }
       app.nodeOutputs['2'] = second
 
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
-      expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledOnce()
+      expect(useNodeOutputStore().setOutputFromLegacy).toHaveBeenCalledWith(
         '2',
         second
       )
@@ -566,7 +511,7 @@ describe('ComfyApp', () => {
       const graph = new LGraph()
       Reflect.set(app, 'rootGraphInternal', graph)
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
-      mockWorkspaceWorkflow.activeWorkflow = workflow
+      useWorkflowStore().activeWorkflow = markLoaded(workflow)
       vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
         output: {},
         workflow: createWorkflowGraphData()
@@ -577,7 +522,7 @@ describe('ComfyApp', () => {
     it('waits for workspace authentication before submitting the prompt', async () => {
       prepareEmptyPromptQueue()
       let resolveToken: (token: string) => void = () => {}
-      mockAuthStore.getWorkspaceAuthToken.mockReturnValueOnce(
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockReturnValueOnce(
         new Promise((resolve) => {
           resolveToken = resolve
         })
@@ -591,7 +536,7 @@ describe('ComfyApp', () => {
 
       const submission = app.queuePrompt(0)
       await vi.waitFor(() =>
-        expect(mockAuthStore.getWorkspaceAuthToken).toHaveBeenCalledOnce()
+        expect(useAuthStore().getWorkspaceAuthToken).toHaveBeenCalledOnce()
       )
       expect(queuePrompt).not.toHaveBeenCalled()
 
@@ -603,16 +548,20 @@ describe('ComfyApp', () => {
     it('waits for a workspace switch before selecting the billing context', async () => {
       prepareEmptyPromptQueue()
       let finishSwitch: () => void = () => {}
-      mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockImplementationOnce(
+      vi.mocked(
+        useTeamWorkspaceStore().waitForWorkspaceSwitch
+      ).mockImplementationOnce(
         () =>
           new Promise<void>((resolve) => {
             finishSwitch = () => {
-              mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+              Object.assign(useTeamWorkspaceStore(), {
+                activeWorkspaceId: 'workspace-b'
+              })
               resolve()
             }
           })
       )
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
         'workspace-token-b'
       )
       const queuePrompt = vi
@@ -625,32 +574,32 @@ describe('ComfyApp', () => {
       const submission = app.queuePrompt(0)
       await vi.waitFor(() =>
         expect(
-          mockTeamWorkspaceStore.waitForWorkspaceSwitch
+          useTeamWorkspaceStore().waitForWorkspaceSwitch
         ).toHaveBeenCalledOnce()
       )
 
-      expect(mockAuthStore.getWorkspaceAuthToken).not.toHaveBeenCalled()
+      expect(useAuthStore().getWorkspaceAuthToken).not.toHaveBeenCalled()
       expect(app.graphToPrompt).not.toHaveBeenCalled()
       expect(queuePrompt).not.toHaveBeenCalled()
 
       finishSwitch()
       await expect(submission).resolves.toBe(true)
 
-      expect(mockAuthStore.getWorkspaceAuthToken).toHaveBeenCalledOnce()
+      expect(useAuthStore().getWorkspaceAuthToken).toHaveBeenCalledOnce()
       expect(queuePrompt).toHaveBeenCalledOnce()
     })
 
     it('does not submit when an in-progress workspace switch fails', async () => {
       prepareEmptyPromptQueue()
-      mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockRejectedValueOnce(
-        new Error('Token exchange failed')
-      )
+      vi.mocked(
+        useTeamWorkspaceStore().waitForWorkspaceSwitch
+      ).mockRejectedValueOnce(new Error('Token exchange failed'))
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
       await expect(app.queuePrompt(0)).resolves.toBe(false)
 
-      expect(mockAuthStore.getWorkspaceAuthToken).not.toHaveBeenCalled()
+      expect(useAuthStore().getWorkspaceAuthToken).not.toHaveBeenCalled()
       expect(app.graphToPrompt).not.toHaveBeenCalled()
       expect(queuePrompt).not.toHaveBeenCalled()
       expect(showDialog).toHaveBeenCalledOnce()
@@ -660,11 +609,17 @@ describe('ComfyApp', () => {
       'uses a workspace initialized while local authentication is pending',
       async () => {
         prepareEmptyPromptQueue()
-        mockTeamWorkspaceStore.activeWorkspaceId = null
-        mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
-          mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-          return 'workspace-token'
+        Object.assign(useTeamWorkspaceStore(), {
+          activeWorkspaceId: null
         })
+        vi.mocked(useAuthStore().getWorkspaceAuthToken).mockImplementationOnce(
+          async () => {
+            Object.assign(useTeamWorkspaceStore(), {
+              activeWorkspaceId: 'workspace-a'
+            })
+            return 'workspace-token'
+          }
+        )
         const queuePrompt = vi
           .spyOn(api, 'queuePrompt')
           .mockImplementation(() => {
@@ -682,11 +637,17 @@ describe('ComfyApp', () => {
       'does not submit when a cloud workspace appears during authentication',
       async () => {
         prepareEmptyPromptQueue()
-        mockTeamWorkspaceStore.activeWorkspaceId = null
-        mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
-          mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-          return 'firebase-token'
+        Object.assign(useTeamWorkspaceStore(), {
+          activeWorkspaceId: null
         })
+        vi.mocked(useAuthStore().getWorkspaceAuthToken).mockImplementationOnce(
+          async () => {
+            Object.assign(useTeamWorkspaceStore(), {
+              activeWorkspaceId: 'workspace-a'
+            })
+            return 'firebase-token'
+          }
+        )
         const queuePrompt = vi.spyOn(api, 'queuePrompt')
         const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -699,10 +660,14 @@ describe('ComfyApp', () => {
 
     it('does not submit when the workspace changes during authentication', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
-        mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
-        return 'workspace-token-a'
-      })
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockImplementationOnce(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-b'
+          })
+          return 'workspace-token-a'
+        }
+      )
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -730,7 +695,9 @@ describe('ComfyApp', () => {
 
       const submission = app.queuePrompt(0)
       await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-b'
+      })
       finishPromptBuild()
 
       await expect(submission).resolves.toBe(false)
@@ -740,8 +707,10 @@ describe('ComfyApp', () => {
 
     it('does not fall back to an API key when workspace authentication fails', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
-      mockApiKeyAuthStore.getApiKey.mockReturnValueOnce('api-key')
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
+        undefined
+      )
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValueOnce('api-key')
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -752,10 +721,14 @@ describe('ComfyApp', () => {
 
     it('does not accept the API key when a Firebase session lost its workspace token', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.currentUser = { uid: 'firebase-user' }
-      mockApiKeyAuthStore.isAuthenticated = true
-      mockApiKeyAuthStore.getApiKey.mockReturnValue('api-key')
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
+      useAuthStore().currentUser = fromPartial({
+        uid: 'firebase-user'
+      })
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue('api-key')
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
+        undefined
+      )
       const queuePrompt = vi.spyOn(api, 'queuePrompt')
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
@@ -766,9 +739,13 @@ describe('ComfyApp', () => {
 
     it('submits with the validated API key when the key session has a workspace', async () => {
       prepareEmptyPromptQueue()
-      mockApiKeyAuthStore.isAuthenticated = true
-      mockApiKeyAuthStore.getApiKey.mockReturnValue('comfyui-valid-key')
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'comfyui-valid-key'
+      )
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
+        undefined
+      )
       const queuePrompt = vi
         .spyOn(api, 'queuePrompt')
         .mockImplementation(() => {
@@ -782,7 +759,7 @@ describe('ComfyApp', () => {
 
     it('does not submit after switching away and back to the same workspace', async () => {
       prepareEmptyPromptQueue()
-      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(
+      vi.mocked(useAuthStore().getWorkspaceAuthToken).mockResolvedValueOnce(
         'workspace-token'
       )
       let finishPromptBuild: () => void = () => {}
@@ -801,10 +778,14 @@ describe('ComfyApp', () => {
 
       const submission = app.queuePrompt(0)
       await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
-      mockTeamWorkspaceStore.workspaceTransitionGeneration++
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
-      mockTeamWorkspaceStore.workspaceTransitionGeneration++
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-b',
+        workspaceTransitionGeneration: 1
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-a',
+        workspaceTransitionGeneration: 2
+      })
       finishPromptBuild()
 
       await expect(submission).resolves.toBe(false)
@@ -870,7 +851,7 @@ describe('ComfyApp', () => {
       }
       Reflect.set(app, 'rootGraphInternal', graph)
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
-      mockWorkspaceWorkflow.activeWorkflow = workflow
+      useWorkflowStore().activeWorkflow = markLoaded(workflow)
       vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
         output: promptOutput,
         workflow: createWorkflowGraphData()
@@ -942,7 +923,7 @@ describe('ComfyApp', () => {
 
     it('attributes a queued job to the mode used when submission started', async () => {
       prepareEmptyPromptQueue()
-      const workflow = mockWorkspaceWorkflow.activeWorkflow
+      const workflow = useWorkflowStore().activeWorkflow
       if (!workflow) throw new Error('Expected an active workflow')
       workflow.activeMode = 'graph'
 
@@ -1794,7 +1775,7 @@ describe('ComfyApp', () => {
         { deferWarnings: true }
       )
 
-      const deferredWorkflow = mockWorkspaceWorkflow.activeWorkflow
+      const deferredWorkflow = useWorkflowStore().activeWorkflow
       expect(missingNodesStore.missingNodesError).toBeNull()
       expect(deferredWorkflow?.pendingWarnings?.missingNodeTypes).toEqual([
         expect.objectContaining({ type: 'UninstalledDeferredNode' })
@@ -2030,23 +2011,13 @@ describe('ComfyApp', () => {
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
       singletonApp.canvas = mockCanvas
       Reflect.set(mockCanvas, 'ds', { scale: 1, offset: [0, 0] })
-      mockWorkspaceWorkflow.createNewTemporary.mockImplementation(
-        workflowStore.createNewTemporary
-      )
-      mockWorkspaceWorkflow.getWorkflowByPath.mockImplementation(
-        workflowStore.getWorkflowByPath
-      )
-      mockWorkspaceWorkflow.isActive.mockImplementation(workflowStore.isActive)
-      mockWorkspaceWorkflow.openWorkflow.mockImplementation(
-        async (workflow) => {
-          const loadedWorkflow = await workflowStore.openWorkflow(workflow)
-          mockWorkspaceWorkflow.activeWorkflow = loadedWorkflow
-          return loadedWorkflow
-        }
-      )
+      vi.mocked(workflowStore.createNewTemporary).mockRestore()
+      vi.mocked(workflowStore.getWorkflowByPath).mockRestore()
+      vi.mocked(workflowStore.isActive).mockRestore()
+      vi.mocked(workflowStore.openWorkflow).mockRestore()
 
       await app.loadApiJson({}, 'api-a')
-      const importedA = mockWorkspaceWorkflow.activeWorkflow
+      const importedA = useWorkflowStore().activeWorkflow
       const importedAId = importedA?.activeState?.id
       if (!importedA || !importedAId) {
         throw new Error('Expected the first imported workflow to have an id')
@@ -2058,7 +2029,7 @@ describe('ComfyApp', () => {
       executionErrorStore.recordNodeErrors(failedKSamplerErrors)
 
       await app.loadApiJson({}, 'api-b')
-      const importedBId = mockWorkspaceWorkflow.activeWorkflow?.activeState?.id
+      const importedBId = useWorkflowStore().activeWorkflow?.activeState?.id
       expect(importedBId).not.toBe(zeroUuid)
       expect(importedBId).not.toBe(importedAId)
       expect(executionErrorStore.lastNodeErrors).toBeNull()
@@ -2080,7 +2051,7 @@ describe('ComfyApp', () => {
           size: -1
         })
       )
-      mockWorkspaceWorkflow.createNewTemporary.mockImplementation(
+      vi.mocked(useWorkflowStore().createNewTemporary).mockImplementation(
         (_path, workflowData) => {
           if (workflowData) {
             importedWorkflow.changeTracker.activeState = workflowData
@@ -2088,18 +2059,18 @@ describe('ComfyApp', () => {
           return importedWorkflow
         }
       )
-      mockWorkspaceWorkflow.getWorkflowByPath.mockImplementation(
-        () => mockWorkspaceWorkflow.activeWorkflow
+      vi.mocked(useWorkflowStore().getWorkflowByPath).mockImplementation(
+        () => useWorkflowStore().activeWorkflow
       )
-      mockWorkspaceWorkflow.isActive.mockImplementation(
-        (workflow) => mockWorkspaceWorkflow.activeWorkflow === workflow
+      vi.mocked(useWorkflowStore().isActive).mockImplementation(
+        (workflow) => useWorkflowStore().activeWorkflow === workflow
       )
 
       await app.loadApiJson({}, 'repeat')
-      const activeWorkflow = mockWorkspaceWorkflow.activeWorkflow
+      const activeWorkflow = useWorkflowStore().activeWorkflow
       await app.loadApiJson({}, 'repeat')
 
-      expect(mockWorkspaceWorkflow.activeWorkflow).toBe(activeWorkflow)
+      expect(useWorkflowStore().activeWorkflow).toBe(activeWorkflow)
     })
   })
 
@@ -2110,14 +2081,14 @@ describe('ComfyApp', () => {
 
       await app.refreshComboInNodes()
 
-      expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'info' })
       )
-      expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'success' })
       )
-      expect(mockToastStore.remove).toHaveBeenCalledWith(
-        mockToastStore.add.mock.calls[0][0]
+      expect(useToastStore().remove).toHaveBeenCalledWith(
+        vi.mocked(useToastStore().add).mock.calls[0][0]
       )
     })
 
@@ -2128,11 +2099,11 @@ describe('ComfyApp', () => {
 
       await expect(app.refreshComboInNodes()).rejects.toThrow(error)
 
-      expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
-      expect(mockToastStore.remove).toHaveBeenCalledWith(
-        mockToastStore.add.mock.calls[0][0]
+      expect(useToastStore().remove).toHaveBeenCalledWith(
+        vi.mocked(useToastStore().add).mock.calls[0][0]
       )
     })
   })
@@ -2622,8 +2593,8 @@ describe('ComfyApp', () => {
 
       await app.handleFile(createTestFile('broken.json', 'application/json'))
 
-      expect(mockToastStore.addAlert).toHaveBeenCalledTimes(1)
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+      expect(useToastStore().addAlert).toHaveBeenCalledTimes(1)
+      expect(useToastStore().addAlert).toHaveBeenCalledWith(
         'Unable to find workflow in broken.json'
       )
       consoleError.mockRestore()
@@ -2668,8 +2639,8 @@ describe('ComfyApp', () => {
         parameters,
         expect.any(Function)
       )
-      expect(mockToastStore[testCase.toastMethod]).toHaveBeenCalledOnce()
-      expect(mockToastStore[testCase.toastMethod]).toHaveBeenCalledWith(
+      expect(useToastStore()[testCase.toastMethod]).toHaveBeenCalledOnce()
+      expect(useToastStore()[testCase.toastMethod]).toHaveBeenCalledWith(
         testCase.expectedToast
       )
       if (testCase.outcome === 'imported-without-embeddings') {
@@ -2754,7 +2725,7 @@ describe('ComfyApp', () => {
       outgoingWorkflow.pendingWarnings = {
         missingNodeTypes: ['OutgoingMissingNode']
       }
-      mockWorkspaceWorkflow.activeWorkflow = outgoingWorkflow
+      useWorkflowStore().activeWorkflow = markLoaded(outgoingWorkflow)
       const realWorkflowStore = useWorkflowStore()
       realWorkflowStore.activeWorkflow = markLoaded(outgoingWorkflow)
       const missingNodesStore = useMissingNodesErrorStore()
@@ -2778,12 +2749,12 @@ describe('ComfyApp', () => {
       const openWorkflowGate = new Promise<void>((resolve) => {
         releaseOpenWorkflow = resolve
       })
-      mockWorkspaceWorkflow.openWorkflow.mockImplementation(
+      vi.mocked(useWorkflowStore().openWorkflow).mockImplementation(
         async (workflow: ComfyWorkflow) => {
           await openWorkflowGate
-          mockWorkspaceWorkflow.activeWorkflow = workflow
+          useWorkflowStore().activeWorkflow = markLoaded(workflow)
           realWorkflowStore.activeWorkflow = markLoaded(workflow)
-          return workflow
+          return markLoaded(workflow)
         }
       )
 
@@ -2792,7 +2763,7 @@ describe('ComfyApp', () => {
 
         document.dispatchEvent(new DragEvent('drop'))
         await vi.waitFor(() => {
-          expect(mockWorkspaceWorkflow.openWorkflow).toHaveBeenCalledOnce()
+          expect(useWorkflowStore().openWorkflow).toHaveBeenCalledOnce()
         })
 
         expect(adjustMouseEvent).toHaveBeenCalledTimes(1)
@@ -2801,9 +2772,7 @@ describe('ComfyApp', () => {
 
         releaseOpenWorkflow()
         await vi.waitFor(() => {
-          expect(mockWorkspaceWorkflow.activeWorkflow).not.toBe(
-            outgoingWorkflow
-          )
+          expect(useWorkflowStore().activeWorkflow).not.toBe(outgoingWorkflow)
         })
         await vi.waitFor(() => {
           expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1,4 +1,11 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { markRaw, ref } from 'vue'
+
+vi.mock(import('@vueuse/router'), () => ({ useRouteHash: () => ref('') }))
 
 import {
   createNestedSubgraphs,
@@ -19,23 +26,10 @@ vi.mock('@/base/assert', () => ({
   assert: mockAssert
 }))
 
-const mockNodeOutputStore = vi.hoisted(() => ({
-  snapshotOutputs: vi.fn(() => ({})),
-  restoreOutputs: vi.fn()
-}))
-
-const mockSubgraphNavigationStore = vi.hoisted(() => ({
-  exportState: vi.fn(() => []),
-  restoreState: vi.fn()
-}))
-
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: null as { changeTracker: unknown } | null,
-  getWorkflowByPath: vi.fn()
-}))
-
 vi.mock('@/scripts/app', () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     graph: {},
     rootGraph: {
       serialize: vi.fn(() => ({
@@ -66,19 +60,6 @@ vi.mock('@/scripts/api', () => ({
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   }
-}))
-
-vi.mock('@/stores/nodeOutputStore', () => ({
-  useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
-}))
-
-vi.mock('@/stores/subgraphNavigationStore', () => ({
-  useSubgraphNavigationStore: vi.fn(() => mockSubgraphNavigationStore)
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  ComfyWorkflow: class {},
-  useWorkflowStore: vi.fn(() => mockWorkflowStore)
 }))
 
 import { app } from '@/scripts/app'
@@ -121,8 +102,10 @@ function createTracker(initialState?: ComfyWorkflowJSON): ChangeTracker {
   const workflow = {
     path: `/test/workflow-${++workflowPathCounter}.json`
   } as never
-  const tracker = new ChangeTracker(workflow, state)
-  mockWorkflowStore.activeWorkflow = { changeTracker: tracker }
+  const tracker = markRaw(new ChangeTracker(workflow, state))
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: tracker
+  })
   return tracker
 }
 
@@ -219,12 +202,16 @@ describe('ChangeTracker', () => {
     nodeIdCounter = 0
     ChangeTracker.isLoadingGraph = false
     ChangeTracker.resetCheckStateWarningForTest()
-    mockWorkflowStore.activeWorkflow = null
-    mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
+    useWorkflowStore().activeWorkflow = null
+    vi.mocked(useWorkflowStore().getWorkflowByPath).mockReturnValue(null)
     mockCanvasState(createState())
     useQueueSettingsStore().mode = 'change'
     app.ui.autoQueueEnabled = false
     app.ui.autoQueueMode = 'instant'
+    vi.mocked(useSubgraphNavigationStore().exportState).mockReturnValue([])
+    vi.mocked(useSubgraphNavigationStore().restoreState).mockImplementation(
+      () => {}
+    )
   })
 
   describe('captureCanvasState', () => {
@@ -270,7 +257,9 @@ describe('ChangeTracker', () => {
 
       it('is a no-op and calls assert when called on inactive tracker', () => {
         const tracker = createTracker()
-        mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+        useWorkflowStore().activeWorkflow = fromPartial({
+          changeTracker: {}
+        })
 
         tracker.captureCanvasState()
 
@@ -452,7 +441,9 @@ describe('ChangeTracker', () => {
         {
           name: 'tracker becomes inactive',
           blockSquash: () => {
-            mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+            useWorkflowStore().activeWorkflow = fromPartial({
+              changeTracker: {}
+            })
           }
         },
         {
@@ -1186,8 +1177,8 @@ describe('ChangeTracker', () => {
       tracker.deactivate()
 
       expect(tracker.activeState).toEqual(changed)
-      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
-      expect(mockSubgraphNavigationStore.exportState).toHaveBeenCalled()
+      expect(useNodeOutputStore().snapshotOutputs).toHaveBeenCalled()
+      expect(useSubgraphNavigationStore().exportState).toHaveBeenCalled()
     })
 
     it('skips captureCanvasState but still calls store during undo/redo', () => {
@@ -1197,17 +1188,19 @@ describe('ChangeTracker', () => {
       tracker.deactivate()
 
       expect(app.rootGraph.serialize).not.toHaveBeenCalled()
-      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
+      expect(useNodeOutputStore().snapshotOutputs).toHaveBeenCalled()
     })
 
     it('is a full no-op and calls assert when called on inactive tracker', () => {
       const tracker = createTracker()
-      mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        changeTracker: {}
+      })
 
       tracker.deactivate()
 
       expect(app.rootGraph.serialize).not.toHaveBeenCalled()
-      expect(mockNodeOutputStore.snapshotOutputs).not.toHaveBeenCalled()
+      expect(useNodeOutputStore().snapshotOutputs).not.toHaveBeenCalled()
       expect(mockAssert).toHaveBeenCalledWith(
         false,
         'ChangeTracker.deactivate() called on inactive tracker'
@@ -1229,7 +1222,9 @@ describe('ChangeTracker', () => {
     it('is a no-op when tracker is inactive', () => {
       const tracker = createTracker()
       const original = tracker.activeState
-      mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+      useWorkflowStore().activeWorkflow = fromPartial({
+        changeTracker: {}
+      })
 
       tracker.prepareForSave()
 

--- a/src/scripts/domWidget.test.ts
+++ b/src/scripts/domWidget.test.ts
@@ -3,12 +3,6 @@ import { describe, expect, test, vi } from 'vitest'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { ComponentWidgetImpl, DOMWidgetImpl } from '@/scripts/domWidget'
 
-vi.mock('@/stores/domWidgetStore', () => ({
-  useDomWidgetStore: () => ({
-    unregisterWidget: vi.fn()
-  })
-}))
-
 vi.mock('@/utils/formatUtil', () => ({
   generateUUID: () => 'test-uuid'
 }))

--- a/src/services/audioService.test.ts
+++ b/src/services/audioService.test.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAudioService } from '@/services/audioService'
@@ -10,10 +11,6 @@ const mockApi = vi.hoisted(() => ({
   fetchApi: vi.fn()
 }))
 
-const mockToastStore = vi.hoisted(() => ({
-  addAlert: vi.fn()
-}))
-
 vi.mock(import('extendable-media-recorder'), () => ({
   register: mockRegister
 }))
@@ -24,10 +21,6 @@ vi.mock(import('extendable-media-recorder-wav-encoder'), () => ({
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: mockApi
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => mockToastStore)
 }))
 
 describe('useAudioService', () => {
@@ -211,7 +204,7 @@ describe('useAudioService', () => {
         'Error uploading temp file: 500 - Internal Server Error'
       )
 
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+      expect(useToastStore().addAlert).toHaveBeenCalledWith(
         'Error uploading temp file: 500 - Internal Server Error'
       )
     })
@@ -242,11 +235,11 @@ describe('useAudioService', () => {
           `Error uploading temp file: ${testCase.status} - ${testCase.statusText}`
         )
 
-        expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        expect(useToastStore().addAlert).toHaveBeenCalledWith(
           `Error uploading temp file: ${testCase.status} - ${testCase.statusText}`
         )
 
-        mockToastStore.addAlert.mockClear()
+        vi.mocked(useToastStore().addAlert).mockClear()
       }
     })
 

--- a/src/services/autoQueueService.test.ts
+++ b/src/services/autoQueueService.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -47,12 +45,6 @@ function setupAndGetAutoQueueGraphChangedListener() {
 
 describe('setupAutoQueueHandler', () => {
   beforeEach(() => {
-    setActivePinia(
-      createTestingPinia({
-        createSpy: vi.fn,
-        stubActions: false
-      })
-    )
     const queueSettingsStore = useQueueSettingsStore()
     queueSettingsStore.mode = 'change'
     queueSettingsStore.batchCount = 2

--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -1,20 +1,19 @@
+import { useAuthStore } from '@/stores/authStore'
 import axios from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock(import('firebase/auth'))
 
 import {
   EventType,
   useCustomerEventsService
 } from '@/services/customerEventsService'
+import type { AuthHeader } from '@/types/authTypes'
 
 // Hoist the mocks to avoid hoisting issues
 const mockAxiosInstance = vi.hoisted(() => ({
   get: vi.fn(),
   interceptors: { response: { use: vi.fn() } }
-}))
-
-const mockAuthStore = vi.hoisted(() => ({
-  getUserAuthHeader: vi.fn(),
-  currentUserIdentity: vi.fn()
 }))
 
 const mockI18n = vi.hoisted(() => ({
@@ -27,10 +26,6 @@ vi.mock<unknown>(import('axios'), () => ({
     create: vi.fn(() => mockAxiosInstance),
     isAxiosError: vi.fn()
   }
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => mockAuthStore)
 }))
 
 vi.mock(import('@/i18n'), () => ({
@@ -46,9 +41,8 @@ describe('useCustomerEventsService', () => {
   let service: ReturnType<typeof useCustomerEventsService>
 
   const mockAuthHeaders = {
-    Authorization: 'Bearer mock-token',
-    'Content-Type': 'application/json'
-  }
+    Authorization: 'Bearer mock-token'
+  } satisfies AuthHeader
 
   const mockEventsResponse = {
     events: [
@@ -81,8 +75,10 @@ describe('useCustomerEventsService', () => {
   }
 
   beforeEach(() => {
-    mockAuthStore.getUserAuthHeader.mockResolvedValue(mockAuthHeaders)
-    mockAuthStore.currentUserIdentity.mockReturnValue('api-key-a')
+    vi.mocked(useAuthStore().getUserAuthHeader).mockResolvedValue(
+      mockAuthHeaders
+    )
+    vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-a')
     mockI18n.d.mockImplementation((date, options) => {
       // Mock i18n date formatting
       if (options?.month === 'short') {
@@ -119,7 +115,7 @@ describe('useCustomerEventsService', () => {
         limit: 10
       })
 
-      expect(mockAuthStore.getUserAuthHeader).toHaveBeenCalled()
+      expect(useAuthStore().getUserAuthHeader).toHaveBeenCalled()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/customers/events', {
         params: { page: 1, limit: 10 },
         headers: mockAuthHeaders
@@ -142,7 +138,7 @@ describe('useCustomerEventsService', () => {
     })
 
     it('should return null when auth headers are missing', async () => {
-      mockAuthStore.getUserAuthHeader.mockResolvedValue(null)
+      vi.mocked(useAuthStore().getUserAuthHeader).mockResolvedValue(null)
 
       const result = await service.getMyEvents()
 
@@ -164,7 +160,7 @@ describe('useCustomerEventsService', () => {
 
       const request = service.getMyEvents()
       await eventsRequestStarted
-      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-b')
       resolveEvents({ data: mockEventsResponse })
 
       await expect(request).resolves.toBeNull()
@@ -184,7 +180,7 @@ describe('useCustomerEventsService', () => {
 
       const request = service.getMyEvents()
       await eventsRequestStarted
-      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-b')
       rejectEvents({
         response: { status: 400, data: { message: 'account A backend error' } }
       })
@@ -195,8 +191,12 @@ describe('useCustomerEventsService', () => {
     })
 
     it('ignores a stale auth preflight once a newer request begins', async () => {
-      let resolveStaleHeader!: (value: unknown) => void
-      mockAuthStore.getUserAuthHeader.mockImplementationOnce(
+      let resolveStaleHeader!: (
+        value: Awaited<
+          ReturnType<ReturnType<typeof useAuthStore>['getUserAuthHeader']>
+        >
+      ) => void
+      vi.mocked(useAuthStore().getUserAuthHeader).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
             resolveStaleHeader = resolve
@@ -204,7 +204,7 @@ describe('useCustomerEventsService', () => {
       )
       const staleRequest = service.getMyEvents()
 
-      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      vi.mocked(useAuthStore().currentUserIdentity).mockReturnValue('api-key-b')
       const activeRequestStarted = new Promise<void>((requestStarted) => {
         mockAxiosInstance.get.mockImplementation(() => {
           requestStarted()

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -1,21 +1,18 @@
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Component } from 'vue'
+import type DowngradeContent from '@/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.vue'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useDialogStore } from '@/stores/dialogStore'
 /**
  * showDowngradeToPersonalDialog must refresh members before the no-members
  * fast path and stay non-dismissable (ESC derives from `closable` in
  * dialogStore); fast-path failures must toast.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
-const showDialog = vi.hoisted(() => vi.fn())
-const closeDialog = vi.hoisted(() => vi.fn())
-const isDialogOpen = vi.hoisted(() => vi.fn())
-const updateDialog = vi.hoisted(() => vi.fn())
-const toastAdd = vi.hoisted(() => vi.fn())
 const refreshMembers = vi.hoisted(() => vi.fn())
 const previewDowngrade = vi.hoisted(() => vi.fn())
 const downgradeToPersonal = vi.hoisted(() => vi.fn())
 const hasOtherMembers = vi.hoisted(() => ({ value: false }))
-const openDialogKeys = ref<string[]>([])
 
 const {
   ReactivationConfirmationRequiredError,
@@ -37,15 +34,6 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    showDialog,
-    closeDialog,
-    isDialogOpen,
-    updateDialog
-  })
-}))
-
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
@@ -64,10 +52,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     isFreeTier: { value: false },
     type: { value: 'legacy' }
   })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
 }))
 
 vi.mock<unknown>(
@@ -94,7 +78,6 @@ import { useDialogService } from '@/services/dialogService'
 describe('showDowngradeToPersonalDialog', () => {
   beforeEach(() => {
     hasOtherMembers.value = false
-    openDialogKeys.value = []
     refreshMembers.mockResolvedValue(undefined)
     previewDowngrade.mockResolvedValue({
       preview: {
@@ -105,17 +88,6 @@ describe('showDowngradeToPersonalDialog', () => {
       requiresReactivationConfirmation: false
     })
     downgradeToPersonal.mockResolvedValue(undefined)
-    isDialogOpen.mockImplementation((key: string) =>
-      openDialogKeys.value.includes(key)
-    )
-    showDialog.mockImplementation(({ key }: { key: string }) => {
-      openDialogKeys.value = [...openDialogKeys.value, key]
-    })
-    closeDialog.mockImplementation(({ key }: { key: string }) => {
-      openDialogKeys.value = openDialogKeys.value.filter(
-        (openKey) => openKey !== key
-      )
-    })
   })
 
   const options = { planName: 'Standard', planSlug: 'standard-monthly' }
@@ -135,7 +107,9 @@ describe('showDowngradeToPersonalDialog', () => {
 
     expect(calls).toEqual(['refresh', 'downgrade'])
     expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly')
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
   })
 
   it('returns the downgrade result from the no-members fast path', async () => {
@@ -155,19 +129,29 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
 
     expect(downgradeToPersonal).not.toHaveBeenCalled()
-    expect(closeDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
     expect(args.key).toBe('downgrade-remove-members')
     expect(args.props.requiresRemoval).toBe(true)
     expect(args.props.requiresReactivation).toBe(false)
-    expect(args.dialogComponentProps.closable).toBe(false)
-    expect(args.dialogComponentProps.dismissableMask).toBe(false)
+    expect(args.dialogComponentProps?.closable).toBe(false)
+    expect(args.dialogComponentProps?.dismissableMask).toBe(false)
 
+    assert(args.dialogComponentProps?.onClose)
     args.dialogComponentProps.onClose()
     await expect(resultPromise).resolves.toBeNull()
   })
@@ -185,14 +169,24 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
 
     expect(downgradeToPersonal).not.toHaveBeenCalled()
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
     expect(args.props.requiresRemoval).toBe(false)
     expect(args.props.requiresReactivation).toBe(true)
     expect(args.props.chargeCents).toBe(1500)
 
+    assert(args.dialogComponentProps?.onClose)
     args.dialogComponentProps.onClose()
     await resultPromise
   })
@@ -207,9 +201,19 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
 
+    assert(typeof args.props.onConfirm === 'function')
     await args.props.onConfirm('standard-monthly', false)
 
     expect(downgradeToPersonal).toHaveBeenCalledWith(
@@ -233,9 +237,19 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
 
+    assert(typeof args.props.onConfirm === 'function')
     await args.props.onConfirm('standard-monthly', true)
 
     expect(downgradeToPersonal).toHaveBeenCalledWith(
@@ -270,8 +284,18 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
+    assert(typeof args.props.onConfirm === 'function')
     expect(args.props.requiresReactivation).toBe(false)
     expect(args.props.chargeCents).toBe(0)
 
@@ -279,7 +303,7 @@ describe('showDowngradeToPersonalDialog', () => {
       args.props.onConfirm('standard-monthly', false)
     ).rejects.toThrow(ReactivationConfirmationRequiredError)
 
-    expect(updateDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledWith({
       key: 'downgrade-remove-members',
       contentProps: { requiresReactivation: true, chargeCents: 1500 }
     })
@@ -323,15 +347,25 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
-    const [args] = showDialog.mock.calls[0]
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
+    const [args] = vi.mocked(
+      useDialogStore().showDialog<Component, typeof DowngradeContent>
+    ).mock.calls[0]
+    assert(args.props)
+    assert(typeof args.props.onConfirm === 'function')
     expect(args.props.chargeCents).toBe(1500)
 
     await expect(
       args.props.onConfirm('standard-monthly', true)
     ).rejects.toThrow(ReactivationAmountChangedError)
 
-    expect(updateDialog).toHaveBeenCalledWith({
+    expect(vi.mocked(useDialogStore().updateDialog)).toHaveBeenCalledWith({
       key: 'downgrade-remove-members',
       contentProps: { requiresReactivation: true, chargeCents: 2000 }
     })
@@ -358,9 +392,15 @@ describe('showDowngradeToPersonalDialog', () => {
 
     const resultPromise =
       useDialogService().showDowngradeToPersonalDialog(options)
-    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(
+        vi.mocked(
+          useDialogStore().showDialog<Component, typeof DowngradeContent>
+        )
+      ).toHaveBeenCalledOnce()
+    )
 
-    openDialogKeys.value = []
+    useDialogStore().dialogStack = []
 
     await expect(resultPromise).resolves.toBeNull()
   })
@@ -370,13 +410,15 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await useDialogService().showDowngradeToPersonalDialog(options)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'Outstanding balance'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
   })
 
   it('toasts and aborts when the member refresh fails', async () => {
@@ -385,10 +427,12 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await useDialogService().showDowngradeToPersonalDialog(options)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error', detail: 'network' })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
     expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 
@@ -397,13 +441,15 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await useDialogService().showDowngradeToPersonalDialog(options)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'Outstanding balance'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(useDialogStore().showDialog<Component, typeof DowngradeContent>)
+    ).not.toHaveBeenCalled()
     expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 })

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -3,13 +3,7 @@
  * Reka-migrated dialog, the dialog stack item must carry `renderer: 'reka'`.
  * Catches accidental reverts of the Reka renderer flip.
  */
-import { describe, expect, it, vi } from 'vitest'
-
-const showDialog = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
@@ -44,20 +38,29 @@ vi.mock<unknown>(
 )
 
 import { useDialogService } from '@/services/dialogService'
+import { useDialogStore } from '@/stores/dialogStore'
 
 describe('dialogService Reka renderer opt-in', () => {
+  let showDialog: ReturnType<
+    typeof vi.mocked<ReturnType<typeof useDialogStore>['showDialog']>
+  >
+
+  beforeEach(() => {
+    showDialog = vi.mocked(useDialogStore().showDialog)
+  })
+
   it("prompt() sets renderer 'reka' and size 'md'", () => {
     void useDialogService().prompt({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('md')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('md')
   })
 
   it("confirm() sets renderer 'reka' and size 'md'", () => {
     void useDialogService().confirm({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('md')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('md')
   })
 
   it('confirm() opens under its own stack key when the caller passes one', () => {
@@ -77,9 +80,9 @@ describe('dialogService Reka renderer opt-in', () => {
   it("showBillingComingSoonDialog() sets renderer 'reka', size 'sm', and 360px contentClass", () => {
     useDialogService().showBillingComingSoonDialog()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('sm')
-    expect(args.dialogComponentProps.contentClass).toBe('max-w-[360px]')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('sm')
+    expect(args.dialogComponentProps?.contentClass).toBe('max-w-[360px]')
   })
 
   it("showExecutionErrorDialog() sets renderer 'reka' and size 'lg'", () => {
@@ -91,25 +94,25 @@ describe('dialogService Reka renderer opt-in', () => {
       traceback: ['line 1', 'line 2']
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('lg')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('lg')
   })
 
   it("showErrorDialog() sets renderer 'reka' and size 'lg'", () => {
     useDialogService().showErrorDialog(new Error('boom'))
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.size).toBe('lg')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.size).toBe('lg')
   })
 
   it("showTopUpCreditsDialog() sets renderer 'reka' with a transparent shrink-wrapped chrome", async () => {
     await useDialogService().showTopUpCreditsDialog()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.pt).toBeUndefined()
-    expect(args.dialogComponentProps.contentClass).toContain('w-fit')
-    expect(args.dialogComponentProps.contentClass).toContain('bg-transparent')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.headless).toBe(true)
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
+    expect(args.dialogComponentProps?.contentClass).toContain('w-fit')
+    expect(args.dialogComponentProps?.contentClass).toContain('bg-transparent')
   })
 
   it("showLayoutDialog() defaults to renderer 'reka' headless without pt", () => {
@@ -120,9 +123,9 @@ describe('dialogService Reka renderer opt-in', () => {
       props: {}
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.pt).toBeUndefined()
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.headless).toBe(true)
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
   })
 
   it('showLayoutDialog() lets callers override the defaults', () => {
@@ -134,9 +137,9 @@ describe('dialogService Reka renderer opt-in', () => {
       dialogComponentProps: { closable: false, contentClass: 'w-170' }
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.closable).toBe(false)
-    expect(args.dialogComponentProps.contentClass).toBe('w-170')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.closable).toBe(false)
+    expect(args.dialogComponentProps?.contentClass).toBe('w-170')
   })
 
   it("showSmallLayoutDialog() sets renderer 'reka' with zeroed section padding", () => {
@@ -146,11 +149,11 @@ describe('dialogService Reka renderer opt-in', () => {
       component: Component
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
-    expect(args.dialogComponentProps.pt).toBeUndefined()
-    expect(args.dialogComponentProps.contentClass).toContain('w-fit')
-    expect(args.dialogComponentProps.headerClass).toBe('p-0')
-    expect(args.dialogComponentProps.bodyClass).toBe('p-0 overflow-y-hidden')
-    expect(args.dialogComponentProps.footerClass).toBe('p-0')
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.pt).toBeUndefined()
+    expect(args.dialogComponentProps?.contentClass).toContain('w-fit')
+    expect(args.dialogComponentProps?.headerClass).toBe('p-0')
+    expect(args.dialogComponentProps?.bodyClass).toBe('p-0 overflow-y-hidden')
+    expect(args.dialogComponentProps?.footerClass).toBe('p-0')
   })
 })

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -1,21 +1,16 @@
+import { useDialogStore } from '@/stores/dialogStore'
 /**
  * showTopUpCreditsDialog routes the paired server capabilities to purchase,
  * subscription, or read-only contact-admin UI.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const showDialog = vi.hoisted(() => vi.fn())
-const closeDialog = vi.hoisted(() => vi.fn())
 const state = vi.hoisted(() => ({
   type: 'workspace' as 'workspace' | 'legacy',
   canTopUp: true,
   canSubscribeSelfServe: false,
   isReady: true,
   initialize: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog, closeDialog })
 }))
 
 vi.mock(import('@/i18n'), () => ({
@@ -64,10 +59,6 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: vi.fn() })
-}))
-
 const showSubscriptionDialog = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(
@@ -94,7 +85,7 @@ describe('showTopUpCreditsDialog', () => {
       isInsufficientCredits: true
     })
 
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('top-up-credits')
     expect(state.initialize).not.toHaveBeenCalled()
   })
@@ -107,15 +98,17 @@ describe('showTopUpCreditsDialog', () => {
       isInsufficientCredits: true
     })
 
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('insufficient-credits-member')
     // The member notice draws its own header + close button, so it must open
     // headless or Reka wraps it in duplicate chrome.
-    expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps?.headless).toBe(true)
+    expect(args.dialogComponentProps?.renderer).toBe('reka')
 
-    args.props.onClose()
-    expect(closeDialog).toHaveBeenCalledWith({
+    const props = args.props
+    assert(props && 'onClose' in props && typeof props.onClose === 'function')
+    props.onClose()
+    expect(vi.mocked(useDialogStore().closeDialog)).toHaveBeenCalledWith({
       key: 'insufficient-credits-member'
     })
   })
@@ -126,7 +119,7 @@ describe('showTopUpCreditsDialog', () => {
 
     await useDialogService().showTopUpCreditsDialog()
 
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('top-up-credits')
   })
 
@@ -136,7 +129,7 @@ describe('showTopUpCreditsDialog', () => {
 
     await useDialogService().showTopUpCreditsDialog()
 
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
     expect(showSubscriptionDialog).not.toHaveBeenCalled()
   })
 
@@ -154,7 +147,7 @@ describe('showTopUpCreditsDialog', () => {
     })
 
     expect(state.initialize).toHaveBeenCalledOnce()
-    const [args] = showDialog.mock.calls[0]
+    const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
     expect(args.key).toBe('top-up-credits')
   })
 
@@ -165,7 +158,7 @@ describe('showTopUpCreditsDialog', () => {
     await useDialogService().showTopUpCreditsDialog()
 
     expect(state.initialize).toHaveBeenCalledOnce()
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
     expect(showSubscriptionDialog).not.toHaveBeenCalled()
   })
 
@@ -178,7 +171,7 @@ describe('showTopUpCreditsDialog', () => {
     expect(showSubscriptionDialog).toHaveBeenCalledWith({
       reason: 'top_up_blocked'
     })
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   describe('non-cloud distribution', () => {
@@ -191,7 +184,7 @@ describe('showTopUpCreditsDialog', () => {
       await useDialogService().showTopUpCreditsDialog()
 
       expect(showSubscriptionDialog).not.toHaveBeenCalled()
-      const [args] = showDialog.mock.calls[0]
+      const [args] = vi.mocked(useDialogStore().showDialog).mock.calls[0]
       expect(args.key).toBe('top-up-credits')
     })
   })

--- a/src/services/hdrViewerService.test.ts
+++ b/src/services/hdrViewerService.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { showDialog } = vi.hoisted(() => ({ showDialog: vi.fn() }))
+import { useDialogStore } from '@/stores/dialogStore'
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
 vi.mock(import('@/i18n'), () => ({ t: (key: string) => key }))
 
 import { openHdrViewer } from './hdrViewerService'
 
 describe('openHdrViewer', () => {
   it('opens a full-screen dialog with the full-resolution url and filename title', () => {
+    const showDialog = vi.mocked(useDialogStore().showDialog)
     openHdrViewer('/api/view?filename=out.exr&preview=webp;75&rand=1')
 
     expect(showDialog).toHaveBeenCalledOnce()
     const options = showDialog.mock.calls[0][0]
     expect(options.key).toBe('hdr-viewer')
     expect(options.title).toBe('out.exr')
-    expect(options.props.imageUrl).toBe('/api/view?filename=out.exr&rand=1')
-    expect(options.dialogComponentProps.size).toBe('full')
+    expect(options.props).toMatchObject({
+      imageUrl: '/api/view?filename=out.exr&rand=1'
+    })
+    expect(options.dialogComponentProps?.size).toBe('full')
   })
 })

--- a/src/services/litegraphService.lateRegistration.test.ts
+++ b/src/services/litegraphService.lateRegistration.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -148,7 +146,6 @@ function layoutEntities(graph: LGraph) {
 }
 
 beforeEach(async () => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   layoutStore.resetForTests()
   await useLitegraphService().registerNodeDef(INSTALLED, nodeDef(INSTALLED))
 })

--- a/src/services/litegraphService.test.ts
+++ b/src/services/litegraphService.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import { cloneDeep } from 'es-toolkit'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
@@ -73,7 +71,6 @@ describe('useLitegraphService().registerNodeDef slot text', () => {
   }
 
   beforeEach(async () => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     mergeBundledSlotText('stale bundled label')
     mergeCustomNodesI18n({
       en: {
@@ -128,7 +125,6 @@ describe('useLitegraphService().registerNodeDef slot text (non-en)', () => {
   }
 
   beforeEach(async () => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     i18n.global.mergeLocaleMessage('en', {
       nodeDefs: {
         [nodeName]: {
@@ -173,7 +169,6 @@ describe('useLitegraphService().registerNodeDef custom widget metadata', () => {
   let retainedWidget: IBaseWidget
 
   beforeEach(async () => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     useWidgetStore().registerCustomWidgets({
       [widgetType]: (node, inputName) => {
         retainedWidget = Object.preventExtensions({

--- a/src/services/providers/registrySearchProvider.test.ts
+++ b/src/services/providers/registrySearchProvider.test.ts
@@ -1,42 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
 
 import { useComfyRegistrySearchProvider } from '@/services/providers/registrySearchProvider'
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
 
-// Mock the store
-vi.mock<unknown>(import('@/stores/comfyRegistryStore'), () => ({
-  useComfyRegistryStore: vi.fn()
-}))
-
 describe('useComfyRegistrySearchProvider', () => {
-  const mockSearchCall = vi.fn()
-  const mockSearchClear = vi.fn()
-  const mockListAllPacksCall = vi.fn()
-  const mockListAllPacksClear = vi.fn()
-
-  const createMockStore = (
-    params: Partial<ReturnType<typeof useComfyRegistryStore>> = {}
-  ) => {
-    return {
-      search: {
-        call: mockSearchCall,
-        clear: mockSearchClear,
-        cancel: vi.fn()
-      },
-      listAllPacks: {
-        call: mockListAllPacksCall,
-        clear: mockListAllPacksClear,
-        cancel: vi.fn()
-      },
-      ...params
-    } as Partial<ReturnType<typeof useComfyRegistryStore>> as ReturnType<
-      typeof useComfyRegistryStore
-    >
-  }
+  let mockSearchCall: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['search']['call']
+  >
+  let mockSearchClear: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['search']['clear']
+  >
+  let mockListAllPacksCall: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['listAllPacks']['call']
+  >
+  let mockListAllPacksClear: MockInstance<
+    ReturnType<typeof useComfyRegistryStore>['listAllPacks']['clear']
+  >
 
   beforeEach(() => {
-    // Setup store mock
-    vi.mocked(useComfyRegistryStore).mockReturnValue(createMockStore())
+    const store = useComfyRegistryStore()
+    mockSearchCall = vi.spyOn(store.search, 'call').mockResolvedValue(null)
+    mockSearchClear = vi.spyOn(store.search, 'clear')
+    mockListAllPacksCall = vi
+      .spyOn(store.listAllPacks, 'call')
+      .mockResolvedValue(null)
+    mockListAllPacksClear = vi.spyOn(store.listAllPacks, 'clear')
   })
 
   describe('searchPacks', () => {

--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
 
 const mockLocalStorage = vi.hoisted(() => ({
   getItem: vi.fn(),
@@ -7,42 +10,36 @@ const mockLocalStorage = vi.hoisted(() => ({
   clear: vi.fn()
 }))
 
-const mockSettingStore = vi.hoisted(() => ({
-  settingValues: {} as Record<string, unknown>,
-  get: vi.fn(),
-  set: vi.fn()
-}))
-
 Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
   writable: true
 })
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => mockSettingStore
-}))
-
 import { useNewUserService } from '@/services/useNewUserService'
 
 describe('useNewUserService', () => {
   let service: ReturnType<typeof useNewUserService>
+  let scope: ReturnType<typeof effectScope>
 
   beforeEach(() => {
-    mockSettingStore.settingValues = {}
+    vi.spyOn(api, 'storeSetting').mockResolvedValue(new Response())
+    useSettingStore().settingValues = {}
 
-    service = useNewUserService()
+    scope = effectScope()
+    scope.run(() => {
+      service = useNewUserService()
+    })
     service.reset()
 
     mockLocalStorage.getItem.mockReturnValue(null)
   })
 
+  afterEach(() => scope.stop())
+
   describe('checkIsNewUser logic', () => {
     it('should identify new user when all conditions are met', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -51,12 +48,11 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when settings exist but TutorialCompleted is undefined', async () => {
-      mockSettingStore.settingValues = { 'some.setting': 'value' }
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark'
+      }
 
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
 
       mockLocalStorage.getItem.mockReturnValue(null)
 
@@ -66,11 +62,10 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when tutorial is completed', async () => {
-      mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': true }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.TutorialCompleted': true
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -79,11 +74,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when workflow exists', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'workflow') return 'some-workflow'
         return null
@@ -95,11 +87,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when previous workflow exists', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.PreviousWorkflow') return 'some-previous-workflow'
         return null
@@ -111,8 +100,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when V1 draft store keys exist', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.Drafts') return '{}'
         return null
@@ -124,8 +113,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when V1 draft order key exists', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftOrder') return '[]'
         return null
@@ -137,8 +126,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when V2 draft index has entries', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftIndex.v2:personal')
           return '{"v":2,"updatedAt":1,"order":["abc"],"entries":{"abc":{"path":"workflows/Untitled.json","name":"Untitled","isTemporary":true,"updatedAt":1}}}'
@@ -151,8 +140,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when V2 draft index exists but is empty', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftIndex.v2:personal')
           return '{"v":2,"updatedAt":1,"order":[],"entries":{}}'
@@ -165,8 +154,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when V2 draft index is malformed', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'Comfy.Workflow.DraftIndex.v2:personal') return 'not json'
         return null
@@ -178,11 +167,10 @@ describe('useNewUserService', () => {
     })
 
     it('should identify new user when tutorial is explicitly false', async () => {
-      mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': false }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return false
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.TutorialCompleted': false
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = false
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -191,14 +179,11 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when has both settings and tutorial completed', async () => {
-      mockSettingStore.settingValues = {
-        'some.setting': 'value',
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark',
         'Comfy.TutorialCompleted': true
       }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -207,11 +192,8 @@ describe('useNewUserService', () => {
     })
 
     it('should identify existing user when only one condition fails', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockImplementation((key: string) => {
         if (key === 'workflow') return 'some-workflow'
         if (key === 'Comfy.PreviousWorkflow') return null
@@ -228,11 +210,8 @@ describe('useNewUserService', () => {
     it('should execute callback immediately if new user is already determined', async () => {
       const mockCallback = vi.fn().mockResolvedValue(undefined)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -258,11 +237,8 @@ describe('useNewUserService', () => {
         .mockRejectedValue(new Error('Callback error'))
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -279,32 +255,28 @@ describe('useNewUserService', () => {
 
   describe('initializeIfNewUser', () => {
     it('should set installed version for new users', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
 
-      expect(mockSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.InstalledVersion',
         '1.24.0'
       )
     })
 
     it('should not set installed version for existing users', async () => {
-      mockSettingStore.settingValues = { 'some.setting': 'value' }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark'
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
 
-      expect(mockSettingStore.set).not.toHaveBeenCalled()
+      expect(useSettingStore().set).not.toHaveBeenCalled()
     })
 
     it('should execute pending callbacks for new users', async () => {
@@ -314,11 +286,8 @@ describe('useNewUserService', () => {
       await service.registerInitCallback(mockCallback1)
       await service.registerInitCallback(mockCallback2)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -332,11 +301,10 @@ describe('useNewUserService', () => {
 
       await service.registerInitCallback(mockCallback)
 
-      mockSettingStore.settingValues = { 'some.setting': 'value' }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return true
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.ColorPalette': 'dark'
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -350,11 +318,8 @@ describe('useNewUserService', () => {
 
       await service.registerInitCallback(mockCallback)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -367,26 +332,20 @@ describe('useNewUserService', () => {
     })
 
     it('should not reinitialize if already determined', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
-      expect(mockSettingStore.set).toHaveBeenCalledTimes(1)
+      expect(useSettingStore().set).toHaveBeenCalledTimes(1)
 
       await service.initializeIfNewUser()
-      expect(mockSettingStore.set).toHaveBeenCalledTimes(1)
+      expect(useSettingStore().set).toHaveBeenCalledTimes(1)
     })
 
     it('should correctly determine new user status', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       expect(service.isNewUser()).toBeNull()
@@ -395,7 +354,7 @@ describe('useNewUserService', () => {
 
       expect(service.isNewUser()).toBe(true)
 
-      expect(mockSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.InstalledVersion',
         expect.any(String)
       )
@@ -408,8 +367,8 @@ describe('useNewUserService', () => {
     })
 
     it('should return cached result after determination', async () => {
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockReturnValue(undefined)
+      useSettingStore().settingValues = {}
+
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -420,11 +379,10 @@ describe('useNewUserService', () => {
 
   describe('edge cases', () => {
     it('should handle settingStore.get returning false as not completed', async () => {
-      mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': false }
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return false
-        return undefined
-      })
+      useSettingStore().settingValues = {
+        'Comfy.TutorialCompleted': false
+      }
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = false
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -436,11 +394,8 @@ describe('useNewUserService', () => {
       const mockCallback1 = vi.fn().mockResolvedValue(undefined)
       const mockCallback2 = vi.fn().mockResolvedValue(undefined)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service.initializeIfNewUser()
@@ -458,11 +413,8 @@ describe('useNewUserService', () => {
       const service1 = useNewUserService()
       const service2 = useNewUserService()
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service1.initializeIfNewUser()
@@ -481,11 +433,8 @@ describe('useNewUserService', () => {
       await service1.registerInitCallback(mockCallback1)
       await service2.registerInitCallback(mockCallback2)
 
-      mockSettingStore.settingValues = {}
-      mockSettingStore.get.mockImplementation((key: string) => {
-        if (key === 'Comfy.TutorialCompleted') return undefined
-        return undefined
-      })
+      useSettingStore().settingValues = {}
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = undefined
       mockLocalStorage.getItem.mockReturnValue(null)
 
       await service1.initializeIfNewUser()

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -1,3 +1,6 @@
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
 import type { Mock } from 'vitest'
@@ -18,52 +21,6 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
   }
 }))
 
-const mockWorkspaceAuthHeader = vi.fn().mockReturnValue(null)
-const mockGetWorkspaceToken = vi.fn().mockReturnValue(undefined)
-const mockEnsureWorkspaceAuthHeader = vi.fn()
-const mockEnsureWorkspaceToken = vi.fn()
-const mockClearWorkspaceContext = vi.fn()
-const mockMintAtLogin = vi.fn().mockResolvedValue(false)
-let mockUnifiedToken: string | null = null
-const mockResetForIdentityChange = vi.fn()
-const mockInitializeWorkspaces = vi.fn().mockResolvedValue(undefined)
-let mockActiveWorkspaceId: string | null = null
-let mockTeamWorkspaceInitState = 'ready'
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({
-      getWorkspaceAuthHeader: mockWorkspaceAuthHeader,
-      getWorkspaceToken: mockGetWorkspaceToken,
-      ensureWorkspaceAuthHeader: mockEnsureWorkspaceAuthHeader,
-      ensureWorkspaceToken: mockEnsureWorkspaceToken,
-      getUnifiedToken: () => mockUnifiedToken ?? undefined,
-      clearWorkspaceContext: mockClearWorkspaceContext,
-      mintAtLogin: mockMintAtLogin,
-      get unifiedToken() {
-        return mockUnifiedToken
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspaceId() {
-        return mockActiveWorkspaceId
-      },
-      get initState() {
-        return mockTeamWorkspaceInitState
-      },
-      initialize: mockInitializeWorkspaces,
-      resetForIdentityChange: mockResetForIdentityChange
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: mockFeatureFlags
@@ -80,27 +37,8 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackAuth: vi.fn() })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: vi.fn() })
-}))
-
 vi.mock(import('@/services/dialogService'))
 vi.mock(import('@/platform/distribution/types'), () => mockDistributionTypes)
-
-const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
-const mockApiKeyState = { isAuthenticated: false }
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => ({
-    getAuthHeader: mockApiKeyGetAuthHeader,
-    getApiKey: vi.fn(),
-    currentUser: null,
-    get isAuthenticated() {
-      return mockApiKeyState.isAuthenticated
-    },
-    storeApiKey: vi.fn(),
-    clearStoredApiKey: vi.fn()
-  })
-}))
 
 type MockUser = Omit<User, 'getIdToken'> & { getIdToken: Mock }
 
@@ -119,23 +57,9 @@ describe('auth token priority chain', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = true
     mockFeatureFlags.unifiedCloudAuthEnabled = false
-    mockUnifiedToken = null
-    mockActiveWorkspaceId = null
-    mockTeamWorkspaceInitState = 'ready'
-    mockWorkspaceAuthHeader.mockReturnValue(null)
-    mockGetWorkspaceToken.mockReturnValue(undefined)
-    mockEnsureWorkspaceAuthHeader.mockResolvedValue(null)
-    mockEnsureWorkspaceToken.mockResolvedValue(null)
-    mockMintAtLogin.mockResolvedValue(false)
-    mockInitializeWorkspaces.mockResolvedValue(undefined)
-    mockApiKeyGetAuthHeader.mockReturnValue(null)
-    mockApiKeyState.isAuthenticated = false
-    mockUser.getIdToken.mockResolvedValue('firebase-token')
-
     vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(
       mockAuth as unknown as ReturnType<typeof vuefire.useFirebaseAuth>
     )
-
     vi.mocked(firebaseAuth.onAuthStateChanged).mockImplementation(
       (_, callback) => {
         authStateCallback = callback as (user: User | null) => void
@@ -143,15 +67,45 @@ describe('auth token priority chain', () => {
         return vi.fn()
       }
     )
-
     store = useAuthStore()
+    useWorkspaceAuthStore().unifiedToken = null
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
+    useTeamWorkspaceStore().initState = 'ready'
+    vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+      null
+    )
+    vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+      undefined
+    )
+    vi.mocked(
+      useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+    ).mockResolvedValue(null)
+    vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+      null
+    )
+    vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockResolvedValue(false)
+    vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockImplementation(
+      () => {}
+    )
+    vi.mocked(useWorkspaceAuthStore().getUnifiedToken).mockImplementation(
+      () => useWorkspaceAuthStore().unifiedToken ?? undefined
+    )
+    vi.mocked(
+      useTeamWorkspaceStore().resetForIdentityChange
+    ).mockImplementation(() => {})
+    vi.mocked(useTeamWorkspaceStore().initialize).mockResolvedValue(undefined)
+    vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
+    Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
+    mockUser.getIdToken.mockResolvedValue('firebase-token')
   })
 
   describe('getAuthHeader priority', () => {
     it('returns workspace auth header when workspace is active', async () => {
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
-      })
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        {
+          Authorization: 'Bearer workspace-token'
+        }
+      )
 
       const header = await store.getAuthHeader()
 
@@ -161,7 +115,9 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace is not active but user is authenticated', async () => {
-      mockWorkspaceAuthHeader.mockReturnValue(null)
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        null
+      )
 
       const header = await store.getAuthHeader()
 
@@ -172,9 +128,11 @@ describe('auth token priority chain', () => {
 
     it('ignores workspace auth header outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
-      })
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        {
+          Authorization: 'Bearer workspace-token'
+        }
+      )
 
       const header = await store.getAuthHeader()
 
@@ -185,20 +143,28 @@ describe('auth token priority chain', () => {
 
     it('keeps generic authentication user-scoped outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(
+        useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+      ).mockResolvedValue({
         Authorization: 'Bearer workspace-token'
       })
 
       const header = await store.getAuthHeader()
 
-      expect(mockEnsureWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceAuthHeader)
+      ).not.toHaveBeenCalled()
       expect(header).toEqual({ Authorization: 'Bearer firebase-token' })
     })
 
     it('returns API key when neither workspace nor Firebase are available', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-key'
+      })
 
       const header = await store.getAuthHeader()
 
@@ -216,7 +182,9 @@ describe('auth token priority chain', () => {
 
   describe('getAuthToken priority', () => {
     it('returns workspace token when workspace is active', async () => {
-      mockGetWorkspaceToken.mockReturnValue('workspace-raw-token')
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+        'workspace-raw-token'
+      )
 
       const token = await store.getAuthToken()
 
@@ -224,7 +192,9 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace token is not available', async () => {
-      mockGetWorkspaceToken.mockReturnValue(undefined)
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+        undefined
+      )
 
       const token = await store.getAuthToken()
 
@@ -233,12 +203,18 @@ describe('auth token priority chain', () => {
 
     it('keeps generic tokens user-scoped outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       const token = await store.getAuthToken()
 
-      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).not.toHaveBeenCalled()
       expect(token).toBe('firebase-token')
     })
   })
@@ -247,25 +223,39 @@ describe('auth token priority chain', () => {
     it('sends the stored API key for workspace calls in an API-key session', async () => {
       mockDistributionTypes.isCloud = false
       authStateCallback(null)
-      mockApiKeyState.isAuthenticated = true
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'comfyui-test' })
-      mockActiveWorkspaceId = 'workspace-123'
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'comfyui-test'
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
 
       await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
         'X-API-KEY': 'comfyui-test'
       })
-      expect(mockEnsureWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceAuthHeader)
+      ).not.toHaveBeenCalled()
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBeUndefined()
-      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).not.toHaveBeenCalled()
     })
 
     it('prefers the Firebase session over a stored API key for workspace calls', async () => {
       mockDistributionTypes.isCloud = false
-      mockApiKeyState.isAuthenticated = true
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'comfyui-test' })
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+      Object.assign(useApiKeyAuthStore(), { isAuthenticated: true })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'comfyui-test'
+      })
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(
+        useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+      ).mockResolvedValue({
         Authorization: 'Bearer workspace-token'
       })
 
@@ -276,11 +266,17 @@ describe('auth token priority chain', () => {
 
     it('uses selected workspace authentication outside Cloud', async () => {
       mockDistributionTypes.isCloud = false
-      mockActiveWorkspaceId = 'workspace-123'
-      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
+      vi.mocked(
+        useWorkspaceAuthStore().ensureWorkspaceAuthHeader
+      ).mockResolvedValue({
         Authorization: 'Bearer workspace-token'
       })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
         Authorization: 'Bearer workspace-token'
@@ -288,20 +284,28 @@ describe('auth token priority chain', () => {
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
       )
-      expect(mockEnsureWorkspaceAuthHeader).toHaveBeenCalledWith(
-        'workspace-123'
-      )
-      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceAuthHeader)
+      ).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).toHaveBeenCalledWith('workspace-123')
     })
 
     it('waits for workspace initialization before queue authentication', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'uninitialized'
-      mockInitializeWorkspaces.mockImplementation(async () => {
-        mockActiveWorkspaceId = 'workspace-123'
-        mockTeamWorkspaceInitState = 'ready'
-      })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      useTeamWorkspaceStore().initState = 'uninitialized'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-123'
+          })
+          useTeamWorkspaceStore().initState = 'ready'
+        }
+      )
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
         Authorization: 'Bearer firebase-token'
@@ -309,18 +313,28 @@ describe('auth token priority chain', () => {
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
       )
-      expect(mockInitializeWorkspaces).toHaveBeenCalledOnce()
-      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useTeamWorkspaceStore().initialize)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).toHaveBeenCalledWith('workspace-123')
     })
 
     it('waits for an in-flight workspace selection before queue authentication', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'loading'
-      mockInitializeWorkspaces.mockImplementation(async () => {
-        mockActiveWorkspaceId = 'workspace-123'
-        mockTeamWorkspaceInitState = 'ready'
-      })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      useTeamWorkspaceStore().initState = 'loading'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-123'
+          })
+          useTeamWorkspaceStore().initState = 'ready'
+        }
+      )
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
@@ -330,48 +344,66 @@ describe('auth token priority chain', () => {
 
     it('fails queue authentication closed after workspace initialization errors', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'uninitialized'
-      mockInitializeWorkspaces.mockRejectedValue(new Error('Network error'))
+      useTeamWorkspaceStore().initState = 'uninitialized'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockRejectedValue(
+        new Error('Network error')
+      )
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBeUndefined()
       expect(mockUser.getIdToken).not.toHaveBeenCalled()
-      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).not.toHaveBeenCalled()
     })
 
     it('retries queue authentication after a previous initialization error', async () => {
       mockDistributionTypes.isCloud = false
-      mockTeamWorkspaceInitState = 'error'
-      mockInitializeWorkspaces.mockImplementation(async () => {
-        mockActiveWorkspaceId = 'workspace-123'
-        mockTeamWorkspaceInitState = 'ready'
-      })
-      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+      useTeamWorkspaceStore().initState = 'error'
+      vi.mocked(useTeamWorkspaceStore().initialize).mockImplementation(
+        async () => {
+          Object.assign(useTeamWorkspaceStore(), {
+            activeWorkspaceId: 'workspace-123'
+          })
+          useTeamWorkspaceStore().initState = 'ready'
+        }
+      )
+      vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken).mockResolvedValue(
+        'workspace-raw-token'
+      )
 
       await expect(store.getWorkspaceAuthToken()).resolves.toBe(
         'workspace-raw-token'
       )
-      expect(mockInitializeWorkspaces).toHaveBeenCalledOnce()
-      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+      expect(
+        vi.mocked(useTeamWorkspaceStore().initialize)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().ensureWorkspaceToken)
+      ).toHaveBeenCalledWith('workspace-123')
     })
   })
 
   describe('unified login mint wiring', () => {
     it('mints the unified Cloud JWT when a cloud user signs in', () => {
       // beforeEach signs in mockUser via the onAuthStateChanged callback.
-      expect(mockMintAtLogin).toHaveBeenCalled()
+      expect(vi.mocked(useWorkspaceAuthStore().mintAtLogin)).toHaveBeenCalled()
     })
 
     it('does not mint on sign-out', () => {
-      mockMintAtLogin.mockClear()
+      vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockClear()
       authStateCallback(null)
-      expect(mockMintAtLogin).not.toHaveBeenCalled()
-      expect(mockClearWorkspaceContext).toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().mintAtLogin)
+      ).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext)
+      ).toHaveBeenCalled()
     })
 
     it('clears account-scoped state before minting for a different user', () => {
-      mockClearWorkspaceContext.mockClear()
-      mockResetForIdentityChange.mockClear()
-      mockMintAtLogin.mockClear()
+      vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockClear()
+      vi.mocked(useTeamWorkspaceStore().resetForIdentityChange).mockClear()
+      vi.mocked(useWorkspaceAuthStore().mintAtLogin).mockClear()
       const nextUser = {
         ...mockUser,
         uid: 'different-user-id',
@@ -380,22 +412,36 @@ describe('auth token priority chain', () => {
 
       authStateCallback(nextUser)
 
-      expect(mockClearWorkspaceContext).toHaveBeenCalledOnce()
-      expect(mockResetForIdentityChange).toHaveBeenCalledOnce()
-      expect(mockMintAtLogin).toHaveBeenCalledOnce()
       expect(
-        mockClearWorkspaceContext.mock.invocationCallOrder[0]
-      ).toBeLessThan(mockMintAtLogin.mock.invocationCallOrder[0])
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useTeamWorkspaceStore().resetForIdentityChange)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().mintAtLogin)
+      ).toHaveBeenCalledOnce()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mock
+          .invocationCallOrder[0]
+      ).toBeLessThan(
+        vi.mocked(useWorkspaceAuthStore().mintAtLogin).mock
+          .invocationCallOrder[0]
+      )
     })
 
     it('keeps account-scoped state for a repeated callback with the same uid', () => {
-      mockClearWorkspaceContext.mockClear()
-      mockResetForIdentityChange.mockClear()
+      vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext).mockClear()
+      vi.mocked(useTeamWorkspaceStore().resetForIdentityChange).mockClear()
 
       authStateCallback({ ...mockUser })
 
-      expect(mockClearWorkspaceContext).not.toHaveBeenCalled()
-      expect(mockResetForIdentityChange).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().clearWorkspaceContext)
+      ).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useTeamWorkspaceStore().resetForIdentityChange)
+      ).not.toHaveBeenCalled()
     })
   })
 
@@ -405,35 +451,49 @@ describe('auth token priority chain', () => {
     })
 
     it('getAuthHeader returns only the unified Cloud JWT, never Firebase or API key', async () => {
-      mockUnifiedToken = 'unified-jwt'
+      useWorkspaceAuthStore().unifiedToken = 'unified-jwt'
       // Even with the legacy sources available, the unified branch wins.
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader).mockReturnValue(
+        {
+          Authorization: 'Bearer workspace-token'
+        }
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-key'
       })
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
 
       const header = await store.getAuthHeader()
 
       expect(header).toEqual({ Authorization: 'Bearer unified-jwt' })
-      expect(mockWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useWorkspaceAuthStore().getWorkspaceAuthHeader)
+      ).not.toHaveBeenCalled()
       expect(mockUser.getIdToken).not.toHaveBeenCalled()
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
     })
 
     it('getAuthHeader returns null when the unified token is empty and does not fall back', async () => {
-      mockUnifiedToken = null
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
+      useWorkspaceAuthStore().unifiedToken = null
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-key'
+      })
 
       const header = await store.getAuthHeader()
 
       expect(header).toBeNull()
       expect(mockUser.getIdToken).not.toHaveBeenCalled()
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
     })
 
     it('getAuthToken returns the unified Cloud JWT, never the Firebase token', async () => {
-      mockUnifiedToken = 'unified-jwt'
-      mockGetWorkspaceToken.mockReturnValue('workspace-raw-token')
+      useWorkspaceAuthStore().unifiedToken = 'unified-jwt'
+      vi.mocked(useWorkspaceAuthStore().getWorkspaceToken).mockReturnValue(
+        'workspace-raw-token'
+      )
 
       const token = await store.getAuthToken()
 
@@ -442,7 +502,7 @@ describe('auth token priority chain', () => {
     })
 
     it('getAuthToken returns undefined when the unified token is empty and does not fall back', async () => {
-      mockUnifiedToken = null
+      useWorkspaceAuthStore().unifiedToken = null
 
       const token = await store.getAuthToken()
 

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -1,32 +1,12 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useDialogStore } from '@/stores/dialogStore'
+import { api } from '@/scripts/api'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
-
-const dialogStack = vi.hoisted(() => [] as unknown[])
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ dialogStack })
-}))
-
-const settings = vi.hoisted(() => {
-  const values = new Map<string, unknown>()
-  return {
-    values,
-    get: (key: string) => values.get(key),
-    set: vi.fn((key: string, value: unknown) => {
-      values.set(key, value)
-      return Promise.resolve()
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settings
-}))
 
 /**
  * Real nodes carry `pos`/`size`; `boundingRect` is litegraph-renderer cache that
@@ -64,10 +44,7 @@ function stubCanvas(nodes: unknown[], selected: unknown[] = []) {
 describe('agentNodeSelectionStore', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    dialogStack.length = 0
-    settings.values.clear()
-    settings.set.mockClear()
-    setActivePinia(createPinia())
+    vi.spyOn(api, 'storeSetting').mockResolvedValue(new Response())
   })
 
   afterEach(() => {
@@ -93,20 +70,20 @@ describe('agentNodeSelectionStore', () => {
   // Flipping the setting rather than overriding the minimap is what keeps the
   // user's own toggle working while they pick.
   it('turns a visible minimap off on entry and back on when leaving', async () => {
-    settings.values.set('Comfy.Minimap.Visible', true)
+    useSettingStore().settingValues['Comfy.Minimap.Visible'] = true
     const store = useAgentNodeSelectionStore()
 
     store.enter()
     await nextTick()
-    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(false)
+    expect(useSettingStore().get('Comfy.Minimap.Visible')).toBe(false)
 
     store.exit()
     await nextTick()
-    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(true)
+    expect(useSettingStore().get('Comfy.Minimap.Visible')).toBe(true)
   })
 
   it('leaves the minimap setting alone when it was already off', async () => {
-    settings.values.set('Comfy.Minimap.Visible', false)
+    useSettingStore().settingValues['Comfy.Minimap.Visible'] = false
     const store = useAgentNodeSelectionStore()
 
     store.enter()
@@ -114,8 +91,8 @@ describe('agentNodeSelectionStore', () => {
     store.exit()
     await nextTick()
 
-    expect(settings.set).not.toHaveBeenCalled()
-    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(false)
+    expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalled()
+    expect(useSettingStore().get('Comfy.Minimap.Visible')).toBe(false)
   })
 
   it('clears the canvas selection on exit', () => {
@@ -234,11 +211,12 @@ describe('agentNodeSelectionStore', () => {
     store.enter()
     await nextTick()
 
-    dialogStack.push({})
+    useDialogStore().showDialog({ key: 'test', component: {} })
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     expect(store.isActive).toBe(true)
 
-    dialogStack.length = 0
+    useDialogStore().dialogStack.length = 0
+    await nextTick()
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     expect(store.isActive).toBe(false)
   })

--- a/src/stores/apiKeyAuthStore.integration.test.ts
+++ b/src/stores/apiKeyAuthStore.integration.test.ts
@@ -1,7 +1,6 @@
 import type { User } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
-import { disposePinia, getActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
@@ -26,28 +25,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
     flags: { unifiedCloudAuthEnabled: false }
   })
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({
-      clearWorkspaceContext: vi.fn(),
-      getWorkspaceAuthHeader: vi.fn().mockReturnValue(null),
-      getUnifiedToken: vi.fn().mockReturnValue(undefined),
-      mintAtLogin: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      activeWorkspaceId: null,
-      resetForIdentityChange: vi.fn()
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackAuth: vi.fn() })
@@ -77,11 +54,6 @@ describe('API key authentication initialization', () => {
       }
     )
     vi.mocked(firebaseAuth.onIdTokenChanged).mockReturnValue(vi.fn())
-  })
-
-  afterEach(() => {
-    const pinia = getActivePinia()
-    if (pinia) disposePinia(pinia)
   })
 
   const customerResponse = (id: string) => ({

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -1,3 +1,6 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { api } from '@/scripts/api'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -60,36 +63,8 @@ vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
   resolveNode: mockResolveNode
 }))
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => ({ read_only: false })
-    })
-  })
-)
-
 vi.mock(import('@/components/builder/useEmptyWorkflowDialog'), () => ({
   useEmptyWorkflowDialog: () => mockEmptyWorkflowDialog
-}))
-
-const mockSettings = vi.hoisted(() => {
-  const store: Record<string, unknown> = {}
-  return {
-    store,
-    get: vi.fn((key: string) => store[key] ?? false),
-    set: vi.fn(async (key: string, value: unknown) => {
-      store[key] = value
-    }),
-    reset() {
-      for (const key of Object.keys(store)) delete store[key]
-    }
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => mockSettings
 }))
 
 import { useAppModeStore } from './appModeStore'
@@ -168,7 +143,10 @@ describe('appModeStore', () => {
     vi.mocked(app.rootGraph).extra = {}
     ChangeTracker.isLoadingGraph = false
     mockResolveNode.mockReturnValue(undefined)
-    mockSettings.reset()
+    vi.spyOn(api, 'storeSetting').mockResolvedValue(new Response())
+    vi.mocked(useCanvasStore().getCanvas).mockReturnValue(
+      fromPartial({ read_only: false })
+    )
     vi.mocked(app.rootGraph).nodes = [{ id: toNodeId(1) } as LGraphNode]
     workflowStore = useWorkflowStore()
     store = useAppModeStore()
@@ -928,34 +906,36 @@ describe('appModeStore', () => {
 
   describe('autoEnableVueNodes', () => {
     it('enables Vue nodes when entering select mode with them disabled', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
       await nextTick()
 
-      expect(mockSettings.set).toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         true
       )
     })
 
     it('does not enable Vue nodes when already enabled', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = true
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
       await nextTick()
 
-      expect(mockSettings.set).not.toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         expect.anything()
       )
     })
 
     it('shows popup when Vue nodes are switched on and not dismissed', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
-      mockSettings.store['Comfy.AppBuilder.VueNodeSwitchDismissed'] = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues[
+        'Comfy.AppBuilder.VueNodeSwitchDismissed'
+      ] = false
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
@@ -965,8 +945,10 @@ describe('appModeStore', () => {
     })
 
     it('does not show popup when previously dismissed', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
-      mockSettings.store['Comfy.AppBuilder.VueNodeSwitchDismissed'] = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues[
+        'Comfy.AppBuilder.VueNodeSwitchDismissed'
+      ] = true
       workflowStore.activeWorkflow = createBuilderWorkflow('graph')
 
       store.enterBuilder()
@@ -976,14 +958,14 @@ describe('appModeStore', () => {
     })
 
     it('does not enable Vue nodes when entering builder:arrange', async () => {
-      mockSettings.store['Comfy.VueNodes.Enabled'] = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       workflowStore.activeWorkflow = createBuilderWorkflowWithOutputs('app')
 
       store.enterBuilder()
       await nextTick()
 
       expect(workflowStore.activeWorkflow.activeMode).toBe('builder:arrange')
-      expect(mockSettings.set).not.toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         expect.anything()
       )

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -3,11 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, watch } from 'vue'
 
 import { useAssetsStore } from '@/stores/assetsStore'
+import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
 import type {
   AssetItem,
   AssetResponse
 } from '@/platform/assets/schemas/assetSchema'
-import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { assetService } from '@/platform/assets/services/assetService'
 
 // Mock the api module
@@ -44,116 +44,29 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-// Mock modelToNodeStore with proper node providers and category lookups
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getAllNodeProviders: vi.fn((category: string) => {
-      const providers: Record<
-        string,
-        Array<{ nodeDef: { name: string }; key: string }>
-      > = {
-        checkpoints: [
-          { nodeDef: { name: 'CheckpointLoaderSimple' }, key: 'ckpt_name' },
-          { nodeDef: { name: 'ImageOnlyCheckpointLoader' }, key: 'ckpt_name' }
-        ],
-        loras: [
-          { nodeDef: { name: 'LoraLoader' }, key: 'lora_name' },
-          { nodeDef: { name: 'LoraLoaderModelOnly' }, key: 'lora_name' }
-        ],
-        vae: [{ nodeDef: { name: 'VAELoader' }, key: 'vae_name' }]
-      }
-      return providers[category] ?? []
-    }),
-    getCategoryForNodeType: vi.fn((nodeType: string) => {
-      const nodeToCategory: Record<string, string> = {
-        CheckpointLoaderSimple: 'checkpoints',
-        ImageOnlyCheckpointLoader: 'checkpoints',
-        LoraLoader: 'loras',
-        LoraLoaderModelOnly: 'loras',
-        VAELoader: 'vae'
-      }
-      return nodeToCategory[nodeType]
-    }),
-    getNodeProvider: vi.fn(),
-    registerDefaults: vi.fn()
-  })
-}))
-
-type MockOutput = {
-  supportsPreview: boolean
-  filename: string
-  subfolder: string
-  type: string
-  url: string
-}
-
-// Per-test override for mock outputs (defaults to single output)
-const mockOutputOverrides = vi.hoisted(() => ({
-  value: null as MockOutput[] | null
-}))
-
-// Mock TaskItemImpl
-const PREVIEWABLE_MEDIA_TYPES = new Set(['images', 'video', 'audio'])
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  TaskItemImpl: class {
-    public flatOutputs: Array<{
-      supportsPreview: boolean
-      filename: string
-      subfolder: string
-      type: string
-      url: string
-    }>
-    public previewOutput:
-      | {
-          supportsPreview: boolean
-          filename: string
-          subfolder: string
-          type: string
-          url: string
-        }
-      | undefined
-    public jobId: string
-    public outputsCount: number | null
-    public previewableOutputsCount: number | undefined
-
-    constructor(public job: JobListItem) {
-      this.jobId = job.id
-      this.outputsCount = job.outputs_count ?? null
-      this.previewableOutputsCount = job.previewable_outputs_count ?? undefined
-      if (mockOutputOverrides.value) {
-        this.flatOutputs = mockOutputOverrides.value
-        const previewable = mockOutputOverrides.value.filter(
-          (o) => o.supportsPreview
-        )
-        this.previewOutput =
-          previewable.findLast((o) => o.type === 'output') ?? previewable.at(-1)
-      } else {
-        const preview = job.preview_output
-        const isPreviewable =
-          !!preview?.filename && PREVIEWABLE_MEDIA_TYPES.has(preview.mediaType)
-        if (preview && isPreviewable) {
-          const item = {
-            supportsPreview: true,
-            filename: preview.filename!,
-            subfolder: preview.subfolder ?? '',
-            type: preview.type ?? 'output',
-            url: `http://test.com/${preview.filename}`
-          }
-          this.flatOutputs = [item]
-          this.previewOutput = item
-        } else {
-          this.flatOutputs = []
-          this.previewOutput = undefined
-        }
-      }
-    }
-
-    get previewableOutputs() {
-      return this.flatOutputs.filter((o) => o.supportsPreview)
-    }
-  }
-}))
+beforeEach(() => {
+  useNodeDefStore().nodeDefsByName = Object.fromEntries(
+    [
+      'CheckpointLoaderSimple',
+      'ImageOnlyCheckpointLoader',
+      'LoraLoader',
+      'LoraLoaderModelOnly',
+      'VAELoader'
+    ].map((name) => [
+      name,
+      new ComfyNodeDefImpl({
+        name,
+        display_name: name,
+        description: '',
+        input: {},
+        output: [],
+        category: 'loaders',
+        python_module: 'nodes',
+        output_node: false
+      })
+    ])
+  )
+})
 
 // Mock asset mappers - add unique timestamps
 vi.mock<unknown>(

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1,3 +1,5 @@
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { FirebaseError } from 'firebase/app'
 import type { User, UserCredential } from 'firebase/auth'
 import * as firebaseAuth from 'firebase/auth'
@@ -40,18 +42,6 @@ const { mockFeatureFlags } = vi.hoisted(() => ({
 const { mockResetSocket } = vi.hoisted(() => ({
   mockResetSocket: vi.fn()
 }))
-
-const mockTeamWorkspaceStore = vi.hoisted(() => ({
-  activeWorkspaceId: null as string | null,
-  resetForIdentityChange: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => mockTeamWorkspaceStore
-  })
-)
 
 type MockUser = Omit<User, 'getIdToken' | 'delete'> & {
   getIdToken: Mock
@@ -132,18 +122,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
 }))
 
 // Mock apiKeyAuthStore
-const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
-const mockApiKeyGetApiKey = vi.fn()
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => ({
-    getAuthHeader: mockApiKeyGetAuthHeader,
-    getApiKey: mockApiKeyGetApiKey,
-    currentUser: null,
-    isAuthenticated: false,
-    storeApiKey: vi.fn(),
-    clearStoredApiKey: vi.fn()
-  })
-}))
 
 describe('useAuthStore', () => {
   let store: ReturnType<typeof useAuthStore>
@@ -217,10 +195,11 @@ describe('useAuthStore', () => {
     mockUser.getIdToken.mockResolvedValue('mock-id-token')
 
     // Default: no API key auth
-    mockApiKeyGetAuthHeader.mockReturnValue(null)
-    mockApiKeyGetApiKey.mockReturnValue(null)
-    mockTeamWorkspaceStore.activeWorkspaceId = null
-    mockTeamWorkspaceStore.resetForIdentityChange.mockReset()
+    vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
+    vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(null)
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: null
+    })
   })
 
   describe('token refresh events', () => {
@@ -333,8 +312,10 @@ describe('useAuthStore', () => {
   describe('user-scoped billing endpoints with API-key sessions', () => {
     beforeEach(() => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
-      mockApiKeyGetApiKey.mockReturnValue('test-api-key')
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-api-key'
+      })
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue('test-api-key')
     })
 
     it('fetchBalance sends the stored API key when no Firebase user exists', async () => {
@@ -350,7 +331,7 @@ describe('useAuthStore', () => {
     })
 
     it('fetchBalance throws userNotAuthenticated when neither credential exists', async () => {
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.fetchBalance()).rejects.toMatchObject({
         name: 'AuthStoreError',
@@ -368,7 +349,9 @@ describe('useAuthStore', () => {
       )
 
       const request = store.fetchBalance()
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
       resolveBalance({ ok: true, json: () => Promise.resolve({ balance: 7 }) })
 
       await expect(request).resolves.toBeNull()
@@ -388,7 +371,9 @@ describe('useAuthStore', () => {
           })
         })
       )
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
     })
 
     it('initiateCreditPurchase sends the stored API key when no Firebase user exists', async () => {
@@ -439,7 +424,7 @@ describe('useAuthStore', () => {
     })
 
     it('accessBillingPortal throws userNotAuthenticated when neither credential exists', async () => {
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.accessBillingPortal()).rejects.toMatchObject({
         name: 'AuthStoreError',
@@ -466,8 +451,10 @@ describe('useAuthStore', () => {
       const payload = { amount_micros: 5_000_000, currency: 'usd' }
 
       await store.initiateCreditPurchase(payload)
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       await store.initiateCreditPurchase(payload)
@@ -505,8 +492,10 @@ describe('useAuthStore', () => {
 
       const request = store.accessBillingPortal()
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreate(mockCreateCustomerResponse)
@@ -533,8 +522,10 @@ describe('useAuthStore', () => {
         currency: 'usd'
       })
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreate(mockCreateCustomerResponse)
@@ -565,8 +556,10 @@ describe('useAuthStore', () => {
 
       const request = store.accessBillingPortal()
       await billingRequestStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveBilling({
@@ -603,8 +596,10 @@ describe('useAuthStore', () => {
         currency: 'usd'
       })
       await creditRequestStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCredit({
@@ -635,8 +630,10 @@ describe('useAuthStore', () => {
 
       const request = store.createCustomer()
       await createRequestStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreate(mockCreateCustomerResponse)
@@ -669,8 +666,10 @@ describe('useAuthStore', () => {
 
       const request = store.accessBillingPortal()
       await bodyParsingStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolvePortalBody({ billing_portal_url: 'https://stripe.test/portal' })
@@ -708,8 +707,10 @@ describe('useAuthStore', () => {
         currency: 'usd'
       })
       await bodyParsingStarted
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
       resolveCreditBody({ checkout_url: 'https://stripe.test/checkout' })
@@ -732,8 +733,10 @@ describe('useAuthStore', () => {
     }
 
     const switchToAnotherApiKey = () => {
-      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
-      mockApiKeyGetAuthHeader.mockReturnValue({
+      vi.mocked(useApiKeyAuthStore().getApiKey).mockReturnValue(
+        'another-api-key'
+      )
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
         'X-API-KEY': 'another-api-key'
       })
     }
@@ -1184,7 +1187,9 @@ describe('useAuthStore', () => {
 
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       const ensureSpy = vi
         .spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader')
@@ -1199,7 +1204,9 @@ describe('useAuthStore', () => {
 
     it('fails closed (no personal Firebase downgrade) when recovery yields no token', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       vi.spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader').mockResolvedValue(
         null
@@ -1213,7 +1220,9 @@ describe('useAuthStore', () => {
 
     it('falls back to Firebase when workspace mode is not yet initialized', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = null
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: null
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       const ensureSpy = vi.spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader')
 
@@ -1227,7 +1236,9 @@ describe('useAuthStore', () => {
   describe('getAuthToken workspace recovery', () => {
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       const ensureSpy = vi
         .spyOn(workspaceAuth, 'ensureWorkspaceToken')
         .mockResolvedValue('recovered-ws-token')
@@ -1241,7 +1252,9 @@ describe('useAuthStore', () => {
 
     it('fails closed (no personal Firebase downgrade) when recovery yields no token', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: 'workspace-123'
+      })
       vi.spyOn(workspaceAuth, 'ensureWorkspaceToken').mockResolvedValue(null)
 
       const token = await store.getAuthToken()
@@ -1252,7 +1265,9 @@ describe('useAuthStore', () => {
 
     it('falls back to Firebase when workspace mode is not yet initialized', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      mockTeamWorkspaceStore.activeWorkspaceId = null
+      Object.assign(useTeamWorkspaceStore(), {
+        activeWorkspaceId: null
+      })
       vi.spyOn(workspaceAuth, 'getWorkspaceToken').mockReturnValue(undefined)
       const ensureSpy = vi.spyOn(workspaceAuth, 'ensureWorkspaceToken')
 
@@ -1619,7 +1634,7 @@ describe('useAuthStore', () => {
 
     it('throws AuthStoreError when not authenticated', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.getAuthHeaderOrThrow()).rejects.toMatchObject({
         name: 'AuthStoreError',
@@ -1662,7 +1677,9 @@ describe('useAuthStore', () => {
 
     it('should use API key auth when no Firebase user is present', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-api-key'
+      })
 
       const result = await store.createCustomer()
 
@@ -1695,16 +1712,20 @@ describe('useAuthStore', () => {
 
     it('should not fall back to API key when Firebase token retrieval fails', async () => {
       mockUser.getIdToken.mockResolvedValue(undefined)
-      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue({
+        'X-API-KEY': 'test-api-key'
+      })
 
       await expect(store.createCustomer()).rejects.toThrow()
-      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useApiKeyAuthStore().getAuthHeader)
+      ).not.toHaveBeenCalled()
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('should throw when no auth method is available', async () => {
       authStateCallback(null)
-      mockApiKeyGetAuthHeader.mockReturnValue(null)
+      vi.mocked(useApiKeyAuthStore().getAuthHeader).mockReturnValue(null)
 
       await expect(store.createCustomer()).rejects.toThrow()
       expect(mockFetch).not.toHaveBeenCalled()

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,7 +1,9 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useUserStore } from '@/stores/userStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { AxiosResponse } from 'axios'
 import { AxiosError } from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import { mergeCustomNodesI18n } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -10,59 +12,21 @@ import { api } from '@/scripts/api'
 
 import { useBootstrapStore } from './bootstrapStore'
 
-vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: {
+vi.mock(import('firebase/auth'))
+vi.mock(import('@/scripts/api'), async (importOriginal) => {
+  const actual = await importOriginal()
+  Object.assign(actual.api, {
     init: vi.fn().mockResolvedValue(undefined),
     getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
     getUserConfig: vi.fn().mockResolvedValue({})
-  }
-}))
-
-vi.mock(import('@/i18n'), () => ({
-  mergeCustomNodesI18n: vi.fn()
-}))
-
-const mockIsSettingsReady = ref(false)
-const mockSettingLoad = vi.hoisted(() => vi.fn(() => Promise.resolve()))
-const mockWorkflowLoad = vi.hoisted(() => vi.fn(() => Promise.resolve()))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    load: mockSettingLoad,
-    get isReady() {
-      return mockIsSettingsReady.value
-    },
-    isLoading: ref(false),
-    error: ref(undefined)
-  }))
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      loadWorkflows: mockWorkflowLoad,
-      syncWorkflows: vi.fn().mockResolvedValue(undefined)
-    }))
   })
-)
+  return actual
+})
 
-const mockNeedsLogin = ref(false)
-vi.mock<unknown>(import('@/stores/userStore'), () => ({
-  useUserStore: vi.fn(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin
-  }))
-}))
-
-const mockIsAuthInitialized = ref(false)
-const mockIsAuthAuthenticated = ref(false)
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({
-    isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated
-  }))
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  mergeCustomNodesI18n: vi.fn()
 }))
 
 const mockDistributionTypes = vi.hoisted(() => ({
@@ -87,16 +51,18 @@ function requestFailure(status: number) {
 
 describe('bootstrapStore', () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false
-    mockIsAuthInitialized.value = false
-    mockIsAuthAuthenticated.value = false
-    mockNeedsLogin.value = false
+    useSettingStore().isReady = false
+    useAuthStore().isInitialized = false
+    Object.assign(useAuthStore(), { isAuthenticated: false })
+    Object.assign(useUserStore(), { needsLogin: false })
     mockDistributionTypes.isCloud = false
-    mockSettingLoad.mockImplementation(() => {
-      mockIsSettingsReady.value = true
+    vi.mocked(useSettingStore().load).mockImplementation(() => {
+      useSettingStore().isReady = true
       return Promise.resolve()
     })
-    mockWorkflowLoad.mockResolvedValue(undefined)
+    vi.mocked(useWorkflowStore().loadWorkflows).mockResolvedValue(undefined)
+    vi.mocked(useWorkflowStore().syncWorkflows).mockResolvedValue(undefined)
+    vi.mocked(useUserStore().initialize).mockResolvedValue(undefined)
   })
 
   it('initializes with all flags false', () => {
@@ -118,8 +84,12 @@ describe('bootstrapStore', () => {
   })
 
   it('records both store phases when their loads reject', async () => {
-    mockSettingLoad.mockRejectedValueOnce(new Error('settings failed'))
-    mockWorkflowLoad.mockRejectedValueOnce(new Error('workflows failed'))
+    vi.mocked(useSettingStore().load).mockRejectedValueOnce(
+      new Error('settings failed')
+    )
+    vi.mocked(useWorkflowStore().loadWorkflows).mockRejectedValueOnce(
+      new Error('workflows failed')
+    )
     const milestone = vi.spyOn(bootstrapTracer, 'milestone')
     const previousPhaseCount = bootstrapTracer.summary().length
     const store = useBootstrapStore()
@@ -182,7 +152,7 @@ describe('bootstrapStore', () => {
       // Firebase resolves with no user (signed-out) — bootstrap must unblock.
       // Previously it also waited for isAuthenticated, which made every
       // signed-out load wait 35s and fire a false Sentry timeout.
-      mockIsAuthInitialized.value = true
+      useAuthStore().isInitialized = true
       await bootstrapPromise
 
       await vi.waitFor(() => {
@@ -203,7 +173,7 @@ describe('bootstrapStore', () => {
         expect(settingStore.isReady).toBe(false)
 
         // Firebase resolves during the retry backoff.
-        mockIsAuthInitialized.value = true
+        useAuthStore().isInitialized = true
         await vi.advanceTimersByTimeAsync(3_001)
         await bootstrapPromise
 

--- a/src/stores/commandStore.test.ts
+++ b/src/stores/commandStore.test.ts
@@ -17,12 +17,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/keybindings/keybindingStore'), () => ({
-  useKeybindingStore: () => ({
-    getKeybindingByCommandId: () => null
-  })
-}))
-
 describe('commandStore', () => {
   describe('registerCommand', () => {
     it('registers a command by id', () => {

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -1,6 +1,5 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromAny } from '@total-typescript/shoehorn'
-import { createTestingPinia } from '@pinia/testing'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
@@ -24,14 +23,6 @@ vi.mock(import('@/i18n'), () => ({
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
-}))
-
-const mockShowErrorsTab = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => mockShowErrorsTab.value)
-  }))
 }))
 
 vi.mock<unknown>(
@@ -624,7 +615,7 @@ describe('executionErrorStore — node error operations', () => {
 
 describe('surfaceMissingModels — silent option', () => {
   beforeEach(() => {
-    mockShowErrorsTab.value = true
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] = true
   })
 
   it('opens error overlay when silent is not specified and setting is enabled', () => {
@@ -691,7 +682,7 @@ describe('surfaceMissingModels — silent option', () => {
 
 describe('surfaceMissingMedia — silent option', () => {
   beforeEach(() => {
-    mockShowErrorsTab.value = true
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] = true
   })
 
   it('opens error overlay when silent is not specified and setting is enabled', () => {
@@ -821,8 +812,6 @@ describe('clearRunErrors', () => {
   let missingNodesStore: ReturnType<typeof useMissingNodesErrorStore>
 
   beforeEach(() => {
-    const pinia = createPinia()
-    setActivePinia(pinia)
     executionErrorStore = useExecutionErrorStore()
     missingNodesStore = useMissingNodesErrorStore()
   })
@@ -874,10 +863,6 @@ describe('clearRunErrors', () => {
 })
 
 describe('added-node error scan coordination', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('keeps overlapping scans isolated by graph until every scan finishes', () => {
     const store = useExecutionErrorStore()
     const graphA = createTestRootGraph()
@@ -914,10 +899,6 @@ describe('setActiveGraph', () => {
       'KSampler'
     )
   }
-
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
 
   it('keeps each graph run errors separate and restores them on return', () => {
     const store = useExecutionErrorStore()

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1,3 +1,6 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -6,30 +9,22 @@ import { api } from '@/scripts/api'
 import { MAX_PROGRESS_JOBS, useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
-import { createNodeLocatorId } from '@/types/nodeIdentification'
+import {
+  createNodeExecutionId,
+  createNodeLocatorId
+} from '@/types/nodeIdentification'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { NodeProgressState } from '@/schemas/apiSchema'
 
 const {
-  mockNodeIdToNodeLocatorId,
-  mockNodeLocatorIdToNodeExecutionId,
-  mockExecutionIdToCurrentId,
-  mockActiveWorkflow,
-  mockOpenWorkflows,
   mockShowTextPreview,
   mockTrackExecutionError,
   mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
   mockTrackSharedWorkflowRun
 } = await vi.hoisted(async () => {
-  const { shallowRef } = await import('vue')
   return {
-    mockNodeIdToNodeLocatorId: vi.fn(),
-    mockNodeLocatorIdToNodeExecutionId: vi.fn(),
-    mockExecutionIdToCurrentId: vi.fn(),
-    mockActiveWorkflow: shallowRef<{ path?: string } | null>(null),
-    mockOpenWorkflows: shallowRef<{ path: string }[]>([]),
     mockShowTextPreview: vi.fn(),
     mockTrackExecutionError: vi.fn(),
     mockTrackExecutionOutcome: vi.fn(),
@@ -57,25 +52,6 @@ beforeEach(() => {
 })
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { toNodeId } from '@/types/nodeId'
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      nodeIdToNodeLocatorId: mockNodeIdToNodeLocatorId,
-      nodeLocatorIdToNodeExecutionId: mockNodeLocatorIdToNodeExecutionId,
-      executionIdToCurrentId: mockExecutionIdToCurrentId,
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      },
-      get openWorkflows() {
-        return mockOpenWorkflows.value
-      },
-      isOpen: (workflow: { path?: string }) =>
-        mockOpenWorkflows.value.some((w) => w.path === workflow.path)
-    }))
-  })
-)
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: true
@@ -126,18 +102,6 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    revokePreviewsByExecutionId: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/jobPreviewStore'), () => ({
-  useJobPreviewStore: () => ({
-    clearPreview: vi.fn()
-  })
-}))
-
 // Mock the app import with proper implementation
 vi.mock<unknown>(import('@/scripts/app'), () => {
   const rootGraph = {
@@ -155,18 +119,19 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
 })
 
 beforeEach(() => {
-  mockActiveWorkflow.value = null
-  mockOpenWorkflows.value = []
+  useWorkflowStore().activeWorkflow = null
+  Object.assign(useWorkflowStore(), { openWorkflows: [] })
+  vi.mocked(useWorkflowStore().isOpen).mockImplementation((workflow) =>
+    useWorkflowStore().openWorkflows.some((open) => open.path === workflow.path)
+  )
 })
 
 function createQueuedWorkflow(path: string = 'workflows/test.json') {
-  return {
+  return fromPartial<LoadedComfyWorkflow>({
     activeState: { id: 'workflow-id' },
     initialState: { id: 'workflow-id' },
     path
-  } as Parameters<
-    ReturnType<typeof useExecutionStore>['storeJob']
-  >[0]['workflow']
+  })
 }
 
 function createPromptNode(title: string, classType: string) {
@@ -244,12 +209,19 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
         'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         toNodeId(456)
       )
-      const mockExecutionId = '123:456'
-      mockNodeLocatorIdToNodeExecutionId.mockReturnValue(mockExecutionId)
+      const mockExecutionId = createNodeExecutionId([
+        toNodeId(123),
+        toNodeId(456)
+      ])
+      vi.mocked(
+        useWorkflowStore().nodeLocatorIdToNodeExecutionId
+      ).mockReturnValue(mockExecutionId)
 
       const result = store.nodeLocatorIdToExecutionId(locatorId)
 
-      expect(mockNodeLocatorIdToNodeExecutionId).toHaveBeenCalledWith(locatorId)
+      expect(
+        vi.mocked(useWorkflowStore().nodeLocatorIdToNodeExecutionId)
+      ).toHaveBeenCalledWith(locatorId)
       expect(result).toBe(mockExecutionId)
     })
 
@@ -258,7 +230,9 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
         'unknown-subgraph-id',
         toNodeId(456)
       )
-      mockNodeLocatorIdToNodeExecutionId.mockReturnValue(null)
+      vi.mocked(
+        useWorkflowStore().nodeLocatorIdToNodeExecutionId
+      ).mockReturnValue(null)
 
       const result = store.nodeLocatorIdToExecutionId(locatorId)
 
@@ -619,7 +593,7 @@ describe('useExecutionStore - workflowStatus', () => {
 
   beforeEach(() => {
     apiEventHandlers.clear()
-    mockOpenWorkflows.value = [workflowA, workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowA, workflowB] })
     store = useExecutionStore()
     store.bindExecutionEvents()
   })
@@ -881,7 +855,7 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionSuccess('job-a')
     fireExecutionSuccess('job-b')
 
-    mockOpenWorkflows.value = [workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowB] })
     await nextTick()
 
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
@@ -894,7 +868,7 @@ describe('useExecutionStore - workflowStatus', () => {
     expect(store.getWorkflowStatus(workflowA)).toBe('running')
 
     // Close the tab while the job is still running.
-    mockOpenWorkflows.value = [workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowB] })
     await nextTick()
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
 
@@ -1072,7 +1046,7 @@ describe('useExecutionStore - background workflow error routing', () => {
 
   beforeEach(() => {
     apiEventHandlers.clear()
-    mockOpenWorkflows.value = [workflowA, workflowB]
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflowA, workflowB] })
     store = useExecutionStore()
     errorStore = useExecutionErrorStore()
     store.bindExecutionEvents()
@@ -1213,7 +1187,9 @@ describe('useExecutionStore - background workflow error routing', () => {
 
   it('buffers a mapped job with an ambiguous path until storeJob', () => {
     const duplicateWorkflow = makeWorkflow('/workflows/c.json', graphBId)
-    mockOpenWorkflows.value = [workflowA, workflowB, duplicateWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [workflowA, workflowB, duplicateWorkflow]
+    })
     store.registerJobWorkflowIdMapping('job-ambiguous', graphBId)
 
     fireExecutionError('job-ambiguous')
@@ -1334,13 +1310,17 @@ describe('useExecutionStore - progress_text startup guard', () => {
     useCanvasStore().canvas = {
       graph: { getNodeById: vi.fn() }
     } as unknown as LGraphCanvas
-    mockExecutionIdToCurrentId.mockReturnValue(undefined)
+    vi.mocked(useWorkflowStore().executionIdToCurrentId).mockReturnValue(
+      undefined
+    )
 
     expect(() =>
       fireProgressText({ nodeId: toNodeId('1:2'), text: 'warming up' })
     ).not.toThrow()
 
-    expect(mockExecutionIdToCurrentId).toHaveBeenCalledWith('1:2')
+    expect(
+      vi.mocked(useWorkflowStore().executionIdToCurrentId)
+    ).toHaveBeenCalledWith('1:2')
     expect(mockShowTextPreview).not.toHaveBeenCalled()
   })
 })
@@ -2267,10 +2247,10 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
   function storeVisibleJob(jobId: string) {
     const workflow = createQueuedWorkflow()
-    mockActiveWorkflow.value = workflow
-    mockOpenWorkflows.value = [workflow]
+    useWorkflowStore().activeWorkflow = workflow
+    Object.assign(useWorkflowStore(), { openWorkflows: [workflow] })
     useExecutionErrorStore().setActiveGraph(
-      workflow.activeState!.id!,
+      workflow.activeState.id!,
       workflow.path
     )
     store.storeJob({

--- a/src/stores/jobPreviewStore.test.ts
+++ b/src/stores/jobPreviewStore.test.ts
@@ -1,19 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useJobPreviewStore } from '@/stores/jobPreviewStore'
 import { releaseSharedObjectUrl } from '@/utils/objectUrlUtil'
-
-const previewMethodRef = ref('latent2rgb')
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => {
-      if (key === 'Comfy.Execution.PreviewMethod') return previewMethodRef.value
-      return undefined
-    }
-  })
-}))
 
 vi.mock(import('@/utils/objectUrlUtil'), () => ({
   retainSharedObjectUrl: vi.fn(),
@@ -22,7 +11,8 @@ vi.mock(import('@/utils/objectUrlUtil'), () => ({
 
 describe('jobPreviewStore', () => {
   beforeEach(() => {
-    previewMethodRef.value = 'latent2rgb'
+    useSettingStore().settingValues['Comfy.Execution.PreviewMethod'] =
+      'latent2rgb'
   })
 
   it('stores preview with nodeId', () => {
@@ -89,7 +79,7 @@ describe('jobPreviewStore', () => {
   })
 
   it('ignores setPreviewUrl when previews are disabled', () => {
-    previewMethodRef.value = 'none'
+    useSettingStore().settingValues['Comfy.Execution.PreviewMethod'] = 'none'
     const store = useJobPreviewStore()
 
     store.setPreviewUrl('p1', 'blob:a', 'node-1')

--- a/src/stores/linkStore.test.ts
+++ b/src/stores/linkStore.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
@@ -43,10 +41,6 @@ function link(
 }
 
 describe('useLinkStore', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('keeps the first registration for a contested target slot', () => {
     const store = useLinkStore()
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -3,15 +3,14 @@ import { nextTick } from 'vue'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
-
-const mockRemoveNodeOutputs = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({ removeNodeOutputs: mockRemoveNodeOutputs })
-}))
 
 const mockApp = vi.hoisted(() => ({
   isGraphReady: true,
+  nodePreviewImages: {},
+  nodeOutputs: {},
   rootGraph: { nodes: [], _nodes: [] } as unknown as LGraph
 }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({ app: mockApp }))
@@ -33,10 +32,6 @@ vi.mock(import('@/i18n'), () => ({
 
 vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: false }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({ get: vi.fn(() => false) }))
-}))
-
 vi.mock<unknown>(
   import('@/platform/missingModel/composables/useMissingModelInteractions'),
   () => ({ clearMissingModelState: vi.fn() })
@@ -57,6 +52,8 @@ describe('FE-230 regression — workflow-load missing-media flagging must not wi
   beforeEach(() => {
     mockApp.isGraphReady = true
     mockApp.rootGraph = { nodes: [], _nodes: [] } as unknown as LGraph
+    useSettingStore().settingValues['Comfy.RightSidePanel.ShowErrorsTab'] =
+      false
   })
 
   it('does not clear node.imgs when verification flags a Load Image as missing on workflow load (e.g. mask-editor saved value)', async () => {
@@ -80,6 +77,6 @@ describe('FE-230 regression — workflow-load missing-media flagging must not wi
     await nextTick()
 
     expect(node.imgs).toEqual([{ src: 'blob:mask-edited' }])
-    expect(mockRemoveNodeOutputs).not.toHaveBeenCalled()
+    expect(useNodeOutputStore().removeNodeOutputs).not.toHaveBeenCalled()
   })
 })

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -48,24 +48,8 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   }
 }))
 
-// Mock the settingStore
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn()
-}))
-
 function enableMocks(useAssetAPI = false) {
-  // Mock settingStore to return the useAssetAPI setting
-  const mockSettingStore = {
-    get: vi.fn().mockImplementation((key: string) => {
-      if (key === 'Comfy.Assets.UseAssetAPI') {
-        return useAssetAPI
-      }
-      return false
-    })
-  }
-  vi.mocked(useSettingStore, { partial: true }).mockReturnValue(
-    mockSettingStore
-  )
+  useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = useAssetAPI
 
   // Mock experimental API - returns objects with name and folders properties
   vi.mocked(api.getModels).mockResolvedValue([

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   ModelNodeProvider,
@@ -76,13 +74,11 @@ const mockNodeDefsByName = Object.fromEntries(
   MOCK_NODE_NAMES.map((name) => [name, createMockNodeDef(name)])
 )
 
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: vi.fn(() => ({
-    nodeDefsByName: mockNodeDefsByName
-  }))
-}))
-
 describe('useModelToNodeStore', () => {
+  beforeEach(() => {
+    useNodeDefStore().nodeDefsByName = mockNodeDefsByName
+  })
+
   describe('modelToNodeMap', () => {
     it('should initialize as empty', () => {
       const modelToNodeStore = useModelToNodeStore()
@@ -468,18 +464,10 @@ describe('useModelToNodeStore', () => {
     })
 
     it('should not register when nodeDefStore is empty', () => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: {}
-      })
+      useNodeDefStore().nodeDefsByName = {}
       const modelToNodeStore = useModelToNodeStore()
       modelToNodeStore.registerDefaults()
       expect(modelToNodeStore.getNodeProvider('checkpoints')).toBeUndefined()
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: mockNodeDefsByName
-      })
     })
   })
 
@@ -491,19 +479,11 @@ describe('useModelToNodeStore', () => {
     })
 
     it('should return empty Record when nodeDefStore is empty', () => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: {}
-      })
+      useNodeDefStore().nodeDefsByName = {}
       const modelToNodeStore = useModelToNodeStore()
 
       const result = modelToNodeStore.getRegisteredNodeTypes()
       expect(result).toStrictEqual({})
-
-      vi.mocked(useNodeDefStore, { partial: true }).mockReturnValue({
-        nodeDefsByName: mockNodeDefsByName
-      })
     })
 
     it('should contain node types to resolve widget name', () => {

--- a/src/stores/nodeDataStore.test.ts
+++ b/src/stores/nodeDataStore.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { assert, beforeEach, describe, expect, it } from 'vitest'
+import { assert, describe, expect, it } from 'vitest'
 import { computed } from 'vue'
 
 import { transferReplacementOwnership } from '@/core/graph/nodeShell/nodeShellState'
@@ -29,10 +27,6 @@ function graphScope(rootGraphId: UUID, owningGraphId: UUID): GraphScope {
 }
 
 describe('useNodeDataStore', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('re-runs consumers when membership changes', () => {
     const store = useNodeDataStore()
     const ids = computed(() =>
@@ -136,10 +130,6 @@ describe('useNodeDataStore', () => {
 })
 
 describe('nodeDataStore registration via LGraph', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function registeredState(graph: LGraph, node: LGraphNode) {
     return useNodeDataStore()
       .getGraphNodesFor(graph.id, graph.id)

--- a/src/stores/nodeDefStore.nodeText.test.ts
+++ b/src/stores/nodeDefStore.nodeText.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { clone } from 'es-toolkit/compat'
-import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { mergeCustomNodesI18n, setActiveLocale } from '@/i18n'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
@@ -129,10 +127,6 @@ describe('ComfyNodeDefImpl node text', () => {
 })
 
 describe('useNodeDefStore locale reactivity', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   afterEach(async () => {
     await setActiveLocale('en')
   })

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -53,16 +53,6 @@ vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   executionIdToNodeLocatorId: vi.fn((_rootGraph: unknown, id: string) => id)
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
-      nodeToNodeLocatorId: vi.fn((node: { id: number }) => String(node.id))
-    }))
-  })
-)
-
 describe('nodeOutputStore setNodeOutputsByExecutionId with merge', () => {
   beforeEach(() => {
     app.nodeOutputs = {}

--- a/src/stores/nodeOutputStore.workflowSwitch.test.ts
+++ b/src/stores/nodeOutputStore.workflowSwitch.test.ts
@@ -1,4 +1,5 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -9,15 +10,6 @@ import { toNodeId } from '@/types/nodeId'
 const { WORKFLOW_A, WORKFLOW_B } = vi.hoisted(() => ({
   WORKFLOW_A: 'workflows/a.json',
   WORKFLOW_B: 'workflows/b.json'
-}))
-
-const mocks = vi.hoisted(() => ({
-  workflowStore: null as unknown as {
-    activeWorkflow: { path: string } | null
-    openWorkflows: { path: string }[]
-    nodeIdToNodeLocatorId: (id: string | number) => string
-    nodeToNodeLocatorId: (node: { id: string | number }) => string
-  }
 }))
 
 vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
@@ -40,20 +32,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mocks.workflowStore = reactive({
-      activeWorkflow: { path: WORKFLOW_A },
-      openWorkflows: [{ path: WORKFLOW_A }, { path: WORKFLOW_B }],
-      nodeIdToNodeLocatorId: (id: string | number) => String(id),
-      nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
-    })
-    return { useWorkflowStore: () => mocks.workflowStore }
-  }
-)
-
 const createMockNode = (id: number): LGraphNode =>
   fromAny<LGraphNode, unknown>({ id: toNodeId(id), type: 'KSampler' })
 
@@ -64,10 +42,10 @@ const createMockNode = (id: number): LGraphNode =>
  */
 function switchToWorkflow(path: string) {
   const store = useNodeOutputStore()
-  const leaving = mocks.workflowStore.activeWorkflow
+  const leaving = useWorkflowStore().activeWorkflow
   if (leaving) store.stashPreviewsForWorkflow(leaving.path)
   store.resetAllOutputsAndPreviews()
-  mocks.workflowStore.activeWorkflow = { path }
+  useWorkflowStore().activeWorkflow = fromPartial({ path })
   store.restorePreviewsForWorkflow(path)
 }
 
@@ -89,11 +67,10 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
       .mockImplementation(() => {})
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
-    mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
-    mocks.workflowStore.openWorkflows = [
-      { path: WORKFLOW_A },
-      { path: WORKFLOW_B }
-    ]
+    useWorkflowStore().activeWorkflow = fromPartial({ path: WORKFLOW_A })
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [{ path: WORKFLOW_A }, { path: WORKFLOW_B }]
+    })
   })
 
   it('keeps a finished run preview when the user switches tabs and comes back', () => {
@@ -157,7 +134,7 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     store.setNodePreviewsByNodeId(createMockNode(5).id, [previewUrl])
     switchToWorkflow(WORKFLOW_B)
 
-    mocks.workflowStore.openWorkflows = [{ path: WORKFLOW_B }]
+    Object.assign(useWorkflowStore(), { openWorkflows: [{ path: WORKFLOW_B }] })
     switchToWorkflow(WORKFLOW_B)
 
     expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
@@ -175,7 +152,7 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     // Back to A: a frame lands between app.clean() and afterLoadNewGraph().
     store.stashPreviewsForWorkflow(WORKFLOW_B)
     store.resetAllOutputsAndPreviews()
-    mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
+    useWorkflowStore().activeWorkflow = fromPartial({ path: WORKFLOW_A })
     store.setNodePreviewsByNodeId(node.id, [arrivedUrl])
     store.restorePreviewsForWorkflow(WORKFLOW_A)
 

--- a/src/stores/queueStore.loadWorkflow.test.ts
+++ b/src/stores/queueStore.loadWorkflow.test.ts
@@ -16,10 +16,6 @@ vi.mock<unknown>(import('@/services/extensionService'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: vi.fn(() => ({}))
-}))
-
 vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 const mockWorkflow: ComfyWorkflowJSON = {

--- a/src/stores/rerouteStore.test.ts
+++ b/src/stores/rerouteStore.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
+import { assert, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
@@ -48,10 +46,6 @@ function link(id: number, targetSlot: number, parentId?: number): LinkTopology {
 }
 
 describe('useRerouteStore', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('refuses to overwrite a registration held by a different chain', () => {
     const store = useRerouteStore()
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/stores/storeCollisionContracts.test.ts
+++ b/src/stores/storeCollisionContracts.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
+import { assert, describe, expect, it, vi } from 'vitest'
 
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
 import type { GraphScope } from '@/types/graphScopeId'
@@ -66,10 +64,6 @@ function rerouteChain(id: number, graphId: UUID = rootA): RerouteChain {
 }
 
 describe('store collision contracts (EX-002)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('nodeDataStore rejects a registration at an occupied identity key', () => {
     const store = useNodeDataStore()
     const incumbent = nodeState(1)

--- a/src/stores/subgraphNavigationStore.navigateToHash.test.ts
+++ b/src/stores/subgraphNavigationStore.navigateToHash.test.ts
@@ -1,8 +1,8 @@
-import { createTestingPinia } from '@pinia/testing'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { disposePinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref, shallowRef } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
 import type * as VueRouter from 'vue-router'
 
@@ -17,11 +17,6 @@ const ids = vi.hoisted(() => ({
   deletedSubgraph: '22222222-2222-4222-8222-222222222222'
 }))
 
-const workflowStoreState = vi.hoisted(() => ({
-  openWorkflows: [] as unknown[],
-  activeSubgraph: undefined as unknown
-}))
-
 const routerMocks = vi.hoisted(() => ({
   push: vi.fn().mockResolvedValue(undefined),
   replace: vi.fn().mockResolvedValue(undefined),
@@ -29,7 +24,6 @@ const routerMocks = vi.hoisted(() => ({
 }))
 
 const routeHashRef = ref('')
-const currentGraphRef = shallowRef<LGraph | null>(null)
 
 vi.mock<unknown>(import('vue-router'), () => ({
   NavigationFailureType: { cancelled: 8, duplicated: 16 },
@@ -74,19 +68,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
   }
 })
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => app.canvas,
-      get currentGraph() {
-        return currentGraphRef.value
-      }
-    })
-  })
-)
-
 const reportErrorMock = vi.hoisted(() => vi.fn())
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
@@ -105,12 +86,6 @@ vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
   () => ({
     useWorkflowService: () => workflowServiceMocks
-  })
-)
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => workflowStoreState
   })
 )
 
@@ -141,18 +116,15 @@ async function flushHashWatcher() {
 }
 
 describe('useSubgraphNavigationStore - navigateToHash validation', () => {
-  let pinia: ReturnType<typeof createTestingPinia>
-
   beforeEach(() => {
-    pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(() => app.canvas)
     app.rootGraph.id = ids.root
     app.rootGraph.subgraphs.clear()
     app.canvas.subgraph = undefined
     app.canvas.graph = app.rootGraph
-    currentGraphRef.value = app.rootGraph
-    workflowStoreState.openWorkflows = []
-    workflowStoreState.activeSubgraph = undefined
+    useCanvasStore().currentGraph = app.rootGraph
+    Object.assign(useWorkflowStore(), { openWorkflows: [] })
+    useWorkflowStore().activeSubgraph = undefined
     routeHashRef.value = ''
     routerMocks.history.state = {}
     routerMocks.push.mockReset().mockImplementation(async (target) => {
@@ -162,8 +134,6 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       applyRouteTarget(target)
     })
   })
-
-  afterEach(() => disposePinia(pinia))
 
   it('navigates to a valid, existing subgraph hash', async () => {
     const subgraph = makeSubgraph(ids.validSubgraph)
@@ -293,7 +263,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const newRootId = '33333333-3333-4333-8333-333333333333'
     app.rootGraph.id = newRootId
     app.canvas.graph = app.rootGraph
-    currentGraphRef.value = app.rootGraph
+    useCanvasStore().currentGraph = app.rootGraph
     await navigationStore.updateHash('workflow-load', workflowNavigationId)
 
     resolveReplace?.()
@@ -307,15 +277,17 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
 
   it('redirects when a workflow load resolves but the subgraph is still missing', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'phantom-workflow.json',
-        activeState: {
-          id: ids.deletedSubgraph,
-          definitions: { subgraphs: [] }
-        }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'phantom-workflow.json',
+          activeState: {
+            id: ids.deletedSubgraph,
+            definitions: { subgraphs: [] }
+          }
+        })
+      ]
+    })
     useSubgraphNavigationStore()
 
     routeHashRef.value = `#${ids.deletedSubgraph}`
@@ -336,15 +308,17 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     workflowServiceMocks.openWorkflow.mockRejectedValueOnce(
       new Error('load failed')
     )
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'broken-workflow.json',
-        activeState: {
-          id: ids.deletedSubgraph,
-          definitions: { subgraphs: [] }
-        }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'broken-workflow.json',
+          activeState: {
+            id: ids.deletedSubgraph,
+            definitions: { subgraphs: [] }
+          }
+        })
+      ]
+    })
     useSubgraphNavigationStore()
 
     routeHashRef.value = `#${ids.deletedSubgraph}`
@@ -370,12 +344,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const secondGraph = makeSubgraph(secondId)
     let resolveOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'first-workflow.json',
-        activeState: { id: firstId, definitions: { subgraphs: [] } }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'first-workflow.json',
+          activeState: { id: firstId, definitions: { subgraphs: [] } }
+        })
+      ]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -407,12 +383,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const secondGraph = makeSubgraph(secondId)
     let resolveOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'first-workflow.json',
-        activeState: { id: firstId, definitions: { subgraphs: [] } }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'first-workflow.json',
+          activeState: { id: firstId, definitions: { subgraphs: [] } }
+        })
+      ]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -420,14 +398,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
             app.rootGraph.id = firstId
             app.rootGraph.subgraphs.set(secondId, secondGraph)
             app.canvas.graph = app.rootGraph
-            currentGraphRef.value = app.rootGraph
+            useCanvasStore().currentGraph = app.rootGraph
             resolve()
           }
         })
     )
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     routerMocks.push.mockImplementation(async (target) => {
       applyRouteTarget(target)
@@ -439,7 +417,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       expect(workflowServiceMocks.openWorkflow).toHaveBeenCalledOnce()
     )
     app.canvas.graph = secondGraph
-    currentGraphRef.value = secondGraph
+    useCanvasStore().currentGraph = secondGraph
     await nextTick()
     resolveOpen?.()
 
@@ -454,12 +432,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const outgoingSubgraph = makeSubgraph(ids.validSubgraph)
     let resolveOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [
-      fromPartial<ComfyWorkflow>({
-        path: 'target-workflow.json',
-        activeState: { id: targetId, definitions: { subgraphs: [] } }
-      })
-    ]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [
+        fromPartial<ComfyWorkflow>({
+          path: 'target-workflow.json',
+          activeState: { id: targetId, definitions: { subgraphs: [] } }
+        })
+      ]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -471,10 +451,10 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     )
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     app.canvas.graph = outgoingSubgraph
-    currentGraphRef.value = outgoingSubgraph
+    useCanvasStore().currentGraph = outgoingSubgraph
     const navigationStore = useSubgraphNavigationStore()
 
     routeHashRef.value = `#${targetId}`
@@ -498,14 +478,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     routeHashRef.value = `#${subgraph.id}`
 
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
 
-    expect(workflowStoreState.activeSubgraph).toBe(subgraph)
+    expect(useWorkflowStore().activeSubgraph).toBe(subgraph)
   })
 
   it('uses the emitted graph during a synchronous graph-change event', async () => {
@@ -513,7 +493,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
 
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     app.canvas.graph = subgraph
     await flushHashWatcher()
 
@@ -532,10 +512,10 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
         definitions: { subgraphs: [{ id: targetSubgraph.id }] }
       }
     })
-    workflowStoreState.openWorkflows = [targetWorkflow]
+    Object.assign(useWorkflowStore(), { openWorkflows: [targetWorkflow] })
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     const navigationStore = useSubgraphNavigationStore()
     workflowServiceMocks.openWorkflow.mockImplementation(
@@ -577,11 +557,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
         definitions: { subgraphs: [{ id: targetSubgraph.id }] }
       }
     })
-    workflowStoreState.openWorkflows = [originalWorkflow]
+    Object.assign(useWorkflowStore(), { openWorkflows: [originalWorkflow] })
     app.rootGraph.subgraphs.set(targetSubgraph.id, targetSubgraph)
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     routeHashRef.value = `#${originalRootId}`
     const navigationStore = useSubgraphNavigationStore()
@@ -625,11 +605,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const subgraph = makeSubgraph(ids.validSubgraph)
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     app.canvas.graph = subgraph
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     routeHashRef.value = `#${subgraph.id}`
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
@@ -650,11 +630,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const subgraph = makeSubgraph(ids.validSubgraph)
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     app.canvas.graph = subgraph
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     routeHashRef.value = `#${subgraph.id}`
     vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
       app.canvas.graph = graph
-      currentGraphRef.value = graph
+      useCanvasStore().currentGraph = graph
     })
     const navigationStore = useSubgraphNavigationStore()
     await navigationStore.updateHash()
@@ -682,11 +662,11 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     })
     let resolveFirstPush: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [routeWorkflow]
+    Object.assign(useWorkflowStore(), { openWorkflows: [routeWorkflow] })
     workflowServiceMocks.openWorkflow.mockImplementation(async () => {
       app.rootGraph.id = routeId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
     })
     routerMocks.push
       .mockImplementationOnce((target) => {
@@ -702,14 +682,14 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     await navigationStore.updateHash()
 
     app.canvas.graph = firstGraph
-    currentGraphRef.value = firstGraph
+    useCanvasStore().currentGraph = firstGraph
     await vi.waitFor(() =>
       expect(routerMocks.push).toHaveBeenCalledWith(
         expect.objectContaining({ hash: `#${firstId}` })
       )
     )
     app.canvas.graph = secondGraph
-    currentGraphRef.value = secondGraph
+    useCanvasStore().currentGraph = secondGraph
     routeHashRef.value = `#${routeId}`
 
     await vi.waitFor(() =>
@@ -739,21 +719,23 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     const secondRoot = fromPartial<LGraph>({ id: secondId })
     let resolveFirstOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [firstWorkflow, secondWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [firstWorkflow, secondWorkflow]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation((workflow) => {
       if (workflow === firstWorkflow) {
         return new Promise<void>((resolve) => {
           resolveFirstOpen = () => {
             app.rootGraph.id = firstId
             app.canvas.graph = app.rootGraph
-            currentGraphRef.value = app.rootGraph
+            useCanvasStore().currentGraph = app.rootGraph
             resolve()
           }
         })
       }
       app.rootGraph.id = secondId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
       return Promise.resolve()
     })
     routerMocks.push.mockImplementation(async (target) => {
@@ -769,7 +751,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       )
     )
     app.canvas.graph = secondRoot
-    currentGraphRef.value = secondRoot
+    useCanvasStore().currentGraph = secondRoot
     resolveFirstOpen?.()
 
     await vi.waitFor(() => {
@@ -795,7 +777,9 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     })
     let rejectFirstOpen: ((error: Error) => void) | undefined
 
-    workflowStoreState.openWorkflows = [firstWorkflow, secondWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [firstWorkflow, secondWorkflow]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation((workflow) => {
       if (workflow === firstWorkflow) {
         return new Promise<void>((_resolve, reject) => {
@@ -804,7 +788,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       }
       app.rootGraph.id = secondId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
       return Promise.resolve()
     })
     useSubgraphNavigationStore()
@@ -843,7 +827,9 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     })
     let resolveFirstOpen: (() => void) | undefined
 
-    workflowStoreState.openWorkflows = [firstWorkflow, secondWorkflow]
+    Object.assign(useWorkflowStore(), {
+      openWorkflows: [firstWorkflow, secondWorkflow]
+    })
     workflowServiceMocks.openWorkflow.mockImplementation((workflow) => {
       if (workflow === firstWorkflow) {
         return new Promise<void>((resolve) => {
@@ -852,7 +838,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
       }
       app.rootGraph.id = secondId
       app.canvas.graph = app.rootGraph
-      currentGraphRef.value = app.rootGraph
+      useCanvasStore().currentGraph = app.rootGraph
       return Promise.resolve()
     })
     useSubgraphNavigationStore()
@@ -888,7 +874,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     // Consume the initial-load swallow so the watcher publish is live.
     await store.updateHash('graph', undefined, app.rootGraph)
 
-    currentGraphRef.value = subgraph
+    useCanvasStore().currentGraph = subgraph
     await vi.waitFor(() => {
       expect(routerMocks.push).toHaveBeenCalledWith(
         expect.objectContaining({ hash: `#${ids.validSubgraph}` })
@@ -931,7 +917,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
   it('ignores endWorkflowNavigation for a superseded intent id', async () => {
     app.rootGraph.id = ids.root
     app.canvas.graph = app.rootGraph
-    currentGraphRef.value = app.rootGraph
+    useCanvasStore().currentGraph = app.rootGraph
     routeHashRef.value = ''
     const store = useSubgraphNavigationStore()
 

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { disposePinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import type * as VueRouter from 'vue-router'
@@ -11,6 +9,7 @@ import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workfl
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { app } from '@/scripts/app'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 type MockSubgraph = Pick<Subgraph, 'id' | 'rootGraph' | '_nodes' | 'nodes'>
 
@@ -83,16 +82,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
   }
 })
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => app.canvas
-    })
-  })
-)
-
 vi.mock(import('@/utils/graphTraversalUtil'), () => ({
   findSubgraphPathById: vi.fn()
 }))
@@ -114,11 +103,8 @@ vi.mock<unknown>(
 )
 
 describe('useSubgraphNavigationStore', () => {
-  let pinia: ReturnType<typeof createTestingPinia>
-
   beforeEach(() => {
-    pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(() => app.canvas)
     app.rootGraph.subgraphs.clear()
     app.rootGraph.id = 'current-root'
     app.canvas.graph = app.rootGraph
@@ -138,8 +124,6 @@ describe('useSubgraphNavigationStore', () => {
     })
     mockOpenWorkflow.mockReset()
   })
-
-  afterEach(() => disposePinia(pinia))
 
   it('should not clear navigation stack when workflow internal state changes', async () => {
     const navigationStore = useSubgraphNavigationStore()

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { nextTick } from 'vue'
 
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -53,15 +54,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
   }
 })
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => app.canvas
-    })
-  })
-)
 vi.mock(import('@vueuse/router'), () => ({ useRouteHash: vi.fn() }))
 
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
@@ -74,6 +66,7 @@ let rafCallbacks: FrameRequestCallback[] = []
 
 describe('useSubgraphNavigationStore - Viewport Persistence', () => {
   beforeEach(() => {
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(() => app.canvas)
     rafCallbacks = []
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       rafCallbacks.push(cb)

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -1,5 +1,8 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock(import('@vueuse/router'), () => ({ useRouteHash: () => ref('') }))
 
 import {
   createTestSubgraph,
@@ -14,6 +17,7 @@ import { app as comfyApp } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { BLUEPRINT_TYPE_PREFIX } from '@/utils/blueprintUtils'
 
 const mockDistributionTypes = vi.hoisted(() => ({
@@ -43,16 +47,6 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
     prompt: () => 'testname',
     confirm: () => true
   }))
-}))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => ({
-    getCanvas: () => comfyApp.canvas
-  }))
-}))
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => ({
-    beginWorkflowNavigation: () => 1
-  })
 }))
 
 // Mock comfyApp globally for the store setup
@@ -98,6 +92,9 @@ describe('useSubgraphStore', () => {
   beforeEach(() => {
     mockDistributionTypes.isCloud = false
     mockDistributionTypes.isDesktop = false
+    vi.mocked(useCanvasStore().getCanvas).mockImplementation(
+      () => comfyApp.canvas
+    )
     store = useSubgraphStore()
   })
 

--- a/src/stores/widgetValueStore.graphReactivity.test.ts
+++ b/src/stores/widgetValueStore.graphReactivity.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, watch } from 'vue'
 
 import { BaseWidget, LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -15,10 +13,6 @@ import { graphScopeOf } from '@/types/graphScopeId'
 import { widgetId } from '@/types/widgetId'
 
 describe('Node Reactivity', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function createTestGraph() {
     const graph = new LGraph()
     const node = new LGraphNode('test')
@@ -79,10 +73,6 @@ describe('Node Reactivity', () => {
 })
 
 describe('Widget input link reactivity', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function createWidgetInputGraph() {
     const graph = new LGraph()
     const node = new LGraphNode('test')
@@ -160,10 +150,6 @@ describe('Widget input link reactivity', () => {
 })
 
 describe('Nested promoted widget mapping', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('maps store identity to deepest concrete widget for two-layer promotions', () => {
     const subgraphA = createTestSubgraph({
       inputs: [{ name: 'a_input', type: '*' }]
@@ -233,10 +219,6 @@ describe('Nested promoted widget mapping', () => {
   })
 })
 describe('Promoted widget render state', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('registers plain render metadata for promoted widgets', () => {
     const subgraph = createTestSubgraph({
       inputs: [{ name: 'ckpt_input', type: '*' }]

--- a/src/stores/workflowTabActivityStore.test.ts
+++ b/src/stores/workflowTabActivityStore.test.ts
@@ -1,13 +1,8 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { useWorkflowTabActivityStore } from './workflowTabActivityStore'
 
 describe('useWorkflowTabActivityStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('tracks and clears the tab being edited', () => {
     const store = useWorkflowTabActivityStore()
 

--- a/src/stores/workspace/bottomPanelStore.test.ts
+++ b/src/stores/workspace/bottomPanelStore.test.ts
@@ -40,12 +40,6 @@ vi.mock(import('@/composables/bottomPanelTabs/useTerminalTabs'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    registerCommand: vi.fn()
-  })
-}))
-
 const mockData = vi.hoisted(() => ({ isDesktop: false }))
 
 vi.mock(import('@/platform/distribution/types'), () => ({

--- a/src/stores/workspace/searchBoxStore.test.ts
+++ b/src/stores/workspace/searchBoxStore.test.ts
@@ -1,44 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useMouse } from '@vueuse/core'
+import { nextTick } from 'vue'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
-import type { useSettingStore } from '@/platform/settings/settingStore'
+import { LGraph, LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
-
-const { mockAdjustMouseEvent } = vi.hoisted(() => ({
-  mockAdjustMouseEvent: vi.fn((event: PointerEvent) => {
-    Object.assign(event, {
-      canvasX: 50,
-      canvasY: 75,
-      deltaX: 0,
-      deltaY: 0,
-      safeOffsetX: event.clientX,
-      safeOffsetY: event.clientY
-    })
-  })
-}))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useMouse: vi.fn(() => ({
-    x: { value: 100 },
-    y: { value: 200 }
-  }))
-}))
-
-const mockSettingStore = createMockSettingStore()
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => mockSettingStore)
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: () => ({ adjustMouseEvent: mockAdjustMouseEvent })
-    })
-  })
-)
+import { createMockMinimapCanvas } from '@/utils/__tests__/litegraphTestUtils'
 
 function createMockPopover(): Pick<
   InstanceType<typeof NodeSearchBoxPopover>,
@@ -47,18 +15,24 @@ function createMockPopover(): Pick<
   return { showSearchBox: vi.fn() }
 }
 
-function createMockSettingStore(): ReturnType<typeof useSettingStore> {
-  return {
-    get: vi.fn()
-  } as Partial<ReturnType<typeof useSettingStore>> as ReturnType<
-    typeof useSettingStore
-  >
-}
-
 describe('useSearchBoxStore', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      createMockMinimapCanvas().getContext
+    )
+    const canvas = new LGraphCanvas(
+      document.createElement('canvas'),
+      new LGraph(),
+      { skip_render: true }
+    )
+    canvas.ds.scale = 2
+    canvas.ds.offset = [0, 25]
+    useCanvasStore().canvas = canvas
+  })
+
   describe('when user has new search box enabled', () => {
     beforeEach(() => {
-      vi.mocked(mockSettingStore.get).mockReturnValue('default')
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl'] = 'default'
     })
 
     it('should show new search box is enabled', () => {
@@ -81,7 +55,8 @@ describe('useSearchBoxStore', () => {
 
   describe('when user has legacy search box enabled', () => {
     beforeEach(() => {
-      vi.mocked(mockSettingStore.get).mockReturnValue('litegraph (legacy)')
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl'] =
+        'litegraph (legacy)'
     })
 
     it('should show new search box is disabled', () => {
@@ -89,10 +64,18 @@ describe('useSearchBoxStore', () => {
       expect(store.newSearchBoxEnabled).toBe(false)
     })
 
-    it('should open legacy search box at mouse position when user presses shortcut', () => {
+    it('should open legacy search box at mouse position when user presses shortcut', async () => {
       const store = useSearchBoxStore()
       const mockPopover = createMockPopover()
       store.setPopoverRef(mockPopover)
+      const adjustMouseEvent = vi.spyOn(
+        useCanvasStore().getCanvas(),
+        'adjustMouseEvent'
+      )
+      window.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 100, clientY: 200 })
+      )
+      await nextTick()
 
       expect(vi.mocked(store.visible)).toBe(false)
 
@@ -108,8 +91,7 @@ describe('useSearchBoxStore', () => {
           canvasY: 75
         })
       )
-      expect(useMouse).toHaveBeenCalledWith({ type: 'client' })
-      expect(mockAdjustMouseEvent).toHaveBeenCalledOnce()
+      expect(adjustMouseEvent).toHaveBeenCalledOnce()
     })
 
     it('should do nothing when user presses shortcut but popover is not ready', () => {
@@ -124,7 +106,8 @@ describe('useSearchBoxStore', () => {
 
   describe('when user configures popover reference', () => {
     beforeEach(() => {
-      vi.mocked(mockSettingStore.get).mockReturnValue('litegraph (legacy)')
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl'] =
+        'litegraph (legacy)'
     })
 
     it('should enable legacy search when popover is set', () => {

--- a/src/stores/workspace/sidebarTabStore.test.ts
+++ b/src/stores/workspace/sidebarTabStore.test.ts
@@ -1,45 +1,12 @@
-import { nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
-const {
-  mockGetSetting,
-  mockRegisterCommand,
-  mockRegisterCommands,
-  mockBrowseModelAssets,
-  registeredCommands,
-  commandStoreCommands
-} = vi.hoisted(() => {
-  const registeredCommands: { id: string; function: () => unknown }[] = []
-  return {
-    mockGetSetting: vi.fn(),
-    mockRegisterCommand: vi.fn((command) => registeredCommands.push(command)),
-    mockRegisterCommands: vi.fn(),
-    mockBrowseModelAssets: vi.fn(),
-    registeredCommands,
-    commandStoreCommands: [] as { id: string; function: () => unknown }[]
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    registerCommand: mockRegisterCommand,
-    commands: commandStoreCommands
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/menuItemStore'), () => ({
-  useMenuItemStore: () => ({
-    registerCommands: mockRegisterCommands
-  })
-}))
+const mockBrowseModelAssets = vi.fn()
 
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key,
@@ -108,21 +75,18 @@ vi.mock(
 
 describe('useSidebarTabStore', () => {
   beforeEach(() => {
-    registeredCommands.length = 0
-    commandStoreCommands.length = 0
+    vi.mocked(useMenuItemStore().registerCommands).mockImplementation(() => {})
   })
 
   const toggleModelLibrary = async () => {
-    const toggleCommand = registeredCommands.find(
+    const toggleCommand = useCommandStore().commands.find(
       (command) => command.id === 'Workspace.ToggleSidebarTab.model-library'
     )
     await toggleCommand?.function()
   }
 
   it('registers the job history tab when QPO V2 is enabled', () => {
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? true : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
 
     const store = useSidebarTabStore()
     store.registerCoreSidebarTabs()
@@ -135,13 +99,11 @@ describe('useSidebarTabStore', () => {
       'workflows',
       'apps'
     ])
-    expect(mockRegisterCommand).toHaveBeenCalledTimes(6)
+    expect(useCommandStore().registerCommand).toHaveBeenCalledTimes(6)
   })
 
   it('does not register the job history tab when QPO V2 is disabled', () => {
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? false : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     const store = useSidebarTabStore()
     store.registerCoreSidebarTabs()
@@ -153,19 +115,16 @@ describe('useSidebarTabStore', () => {
       'workflows',
       'apps'
     ])
-    expect(mockRegisterCommand).toHaveBeenCalledTimes(5)
+    expect(useCommandStore().registerCommand).toHaveBeenCalledTimes(5)
   })
 
   it('prepends the job history tab when QPO V2 is toggled on', async () => {
-    const qpoV2Enabled = ref(false)
-    mockGetSetting.mockImplementation((key: string) =>
-      key === 'Comfy.Queue.QPOV2' ? qpoV2Enabled.value : undefined
-    )
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
 
     const store = useSidebarTabStore()
     store.registerCoreSidebarTabs()
 
-    qpoV2Enabled.value = true
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
     await nextTick()
 
     expect(store.sidebarTabs.map((tab) => tab.id)).toEqual([
@@ -176,15 +135,14 @@ describe('useSidebarTabStore', () => {
       'workflows',
       'apps'
     ])
-    expect(mockRegisterCommand).toHaveBeenCalledTimes(6)
+    expect(useCommandStore().registerCommand).toHaveBeenCalledTimes(6)
   })
 
   describe('model library view selection', () => {
     it('toggles the sidebar tab when the asset view is disabled', async () => {
-      mockGetSetting.mockImplementation((key: string) =>
-        key === 'Comfy.ModelLibrary.UseAssetBrowser' ? false : undefined
-      )
-      commandStoreCommands.push({
+      useSettingStore().settingValues['Comfy.ModelLibrary.UseAssetBrowser'] =
+        false
+      useCommandStore().registerCommand({
         id: 'Comfy.BrowseModelAssets',
         function: mockBrowseModelAssets
       })
@@ -199,13 +157,10 @@ describe('useSidebarTabStore', () => {
     })
 
     it('opens the asset browser when the browser and asset API are enabled', async () => {
-      mockGetSetting.mockImplementation((key: string) =>
-        key === 'Comfy.ModelLibrary.UseAssetBrowser' ||
-        key === 'Comfy.Assets.UseAssetAPI'
-          ? true
-          : undefined
-      )
-      commandStoreCommands.push({
+      useSettingStore().settingValues['Comfy.ModelLibrary.UseAssetBrowser'] =
+        true
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
+      useCommandStore().registerCommand({
         id: 'Comfy.BrowseModelAssets',
         function: mockBrowseModelAssets
       })
@@ -220,10 +175,10 @@ describe('useSidebarTabStore', () => {
     })
 
     it('falls back to the sidebar tree when the asset API is disabled', async () => {
-      mockGetSetting.mockImplementation((key: string) =>
-        key === 'Comfy.ModelLibrary.UseAssetBrowser' ? true : false
-      )
-      commandStoreCommands.push({
+      useSettingStore().settingValues['Comfy.ModelLibrary.UseAssetBrowser'] =
+        true
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = false
+      useCommandStore().registerCommand({
         id: 'Comfy.BrowseModelAssets',
         function: mockBrowseModelAssets
       })

--- a/src/systems/badgeSystem.pricing.test.ts
+++ b/src/systems/badgeSystem.pricing.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useLinkStore } from '@/stores/linkStore'
@@ -27,13 +26,6 @@ vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => {
   }
 })
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.NodeBadge.ShowApiPricing' ? true : undefined
-  })
-}))
-
 class ApiNode extends LGraphNode {
   static override nodeData = { name: 'ApiNode', api_node: true }
 }
@@ -46,7 +38,7 @@ function scopeOf(id: string) {
 
 describe('badge derivation pricing input connectivity', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
+    useSettingStore().settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
     displayPrice = '$disconnected'
     getNodeDisplayPrice.mockClear()
   })

--- a/src/systems/badgeSystem.subgraph.test.ts
+++ b/src/systems/badgeSystem.subgraph.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { nextTick } from 'vue'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -33,20 +32,13 @@ vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.NodeBadge.ShowApiPricing' ? true : undefined
-  })
-}))
-
 class ApiNode extends LGraphNode {
   static override nodeData = { name: 'ApiNode', api_node: true }
 }
 
 describe('badge derivation subgraph credits aggregation', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
+    useSettingStore().settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
     getNodeDisplayPrice.mockReset()
     getNodeDisplayPrice.mockImplementation(defaultDisplayPrice)
     pricingMocks.hasDynamicPricing.mockReset()

--- a/src/systems/badgeSystem.test.ts
+++ b/src/systems/badgeSystem.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
@@ -157,10 +155,6 @@ describe('computeBadges', () => {
 })
 
 describe('nodeBadges', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function makeNode(id: number): LGraphNode {
     const node = new LGraphNode('Test', 'TestNode')
     node.id = toNodeId(id)

--- a/src/utils/executionUtil.stability.test.ts
+++ b/src/utils/executionUtil.stability.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   LGraph,
@@ -65,10 +63,6 @@ function buildGraph() {
 }
 
 describe('graphToPrompt API prompt stability', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('produces an identical payload when called twice on the same graph', async () => {
     const { graph } = buildGraph()
 

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { CurveData } from '@/components/curve/types'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -30,10 +28,6 @@ async function promptInputs(graph: LGraph, node: LGraphNode) {
 }
 
 describe('graphToPrompt widget serialization', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('tags curve widget values with the CURVE type marker', async () => {
     const graph = new LGraph()
     const node = addNode(graph, 'CurveEditor')

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -1,7 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
 import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
@@ -340,8 +338,6 @@ describe('fixBadLinks', () => {
 })
 
 describe('fixBadLinks ↔ linkStore integration', () => {
-  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
   it('treats a store-registered link as consistent without repairs', () => {
     const graph = new LGraph()
     const a = new LGraphNode('A')

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -20,8 +18,6 @@ import {
   resolveNode
 } from './litegraphUtil'
 
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
-
 const mockBringNodeToFront = vi.fn()
 
 vi.mock(
@@ -31,10 +27,6 @@ vi.mock(
     useNodeZIndex: () => ({ bringNodeToFront: mockBringNodeToFront })
   })
 )
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert: vi.fn() })
-}))
 
 describe('resolveNode', () => {
   it('returns undefined when graph is null', () => {

--- a/src/utils/searchAndReplace.test.ts
+++ b/src/utils/searchAndReplace.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { applyTextReplacements } from '@/utils/searchAndReplace'
@@ -14,10 +12,6 @@ function graphWithWidgetValue(value: string): LGraph {
 }
 
 describe('applyTextReplacements', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   // Test specifically the filename sanitization part
   describe('filename sanitization', () => {
     it('should replace invalid filename characters with underscores', () => {

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type * as VueUseCore from '@vueuse/core'
@@ -8,8 +7,39 @@ import { useReconnectQueueRefresh } from '@/composables/useReconnectQueueRefresh
 import { useReconnectingNotification } from '@/composables/useReconnectingNotification'
 import type * as DistributionTypes from '@/platform/distribution/types'
 import type * as I18nModule from '@/i18n'
+import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
-const apiMock = vi.hoisted(() => new EventTarget())
+beforeEach(() => {
+  vi.mocked(useVersionCompatibilityStore().initialize).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useExecutionStore().bindExecutionEvents).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useExecutionStore().unbindExecutionEvents).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useMenuItemStore().registerCoreMenuCommands).mockImplementation(
+    () => {}
+  )
+  vi.mocked(
+    useBottomPanelStore().registerCoreBottomPanelTabs
+  ).mockResolvedValue(undefined)
+  vi.mocked(useSidebarTabStore().registerCoreSidebarTabs).mockImplementation(
+    () => {}
+  )
+})
+
+const apiMock = vi.hoisted(() =>
+  Object.assign(new EventTarget(), {
+    getServerFeature: vi.fn((_name: string, fallback?: unknown) => fallback),
+    getSystemStats: vi.fn(async () => ({ system: {}, devices: [] }))
+  })
+)
 const distribution = vi.hoisted(
   (): {
     isCloud: typeof DistributionTypes.isCloud
@@ -21,6 +51,12 @@ const distribution = vi.hoisted(
 )
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiMock }))
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn(async () => {}),
+  onAuthStateChanged: vi.fn(() => () => {}),
+  onIdTokenChanged: vi.fn(() => () => {})
+}))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -74,9 +110,7 @@ vi.mock(import('@/i18n'), async (importOriginal) => {
   return { ...actual, loadLocale: vi.fn().mockResolvedValue(undefined) }
 })
 vi.mock(import('@/platform/distribution/types'), () => distribution)
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: vi.fn(() => undefined), set: vi.fn() })
-}))
+
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => undefined
 }))
@@ -86,22 +120,7 @@ vi.mock(
     useFrontendVersionMismatchWarning: vi.fn()
   })
 )
-vi.mock<unknown>(
-  import('@/platform/updates/common/versionCompatibilityStore'),
-  () => ({
-    useVersionCompatibilityStore: () => ({
-      initialize: vi.fn().mockResolvedValue(undefined)
-    })
-  })
-)
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), async () => {
-  const { defineStore } = await import('pinia')
-  return {
-    useCanvasStore: defineStore('canvas-test-stub', () => ({
-      linearMode: ref(false)
-    }))
-  }
-})
+
 vi.mock(import('@/services/autoQueueService'), () => ({
   setupAutoQueueHandler: vi.fn()
 }))
@@ -111,65 +130,7 @@ vi.mock<unknown>(import('@/platform/keybindings/keybindingService'), () => ({
     keybindHandler: vi.fn()
   })
 }))
-vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ isBuilderMode: ref(false) })
-}))
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({ updateHistory: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ registerCommands: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    bindExecutionEvents: vi.fn(),
-    unbindExecutionEvents: vi.fn(),
-    activeJobId: null,
-    clearActiveJobIfStale: vi.fn()
-  })
-}))
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({ isAuthenticated: false })
-}))
-vi.mock<unknown>(import('@/stores/menuItemStore'), () => ({
-  useMenuItemStore: () => ({ registerCoreMenuCommands: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/modelStore'), () => ({
-  useModelStore: () => ({})
-}))
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({}),
-  useNodeFrequencyStore: () => ({})
-}))
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    update: vi.fn(),
-    runningTasks: [],
-    pendingTasks: [],
-    tasks: [],
-    maxHistoryItems: 64
-  }),
-  useQueuePendingTaskCountStore: () => ({ update: vi.fn() })
-}))
-vi.mock<unknown>(import('@/stores/serverConfigStore'), () => ({
-  useServerConfigStore: () => ({})
-}))
-vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), () => ({
-  useBottomPanelStore: () => ({
-    registerCoreBottomPanelTabs: vi.fn().mockResolvedValue(undefined)
-  })
-}))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: { light_theme: true, colors: { comfy_base: {} } }
-  })
-}))
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => ({
-    registerCoreSidebarTabs: vi.fn(),
-    activeSidebarTabId: null
-  })
-}))
+
 vi.mock<unknown>(import('@/utils/envUtil'), () => ({
   electronAPI: () => ({
     changeTheme: vi.fn(),

--- a/src/views/LinearView.test.ts
+++ b/src/views/LinearView.test.ts
@@ -2,9 +2,21 @@ import { render, screen, within } from '@testing-library/vue'
 import type { DetachedWindowAPI } from 'happy-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import type { SidebarTabExtension } from '@/types/extensionTypes'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import LinearView from './LinearView.vue'
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn(async () => {}),
+  onAuthStateChanged: vi.fn(() => () => {}),
+  onIdTokenChanged: vi.fn(() => () => {})
+}))
 
 interface ViewState {
   sidebarLocation: 'left' | 'right'
@@ -13,49 +25,6 @@ interface ViewState {
   activeTab: SidebarTabExtension | null
   hasOutputs: boolean
 }
-
-const state = vi.hoisted<ViewState>(() => ({
-  sidebarLocation: 'left',
-  isBuilderMode: false,
-  isArrangeMode: false,
-  activeTab: null,
-  hasOutputs: false
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.Sidebar.Location' ? state.sidebarLocation : undefined
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    sidebarTab: {
-      get activeSidebarTab() {
-        return state.activeTab
-      }
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
-  const { computed } = await import('vue')
-  return {
-    useAppMode: () => ({
-      isBuilderMode: computed(() => state.isBuilderMode),
-      isArrangeMode: computed(() => state.isArrangeMode)
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { reactive, computed } = await import('vue')
-  return {
-    useAppModeStore: () =>
-      reactive({ hasOutputs: computed(() => state.hasOutputs) })
-  }
-})
 
 vi.mock(
   import('@/workbench/extensions/agent/composables/useAgentDockMount'),
@@ -114,7 +83,25 @@ const baseStubs = {
 }
 
 function renderView(overrides: Partial<ViewState> = {}) {
-  Object.assign(state, overrides)
+  const state: ViewState = {
+    sidebarLocation: 'left',
+    isBuilderMode: false,
+    isArrangeMode: false,
+    activeTab: null,
+    hasOutputs: false,
+    ...overrides
+  }
+  useWorkflowStore().activeWorkflow = createMockLoadedWorkflow({
+    activeMode: state.isArrangeMode
+      ? 'builder:arrange'
+      : state.isBuilderMode
+        ? 'builder:inputs'
+        : 'app'
+  })
+  useSettingStore().settingValues['Comfy.Sidebar.Location'] =
+    state.sidebarLocation
+  Object.assign(useSidebarTabStore(), { activeSidebarTab: state.activeTab })
+  Object.assign(useAppModeStore(), { hasOutputs: state.hasOutputs })
   return render(LinearView, {
     global: { stubs: baseStubs }
   })
@@ -136,13 +123,6 @@ function expectRenderedBefore(first: HTMLElement, second: HTMLElement) {
 describe('LinearView', () => {
   beforeEach(() => {
     setViewport(DESKTOP_WIDTH)
-    Object.assign(state, {
-      sidebarLocation: 'left',
-      isBuilderMode: false,
-      isArrangeMode: false,
-      activeTab: null,
-      hasOutputs: false
-    } satisfies ViewState)
   })
 
   it('renders only the mobile display on small screens', () => {

--- a/src/views/UserSelectView.test.ts
+++ b/src/views/UserSelectView.test.ts
@@ -4,6 +4,8 @@ import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { useUserStore } from '@/stores/userStore'
+
 import UserSelectView from './UserSelectView.vue'
 
 const i18n = createI18n({
@@ -17,15 +19,7 @@ vi.mock<unknown>(import('vue-router'), () => ({
   useRouter: () => ({ push: mockRouterPush })
 }))
 
-const userStoreMock = vi.hoisted(() => ({
-  users: [] as Array<{ userId: string; username: string }>,
-  initialize: vi.fn().mockResolvedValue(undefined),
-  createUser: vi.fn(),
-  login: vi.fn().mockResolvedValue(undefined)
-}))
-vi.mock<unknown>(import('@/stores/userStore'), () => ({
-  useUserStore: () => userStoreMock
-}))
+let userStoreMock: ReturnType<typeof useUserStore>
 
 vi.mock<unknown>(import('@/views/templates/BaseViewTemplate.vue'), () => ({
   default: {
@@ -43,7 +37,9 @@ const mountView = () =>
 
 describe('UserSelectView', () => {
   beforeEach(() => {
-    userStoreMock.users = []
+    userStoreMock = useUserStore()
+    vi.mocked(userStoreMock.initialize).mockResolvedValue(undefined)
+    vi.mocked(userStoreMock.login).mockResolvedValue(undefined)
   })
 
   it('initializes the user store on mount', async () => {
@@ -68,7 +64,7 @@ describe('UserSelectView', () => {
 
   it('creates a new user, logs in, and navigates home', async () => {
     const newUser = { userId: 'u1', username: 'bob' }
-    userStoreMock.createUser.mockResolvedValueOnce(newUser)
+    vi.mocked(userStoreMock.createUser).mockResolvedValueOnce(newUser)
     mountView()
 
     await userEvent.type(
@@ -85,7 +81,7 @@ describe('UserSelectView', () => {
   })
 
   it('shows an error when the entered username already exists', async () => {
-    userStoreMock.users = [{ userId: 'u1', username: 'bob' }]
+    Object.assign(userStoreMock, { users: [{ userId: 'u1', username: 'bob' }] })
     mountView()
 
     await userEvent.type(
@@ -99,7 +95,7 @@ describe('UserSelectView', () => {
   })
 
   it('surfaces createUser failures as a login error', async () => {
-    userStoreMock.createUser.mockRejectedValueOnce(new Error('boom'))
+    vi.mocked(userStoreMock.createUser).mockRejectedValueOnce(new Error('boom'))
     mountView()
 
     await userEvent.type(

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Replace the state/services domain of #17222 plus local-instance removal from #17223 with global testing Pinia.

## Changes

- 62 files including the identical four-file shared lifecycle prerequisite. Targets main and can merge independently.
- Real store actions unless explicitly stubbed. Preserve scenario state and fixtures.
- Enforcement and documentation remain deferred to #17223.

## Review Focus

- All 58 domain paths are byte-identical to the corresponding files in [the immutable source](https://github.com/Comfy-Org/ComfyUI_frontend/commit/beb2e861ef0a168b0e0bd06edde4d80c050005c2).
- `pnpm test:unit` with all 58 changed domain test paths plus three shared tests: 61 files passed, 1,294 tests passed and one existing skip.
- Passed: `pnpm typecheck`, `pnpm typecheck:scripts`, scoped ESLint, type-aware Oxlint, cleanup audit, formatting, `pnpm knip`, and `git diff --check`.

<details>
<summary>Common lifecycle prerequisite</summary>

- `vitest.setup.ts`
- `scripts/testingPinia.test.ts`
- `src/components/node/NodePreview.test.ts`
- `src/renderer/extensions/vueNodes/components/LGraphNode.test.ts`

</details>
