### PR TITLE
test: use global Pinia in composable tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -1,33 +1,30 @@
+import { useAuthStore } from '@/stores/authStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { FirebaseError } from 'firebase/app'
 import { AuthErrorCodes } from 'firebase/auth'
+import type { UserCredential } from 'firebase/auth'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import enLocale from '@/locales/en/main.json'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))
+
 type ModifiedWorkflow = Pick<ComfyWorkflow, 'path' | 'isModified'>
 
-const mockAuthStore = vi.hoisted(() => ({
-  login: vi.fn(async () => undefined),
-  loginWithGoogle: vi.fn(async () => undefined),
-  loginWithGithub: vi.fn(async () => undefined),
-  register: vi.fn(async () => undefined),
-  logout: vi.fn(async () => undefined),
-  initiateCreditPurchase: vi.fn(
-    async (): Promise<{ checkout_url?: string }> => ({
-      checkout_url: 'https://checkout.stripe.test'
-    })
-  )
-}))
+let mockAuthStore: ReturnType<typeof useAuthStore>
 
-const mockToastStore = vi.hoisted(() => ({
-  add: vi.fn()
-}))
+let mockToastStore: ReturnType<typeof useToastStore>
 
-const mockWorkflowStore = vi.hoisted(() => ({
-  modifiedWorkflows: [] as ModifiedWorkflow[]
-}))
+let mockWorkflowStore: ReturnType<typeof useWorkflowStore>
 
 const mockWorkflowService = vi.hoisted(() => ({
   saveWorkflow: vi.fn(async () => true)
@@ -90,21 +87,10 @@ vi.mock<unknown>(import('@/composables/billing/usePendingTopup'), () => ({
   usePendingTopup: () => ({ startPendingTopup: mockStartPendingTopup })
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => mockToastStore)
-}))
-
 vi.mock(import('@/platform/workflow/persistence/base/storageIO'), () => ({
   clearAllWorkflowStorage: mockClearAllWorkflowStorage,
   prepareWorkflowLogoutTransition: mockPrepareWorkflowLogoutTransition
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => mockWorkflowStore)
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -115,10 +101,6 @@ vi.mock<unknown>(
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: vi.fn(() => mockDialogService)
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => mockAuthStore)
 }))
 
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
@@ -155,6 +137,18 @@ function makeWorkflow(path: string): ModifiedWorkflow {
 }
 
 beforeEach(() => {
+  mockAuthStore = useAuthStore()
+  mockToastStore = useToastStore()
+  mockWorkflowStore = useWorkflowStore()
+  vi.mocked(mockAuthStore.initiateCreditPurchase).mockResolvedValue({
+    checkout_url: 'https://checkout.stripe.test'
+  })
+  vi.mocked(mockAuthStore.logout).mockResolvedValue(undefined)
+  vi.mocked(mockAuthStore.sendPasswordReset).mockResolvedValue(undefined)
+  const credential = fromPartial<UserCredential>({ user: { uid: 'test-user' } })
+  vi.mocked(mockAuthStore.login).mockResolvedValue(credential)
+  vi.mocked(mockAuthStore.register).mockResolvedValue(credential)
+  vi.mocked(mockAuthStore.loginWithGoogle).mockResolvedValue(credential)
   mockDistributionState.isCloud = false
   mockBillingState.canAccessSubscriptionFeatures = false
 })
@@ -179,7 +173,7 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 
   it('does not start tracking or open checkout when no checkout URL is returned', async () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null)
-    mockAuthStore.initiateCreditPurchase.mockResolvedValueOnce({})
+    vi.mocked(mockAuthStore.initiateCreditPurchase).mockResolvedValueOnce({})
     const { purchaseCreditsDirect } = useAuthActions()
 
     await expect(purchaseCreditsDirect(25)).rejects.toThrow()
@@ -190,7 +184,7 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 
   it('does not start tracking or open checkout when the purchase request rejects', async () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null)
-    mockAuthStore.initiateCreditPurchase.mockRejectedValueOnce(
+    vi.mocked(mockAuthStore.initiateCreditPurchase).mockRejectedValueOnce(
       new Error('network down')
     )
     const { purchaseCreditsDirect } = useAuthActions()
@@ -205,12 +199,14 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 describe('useAuthActions.logout', () => {
   beforeEach(() => {
     mockDistributionState.isCloud = true
-    mockWorkflowStore.modifiedWorkflows = []
+    Object.assign(mockWorkflowStore, { modifiedWorkflows: [] })
   })
 
   it('logs out on non-cloud distributions without prompting when workflows are modified', async () => {
     mockDistributionState.isCloud = false
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     const { logout } = useAuthActions()
 
     await logout()
@@ -241,7 +237,9 @@ describe('useAuthActions.logout', () => {
 
     expect(mockPrepareWorkflowLogoutTransition).toHaveBeenCalledOnce()
     expect(mockClearAllWorkflowStorage).toHaveBeenCalledExactlyOnceWith()
-    expect(mockAuthStore.logout.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      vi.mocked(mockAuthStore.logout).mock.invocationCallOrder[0]
+    ).toBeLessThan(
       mockPrepareWorkflowLogoutTransition.mock.invocationCallOrder[0]
     )
     expect(
@@ -253,7 +251,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('does not clear cloud workflows when logout fails', async () => {
-    mockAuthStore.logout.mockRejectedValueOnce(new Error('network failed'))
+    vi.mocked(mockAuthStore.logout).mockRejectedValueOnce(
+      new Error('network failed')
+    )
     const { logout } = useAuthActions()
 
     await logout()
@@ -263,7 +263,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('cancels sign-out when the dialog is dismissed (null)', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(null)
     const { logout } = useAuthActions()
 
@@ -275,7 +277,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('signs out without saving when the user picks "Sign out anyway" (false)', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(false)
     const { logout } = useAuthActions()
 
@@ -287,7 +291,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('cancels sign-out when saving a workflow is cancelled', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(true)
     mockWorkflowService.saveWorkflow.mockResolvedValueOnce(false)
     const { logout } = useAuthActions()
@@ -299,10 +305,9 @@ describe('useAuthActions.logout', () => {
   })
 
   it('does not log out if a workflow save fails', async () => {
-    mockWorkflowStore.modifiedWorkflows = [
-      makeWorkflow('a.json'),
-      makeWorkflow('b.json')
-    ]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json'), makeWorkflow('b.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(true)
     mockWorkflowService.saveWorkflow.mockRejectedValueOnce(
       new Error('disk full')
@@ -320,7 +325,7 @@ describe('useAuthActions.logout', () => {
 
   it('saves every modified workflow before signing out when user picks Save (true)', async () => {
     const workflows = [makeWorkflow('a.json'), makeWorkflow('b.json')]
-    mockWorkflowStore.modifiedWorkflows = workflows
+    Object.assign(mockWorkflowStore, { modifiedWorkflows: workflows })
     mockDialogService.confirm.mockResolvedValueOnce(true)
     const { logout } = useAuthActions()
 
@@ -338,14 +343,16 @@ describe('useAuthActions.logout', () => {
     expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
     expect(
       mockWorkflowService.saveWorkflow.mock.invocationCallOrder[1]
-    ).toBeLessThan(mockAuthStore.logout.mock.invocationCallOrder[0])
+    ).toBeLessThan(vi.mocked(mockAuthStore.logout).mock.invocationCallOrder[0])
     expect(
       mockWorkflowService.saveWorkflow.mock.invocationCallOrder[0]
     ).toBeLessThan(mockWorkflowService.saveWorkflow.mock.invocationCallOrder[1])
   })
 
   it('passes denyLabel "Sign out anyway" to the dialog', async () => {
-    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    Object.assign(mockWorkflowStore, {
+      modifiedWorkflows: [makeWorkflow('a.json')]
+    })
     mockDialogService.confirm.mockResolvedValueOnce(null)
     const { logout } = useAuthActions()
 
@@ -364,12 +371,12 @@ describe('useAuthActions.logout', () => {
 
 describe('useAuthActions auth flow error telemetry', () => {
   beforeEach(() => {
-    mockWorkflowStore.modifiedWorkflows = []
+    Object.assign(mockWorkflowStore, { modifiedWorkflows: [] })
   })
 
   it('tracks email sign-in Firebase failures and still shows the error toast', async () => {
     const error = new FirebaseError('auth/user-not-found', 'msg')
-    mockAuthStore.login.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.login).mockRejectedValueOnce(error)
     const { signInWithEmail } = useAuthActions()
 
     await expect(
@@ -389,7 +396,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('tracks unknown errors for email sign-up failures', async () => {
     const error = new Error('network failed')
-    mockAuthStore.register.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.register).mockRejectedValueOnce(error)
     const { signUpWithEmail } = useAuthActions()
 
     await expect(
@@ -404,7 +411,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('tracks Google sign-up failures separately from sign-in failures', async () => {
     const error = new FirebaseError('auth/popup-closed-by-user', 'msg')
-    mockAuthStore.loginWithGoogle.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.loginWithGoogle).mockRejectedValueOnce(error)
     const { signInWithGoogle } = useAuthActions()
 
     await expect(signInWithGoogle({ isNewUser: true })).resolves.toBeUndefined()
@@ -417,7 +424,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('tracks GitHub sign-up failures separately from sign-in failures', async () => {
     const error = new FirebaseError('auth/popup-closed-by-user', 'msg')
-    mockAuthStore.loginWithGithub.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.loginWithGithub).mockRejectedValueOnce(error)
     const { signInWithGithub } = useAuthActions()
 
     await expect(signInWithGithub({ isNewUser: true })).resolves.toBeUndefined()
@@ -430,7 +437,7 @@ describe('useAuthActions auth flow error telemetry', () => {
 
   it('does not track auth failures for logout failures', async () => {
     const error = new FirebaseError('auth/network-request-failed', 'msg')
-    mockAuthStore.logout.mockRejectedValueOnce(error)
+    vi.mocked(mockAuthStore.logout).mockRejectedValueOnce(error)
     const { logout } = useAuthActions()
 
     await logout()

--- a/src/composables/auth/useCurrentUser.test.ts
+++ b/src/composables/auth/useCurrentUser.test.ts
@@ -1,38 +1,30 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAuthStore } from '@/stores/authStore'
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCurrentUser } from './useCurrentUser'
 
-const mockAuthState = {
-  currentUser: null as { uid: string } | null,
-  loading: false,
-  tokenRefreshTrigger: 0
-}
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => mockAuthState
-}))
+vi.mock(import('firebase/auth'))
 
-const mockApiKeyState = {
-  isAuthenticated: false,
-  currentUser: null as { id: string; email?: string; name?: string } | null
-}
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: () => mockApiKeyState
-}))
+let mockAuthState: ReturnType<typeof useAuthStore>
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
-}))
+let mockApiKeyState: ReturnType<typeof useApiKeyAuthStore>
 
 describe('useCurrentUser', () => {
   beforeEach(() => {
+    mockAuthState = useAuthStore()
+    mockApiKeyState = useApiKeyAuthStore()
     mockAuthState.currentUser = null
-    mockApiKeyState.isAuthenticated = false
+    Object.assign(mockApiKeyState, { isAuthenticated: false })
     mockApiKeyState.currentUser = null
   })
 
   it('treats a key-only session as an API-key login', () => {
-    mockApiKeyState.isAuthenticated = true
-    mockApiKeyState.currentUser = { id: 'key-user' }
+    Object.assign(mockApiKeyState, { isAuthenticated: true })
+    mockApiKeyState.currentUser = fromPartial<
+      NonNullable<typeof mockApiKeyState.currentUser>
+    >({ id: 'key-user' })
 
     const { isApiKeyLogin, isLoggedIn, resolvedUserInfo } = useCurrentUser()
 
@@ -42,9 +34,13 @@ describe('useCurrentUser', () => {
   })
 
   it('gives the Firebase session precedence over a stored API key', () => {
-    mockAuthState.currentUser = { uid: 'firebase-user' }
-    mockApiKeyState.isAuthenticated = true
-    mockApiKeyState.currentUser = { id: 'key-user' }
+    mockAuthState.currentUser = fromPartial<
+      NonNullable<typeof mockAuthState.currentUser>
+    >({ uid: 'firebase-user' })
+    Object.assign(mockApiKeyState, { isAuthenticated: true })
+    mockApiKeyState.currentUser = fromPartial<
+      NonNullable<typeof mockApiKeyState.currentUser>
+    >({ id: 'key-user' })
 
     const { isApiKeyLogin, isLoggedIn, resolvedUserInfo } = useCurrentUser()
 

--- a/src/composables/billing/topupBalanceRefresh.test.ts
+++ b/src/composables/billing/topupBalanceRefresh.test.ts
@@ -1,21 +1,14 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from '@/stores/authStore'
+import { storeToRefs } from 'pinia'
+import type { Mock } from 'vitest'
+import type { Ref } from 'vue'
 
 import { watchForTopupBalanceUpdate } from './topupBalanceRefresh'
 
-const mockFetchBalance = vi.fn()
-const mockBalance = {
-  value: { amount_micros: 1_000 } as { amount_micros: number } | null
-}
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    get balance() {
-      return mockBalance.value
-    },
-    fetchBalance: mockFetchBalance
-  })
-}))
+vi.mock(import('firebase/auth'))
+let mockFetchBalance: Mock<ReturnType<typeof useAuthStore>['fetchBalance']>
+let mockBalance: Ref<ReturnType<typeof useAuthStore>['balance']>
 
 function returnToApp() {
   vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
@@ -24,11 +17,15 @@ function returnToApp() {
 
 describe('watchForTopupBalanceUpdate', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    const store = useAuthStore()
+    mockFetchBalance = vi.mocked(store.fetchBalance)
+    mockBalance = storeToRefs(store).balance
     vi.useFakeTimers()
-    mockFetchBalance.mockReset()
-    mockFetchBalance.mockResolvedValue({ amount_micros: 1_000 })
-    mockBalance.value = { amount_micros: 1_000 }
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 1_000
+    })
+    mockBalance.value = { currency: 'usd', amount_micros: 1_000 }
   })
 
   it('does not refresh until the app tab is visible again', async () => {
@@ -58,7 +55,10 @@ describe('watchForTopupBalanceUpdate', () => {
   })
 
   it('stops retrying once the balance increases', async () => {
-    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 6_000
+    })
 
     watchForTopupBalanceUpdate()
     returnToApp()
@@ -78,7 +78,10 @@ describe('watchForTopupBalanceUpdate', () => {
     expect(spentOnBounce).toBeGreaterThan(1)
 
     // The real return, after paying, must still refresh.
-    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 6_000
+    })
     returnToApp()
     await vi.advanceTimersByTimeAsync(0)
 
@@ -116,7 +119,10 @@ describe('watchForTopupBalanceUpdate', () => {
       await vi.advanceTimersByTimeAsync(60_000)
     }
     mockFetchBalance.mockClear()
-    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    mockFetchBalance.mockResolvedValue({
+      currency: 'usd',
+      amount_micros: 6_000
+    })
 
     returnToApp()
     await vi.advanceTimersByTimeAsync(0)

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import { effectScope, nextTick, computed } from 'vue'
+import type { Ref } from 'vue'
+import type { Mock } from 'vitest'
+import { storeToRefs } from 'pinia'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAuthStore } from '@/stores/authStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type {
@@ -13,6 +19,8 @@ import {
 } from '@/platform/remoteConfig/remoteConfig'
 
 import { useBillingContext as useSharedBillingContext } from './useBillingContext'
+
+vi.mock(import('firebase/auth'))
 
 function useBillingContext() {
   const scope = effectScope()
@@ -32,16 +40,11 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 }
 
 const {
-  mockIsPersonal,
-  mockBillingRail,
   mockPlans,
   mockFetchPlans,
   mockLegacyFetchStatus,
-  mockLegacyFetchBalance,
   mockLegacySubscribe,
   mockPurchaseCredits,
-  mockUpdateActiveWorkspace,
-  mockSetWorkspaceBillingRail,
   mockLegacyStatus,
   mockBillingStatus
 } = vi.hoisted(() => {
@@ -54,16 +57,11 @@ const {
     }
   }
   return {
-    mockIsPersonal: { value: true },
-    mockBillingRail: { value: undefined as BillingRail | undefined },
     mockPlans: { value: [] as Plan[] },
     mockFetchPlans: vi.fn(async () => undefined),
     mockLegacyFetchStatus: vi.fn(async () => undefined),
-    mockLegacyFetchBalance: vi.fn(async () => undefined),
     mockLegacySubscribe: vi.fn(async () => undefined),
     mockPurchaseCredits: vi.fn(),
-    mockUpdateActiveWorkspace: vi.fn(),
-    mockSetWorkspaceBillingRail: vi.fn(),
     mockLegacyStatus: {
       value: {
         is_active: true,
@@ -75,38 +73,19 @@ const {
   }
 })
 
-vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
+let mockIsPersonal: Ref<boolean>
+let mockBillingRail: Ref<BillingRail | null | undefined>
+let mockLegacyFetchBalance: Mock<
+  ReturnType<typeof useAuthStore>['fetchBalance']
+>
+let mockUpdateActiveWorkspace: Mock<
+  ReturnType<typeof useTeamWorkspaceStore>['updateActiveWorkspace']
+>
+let mockSetWorkspaceBillingRail: Mock<
+  ReturnType<typeof useTeamWorkspaceStore>['setWorkspaceBillingRail']
+>
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  async () => {
-    const { ref } = await import('vue')
-    const billingRailRef = ref(mockBillingRail.value)
-    Object.defineProperty(mockBillingRail, 'value', {
-      get: () => billingRailRef.value,
-      set: (value: BillingRail | undefined) => {
-        billingRailRef.value = value
-      }
-    })
-    return {
-      useTeamWorkspaceStore: () => ({
-        get isInPersonalWorkspace() {
-          return mockIsPersonal.value
-        },
-        get activeWorkspace() {
-          return mockIsPersonal.value
-            ? { id: 'personal-123', type: 'personal' }
-            : { id: 'team-456', type: 'team' }
-        },
-        get activeWorkspaceBillingRail() {
-          return mockBillingRail.value
-        },
-        updateActiveWorkspace: mockUpdateActiveWorkspace,
-        setWorkspaceBillingRail: mockSetWorkspaceBillingRail
-      })
-    }
-  }
-)
+vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
 
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useSubscription'),
@@ -149,13 +128,6 @@ vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    balance: { amount_micros: 5000000 },
-    fetchBalance: mockLegacyFetchBalance
-  })
-}))
-
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useBillingPlans'),
   () => ({
@@ -189,6 +161,29 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
 
 describe('useBillingContext', () => {
   beforeEach(() => {
+    const workspaceStore = useTeamWorkspaceStore()
+    const refs = storeToRefs(workspaceStore)
+    mockIsPersonal = refs.isInPersonalWorkspace
+    mockBillingRail = refs.activeWorkspaceBillingRail
+    Object.assign(workspaceStore, {
+      activeWorkspace: computed(() =>
+        fromPartial<NonNullable<typeof workspaceStore.activeWorkspace>>({
+          id: mockIsPersonal.value ? 'personal-123' : 'team-456',
+          type: mockIsPersonal.value ? 'personal' : 'team'
+        })
+      )
+    })
+    const authStore = useAuthStore()
+    authStore.balance = { currency: 'usd', amount_micros: 5000000 }
+    mockLegacyFetchBalance = vi
+      .mocked(authStore.fetchBalance)
+      .mockResolvedValue(authStore.balance)
+    mockUpdateActiveWorkspace = vi
+      .mocked(workspaceStore.updateActiveWorkspace)
+      .mockImplementation(() => {})
+    mockSetWorkspaceBillingRail = vi.mocked(
+      workspaceStore.setWorkspaceBillingRail
+    )
     remoteConfig.value = {}
     remoteConfigState.value = 'unloaded'
     mockIsPersonal.value = true

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -1,24 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { storeToRefs } from 'pinia'
+import type { Ref } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 import type { BillingRail } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingRouting } from './useBillingRouting'
 
-const {
-  mockIsCloud,
-  mockLegacyBillingMigrationEnabled,
-  mockActiveWorkspace,
-  mockActiveWorkspaceBillingRail
-} = vi.hoisted(() => ({
+const { mockIsCloud, mockLegacyBillingMigrationEnabled } = vi.hoisted(() => ({
   mockIsCloud: { value: true },
-  mockLegacyBillingMigrationEnabled: { value: false },
-  mockActiveWorkspace: {
-    value: null as { id: string; type: 'personal' | 'team' } | null
-  },
-  mockActiveWorkspaceBillingRail: {
-    value: null as BillingRail | null
-  }
+  mockLegacyBillingMigrationEnabled: { value: false }
 }))
+
+let mockActiveWorkspace: Ref<
+  ReturnType<typeof useTeamWorkspaceStore>['activeWorkspace']
+>
+let mockActiveWorkspaceBillingRail: Ref<BillingRail | null>
 
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
@@ -36,25 +34,18 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/teamWorkspaceStore'),
-  () => ({
-    useTeamWorkspaceStore: () => ({
-      get activeWorkspace() {
-        return mockActiveWorkspace.value
-      },
-      get activeWorkspaceBillingRail() {
-        return mockActiveWorkspaceBillingRail.value
-      }
-    })
-  })
-)
-
-const personal = { id: 'w-personal', type: 'personal' as const }
-const team = { id: 'w-team', type: 'team' as const }
+const personal = fromPartial<
+  NonNullable<ReturnType<typeof useTeamWorkspaceStore>['activeWorkspace']>
+>({ id: 'w-personal', type: 'personal' })
+const team = fromPartial<
+  NonNullable<ReturnType<typeof useTeamWorkspaceStore>['activeWorkspace']>
+>({ id: 'w-team', type: 'team' })
 
 describe('useBillingRouting', () => {
   beforeEach(() => {
+    const refs = storeToRefs(useTeamWorkspaceStore())
+    mockActiveWorkspace = refs.activeWorkspace
+    mockActiveWorkspaceBillingRail = refs.activeWorkspaceBillingRail
     mockIsCloud.value = true
     mockLegacyBillingMigrationEnabled.value = false
     mockActiveWorkspace.value = personal

--- a/src/composables/billing/useLegacyBilling.test.ts
+++ b/src/composables/billing/useLegacyBilling.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useLegacyBilling } from './useLegacyBilling'
 
+vi.mock(import('firebase/auth'))
+
 const mockSubscribe = vi.fn()
 const mockSubscribeDirect = vi.fn()
 
@@ -27,10 +29,6 @@ vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: () => ({
     purchaseCredits: vi.fn()
   })
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({ balance: null })
 }))
 
 describe('useLegacyBilling', () => {

--- a/src/composables/billing/usePartnerNodesRunGate.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.test.ts
@@ -4,7 +4,9 @@ import type { EffectScope, Ref } from 'vue'
 
 import * as currentUserModule from '@/composables/auth/useCurrentUser'
 import * as featureFlagsModule from '@/composables/useFeatureFlags'
-import * as authStoreModule from '@/stores/authStore'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock(import('firebase/auth'))
 
 import {
   partnerRunGateBlocksAutoQueue,
@@ -43,21 +45,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), async () => {
   }
 })
 
-vi.mock<unknown>(import('@/stores/authStore'), async () => {
-  const { ref } = await import('vue')
-  const initialized = ref(true)
-  return {
-    useAuthStore: () => ({
-      get isInitialized() {
-        return initialized.value
-      }
-    }),
-    __setAuthResolved: (value: boolean) => {
-      initialized.value = value
-    }
-  }
-})
-
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), async () => {
   const { reactive } = await import('vue')
   const flags = reactive({ partnerRunGateEnabled: true })
@@ -77,9 +64,6 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 const { __setLoggedIn } = currentUserModule as typeof currentUserModule & {
   __setLoggedIn: (value: boolean) => void
 }
-const { __setAuthResolved } = authStoreModule as typeof authStoreModule & {
-  __setAuthResolved: (value: boolean) => void
-}
 const { __setPartnerRunGateEnabled } =
   featureFlagsModule as typeof featureFlagsModule & {
     __setPartnerRunGateEnabled: (value: boolean) => void
@@ -97,7 +81,7 @@ describe('usePartnerNodesRunGate', () => {
     state.hasPartnerNodes = ref(false)
     state.partnerNodes = ref([])
     __setLoggedIn(false)
-    __setAuthResolved(true)
+    useAuthStore().isInitialized = true
     __setPartnerRunGateEnabled(true)
   })
 
@@ -180,14 +164,14 @@ describe('usePartnerNodesRunGate', () => {
 
   it('does not gate while auth is still resolving, then follows the outcome', async () => {
     state.hasPartnerNodes.value = true
-    __setAuthResolved(false)
+    useAuthStore().isInitialized = false
     const { gate } = setup()
     expect(gate.value, 'unresolved auth must never read as signed-out').toBe(
       'none'
     )
 
     __setLoggedIn(true)
-    __setAuthResolved(true)
+    useAuthStore().isInitialized = true
     await nextTick()
     expect(gate.value, 'a signed-in resolution keeps the gate open').toBe(
       'none'
@@ -214,7 +198,7 @@ describe('partnerRunGateBlocksAutoQueue', () => {
   beforeEach(() => {
     state.partnerNodes = ref([])
     __setLoggedIn(false)
-    __setAuthResolved(true)
+    useAuthStore().isInitialized = true
     __setPartnerRunGateEnabled(true)
   })
 
@@ -232,7 +216,7 @@ describe('partnerRunGateBlocksAutoQueue', () => {
 
   it('never blocks while auth is still resolving', () => {
     state.partnerNodes.value = [{ nodeName: 'Kling', displayName: 'Kling' }]
-    __setAuthResolved(false)
+    useAuthStore().isInitialized = false
     expect(partnerRunGateBlocksAutoQueue()).toBe(false)
   })
 

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -6,36 +6,19 @@ import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
 import { useBoundingBoxes } from './useBoundingBoxes'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import { toNodeId } from '@/types/nodeId'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
-const { appState, outputState } = vi.hoisted(() => {
-  const appState: { node: MockNode | null } = { node: null }
-  const outputState: {
-    outputs: { input_bboxes: unknown } | undefined
-    nodeOutputs: { value: Record<string, unknown> } | null
-  } = {
-    outputs: undefined,
-    nodeOutputs: null as { value: Record<string, unknown> } | null
-  }
-  return { appState, outputState }
-})
+const appState = vi.hoisted(() => ({ node: null as MockNode | null }))
+let incomingOutputs: { input_bboxes: unknown } | undefined
+let outputStore: ReturnType<typeof useNodeOutputStore>
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: { getNodeById: () => appState.node } } }
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), async () => {
-  const { ref } = await import('vue')
-  const nodeOutputs = ref<Record<string, unknown>>({})
-  outputState.nodeOutputs = nodeOutputs
-  return {
-    useNodeOutputStore: () => ({
-      nodeOutputs,
-      nodePreviewImages: ref({}),
-      getNodeImageUrls: () => undefined,
-      getNodeOutputs: () => outputState.outputs
-    })
+  app: {
+    canvas: { graph: { getNodeById: () => appState.node } },
+    nodeOutputs: {},
+    nodePreviewImages: {}
   }
-})
+}))
 
 const ctx = {
   measureText: (s: string) => ({ width: s.length * 7 }),
@@ -177,9 +160,12 @@ function makeConnectedNode(): MockNode {
 }
 
 beforeEach(() => {
+  outputStore = useNodeOutputStore()
+  vi.mocked(outputStore.getNodeOutputs).mockImplementation(
+    () => incomingOutputs
+  )
   appState.node = makeNode()
-  outputState.outputs = undefined
-  if (outputState.nodeOutputs) outputState.nodeOutputs.value = {}
+  incomingOutputs = undefined
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
     void Promise.resolve().then(() => cb(0))
     return 1
@@ -293,7 +279,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const node = makeConnectedNode()
     appState.node = node
     const incoming = [box({ x: 0, width: 100 })]
-    outputState.outputs = { input_bboxes: incoming }
+    incomingOutputs = { input_bboxes: incoming }
     const c = setup([box({ x: 200, width: 300 })])
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(300)
@@ -305,15 +291,15 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const incoming = [box({ x: 0, width: 100 })]
     setLastIncomingOf(node, incoming)
     appState.node = node
-    outputState.outputs = { input_bboxes: incoming }
+    incomingOutputs = { input_bboxes: incoming }
     const c = setup([box({ x: 200, width: 300 })])
-    outputState.nodeOutputs!.value = { updated: true }
+    outputStore.nodeOutputs = { output: { updated: true } }
     await flush()
     expect(modelBoxes(c)[0].width).toBe(300)
   })
 
   it('ignores incoming output when the input is not connected', () => {
-    outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
+    incomingOutputs = { input_bboxes: [box({ x: 0, width: 100 })] }
     const c = setup([])
     expect(modelBoxes(c)).toHaveLength(0)
   })
@@ -321,7 +307,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
   it('ignores an output containing an invalid bounding box', () => {
     const node = makeConnectedNode()
     appState.node = node
-    outputState.outputs = {
+    incomingOutputs = {
       input_bboxes: [box(), { x: 1 }]
     }
 
@@ -335,8 +321,8 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     appState.node = makeConnectedNode()
     const c = setup([])
 
-    outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
-    outputState.nodeOutputs!.value = { n: 1 }
+    incomingOutputs = { input_bboxes: [box({ x: 0, width: 100 })] }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(1)
 
@@ -344,7 +330,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     await flush()
     expect(modelBoxes(c)).toHaveLength(0)
 
-    outputState.nodeOutputs!.value = { n: 2 }
+    outputStore.nodeOutputs = { n: { revision: 2 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(100)
@@ -358,15 +344,15 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     }
     const c = setup([])
 
-    outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
-    outputState.nodeOutputs!.value = { n: 1 }
+    incomingOutputs = { input_bboxes: [box({ x: 0, width: 100 })] }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(1)
 
     c.clearAll()
     await flush()
     connected = false
-    outputState.nodeOutputs!.value = { n: 2 }
+    outputStore.nodeOutputs = { n: { revision: 2 } }
     await flush()
     expect(modelBoxes(c)).toHaveLength(0)
   })
@@ -378,10 +364,10 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     c.onPointerDown(pe(10, 10))
     c.onCanvasPointerMove(pe(50, 50))
 
-    outputState.outputs = {
+    incomingOutputs = {
       input_bboxes: [box({ x: 0, width: 100, height: 100 })]
     }
-    outputState.nodeOutputs!.value = { n: 1 }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
 
     c.onDocPointerUp(pe(50, 50))
@@ -397,8 +383,8 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     expect(modelBoxes(c)).toHaveLength(0)
 
     const incoming = [box({ x: 0, width: 100 })]
-    outputState.outputs = { input_bboxes: incoming }
-    outputState.nodeOutputs!.value = { updated: true }
+    incomingOutputs = { input_bboxes: incoming }
+    outputStore.nodeOutputs = { output: { updated: true } }
     await flush()
 
     expect(modelBoxes(c)).toHaveLength(1)
@@ -413,8 +399,8 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const c = setup([box({ x: 200, width: 300 })])
 
     const changed = [box({ x: 64, width: 128 })]
-    outputState.outputs = { input_bboxes: changed }
-    outputState.nodeOutputs!.value = { n: 1 }
+    incomingOutputs = { input_bboxes: changed }
+    outputStore.nodeOutputs = { n: { revision: 1 } }
     await flush()
 
     expect(modelBoxes(c)[0].width).toBe(128)

--- a/src/composables/canvas/useFocusNode.test.ts
+++ b/src/composables/canvas/useFocusNode.test.ts
@@ -1,34 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const viewport = [0, 0, 900, 700] as const
-const { canvasStore, createCanvas } = vi.hoisted(() => {
-  function createCanvas() {
-    const canvas = {
-      graph: undefined as unknown,
-      subgraph: undefined as unknown,
-      setGraph: vi.fn(),
-      animateToBounds: vi.fn()
-    }
-    canvas.setGraph.mockImplementation((graph) => {
-      canvas.graph = graph
-    })
-    return canvas
-  }
-
-  const canvasStore: {
-    canvas: ReturnType<typeof createCanvas> | undefined
-  } = { canvas: createCanvas() }
-  return {
-    canvasStore,
-    createCanvas
-  }
-})
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => canvasStore
-}))
+function createCanvas() {
+  const canvas = fromPartial<LGraphCanvas>({
+    graph: null,
+    subgraph: undefined,
+    setGraph: vi.fn(),
+    animateToBounds: vi.fn()
+  })
+  vi.mocked(canvas.setGraph).mockImplementation((graph) => {
+    canvas.graph = graph
+  })
+  return canvas
+}
+let canvasStore: ReturnType<typeof useCanvasStore>
 vi.mock(import('@/composables/canvas/visibleCanvasViewport'), () => ({
   visibleCanvasViewport: () => viewport
 }))
@@ -40,6 +33,7 @@ describe('useFocusNode', () => {
   let animationFrames: FrameRequestCallback[]
 
   beforeEach(() => {
+    canvasStore = useCanvasStore()
     canvasStore.canvas = createCanvas()
     animationFrames = []
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
@@ -102,7 +96,7 @@ describe('useFocusNode', () => {
     const focusPromise = useFocusNode().focusNodeInstance(node)
 
     await vi.waitFor(() => expect(animationFrames).toHaveLength(1))
-    canvasStore.canvas = undefined
+    canvasStore.canvas = null
     finishNavigationFrames()
     await focusPromise
 

--- a/src/composables/canvas/visibleCanvasViewport.test.ts
+++ b/src/composables/canvas/visibleCanvasViewport.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -13,7 +12,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 describe('visibleCanvasViewport', () => {
   beforeEach(() => {
     localStorage.clear()
-    setActivePinia(createPinia())
     vi.stubGlobal('devicePixelRatio', 2)
   })
 

--- a/src/composables/graph/useGraphHierarchy.test.ts
+++ b/src/composables/graph/useGraphHierarchy.test.ts
@@ -1,8 +1,12 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
-import type { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  LGraphCanvas,
+  LGraphGroup,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
 import * as measure from '@/lib/litegraph/src/measure'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import {
@@ -10,8 +14,6 @@ import {
   createMockLGraphGroup
 } from '@/utils/__tests__/litegraphTestUtils'
 import { useGraphHierarchy } from './useGraphHierarchy'
-
-vi.mock(import('@/renderer/core/canvas/canvasStore'))
 
 function createMockNode(overrides: Partial<LGraphNode> = {}): LGraphNode {
   return Object.assign(
@@ -28,7 +30,7 @@ function createMockGroup(overrides: Partial<LGraphGroup> = {}): LGraphGroup {
 }
 
 describe('useGraphHierarchy', () => {
-  let mockCanvasStore: Partial<ReturnType<typeof useCanvasStore>>
+  let mockCanvasStore: ReturnType<typeof useCanvasStore>
   let mockNode: LGraphNode
   let mockGroups: LGraphGroup[]
 
@@ -36,29 +38,10 @@ describe('useGraphHierarchy', () => {
     mockNode = createMockNode()
     mockGroups = []
 
-    mockCanvasStore = fromAny<
-      Partial<ReturnType<typeof useCanvasStore>>,
-      unknown
-    >({
-      canvas: {
-        graph: {
-          groups: mockGroups
-        }
-      },
-      $id: 'canvas',
-      $state: {},
-      $patch: vi.fn(),
-      $reset: vi.fn(),
-      $subscribe: vi.fn(),
-      $onAction: vi.fn(),
-      $dispose: vi.fn(),
-      _customProperties: new Set(),
-      _p: {}
+    mockCanvasStore = useCanvasStore()
+    mockCanvasStore.canvas = fromPartial<LGraphCanvas>({
+      graph: { groups: mockGroups }
     })
-
-    vi.mocked(useCanvasStore).mockReturnValue(
-      mockCanvasStore as ReturnType<typeof useCanvasStore>
-    )
   })
 
   describe('findParentGroup', () => {

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -7,30 +7,20 @@ import type {
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
-const {
-  mockShowNodeOptions,
-  mockUpdateSelectedItems,
-  mockGetCanvasContextMenuTarget
-} = vi.hoisted(() => ({
-  mockShowNodeOptions: vi.fn(),
-  mockUpdateSelectedItems: vi.fn(),
-  mockGetCanvasContextMenuTarget: vi.fn<
-    () => { reroute?: unknown; group?: unknown }
-  >(() => ({}))
-}))
+const { mockShowNodeOptions, mockGetCanvasContextMenuTarget } = vi.hoisted(
+  () => ({
+    mockShowNodeOptions: vi.fn(),
+    mockGetCanvasContextMenuTarget: vi.fn<
+      () => { reroute?: unknown; group?: unknown }
+    >(() => ({}))
+  })
+)
 
 vi.mock(import('@/composables/graph/useMoreOptionsMenu'), () => ({
   showNodeOptions: mockShowNodeOptions
 }))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({ updateSelectedItems: mockUpdateSelectedItems })
-  })
-)
 
 vi.mock<unknown>(
   import('@/lib/litegraph/src/canvas/getCanvasContextMenuTarget'),
@@ -55,8 +45,12 @@ describe('useGroupContextMenu', () => {
   }
   let legacyMenuMock: ReturnType<typeof vi.fn>
   let stubCanvas: StubCanvas
+  let mockUpdateSelectedItems: ReturnType<
+    typeof vi.mocked<ReturnType<typeof useCanvasStore>['updateSelectedItems']>
+  >
 
   beforeEach(() => {
+    mockUpdateSelectedItems = vi.mocked(useCanvasStore().updateSelectedItems)
     LiteGraph.vueNodesMode = true
     group = { id: 1, recomputeInsideNodes: vi.fn() }
     mockGetCanvasContextMenuTarget.mockReturnValue({ group })

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -24,10 +24,6 @@ const i18n = createI18n({
   }
 })
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
-}))
-
 function setupComposable() {
   let composable!: ReturnType<typeof useImageMenuOptions>
   const Wrapper = defineComponent({

--- a/src/composables/graph/useNodeErrorFlagSync.test.ts
+++ b/src/composables/graph/useNodeErrorFlagSync.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -14,10 +12,6 @@ import { app } from '@/scripts/app'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 
 describe('reconcileNodeErrorFlags (via lastNodeErrors watcher)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   function setupGraphWithStore() {
     const graph = new LGraph()
     const nodeA = new LGraphNode('KSampler')

--- a/src/composables/graph/useSelectionOperations.deleteGuard.test.ts
+++ b/src/composables/graph/useSelectionOperations.deleteGuard.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useSelectionOperations } from '@/composables/graph/useSelectionOperations'
 import { app } from '@/scripts/app'
@@ -31,10 +30,6 @@ function stubCanvas(selectOnly: boolean) {
 }
 
 describe('useSelectionOperations delete guard', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('does not delete while the canvas is picking-only', () => {
     const { deleteSelected } = stubCanvas(true)
 

--- a/src/composables/graph/useSelectionState.test.ts
+++ b/src/composables/graph/useSelectionState.test.ts
@@ -1,6 +1,4 @@
 import { toGroupId } from '@/types/groupId'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { useSelectionState } from '@/composables/graph/useSelectionState'
@@ -78,12 +76,6 @@ function mockSettingValues(overrides: Record<string, unknown> = {}) {
 
 describe('useSelectionState', () => {
   beforeEach(() => {
-    // Create testing Pinia instance
-    setActivePinia(
-      createTestingPinia({
-        createSpy: vi.fn
-      })
-    )
     mockSettingValues()
 
     // Setup mock utility functions

--- a/src/composables/graph/useSubgraphOperations.test.ts
+++ b/src/composables/graph/useSubgraphOperations.test.ts
@@ -1,11 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode, SubgraphNode } from '@/lib/litegraph/src/litegraph'
-
-const mocks = vi.hoisted(() => ({
-  publishSubgraph: vi.fn(),
-  selectedItems: [] as unknown[]
-}))
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSubgraphStore } from '@/stores/subgraphStore'
+import { useSubgraphOperations } from './useSubgraphOperations'
 
 vi.mock<unknown>(
   import('@/composables/canvas/useSelectedLiteGraphItems'),
@@ -15,41 +13,6 @@ vi.mock<unknown>(
     })
   })
 )
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      getCanvas: vi.fn(),
-      get selectedItems() {
-        return mocks.selectedItems
-      },
-      updateSelectedItems: vi.fn()
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: null
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    revokeSubgraphPreviews: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: () => ({
-    publishSubgraph: mocks.publishSubgraph
-  })
-}))
 
 function createSubgraphNode(): SubgraphNode {
   const node = Object.create(SubgraphNode.prototype)
@@ -62,54 +25,45 @@ function createRegularNode(): LGraphNode {
 
 describe('useSubgraphOperations', () => {
   beforeEach(() => {
-    mocks.selectedItems = []
+    vi.mocked(useSubgraphStore().publishSubgraph).mockResolvedValue(undefined)
   })
 
   it('addSubgraphToLibrary calls publishSubgraph when single SubgraphNode selected', async () => {
-    mocks.selectedItems = [createSubgraphNode()]
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = [createSubgraphNode()]
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).toHaveBeenCalledOnce()
+    expect(useSubgraphStore().publishSubgraph).toHaveBeenCalledOnce()
   })
 
   it('addSubgraphToLibrary does not call publishSubgraph when no items selected', async () => {
-    mocks.selectedItems = []
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = []
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).not.toHaveBeenCalled()
+    expect(useSubgraphStore().publishSubgraph).not.toHaveBeenCalled()
   })
 
   it('addSubgraphToLibrary does not call publishSubgraph when multiple items selected', async () => {
-    mocks.selectedItems = [createSubgraphNode(), createSubgraphNode()]
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = [
+      createSubgraphNode(),
+      createSubgraphNode()
+    ]
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).not.toHaveBeenCalled()
+    expect(useSubgraphStore().publishSubgraph).not.toHaveBeenCalled()
   })
 
   it('addSubgraphToLibrary does not call publishSubgraph when selected item is not a SubgraphNode', async () => {
-    mocks.selectedItems = [createRegularNode()]
-
-    const { useSubgraphOperations } =
-      await import('@/composables/graph/useSubgraphOperations')
+    useCanvasStore().selectedItems = [createRegularNode()]
     const { addSubgraphToLibrary } = useSubgraphOperations()
 
     await addSubgraphToLibrary()
 
-    expect(mocks.publishSubgraph).not.toHaveBeenCalled()
+    expect(useSubgraphStore().publishSubgraph).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -1,30 +1,12 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, ref } from 'vue'
 import type { EffectScope } from 'vue'
+import { BrushShape, Tools } from '@/extensions/core/maskeditor/types'
 
-// vi.hoisted runs before imports — only vi.fn() is safe here (no Vue)
-const saveStateSpy = vi.hoisted(() => vi.fn())
+let saveStateSpy: ReturnType<typeof vi.spyOn>
 
-const mockStoreDef = vi.hoisted(() => ({
-  brushSettings: {
-    size: 20,
-    hardness: 0.9,
-    opacity: 1,
-    stepSize: 5,
-    type: 'arc'
-  },
-  currentTool: 'pen' as string,
-  activeLayer: 'mask' as string,
-  maskCanvas: null as HTMLCanvasElement | null,
-  maskCtx: null as CanvasRenderingContext2D | null,
-  rgbCanvas: null as HTMLCanvasElement | null,
-  rgbCtx: null as CanvasRenderingContext2D | null,
-  maskBlendMode: 'black',
-  maskOpacity: 0.8,
-  maskColor: { r: 0, g: 0, b: 0 },
-  rgbColor: '#FF0000',
-  canvasHistory: { saveState: saveStateSpy }
-}))
+let mockStoreDef: ReturnType<typeof useMaskEditorStore>
 
 // vi.mock factory runs after hoisting — ref/computed from Vue are available
 vi.mock(import('./useGPUResources'), () => {
@@ -81,10 +63,6 @@ vi.mock(import('./useBrushAdjustment'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStoreDef)
-}))
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { registerExtension: vi.fn() }
 }))
@@ -128,8 +106,20 @@ function setup() {
 }
 
 beforeEach(() => {
+  mockStoreDef = useMaskEditorStore()
+  mockStoreDef.brushSettings = {
+    size: 20,
+    hardness: 0.9,
+    opacity: 1,
+    stepSize: 5,
+    type: BrushShape.Arc
+  }
+  saveStateSpy = vi
+    .spyOn(mockStoreDef.canvasHistory, 'saveState')
+    .mockImplementation(() => {})
   const mockCtx = makeMockCtx()
   const mockCanvas = {
+    getContext: vi.fn().mockImplementation(() => mockStoreDef.rgbCtx),
     width: 200,
     height: 200,
     style: { opacity: '' }
@@ -139,7 +129,7 @@ beforeEach(() => {
   mockStoreDef.maskCtx = mockCtx
   mockStoreDef.rgbCanvas = mockCanvas
   mockStoreDef.rgbCtx = mockCtx
-  mockStoreDef.currentTool = 'pen'
+  mockStoreDef.currentTool = Tools.MaskPen
   mockStoreDef.activeLayer = 'mask'
 
   const gpu = useGPUResources()
@@ -167,7 +157,7 @@ describe('startDrawing', () => {
   })
 
   it('sets DestinationOut composition when tool is eraser', async () => {
-    mockStoreDef.currentTool = 'eraser'
+    mockStoreDef.currentTool = Tools.Eraser
     const { startDrawing } = setup()
     await startDrawing(makePointerEvent(50, 50))
     expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
@@ -233,7 +223,7 @@ describe('handleDrawing', () => {
   })
 
   it('sets DestinationOut composition when tool is eraser during move', async () => {
-    mockStoreDef.currentTool = 'eraser'
+    mockStoreDef.currentTool = Tools.Eraser
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
       cb(0)
       return 0
@@ -266,6 +256,7 @@ describe('drawEnd canvas visibility', () => {
   it('restores rgb canvas opacity when activeLayer is rgb', async () => {
     mockStoreDef.activeLayer = 'rgb'
     const mockRgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStoreDef.rgbCtx),
       width: 200,
       height: 200,
       style: { opacity: '' }
@@ -308,7 +299,7 @@ describe('drawEnd', () => {
   })
 
   it('passes isErasing=true to compositeStroke when tool is eraser', async () => {
-    mockStoreDef.currentTool = 'eraser'
+    mockStoreDef.currentTool = Tools.Eraser
     const { startDrawing, drawEnd } = setup()
     await startDrawing(makePointerEvent(50, 50))
     await drawEnd(makePointerEvent(60, 60))
@@ -318,6 +309,7 @@ describe('drawEnd', () => {
   it('restores mask canvas opacity after drawing on mask layer', async () => {
     mockStoreDef.activeLayer = 'mask'
     const mockMaskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStoreDef.maskCtx),
       width: 200,
       height: 200,
       style: { opacity: '' }

--- a/src/composables/maskeditor/useCanvasHistory.test.ts
+++ b/src/composables/maskeditor/useCanvasHistory.test.ts
@@ -1,69 +1,9 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { useCanvasHistory } from '@/composables/maskeditor/useCanvasHistory'
 
-// Define the store shape to avoid 'any' and cast to the expected type
-interface MaskEditorStoreState {
-  maskCanvas: HTMLCanvasElement | null
-  rgbCanvas: HTMLCanvasElement | null
-  imgCanvas: HTMLCanvasElement | null
-  maskCtx: CanvasRenderingContext2D | null
-  rgbCtx: CanvasRenderingContext2D | null
-  imgCtx: CanvasRenderingContext2D | null
-}
-
-// Use vi.hoisted to create isolated mock state container
-const mockRefs = vi.hoisted(() => ({
-  maskCanvas: null as HTMLCanvasElement | null,
-  rgbCanvas: null as HTMLCanvasElement | null,
-  imgCanvas: null as HTMLCanvasElement | null,
-  maskCtx: null as CanvasRenderingContext2D | null,
-  rgbCtx: null as CanvasRenderingContext2D | null,
-  imgCtx: null as CanvasRenderingContext2D | null
-}))
-
-const mockStore: MaskEditorStoreState = {
-  get maskCanvas() {
-    return mockRefs.maskCanvas
-  },
-  set maskCanvas(val) {
-    mockRefs.maskCanvas = val
-  },
-  get rgbCanvas() {
-    return mockRefs.rgbCanvas
-  },
-  set rgbCanvas(val) {
-    mockRefs.rgbCanvas = val
-  },
-  get imgCanvas() {
-    return mockRefs.imgCanvas
-  },
-  set imgCanvas(val) {
-    mockRefs.imgCanvas = val
-  },
-  get maskCtx() {
-    return mockRefs.maskCtx
-  },
-  set maskCtx(val) {
-    mockRefs.maskCtx = val
-  },
-  get rgbCtx() {
-    return mockRefs.rgbCtx
-  },
-  set rgbCtx(val) {
-    mockRefs.rgbCtx = val
-  },
-  get imgCtx() {
-    return mockRefs.imgCtx
-  },
-  set imgCtx(val) {
-    mockRefs.imgCtx = val
-  }
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockRefs: ReturnType<typeof useMaskEditorStore>
 
 // Mock ImageBitmap using safe global augmentation pattern
 if (typeof globalThis.ImageBitmap === 'undefined') {
@@ -80,6 +20,7 @@ if (typeof globalThis.ImageBitmap === 'undefined') {
 
 describe('useCanvasHistory', () => {
   beforeEach(() => {
+    mockRefs = useMaskEditorStore()
     let rafCallCount = 0
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
       (cb: FrameRequestCallback) => {
@@ -122,16 +63,19 @@ describe('useCanvasHistory', () => {
 
     // Mock canvases using explicit partial-cast pattern
     mockRefs.maskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
       width: 100,
       height: 100
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockRefs.rgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockRefs.rgbCtx),
       width: 100,
       height: 100
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockRefs.imgCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockRefs.imgCtx),
       width: 100,
       height: 100
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
@@ -166,6 +110,7 @@ describe('useCanvasHistory', () => {
       const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
 
       mockRefs.maskCanvas = {
+        getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
         // oxlint-disable-next-line no-misused-spread
         ...mockRefs.maskCanvas,
         width: 0,
@@ -178,6 +123,7 @@ describe('useCanvasHistory', () => {
       expect(rafSpy).toHaveBeenCalled()
 
       mockRefs.maskCanvas = {
+        getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
         width: 100,
         height: 100
       } as Partial<HTMLCanvasElement> as HTMLCanvasElement
@@ -623,6 +569,7 @@ describe('useCanvasHistory', () => {
     it('should handle zero-sized canvas', () => {
       if (mockRefs.maskCanvas) {
         mockRefs.maskCanvas = {
+          getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
           width: 0,
           height: 0
         } as Partial<HTMLCanvasElement> as HTMLCanvasElement

--- a/src/composables/maskeditor/useCanvasManager.test.ts
+++ b/src/composables/maskeditor/useCanvasManager.test.ts
@@ -1,23 +1,11 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MaskBlendMode } from '@/extensions/core/maskeditor/types'
 import { useCanvasManager } from '@/composables/maskeditor/useCanvasManager'
-const mockStore = {
-  imgCanvas: null! as HTMLCanvasElement,
-  maskCanvas: null! as HTMLCanvasElement,
-  rgbCanvas: null! as HTMLCanvasElement,
-  imgCtx: null! as CanvasRenderingContext2D,
-  maskCtx: null! as CanvasRenderingContext2D,
-  rgbCtx: null! as CanvasRenderingContext2D,
-  canvasBackground: null! as HTMLElement,
-  maskColor: { r: 0, g: 0, b: 0 },
-  maskBlendMode: MaskBlendMode.Black,
-  maskOpacity: 0.8
-}
+import { fromPartial } from '@total-typescript/shoehorn'
 
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 function createMockImage(width: number, height: number): HTMLImageElement {
   return {
@@ -30,6 +18,7 @@ describe('useCanvasManager', () => {
   let mockImageData: ImageData
 
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
     mockImageData = {
       data: new Uint8ClampedArray(100 * 100 * 4),
       width: 100,
@@ -56,24 +45,27 @@ describe('useCanvasManager', () => {
     mockStore.rgbCtx = partialRgbCtx as CanvasRenderingContext2D
 
     const partialImgCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 0,
       height: 0
     }
     mockStore.imgCanvas = partialImgCanvas as HTMLCanvasElement
 
-    mockStore.maskCanvas = {
+    mockStore.maskCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 0,
       height: 0,
       style: {
         mixBlendMode: '',
         opacity: ''
-      } as Pick<CSSStyleDeclaration, 'mixBlendMode' | 'opacity'>
-    } as HTMLCanvasElement
+      }
+    })
 
-    mockStore.rgbCanvas = {
+    mockStore.rgbCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 0,
       height: 0
-    } as HTMLCanvasElement
+    })
 
     mockStore.canvasBackground = {
       style: {
@@ -81,7 +73,7 @@ describe('useCanvasManager', () => {
       } as Pick<CSSStyleDeclaration, 'backgroundColor'>
     } as HTMLElement
 
-    mockStore.maskColor = { r: 0, g: 0, b: 0 }
+    Object.assign(mockStore, { maskColor: { r: 0, g: 0, b: 0 } })
     mockStore.maskBlendMode = MaskBlendMode.Black
     mockStore.maskOpacity = 0.8
   })
@@ -95,12 +87,12 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.imgCanvas.width).toBe(512)
-      expect(mockStore.imgCanvas.height).toBe(512)
-      expect(mockStore.maskCanvas.width).toBe(512)
-      expect(mockStore.maskCanvas.height).toBe(512)
-      expect(mockStore.rgbCanvas.width).toBe(512)
-      expect(mockStore.rgbCanvas.height).toBe(512)
+      expect(mockStore.imgCanvas!.width).toBe(512)
+      expect(mockStore.imgCanvas!.height).toBe(512)
+      expect(mockStore.maskCanvas!.width).toBe(512)
+      expect(mockStore.maskCanvas!.height).toBe(512)
+      expect(mockStore.rgbCanvas!.width).toBe(512)
+      expect(mockStore.rgbCanvas!.height).toBe(512)
     })
 
     it('should draw original image', async () => {
@@ -111,7 +103,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.imgCtx.drawImage).toHaveBeenCalledWith(
+      expect(mockStore.imgCtx!.drawImage).toHaveBeenCalledWith(
         origImage,
         0,
         0,
@@ -129,7 +121,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, paintImage)
 
-      expect(mockStore.rgbCtx.drawImage).toHaveBeenCalledWith(
+      expect(mockStore.rgbCtx!.drawImage).toHaveBeenCalledWith(
         paintImage,
         0,
         0,
@@ -146,7 +138,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.rgbCtx.drawImage).not.toHaveBeenCalled()
+      expect(mockStore.rgbCtx!.drawImage).not.toHaveBeenCalled()
     })
 
     it('should prepare mask', async () => {
@@ -157,15 +149,15 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.maskCtx.drawImage).toHaveBeenCalled()
-      expect(mockStore.maskCtx.getImageData).toHaveBeenCalled()
-      expect(mockStore.maskCtx.putImageData).toHaveBeenCalled()
+      expect(mockStore.maskCtx!.drawImage).toHaveBeenCalled()
+      expect(mockStore.maskCtx!.getImageData).toHaveBeenCalled()
+      expect(mockStore.maskCtx!.putImageData).toHaveBeenCalled()
     })
 
     it('should throw error when canvas missing', async () => {
       const manager = useCanvasManager()
 
-      mockStore.imgCanvas = null! as HTMLCanvasElement
+      mockStore.imgCanvas = null
 
       const origImage = createMockImage(512, 512)
       const maskImage = createMockImage(512, 512)
@@ -194,14 +186,14 @@ describe('useCanvasManager', () => {
       const manager = useCanvasManager()
 
       mockStore.maskBlendMode = MaskBlendMode.Black
-      mockStore.maskColor = { r: 0, g: 0, b: 0 }
+      Object.assign(mockStore, { maskColor: { r: 0, g: 0, b: 0 } })
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCtx.fillStyle).toBe('rgb(0, 0, 0)')
-      expect(mockStore.maskCanvas.style.mixBlendMode).toBe('initial')
-      expect(mockStore.maskCanvas.style.opacity).toBe('0.8')
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe(
+      expect(mockStore.maskCtx!.fillStyle).toBe('rgb(0, 0, 0)')
+      expect(mockStore.maskCanvas!.style.mixBlendMode).toBe('initial')
+      expect(mockStore.maskCanvas!.style.opacity).toBe('0.8')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe(
         'rgba(0,0,0,1)'
       )
     })
@@ -210,13 +202,13 @@ describe('useCanvasManager', () => {
       const manager = useCanvasManager()
 
       mockStore.maskBlendMode = MaskBlendMode.White
-      mockStore.maskColor = { r: 255, g: 255, b: 255 }
+      Object.assign(mockStore, { maskColor: { r: 255, g: 255, b: 255 } })
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCtx.fillStyle).toBe('rgb(255, 255, 255)')
-      expect(mockStore.maskCanvas.style.mixBlendMode).toBe('initial')
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe(
+      expect(mockStore.maskCtx!.fillStyle).toBe('rgb(255, 255, 255)')
+      expect(mockStore.maskCanvas!.style.mixBlendMode).toBe('initial')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe(
         'rgba(255,255,255,1)'
       )
     })
@@ -225,13 +217,13 @@ describe('useCanvasManager', () => {
       const manager = useCanvasManager()
 
       mockStore.maskBlendMode = MaskBlendMode.Negative
-      mockStore.maskColor = { r: 255, g: 255, b: 255 }
+      Object.assign(mockStore, { maskColor: { r: 255, g: 255, b: 255 } })
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCanvas.style.mixBlendMode).toBe('difference')
-      expect(mockStore.maskCanvas.style.opacity).toBe('1')
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe(
+      expect(mockStore.maskCanvas!.style.mixBlendMode).toBe('difference')
+      expect(mockStore.maskCanvas!.style.opacity).toBe('1')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe(
         'rgba(255,255,255,1)'
       )
     })
@@ -239,9 +231,9 @@ describe('useCanvasManager', () => {
     it('should update all pixels with mask color', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskColor = { r: 128, g: 64, b: 32 }
-      mockStore.maskCanvas.width = 100
-      mockStore.maskCanvas.height = 100
+      Object.assign(mockStore, { maskColor: { r: 128, g: 64, b: 32 } })
+      mockStore.maskCanvas!.width = 100
+      mockStore.maskCanvas!.height = 100
 
       await manager.updateMaskColor()
 
@@ -251,7 +243,7 @@ describe('useCanvasManager', () => {
         expect(mockImageData.data[i + 2]).toBe(32)
       }
 
-      expect(mockStore.maskCtx.putImageData).toHaveBeenCalledWith(
+      expect(mockStore.maskCtx!.putImageData).toHaveBeenCalledWith(
         mockImageData,
         0,
         0
@@ -261,11 +253,11 @@ describe('useCanvasManager', () => {
     it('should return early when canvas missing', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskCanvas = null! as HTMLCanvasElement
+      mockStore.maskCanvas = null
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCtx.getImageData).not.toHaveBeenCalled()
+      expect(mockStore.maskCtx!.getImageData).not.toHaveBeenCalled()
     })
 
     it('should return early when context missing', async () => {
@@ -275,7 +267,7 @@ describe('useCanvasManager', () => {
 
       await manager.updateMaskColor()
 
-      expect(mockStore.canvasBackground.style.backgroundColor).toBe('')
+      expect(mockStore.canvasBackground!.style.backgroundColor).toBe('')
     })
 
     it('should handle different opacity values', async () => {
@@ -285,7 +277,7 @@ describe('useCanvasManager', () => {
 
       await manager.updateMaskColor()
 
-      expect(mockStore.maskCanvas.style.opacity).toBe('0.5')
+      expect(mockStore.maskCanvas!.style.opacity).toBe('0.5')
     })
   })
 
@@ -310,7 +302,7 @@ describe('useCanvasManager', () => {
     it('should apply mask color to all pixels', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskColor = { r: 100, g: 150, b: 200 }
+      Object.assign(mockStore, { maskColor: { r: 100, g: 150, b: 200 } })
 
       const origImage = createMockImage(100, 100)
       const maskImage = createMockImage(100, 100)
@@ -332,7 +324,7 @@ describe('useCanvasManager', () => {
 
       await manager.invalidateCanvas(origImage, maskImage, null)
 
-      expect(mockStore.maskCtx.globalCompositeOperation).toBe('source-over')
+      expect(mockStore.maskCtx!.globalCompositeOperation).toBe('source-over')
     })
   })
 })

--- a/src/composables/maskeditor/useCanvasTools.test.ts
+++ b/src/composables/maskeditor/useCanvasTools.test.ts
@@ -1,61 +1,25 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ColorComparisonMethod } from '@/extensions/core/maskeditor/types'
+import {
+  ColorComparisonMethod,
+  MaskBlendMode
+} from '@/extensions/core/maskeditor/types'
 
 import { useCanvasTools } from '@/composables/maskeditor/useCanvasTools'
 
-// Mock store interface matching the real store's nullable fields
-interface MockMaskEditorStore {
-  maskCtx: CanvasRenderingContext2D | null
-  imgCtx: CanvasRenderingContext2D | null
-  maskCanvas: HTMLCanvasElement | null
-  imgCanvas: HTMLCanvasElement | null
-  rgbCtx: CanvasRenderingContext2D | null
-  rgbCanvas: HTMLCanvasElement | null
-  maskColor: { r: number; g: number; b: number }
-  paintBucketTolerance: number
-  fillOpacity: number
-  colorSelectTolerance: number
-  colorComparisonMethod: ColorComparisonMethod
-  selectionOpacity: number
-  applyWholeImage: boolean
-  maskBoundary: boolean
-  maskTolerance: number
-  canvasHistory: { saveState: ReturnType<typeof vi.fn> }
-}
+let mockCanvasHistory: ReturnType<typeof useMaskEditorStore>['canvasHistory']
 
-const mockCanvasHistory = {
-  saveState: vi.fn()
-}
-
-const mockStore: MockMaskEditorStore = {
-  maskCtx: null,
-  imgCtx: null,
-  maskCanvas: null,
-  imgCanvas: null,
-  rgbCtx: null,
-  rgbCanvas: null,
-  maskColor: { r: 255, g: 255, b: 255 },
-  paintBucketTolerance: 10,
-  fillOpacity: 100,
-  colorSelectTolerance: 30,
-  colorComparisonMethod: ColorComparisonMethod.Simple,
-  selectionOpacity: 100,
-  applyWholeImage: false,
-  maskBoundary: false,
-  maskTolerance: 10,
-  canvasHistory: mockCanvasHistory
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 describe('useCanvasTools', () => {
   let mockMaskImageData: ImageData
   let mockImgImageData: ImageData
 
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
+    mockCanvasHistory = mockStore.canvasHistory
+    vi.spyOn(mockCanvasHistory, 'saveState').mockImplementation(() => {})
     mockMaskImageData = {
       data: new Uint8ClampedArray(100 * 100 * 4),
       width: 100,
@@ -93,24 +57,27 @@ describe('useCanvasTools', () => {
     mockStore.rgbCtx = partialRgbCtx as CanvasRenderingContext2D
 
     const partialMaskCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 100,
       height: 100
     }
     mockStore.maskCanvas = partialMaskCanvas as HTMLCanvasElement
 
     const partialImgCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 100,
       height: 100
     }
     mockStore.imgCanvas = partialImgCanvas as HTMLCanvasElement
 
     const partialRgbCanvas: Partial<HTMLCanvasElement> = {
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 100,
       height: 100
     }
     mockStore.rgbCanvas = partialRgbCanvas as HTMLCanvasElement
 
-    mockStore.maskColor = { r: 255, g: 255, b: 255 }
+    mockStore.maskBlendMode = MaskBlendMode.White
     mockStore.paintBucketTolerance = 10
     mockStore.fillOpacity = 100
     mockStore.colorSelectTolerance = 30
@@ -203,7 +170,7 @@ describe('useCanvasTools', () => {
     })
 
     it('should apply mask color', () => {
-      mockStore.maskColor = { r: 128, g: 64, b: 32 }
+      Object.assign(mockStore, { maskColor: { r: 128, g: 64, b: 32 } })
 
       const tools = useCanvasTools()
 

--- a/src/composables/maskeditor/useCanvasTransform.test.ts
+++ b/src/composables/maskeditor/useCanvasTransform.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCanvasTransform } from '@/composables/maskeditor/useCanvasTransform'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 interface IMockCanvas {
   width: number
   height: number
+  getContext: () => CanvasRenderingContext2D | null
 }
 
 interface IMockContext {
@@ -13,53 +16,8 @@ interface IMockContext {
   drawImage: ReturnType<typeof vi.fn>
 }
 
-interface IMockCanvasHistory {
-  saveState: ReturnType<typeof vi.fn>
-}
-
-interface IMockStore {
-  maskCanvas: IMockCanvas | null
-  rgbCanvas: IMockCanvas | null
-  imgCanvas: IMockCanvas | null
-  maskCtx: IMockContext | null
-  rgbCtx: IMockContext | null
-  imgCtx: IMockContext | null
-  tgpuRoot: unknown
-  canvasHistory: IMockCanvasHistory
-  gpuTexturesNeedRecreation: boolean
-  gpuTextureWidth: number
-  gpuTextureHeight: number
-  pendingGPUMaskData: Uint8ClampedArray | null
-  pendingGPURgbData: Uint8ClampedArray | null
-}
-
-const { mockStore, mockCanvasHistory } = vi.hoisted(() => {
-  const mockCanvasHistory: IMockCanvasHistory = {
-    saveState: vi.fn()
-  }
-
-  const mockStore: IMockStore = {
-    maskCanvas: null,
-    rgbCanvas: null,
-    imgCanvas: null,
-    maskCtx: null,
-    rgbCtx: null,
-    imgCtx: null,
-    tgpuRoot: null,
-    canvasHistory: mockCanvasHistory,
-    gpuTexturesNeedRecreation: false,
-    gpuTextureWidth: 0,
-    gpuTextureHeight: 0,
-    pendingGPUMaskData: null,
-    pendingGPURgbData: null
-  }
-
-  return { mockStore, mockCanvasHistory }
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
+let mockCanvasHistory: ReturnType<typeof useMaskEditorStore>['canvasHistory']
 
 // Mock ImageData with improved type safety
 if (typeof globalThis.ImageData === 'undefined') {
@@ -120,6 +78,9 @@ describe('useCanvasTransform', () => {
   let mockImgCtx: IMockContext
 
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
+    mockCanvasHistory = mockStore.canvasHistory
+    vi.spyOn(mockCanvasHistory, 'saveState').mockImplementation(() => {})
     const createMockImageData = (width: number, height: number) => {
       const data = new Uint8ClampedArray(width * height * 4)
       for (let i = 0; i < data.length; i += 4) {
@@ -157,26 +118,29 @@ describe('useCanvasTransform', () => {
     }
 
     mockMaskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 100,
       height: 50
     }
 
     mockRgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 100,
       height: 50
     }
 
     mockImgCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 100,
       height: 50
     }
 
-    mockStore.maskCanvas = mockMaskCanvas
-    mockStore.rgbCanvas = mockRgbCanvas
-    mockStore.imgCanvas = mockImgCanvas
-    mockStore.maskCtx = mockMaskCtx
-    mockStore.rgbCtx = mockRgbCtx
-    mockStore.imgCtx = mockImgCtx
+    mockStore.maskCanvas = fromPartial<HTMLCanvasElement>(mockMaskCanvas)
+    mockStore.rgbCanvas = fromPartial<HTMLCanvasElement>(mockRgbCanvas)
+    mockStore.imgCanvas = fromPartial<HTMLCanvasElement>(mockImgCanvas)
+    mockStore.maskCtx = fromPartial<CanvasRenderingContext2D>(mockMaskCtx)
+    mockStore.rgbCtx = fromPartial<CanvasRenderingContext2D>(mockRgbCtx)
+    mockStore.imgCtx = fromPartial<CanvasRenderingContext2D>(mockImgCtx)
     mockStore.tgpuRoot = null
     mockStore.gpuTexturesNeedRecreation = false
     mockStore.gpuTextureWidth = 0
@@ -226,15 +190,15 @@ describe('useCanvasTransform', () => {
 
       expect(mockCanvasHistory.saveState).toHaveBeenCalled()
 
-      const savedArgs = mockCanvasHistory.saveState.mock.calls[0]
+      const savedArgs = vi.mocked(mockCanvasHistory.saveState).mock.calls[0]
       expect(savedArgs).toHaveLength(3)
 
-      expect(savedArgs[0].width).toBe(50)
-      expect(savedArgs[0].height).toBe(100)
-      expect(savedArgs[1].width).toBe(50)
-      expect(savedArgs[1].height).toBe(100)
-      expect(savedArgs[2].width).toBe(50)
-      expect(savedArgs[2].height).toBe(100)
+      expect(savedArgs[0]!.width).toBe(50)
+      expect(savedArgs[0]!.height).toBe(100)
+      expect(savedArgs[1]!.width).toBe(50)
+      expect(savedArgs[1]!.height).toBe(100)
+      expect(savedArgs[2]!.width).toBe(50)
+      expect(savedArgs[2]!.height).toBe(100)
     })
 
     it('should log error when canvas contexts not ready', async () => {
@@ -254,7 +218,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should handle GPU texture recreation when GPU is active', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
 
       const transform = useCanvasTransform()
       await transform.rotateClockwise()
@@ -464,7 +430,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should handle GPU texture recreation when GPU is active', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
 
       const transform = useCanvasTransform()
       await transform.mirrorHorizontal()
@@ -529,7 +497,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should handle GPU texture recreation when GPU is active', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
 
       const transform = useCanvasTransform()
       await transform.mirrorVertical()
@@ -619,7 +589,9 @@ describe('useCanvasTransform', () => {
 
   describe('GPU integration', () => {
     it('should set GPU recreation flags for rotation', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
       mockMaskCanvas.width = 100
       mockMaskCanvas.height = 50
 
@@ -634,7 +606,9 @@ describe('useCanvasTransform', () => {
     })
 
     it('should premultiply alpha when preparing GPU data', async () => {
-      mockStore.tgpuRoot = {}
+      mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>(
+        {}
+      )
       mockMaskCanvas.width = 1
       mockMaskCanvas.height = 1
 

--- a/src/composables/maskeditor/useCoordinateTransform.test.ts
+++ b/src/composables/maskeditor/useCoordinateTransform.test.ts
@@ -1,22 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCoordinateTransform } from '@/composables/maskeditor/useCoordinateTransform'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-type MockStore = {
-  pointerZone: HTMLElement | null
-  canvasContainer: HTMLElement | null
-  maskCanvas: HTMLCanvasElement | null
-}
-
-const mockStore: MockStore = {
-  pointerZone: null,
-  canvasContainer: null,
-  maskCanvas: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock(import('@vueuse/core'), () => ({
   createSharedComposable: <T extends (...args: unknown[]) => unknown>(fn: T) =>
@@ -65,9 +52,7 @@ const createCanvasWithRect = (
 
 describe('useCoordinateTransform', () => {
   beforeEach(() => {
-    mockStore.pointerZone = null
-    mockStore.canvasContainer = null
-    mockStore.maskCanvas = null
+    mockStore = useMaskEditorStore()
   })
 
   describe('screenToCanvas', () => {

--- a/src/composables/maskeditor/useGPUResources.test.ts
+++ b/src/composables/maskeditor/useGPUResources.test.ts
@@ -1,6 +1,7 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 vi.mock<unknown>(import('typegpu'), () => ({
@@ -28,36 +29,7 @@ vi.mock<unknown>(import('./gpu/GPUBrushRenderer'), () => ({
   )
 }))
 
-const tgpuRoot: unknown = null
-const mockStore = reactive({
-  tgpuRoot,
-  maskCanvas: null as HTMLCanvasElement | null,
-  rgbCanvas: null as HTMLCanvasElement | null,
-  maskCtx: null as CanvasRenderingContext2D | null,
-  rgbCtx: null as CanvasRenderingContext2D | null,
-  clearTrigger: 0,
-  canvasHistory: { currentStateIndex: 0 },
-  gpuTexturesNeedRecreation: false,
-  gpuTextureWidth: 0,
-  gpuTextureHeight: 0,
-  pendingGPUMaskData: null,
-  pendingGPURgbData: null,
-  brushSettings: {
-    size: 20,
-    hardness: 0.9,
-    opacity: 1,
-    stepSize: 5,
-    type: 'arc'
-  },
-  activeLayer: 'mask',
-  currentTool: 'pen',
-  maskColor: { r: 0, g: 0, b: 0 },
-  rgbColor: '#FF0000'
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 import { resetDirtyRect } from './brushDrawingUtils'
 import { useGPUResources } from './useGPUResources'
@@ -70,6 +42,7 @@ function setup() {
 }
 
 beforeEach(() => {
+  mockStore = useMaskEditorStore()
   mockStore.tgpuRoot = null
   mockStore.maskCanvas = null
   mockStore.rgbCanvas = null
@@ -186,7 +159,9 @@ describe('watchers', () => {
 describe('initGPUResources with pre-existing tgpuRoot', () => {
   it('returns early with a warning when canvas contexts are not ready', async () => {
     const { initGPUResources, hasRenderer } = setup()
-    mockStore.tgpuRoot = { device: {} }
+    mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>({
+      device: {}
+    })
     await initGPUResources()
     expect(hasRenderer.value).toBe(false)
   })
@@ -235,12 +210,16 @@ describe('gpuRender', () => {
         writeTexture: vi.fn()
       }
     }
-    mockStore.tgpuRoot = { device: gpuDevice }
+    mockStore.tgpuRoot = fromPartial<NonNullable<typeof mockStore.tgpuRoot>>({
+      device: gpuDevice
+    })
     mockStore.maskCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockReturnValue(context),
       width: 4,
       height: 4
     })
     mockStore.rgbCanvas = fromPartial<HTMLCanvasElement>({
+      getContext: vi.fn().mockReturnValue(context),
       width: 4,
       height: 4
     })

--- a/src/composables/maskeditor/useImageLoader.test.ts
+++ b/src/composables/maskeditor/useImageLoader.test.ts
@@ -1,49 +1,18 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toNodeId } from '@/types/nodeId'
 
 import { useImageLoader } from '@/composables/maskeditor/useImageLoader'
-
-type MockStore = {
-  imgCanvas: HTMLCanvasElement | null
-  maskCanvas: HTMLCanvasElement | null
-  rgbCanvas: HTMLCanvasElement | null
-  imgCtx: CanvasRenderingContext2D | null
-  maskCtx: CanvasRenderingContext2D | null
-  image: HTMLImageElement | null
-}
-
-type MockDataStore = {
-  inputData: {
-    baseLayer: { image: HTMLImageElement }
-    maskLayer: { image: HTMLImageElement }
-    paintLayer: { image: HTMLImageElement } | null
-  } | null
-}
 
 const mockCanvasManager = {
   invalidateCanvas: vi.fn().mockResolvedValue(undefined),
   updateMaskColor: vi.fn().mockResolvedValue(undefined)
 }
 
-const mockStore: MockStore = {
-  imgCanvas: null,
-  maskCanvas: null,
-  rgbCanvas: null,
-  imgCtx: null,
-  maskCtx: null,
-  image: null
-}
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
-const mockDataStore: MockDataStore = {
-  inputData: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: vi.fn(() => mockDataStore)
-}))
+let mockDataStore: ReturnType<typeof useMaskEditorDataStore>
 
 vi.mock(import('@/composables/maskeditor/useCanvasManager'), () => ({
   useCanvasManager: vi.fn(() => mockCanvasManager)
@@ -60,20 +29,11 @@ describe('useImageLoader', () => {
   let mockPaintImage: HTMLImageElement
 
   beforeEach(() => {
-    mockBaseImage = {
-      width: 512,
-      height: 512
-    } as HTMLImageElement
-
-    mockMaskImage = {
-      width: 512,
-      height: 512
-    } as HTMLImageElement
-
-    mockPaintImage = {
-      width: 512,
-      height: 512
-    } as HTMLImageElement
+    mockStore = useMaskEditorStore()
+    mockDataStore = useMaskEditorDataStore()
+    mockBaseImage = new Image(512, 512)
+    mockMaskImage = new Image(512, 512)
+    mockPaintImage = new Image(512, 512)
 
     mockStore.imgCtx = {
       clearRect: vi.fn()
@@ -84,24 +44,29 @@ describe('useImageLoader', () => {
     } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
 
     mockStore.imgCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.imgCtx),
       width: 0,
       height: 0
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockStore.maskCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.maskCtx),
       width: 0,
       height: 0
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockStore.rgbCanvas = {
+      getContext: vi.fn().mockImplementation(() => mockStore.rgbCtx),
       width: 0,
       height: 0
     } as Partial<HTMLCanvasElement> as HTMLCanvasElement
 
     mockDataStore.inputData = {
-      baseLayer: { image: mockBaseImage },
-      maskLayer: { image: mockMaskImage },
-      paintLayer: { image: mockPaintImage }
+      baseLayer: { image: mockBaseImage, url: 'base.png' },
+      maskLayer: { image: mockMaskImage, url: 'mask.png' },
+      paintLayer: { image: mockPaintImage, url: 'paint.png' },
+      sourceRef: { filename: 'base.png' },
+      nodeId: toNodeId(1)
     }
   })
 
@@ -150,9 +115,10 @@ describe('useImageLoader', () => {
 
     it('should handle missing paintLayer', async () => {
       mockDataStore.inputData = {
-        baseLayer: { image: mockBaseImage },
-        maskLayer: { image: mockMaskImage },
-        paintLayer: null
+        baseLayer: { image: mockBaseImage, url: 'base.png' },
+        maskLayer: { image: mockMaskImage, url: 'mask.png' },
+        sourceRef: { filename: 'base.png', subfolder: '', type: 'input' },
+        nodeId: toNodeId(1)
       }
 
       const loader = useImageLoader()

--- a/src/composables/maskeditor/useKeyboard.test.ts
+++ b/src/composables/maskeditor/useKeyboard.test.ts
@@ -1,32 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeyboard } from '@/composables/maskeditor/useKeyboard'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-type MockCanvasHistory = {
-  undo: ReturnType<typeof vi.fn>
-  redo: ReturnType<typeof vi.fn>
-}
-
-type MockStore = {
-  canvasHistory: MockCanvasHistory
-}
-
-const { mockStore, mockCanvasHistory } = vi.hoisted(() => {
-  const mockCanvasHistory: MockCanvasHistory = {
-    undo: vi.fn(),
-    redo: vi.fn()
-  }
-
-  const mockStore: MockStore = {
-    canvasHistory: mockCanvasHistory
-  }
-
-  return { mockStore, mockCanvasHistory }
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockCanvasHistory: ReturnType<typeof useMaskEditorStore>['canvasHistory']
 
 const dispatchKeyDown = (
   init: KeyboardEventInit & { key: string }
@@ -44,6 +21,9 @@ describe('useKeyboard', () => {
   let keyboard: ReturnType<typeof useKeyboard>
 
   beforeEach(() => {
+    mockCanvasHistory = useMaskEditorStore().canvasHistory
+    vi.spyOn(mockCanvasHistory, 'undo').mockImplementation(() => {})
+    vi.spyOn(mockCanvasHistory, 'redo').mockImplementation(() => {})
     keyboard = useKeyboard()
     keyboard.addListeners()
   })

--- a/src/composables/maskeditor/useMaskEditor.test.ts
+++ b/src/composables/maskeditor/useMaskEditor.test.ts
@@ -1,14 +1,9 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
-const mockDialogStore = vi.hoisted(() => ({
-  showDialog: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => mockDialogStore
-}))
+let mockDialogStore: ReturnType<typeof useDialogStore>
 
 vi.mock<unknown>(
   import('@/components/maskeditor/dialog/TopBarHeader.vue'),
@@ -42,6 +37,7 @@ describe('useMaskEditor', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    mockDialogStore = useDialogStore()
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -1,3 +1,4 @@
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,23 +9,7 @@ import { widgetId } from '@/types/widgetId'
 import { api } from '@/scripts/api'
 import { useMaskEditorLoader } from './useMaskEditorLoader'
 
-// ---- Module Mocks ----
-
-const mockDataStore: Record<string, unknown> = {
-  inputData: null,
-  sourceNode: null,
-  setLoading: vi.fn()
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: vi.fn(() => mockDataStore)
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: vi.fn(() => ({
-    getNodeOutputs: vi.fn(() => undefined)
-  }))
-}))
+let mockDataStore: ReturnType<typeof useMaskEditorDataStore>
 
 const distribution = vi.hoisted(() => ({ isCloud: false }))
 
@@ -43,6 +28,8 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     getPreviewFormatParam: vi.fn(() => ''),
     getRandParam: vi.fn(() => '')
   }
@@ -100,6 +87,7 @@ function requestedLayerUrls(layerFilename: string): string[] {
 
 describe('useMaskEditorLoader', () => {
   beforeEach(() => {
+    mockDataStore = useMaskEditorDataStore()
     requestedUrls.length = 0
     failUrlPattern = null
     distribution.isCloud = false

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -1,5 +1,8 @@
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { markRaw } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -11,17 +14,7 @@ import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { decodePng } from '@/utils/__fixtures__/decodePng'
 import { useMaskEditorSaver } from './useMaskEditorSaver'
 
-// ---- Module Mocks ----
-
-const mockDataStore: Record<string, unknown> = {
-  sourceNode: null,
-  inputData: null,
-  outputData: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorDataStore'), () => ({
-  useMaskEditorDataStore: vi.fn(() => mockDataStore)
-}))
+let mockDataStore: ReturnType<typeof useMaskEditorDataStore>
 
 const CANVAS_SIZE = 4
 const CANVAS_BYTES = CANVAS_SIZE * CANVAS_SIZE * 4
@@ -73,18 +66,10 @@ function createMockCanvas(seed?: Uint8ClampedArray): HTMLCanvasElement {
     toDataURL: vi.fn(() => 'data:image/png;base64,mock')
   })
   canvasPixels.set(canvas, pixels)
-  return canvas
+  return markRaw(canvas)
 }
 
-const mockEditorStore: Record<string, HTMLCanvasElement | null> = {
-  maskCanvas: null,
-  rgbCanvas: null,
-  imgCanvas: null
-}
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockEditorStore)
-}))
+let mockEditorStore: ReturnType<typeof useMaskEditorStore>
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -105,16 +90,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: false }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
-      nodeToNodeLocatorId: vi.fn((node: { id: number }) => String(node.id))
-    }))
-  })
-)
-
 vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
   executionIdToNodeLocatorId: vi.fn((_rootGraph: unknown, id: string) => id)
 }))
@@ -124,6 +99,8 @@ describe('useMaskEditorSaver', () => {
   const originalCreateElement = document.createElement.bind(document)
 
   beforeEach(() => {
+    mockDataStore = useMaskEditorDataStore()
+    mockEditorStore = useMaskEditorStore()
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
 
@@ -152,7 +129,7 @@ describe('useMaskEditorSaver', () => {
       baseLayer: { image: {} as HTMLImageElement, url: 'base.png' },
       maskLayer: { image: {} as HTMLImageElement, url: 'mask.png' },
       sourceRef: { filename: 'original.png', subfolder: '', type: 'input' },
-      nodeId: 42
+      nodeId: toNodeId(42)
     }
     mockDataStore.outputData = null
 

--- a/src/composables/maskeditor/usePanAndZoom.test.ts
+++ b/src/composables/maskeditor/usePanAndZoom.test.ts
@@ -1,41 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { usePanAndZoom } from '@/composables/maskeditor/usePanAndZoom'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
-interface IMockStore {
-  canvasContainer: HTMLElement | null
-  maskCanvas: HTMLCanvasElement | null
-  rgbCanvas: HTMLCanvasElement | null
-  isPanning: boolean
-  brushVisible: boolean
-  displayZoomRatio: number
-  resetZoomTrigger: number
-  canvasHistory: { undo: ReturnType<typeof vi.fn> }
-  setCursorPoint: ReturnType<typeof vi.fn>
-  setPanOffset: ReturnType<typeof vi.fn>
-  setZoomRatio: ReturnType<typeof vi.fn>
-}
-
-const { mockStore } = vi.hoisted(() => {
-  const mockStore: IMockStore = {
-    canvasContainer: null,
-    maskCanvas: null,
-    rgbCanvas: null,
-    isPanning: false,
-    brushVisible: true,
-    displayZoomRatio: 1,
-    resetZoomTrigger: 0,
-    canvasHistory: { undo: vi.fn() },
-    setCursorPoint: vi.fn(),
-    setPanOffset: vi.fn(),
-    setZoomRatio: vi.fn()
-  }
-  return { mockStore }
-})
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 function createMockElement(width = 1200, height = 800): HTMLElement {
   return {
@@ -58,6 +26,7 @@ function createMockCanvas(width: number, height: number): HTMLCanvasElement {
   return {
     width,
     height,
+    getContext: vi.fn().mockImplementation(() => null),
     clientWidth: width,
     clientHeight: height,
     style: {} as CSSStyleDeclaration,
@@ -107,6 +76,8 @@ async function initComposable() {
 
 describe('usePanAndZoom', () => {
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
+    vi.spyOn(mockStore.canvasHistory, 'undo').mockImplementation(() => {})
     mockStore.canvasContainer = null
     mockStore.maskCanvas = null
     mockStore.rgbCanvas = null
@@ -207,7 +178,7 @@ describe('usePanAndZoom', () => {
   describe('zoom', () => {
     it('zooms in with negative deltaY and updates store', async () => {
       const { pz } = await initComposable()
-      const initialZoom = vi.mocked(mockStore.setZoomRatio).mock.calls[0]?.[0]
+      const initialZoom = mockStore.zoomRatio
 
       await pz.zoom({
         clientX: 400,
@@ -216,7 +187,7 @@ describe('usePanAndZoom', () => {
       } as WheelEvent)
 
       const zoomValue = vi.mocked(mockStore.setZoomRatio).mock.calls[0][0]
-      expect(zoomValue).toBeGreaterThan(initialZoom ?? 0)
+      expect(zoomValue).toBeGreaterThan(initialZoom)
     })
 
     it('zooms out with positive deltaY producing smaller zoom', async () => {
@@ -252,7 +223,7 @@ describe('usePanAndZoom', () => {
         } as WheelEvent)
       }
 
-      const calls = mockStore.setZoomRatio.mock.calls
+      const calls = vi.mocked(mockStore.setZoomRatio).mock.calls
       expect(calls[calls.length - 1][0]).toBeGreaterThanOrEqual(0.2)
     })
 
@@ -267,7 +238,7 @@ describe('usePanAndZoom', () => {
         } as WheelEvent)
       }
 
-      const calls = mockStore.setZoomRatio.mock.calls
+      const calls = vi.mocked(mockStore.setZoomRatio).mock.calls
       expect(calls[calls.length - 1][0]).toBeLessThanOrEqual(10)
     })
 

--- a/src/composables/maskeditor/useToolManager.test.ts
+++ b/src/composables/maskeditor/useToolManager.test.ts
@@ -1,30 +1,13 @@
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 import { useBrushDrawing } from '@/composables/maskeditor/useBrushDrawing'
 import { useToolManager } from '@/composables/maskeditor/useToolManager'
 import { Tools } from '@/extensions/core/maskeditor/types'
 
-type MockStore = {
-  currentTool: Tools
-  activeLayer: 'mask' | 'rgb'
-  pointerZone: HTMLElement | null
-  brushVisible: boolean
-  brushPreviewGradientVisible: boolean
-  isAdjustingBrush: boolean
-  isPanning: boolean
-}
-
-const mockStore = reactive<MockStore>({
-  currentTool: Tools.MaskPen,
-  activeLayer: 'mask',
-  pointerZone: null,
-  brushVisible: true,
-  brushPreviewGradientVisible: false,
-  isAdjustingBrush: false,
-  isPanning: false
-})
+let mockStore: ReturnType<typeof useMaskEditorStore>
 
 const mockBrushDrawing = {
   startDrawing: vi.fn().mockResolvedValue(undefined),
@@ -47,10 +30,6 @@ const mockCoordinateTransform = {
   })),
   canvasToScreen: vi.fn()
 }
-
-vi.mock<unknown>(import('@/stores/maskEditorStore'), () => ({
-  useMaskEditorStore: vi.fn(() => mockStore)
-}))
 
 vi.mock<unknown>(import('@/composables/maskeditor/useBrushDrawing'), () => ({
   useBrushDrawing: vi.fn(() => mockBrushDrawing)
@@ -137,6 +116,7 @@ const setup = (): ReturnType<typeof useToolManager> => {
 
 describe('useToolManager', () => {
   beforeEach(() => {
+    mockStore = useMaskEditorStore()
     mockStore.currentTool = Tools.MaskPen
     mockStore.activeLayer = 'mask'
     mockStore.pointerZone = document.createElement('div')

--- a/src/composables/node/badgeRendererParity.test.ts
+++ b/src/composables/node/badgeRendererParity.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { effectScope } from 'vue'
 
 import { badgeDrawObjects } from '@/lib/litegraph/src/nodeBadgeDraw'
@@ -16,27 +15,13 @@ import { nodeBadges } from '@/systems/badgeSystem'
 import type { NodeState } from '@/types/nodeState'
 import { NodeBadgeMode } from '@/types/nodeSource'
 
-const settings = vi.hoisted(() => ({ values: new Map<string, unknown>() }))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => settings.values.get(key) })
-}))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: {
-      colors: {
-        litegraph_base: { BADGE_FG_COLOR: '#fff', BADGE_BG_COLOR: '#000' }
-      }
-    }
-  })
-}))
-
 const CORE_SOURCE_BADGE = '🦊'
 
 function setModes(mode: NodeBadgeMode) {
-  settings.values.set('Comfy.NodeBadge.NodeIdBadgeMode', mode)
-  settings.values.set('Comfy.NodeBadge.NodeLifeCycleBadgeMode', mode)
-  settings.values.set('Comfy.NodeBadge.NodeSourceBadgeMode', mode)
+  useSettingStore().settingValues['Comfy.NodeBadge.NodeIdBadgeMode'] = mode
+  useSettingStore().settingValues['Comfy.NodeBadge.NodeLifeCycleBadgeMode'] =
+    mode
+  useSettingStore().settingValues['Comfy.NodeBadge.NodeSourceBadgeMode'] = mode
 }
 
 function seedNodeDef(name: string, pythonModule: string) {
@@ -89,11 +74,6 @@ function vueBadgeText(node: LGraphNode): string {
 }
 
 describe('badge renderer parity (I2)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    settings.values = new Map<string, unknown>()
-  })
-
   function setup(
     mode: NodeBadgeMode,
     type: string,

--- a/src/composables/node/startModelNodeDragFromAsset.test.ts
+++ b/src/composables/node/startModelNodeDragFromAsset.test.ts
@@ -2,18 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { startModelNodeDragFromAsset } from '@/composables/node/startModelNodeDragFromAsset'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 
-const { mockStartDrag, mockGetNodeProvider } = vi.hoisted(() => ({
-  mockStartDrag: vi.fn(),
-  mockGetNodeProvider: vi.fn()
-}))
+const mockStartDrag = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   useNodeDragToCanvas: () => ({ startDrag: mockStartDrag })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
 }))
 
 function createAsset(overrides: Partial<AssetItem> = {}): AssetItem {
@@ -35,8 +31,13 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('starts a ghost drag for the resolved node carrying the widget value', () => {
-    const nodeDef = { name: 'CheckpointLoaderSimple' }
-    mockGetNodeProvider.mockReturnValue({ nodeDef, key: 'ckpt_name' })
+    const nodeDef = fromPartial<ComfyNodeDefImpl>({
+      name: 'CheckpointLoaderSimple'
+    })
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
+      nodeDef,
+      key: 'ckpt_name'
+    })
 
     const error = startModelNodeDragFromAsset(createAsset())
 
@@ -48,8 +49,13 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('threads the node-add source through to the drag', () => {
-    const nodeDef = { name: 'CheckpointLoaderSimple' }
-    mockGetNodeProvider.mockReturnValue({ nodeDef, key: 'ckpt_name' })
+    const nodeDef = fromPartial<ComfyNodeDefImpl>({
+      name: 'CheckpointLoaderSimple'
+    })
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
+      nodeDef,
+      key: 'ckpt_name'
+    })
 
     startModelNodeDragFromAsset(createAsset(), 'asset_browser')
 
@@ -60,8 +66,11 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('carries no widget value when the provider has no key', () => {
-    const nodeDef = { name: 'FL_ChatterboxVC' }
-    mockGetNodeProvider.mockReturnValue({ nodeDef, key: '' })
+    const nodeDef = fromPartial<ComfyNodeDefImpl>({ name: 'FL_ChatterboxVC' })
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue({
+      nodeDef,
+      key: ''
+    })
 
     startModelNodeDragFromAsset(
       createAsset({
@@ -77,7 +86,7 @@ describe('startModelNodeDragFromAsset', () => {
   })
 
   it('returns the resolution error and does not start a drag for an invalid asset', () => {
-    mockGetNodeProvider.mockReturnValue(null)
+    vi.mocked(useModelToNodeStore().getNodeProvider).mockReturnValue(undefined)
 
     const error = startModelNodeDragFromAsset(createAsset())
 

--- a/src/composables/node/useNodeBadge.test.ts
+++ b/src/composables/node/useNodeBadge.test.ts
@@ -1,18 +1,22 @@
 import { render } from '@testing-library/vue'
-import { defineComponent, nextTick, ref } from 'vue'
+import { defineComponent, nextTick, ref, toRef } from 'vue'
+import type { Ref } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useExtensionStore } from '@/stores/extensionStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { NodeBadgeMode } from '@/types/nodeSource'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ComfyExtension } from '@/types/comfy'
 import { app } from '@/scripts/app'
 
 const mocks = vi.hoisted(() => ({
-  extensionInstalled: false,
-  installNodeBadges: vi.fn(),
-  registerExtension: vi.fn()
+  installNodeBadges: vi.fn()
 }))
 
-const badgeMode = ref(false)
-const showApiPricingBadge = ref(false)
+let badgeMode: Ref<string | undefined>
+let showApiPricingBadge: Ref<boolean | undefined>
 const pricingRevision = ref(0)
 const canvasEventListeners = new Map<string, EventListener>()
 const canvas = {
@@ -23,42 +27,18 @@ const canvas = {
   },
   setDirty: vi.fn()
 }
-let canvasReady = true
+let canvasStore: ReturnType<typeof useCanvasStore>
 
 vi.mock(import('@/systems/badgeSystem'), () => ({
   installNodeBadges: mocks.installNodeBadges
 }))
-vi.mock<unknown>(import('@/stores/extensionStore'), () => ({
-  useExtensionStore: () => ({
-    isExtensionInstalled: () => mocks.extensionInstalled,
-    registerExtension: (extension: ComfyExtension) => {
-      mocks.extensionInstalled = true
-      mocks.registerExtension(extension)
-    }
-  })
-}))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      key === 'Comfy.NodeBadge.ShowApiPricing'
-        ? showApiPricingBadge.value
-        : badgeMode.value
-  })
-}))
 vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
   useNodePricing: () => ({ pricingRevision })
-}))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    get canvas() {
-      return canvasReady ? canvas : undefined
-    }
-  })
 }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     get canvas() {
-      return canvasReady ? canvas : undefined
+      return canvasStore.canvas
     }
   }
 }))
@@ -78,40 +58,44 @@ function renderComposable() {
 
 describe('useNodeBadge', () => {
   beforeEach(() => {
-    mocks.extensionInstalled = false
-    badgeMode.value = false
+    const settings = useSettingStore().settingValues
+    badgeMode = toRef(settings, 'Comfy.NodeBadge.NodeIdBadgeMode')
+    showApiPricingBadge = toRef(settings, 'Comfy.NodeBadge.ShowApiPricing')
+    canvasStore = useCanvasStore()
+    badgeMode.value = NodeBadgeMode.None
     showApiPricingBadge.value = false
     pricingRevision.value = 0
     canvasEventListeners.clear()
-    canvasReady = true
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
   })
 
   it('keeps the extension-owned provider installed across canvas remounts', async () => {
     const firstMount = renderComposable()
-    const extension = mocks.registerExtension.mock.calls[0][0] as ComfyExtension
+    const extension = vi.mocked(useExtensionStore().registerExtension).mock
+      .calls[0][0]
     await extension.init?.(app)
 
     firstMount.unmount()
 
     const secondMount = renderComposable()
 
-    expect(mocks.registerExtension).toHaveBeenCalledOnce()
+    expect(useExtensionStore().registerExtension).toHaveBeenCalledOnce()
     expect(mocks.installNodeBadges).toHaveBeenCalledOnce()
 
     secondMount.unmount()
   })
 
   it('allows badge settings to change before the canvas is ready', async () => {
-    canvasReady = false
+    canvasStore.canvas = null
     const component = renderComposable()
 
-    badgeMode.value = true
+    badgeMode.value = NodeBadgeMode.ShowAll
     await nextTick()
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
 
-    canvasReady = true
-    badgeMode.value = false
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
+    badgeMode.value = NodeBadgeMode.None
     await nextTick()
 
     expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
@@ -120,7 +104,7 @@ describe('useNodeBadge', () => {
 
   it('allows pricing to update before the canvas is ready', async () => {
     showApiPricingBadge.value = true
-    canvasReady = false
+    canvasStore.canvas = null
     const component = renderComposable()
 
     pricingRevision.value++
@@ -128,7 +112,7 @@ describe('useNodeBadge', () => {
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
 
-    canvasReady = true
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
     pricingRevision.value++
     await nextTick()
 
@@ -138,9 +122,10 @@ describe('useNodeBadge', () => {
 
   it('allows the canvas to be removed before a graph event arrives', async () => {
     const component = renderComposable()
-    const extension = mocks.registerExtension.mock.calls[0][0] as ComfyExtension
+    const extension = vi.mocked(useExtensionStore().registerExtension).mock
+      .calls[0][0]
     await extension.init?.(app)
-    canvasReady = false
+    canvasStore.canvas = null
 
     canvasEventListeners.get('litegraph:set-graph')?.(
       new Event('litegraph:set-graph')
@@ -148,7 +133,7 @@ describe('useNodeBadge', () => {
 
     expect(canvas.setDirty).not.toHaveBeenCalled()
 
-    canvasReady = true
+    canvasStore.canvas = fromPartial<LGraphCanvas>(canvas)
     canvasEventListeners.get('litegraph:set-graph')?.(
       new Event('litegraph:set-graph')
     )

--- a/src/composables/node/useNodeDragToCanvas.test.ts
+++ b/src/composables/node/useNodeDragToCanvas.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
-import type { useNodeDragToCanvas as UseNodeDragToCanvasType } from './useNodeDragToCanvas'
+import { useNodeDragToCanvas } from './useNodeDragToCanvas'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const {
   mockAddNodeOnGraph,
   mockConvertEventToCanvasOffset,
   mockSelectItems,
-  mockCanvas,
-  mockToastAdd
+  mockCanvas
 } = vi.hoisted(() => {
   const mockConvertEventToCanvasOffset = vi.fn()
   const mockSelectItems = vi.fn()
@@ -16,9 +19,10 @@ const {
     mockAddNodeOnGraph: vi.fn(),
     mockConvertEventToCanvasOffset,
     mockSelectItems,
-    mockToastAdd: vi.fn(),
     mockCanvas: {
       canvas: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
         getBoundingClientRect: vi.fn()
       },
       convertEventToCanvasOffset: mockConvertEventToCanvasOffset,
@@ -27,11 +31,7 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => ({
-    canvas: mockCanvas
-  }))
-}))
+let mockToastAdd: ReturnType<typeof useToastStore>['add']
 
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: vi.fn(() => ({
@@ -39,25 +39,17 @@ vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({ add: mockToastAdd }))
-}))
-
 vi.mock(import('@/i18n'), () => ({ t: (key: string) => key }))
 
 describe('useNodeDragToCanvas', () => {
-  let useNodeDragToCanvas: typeof UseNodeDragToCanvasType
-
   const mockNodeDef = {
     name: 'TestNode',
     display_name: 'Test Node'
   } as ComfyNodeDefImpl
 
-  beforeEach(async () => {
-    vi.resetModules()
-
-    const module = await import('./useNodeDragToCanvas')
-    useNodeDragToCanvas = module.useNodeDragToCanvas
+  beforeEach(() => {
+    useCanvasStore().canvas = fromPartial<LGraphCanvas>(mockCanvas)
+    mockToastAdd = useToastStore().add
   })
 
   afterEach(() => {

--- a/src/composables/node/useNodeImage.test.ts
+++ b/src/composables/node/useNodeImage.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import { useNodeVideo } from '@/composables/node/useNodeImage'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { createMockMediaNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
 
-const { canvasInteractionsMock, nodeOutputStoreMock } = vi.hoisted(() => ({
+const { canvasInteractionsMock } = vi.hoisted(() => ({
   canvasInteractionsMock: {
     handleWheel: vi.fn(),
     handlePointerDown: vi.fn(),
     handlePointerMove: vi.fn()
-  },
-  nodeOutputStoreMock: {
-    getNodeImageUrls: vi.fn<(node: unknown) => string[] | undefined>()
   }
 }))
 
@@ -20,9 +18,6 @@ vi.mock<unknown>(
     useCanvasInteractions: () => canvasInteractionsMock
   })
 )
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => nodeOutputStoreMock
-}))
 vi.mock(import('@/utils/imageUtil'), () => ({
   fitDimensionsToNodeWidth: () => ({ minHeight: 256, minWidth: 256 })
 }))
@@ -31,7 +26,9 @@ describe('useNodeVideo', () => {
   async function setup() {
     vi.clearAllMocks()
 
-    nodeOutputStoreMock.getNodeImageUrls.mockReturnValue(['http://video/1.mp4'])
+    vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([
+      'http://video/1.mp4'
+    ])
     const node = createMockMediaNode({
       size: [400, 400],
       graph: { setDirtyCanvas: vi.fn() }

--- a/src/composables/node/useNodeImageUpload.test.ts
+++ b/src/composables/node/useNodeImageUpload.test.ts
@@ -3,12 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ResultItem } from '@/schemas/apiSchema'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useNodeImageUpload } from './useNodeImageUpload'
+import type { Mock } from 'vitest'
 
-const { mockFetchApi, mockAddAlert, mockInvalidateInputs } = vi.hoisted(() => ({
-  mockFetchApi: vi.fn(),
-  mockAddAlert: vi.fn(),
-  mockInvalidateInputs: vi.fn()
-}))
+const mockFetchApi = vi.hoisted(() => vi.fn())
+let mockAddAlert: ReturnType<typeof useToastStore>['addAlert']
+let mockInvalidateInputs: Mock<
+  ReturnType<typeof useAssetsStore>['inputAssets']['invalidate']
+>
 
 let capturedDragOnDrop: (files: File[]) => Promise<string[]>
 
@@ -33,18 +37,13 @@ vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert: mockAddAlert })
-}))
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
-  api: { fetchApi: mockFetchApi }
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    inputAssets: { invalidate: mockInvalidateInputs }
-  })
+  api: {
+    fetchApi: mockFetchApi,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getServerFeature: vi.fn()
+  }
 }))
 
 function createMockNode(): LGraphNode {
@@ -80,14 +79,16 @@ describe('useNodeImageUpload', () => {
   let onUploadStart: (files: File[]) => void
   let onUploadError: () => void
 
-  beforeEach(async () => {
-    vi.resetModules()
+  beforeEach(() => {
+    mockAddAlert = useToastStore().addAlert
+    mockInvalidateInputs = vi
+      .spyOn(useAssetsStore().inputAssets, 'invalidate')
+      .mockResolvedValue(undefined)
     node = createMockNode()
     onUploadComplete = vi.fn()
     onUploadStart = vi.fn()
     onUploadError = vi.fn()
 
-    const { useNodeImageUpload } = await import('./useNodeImageUpload')
     useNodeImageUpload(node, {
       onUploadComplete,
       onUploadStart,

--- a/src/composables/node/useNodePreviewAndDrag.test.ts
+++ b/src/composables/node/useNodePreviewAndDrag.test.ts
@@ -15,12 +15,6 @@ vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn().mockReturnValue('left')
-  })
-}))
-
 describe('useNodePreviewAndDrag', () => {
   const mockNodeDef = {
     name: 'TestNode',

--- a/src/composables/node/usePartnerNodesInGraph.test.ts
+++ b/src/composables/node/usePartnerNodesInGraph.test.ts
@@ -3,7 +3,11 @@ import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
 import * as apiModule from '@/scripts/api'
-import * as workflowStoreModule from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 import { usePartnerNodesInGraph } from './usePartnerNodesInGraph'
 
@@ -14,17 +18,7 @@ interface FakeNode {
 }
 
 const hoisted = vi.hoisted(() => ({
-  nodeDefsByName: {} as Record<
-    string,
-    { name: string; display_name: string; api_node: boolean }
-  >,
   rootGraph: undefined as { nodes: unknown[] } | undefined
-}))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    fromLGraphNode: (node: FakeNode) => hoisted.nodeDefsByName[node.type]
-  })
 }))
 
 // Mirrors ComfyApp: reading `rootGraph` before init logs an error, so
@@ -57,38 +51,15 @@ const { __dispatchGraphChanged } = apiModule as typeof apiModule & {
   __dispatchGraphChanged: () => void
 }
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { ref } = await import('vue')
-    const activeWorkflow = ref<{ path: string } | null>(null)
-    return {
-      useWorkflowStore: () => ({
-        get activeWorkflow() {
-          return activeWorkflow.value
-        }
-      }),
-      __setActiveWorkflow: (workflow: { path: string } | null) => {
-        activeWorkflow.value = workflow
-      }
-    }
-  }
-)
-
-const { __setActiveWorkflow } =
-  workflowStoreModule as typeof workflowStoreModule & {
-    __setActiveWorkflow: (workflow: { path: string } | null) => void
-  }
-
 function defineNodeDef(
   name: string,
   { apiNode = false, displayName = '' } = {}
 ) {
-  hoisted.nodeDefsByName[name] = {
+  useNodeDefStore().nodeDefsByName[name] = fromPartial<ComfyNodeDefImpl>({
     name,
     display_name: displayName,
     api_node: apiNode
-  }
+  })
 }
 
 function node(type: string): FakeNode {
@@ -108,9 +79,7 @@ function setup() {
 
 describe('usePartnerNodesInGraph', () => {
   beforeEach(() => {
-    hoisted.nodeDefsByName = {}
     hoisted.rootGraph = undefined
-    __setActiveWorkflow(null)
   })
 
   afterEach(() => {
@@ -151,10 +120,11 @@ describe('usePartnerNodesInGraph', () => {
   })
 
   it('ignores a def that is missing the api_node field entirely', () => {
-    hoisted.nodeDefsByName['MalformedDef'] = {
-      name: 'MalformedDef',
-      display_name: 'Malformed'
-    } as (typeof hoisted.nodeDefsByName)[string]
+    useNodeDefStore().nodeDefsByName['MalformedDef'] =
+      fromPartial<ComfyNodeDefImpl>({
+        name: 'MalformedDef',
+        display_name: 'Malformed'
+      })
     hoisted.rootGraph = { nodes: [node('MalformedDef')] }
 
     const { hasPartnerNodes } = setup()
@@ -206,7 +176,11 @@ describe('usePartnerNodesInGraph', () => {
     nodes.push(node('Partner'))
     expect(hasPartnerNodes.value).toBe(false)
 
-    __setActiveWorkflow({ path: 'workflows/partner.json' })
+    Object.assign(useWorkflowStore(), {
+      activeWorkflow: fromPartial<ComfyWorkflow>({
+        path: 'workflows/partner.json'
+      })
+    })
     await nextTick()
 
     expect(hasPartnerNodes.value).toBe(true)

--- a/src/composables/node/usePromotedPreviews.test.ts
+++ b/src/composables/node/usePromotedPreviews.test.ts
@@ -1,5 +1,4 @@
-import { reactive } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import {
@@ -16,35 +15,6 @@ import { toNodeId } from '@/types/nodeId'
 
 import { CANVAS_IMAGE_PREVIEW_WIDGET } from './canvasImagePreviewTypes'
 import { usePromotedPreviews } from './usePromotedPreviews'
-
-type MockNodeOutputStore = Pick<
-  ReturnType<typeof useNodeOutputStore>,
-  | 'nodeOutputs'
-  | 'nodePreviewImages'
-  | 'getNodeImageUrls'
-  | 'getNodeImageUrlsByExecutionId'
-  | 'getNodeOutputByExecutionId'
-  | 'getNodePreviewImagesByExecutionId'
->
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => {
-  const store: MockNodeOutputStore = {
-    nodeOutputs: reactive<MockNodeOutputStore['nodeOutputs']>({}),
-    nodePreviewImages: reactive<MockNodeOutputStore['nodePreviewImages']>({}),
-    getNodeImageUrls: vi.fn(),
-    getNodeImageUrlsByExecutionId: vi.fn(),
-    getNodeOutputByExecutionId: vi.fn(),
-    getNodePreviewImagesByExecutionId: vi.fn()
-  }
-  return { useNodeOutputStore: () => store }
-})
-
-function clearMockNodeOutputStore() {
-  const { nodeOutputs, nodePreviewImages } = useNodeOutputStore()
-  for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
-  for (const key of Object.keys(nodePreviewImages))
-    delete nodePreviewImages[key]
-}
 
 function createSetup() {
   const subgraph = createTestSubgraph()
@@ -125,10 +95,6 @@ function arrangePromotedPreview(options: ArrangeOptions = {}) {
 }
 
 describe(usePromotedPreviews, () => {
-  beforeEach(() => {
-    clearMockNodeOutputStore()
-  })
-
   it('returns empty array for non-SubgraphNode', () => {
     const node = new LGraphNode('test')
     const { promotedPreviews } = usePromotedPreviews(() => node)

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -13,10 +13,12 @@ import type { NodeId } from '@/types/nodeId'
 
 import { usePainter } from './usePainter'
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal()),
   useElementSize: vi.fn(() => ({
     width: ref(512),
-    height: ref(512)
+    height: ref(512),
+    stop: vi.fn()
   }))
 }))
 
@@ -31,20 +33,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => {
-  const store = { addAlert: vi.fn() }
-  return { useToastStore: () => store }
-})
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => {
-  const store = {
-    getNodeImageUrls: vi.fn(() => undefined),
-    nodeOutputs: {},
-    nodePreviewImages: {}
-  }
-  return { useNodeOutputStore: () => store }
-})
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: vi.fn((path: string) => `http://localhost:8188${path}`),
@@ -55,7 +43,11 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 const fixture = vi.hoisted((): { node: LGraphNode | null } => ({ node: null }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: { getNodeById: () => fixture.node } } }
+  app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
+    canvas: { graph: { getNodeById: () => fixture.node } }
+  }
 }))
 
 const i18n = createI18n({

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -1,6 +1,11 @@
 import { render } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useQueueStore } from '@/stores/queueStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useJobPreviewStore } from '@/stores/jobPreviewStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { nextTick, reactive, ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -76,111 +81,22 @@ vi.mock<unknown>(import('@/utils/queueUtil'), () => ({
   jobStateFromTask: vi.fn((task: TestTask): JobState => task.mockState)
 }))
 
-let queueStoreMock:
-  | {
-      pendingTasks: TestTask[]
-      runningTasks: TestTask[]
-      historyTasks: TestTask[]
-    }
-  | undefined
-const ensureQueueStore = () => {
-  if (!queueStoreMock) {
-    queueStoreMock = reactive({
-      pendingTasks: [] as TestTask[],
-      runningTasks: [] as TestTask[],
-      historyTasks: [] as TestTask[]
-    })
-  }
-  return queueStoreMock
-}
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => {
-    return ensureQueueStore()
-  }
-}))
-
-let executionStoreMock:
-  | {
-      activeJobId: string | null
-      executingNode: null | { title?: string; type?: string }
-      isJobInitializing: (jobId?: string | number) => boolean
-    }
-  | undefined
-let isJobInitializingMock: ((jobId?: string | number) => boolean) | undefined
-const ensureExecutionStore = () => {
-  if (!isJobInitializingMock) {
-    isJobInitializingMock = vi.fn(() => false)
-  }
-  const isJobInitializing = isJobInitializingMock
-  if (!executionStoreMock) {
-    executionStoreMock = reactive({
-      activeJobId: null as string | null,
-      executingNode: null as null | { title?: string; type?: string },
-      isJobInitializing: (jobId?: string | number) => isJobInitializing(jobId)
-    })
-  }
-  return executionStoreMock
-}
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => {
-    return ensureExecutionStore()
-  }
-}))
-
-let jobPreviewStoreMock:
-  | {
-      previewsByPromptId: Record<string, string>
-      isPreviewEnabled: boolean
-    }
-  | undefined
-const ensureJobPreviewStore = () => {
-  if (!jobPreviewStoreMock) {
-    jobPreviewStoreMock = reactive({
-      previewsByPromptId: {},
-      isPreviewEnabled: true
-    })
-  }
-  return jobPreviewStoreMock
-}
-vi.mock<unknown>(import('@/stores/jobPreviewStore'), () => ({
-  useJobPreviewStore: () => {
-    return ensureJobPreviewStore()
-  }
-}))
-
-let workflowStoreMock:
-  | {
-      activeWorkflow: null | { activeState?: { id?: string } }
-    }
-  | undefined
-const ensureWorkflowStore = () => {
-  if (!workflowStoreMock) {
-    workflowStoreMock = reactive({
-      activeWorkflow: null as null | { activeState?: { id?: string } }
-    })
-  }
-  return workflowStoreMock
-}
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => {
-      return ensureWorkflowStore()
-    }
-  })
-)
+let isJobInitializingMock: ReturnType<
+  typeof useExecutionStore
+>['isJobInitializing']
 
 const createTask = (
   overrides: Partial<TestTask> & { mockState?: JobState } = {}
-): TestTask => ({
-  jobId: overrides.jobId ?? `task-${Math.random().toString(36).slice(2, 7)}`,
-  job: overrides.job ?? { priority: 0 },
-  mockState: overrides.mockState ?? 'pending',
-  executionTime: overrides.executionTime,
-  executionEndTimestamp: overrides.executionEndTimestamp,
-  createTime: overrides.createTime,
-  workflowId: overrides.workflowId
-})
+): TaskItemImpl & TestTask =>
+  fromPartial<TaskItemImpl & TestTask>({
+    jobId: overrides.jobId ?? `task-${Math.random().toString(36).slice(2, 7)}`,
+    job: overrides.job ?? { priority: 0 },
+    mockState: overrides.mockState ?? 'pending',
+    executionTime: overrides.executionTime,
+    executionEndTimestamp: overrides.executionEndTimestamp,
+    createTime: overrides.createTime,
+    workflowId: overrides.workflowId
+  })
 
 const mountUseJobList = () => {
   let composable: ReturnType<typeof useJobList>
@@ -202,30 +118,28 @@ const mountUseJobList = () => {
 }
 
 const resetStores = () => {
-  const queueStore = ensureQueueStore()
+  isJobInitializingMock = useExecutionStore().isJobInitializing
+  const queueStore = useQueueStore()
   queueStore.pendingTasks = []
   queueStore.runningTasks = []
   queueStore.historyTasks = []
 
-  const executionStore = ensureExecutionStore()
+  const executionStore = useExecutionStore()
   executionStore.activeJobId = null
-  executionStore.executingNode = null
+  Object.assign(executionStore, { executingNode: null })
 
-  const jobPreviewStore = ensureJobPreviewStore()
-  jobPreviewStore.previewsByPromptId = {}
-  jobPreviewStore.isPreviewEnabled = true
+  const jobPreviewStore = useJobPreviewStore()
+  Object.assign(jobPreviewStore, { previewsByPromptId: {} })
+  Object.assign(jobPreviewStore, { isPreviewEnabled: true })
 
-  const workflowStore = ensureWorkflowStore()
+  const workflowStore = useWorkflowStore()
   workflowStore.activeWorkflow = null
 
   const progress = ensureProgressRefs()
   progress.totalPercent.value = 0
   progress.currentNodePercent.value = 0
 
-  if (isJobInitializingMock) {
-    vi.mocked(isJobInitializingMock).mockReset()
-    vi.mocked(isJobInitializingMock).mockReturnValue(false)
-  }
+  vi.mocked(isJobInitializingMock).mockReturnValue(false)
 }
 
 const flush = async () => {
@@ -257,7 +171,7 @@ describe('useJobList', () => {
   }
 
   it('tracks recently added pending jobs and clears the hint after expiry', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: '1', job: { priority: 1 }, mockState: 'pending' })
     ]
 
@@ -285,7 +199,7 @@ describe('useJobList', () => {
 
   it('removes pending hint immediately when the task leaves the queue', async () => {
     const taskId = '2'
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: taskId, job: { priority: 1 }, mockState: 'pending' })
     ]
 
@@ -293,12 +207,12 @@ describe('useJobList', () => {
     await flush()
     void jobItems.value
 
-    ensureQueueStore().pendingTasks = []
+    useQueueStore().pendingTasks = []
     await flush()
     expect(vi.getTimerCount()).toBe(0)
 
     vi.mocked(buildJobDisplay).mockClear()
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: taskId, job: { priority: 2 }, mockState: 'pending' })
     ]
     await flush()
@@ -311,7 +225,7 @@ describe('useJobList', () => {
   })
 
   it('cleans up timeouts on unmount', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({ jobId: '3', job: { priority: 1 }, mockState: 'pending' })
     ]
 
@@ -326,7 +240,7 @@ describe('useJobList', () => {
   })
 
   it('sorts all tasks by create time', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({
         jobId: 'p',
         job: { priority: 1 },
@@ -334,7 +248,7 @@ describe('useJobList', () => {
         createTime: 3000
       })
     ]
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'r',
         job: { priority: 5 },
@@ -342,7 +256,7 @@ describe('useJobList', () => {
         createTime: 2000
       })
     ]
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'h',
         job: { priority: 3 },
@@ -363,7 +277,7 @@ describe('useJobList', () => {
   })
 
   it('filters by job tab and resets failed tab when failures disappear', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({ jobId: 'c', job: { priority: 3 }, mockState: 'completed' }),
       createTask({ jobId: 'f', job: { priority: 2 }, mockState: 'failed' }),
       createTask({ jobId: 'p', job: { priority: 1 }, mockState: 'pending' })
@@ -381,7 +295,7 @@ describe('useJobList', () => {
     expect(instance.filteredTasks.value.map((t) => t.jobId)).toEqual(['f'])
     expect(instance.hasFailedJobs.value).toBe(true)
 
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({ jobId: 'c', job: { priority: 3 }, mockState: 'completed' })
     ]
     await flush()
@@ -391,7 +305,7 @@ describe('useJobList', () => {
   })
 
   it('filters by active workflow when requested', async () => {
-    ensureQueueStore().pendingTasks = [
+    useQueueStore().pendingTasks = [
       createTask({
         jobId: 'wf-1',
         job: { priority: 2 },
@@ -413,14 +327,16 @@ describe('useJobList', () => {
     await flush()
     expect(instance.filteredTasks.value).toEqual([])
 
-    ensureWorkflowStore().activeWorkflow = { activeState: { id: 'workflow-1' } }
+    useWorkflowStore().activeWorkflow = fromPartial<
+      NonNullable<ReturnType<typeof useWorkflowStore>['activeWorkflow']>
+    >({ activeState: { id: 'workflow-1' } })
     await flush()
 
     expect(instance.filteredTasks.value.map((t) => t.jobId)).toEqual(['wf-1'])
   })
 
   it('filters jobs by search query', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'alpha',
         job: { priority: 2 },
@@ -465,7 +381,7 @@ describe('useJobList', () => {
   })
 
   it('hydrates job items with active progress and compute hours', async () => {
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'active',
         job: { priority: 3 },
@@ -480,9 +396,9 @@ describe('useJobList', () => {
       })
     ]
 
-    const executionStore = ensureExecutionStore()
+    const executionStore = useExecutionStore()
     executionStore.activeJobId = 'active'
-    executionStore.executingNode = { title: 'Render Node' }
+    Object.assign(executionStore, { executingNode: { title: 'Render Node' } })
     const progress = ensureProgressRefs()
     progress.totalPercent.value = 80
     progress.currentNodePercent.value = 40
@@ -503,17 +419,19 @@ describe('useJobList', () => {
   })
 
   it('assigns preview urls for running jobs when previews enabled', async () => {
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'live-preview',
         job: { priority: 1 },
         mockState: 'running'
       })
     ]
-    ensureJobPreviewStore().previewsByPromptId = {
-      'live-preview': 'blob:preview-url'
-    }
-    ensureJobPreviewStore().isPreviewEnabled = true
+    Object.assign(useJobPreviewStore(), {
+      previewsByPromptId: {
+        'live-preview': 'blob:preview-url'
+      }
+    })
+    Object.assign(useJobPreviewStore(), { isPreviewEnabled: true })
 
     const { jobItems } = initComposable()
     await flush()
@@ -522,17 +440,19 @@ describe('useJobList', () => {
   })
 
   it('omits preview urls when previews are disabled', async () => {
-    ensureQueueStore().runningTasks = [
+    useQueueStore().runningTasks = [
       createTask({
         jobId: 'disabled-preview',
         job: { priority: 1 },
         mockState: 'running'
       })
     ]
-    ensureJobPreviewStore().previewsByPromptId = {
-      'disabled-preview': 'blob:preview-url'
-    }
-    ensureJobPreviewStore().isPreviewEnabled = false
+    Object.assign(useJobPreviewStore(), {
+      previewsByPromptId: {
+        'disabled-preview': 'blob:preview-url'
+      }
+    })
+    Object.assign(useJobPreviewStore(), { isPreviewEnabled: false })
 
     const { jobItems } = initComposable()
     await flush()
@@ -546,14 +466,18 @@ describe('useJobList', () => {
 
     expect(instance.currentNodeName.value).toBe('--')
 
-    ensureExecutionStore().executingNode = { title: '  Visible Node  ' }
+    Object.assign(useExecutionStore(), {
+      executingNode: { title: '  Visible Node  ' }
+    })
     await flush()
     expect(instance.currentNodeName.value).toBe('Visible Node')
 
-    ensureExecutionStore().executingNode = {
-      title: '   ',
-      type: 'My Node Type'
-    }
+    Object.assign(useExecutionStore(), {
+      executingNode: {
+        title: '   ',
+        type: 'My Node Type'
+      }
+    })
     await flush()
     expect(instance.currentNodeName.value).toBe(
       'i18n(My Node Type.display_name)'
@@ -561,7 +485,7 @@ describe('useJobList', () => {
   })
 
   it('groups terminal jobs without an execution end timestamp by create time', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'failed-before-execution',
         job: { priority: 1 },
@@ -588,7 +512,7 @@ describe('useJobList', () => {
   })
 
   it('groups job items by date label and sorts by total generation time when requested', async () => {
-    ensureQueueStore().historyTasks = [
+    useQueueStore().historyTasks = [
       createTask({
         jobId: 'today-small',
         job: { priority: 4 },

--- a/src/composables/queue/useJobMenu.test.ts
+++ b/src/composables/queue/useJobMenu.test.ts
@@ -1,3 +1,9 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useQueueStore } from '@/stores/queueStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
@@ -11,6 +17,8 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 
 const downloadFileMock = vi.fn()
 vi.mock(import('@/base/common/downloadUtil'), () => ({
+  downloadBlob: (filename: string, blob: Blob) =>
+    downloadBlobMock(filename, blob),
   downloadFile: (url: string, filename?: string) => {
     if (filename === undefined) {
       return downloadFileMock(url)
@@ -51,12 +59,7 @@ vi.mock<unknown>(
   })
 )
 
-const settingStoreMock = {
-  get: vi.fn()
-}
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settingStoreMock
-}))
+let settingStoreMock: ReturnType<typeof useSettingStore>
 
 const workflowServiceMock = {
   openWorkflow: vi.fn()
@@ -68,30 +71,18 @@ vi.mock<unknown>(
   })
 )
 
-const workflowStoreMock = {
-  createTemporary: vi.fn()
-}
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => workflowStoreMock,
-    ComfyWorkflow: class {}
-  })
-)
+let workflowStoreMock: ReturnType<typeof useWorkflowStore>
 
 const cancelJobMock = vi.fn()
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
     cancelJob: (jobId: string) => cancelJobMock(jobId)
   }
 }))
 
 const downloadBlobMock = vi.fn()
-vi.mock(import('@/scripts/utils'), () => ({
-  downloadBlob: (filename: string, blob: Blob) =>
-    downloadBlobMock(filename, blob)
-}))
-
 const dialogServiceMock = {
   showErrorDialog: vi.fn(),
   showExecutionErrorDialog: vi.fn(),
@@ -109,30 +100,9 @@ vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => litegraphServiceMock
 }))
 
-const nodeDefStoreMock: {
-  nodeDefsByName: Record<string, Partial<ComfyNodeDefImpl>>
-} = {
-  nodeDefsByName: {}
-}
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => nodeDefStoreMock,
-  ComfyNodeDefImpl: class {}
-}))
+let nodeDefStoreMock: ReturnType<typeof useNodeDefStore>
 
-const queueStoreMock = {
-  update: vi.fn(),
-  delete: vi.fn()
-}
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => queueStoreMock
-}))
-
-const executionStoreMock = {
-  clearInitializationByJobId: vi.fn()
-}
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => executionStoreMock
-}))
+let queueStoreMock: ReturnType<typeof useQueueStore>
 
 const getJobWorkflowMock = vi.fn()
 vi.mock(import('@/services/jobOutputCache'), () => ({
@@ -140,7 +110,6 @@ vi.mock(import('@/services/jobOutputCache'), () => ({
 }))
 
 import { useJobMenu } from '@/composables/queue/useJobMenu'
-import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type { TaskItemImpl } from '@/stores/queueStore'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 
@@ -181,17 +150,24 @@ const findActionEntry = (entries: MenuEntry[], key: string) =>
 
 describe('useJobMenu', () => {
   beforeEach(() => {
+    settingStoreMock = useSettingStore()
+    workflowStoreMock = useWorkflowStore()
+    nodeDefStoreMock = useNodeDefStore()
+    queueStoreMock = useQueueStore()
     currentItem = ref<JobListItem | null>(null)
-    settingStoreMock.get.mockReturnValue(false)
+    vi.mocked(settingStoreMock.get).mockReturnValue(false)
     dialogServiceMock.prompt.mockResolvedValue(undefined)
     litegraphServiceMock.getCanvasCenter.mockReturnValue([100, 200])
     litegraphServiceMock.addNodeOnGraph.mockReturnValue(null)
-    workflowStoreMock.createTemporary.mockImplementation((filename, data) => ({
-      filename,
-      data
-    }))
-    queueStoreMock.update.mockResolvedValue(undefined)
-    queueStoreMock.delete.mockResolvedValue(undefined)
+    vi.mocked(workflowStoreMock.createTemporary).mockImplementation(
+      (filename, data) =>
+        fromPartial<ReturnType<typeof workflowStoreMock.createTemporary>>({
+          filename: filename ?? 'Untitled',
+          content: JSON.stringify(data)
+        })
+    )
+    vi.mocked(queueStoreMock.update).mockResolvedValue(undefined)
+    vi.mocked(queueStoreMock.delete).mockResolvedValue(undefined)
     cancelJobMock.mockResolvedValue(undefined)
     mediaAssetActionsMock.deleteAssets.mockResolvedValue(false)
     mapTaskOutputToAssetItemMock.mockImplementation((task, output) => ({
@@ -199,9 +175,9 @@ describe('useJobMenu', () => {
       output
     }))
     nodeDefStoreMock.nodeDefsByName = {
-      LoadImage: { name: 'LoadImage' },
-      LoadVideo: { name: 'LoadVideo' },
-      LoadAudio: { name: 'LoadAudio' }
+      LoadImage: fromPartial<ComfyNodeDefImpl>({ name: 'LoadImage' }),
+      LoadVideo: fromPartial<ComfyNodeDefImpl>({ name: 'LoadVideo' }),
+      LoadAudio: fromPartial<ComfyNodeDefImpl>({ name: 'LoadAudio' })
     }
     // Default: no workflow available via lazy loading
     getJobWorkflowMock.mockResolvedValue(undefined)
@@ -227,7 +203,7 @@ describe('useJobMenu', () => {
     )
     expect(workflowServiceMock.openWorkflow).toHaveBeenCalledWith({
       filename: 'Job 55.json',
-      data: workflow
+      content: JSON.stringify(workflow)
     })
   })
 
@@ -648,7 +624,7 @@ describe('useJobMenu', () => {
   })
 
   it('prompts for filename when setting enabled', async () => {
-    settingStoreMock.get.mockReturnValue(true)
+    vi.mocked(settingStoreMock.get).mockReturnValue(true)
     dialogServiceMock.prompt.mockResolvedValue('custom-name')
     getJobWorkflowMock.mockResolvedValue({})
     const { jobMenuEntries } = mountJobMenu()
@@ -672,7 +648,7 @@ describe('useJobMenu', () => {
   })
 
   it('keeps existing json extension when exporting workflow', async () => {
-    settingStoreMock.get.mockReturnValue(true)
+    vi.mocked(settingStoreMock.get).mockReturnValue(true)
     dialogServiceMock.prompt.mockResolvedValue('existing.json')
     getJobWorkflowMock.mockResolvedValue({ foo: 'bar' })
     const { jobMenuEntries } = mountJobMenu()
@@ -692,7 +668,7 @@ describe('useJobMenu', () => {
   })
 
   it('abandons export when prompt cancelled', async () => {
-    settingStoreMock.get.mockReturnValue(true)
+    vi.mocked(settingStoreMock.get).mockReturnValue(true)
     dialogServiceMock.prompt.mockResolvedValue('')
     getJobWorkflowMock.mockResolvedValue({})
     const { jobMenuEntries } = mountJobMenu()

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive } from 'vue'
+import { nextTick } from 'vue'
 
 import { useQueueNotificationBanners } from '@/composables/queue/useQueueNotificationBanners'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useQueueStore } from '@/stores/queueStore'
+import type { TaskItemImpl } from '@/stores/queueStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const mockApi = vi.hoisted(() => new EventTarget())
 
@@ -21,28 +23,6 @@ type MockTask = {
   }
 }
 
-vi.mock<unknown>(import('@/stores/queueStore'), () => {
-  const state = reactive({
-    pendingTasks: [] as MockTask[],
-    runningTasks: [] as MockTask[],
-    historyTasks: [] as MockTask[]
-  })
-
-  return {
-    useQueueStore: () => state
-  }
-})
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => {
-  const state = reactive({
-    isIdle: true
-  })
-
-  return {
-    useExecutionStore: () => state
-  }
-})
-
 const mountComposable = () => {
   let composable: ReturnType<typeof useQueueNotificationBanners>
   const result = render({
@@ -56,19 +36,11 @@ const mountComposable = () => {
 }
 
 describe(useQueueNotificationBanners, () => {
-  const queueStore = () =>
-    useQueueStore() as {
-      pendingTasks: MockTask[]
-      runningTasks: MockTask[]
-      historyTasks: MockTask[]
-    }
-  const executionStore = () => useExecutionStore() as { isIdle: boolean }
-
   const resetState = () => {
-    queueStore().pendingTasks = []
-    queueStore().runningTasks = []
-    queueStore().historyTasks = []
-    executionStore().isIdle = true
+    useQueueStore().pendingTasks = []
+    useQueueStore().runningTasks = []
+    useQueueStore().historyTasks = []
+    Object.assign(useExecutionStore(), { isIdle: true })
   }
 
   const createTask = (
@@ -78,7 +50,7 @@ describe(useQueueNotificationBanners, () => {
       previewUrl?: string
       isImage?: boolean
     } = {}
-  ): MockTask => {
+  ): TaskItemImpl => {
     const {
       state = 'Completed',
       ts = Date.now(),
@@ -98,23 +70,26 @@ describe(useQueueNotificationBanners, () => {
       }
     }
 
-    return task
+    return fromPartial<TaskItemImpl>({
+      ...task,
+      displayStatus: state as TaskItemImpl['displayStatus']
+    })
   }
 
   const runBatch = async (options: {
     start: number
     finish: number
-    tasks: MockTask[]
+    tasks: TaskItemImpl[]
   }) => {
     const { start, finish, tasks } = options
 
     vi.setSystemTime(start)
-    executionStore().isIdle = false
+    Object.assign(useExecutionStore(), { isIdle: false })
     await nextTick()
 
     vi.setSystemTime(finish)
-    queueStore().historyTasks = tasks
-    executionStore().isIdle = true
+    useQueueStore().historyTasks = tasks
+    Object.assign(useExecutionStore(), { isIdle: true })
     await nextTick()
   }
 
@@ -124,7 +99,6 @@ describe(useQueueNotificationBanners, () => {
 
   afterEach(() => {
     vi.runOnlyPendingTimers()
-    resetState()
   })
 
   it('shows queued notifications from promptQueued events', async () => {
@@ -235,17 +209,17 @@ describe(useQueueNotificationBanners, () => {
 
     try {
       vi.setSystemTime(now + 4_000)
-      executionStore().isIdle = false
+      Object.assign(useExecutionStore(), { isIdle: false })
       await nextTick()
 
       vi.setSystemTime(now + 4_100)
-      executionStore().isIdle = true
-      queueStore().historyTasks = []
+      Object.assign(useExecutionStore(), { isIdle: true })
+      useQueueStore().historyTasks = []
       await nextTick()
 
       expect(composable.currentNotification.value).toBeNull()
 
-      queueStore().historyTasks = [
+      useQueueStore().historyTasks = [
         createTask({
           ts: now + 4_050,
           previewUrl: 'https://example.com/race-preview.png'

--- a/src/composables/queue/useQueueProgress.test.ts
+++ b/src/composables/queue/useQueueProgress.test.ts
@@ -1,35 +1,17 @@
 import { render } from '@testing-library/vue'
-import { nextTick, ref } from 'vue'
-import type { Ref } from 'vue'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useExecutionStore } from '@/stores/executionStore'
 
 import { useQueueProgress } from '@/composables/queue/useQueueProgress'
 import { formatPercent0 } from '@/utils/numberUtil'
-
-type ProgressValue = number | null
-
-const executionProgressRef: Ref<ProgressValue> = ref(null)
-const executingNodeProgressRef: Ref<ProgressValue> = ref(null)
 
 const i18n = createI18n({
   legacy: false,
   locale: 'en-US',
   messages: { 'en-US': {}, 'fr-FR': {} }
 })
-
-const createExecutionStoreMock = () => ({
-  get executionProgress() {
-    return executionProgressRef.value ?? undefined
-  },
-  get executingNodeProgress() {
-    return executingNodeProgressRef.value ?? undefined
-  }
-})
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => createExecutionStoreMock()
-}))
 
 const mountUseQueueProgress = () => {
   let composable: ReturnType<typeof useQueueProgress>
@@ -47,11 +29,13 @@ const mountUseQueueProgress = () => {
 }
 
 const setExecutionProgress = (value?: number | null) => {
-  executionProgressRef.value = value ?? null
+  Object.assign(useExecutionStore(), { executionProgress: value ?? undefined })
 }
 
 const setExecutingNodeProgress = (value?: number | null) => {
-  executingNodeProgressRef.value = value ?? null
+  Object.assign(useExecutionStore(), {
+    executingNodeProgress: value ?? undefined
+  })
 }
 
 describe('useQueueProgress', () => {

--- a/src/composables/sidebarTabs/useAssetsSidebarTab.test.ts
+++ b/src/composables/sidebarTabs/useAssetsSidebarTab.test.ts
@@ -1,17 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAssetsSidebarBadgeStore } from '@/stores/workspace/assetsSidebarBadgeStore'
 
 import { useAssetsSidebarTab } from '@/composables/sidebarTabs/useAssetsSidebarTab'
-
-const { mockGetSetting, mockUnseenAddedAssetsCount } = vi.hoisted(() => ({
-  mockGetSetting: vi.fn(),
-  mockUnseenAddedAssetsCount: { value: 0 }
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGetSetting
-  })
-}))
 
 vi.mock<unknown>(
   import('@/components/sidebar/tabs/AssetsSidebarTab.vue'),
@@ -20,16 +11,10 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/workspace/assetsSidebarBadgeStore'), () => ({
-  useAssetsSidebarBadgeStore: () => ({
-    unseenAddedAssetsCount: mockUnseenAddedAssetsCount.value
-  })
-}))
-
 describe('useAssetsSidebarTab', () => {
   it('hides icon badge when QPO V2 is disabled', () => {
-    mockGetSetting.mockReturnValue(false)
-    mockUnseenAddedAssetsCount.value = 3
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = false
+    Object.assign(useAssetsSidebarBadgeStore(), { unseenAddedAssetsCount: 3 })
 
     const sidebarTab = useAssetsSidebarTab()
 
@@ -38,8 +23,8 @@ describe('useAssetsSidebarTab', () => {
   })
 
   it('shows unseen added assets count when QPO V2 is enabled', () => {
-    mockGetSetting.mockReturnValue(true)
-    mockUnseenAddedAssetsCount.value = 3
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
+    Object.assign(useAssetsSidebarBadgeStore(), { unseenAddedAssetsCount: 3 })
 
     const sidebarTab = useAssetsSidebarTab()
 
@@ -48,8 +33,7 @@ describe('useAssetsSidebarTab', () => {
   })
 
   it('hides badge when there are no unseen added assets', () => {
-    mockGetSetting.mockReturnValue(true)
-    mockUnseenAddedAssetsCount.value = 0
+    useSettingStore().settingValues['Comfy.Queue.QPOV2'] = true
 
     const sidebarTab = useAssetsSidebarTab()
 

--- a/src/composables/sidebarTabs/useJobHistorySidebarTab.test.ts
+++ b/src/composables/sidebarTabs/useJobHistorySidebarTab.test.ts
@@ -1,11 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { useQueueStore } from '@/stores/queueStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 import { useJobHistorySidebarTab } from '@/composables/sidebarTabs/useJobHistorySidebarTab'
-
-const { mockActiveJobsCount, mockActiveSidebarTabId } = vi.hoisted(() => ({
-  mockActiveJobsCount: { value: 0 },
-  mockActiveSidebarTabId: { value: null as string | null }
-}))
 
 vi.mock<unknown>(
   import('@/components/sidebar/tabs/JobHistorySidebarTab.vue'),
@@ -14,27 +11,10 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    activeJobsCount: mockActiveJobsCount.value
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => ({
-    activeSidebarTabId: mockActiveSidebarTabId.value
-  })
-}))
-
 describe('useJobHistorySidebarTab', () => {
-  beforeEach(() => {
-    mockActiveSidebarTabId.value = null
-    mockActiveJobsCount.value = 0
-  })
-
   it('shows active jobs count while the panel is closed', () => {
-    mockActiveSidebarTabId.value = 'assets'
-    mockActiveJobsCount.value = 3
+    useSidebarTabStore().activeSidebarTabId = 'assets'
+    Object.assign(useQueueStore(), { activeJobsCount: 3 })
 
     const sidebarTab = useJobHistorySidebarTab()
 
@@ -43,8 +23,8 @@ describe('useJobHistorySidebarTab', () => {
   })
 
   it('hides badge while the job history panel is open', () => {
-    mockActiveSidebarTabId.value = 'job-history'
-    mockActiveJobsCount.value = 3
+    useSidebarTabStore().activeSidebarTabId = 'job-history'
+    Object.assign(useQueueStore(), { activeJobsCount: 3 })
 
     const sidebarTab = useJobHistorySidebarTab()
 
@@ -52,8 +32,7 @@ describe('useJobHistorySidebarTab', () => {
   })
 
   it('hides badge when there are no active jobs', () => {
-    mockActiveSidebarTabId.value = null
-    mockActiveJobsCount.value = 0
+    useSidebarTabStore().activeSidebarTabId = null
 
     const sidebarTab = useJobHistorySidebarTab()
 

--- a/src/composables/useBrowserTabTitle.test.ts
+++ b/src/composables/useBrowserTabTitle.test.ts
@@ -1,7 +1,14 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive } from 'vue'
+import { effectScope, nextTick } from 'vue'
 
 import { useBrowserTabTitle } from '@/composables/useBrowserTabTitle'
+
+vi.mock(import('firebase/auth'))
 
 // Mock i18n module
 vi.mock<unknown>(import('@/i18n'), () => ({
@@ -9,73 +16,31 @@ vi.mock<unknown>(import('@/i18n'), () => ({
     key === 'g.nodesRunning' ? 'nodes running' : fallback
 }))
 
-// Mock the execution store
-const executionStore = reactive<{
-  isIdle: boolean
-  executionProgress: number
-  executingNode: null | {
-    title?: string
-    type?: string
-  }
-  executingNodeProgress: number
-  nodeProgressStates: Record<string, unknown>
-}>({
-  isIdle: true,
-  executionProgress: 0,
-  executingNode: null,
-  executingNodeProgress: 0,
-  nodeProgressStates: {}
-})
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => executionStore
-}))
+let executionStore: ReturnType<typeof useExecutionStore>
 
-// Mock the setting store
-const settingStore = reactive({
-  get: vi.fn((_key: string) => 'Enabled')
-})
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => settingStore
-}))
+let settingStore: ReturnType<typeof useSettingStore>
 
-// Mock the workflow store
-const workflowStore = reactive<{
-  activeWorkflow: {
-    filename: string
-    isModified: boolean
-    isPersisted: boolean
-  } | null
-}>({
-  activeWorkflow: null
-})
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => workflowStore
-  })
-)
+let workflowStore: ReturnType<typeof useWorkflowStore>
 
-// Mock the workspace store
-const workspaceStore = reactive({
-  shiftDown: false
-})
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => workspaceStore
-}))
+let workspaceStore: ReturnType<typeof useWorkspaceStore>
 
 describe('useBrowserTabTitle', () => {
   beforeEach(() => {
+    executionStore = useExecutionStore()
+    settingStore = useSettingStore()
+    workflowStore = useWorkflowStore()
+    workspaceStore = useWorkspaceStore()
     // reset execution store
-    executionStore.isIdle = true
-    executionStore.executionProgress = 0
-    executionStore.executingNode = null
-    executionStore.executingNodeProgress = 0
+    Object.assign(executionStore, { isIdle: true })
+    Object.assign(executionStore, { executionProgress: 0 })
+    Object.assign(executionStore, { executingNode: null })
+    Object.assign(executionStore, { executingNodeProgress: 0 })
     executionStore.nodeProgressStates = {}
 
     // reset setting and workflow stores
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
     workflowStore.activeWorkflow = null
-    workspaceStore.shiftDown = false
+    Object.assign(workspaceStore, { shiftDown: false })
 
     // reset document title
     document.title = ''
@@ -90,11 +55,13 @@ describe('useBrowserTabTitle', () => {
 
   it('sets workflow name as title when workflow exists and menu enabled', async () => {
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: false,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -104,11 +71,13 @@ describe('useBrowserTabTitle', () => {
 
   it('adds asterisk for unsaved workflow', async () => {
     vi.mocked(settingStore.get).mockReturnValue('Enabled')
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: true,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -122,11 +91,13 @@ describe('useBrowserTabTitle', () => {
       if (key === 'Comfy.UseNewMenu') return 'Enabled'
       return 'Enabled'
     })
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: true,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -140,12 +111,14 @@ describe('useBrowserTabTitle', () => {
       if (key === 'Comfy.UseNewMenu') return 'Enabled'
       return 'Enabled'
     })
-    workspaceStore.shiftDown = true
-    workflowStore.activeWorkflow = {
+    Object.assign(workspaceStore, { shiftDown: true })
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: true,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -155,11 +128,13 @@ describe('useBrowserTabTitle', () => {
 
   it('disables workflow title when menu disabled', async () => {
     vi.mocked(settingStore.get).mockReturnValue('Disabled')
-    workflowStore.activeWorkflow = {
+    workflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof workflowStore.activeWorkflow>
+    >({
       filename: 'myFlow',
       isModified: false,
       isPersisted: true
-    }
+    })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -168,8 +143,8 @@ describe('useBrowserTabTitle', () => {
   })
 
   it('shows execution progress when not idle without workflow', async () => {
-    executionStore.isIdle = false
-    executionStore.executionProgress = 0.3
+    Object.assign(executionStore, { isIdle: false })
+    Object.assign(executionStore, { executionProgress: 0.3 })
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
     await nextTick()
@@ -178,13 +153,21 @@ describe('useBrowserTabTitle', () => {
   })
 
   it('shows node execution title when executing a node using nodeProgressStates', async () => {
-    executionStore.isIdle = false
-    executionStore.executionProgress = 0.4
-    executionStore.executingNode = {
-      type: 'Foo'
-    }
+    Object.assign(executionStore, { isIdle: false })
+    Object.assign(executionStore, { executionProgress: 0.4 })
+    Object.assign(executionStore, {
+      executingNode: {
+        type: 'Foo'
+      }
+    })
     executionStore.nodeProgressStates = {
-      '1': { state: 'running', value: 5, max: 10, node: '1', prompt_id: 'test' }
+      '1': {
+        state: 'running',
+        value: 5,
+        max: 10,
+        node_id: '1',
+        prompt_id: 'test'
+      }
     }
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())
@@ -194,17 +177,23 @@ describe('useBrowserTabTitle', () => {
   })
 
   it('shows multiple nodes running when multiple nodes are executing', async () => {
-    executionStore.isIdle = false
-    executionStore.executionProgress = 0.4
+    Object.assign(executionStore, { isIdle: false })
+    Object.assign(executionStore, { executionProgress: 0.4 })
     executionStore.nodeProgressStates = {
       '1': {
         state: 'running',
         value: 5,
         max: 10,
-        node: '1',
+        node_id: '1',
         prompt_id: 'test'
       },
-      '2': { state: 'running', value: 8, max: 10, node: '2', prompt_id: 'test' }
+      '2': {
+        state: 'running',
+        value: 8,
+        max: 10,
+        node_id: '2',
+        prompt_id: 'test'
+      }
     }
     const scope = effectScope()
     scope.run(() => useBrowserTabTitle())

--- a/src/composables/useCameraInfo.test.ts
+++ b/src/composables/useCameraInfo.test.ts
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 interface ViewportInstance {
   ctorArgs: unknown[]
@@ -18,7 +19,7 @@ interface ViewportInstance {
   }
 }
 
-const { ViewportMock, instances, addAlert } = vi.hoisted(() => {
+const { ViewportMock, instances } = vi.hoisted(() => {
   const instances: ViewportInstance[] = []
   const ViewportMock = vi.fn(function (...ctorArgs: unknown[]) {
     const instance: ViewportInstance = {
@@ -37,7 +38,7 @@ const { ViewportMock, instances, addAlert } = vi.hoisted(() => {
     instances.push(instance)
     return instance
   })
-  return { ViewportMock, instances, addAlert: vi.fn() }
+  return { ViewportMock, instances }
 })
 
 vi.mock<unknown>(
@@ -46,9 +47,6 @@ vi.mock<unknown>(
     CameraInfoViewport: ViewportMock
   })
 )
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ addAlert })
-}))
 
 import { useCameraInfo } from './useCameraInfo'
 
@@ -83,7 +81,6 @@ function nodeRef(node: FakeNode) {
 beforeEach(() => {
   instances.length = 0
   ViewportMock.mockClear()
-  addAlert.mockClear()
 })
 
 describe('useCameraInfo', () => {
@@ -120,7 +117,7 @@ describe('useCameraInfo', () => {
     const camera = useCameraInfo(nodeRef(makeNode({ mode: 'orbit' })))
 
     expect(() => camera.initialize(document.createElement('div'))).not.toThrow()
-    expect(addAlert).toHaveBeenCalledOnce()
+    expect(useToastStore().addAlert).toHaveBeenCalledOnce()
 
     consoleError.mockRestore()
   })

--- a/src/composables/useCopy.test.ts
+++ b/src/composables/useCopy.test.ts
@@ -1,36 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, onTestFinished } from 'vitest'
+import { effectScope } from 'vue'
 import { useCopy } from './useCopy'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 const copyMocks = vi.hoisted(() => ({
-  copyHandler: undefined as ((event: ClipboardEvent) => unknown) | undefined,
   canvas: {
     selectedItems: new Set<object>([{}]),
     copyToClipboard: vi.fn()
   }
 }))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useEventListener: vi.fn(
-    (
-      _target: EventTarget,
-      event: string,
-      handler: (event: ClipboardEvent) => unknown
-    ) => {
-      if (event === 'copy') copyMocks.copyHandler = handler
-      return vi.fn()
-    }
-  )
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: copyMocks.canvas
-    })
-  })
-)
 
 vi.mock(
   import('@/workbench/eventHelpers'),
@@ -45,17 +25,23 @@ const multiChunkPayloadLength = 0x8000 * 6 + 123
 function copySerializedData(serializedData: string): DataTransfer {
   copyMocks.canvas.copyToClipboard.mockReturnValue(serializedData)
 
-  useCopy()
+  const listenerSpy = vi.spyOn(document, 'addEventListener')
+  const scope = effectScope()
+  scope.run(useCopy)
+  onTestFinished(() => scope.stop())
 
   const dataTransfer = new DataTransfer()
   const event = new ClipboardEvent('copy', {
     clipboardData: dataTransfer
   })
-  const copyHandler = copyMocks.copyHandler
+  const copyHandler = listenerSpy.mock.calls.find(
+    ([name]) => name === 'copy'
+  )?.[1]
   expect(copyHandler).toBeDefined()
-  if (!copyHandler) throw new Error('Expected copy handler to be registered')
+  if (typeof copyHandler !== 'function')
+    throw new Error('Expected copy handler to be registered')
 
-  expect(() => copyHandler(event)).not.toThrow()
+  expect(() => copyHandler.call(document, event)).not.toThrow()
 
   return dataTransfer
 }
@@ -74,7 +60,7 @@ function readSerializedClipboardMetadata(dataTransfer: DataTransfer): string {
 
 describe('useCopy', () => {
   beforeEach(() => {
-    copyMocks.copyHandler = undefined
+    useCanvasStore().canvas = fromPartial<LGraphCanvas>(copyMocks.canvas)
   })
 
   it('should write large serialized node data to clipboard metadata', () => {

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCoreCommands } from '@/composables/useCoreCommands'
@@ -8,7 +9,11 @@ import type * as DistributionModule from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import type * as ModelStoreModule from '@/stores/modelStore'
+import { useModelStore } from '@/stores/modelStore'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type { Mock } from 'vitest'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { fromPartial } from '@total-typescript/shoehorn'
 
@@ -40,7 +45,11 @@ vi.mock<unknown>(import('@/scripts/app'), () => {
     selectItems: vi.fn(),
     deleteSelected: vi.fn(),
     selectOnly: false,
-    canvas: { dispatchEvent: vi.fn() },
+    canvas: {
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    },
     read_only: false,
     ds: mockDs,
     setDirty: vi.fn()
@@ -68,19 +77,14 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
     dispatchCustomEvent: vi.fn(),
     apiURL: vi.fn(() => 'http://localhost:8188'),
     addEventListener: vi.fn(),
+    addCustomEventListener: vi.fn(),
     removeEventListener: vi.fn(),
+    removeCustomEventListener: vi.fn(),
     getServerFeature: vi.fn(() => false)
   }
 }))
 
-const mockModelStoreRefresh = vi.fn().mockResolvedValue(undefined)
-vi.mock<unknown>(import('@/stores/modelStore'), async (importOriginal) => {
-  const actual = await importOriginal<typeof ModelStoreModule>()
-  return {
-    ...actual,
-    useModelStore: () => ({ refresh: mockModelStoreRefresh })
-  }
-})
+let mockModelStoreRefresh: Mock<ReturnType<typeof useModelStore>['refresh']>
 
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
@@ -90,26 +94,11 @@ vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
   }
 }))
 
-const mockMissingModelStoreRefresh = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(undefined)
-)
-vi.mock<unknown>(import('@/platform/missingModel/missingModelStore'), () => ({
-  useMissingModelStore: () => ({
-    refreshMissingModels: mockMissingModelStoreRefresh
-  })
-}))
+let mockMissingModelStoreRefresh: Mock<
+  ReturnType<typeof useMissingModelStore>['refreshMissingModels']
+>
 
-vi.mock(import('@/platform/settings/settingStore'))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: vi.fn(() => ({}))
-}))
-
-vi.mock<unknown>(import('firebase/auth'), () => ({
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -153,14 +142,7 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({}))
-}))
-
-const mockToastAdd = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({ add: mockToastAdd }))
-}))
+let mockToastAdd: ReturnType<typeof useToastStore>['add']
 
 const mockAssetBrowse = vi.hoisted(() =>
   vi.fn<(options: { onAssetSelected?: (asset: AssetItem) => void }) => void>()
@@ -180,39 +162,8 @@ vi.mock(import('@/composables/node/startModelNodeDragFromAsset'), () => ({
 const mockChangeTracker = vi.hoisted(() => ({
   captureCanvasState: vi.fn()
 }))
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: {
-    changeTracker: mockChangeTracker
-  }
-}))
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => mockWorkflowStore)
-  })
-)
 
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: vi.fn(() => ({}))
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: vi.fn(() => ({
-      getCanvas: () => app.canvas,
-      canvas: app.canvas
-    })),
-    useTitleEditorStore: vi.fn(() => ({
-      titleEditorTarget: null
-    }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({}))
-}))
+let mockWorkflowStore: ReturnType<typeof useWorkflowStore>
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: vi.fn(() => ({}))
@@ -249,10 +200,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     },
     showSubscriptionDialog: mockBillingState.showSubscriptionDialog
   }))
-}))
-
-vi.mock<unknown>(import('@/stores/queueSettingsStore'), () => ({
-  useQueueSettingsStore: vi.fn(() => ({ batchCount: 1 }))
 }))
 
 describe('useCoreCommands', () => {
@@ -310,52 +257,28 @@ describe('useCoreCommands', () => {
 
   const mockSubgraph = createMockSubgraph()!
 
-  function createMockSettingStore(
-    getReturnValue: boolean
-  ): ReturnType<typeof useSettingStore> {
-    return fromPartial<ReturnType<typeof useSettingStore>>({
-      get: vi.fn().mockReturnValue(getReturnValue),
-      addSetting: vi.fn(),
-      load: vi.fn(),
-      set: vi.fn(),
-      setMany: vi.fn(),
-      exists: vi.fn(),
-      getDefaultValue: vi.fn(),
-      isReady: true,
-      isLoading: false,
-      error: undefined,
-      settingValues: {},
-      settingsById: {},
-      $id: 'setting',
-      $state: {
-        settingValues: {},
-        settingsById: {},
-        isReady: true,
-        isLoading: false,
-        error: undefined
-      },
-      $patch: vi.fn(),
-      $reset: vi.fn(),
-      $subscribe: vi.fn(),
-      $onAction: vi.fn(),
-      $dispose: vi.fn(),
-      _customProperties: new Set()
-    })
-  }
-
   beforeEach(() => {
+    mockWorkflowStore = useWorkflowStore()
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({ changeTracker: mockChangeTracker })
+    useCanvasStore().canvas = app.canvas
+    mockModelStoreRefresh = vi.mocked(useModelStore().refresh)
+    mockMissingModelStoreRefresh = vi.mocked(
+      useMissingModelStore().refreshMissingModels
+    )
+    mockToastAdd = useToastStore().add
     mockDistributionState.isCloud = false
     mockBillingState.canAccessSubscriptionFeatures = true
     mockBillingState.subscriptionTier = null
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
-    mockModelStoreRefresh.mockResolvedValue(undefined)
+    mockModelStoreRefresh.mockResolvedValue(true)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
 
     // Reset app state
     app.canvas.subgraph = undefined
 
-    // Mock settings store
-    vi.mocked(useSettingStore).mockReturnValue(createMockSettingStore(false))
+    useSettingStore().settingValues['Comfy.ConfirmClear'] = false
 
     // Mock global confirm
     global.confirm = vi.fn().mockReturnValue(true)
@@ -407,7 +330,7 @@ describe('useCoreCommands', () => {
 
     it('should respect confirmation setting', async () => {
       // Mock confirmation required
-      vi.mocked(useSettingStore).mockReturnValue(createMockSettingStore(true))
+      useSettingStore().settingValues['Comfy.ConfirmClear'] = true
 
       global.confirm = vi.fn().mockReturnValue(false) // User cancels
 
@@ -695,6 +618,7 @@ describe('useCoreCommands', () => {
       })
       mockModelStoreRefresh.mockImplementation(async () => {
         order.push('models')
+        return true
       })
       mockMissingModelStoreRefresh.mockImplementation(async () => {
         order.push('missing')
@@ -856,7 +780,7 @@ describe('useCoreCommands', () => {
     const asset = fromPartial<AssetItem>({ id: 'asset-1' })
 
     async function selectAssetFromBrowser() {
-      vi.mocked(useSettingStore).mockReturnValue(createMockSettingStore(true))
+      useSettingStore().settingValues['Comfy.Assets.UseAssetAPI'] = true
 
       const command = useCoreCommands().find(
         (cmd) => cmd.id === 'Comfy.BrowseModelAssets'

--- a/src/composables/useErrorHandling.test.ts
+++ b/src/composables/useErrorHandling.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ErrorRecoveryStrategy } from '@/composables/useErrorHandling'
@@ -11,7 +9,6 @@ describe('useErrorHandling', () => {
   let errorHandler: ReturnType<typeof useErrorHandling>
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia())
     errorHandler = useErrorHandling()
   })
 

--- a/src/composables/useImageCrop.test.ts
+++ b/src/composables/useImageCrop.test.ts
@@ -1,17 +1,19 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { createApp, defineComponent, nextTick, reactive, ref } from 'vue'
+import { createApp, defineComponent, nextTick, ref, computed } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import WidgetImageCrop from '@/components/imagecrop/WidgetImageCrop.vue'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import type { resolveNode } from '@/utils/litegraphUtil'
 import {
   createMockLGraphNode,
   createMockSubgraphNode
@@ -21,55 +23,30 @@ import { imageCropLoadingAfterUrlChange, useImageCrop } from './useImageCrop'
 
 const resizeObserverCallbacks: Array<() => void> = []
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useResizeObserver: (_target: unknown, cb: () => void) => {
-    resizeObserverCallbacks.push(cb)
-    return { stop: vi.fn() }
+vi.mock(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  useResizeObserver: (_target: unknown, cb: ResizeObserverCallback) => {
+    resizeObserverCallbacks.push(() => cb([], fromPartial<ResizeObserver>({})))
+    return { stop: vi.fn(), isSupported: computed(() => true) }
   }
 }))
 
-const mockResolveNode = vi.hoisted(() =>
-  vi.fn<(id: NodeId) => LGraphNode | null>()
-)
-vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
-  resolveNode: (id: NodeId) => mockResolveNode(id)
+const mockResolveNode = vi.hoisted(() => vi.fn<typeof resolveNode>())
+vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveNode: mockResolveNode
 }))
 
-const mockGetNodeImageUrls = vi.hoisted(() =>
-  vi.fn<(node: LGraphNode) => string[] | null | undefined>()
-)
+let mockGetNodeImageUrls: Mock<
+  ReturnType<typeof useNodeOutputStore>['getNodeImageUrls']
+>
 
-type MockOutputStore = {
-  nodeOutputs: Record<string, unknown>
-  nodePreviewImages: Record<string, unknown>
-  getNodeImageUrls: typeof mockGetNodeImageUrls
-}
-
-const useNodeOutputStoreMock = vi.hoisted(() => vi.fn<() => MockOutputStore>())
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => useNodeOutputStoreMock()
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => ({
-      canvas: {
-        graph: {
-          rootGraph: { id: 'test-graph' }
-        }
-      }
-    })
+beforeEach(() => {
+  mockGetNodeImageUrls = vi.mocked(useNodeOutputStore().getNodeImageUrls)
+  useCanvasStore().canvas = fromPartial<LGraphCanvas>({
+    graph: { rootGraph: { id: 'test-graph' } }
   })
-)
-
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => ({
-    getNodeWidgets: vi.fn(() => [])
-  })
-}))
+})
 
 const ImageCropHarness = defineComponent({
   name: 'ImageCropHarness',
@@ -227,16 +204,11 @@ describe('imageCropLoadingAfterUrlChange', () => {
 describe('useImageCrop', () => {
   let sourceNode: LGraphNode
   let cropNode: LGraphNode
-  let outputStore: MockOutputStore
+  let outputStore: ReturnType<typeof useNodeOutputStore>
 
   beforeEach(() => {
     resizeObserverCallbacks.length = 0
-    outputStore = {
-      nodeOutputs: reactive<Record<string, unknown>>({}),
-      nodePreviewImages: reactive<Record<string, unknown>>({}),
-      getNodeImageUrls: mockGetNodeImageUrls
-    }
-    useNodeOutputStoreMock.mockReturnValue(outputStore)
+    outputStore = useNodeOutputStore()
     sourceNode = createMockLGraphNode({
       id: 99,
       isSubgraphNode: () => false
@@ -249,9 +221,8 @@ describe('useImageCrop', () => {
     })
     mockResolveNode.mockReturnValue(cropNode)
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? ['https://example.com/a.png'] : null
+      n === sourceNode ? ['https://example.com/a.png'] : undefined
     )
-    setActivePinia(createTestingPinia({ stubActions: true }))
   })
 
   afterEach(() => {
@@ -267,7 +238,7 @@ describe('useImageCrop', () => {
   })
 
   it('returns null image URL when the graph node cannot be resolved', async () => {
-    mockResolveNode.mockReturnValue(null)
+    mockResolveNode.mockReturnValue(undefined)
     const vm = await mountHarness()
     expect(vm.imageUrl).toBeNull()
   })
@@ -318,7 +289,7 @@ describe('useImageCrop', () => {
     })
     mockResolveNode.mockReturnValue(sgCrop)
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === innerSource ? ['https://subgraph.png'] : null
+      n === innerSource ? ['https://subgraph.png'] : undefined
     )
 
     const vm = await mountHarness()
@@ -330,7 +301,7 @@ describe('useImageCrop', () => {
     expect(vm.imageUrl).toBe('https://example.com/a.png')
 
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? ['https://example.com/b.png'] : null
+      n === sourceNode ? ['https://example.com/b.png'] : undefined
     )
     outputStore.nodeOutputs['touch'] = { updated: true }
 
@@ -341,7 +312,7 @@ describe('useImageCrop', () => {
   it('updates imageUrl when nodePreviewImages change', async () => {
     let url = 'https://example.com/a.png'
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? [url] : null
+      n === sourceNode ? [url] : undefined
     )
     const vm = await mountHarness()
     expect(vm.imageUrl).toBe('https://example.com/a.png')
@@ -402,7 +373,7 @@ describe('useImageCrop', () => {
     expect(vm.imageUrl).toBe('https://example.com/a.png')
 
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === sourceNode ? ['https://example.com/b.png'] : null
+      n === sourceNode ? ['https://example.com/b.png'] : undefined
     )
     outputStore.nodeOutputs['touch'] = {}
     await flushTicks()
@@ -422,7 +393,7 @@ describe('useImageCrop', () => {
   })
 
   it('does not start dragging when there is no image', async () => {
-    mockGetNodeImageUrls.mockReturnValue(null)
+    mockGetNodeImageUrls.mockReturnValue(undefined)
     const vm = await mountHarness()
     expect(vm.imageUrl).toBeNull()
     const xBefore = vm.cropX as number
@@ -623,12 +594,6 @@ describe('WidgetImageCrop', () => {
 
   beforeEach(() => {
     resizeObserverCallbacks.length = 0
-    const outputStore: MockOutputStore = {
-      nodeOutputs: reactive<Record<string, unknown>>({}),
-      nodePreviewImages: reactive<Record<string, unknown>>({}),
-      getNodeImageUrls: mockGetNodeImageUrls
-    }
-    useNodeOutputStoreMock.mockReturnValue(outputStore)
     const source = createMockLGraphNode({ id: 99, isSubgraphNode: () => false })
     const crop = createMockLGraphNode({
       id: 2,
@@ -638,13 +603,12 @@ describe('WidgetImageCrop', () => {
     })
     mockResolveNode.mockReturnValue(crop)
     mockGetNodeImageUrls.mockImplementation((n) =>
-      n === source ? ['https://example.com/a.png'] : null
+      n === source ? ['https://example.com/a.png'] : undefined
     )
-    setActivePinia(createTestingPinia({ stubActions: true }))
   })
 
   it('renders empty state copy when no image URL is available', async () => {
-    mockGetNodeImageUrls.mockReturnValue(null)
+    mockGetNodeImageUrls.mockReturnValue(undefined)
     const widget = fromPartial<SimplifiedWidget>({
       type: 'imagecrop',
       options: {}

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref, shallowRef } from 'vue'
-import { createPinia, setActivePinia } from 'pinia'
+import { nextTick, ref, shallowRef, effectScope } from 'vue'
+import type { EffectScope } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 import {
   getLoad3dOutputCache,
@@ -8,7 +9,7 @@ import {
   markLoad3dSceneDirty,
   nodeToLoad3dMap,
   setLoad3dOutputCache,
-  useLoad3d
+  useLoad3d as useLoad3dImpl
 } from '@/composables/useLoad3d'
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
@@ -51,10 +52,6 @@ vi.mock<unknown>(import('@/extensions/core/load3d/Load3dUtils'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn()
-}))
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     apiURL: vi.fn(),
@@ -68,38 +65,25 @@ vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key) => key)
 }))
 
-const { settingGetMock } = vi.hoisted(() => ({
-  settingGetMock: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: settingGetMock })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: vi.fn()
-  })
-)
-
 vi.mock(import('@/platform/assets/utils/assetPreviewUtil'), () => ({
   isAssetPreviewSupported: vi.fn(() => false),
   persistThumbnail: vi.fn().mockResolvedValue(undefined)
 }))
 
 describe('useLoad3d', () => {
+  let scope: EffectScope
+  function useLoad3d(...args: Parameters<typeof useLoad3dImpl>) {
+    return scope.run(() => useLoad3dImpl(...args))!
+  }
+  afterEach(() => scope.stop())
   let mockLoad3d: Partial<Load3d>
   let mockNode: LGraphNode
   let mockToastStore: ReturnType<typeof useToastStore>
 
   beforeEach(() => {
+    scope = effectScope()
     nodeToLoad3dMap.clear()
-    setActivePinia(undefined)
-    settingGetMock.mockImplementation((key: string) =>
-      key === 'Comfy.Load3D.BackgroundColor' ? '282828' : undefined
-    )
+    useSettingStore().settingValues['Comfy.Load3D.BackgroundColor'] = '282828'
 
     mockNode = createMockLGraphNode({
       properties: {
@@ -217,12 +201,7 @@ describe('useLoad3d', () => {
     })
     vi.mocked(createLoad3d).mockImplementation(() => mockLoad3d as Load3d)
 
-    mockToastStore = {
-      addAlert: vi.fn()
-    } as Partial<ReturnType<typeof useToastStore>> as ReturnType<
-      typeof useToastStore
-    >
-    vi.mocked(useToastStore).mockReturnValue(mockToastStore)
+    mockToastStore = useToastStore()
   })
 
   describe('initialization', () => {
@@ -399,15 +378,7 @@ describe('useLoad3d', () => {
     })
 
     it('defaults background color from the Comfy.Load3D.BackgroundColor setting', () => {
-      setActivePinia(createPinia())
-      vi.mocked(useCanvasStore).mockReturnValue(
-        reactive({ appScalePercentage: 100 }) as unknown as ReturnType<
-          typeof useCanvasStore
-        >
-      )
-      settingGetMock.mockImplementation((key: string) =>
-        key === 'Comfy.Load3D.BackgroundColor' ? '123456' : undefined
-      )
+      useSettingStore().settingValues['Comfy.Load3D.BackgroundColor'] = '123456'
 
       const composable = useLoad3d(mockNode)
 
@@ -443,11 +414,7 @@ describe('useLoad3d', () => {
 
   describe('zoom watcher', () => {
     it('calls load3d.handleResize after debounce when canvas appScalePercentage changes', async () => {
-      const canvasStore = reactive({ appScalePercentage: 100 })
-      setActivePinia(createPinia())
-      vi.mocked(useCanvasStore).mockReturnValue(
-        canvasStore as unknown as ReturnType<typeof useCanvasStore>
-      )
+      const canvasStore = useCanvasStore()
 
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')
@@ -464,11 +431,7 @@ describe('useLoad3d', () => {
     })
 
     it('debounces rapid zoom changes into a single handleResize call', async () => {
-      const canvasStore = reactive({ appScalePercentage: 100 })
-      setActivePinia(createPinia())
-      vi.mocked(useCanvasStore).mockReturnValue(
-        canvasStore as unknown as ReturnType<typeof useCanvasStore>
-      )
+      const canvasStore = useCanvasStore()
 
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')

--- a/src/composables/useLoad3dDrag.test.ts
+++ b/src/composables/useLoad3dDrag.test.ts
@@ -6,10 +6,6 @@ import { SUPPORTED_EXTENSIONS } from '@/extensions/core/load3d/constants'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { createMockFileList } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn()
-}))
-
 vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key) => key)
 }))
@@ -40,12 +36,7 @@ describe('useLoad3dDrag', () => {
   let mockOnModelDrop: (file: File) => void | Promise<void>
 
   beforeEach(() => {
-    mockToastStore = {
-      addAlert: vi.fn()
-    } as Partial<ReturnType<typeof useToastStore>> as ReturnType<
-      typeof useToastStore
-    >
-    vi.mocked(useToastStore).mockReturnValue(mockToastStore)
+    mockToastStore = useToastStore()
 
     mockOnModelDrop = vi.fn()
   })

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -15,10 +15,6 @@ vi.mock(import('@/services/load3dService'), () => ({
   useLoad3dService: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn()
-}))
-
 vi.mock<unknown>(import('@/extensions/core/load3d/Load3dUtils'), () => ({
   default: {
     uploadFile: vi.fn(),
@@ -194,12 +190,7 @@ describe('useLoad3dViewer', () => {
     >
     vi.mocked(useLoad3dService).mockReturnValue(mockLoad3dService)
 
-    mockToastStore = {
-      addAlert: vi.fn()
-    } as Partial<ReturnType<typeof useToastStore>> as ReturnType<
-      typeof useToastStore
-    >
-    vi.mocked(useToastStore).mockReturnValue(mockToastStore)
+    mockToastStore = useToastStore()
   })
 
   describe('initialization', () => {

--- a/src/composables/useNewMenuItemIndicator.test.ts
+++ b/src/composables/useNewMenuItemIndicator.test.ts
@@ -1,16 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNewMenuItemIndicator } from '@/composables/useNewMenuItemIndicator'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { WorkflowMenuItem } from '@/types/workflowMenuItem'
-
-const mockSettingStore = vi.hoisted(() => ({
-  get: vi.fn((): string[] => []),
-  set: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => mockSettingStore)
-}))
 
 function createItems(...ids: string[]): WorkflowMenuItem[] {
   return ids.map((id) => ({
@@ -24,8 +16,12 @@ function createItems(...ids: string[]): WorkflowMenuItem[] {
 }
 
 describe('useNewMenuItemIndicator', () => {
+  let settingStore: ReturnType<typeof useSettingStore>
+
   beforeEach(() => {
-    mockSettingStore.get.mockReturnValue([])
+    settingStore = useSettingStore()
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = []
+    vi.mocked(settingStore.set).mockResolvedValue()
   })
 
   it('reports unseen items when no items have been seen', () => {
@@ -36,7 +32,9 @@ describe('useNewMenuItemIndicator', () => {
   })
 
   it('reports no unseen items when all new items are already seen', () => {
-    mockSettingStore.get.mockReturnValue(['feature-a'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'feature-a'
+    ]
     const items = createItems('feature-a')
     const { hasUnseenItems } = useNewMenuItemIndicator(() => items)
 
@@ -44,7 +42,9 @@ describe('useNewMenuItemIndicator', () => {
   })
 
   it('reports unseen when some new items are not yet seen', () => {
-    mockSettingStore.get.mockReturnValue(['feature-a'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'feature-a'
+    ]
     const items = createItems('feature-a', 'feature-b')
     const { hasUnseenItems } = useNewMenuItemIndicator(() => items)
 
@@ -76,20 +76,23 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a', 'feature-b']
     )
   })
 
   it('markAsSeen replaces stale entries with current new items', () => {
-    mockSettingStore.get.mockReturnValue(['old-feature', 'feature-a'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'old-feature',
+      'feature-a'
+    ]
     const items = createItems('feature-a')
     const { markAsSeen } = useNewMenuItemIndicator(() => items)
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a']
     )
@@ -129,14 +132,16 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a']
     )
   })
 
   it('markAsSeen retains previously-seen hidden items', () => {
-    mockSettingStore.get.mockReturnValue(['hidden-feature'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'hidden-feature'
+    ]
     const items: WorkflowMenuItem[] = [
       ...createItems('feature-a'),
       {
@@ -153,20 +158,23 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).toHaveBeenCalledWith(
+    expect(settingStore.set).toHaveBeenCalledWith(
       'Comfy.WorkflowActions.SeenItems',
       ['feature-a', 'hidden-feature']
     )
   })
 
   it('markAsSeen skips write when stored list already matches', () => {
-    mockSettingStore.get.mockReturnValue(['feature-a', 'feature-b'])
+    settingStore.settingValues['Comfy.WorkflowActions.SeenItems'] = [
+      'feature-a',
+      'feature-b'
+    ]
     const items = createItems('feature-a', 'feature-b')
     const { markAsSeen } = useNewMenuItemIndicator(() => items)
 
     markAsSeen()
 
-    expect(mockSettingStore.set).not.toHaveBeenCalled()
+    expect(settingStore.set).not.toHaveBeenCalled()
   })
 
   it('markAsSeen does nothing when there are no new items', () => {
@@ -177,6 +185,6 @@ describe('useNewMenuItemIndicator', () => {
 
     markAsSeen()
 
-    expect(mockSettingStore.set).not.toHaveBeenCalled()
+    expect(settingStore.set).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/usePaste.test.ts
+++ b/src/composables/usePaste.test.ts
@@ -1,4 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import type { EffectScope } from 'vue'
 import type {
   LGraphCanvas,
   LGraph,
@@ -7,12 +11,7 @@ import type {
 } from '@/lib/litegraph/src/litegraph'
 import { app } from '@/scripts/app'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
-import {
-  createNode,
-  isAudioNode,
-  isImageNode,
-  isVideoNode
-} from '@/utils/litegraphUtil'
+import { createNode } from '@/utils/litegraphUtil'
 import {
   cloneDataTransfer,
   pasteAudioNode,
@@ -21,8 +20,10 @@ import {
   pasteImageNodes,
   pasteVideoNode,
   pasteVideoNodes,
-  usePaste
+  usePaste as usePasteImpl
 } from './usePaste'
+
+vi.mock(import('firebase/auth'))
 
 function createMockNode(): LGraphNode {
   return createMockLGraphNode({
@@ -70,55 +71,35 @@ const mockCanvas = {
   _deserializeItems: vi.fn()
 } as Partial<LGraphCanvas> as LGraphCanvas
 
-const mockCanvasStore = {
-  canvas: mockCanvas,
-  getCanvas: vi.fn(() => mockCanvas)
+let mockCanvasStore: ReturnType<typeof useCanvasStore>
+
+let mockWorkspaceStore: ReturnType<typeof useWorkspaceStore>
+let scope: EffectScope
+
+function usePaste() {
+  scope.run(usePasteImpl)
 }
 
-const mockWorkspaceStore = {
-  shiftDown: false
-}
+afterEach(() => scope.stop())
 
-vi.mock(import('@vueuse/core'), () => ({
-  useEventListener: vi.fn((target, event, handler) => {
-    target.addEventListener(event, handler)
-    return () => target.removeEventListener(event, handler)
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'),
-
-  () => ({
-    useCanvasStore: () => mockCanvasStore
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => mockWorkspaceStore
-}))
+beforeEach(() => {
+  scope = effectScope()
+  mockWorkspaceStore = useWorkspaceStore()
+  mockCanvasStore = useCanvasStore()
+  mockCanvasStore.canvas = mockCanvas
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
+    nodeOutputs: {},
+    nodePreviewImages: {},
     loadGraphData: vi.fn()
   }
 }))
 
-vi.mock<unknown>(
-  import('@/lib/litegraph/src/litegraph'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    LiteGraph: {
-      createNode: vi.fn()
-    }
-  })
-)
-
-vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
-  createNode: vi.fn(),
-  isAudioNode: vi.fn(),
-  isImageNode: vi.fn(),
-  isVideoNode: vi.fn()
+vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  createNode: vi.fn()
 }))
 
 vi.mock(
@@ -403,7 +384,7 @@ describe('pasteVideoNodes', () => {
 describe('usePaste', () => {
   beforeEach(() => {
     mockCanvas.current_node = null
-    mockWorkspaceStore.shiftDown = false
+    Object.assign(mockWorkspaceStore, { shiftDown: false })
     vi.mocked(mockCanvas.graph!.add).mockImplementation(
       (node: LGraphNode | LGraphGroup | null) => node as LGraphNode
     )
@@ -450,7 +431,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isAudioNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'audio'
 
     usePaste()
 
@@ -489,7 +470,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isVideoNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'video'
 
     usePaste()
 
@@ -561,7 +542,7 @@ describe('usePaste', () => {
   })
 
   it('should ignore paste when shift is down', () => {
-    mockWorkspaceStore.shiftDown = true
+    Object.assign(mockWorkspaceStore, { shiftDown: true })
 
     usePaste()
 
@@ -580,7 +561,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isImageNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'image'
 
     usePaste()
 
@@ -632,7 +613,7 @@ describe('usePaste', () => {
       pasteFiles: vi.fn()
     })
     mockCanvas.current_node = mockNode
-    vi.mocked(isImageNode).mockReturnValue(true)
+    mockNode.previewMediaType = 'image'
 
     usePaste()
 

--- a/src/composables/useReconnectingNotification.test.ts
+++ b/src/composables/useReconnectingNotification.test.ts
@@ -4,6 +4,7 @@ import { defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { useReconnectingNotification } from '@/composables/useReconnectingNotification'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 const mockToastAdd = vi.fn()
 const mockToastRemove = vi.fn()
@@ -43,23 +44,10 @@ function setupComposable(): ReturnType<typeof useReconnectingNotification> {
   return result
 }
 
-const settingMocks = vi.hoisted(() => ({
-  disableToast: false
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.Toast.DisableReconnectingToast')
-        return settingMocks.disableToast
-      return undefined
-    })
-  }))
-}))
-
 describe('useReconnectingNotification', () => {
   beforeEach(() => {
-    settingMocks.disableToast = false
+    useSettingStore().settingValues['Comfy.Toast.DisableReconnectingToast'] =
+      false
   })
 
   it('does not show toast immediately on reconnecting', () => {
@@ -121,7 +109,8 @@ describe('useReconnectingNotification', () => {
   })
 
   it('does nothing when toast is disabled via setting', () => {
-    settingMocks.disableToast = true
+    useSettingStore().settingValues['Comfy.Toast.DisableReconnectingToast'] =
+      true
     const { onReconnecting, onReconnected } = setupComposable()
 
     onReconnecting()

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -1,53 +1,19 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useTemplateRankingStore } from '@/stores/templateRankingStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
 import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
 
-const defaultSettingStore = {
-  get: vi.fn((key: string) => {
-    switch (key) {
-      case 'Comfy.Templates.SelectedModels':
-      case 'Comfy.Templates.SelectedUseCases':
-      case 'Comfy.Templates.SelectedRunsOn':
-        return []
-      case 'Comfy.Templates.SortBy':
-        return 'newest'
-      default:
-        return undefined
-    }
-  }),
-  set: vi.fn().mockResolvedValue(undefined)
-}
+let defaultSettingStore: ReturnType<typeof useSettingStore>
 
-const defaultRankingStore = {
-  computeDefaultScore: vi.fn(
-    (_date?: string, _rank?: number, usage: number = 0) => usage
-  ),
-  computeFreshness: vi.fn(() => 0.5),
-  largestUsageScore: 0
-}
+let defaultRankingStore: ReturnType<typeof useTemplateRankingStore>
 
-const mockSystemStatsStore = {
-  systemStats: {
-    system: {
-      os: 'linux'
-    }
-  }
-}
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => defaultSettingStore)
-}))
-
-vi.mock<unknown>(import('@/stores/templateRankingStore'), () => ({
-  useTemplateRankingStore: vi.fn(() => defaultRankingStore)
-}))
-
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: vi.fn(() => mockSystemStatsStore)
-}))
+let mockSystemStatsStore: ReturnType<typeof useSystemStatsStore>
 
 const trackTemplateFilterChanged = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
@@ -66,8 +32,24 @@ vi.mock(
 
 describe('useTemplateFiltering', () => {
   beforeEach(() => {
+    defaultSettingStore = useSettingStore()
+    defaultRankingStore = useTemplateRankingStore()
+    mockSystemStatsStore = useSystemStatsStore()
+    defaultSettingStore.settingValues = {
+      'Comfy.Templates.SelectedModels': [],
+      'Comfy.Templates.SelectedUseCases': [],
+      'Comfy.Templates.SelectedRunsOn': [],
+      'Comfy.Templates.SortBy': 'newest'
+    }
+    vi.mocked(defaultSettingStore.set).mockResolvedValue(undefined)
+    vi.mocked(defaultRankingStore.computeDefaultScore).mockImplementation(
+      (_date, _rank, usage = 0) => usage
+    )
+    vi.mocked(defaultRankingStore.computeFreshness).mockReturnValue(0.5)
     vi.stubGlobal('__DISTRIBUTION__', 'localhost')
-    mockSystemStatsStore.systemStats.system.os = 'linux'
+    mockSystemStatsStore.systemStats = fromPartial<
+      NonNullable<typeof mockSystemStatsStore.systemStats>
+    >({ system: { os: 'linux' } })
   })
 
   it('filters by search text, models, tags, and license with debounce handling', async () => {
@@ -1087,7 +1069,7 @@ describe('useTemplateFiltering', () => {
 
     it('mac distribution matches templates with mac includeOnDistributions', () => {
       setDistribution('desktop')
-      mockSystemStatsStore.systemStats.system.os = 'darwin'
+      mockSystemStatsStore.systemStats!.system.os = 'darwin'
 
       const macTemplate: TemplateInfo = {
         name: 'mac-template',

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -4,10 +4,12 @@ import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { fromPartial } from '@total-typescript/shoehorn'
+import { until } from '@vueuse/core'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
 import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
+import { api } from '@/scripts/api'
 
 let defaultSettingStore: ReturnType<typeof useSettingStore>
 
@@ -31,10 +33,16 @@ vi.mock(
 )
 
 describe('useTemplateFiltering', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.spyOn(api, 'getSystemStats').mockResolvedValue(
+      fromPartial<Awaited<ReturnType<typeof api.getSystemStats>>>({
+        system: { os: 'linux' }
+      })
+    )
     defaultSettingStore = useSettingStore()
     defaultRankingStore = useTemplateRankingStore()
     mockSystemStatsStore = useSystemStatsStore()
+    await until(() => mockSystemStatsStore.isInitialized).toBe(true)
     defaultSettingStore.settingValues = {
       'Comfy.Templates.SelectedModels': [],
       'Comfy.Templates.SelectedUseCases': [],

--- a/src/composables/useWorkflowActionsMenu.test.ts
+++ b/src/composables/useWorkflowActionsMenu.test.ts
@@ -1,3 +1,12 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import {
+  useWorkflowBookmarkStore,
+  useWorkflowStore
+} from '@/platform/workflow/management/stores/workflowStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useSubgraphStore } from '@/stores/subgraphStore'
+import { useMenuItemStore } from '@/stores/menuItemStore'
+import { useAppModeStore } from '@/stores/appModeStore'
 import { render } from '@testing-library/vue'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -6,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useWorkflowActionsMenu as useWorkflowActionsMenuComposable } from '@/composables/useWorkflowActionsMenu'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import type { WorkflowMenuAction } from '@/types/workflowMenuItem'
+import { toNodeId } from '@/types/nodeId'
 
 const i18n = createI18n({
   legacy: false,
@@ -15,14 +25,9 @@ const i18n = createI18n({
   fallbackWarn: false
 })
 
-const mockBookmarkStore = vi.hoisted(() => ({
-  isBookmarked: vi.fn(() => false),
-  toggleBookmarked: vi.fn()
-}))
+let mockBookmarkStore: ReturnType<typeof useWorkflowBookmarkStore>
 
-const mockWorkflowStore = vi.hoisted(() => ({
-  activeWorkflow: { path: 'test.json', isPersisted: true } as ComfyWorkflow
-}))
+let mockWorkflowStore: ReturnType<typeof useWorkflowStore>
 
 const mockWorkflowService = vi.hoisted(() => ({
   openWorkflow: vi.fn(),
@@ -31,46 +36,17 @@ const mockWorkflowService = vi.hoisted(() => ({
   deleteWorkflow: vi.fn()
 }))
 
-const mockCommandStore = vi.hoisted(() => ({
-  execute: vi.fn()
-}))
+let mockCommandStore: ReturnType<typeof useCommandStore>
 
-const mockSubgraphStore = vi.hoisted(() => ({
-  isSubgraphBlueprint: vi.fn(() => false)
-}))
+let mockSubgraphStore: ReturnType<typeof useSubgraphStore>
 
-const mockMenuItemStore = vi.hoisted(() => ({
-  hasSeenLinear: false
-}))
+let mockMenuItemStore: ReturnType<typeof useMenuItemStore>
 
-const mockAppModeStore = vi.hoisted(() => ({
-  enterBuilder: vi.fn(),
-  pruneLinearData: vi.fn(
-    (
-      data?: Partial<{
-        inputs: [number | string, string][]
-        outputs: (number | string)[]
-      }>
-    ) => ({
-      inputs: data?.inputs ?? [],
-      outputs: data?.outputs ?? []
-    })
-  ),
-  selectedInputs: [] as [number | string, string][],
-  selectedOutputs: [] as (number | string)[]
-}))
+let mockAppModeStore: ReturnType<typeof useAppModeStore>
 
 const mockFeatureFlags = vi.hoisted(() => ({
   flags: { linearToggleEnabled: false }
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => mockWorkflowStore),
-    useWorkflowBookmarkStore: vi.fn(() => mockBookmarkStore)
-  })
-)
 
 vi.mock<unknown>(
   import('@/platform/workflow/core/services/workflowService'),
@@ -78,24 +54,6 @@ vi.mock<unknown>(
     useWorkflowService: vi.fn(() => mockWorkflowService)
   })
 )
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => mockCommandStore)
-}))
-
-vi.mock<unknown>(import('@/stores/subgraphStore'), () => ({
-  useSubgraphStore: vi.fn(() => mockSubgraphStore)
-}))
-
-vi.mock<unknown>(import('@/stores/menuItemStore'), () => ({
-  useMenuItemStore: vi.fn(() => mockMenuItemStore)
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: vi.fn(() => mockAppModeStore)
-}))
-
-vi.mock(import('@/composables/useErrorHandling'), () => ({}))
 
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: vi.fn(() => mockFeatureFlags)
@@ -135,16 +93,26 @@ function findItem(items: MenuItems, label: string): WorkflowMenuAction {
 
 describe('useWorkflowActionsMenu', () => {
   beforeEach(() => {
-    mockBookmarkStore.isBookmarked.mockReturnValue(false)
-    mockSubgraphStore.isSubgraphBlueprint.mockReturnValue(false)
+    mockBookmarkStore = useWorkflowBookmarkStore()
+    mockWorkflowStore = useWorkflowStore()
+    mockCommandStore = useCommandStore()
+    mockSubgraphStore = useSubgraphStore()
+    mockMenuItemStore = useMenuItemStore()
+    mockAppModeStore = useAppModeStore()
+    vi.mocked(mockCommandStore.execute).mockResolvedValue(undefined)
+    vi.mocked(mockBookmarkStore.toggleBookmarked).mockResolvedValue(undefined)
+    vi.mocked(mockBookmarkStore.isBookmarked).mockReturnValue(false)
+    vi.mocked(mockSubgraphStore.isSubgraphBlueprint).mockReturnValue(false)
     mockMenuItemStore.hasSeenLinear = false
     mockFeatureFlags.flags.linearToggleEnabled = false
     mockAppModeStore.selectedInputs.length = 0
     mockAppModeStore.selectedOutputs.length = 0
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true
-    } as ComfyWorkflow
+    })
   })
 
   it('shows root-level items by default', () => {
@@ -221,11 +189,13 @@ describe('useWorkflowActionsMenu', () => {
 
   it('shows "go to workflow mode" when in linear mode', () => {
     mockFeatureFlags.flags.linearToggleEnabled = true
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true,
       activeMode: 'app'
-    } as ComfyWorkflow
+    })
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const labels = menuLabels(menuItems.value)
@@ -235,7 +205,7 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('shows bookmark label based on bookmark state', () => {
-    mockBookmarkStore.isBookmarked.mockReturnValue(true)
+    vi.mocked(mockBookmarkStore.isBookmarked).mockReturnValue(true)
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const labels = menuLabels(menuItems.value)
@@ -274,7 +244,7 @@ describe('useWorkflowActionsMenu', () => {
       isTemporary: false
     } as ComfyWorkflow)
 
-    mockBookmarkStore.isBookmarked.mockReturnValue(false)
+    vi.mocked(mockBookmarkStore.isBookmarked).mockReturnValue(false)
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), {
       isRoot: true,
@@ -286,7 +256,7 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('shows publish item for blueprints', () => {
-    mockSubgraphStore.isSubgraphBlueprint.mockReturnValue(true)
+    vi.mocked(mockSubgraphStore.isSubgraphBlueprint).mockReturnValue(true)
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const labels = menuLabels(menuItems.value)
@@ -345,12 +315,14 @@ describe('useWorkflowActionsMenu', () => {
 
   it('shows "Edit app" when workflow has linear data', async () => {
     mockFeatureFlags.flags.linearToggleEnabled = true
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true
-    } as ComfyWorkflow
+    })
     mockAppModeStore.selectedInputs.push([1, 'widget'])
-    mockAppModeStore.selectedOutputs.push(2)
+    mockAppModeStore.selectedOutputs.push(toNodeId(2))
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const item = findItem(menuItems.value, 'breadcrumbsMenu.editBuilderMode')
@@ -372,10 +344,12 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('rename is disabled for unpersisted root workflows', () => {
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: false
-    } as ComfyWorkflow
+    })
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const rename = findItem(menuItems.value, 'g.rename')
@@ -384,11 +358,13 @@ describe('useWorkflowActionsMenu', () => {
   })
 
   it('bookmark is disabled for temporary workflows', () => {
-    mockWorkflowStore.activeWorkflow = {
+    mockWorkflowStore.activeWorkflow = fromPartial<
+      NonNullable<typeof mockWorkflowStore.activeWorkflow>
+    >({
       path: 'test.json',
       isPersisted: true,
       isTemporary: true
-    } as ComfyWorkflow
+    })
 
     const { menuItems } = useWorkflowActionsMenu(vi.fn(), { isRoot: true })
     const bookmark = findItem(menuItems.value, 'tabMenu.addToBookmarks')

--- a/src/composables/useWorkflowStatusDismissal.test.ts
+++ b/src/composables/useWorkflowStatusDismissal.test.ts
@@ -1,43 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import { effectScope, nextTick, shallowRef, markRaw } from 'vue'
+import { storeToRefs } from 'pinia'
+import type { Ref } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
 
 import type { WorkflowExecutionStatus } from '@/stores/executionStore'
 
-const { mockActiveWorkflow, statusMap } = await vi.hoisted(async () => {
-  const { shallowRef } = await import('vue')
-  return {
-    mockActiveWorkflow: shallowRef<object | null>(null),
-    statusMap: shallowRef<Map<object, WorkflowExecutionStatus>>(new Map())
-  }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return mockActiveWorkflow.value
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    getWorkflowStatus: (workflow: object | null | undefined) =>
-      workflow ? statusMap.value.get(workflow) : undefined,
-    clearWorkflowStatus: (workflow: object) => {
-      const next = new Map(statusMap.value)
-      next.delete(workflow)
-      statusMap.value = next
-    }
-  })
-}))
+let mockActiveWorkflow: Ref<ComfyWorkflow | null>
+const statusMap = shallowRef(new Map<ComfyWorkflow, WorkflowExecutionStatus>())
 
 import { useWorkflowStatusDismissal } from './useWorkflowStatusDismissal'
 
-const workflowA = { path: '/a.json' }
-const workflowB = { path: '/b.json' }
+const workflowA = markRaw(fromPartial<ComfyWorkflow>({ path: '/a.json' }))
+const workflowB = markRaw(fromPartial<ComfyWorkflow>({ path: '/b.json' }))
 
 function mount() {
   const scope = effectScope()
@@ -47,6 +25,18 @@ function mount() {
 
 describe('useWorkflowStatusDismissal', () => {
   beforeEach(() => {
+    mockActiveWorkflow = storeToRefs(useWorkflowStore()).activeWorkflow
+    const executionStore = useExecutionStore()
+    vi.mocked(executionStore.getWorkflowStatus).mockImplementation(
+      (workflow) => (workflow ? statusMap.value.get(workflow) : undefined)
+    )
+    vi.mocked(executionStore.clearWorkflowStatus).mockImplementation(
+      (workflow) => {
+        statusMap.value = new Map(
+          [...statusMap.value].filter(([entry]) => entry !== workflow)
+        )
+      }
+    )
     mockActiveWorkflow.value = null
     statusMap.value = new Map()
   })

--- a/src/composables/useWorkflowTemplateSelectorDialog.test.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDialogStore } from '@/stores/dialogStore'
 
 const mockDialogService = vi.hoisted(() => ({
   showLayoutDialog: vi.fn()
 }))
 
-const mockDialogStore = vi.hoisted(() => ({
-  closeDialog: vi.fn()
-}))
+let mockDialogStore: ReturnType<typeof useDialogStore>
 
 const mockNewUserService = vi.hoisted(() => ({
   isNewUser: vi.fn()
@@ -18,10 +17,6 @@ const mockTelemetry = vi.hoisted(() => ({
 
 vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => mockDialogService
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => mockDialogStore
 }))
 
 vi.mock<unknown>(import('@/services/useNewUserService'), () => ({
@@ -42,6 +37,10 @@ vi.mock<unknown>(
 import { useWorkflowTemplateSelectorDialog } from './useWorkflowTemplateSelectorDialog'
 
 describe('useWorkflowTemplateSelectorDialog', () => {
+  beforeEach(() => {
+    mockDialogStore = useDialogStore()
+  })
+
   describe('show', () => {
     it('defaults to "all" category for non-new users', () => {
       mockNewUserService.isNewUser.mockReturnValue(false)

--- a/src/composables/video/useVideoSourceUrl.test.ts
+++ b/src/composables/video/useVideoSourceUrl.test.ts
@@ -1,55 +1,31 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 import { useVideoSourceUrl } from './useVideoSourceUrl'
 
-const mocks = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { reactive } = require('vue')
-  return {
-    nodeOutputs: reactive({}) as Record<string, unknown>,
-    nodePreviewImages: reactive({}) as Record<string, unknown>,
-    getNodeImageUrls: vi.fn<(node: unknown) => string[] | undefined>(),
-    getWidget: vi.fn()
-  }
-})
+let outputStore: ReturnType<typeof useNodeOutputStore>
+let widgetStore: ReturnType<typeof useWidgetValueStore>
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: { apiURL: (path: string) => `/api${path}` }
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { getPreviewFormatParam: () => '' }
+  app: {
+    getPreviewFormatParam: () => '',
+    nodeOutputs: {},
+    nodePreviewImages: {}
+  }
 }))
 
 vi.mock(import('@/platform/distribution/cloudPreviewUtil'), () => ({
   appendCloudResParam: vi.fn()
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeToNodeLocatorId: (node: { id: string }) => node.id
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    nodeOutputs: mocks.nodeOutputs,
-    nodePreviewImages: mocks.nodePreviewImages,
-    getNodeImageUrls: mocks.getNodeImageUrls
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => ({
-    getWidget: mocks.getWidget
-  })
 }))
 
 function fakeNode(overrides: Record<string, unknown> = {}): LGraphNode {
@@ -79,11 +55,13 @@ function mountSource(node: LGraphNode) {
 
 describe('useVideoSourceUrl', () => {
   beforeEach(() => {
-    for (const key of Object.keys(mocks.nodeOutputs)) {
-      delete mocks.nodeOutputs[key]
+    outputStore = useNodeOutputStore()
+    widgetStore = useWidgetValueStore()
+    for (const key of Object.keys(outputStore.nodeOutputs)) {
+      delete outputStore.nodeOutputs[key]
     }
-    for (const key of Object.keys(mocks.nodePreviewImages)) {
-      delete mocks.nodePreviewImages[key]
+    for (const key of Object.keys(outputStore.nodePreviewImages)) {
+      delete outputStore.nodePreviewImages[key]
     }
   })
 
@@ -104,10 +82,10 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('recovers when the input link appears after mount', async () => {
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=out.mp4&type=temp&rand=0.5'
     ])
-    mocks.getWidget.mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(undefined)
     const upstream = fakeNode({ id: 'upstream' })
     let connected = false
     const node = fakeNode({
@@ -119,7 +97,7 @@ describe('useVideoSourceUrl', () => {
     expect(videoUrl.value).toBeUndefined()
 
     connected = true
-    mocks.nodeOutputs['upstream'] = { images: [{ filename: 'out.mp4' }] }
+    outputStore.nodeOutputs['upstream'] = { images: [{ filename: 'out.mp4' }] }
     const fireConnectionsChange =
       node.onConnectionsChange as unknown as () => void
     fireConnectionsChange()
@@ -129,8 +107,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('switches from the file widget to the executed preview when outputs arrive', async () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'clip.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'clip.mp4'
+      })
+    )
 
     const upstream = fakeNode({ id: 'up' })
     const node = fakeNode({
@@ -141,20 +123,20 @@ describe('useVideoSourceUrl', () => {
     const { videoUrl } = mountSource(node)
     expect(videoUrl.value).toContain('filename=clip.mp4')
 
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=out.mp4&type=temp'
     ])
-    mocks.nodeOutputs['up'] = { images: [{ filename: 'out.mp4' }] }
+    outputStore.nodeOutputs['up'] = { images: [{ filename: 'out.mp4' }] }
     await nextTick()
 
     expect(videoUrl.value).toBe('/api/view?filename=out.mp4&type=temp')
   })
 
   it('prefers upstream outputs and strips the rand cache-buster', () => {
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=out.mp4&type=temp&rand=0.123'
     ])
-    mocks.getWidget.mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(undefined)
 
     const upstream = fakeNode({ id: 'up' })
     const node = fakeNode({
@@ -168,8 +150,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('falls back to the upstream file widget before any execution', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'clip.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'clip.mp4'
+      })
+    )
 
     const upstream = fakeNode({ id: 'up' })
     const node = fakeNode({
@@ -184,10 +170,14 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('uses the node itself as source when there is no video input', () => {
-    mocks.getNodeImageUrls.mockReturnValue([
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue([
       '/api/view?filename=already-trimmed.mp4&type=temp'
     ])
-    mocks.getWidget.mockReturnValue({ value: 'raw.mp4' })
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'raw.mp4'
+      })
+    )
 
     const node = fakeNode()
 
@@ -197,8 +187,8 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves nothing when the video input is not linked', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue(undefined)
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(undefined)
 
     const node = fakeNode({
       inputs: [{ name: 'video' }],
@@ -211,8 +201,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves through a subgraph output to the inner source node', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'inner.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'inner.mp4'
+      })
+    )
 
     const innerNode = fakeNode({ id: 'inner' })
     const subgraphNode = fakeNode({
@@ -232,8 +226,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves through nested subgraph outputs to the innermost source node', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'deep.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'deep.mp4'
+      })
+    )
 
     const innerNode = fakeNode({ id: 'inner' })
     const innerSubgraphNode = fakeNode({
@@ -264,8 +262,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves nothing when subgraph resolution loops back on itself', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'loop.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'loop.mp4'
+      })
+    )
 
     const loopingSubgraphNode = fakeNode({
       id: 'loop-sub',
@@ -289,8 +291,12 @@ describe('useVideoSourceUrl', () => {
   })
 
   it('resolves nothing when the subgraph link is missing', () => {
-    mocks.getNodeImageUrls.mockReturnValue(undefined)
-    mocks.getWidget.mockReturnValue({ value: 'inner.mp4' })
+    vi.mocked(outputStore.getNodeImageUrls).mockReturnValue(undefined)
+    vi.mocked(widgetStore.getWidget).mockReturnValue(
+      fromPartial<NonNullable<ReturnType<typeof widgetStore.getWidget>>>({
+        value: 'inner.mp4'
+      })
+    )
 
     const subgraphNode = fakeNode({
       id: 'sub',

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Supersedes the composable-test migrations from #17222 and #17223 with real Pinia state and action spies.

## Changes

- 68 changed files: 64 composable tests plus the four shared lifecycle files.
- Includes the shared Pinia disposal regression and singleton-reuse fixes. Each domain branch starts from the same prerequisite and targets main independently, so any domain can merge first.
- Enforcement and documentation remain deferred to #17223.

## Review Focus

- All 68 final blobs match the pinned migration source. No domain stacking or assertion weakening.
- Validation: 67 test files and 1,113 tests passed, including all changed tests and the three shared regressions. Frontend and scripts typechecks, scoped ESLint, type-aware Oxlint, cleanup audit, format check, knip, and actual commit hooks passed.
