### PR TITLE
test: use global Pinia in assets and workflow tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -1,6 +1,6 @@
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@/i18n'
@@ -22,29 +22,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
         return false
       }
     }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => {
-  const getAssets = vi.fn((key: string) => mockAssetsByKey.get(key) ?? [])
-  const isModelLoading = vi.fn(
-    (key: string) => mockLoadingByKey.get(key) ?? false
-  )
-  const updateModelsForNodeType = vi.fn()
-  const updateModelsForTag = vi.fn()
-  return {
-    useAssetsStore: () => ({
-      getAssets,
-      isModelLoading,
-      updateModelsForNodeType,
-      updateModelsForTag
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getCategoryForNodeType: () => 'checkpoints'
   })
 }))
 
@@ -161,6 +138,25 @@ vi.mock<unknown>(import('@/platform/assets/components/AssetGrid.vue'), () => ({
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
+beforeEach(() => {
+  vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockImplementation(
+    () => 'checkpoints'
+  )
+})
+
+beforeEach(() => {
+  const getAssets = vi.fn((key: string) => mockAssetsByKey.get(key) ?? [])
+  const isModelLoading = vi.fn(
+    (key: string) => mockLoadingByKey.get(key) ?? false
+  )
+  vi.mocked(useAssetsStore().getAssets).mockImplementation(getAssets)
+  vi.mocked(useAssetsStore().isModelLoading).mockImplementation(isModelLoading)
+  vi.mocked(useAssetsStore().updateModelsForNodeType).mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useAssetsStore().updateModelsForTag).mockResolvedValue(undefined)
+})
+
 describe('AssetBrowserModal', () => {
   const createTestAsset = (
     id: string,
@@ -184,13 +180,10 @@ describe('AssetBrowserModal', () => {
   })
 
   function renderModal(props: Record<string, unknown>) {
-    const pinia = createPinia()
-    setActivePinia(pinia)
-
     return render(AssetBrowserModal, {
       props,
       global: {
-        plugins: [pinia, i18n],
+        plugins: [i18n],
         stubs: {
           'i-lucide:folder': {
             template: '<div data-testid="folder-icon"></div>'

--- a/src/platform/assets/components/AssetCard.test.ts
+++ b/src/platform/assets/components/AssetCard.test.ts
@@ -1,30 +1,15 @@
+import type * as VueUseModule from '@vueuse/core'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import AssetCard from '@/platform/assets/components/AssetCard.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => 0
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/assetDownloadStore'), () => ({
-  useAssetDownloadStore: () => ({
-    isDownloadedThisSession: () => false,
-    acknowledgeAsset: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: vi.fn()
-  })
-}))
 
 vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   assetService: {
@@ -36,7 +21,8 @@ vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
   showConfirmDialog: vi.fn()
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUseModule>()),
   useImage: () => ({ isLoading: false, error: null })
 }))
 
@@ -86,6 +72,17 @@ function renderCard(asset: AssetDisplayItem) {
     }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => 0)
+  vi.mocked(useAssetDownloadStore().isDownloadedThisSession).mockImplementation(
+    () => false
+  )
+  vi.mocked(useAssetDownloadStore().acknowledgeAsset).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => undefined)
+})
 
 describe('AssetCard', () => {
   describe('FE-228: filename rendering', () => {

--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -1,7 +1,8 @@
+import { useAssetsStore } from '@/stores/assetsStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
@@ -11,10 +12,6 @@ import { MIME_ASSET_INFO } from '@/platform/assets/schemas/mediaAssetSchema'
 
 const { downloadAssets } = vi.hoisted(() => ({
   downloadAssets: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({ isAssetDeleting: () => false })
 }))
 
 vi.mock<unknown>(import('../composables/useMediaAssetActions'), () => ({
@@ -84,6 +81,10 @@ function dispatchDragStart(
   container.querySelector('[data-asset-id="a"]')!.dispatchEvent(event)
   return { event, add }
 }
+
+beforeEach(() => {
+  vi.mocked(useAssetsStore().isAssetDeleting).mockImplementation(() => false)
+})
 
 describe('MediaAssetCard', () => {
   describe('dragStart', () => {

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -70,7 +70,7 @@ describe('ModelInfoPanel', () => {
     return render(ModelInfoPanel, {
       props: { asset },
       global: {
-        plugins: [createTestingPinia({ stubActions: false }), i18n]
+        plugins: [getActivePinia()!, i18n]
       }
     })
   }

--- a/src/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -1,14 +1,16 @@
+import type * as I18nModule from '@/i18n'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { describe, expect, it, vi } from 'vitest'
+import type { ComponentProps } from 'vue-component-type-helpers'
 
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import type AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
-vi.mock(import('@/stores/dialogStore'))
-
-vi.mock<unknown>(import('@/i18n'), () => ({
+vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: (key: string, params?: Record<string, string>) => {
     if (params) {
       return `${key}:${JSON.stringify(params)}`
@@ -32,12 +34,15 @@ function createMockAsset(overrides: Partial<AssetItem> = {}): AssetItem {
 }
 
 function setupDialogMocks() {
-  const mockShowDialog = vi.fn()
-  const mockCloseDialog = vi.fn()
-  vi.mocked(useDialogStore, { partial: true }).mockReturnValue({
-    showDialog: mockShowDialog,
-    closeDialog: mockCloseDialog
-  })
+  const dialogStore = useDialogStore()
+  type BrowserProps = ComponentProps<typeof AssetBrowserModal>
+  const showDialog: (
+    options: Omit<Parameters<typeof dialogStore.showDialog>[0], 'props'> & {
+      props: BrowserProps & Required<Pick<BrowserProps, 'onSelect' | 'onClose'>>
+    }
+  ) => ReturnType<typeof dialogStore.showDialog> = dialogStore.showDialog
+  const mockShowDialog = vi.mocked(showDialog)
+  const mockCloseDialog = vi.mocked(dialogStore.closeDialog)
 
   return { mockShowDialog, mockCloseDialog }
 }

--- a/src/platform/assets/composables/useAssetSelection.property.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.property.test.ts
@@ -1,7 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import * as fc from 'fast-check'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -51,7 +50,6 @@ describe('useAssetSelection properties', () => {
           arbAssets(1, 15),
           arbAssets(1, 15),
           (initialAssets, visibleAssets) => {
-            setActivePinia(createPinia())
             const selection = useAssetSelection()
             const store = useAssetSelectionStore()
 
@@ -73,7 +71,6 @@ describe('useAssetSelection properties', () => {
           arbAssets(1, 15),
           arbAssets(1, 15),
           (initialAssets, visibleAssets) => {
-            setActivePinia(createPinia())
             const selection = useAssetSelection()
             const store = useAssetSelectionStore()
 
@@ -93,7 +90,6 @@ describe('useAssetSelection properties', () => {
     it('reconcile with superset of selected assets preserves all selections', () => {
       fc.assert(
         fc.property(arbAssets(1, 15), (assets) => {
-          setActivePinia(createPinia())
           const selection = useAssetSelection()
           const store = useAssetSelectionStore()
 
@@ -110,7 +106,6 @@ describe('useAssetSelection properties', () => {
     it('reconcile with empty visible assets clears selection', () => {
       fc.assert(
         fc.property(arbAssets(1, 15), (initialAssets) => {
-          setActivePinia(createPinia())
           const selection = useAssetSelection()
           const store = useAssetSelectionStore()
 
@@ -127,7 +122,6 @@ describe('useAssetSelection properties', () => {
     it('selectAll then getSelectedAssets returns all assets', () => {
       fc.assert(
         fc.property(arbAssets(0, 20), (assets) => {
-          setActivePinia(createPinia())
           const selection = useAssetSelection()
 
           selection.selectAll(assets)
@@ -161,7 +155,6 @@ describe('useAssetSelection properties', () => {
 
       fc.assert(
         fc.property(arbAssetWithMeta, (asset) => {
-          setActivePinia(createPinia())
           const selection = useAssetSelection()
           expect(selection.getOutputCount(asset)).toBeGreaterThanOrEqual(1)
         })
@@ -188,7 +181,6 @@ describe('useAssetSelection properties', () => {
 
       fc.assert(
         fc.property(fc.array(arbAssetWithMeta, { maxLength: 20 }), (assets) => {
-          setActivePinia(createPinia())
           const selection = useAssetSelection()
           expect(selection.getTotalOutputCount(assets)).toBeGreaterThanOrEqual(
             assets.length

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1,3 +1,10 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useAssetExportStore } from '@/stores/assetExportStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { CreateAssetExportData } from '@comfyorg/ingest-types'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { useToast } from 'primevue/usetoast'
@@ -23,7 +30,8 @@ vi.mock(import('@/base/common/downloadUtil'), () => ({
   downloadFile: mockDownloadFile
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockIsCloud.value
   }
@@ -41,38 +49,11 @@ vi.mock<unknown>(
 )
 
 const mockShowDialog = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    showDialog: mockShowDialog
-  })
-}))
 
 const mockInvalidateModelsForCategory = vi.hoisted(() => vi.fn())
 const mockSetAssetDeleting = vi.hoisted(() => vi.fn())
 const mockHasCategory = vi.hoisted(() => vi.fn())
 const mockInputAssets = vi.hoisted(() => ({ items: [] as AssetItem[] }))
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    setAssetDeleting: mockSetAssetDeleting,
-    inputAssets: {
-      get items() {
-        return mockInputAssets.items
-      },
-      invalidate: (stale?: string[]) => {
-        const ids = new Set(stale)
-        mockInputAssets.items = mockInputAssets.items.filter(
-          (item) => !ids.has(item.id)
-        )
-      }
-    },
-    invalidateModelsForCategory: mockInvalidateModelsForCategory,
-    hasCategory: mockHasCategory
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({})
-}))
 
 vi.mock(import('@/composables/useCopyToClipboard'), () => ({
   useCopyToClipboard: () => ({
@@ -103,17 +84,6 @@ const litegraphServiceMock = vi.hoisted(() => ({
 }))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => litegraphServiceMock
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    nodeDefsByName: {
-      LoadImage: {
-        name: 'LoadImage',
-        display_name: 'Load Image'
-      }
-    }
-  })
 }))
 
 vi.mock<unknown>(import('@/utils/loaderNodeUtil'), () => ({
@@ -162,11 +132,6 @@ vi.mock<unknown>(import('../services/assetService'), () => ({
 }))
 
 const mockTrackExport = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/assetExportStore'), () => ({
-  useAssetExportStore: () => ({
-    trackExport: mockTrackExport
-  })
-}))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -185,6 +150,8 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 const mockAppGraph = vi.hoisted(() => ({ value: { _nodes: [] as unknown[] } }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     get graph() {
       return mockAppGraph.value
     },
@@ -196,24 +163,8 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 const mockRemoveNodeOutputs = vi.hoisted(() => vi.fn())
 const mockRemoveNodeOutputsForNode = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    removeNodeOutputs: mockRemoveNodeOutputs,
-    removeNodeOutputsForNode: mockRemoveNodeOutputsForNode
-  })
-}))
 
 const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: { captureCanvasState: mockCaptureCanvasState }
-      }
-    })
-  })
-)
 
 const mockClearNodePreviewCache = vi.hoisted(() => vi.fn())
 vi.mock(import('../utils/clearNodePreviewCacheForValues'), () => ({
@@ -309,6 +260,49 @@ function useMediaAssetActions() {
 }
 
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
+
+beforeEach(() => {
+  useNodeDefStore().nodeDefsByName = {
+    LoadImage: fromPartial({
+      name: 'LoadImage',
+      display_name: 'Load Image'
+    })
+  }
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { captureCanvasState: mockCaptureCanvasState }
+  })
+})
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().showDialog).mockImplementation(mockShowDialog)
+  vi.mocked(useAssetsStore().setAssetDeleting).mockImplementation(
+    mockSetAssetDeleting
+  )
+  vi.spyOn(useAssetsStore().inputAssets, 'items', 'get').mockImplementation(
+    () => mockInputAssets.items
+  )
+  vi.spyOn(useAssetsStore().inputAssets, 'invalidate').mockImplementation(
+    async (stale?: string[]) => {
+      const ids = new Set(stale)
+      mockInputAssets.items = mockInputAssets.items.filter(
+        (item) => !ids.has(item.id)
+      )
+    }
+  )
+  vi.mocked(useAssetsStore().invalidateModelsForCategory).mockImplementation(
+    mockInvalidateModelsForCategory
+  )
+  vi.mocked(useAssetsStore().hasCategory).mockImplementation(mockHasCategory)
+  vi.mocked(useAssetExportStore().trackExport).mockImplementation(
+    mockTrackExport
+  )
+  vi.mocked(useNodeOutputStore().removeNodeOutputs).mockImplementation(
+    mockRemoveNodeOutputs
+  )
+  vi.mocked(useNodeOutputStore().removeNodeOutputsForNode).mockImplementation(
+    mockRemoveNodeOutputsForNode
+  )
+})
 
 describe('useMediaAssetActions', () => {
   beforeEach(() => {

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -1,3 +1,9 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import type { ComfyApp } from '@/scripts/app'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import { useAssetsStore } from '@/stores/assetsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -14,7 +20,8 @@ const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 const mockSettingStoreGet = vi.hoisted(() => vi.fn(() => false))
 const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: true }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return mockDistributionState.isCloud
   }
@@ -30,47 +37,19 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: mockSettingStoreGet
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => {
-  const registeredNodeTypes: Record<string, string> = {
-    CheckpointLoaderSimple: 'ckpt_name',
-    LoraLoader: 'lora_name'
-  }
-  const nodeTypeCategories: Record<string, string> = {
-    CheckpointLoaderSimple: 'checkpoints',
-    LoraLoader: 'loras'
-  }
-  return {
-    useModelToNodeStore: vi.fn(() => ({
-      getRegisteredNodeTypes: () => registeredNodeTypes,
-      getCategoryForNodeType: vi.fn(
-        (nodeType: string) => nodeTypeCategories[nodeType]
-      )
-    }))
-  }
-})
-
 const mockInvalidateInputAssets = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    inputAssets: { invalidate: mockInvalidateInputAssets }
-  })
-}))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     fetchApi: vi.fn(),
+    addEventListener: vi.fn(),
     addCustomEventListener: vi.fn(),
     removeCustomEventListener: vi.fn()
   }
 }))
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
@@ -121,6 +100,30 @@ function validAsset(overrides: Partial<AssetItem> = {}): AssetItem {
     ...overrides
   }
 }
+
+beforeEach(() => {
+  const registeredNodeTypes: Record<string, string> = {
+    CheckpointLoaderSimple: 'ckpt_name',
+    LoraLoader: 'lora_name'
+  }
+  const nodeTypeCategories: Record<string, string> = {
+    CheckpointLoaderSimple: 'checkpoints',
+    LoraLoader: 'loras'
+  }
+  vi.mocked(useModelToNodeStore().getRegisteredNodeTypes).mockImplementation(
+    () => registeredNodeTypes
+  )
+  vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockImplementation(
+    (nodeType: string) => nodeTypeCategories[nodeType]
+  )
+  vi.spyOn(useAssetsStore().inputAssets, 'invalidate').mockImplementation(
+    mockInvalidateInputAssets
+  )
+})
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(mockSettingStoreGet)
+})
 
 describe(assetService.shouldUseAssetBrowser, () => {
   beforeEach(() => {
@@ -1178,4 +1181,9 @@ describe(assetService.getAssetsForNodeType, () => {
     expect(assets).toEqual([])
     expect(fetchApiMock).not.toHaveBeenCalled()
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/assets/utils/assetPreviewUtil.test.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import type { ComfyApp } from '@/scripts/app'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   findOutputAsset,
@@ -19,6 +21,7 @@ const mockInvalidateOutputAssets = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
+    addEventListener: vi.fn(),
     fetchApi: mockFetchApi,
     apiURL: mockApiURL,
     api_base: '',
@@ -32,12 +35,6 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
     uploadAssetFromBase64: mockUploadAssetFromBase64,
     updateAsset: mockUpdateAsset
   }
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    outputAssets: { invalidate: mockInvalidateOutputAssets }
-  })
 }))
 
 function mockFetchResponse(assets: Record<string, unknown>[]) {
@@ -82,6 +79,12 @@ const localAssetWithPreview = {
   preview_id: '3df94ee8-preview',
   preview_url: '/api/view?type=output&filename=preview.png'
 }
+
+beforeEach(() => {
+  vi.spyOn(useAssetsStore().outputAssets, 'invalidate').mockImplementation(
+    mockInvalidateOutputAssets
+  )
+})
 
 describe('isAssetPreviewSupported', () => {
   it('returns true when asset API is enabled (cloud)', () => {
@@ -315,4 +318,9 @@ describe('persistThumbnail', () => {
 
     expect(mockInvalidateOutputAssets).not.toHaveBeenCalled()
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/assets/utils/createAssetWidget.test.ts
+++ b/src/platform/assets/utils/createAssetWidget.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -9,6 +7,8 @@ import type {
 } from '@/lib/litegraph/src/types/widgets'
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import { createAssetWidget } from './createAssetWidget'
 
@@ -70,19 +70,9 @@ describe('createAssetWidget', () => {
   let captureCanvasState: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    captureCanvasState = vi.fn()
-    setActivePinia(
-      createTestingPinia({
-        stubActions: false,
-        initialState: {
-          workflow: {
-            activeWorkflow: {
-              changeTracker: { captureCanvasState }
-            }
-          }
-        }
-      })
-    )
+    const workflow = createMockLoadedWorkflow()
+    captureCanvasState = vi.mocked(workflow.changeTracker.captureCanvasState)
+    useWorkflowStore().activeWorkflow = workflow
   })
 
   it('preserves regular asset widget change handling for the owning widget', async () => {

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -1,3 +1,4 @@
+import type * as DistributionModule from '@/platform/distribution/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -10,7 +11,8 @@ import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 
 import { markDeletedAssetsAsMissingMedia } from './markDeletedAssetsAsMissingMedia'
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: true
 }))
 
@@ -18,14 +20,6 @@ const mockScanNodeMediaCandidates = vi.hoisted(() => vi.fn())
 vi.mock(import('@/platform/missingMedia/missingMediaScan'), () => ({
   scanNodeMediaCandidates: mockScanNodeMediaCandidates
 }))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({ currentGraph: null })
-  })
-)
 
 function makeGraph(nodes: unknown[]): LGraph {
   return { nodes } as unknown as LGraph

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
@@ -1,3 +1,4 @@
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
@@ -5,10 +6,6 @@ import { resolveModelNodeFromAsset } from '@/platform/assets/utils/resolveModelN
 
 const mockGetNodeProvider = vi.hoisted(() => vi.fn())
 const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: false }))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
-}))
 
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
@@ -56,6 +53,12 @@ function mockProvider(
 ) {
   mockGetNodeProvider.mockReturnValue(provider)
 }
+
+beforeEach(() => {
+  vi.mocked(useModelToNodeStore().getNodeProvider).mockImplementation(
+    mockGetNodeProvider
+  )
+})
 
 describe('resolveModelNodeFromAsset', () => {
   beforeEach(() => {

--- a/src/platform/workflow/core/services/workflowActionsService.test.ts
+++ b/src/platform/workflow/core/services/workflowActionsService.test.ts
@@ -1,29 +1,14 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import * as utils from '@/scripts/utils'
 import { useWorkflowActionsService } from './workflowActionsService'
 
 const mockPrompt = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ prompt: mockPrompt })
 }))
-
-const mockGetSetting = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: mockGetSetting })
-}))
-
-const mockDownloadBlob = vi.hoisted(() => vi.fn())
-vi.mock(import('@/scripts/utils'), () => ({
-  downloadBlob: mockDownloadBlob
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ createTemporary: vi.fn() })
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -40,41 +25,45 @@ const minimalWorkflow: ComfyWorkflowJSON = {
   links: []
 }
 
+beforeEach(() => {
+  vi.spyOn(utils, 'downloadBlob').mockImplementation(() => {})
+})
+
 describe('workflowActionsService.exportWorkflowAction', () => {
   it('returns { cancelled: true } when the user dismisses the filename prompt', async () => {
-    mockGetSetting.mockReturnValue(true)
+    useSettingStore().settingValues['Comfy.PromptFilename'] = true
     mockPrompt.mockResolvedValue(null)
     const { exportWorkflowAction } = useWorkflowActionsService()
 
     const result = await exportWorkflowAction(minimalWorkflow, 'wf.json')
 
     expect(result).toEqual({ success: false, cancelled: true })
-    expect(mockDownloadBlob).not.toHaveBeenCalled()
+    expect(utils.downloadBlob).not.toHaveBeenCalled()
   })
 
   it('downloads with the prompted filename and returns success', async () => {
-    mockGetSetting.mockReturnValue(true)
+    useSettingStore().settingValues['Comfy.PromptFilename'] = true
     mockPrompt.mockResolvedValue('custom')
     const { exportWorkflowAction } = useWorkflowActionsService()
 
     const result = await exportWorkflowAction(minimalWorkflow, 'wf.json')
 
     expect(result).toEqual({ success: true })
-    expect(mockDownloadBlob).toHaveBeenCalledWith(
+    expect(utils.downloadBlob).toHaveBeenCalledWith(
       'custom.json',
       expect.any(Blob)
     )
   })
 
   it('skips the prompt and uses the default filename when the setting is off', async () => {
-    mockGetSetting.mockReturnValue(false)
+    useSettingStore().settingValues['Comfy.PromptFilename'] = false
     const { exportWorkflowAction } = useWorkflowActionsService()
 
     const result = await exportWorkflowAction(minimalWorkflow, 'default.json')
 
     expect(result).toEqual({ success: true })
     expect(mockPrompt).not.toHaveBeenCalled()
-    expect(mockDownloadBlob).toHaveBeenCalledWith(
+    expect(utils.downloadBlob).toHaveBeenCalledWith(
       'default.json',
       expect.any(Blob)
     )
@@ -89,6 +78,6 @@ describe('workflowActionsService.exportWorkflowAction', () => {
       success: false,
       error: 'No workflow data available'
     })
-    expect(mockDownloadBlob).not.toHaveBeenCalled()
+    expect(utils.downloadBlob).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workflow/core/services/workflowService.insertWorkflow.test.ts
+++ b/src/platform/workflow/core/services/workflowService.insertWorkflow.test.ts
@@ -1,5 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
+import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -35,14 +36,6 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
@@ -64,30 +57,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     trackWorkflowSaved: vi.fn(),
     trackEnterLinear: vi.fn()
   })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/persistence/stores/workflowDraftStoreV2'),
-  () => ({
-    useWorkflowDraftStoreV2: () => ({
-      saveDraft: vi.fn(() => true),
-      getDraft: vi.fn(),
-      removeDraft: vi.fn(),
-      markDraftUsed: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({ clear: vi.fn() })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => ({ saveCurrentViewport: vi.fn() })
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({})
 }))
 
 const PROBE_NODE_TYPE = 'test/insert-workflow-probe'
@@ -148,9 +117,21 @@ beforeEach(() => {
   )
 })
 
+beforeEach(() => {
+  vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockImplementation(() => true)
+  vi.mocked(useWorkflowDraftStoreV2().getDraft).mockReturnValue(null)
+  vi.mocked(useWorkflowDraftStoreV2().removeDraft).mockImplementation(() => {})
+  vi.mocked(useWorkflowDraftStoreV2().markDraftUsed).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useDomWidgetStore().clear).mockImplementation(() => {})
+  vi.mocked(
+    useSubgraphNavigationStore().saveCurrentViewport
+  ).mockImplementation(() => {})
+})
+
 describe('insertWorkflow scratch graph isolation', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()
   })
 
@@ -218,4 +199,9 @@ describe('insertWorkflow scratch graph isolation', () => {
       { position: [100, 200] }
     )
   })
+})
+
+vi.mock(import('@vueuse/router'), async () => {
+  const { ref } = await import('vue')
+  return { useRouteHash: () => ref('') }
 })

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1,5 +1,7 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
+import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
+import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -77,22 +79,6 @@ const { mockConfirm, mockTrackWorkflowSaved } = vi.hoisted(() => ({
   mockTrackWorkflowSaved: vi.fn()
 }))
 
-const draftStoreMocks = vi.hoisted(() => ({
-  saveDraft: vi.fn(() => true),
-  getDraft: vi.fn(),
-  removeDraft: vi.fn(),
-  markDraftUsed: vi.fn()
-}))
-
-const subgraphNavigationMocks = vi.hoisted(() => ({
-  navigationIntentId: 0,
-  beginWorkflowNavigation: vi.fn(
-    () => ++subgraphNavigationMocks.navigationIntentId
-  ),
-  endWorkflowNavigation: vi.fn(),
-  saveCurrentViewport: vi.fn()
-}))
-
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     prompt: vi.fn(),
@@ -103,7 +89,7 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: { ds: { offset: [0, 0], scale: 1 } },
-    rootGraph: { serialize: vi.fn(() => ({})), extra: {} },
+    rootGraph: { serialize: vi.fn(() => ({})), extra: {}, nodes: [] },
     loadGraphData: vi.fn(),
     nodeOutputs: {},
     nodePreviewImages: {}
@@ -114,14 +100,6 @@ vi.mock<unknown>(import('@/scripts/defaultGraph'), () => ({
   defaultGraph: {},
   blankGraph: {}
 }))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({ linearMode: false })
-  })
-)
 
 vi.mock<unknown>(
   import('@/renderer/core/thumbnail/useWorkflowThumbnail'), // eslint-disable-line import-x/no-restricted-paths
@@ -145,31 +123,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     trackDefaultViewSet: vi.fn(),
     trackWorkflowSaved: mockTrackWorkflowSaved,
     trackEnterLinear: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/persistence/stores/workflowDraftStoreV2'),
-  () => ({
-    useWorkflowDraftStoreV2: () => draftStoreMocks
-  })
-)
-
-vi.mock<unknown>(import('@/stores/domWidgetStore'), () => ({
-  useDomWidgetStore: () => ({
-    clear: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphNavigationStore'), () => ({
-  useSubgraphNavigationStore: () => subgraphNavigationMocks
-}))
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    get workflow() {
-      return useWorkflowStore()
-    }
   })
 }))
 
@@ -198,12 +151,28 @@ function enableWarningSettings() {
   )
 }
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { linearMode: false })
+  vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockImplementation(() => true)
+  vi.mocked(useWorkflowDraftStoreV2().getDraft).mockReturnValue(null)
+  vi.mocked(useWorkflowDraftStoreV2().removeDraft).mockImplementation(() => {})
+  vi.mocked(useWorkflowDraftStoreV2().markDraftUsed).mockImplementation(
+    () => {}
+  )
+  vi.mocked(useDomWidgetStore().clear).mockImplementation(() => {})
+  vi.mocked(
+    useSubgraphNavigationStore().saveCurrentViewport
+  ).mockImplementation(() => {})
+  vi.mocked(
+    useSubgraphNavigationStore().endWorkflowNavigation
+  ).mockImplementation(() => {})
+})
+
 describe('useWorkflowService', () => {
   beforeEach(() => {
     vi.mocked(app.loadGraphData).mockResolvedValue(true)
     resetWorkflowLoadQueueForTests()
-    draftStoreMocks.saveDraft.mockReturnValue(true)
-    subgraphNavigationMocks.navigationIntentId = 0
+    vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -330,9 +299,9 @@ describe('useWorkflowService', () => {
 
       useWorkflowService().beforeLoadNewGraph(false)
 
-      expect(subgraphNavigationMocks.saveCurrentViewport).toHaveBeenCalledWith(
-        false
-      )
+      expect(
+        useSubgraphNavigationStore().saveCurrentViewport
+      ).toHaveBeenCalledWith(false)
     })
 
     it('arms suppression by default for a clean workflow load', () => {
@@ -340,9 +309,9 @@ describe('useWorkflowService', () => {
 
       useWorkflowService().beforeLoadNewGraph()
 
-      expect(subgraphNavigationMocks.saveCurrentViewport).toHaveBeenCalledWith(
-        true
-      )
+      expect(
+        useSubgraphNavigationStore().saveCurrentViewport
+      ).toHaveBeenCalledWith(true)
     })
 
     it('should cache missingModelCandidates and missingMediaCandidates to activeWorkflow.pendingWarnings', () => {
@@ -372,8 +341,12 @@ describe('useWorkflowService', () => {
         }
       ]
 
-      useMissingModelStore().missingModelCandidates = modelCandidates
-      useMissingMediaStore().missingMediaCandidates = mediaCandidates
+      Object.assign(useMissingModelStore(), {
+        missingModelCandidates: modelCandidates
+      })
+      Object.assign(useMissingMediaStore(), {
+        missingMediaCandidates: mediaCandidates
+      })
 
       useWorkflowService().beforeLoadNewGraph()
 
@@ -411,7 +384,7 @@ describe('useWorkflowService', () => {
 
       useWorkflowService().beforeLoadNewGraph()
 
-      expect(draftStoreMocks.saveDraft).toHaveBeenCalledWith(
+      expect(useWorkflowDraftStoreV2().saveDraft).toHaveBeenCalledWith(
         activeWorkflow.path,
         JSON.stringify(activeWorkflow.activeState),
         {
@@ -426,7 +399,7 @@ describe('useWorkflowService', () => {
         return key === 'Comfy.Workflow.Persist'
       })
       const addToastSpy = vi.spyOn(useToastStore(), 'add')
-      draftStoreMocks.saveDraft.mockReturnValue(false)
+      vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockReturnValue(false)
       const activeWorkflow = createModeTestWorkflow({
         path: 'workflows/test.json'
       })
@@ -452,7 +425,7 @@ describe('useWorkflowService', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {})
       const error = new Error('storage unavailable')
-      draftStoreMocks.saveDraft.mockImplementation(() => {
+      vi.mocked(useWorkflowDraftStoreV2().saveDraft).mockImplementation(() => {
         throw error
       })
       const activeWorkflow = createModeTestWorkflow({
@@ -569,7 +542,7 @@ describe('useWorkflowService', () => {
       // The Aug-12 review's baked-in gap, un-baked: a tab that failed to
       // close must keep its draft.
       expect(storeClose).not.toHaveBeenCalled()
-      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalled()
+      expect(useWorkflowDraftStoreV2().removeDraft).not.toHaveBeenCalled()
       consoleError.mockRestore()
     })
 
@@ -600,14 +573,14 @@ describe('useWorkflowService', () => {
       ).resolves.toBe(false)
 
       expect(storeClose).not.toHaveBeenCalled()
-      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalled()
+      expect(useWorkflowDraftStoreV2().removeDraft).not.toHaveBeenCalled()
       expect(workflowStore.openWorkflows.map((open) => open.path)).toContain(
         'workflows/closing.json'
       )
       // The failed load's intent is released (guarded no-op when the hash
       // publish already superseded it) - pins the sibling of the catch path.
       expect(
-        subgraphNavigationMocks.endWorkflowNavigation
+        useSubgraphNavigationStore().endWorkflowNavigation
       ).toHaveBeenCalledWith(1)
     })
 
@@ -631,7 +604,7 @@ describe('useWorkflowService', () => {
       ).resolves.toBe(false)
 
       expect(storeClose).not.toHaveBeenCalled()
-      expect(draftStoreMocks.removeDraft).not.toHaveBeenCalled()
+      expect(useWorkflowDraftStoreV2().removeDraft).not.toHaveBeenCalled()
       expect(workflowStore.openWorkflows.map((open) => open.path)).toContain(
         'workflows/closing.json'
       )
@@ -748,7 +721,7 @@ describe('useWorkflowService', () => {
         errorType: 'workflow_load_failure'
       })
       expect(
-        subgraphNavigationMocks.endWorkflowNavigation
+        useSubgraphNavigationStore().endWorkflowNavigation
       ).toHaveBeenCalledWith(1)
       expect(
         vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
@@ -1647,7 +1620,6 @@ describe('useWorkflowService', () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>
 
     beforeEach(() => {
-      setActivePinia(createTestingPinia())
       workflowStore = useWorkflowStore()
     })
 
@@ -1741,7 +1713,6 @@ describe('useWorkflowService', () => {
     let existingWorkflow: LoadedComfyWorkflow
 
     beforeEach(() => {
-      setActivePinia(createTestingPinia())
       workflowStore = useWorkflowStore()
       existingWorkflow = createModeTestWorkflow({
         path: 'workflows/repeat.json'
@@ -2245,7 +2216,6 @@ describe('useWorkflowService', () => {
 
   describe('renameWorkflow', () => {
     it('keeps run errors attached to a renamed workflow', async () => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
       const workflowStore = useWorkflowStore()
       const service = useWorkflowService()
       const executionErrorStore = useExecutionErrorStore()
@@ -2745,3 +2715,15 @@ describe('useWorkflowService', () => {
     })
   })
 })
+
+vi.mock(import('@vueuse/router'), async () => {
+  const { ref } = await import('vue')
+  return { useRouteHash: () => ref('') }
+})
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
+}))

--- a/src/platform/workflow/core/utils/workflowToClipboardItems.integration.test.ts
+++ b/src/platform/workflow/core/utils/workflowToClipboardItems.integration.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ISlotType } from '@/lib/litegraph/src/interfaces'
 import {
@@ -21,19 +19,9 @@ import { createUuidv4 } from '@/utils/uuid'
 
 import { workflowToClipboardItems } from './workflowToClipboardItems'
 
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('workflow clipboard insertion', () => {
   it('pastes reroutes at their source-relative position', () => {

--- a/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
@@ -1,5 +1,7 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
 
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowAutoSave } from '@/platform/workflow/persistence/composables/useWorkflowAutoSave'
@@ -21,35 +23,18 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key) => {
-      if (key === 'Comfy.Workflow.AutoSave') return mockAutoSaveSetting
-      if (key === 'Comfy.Workflow.AutoSaveDelay') return mockAutoSaveDelay
-      return null
-    })
-  }))
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      activeWorkflow: mockActiveWorkflow
-    }))
-  })
-)
-
-let mockAutoSaveSetting: string = 'off'
-let mockAutoSaveDelay: number = 1000
-let mockActiveWorkflow: { isModified: boolean; isPersisted?: boolean } | null =
-  null
+beforeEach(() => {
+  useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'off'
+  useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+})
 
 describe('useWorkflowAutoSave', () => {
   it('should auto-save workflow after delay when modified and autosave enabled', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -63,14 +48,16 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).toHaveBeenCalledWith(
-      mockActiveWorkflow
+      useWorkflowStore().activeWorkflow
     )
   })
 
   it('should not auto-save workflow after delay when not modified and autosave enabled', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: false, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: false, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -84,14 +71,16 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalledWith(
-      mockActiveWorkflow
+      useWorkflowStore().activeWorkflow
     )
   })
 
   it('should not auto save workflow when autosave is off', async () => {
-    mockAutoSaveSetting = 'off'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'off'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -101,16 +90,18 @@ describe('useWorkflowAutoSave', () => {
       }
     })
 
-    vi.advanceTimersByTime(mockAutoSaveDelay)
+    vi.advanceTimersByTime(1000)
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalled()
   })
 
   it('should respect the user specified auto save delay', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 2000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 2000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -131,9 +122,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should debounce save requests', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 2000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 2000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -161,9 +154,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should handle save error gracefully', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -195,9 +190,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should queue autosave requests during saving and reschedule after save completes', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -229,7 +226,7 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should clean up event listeners on component unmount', async () => {
-    mockAutoSaveSetting = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
 
     const { unmount } = render({
       template: `<div></div>`,
@@ -245,9 +242,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should handle edge case delay values properly', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 0
-    mockActiveWorkflow = { isModified: true, isPersisted: true }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 0
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: true }
+    })
 
     render({
       template: `<div></div>`,
@@ -263,7 +262,7 @@ describe('useWorkflowAutoSave', () => {
     expect(serviceInstance.saveWorkflow).toHaveBeenCalledTimes(1)
     serviceInstance.saveWorkflow.mockClear()
 
-    mockAutoSaveDelay = -500
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = -500
 
     const graphChangedCallback = vi.mocked(api.addEventListener).mock
       .calls[0][1]
@@ -275,9 +274,11 @@ describe('useWorkflowAutoSave', () => {
   })
 
   it('should not autosave if workflow is not persisted', async () => {
-    mockAutoSaveSetting = 'after delay'
-    mockAutoSaveDelay = 1000
-    mockActiveWorkflow = { isModified: true, isPersisted: false }
+    useSettingStore().settingValues['Comfy.Workflow.AutoSave'] = 'after delay'
+    useSettingStore().settingValues['Comfy.Workflow.AutoSaveDelay'] = 1000
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { isModified: true, isPersisted: false }
+    })
 
     render({
       template: `<div></div>`,
@@ -291,7 +292,7 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalledWith(
-      mockActiveWorkflow
+      useWorkflowStore().activeWorkflow
     )
   })
 })

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -1,5 +1,8 @@
+import { useCommandStore } from '@/stores/commandStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, nextTick, reactive } from 'vue'
+import { createApp, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
@@ -8,28 +11,6 @@ import { StorageKeys } from '../base/storageKeys'
 import * as storageIO from '../base/storageIO'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowPersistenceV2 } from './useWorkflowPersistenceV2'
-
-const settingMocks = vi.hoisted(() => ({
-  persistRef: null as { value: boolean } | null,
-  values: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), async () => {
-  const { ref } = await import('vue')
-  settingMocks.persistRef = ref(true)
-  return {
-    useSettingStore: vi.fn(() => ({
-      get: vi.fn((key: string) => {
-        if (key === 'Comfy.Workflow.Persist')
-          return settingMocks.persistRef!.value
-        return settingMocks.values[key]
-      }),
-      set: vi.fn((key: string, value: unknown) => {
-        settingMocks.values[key] = value
-      })
-    }))
-  }
-})
 
 const mockToastAdd = vi.fn()
 vi.mock<unknown>(
@@ -80,16 +61,6 @@ vi.mock(
     })
   })
 )
-
-const commandStoreMocks = vi.hoisted(() => ({
-  execute: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: commandStoreMocks.execute
-  })
-}))
 
 const routeMocks = vi.hoisted(() => ({
   query: {} as Record<string, unknown>
@@ -155,18 +126,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-const teamWorkspaceStoreMocks = reactive({
-  initState: 'uninitialized',
-  activeWorkspaceId: null as string | null
-})
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => teamWorkspaceStoreMocks
-  })
-)
-
 vi.mock(import('../migration/migrateV1toV2'), () => ({
   migrateV1toV2: vi.fn()
 }))
@@ -212,6 +171,10 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 
 type WorkflowPersistence = ReturnType<typeof useWorkflowPersistenceV2>
 
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
+
 describe('useWorkflowPersistenceV2', () => {
   const mountedApps: Array<{
     app: ReturnType<typeof createApp>
@@ -219,8 +182,7 @@ describe('useWorkflowPersistenceV2', () => {
   }> = []
 
   beforeEach(() => {
-    settingMocks.persistRef!.value = true
-    settingMocks.values = {}
+    useSettingStore().settingValues['Comfy.Workflow.Persist'] = true
     mocks.state.graphChangedHandler = null
     mocks.state.currentGraph = { initial: true }
     mocks.serializeMock.mockImplementation(() => mocks.state.currentGraph)
@@ -237,8 +199,8 @@ describe('useWorkflowPersistenceV2', () => {
     routeMocks.query = {}
     preservedQueryMocks.payloads = {}
     distributionMocks.isCloud = false
-    teamWorkspaceStoreMocks.initState = 'uninitialized'
-    teamWorkspaceStoreMocks.activeWorkspaceId = null
+    Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: null })
   })
 
   afterEach(() => {
@@ -329,7 +291,7 @@ describe('useWorkflowPersistenceV2', () => {
       mountWorkflowPersistence()
       expect(resetSpy).not.toHaveBeenCalled()
 
-      settingMocks.persistRef!.value = false
+      useSettingStore().settingValues['Comfy.Workflow.Persist'] = false
       await nextTick()
 
       expect(resetSpy).toHaveBeenCalledOnce()
@@ -582,7 +544,7 @@ describe('useWorkflowPersistenceV2', () => {
     })
 
     it('skips activation when persistence is disabled', async () => {
-      settingMocks.persistRef!.value = false
+      useSettingStore().settingValues['Comfy.Workflow.Persist'] = false
       vi.spyOn(useWorkflowStore(), 'loadWorkflows').mockResolvedValue()
 
       const { restoreWorkflowTabsState } = mountWorkflowPersistence()
@@ -608,7 +570,7 @@ describe('useWorkflowPersistenceV2', () => {
       await mountWorkflowPersistence().initializeWorkflow()
 
       expect(
-        settingMocks.values['Comfy.TutorialCompleted'],
+        useSettingStore().settingValues['Comfy.TutorialCompleted'],
         'Startup must not mark the tutorial completed; deciding that is the onboarding entry point’s job, not the graph loader’s'
       ).toBeUndefined()
     })
@@ -678,7 +640,7 @@ describe('useWorkflowPersistenceV2', () => {
     })
 
     it('reports restored for a user who already completed the tutorial', async () => {
-      settingMocks.values['Comfy.TutorialCompleted'] = true
+      useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
 
       const { initializeWorkflow } = mountWorkflowPersistence()
 
@@ -863,8 +825,8 @@ describe('useWorkflowPersistenceV2', () => {
       })
     ).toBe(false)
 
-    teamWorkspaceStoreMocks.activeWorkspaceId = 'workspace-a'
-    teamWorkspaceStoreMocks.initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-a' })
+    Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
     await nextTick()
 
     expect(
@@ -890,8 +852,8 @@ describe('useWorkflowPersistenceV2', () => {
     onLogout()
     onUserResolved({ id: 'user-c' })
 
-    teamWorkspaceStoreMocks.activeWorkspaceId = 'workspace-c'
-    teamWorkspaceStoreMocks.initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), { activeWorkspaceId: 'workspace-c' })
+    Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
     await nextTick()
 
     expect(completeTransitionSpy).toHaveBeenCalledOnce()
@@ -912,7 +874,7 @@ describe('useWorkflowPersistenceV2', () => {
 
     expect(completeTransitionSpy).not.toHaveBeenCalled()
 
-    teamWorkspaceStoreMocks.initState = 'error'
+    Object.assign(useTeamWorkspaceStore(), { initState: 'error' })
     await nextTick()
 
     expect(completeTransitionSpy).toHaveBeenCalledOnce()
@@ -961,8 +923,10 @@ describe('useWorkflowPersistenceV2', () => {
       WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
       JSON.stringify({ id: destinationWorkspaceId, type: 'team' })
     )
-    teamWorkspaceStoreMocks.activeWorkspaceId = destinationWorkspaceId
-    teamWorkspaceStoreMocks.initState = 'ready'
+    Object.assign(useTeamWorkspaceStore(), {
+      activeWorkspaceId: destinationWorkspaceId
+    })
+    Object.assign(useTeamWorkspaceStore(), { initState: 'ready' })
     await nextTick()
 
     mocks.state.currentGraph = { marker: 'destination-edit' }

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
@@ -1,8 +1,6 @@
 import * as fc from 'fast-check'
 import type { Command } from 'fast-check'
 
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
 import { MAX_DRAFTS } from '../base/draftTypes'
@@ -254,8 +252,7 @@ class ResetCommand implements Command<PersistenceModel, PersistenceReal> {
   }
 
   run(model: PersistenceModel, real: PersistenceReal) {
-    // Simulate page reload: new Pinia + new store, but storage persists
-    setActivePinia(createTestingPinia({ stubActions: false }))
+    real.draftStore.$dispose()
     real.draftStore = useWorkflowDraftStoreV2()
 
     for (const [path, expected] of model.drafts) {
@@ -344,7 +341,7 @@ describe('workflowDraftStoreV2 FSM', () => {
           // Clear storage between each fast-check run
           localStorage.clear()
           sessionStorage.clear()
-          setActivePinia(createTestingPinia({ stubActions: false }))
+          useWorkflowDraftStoreV2().$dispose()
 
           const model: PersistenceModel = {
             drafts: new Map(),

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
 import type { MockInstance } from 'vitest'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { reportError } from '@/platform/telemetry/reportError'
@@ -70,7 +68,6 @@ function failPayloadWrites(failTimes = Infinity): MockInstance {
 
 describe('workflowDraftStoreV2', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()
     sessionStorage.clear()
     resetStorageAvailable()

--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
@@ -1,30 +1,11 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive } from 'vue'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import ShareWorkflowDialogContent from '@/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue'
-
-const mockWorkflowStore = reactive<{
-  activeWorkflow: {
-    path: string
-    directory: string
-    filename: string
-    isTemporary: boolean
-    isModified: boolean
-    lastModified: number
-  } | null
-}>({
-  activeWorkflow: null
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => mockWorkflowStore
-  })
-)
 
 const mockTrackShareFlow = vi.hoisted(() => vi.fn())
 
@@ -164,14 +145,16 @@ describe('ShareWorkflowDialogContent', () => {
   const onClose = vi.fn()
 
   beforeEach(() => {
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: false,
-      lastModified: 1000
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: false,
+        lastModified: 1000
+      }
+    })
     mockGetPublishStatus.mockResolvedValue({
       isPublished: false,
       shareId: null,
@@ -233,14 +216,16 @@ describe('ShareWorkflowDialogContent', () => {
   }
 
   it('renders in unsaved state when workflow is modified', async () => {
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: true,
-      lastModified: 1000
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: true,
+        lastModified: 1000
+      }
+    })
     const { container } = renderComponent()
     await flushPromises()
 
@@ -429,14 +414,16 @@ describe('ShareWorkflowDialogContent', () => {
     const publishedAt = new Date('2026-01-15T00:00:00Z')
     const savedAfterPublishMs = publishedAt.getTime() + 60_000
 
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: false,
-      lastModified: savedAfterPublishMs
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: false,
+        lastModified: savedAfterPublishMs
+      }
+    })
     mockGetPublishStatus.mockResolvedValue({
       isPublished: true,
       shareId: 'abc-123',
@@ -455,14 +442,16 @@ describe('ShareWorkflowDialogContent', () => {
     const publishedAt = new Date('2026-01-15T00:00:00Z')
     const savedBeforePublishMs = publishedAt.getTime() - 60_000
 
-    mockWorkflowStore.activeWorkflow = {
-      path: 'workflows/test.json',
-      directory: 'workflows',
-      filename: 'test.json',
-      isTemporary: false,
-      isModified: false,
-      lastModified: savedBeforePublishMs
-    }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: {
+        path: 'workflows/test.json',
+        directory: 'workflows',
+        filename: 'test.json',
+        isTemporary: false,
+        isModified: false,
+        lastModified: savedBeforePublishMs
+      }
+    })
     mockGetPublishStatus.mockResolvedValue({
       isPublished: true,
       shareId: 'abc-123',
@@ -479,14 +468,16 @@ describe('ShareWorkflowDialogContent', () => {
 
   describe('error and edge cases', () => {
     it('renders unsaved state when workflow is temporary', async () => {
-      mockWorkflowStore.activeWorkflow = {
-        path: 'workflows/Unsaved Workflow.json',
-        directory: 'workflows',
-        filename: 'Unsaved Workflow.json',
-        isTemporary: true,
-        isModified: false,
-        lastModified: 1000
-      }
+      Object.assign(useWorkflowStore(), {
+        activeWorkflow: {
+          path: 'workflows/Unsaved Workflow.json',
+          directory: 'workflows',
+          filename: 'Unsaved Workflow.json',
+          isTemporary: true,
+          isModified: false,
+          lastModified: 1000
+        }
+      })
       const { container } = renderComponent()
       await flushPromises()
 
@@ -532,7 +523,7 @@ describe('ShareWorkflowDialogContent', () => {
     })
 
     it('renders unsaved state when no active workflow exists', async () => {
-      mockWorkflowStore.activeWorkflow = null
+      Object.assign(useWorkflowStore(), { activeWorkflow: null })
       const { container } = renderComponent()
       await flushPromises()
 
@@ -547,7 +538,7 @@ describe('ShareWorkflowDialogContent', () => {
       renderComponent()
       await flushPromises()
 
-      mockWorkflowStore.activeWorkflow = null
+      Object.assign(useWorkflowStore(), { activeWorkflow: null })
 
       const publishButton = screen.getByRole('button', {
         name: /Create link/i

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -1,4 +1,6 @@
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -110,8 +112,8 @@ vi.mock<unknown>(
   })
 )
 
-function setActiveWorkflow(workflow: Record<string, unknown> | null) {
-  Object.assign(useWorkflowStore(), { activeWorkflow: workflow })
+function setActiveWorkflow(workflow: Partial<LoadedComfyWorkflow>) {
+  useWorkflowStore().activeWorkflow = fromPartial<LoadedComfyWorkflow>(workflow)
 }
 
 function createTestI18n() {

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -109,41 +110,8 @@ vi.mock<unknown>(
   })
 )
 
-const mockWorkflowStore = vi.hoisted(() => {
-  return {
-    instance: null as { activeWorkflow: Record<string, unknown> | null } | null
-  }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mockWorkflowStore.instance = reactive({
-      activeWorkflow: {
-        path: 'workflows/test.json',
-        filename: 'test.json',
-        directory: 'workflows',
-        isTemporary: false,
-        isModified: false
-      }
-    })
-    return {
-      useWorkflowStore: () => ({
-        ...mockWorkflowStore.instance,
-        get activeWorkflow() {
-          return mockWorkflowStore.instance?.activeWorkflow ?? null
-        },
-        saveWorkflow: vi.fn()
-      })
-    }
-  }
-)
-
 function setActiveWorkflow(workflow: Record<string, unknown> | null) {
-  if (mockWorkflowStore.instance) {
-    mockWorkflowStore.instance.activeWorkflow = workflow
-  }
+  Object.assign(useWorkflowStore(), { activeWorkflow: workflow })
 }
 
 function createTestI18n() {
@@ -171,6 +139,10 @@ function createTestI18n() {
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
+
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().saveWorkflow).mockResolvedValue(undefined)
+})
 
 describe('ComfyHubPublishDialog', () => {
   const onClose = vi.fn()

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyHubProfile } from '@/schemas/apiSchema'
@@ -40,19 +41,6 @@ vi.mock<unknown>(
   })
 )
 
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: {
-    path: 'workflows/demo-workflow.json'
-  }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => mockWorkflowStore
-  })
-)
-
 const { useComfyHubPublishSubmission } =
   await import('./useComfyHubPublishSubmission')
 
@@ -78,6 +66,12 @@ function createFormData(
     ...overrides
   }
 }
+
+beforeEach(() => {
+  Object.assign(useWorkflowStore(), {
+    activeWorkflow: { path: 'workflows/demo-workflow.json' }
+  })
+})
 
 describe('useComfyHubPublishSubmission', () => {
   beforeEach(() => {

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
@@ -1,4 +1,6 @@
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyHubProfile } from '@/schemas/apiSchema'
@@ -68,8 +70,8 @@ function createFormData(
 }
 
 beforeEach(() => {
-  Object.assign(useWorkflowStore(), {
-    activeWorkflow: { path: 'workflows/demo-workflow.json' }
+  useWorkflowStore().activeWorkflow = fromPartial<LoadedComfyWorkflow>({
+    path: 'workflows/demo-workflow.json'
   })
 })
 

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
@@ -1,26 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const mockActiveWorkflow = vi.hoisted(() => ({
-  value: { filename: 'my-workflow.json' } as { filename: string } | null
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 const { cachePublishPrefill, getCachedPrefill, useComfyHubPublishWizard } =
   await import('./useComfyHubPublishWizard')
 
 describe('useComfyHubPublishWizard', () => {
   beforeEach(() => {
-    mockActiveWorkflow.value = { filename: 'my-workflow.json' }
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: { filename: 'my-workflow.json' }
+    })
   })
 
   describe('createDefaultFormData', () => {
@@ -30,7 +18,7 @@ describe('useComfyHubPublishWizard', () => {
     })
 
     it('defaults name to empty string when no active workflow', () => {
-      mockActiveWorkflow.value = null
+      Object.assign(useWorkflowStore(), { activeWorkflow: null })
       const { formData } = useComfyHubPublishWizard()
       expect(formData.value.name).toBe('')
     })

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
@@ -1,4 +1,6 @@
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 const { cachePublishPrefill, getCachedPrefill, useComfyHubPublishWizard } =
@@ -6,8 +8,8 @@ const { cachePublishPrefill, getCachedPrefill, useComfyHubPublishWizard } =
 
 describe('useComfyHubPublishWizard', () => {
   beforeEach(() => {
-    Object.assign(useWorkflowStore(), {
-      activeWorkflow: { filename: 'my-workflow.json' }
+    useWorkflowStore().activeWorkflow = fromPartial<LoadedComfyWorkflow>({
+      filename: 'my-workflow.json'
     })
   })
 
@@ -18,7 +20,7 @@ describe('useComfyHubPublishWizard', () => {
     })
 
     it('defaults name to empty string when no active workflow', () => {
-      Object.assign(useWorkflowStore(), { activeWorkflow: null })
+      useWorkflowStore().activeWorkflow = null
       const { formData } = useComfyHubPublishWizard()
       expect(formData.value.name).toBe('')
     })

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -1,3 +1,4 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
@@ -113,7 +114,7 @@ function useSharedWorkflowUrlLoader() {
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
-const mockCloseDialog = vi.hoisted(() => vi.fn())
+
 const mockHideTemplateSelector = vi.hoisted(() => vi.fn())
 const mockDialogStack = vi.hoisted(
   () =>
@@ -123,19 +124,10 @@ const mockDialogStack = vi.hoisted(
       dialogComponentProps: Record<string, unknown>
     }>
 )
-const mockUpdateDialog = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({
     showLayoutDialog: mockShowLayoutDialog
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    dialogStack: mockDialogStack,
-    closeDialog: mockCloseDialog,
-    updateDialog: mockUpdateDialog
   })
 }))
 
@@ -208,13 +200,19 @@ function createDeferred() {
   return { promise, resolve }
 }
 
+beforeEach(() => {
+  Object.assign(useDialogStore(), { dialogStack: [] })
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+  vi.mocked(useDialogStore().updateDialog).mockReturnValue(false)
+})
+
 describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
     mockQueryParams = {}
     mockIsLoggedIn.value = false
     mockDialogStack.length = 0
     mockShowLayoutDialog.mockImplementation(createDialogInstance)
-    mockUpdateDialog.mockImplementation(
+    vi.mocked(useDialogStore().updateDialog).mockImplementation(
       (options: {
         key: string
         contentProps?: Record<string, unknown>
@@ -335,19 +333,19 @@ describe('useSharedWorkflowUrlLoader', () => {
     await Promise.resolve()
 
     expect(dialogInstance.contentProps.openingAction).toBe('copy-and-open')
-    expect(mockUpdateDialog).toHaveBeenCalledWith({
+    expect(useDialogStore().updateDialog).toHaveBeenCalledWith({
       key: 'open-shared-workflow',
       contentProps: { openingAction: 'copy-and-open' }
     })
     expect(dialogInstance.dialogComponentProps.closable).toBeUndefined()
     expect(dialogInstance.dialogComponentProps.closeOnEscape).toBeUndefined()
     expect(dialogInstance.dialogComponentProps.dismissableMask).toBeUndefined()
-    expect(mockCloseDialog).not.toHaveBeenCalled()
+    expect(useDialogStore().closeDialog).not.toHaveBeenCalled()
 
     graphLoad.resolve()
     await loadPromise
 
-    expect(mockCloseDialog).toHaveBeenLastCalledWith({
+    expect(useDialogStore().closeDialog).toHaveBeenLastCalledWith({
       key: 'open-shared-workflow'
     })
   })

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -1,3 +1,4 @@
+import { useAssetsStore } from '@/stores/assetsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HubWorkflowDetail } from '@comfyorg/ingest-types'
@@ -19,22 +20,23 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 const mockGetShareableAssets = vi.fn()
 const mockFetchApi = vi.fn()
-const mockInvalidateInputAssets = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    inputAssets: { invalidate: mockInvalidateInputAssets }
-  })
-}))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
+    addEventListener: vi.fn(),
+    getServerFeature: (_name: string, defaultValue: unknown) => defaultValue,
     getShareableAssets: (...args: unknown[]) => mockGetShareableAssets(...args),
     fetchApi: (...args: unknown[]) => mockFetchApi(...args),
     apiURL: (route: string) => `/api${route}`,
     fileURL: (route: string) => route
   }
 }))
+
+beforeEach(() => {
+  vi.spyOn(useAssetsStore().inputAssets, 'invalidate').mockResolvedValue(
+    undefined
+  )
+})
 
 describe(useWorkflowShareService, () => {
   const mockShareableAssets: AssetInfo[] = [
@@ -387,7 +389,7 @@ describe(useWorkflowShareService, () => {
         share_id: 'share-id-1'
       })
     })
-    expect(mockInvalidateInputAssets).toHaveBeenCalledOnce()
+    expect(useAssetsStore().inputAssets.invalidate).toHaveBeenCalledOnce()
   })
 
   it('omits share_id from the payload when not provided', async () => {
@@ -424,7 +426,7 @@ describe(useWorkflowShareService, () => {
     await expect(
       service.importPublishedAssets(['bad-id'], 'share-id-1')
     ).rejects.toThrow('Failed to import assets: 400')
-    expect(mockInvalidateInputAssets).not.toHaveBeenCalled()
+    expect(useAssetsStore().inputAssets.invalidate).not.toHaveBeenCalled()
   })
 
   it('throws when shared workflow payload is invalid', async () => {

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -1,3 +1,4 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent } from 'vue'
@@ -85,23 +86,14 @@ function useTemplateUrlLoader() {
 
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
-// Mock canvas store
-const mockCanvasStore = {
-  linearMode: false
-}
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => mockCanvasStore
-  })
-)
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { linearMode: false })
+})
 
 describe('useTemplateUrlLoader', () => {
   beforeEach(() => {
     mockQueryParams = {}
-    mockCanvasStore.linearMode = false
+    Object.assign(useCanvasStore(), { linearMode: false })
   })
 
   it('does not load template when no query param present', () => {
@@ -309,7 +301,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(true)
+    expect(useCanvasStore().linearMode).toBe(true)
   })
 
   it('does not set linear mode when template loading fails', async () => {
@@ -319,7 +311,7 @@ describe('useTemplateUrlLoader', () => {
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
 
-    expect(mockCanvasStore.linearMode).toBe(false)
+    expect(useCanvasStore().linearMode).toBe(false)
   })
 
   it('does not set linear mode when mode parameter is not linear', async () => {
@@ -332,7 +324,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(false)
+    expect(useCanvasStore().linearMode).toBe(false)
   })
 
   it('rejects invalid mode parameter with special characters', () => {
@@ -372,7 +364,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(false)
+    expect(useCanvasStore().linearMode).toBe(false)
 
     consoleSpy.mockRestore()
   })
@@ -387,7 +379,7 @@ describe('useTemplateUrlLoader', () => {
       'flux_simple',
       'default'
     )
-    expect(mockCanvasStore.linearMode).toBe(true)
+    expect(useCanvasStore().linearMode).toBe(true)
   })
 
   it('accepts valid format but warns about unsupported modes', async () => {
@@ -397,7 +389,7 @@ describe('useTemplateUrlLoader', () => {
     for (const mode of unsupportedModes) {
       vi.clearAllMocks()
       consoleSpy.mockClear()
-      mockCanvasStore.linearMode = false
+      Object.assign(useCanvasStore(), { linearMode: false })
       mockQueryParams = { template: 'flux_simple', mode }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -410,7 +402,7 @@ describe('useTemplateUrlLoader', () => {
         'flux_simple',
         'default'
       )
-      expect(mockCanvasStore.linearMode).toBe(false)
+      expect(useCanvasStore().linearMode).toBe(false)
     }
 
     consoleSpy.mockRestore()

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -85,12 +85,6 @@ type MockWorkflowTemplatesStore = ReturnType<typeof useWorkflowTemplatesStore>
 
 beforeEach(() => {
   vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
-  vi.mocked(usePartnerNodesEducationStore().requestCard).mockImplementation(
-    () => {}
-  )
-  vi.mocked(usePartnerNodesEducationStore().dismissCard).mockImplementation(
-    () => {}
-  )
 })
 
 describe('useTemplateWorkflows', () => {
@@ -369,7 +363,7 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledWith(
+    expect(usePartnerNodesEducationStore().requestedForWorkflowKey).toBe(
       'loaded-template'
     )
   })
@@ -378,12 +372,13 @@ describe('useTemplateWorkflows', () => {
     const { loadWorkflowTemplate } = useTemplateWorkflows()
     mockWorkflowTemplatesStore.isLoaded = true
     mockWorkflowTemplatesStore.enhancedTemplates.push(enhancedTemplate(true))
+    usePartnerNodesEducationStore().requestedForWorkflowKey =
+      'previous-template'
     mockLoadedWorkflow.value = undefined
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(usePartnerNodesEducationStore().requestCard).not.toHaveBeenCalled()
-    expect(usePartnerNodesEducationStore().dismissCard).toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().isCardRequested).toBe(false)
   })
 
   it('binds to the workflow this load activated, resolved by loadGraphData', async () => {
@@ -398,7 +393,7 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledWith(
+    expect(usePartnerNodesEducationStore().requestedForWorkflowKey).toBe(
       'template-a'
     )
   })
@@ -410,7 +405,7 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(usePartnerNodesEducationStore().requestCard).not.toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().isCardRequested).toBe(false)
   })
 
   it('retires an earlier request when an open-source template loads next', async () => {
@@ -422,12 +417,14 @@ describe('useTemplateWorkflows', () => {
     )
 
     await loadWorkflowTemplate('template1', 'default')
-    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledTimes(1)
+    expect(usePartnerNodesEducationStore().requestedForWorkflowKey).toBe(
+      'loaded-template'
+    )
 
     // The open-source template may still contain partner nodes, so the card
     // would otherwise linger and describe the wrong template.
     await loadWorkflowTemplate('template2', 'default')
-    expect(usePartnerNodesEducationStore().dismissCard).toHaveBeenCalledTimes(1)
+    expect(usePartnerNodesEducationStore().isCardRequested).toBe(false)
   })
 
   it('should handle errors when loading templates', async () => {

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -1,3 +1,5 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { usePartnerNodesEducationStore } from '@/platform/workflow/templates/stores/partnerNodesEducationStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent } from 'vue'
@@ -9,14 +11,6 @@ import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/reposit
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
-
-// Mock the store
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
-  () => ({
-    useWorkflowTemplatesStore: vi.fn()
-  })
-)
 
 // Mock the API
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -63,13 +57,6 @@ function useTemplateWorkflows() {
 
 afterEach(() => apps.splice(0).forEach((app) => app.unmount()))
 
-// Mock the dialog store
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: vi.fn(() => ({
-    closeDialog: vi.fn()
-  }))
-}))
-
 // useTelemetry() returns null in OSS, a dispatcher in cloud — toggle via mockIsCloud.
 const { mockIsCloud, mockTrackTemplate } = vi.hoisted(() => ({
   mockIsCloud: { value: true },
@@ -81,12 +68,9 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
     mockIsCloud.value ? { trackTemplate: mockTrackTemplate } : null
 }))
 
-const { mockDistributionIsCloud, mockRequestCard, mockDismissCard } =
-  vi.hoisted(() => ({
-    mockDistributionIsCloud: { value: false },
-    mockRequestCard: vi.fn(),
-    mockDismissCard: vi.fn()
-  }))
+const { mockDistributionIsCloud } = vi.hoisted(() => ({
+  mockDistributionIsCloud: { value: false }
+}))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -94,20 +78,20 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/stores/partnerNodesEducationStore'),
-  () => ({
-    usePartnerNodesEducationStore: () => ({
-      requestCard: mockRequestCard,
-      dismissCard: mockDismissCard
-    })
-  })
-)
-
 // Mock fetch
 global.fetch = vi.fn()
 
 type MockWorkflowTemplatesStore = ReturnType<typeof useWorkflowTemplatesStore>
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => {})
+  vi.mocked(usePartnerNodesEducationStore().requestCard).mockImplementation(
+    () => {}
+  )
+  vi.mocked(usePartnerNodesEducationStore().dismissCard).mockImplementation(
+    () => {}
+  )
+})
 
 describe('useTemplateWorkflows', () => {
   let mockWorkflowTemplatesStore: MockWorkflowTemplatesStore
@@ -117,9 +101,12 @@ describe('useTemplateWorkflows', () => {
     mockDistributionIsCloud.value = false
     mockLoadedWorkflow.value = { key: 'loaded-template' }
 
-    mockWorkflowTemplatesStore = {
+    mockWorkflowTemplatesStore = useWorkflowTemplatesStore()
+    vi.mocked(
+      mockWorkflowTemplatesStore.loadWorkflowTemplates
+    ).mockResolvedValue(undefined)
+    Object.assign(mockWorkflowTemplatesStore, {
       isLoaded: false,
-      loadWorkflowTemplates: vi.fn().mockResolvedValue(true),
       enhancedTemplates: [],
       groupedTemplates: [
         {
@@ -165,11 +152,7 @@ describe('useTemplateWorkflows', () => {
           ]
         }
       ]
-    } as Partial<MockWorkflowTemplatesStore> as MockWorkflowTemplatesStore
-
-    vi.mocked(useWorkflowTemplatesStore).mockReturnValue(
-      mockWorkflowTemplatesStore
-    )
+    })
 
     // Mock fetch response
     vi.mocked(fetch).mockResolvedValue({
@@ -386,7 +369,9 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).toHaveBeenCalledWith('loaded-template')
+    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledWith(
+      'loaded-template'
+    )
   })
 
   it('retires the card instead of requesting it when no workflow was activated', async () => {
@@ -397,8 +382,8 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).not.toHaveBeenCalled()
-    expect(mockDismissCard).toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().requestCard).not.toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().dismissCard).toHaveBeenCalled()
   })
 
   it('binds to the workflow this load activated, resolved by loadGraphData', async () => {
@@ -413,7 +398,9 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).toHaveBeenCalledWith('template-a')
+    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledWith(
+      'template-a'
+    )
   })
 
   it('does not request the education card for open-source templates', async () => {
@@ -423,7 +410,7 @@ describe('useTemplateWorkflows', () => {
 
     await loadWorkflowTemplate('template1', 'default')
 
-    expect(mockRequestCard).not.toHaveBeenCalled()
+    expect(usePartnerNodesEducationStore().requestCard).not.toHaveBeenCalled()
   })
 
   it('retires an earlier request when an open-source template loads next', async () => {
@@ -435,12 +422,12 @@ describe('useTemplateWorkflows', () => {
     )
 
     await loadWorkflowTemplate('template1', 'default')
-    expect(mockRequestCard).toHaveBeenCalledTimes(1)
+    expect(usePartnerNodesEducationStore().requestCard).toHaveBeenCalledTimes(1)
 
     // The open-source template may still contain partner nodes, so the card
     // would otherwise linger and describe the wrong template.
     await loadWorkflowTemplate('template2', 'default')
-    expect(mockDismissCard).toHaveBeenCalledTimes(1)
+    expect(usePartnerNodesEducationStore().dismissCard).toHaveBeenCalledTimes(1)
   })
 
   it('should handle errors when loading templates', async () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Use the global testing Pinia in assets and workflow tests, replacing this domain's migration from #17222 and local-instance cleanup from #17223.

## Changes

- 32 files: 28 domain tests plus the identical four-file shared lifecycle prerequisite.
- Preserves real-store state/action setup, independent effect scopes, and non-Pinia layout-store mocks.
- Independently targets main from the shared lifecycle prerequisite; no other domain branch is required. Rule enforcement and documentation remain deferred to #17223.

## Review Focus

- All 28 domain file blobs match the immutable source commit from #17223.
- Passed all 31 selected test files, 587 tests, including all three shared tests.
- Passed `pnpm typecheck`, `pnpm typecheck:scripts`, scoped ESLint, type-aware Oxlint, cleanup audit, formatting, `pnpm knip`, and `git diff --check`.
- Real commit hooks passed, including full lint and typecheck.
