### PR TITLE
test: use global Pinia in renderer tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -160,7 +160,6 @@ export { BaseWidget } from './widgets/BaseWidget'
 export { LegacyWidget } from './widgets/LegacyWidget'
 
 export { isComboWidget } from './widgets/widgetMap'
-/** @knipIgnoreUnusedButUsedByCustomNodes */
 export { isAssetWidget } from './widgets/widgetMap'
 // Additional test-specific exports
 export { LGraphButton } from './LGraphButton'

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -288,7 +288,6 @@ export function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
 
 /**
  * Type guard: Narrow **from {@link IBaseWidget}** to {@link IAssetWidget}.
- * @knipIgnoreUnusedButUsedByCustomNodes
  */
 export function isAssetWidget(widget: IBaseWidget): widget is IAssetWidget {
   return widget.type === 'asset'

--- a/src/renderer/core/canvas/canvasRedrawBudget.test.ts
+++ b/src/renderer/core/canvas/canvasRedrawBudget.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 
@@ -77,7 +75,6 @@ describe('canvas redraw budget while progress events stream in', () => {
   let previousVueNodesMode: boolean
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     previousVueNodesMode = LiteGraph.vueNodesMode
     LiteGraph.vueNodesMode = false
 

--- a/src/renderer/core/canvas/litegraph/arrangeForLegacyRender.test.ts
+++ b/src/renderer/core/canvas/litegraph/arrangeForLegacyRender.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
@@ -22,10 +20,6 @@ function addedNode(graph: LGraph, id?: number) {
 }
 
 describe('arrangeForLegacyRender', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   afterEach(() => {
     LiteGraph.vueNodesMode = false
   })

--- a/src/renderer/core/canvas/litegraph/notifyLayoutChanges.test.ts
+++ b/src/renderer/core/canvas/litegraph/notifyLayoutChanges.test.ts
@@ -1,6 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { notifyLayoutChanges } from '@/renderer/core/canvas/litegraph/notifyLayoutChanges'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
@@ -9,8 +7,6 @@ import { LayoutSource } from '@/renderer/core/layout/types'
 import { toGroupId } from '@/types/groupId'
 import { createUuidv4 } from '@/utils/uuid'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
-
-beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function setup() {
   const graph = new LGraph()

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -6,22 +6,6 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { app } from '@/scripts/app'
 
-// Mock stores
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => {
-  const getCanvas = vi.fn()
-  const setCursorStyle = vi.fn()
-  return {
-    useCanvasStore: vi.fn(() => ({
-      getCanvas,
-      setCursorStyle,
-      isReadOnly: false
-    }))
-  }
-})
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => {
-  const getFn = vi.fn()
-  return { useSettingStore: vi.fn(() => ({ get: getFn })) }
-})
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: {

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.perf.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.perf.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { effect, stop } from 'vue'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -26,7 +24,6 @@ type RenderCounts = {
 
 describe('renderer geometry boundary complexity', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     layoutStore.resetForTests()
     LiteGraph.vueNodesMode = false
   })

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -17,7 +15,6 @@ import {
 
 describe('node layout attachment ownership', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     layoutStore.resetForTests()
   })
 

--- a/src/renderer/core/layout/operations/layoutMutations.test.ts
+++ b/src/renderer/core/layout/operations/layoutMutations.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -40,7 +38,6 @@ function seedNode(
 }
 
 beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   seedNode(NODE_1, [10, 20], [200, 100], 0)
   seedNode(NODE_2, [300, 400], [150, 80], 1)
 })

--- a/src/renderer/core/layout/store/hitTargetAuthority.test.ts
+++ b/src/renderer/core/layout/store/hitTargetAuthority.test.ts
@@ -12,9 +12,6 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { toGroupId } from '@/types/groupId'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({})
-}))
 vi.mock<unknown>(import('@/services/litegraphService'), () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))

--- a/src/renderer/core/layout/store/layoutStore.multiHolder.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.multiHolder.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { effectScope, watchEffect } from 'vue'
 
@@ -73,7 +71,6 @@ describe('layoutStore node layout refs', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     layoutStore.resetForTests()
   })
 

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -1,6 +1,4 @@
 import { toGroupId } from '@/types/groupId'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
@@ -26,10 +24,6 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 }))
 
 const GRAPH = createUuidv4()
-
-beforeEach(() => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
-})
 
 describe('layoutStore CRDT operations', () => {
   beforeEach(() => {

--- a/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
+++ b/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
@@ -10,7 +10,6 @@
  * workbench must not import renderer, so the wiring takes the store's seams
  * injected - exactly as the composition root will inject them.
  */
-import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -96,7 +95,6 @@ describe('mint ports against the real layout store delivery', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     minted = []
     graphId = createUuidv4()
     scope = {

--- a/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
+++ b/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
@@ -17,15 +17,9 @@ const { getNodeById } = vi.hoisted(() => ({
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: { getNodeById } } }
+  app: { canvas: { graph: { getNodeById } }, nodePreviewImages: {} }
 }))
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    getNodeImageUrls: () => undefined,
-    nodeOutputs: {},
-    nodePreviewImages: {}
-  })
-}))
+
 vi.mock(
   import('@/renderer/extensions/compositor/composables/useCompositorEditor'),
   () => ({

--- a/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
@@ -1,3 +1,5 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent } from 'vue'
@@ -12,17 +14,6 @@ import {
   setCompositorLayers
 } from './useCompositorLayers'
 
-const { showDialog, toastAdd } = vi.hoisted(() => ({
-  showDialog: vi.fn(),
-  toastAdd: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -53,6 +44,10 @@ afterEach(() => {
   for (const app of apps.splice(0)) app.unmount()
 })
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
 describe('useCompositorEditor', () => {
   const node = { id: toNodeId(1) } as unknown as LGraphNode
 
@@ -63,13 +58,13 @@ describe('useCompositorEditor', () => {
   it('shows a toast and keeps the dialog closed without cached layers', () => {
     renderCompositorEditor().openCompositorEditor(node)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'info',
         detail: 'compositor.runWorkflowFirst'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   it('shows a toast when layers are cached without a fingerprint', () => {
@@ -79,13 +74,13 @@ describe('useCompositorEditor', () => {
 
     renderCompositorEditor().openCompositorEditor(node)
 
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'info',
         detail: 'compositor.runWorkflowFirst'
       })
     )
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   it('opens the layer editor in compositor mode when layers are cached', () => {
@@ -97,8 +92,8 @@ describe('useCompositorEditor', () => {
 
     renderCompositorEditor().openCompositorEditor(node)
 
-    expect(toastAdd).not.toHaveBeenCalled()
-    expect(showDialog).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).toHaveBeenCalledWith(
       expect.objectContaining({
         key: 'global-layer-editor',
         props: { node, mode: 'compositor' }

--- a/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent, ref } from 'vue'
@@ -9,13 +10,13 @@ import { toNodeId } from '@/types/nodeId'
 
 import { useCompositorPsdDownload } from './useCompositorPsdDownload'
 
-const { buildSessionPsdBlob, downloadBlob, loadCompositorSession, toastAdd } =
-  vi.hoisted(() => ({
+const { buildSessionPsdBlob, downloadBlob, loadCompositorSession } = vi.hoisted(
+  () => ({
     buildSessionPsdBlob: vi.fn(async () => new Blob(['psd'])),
     downloadBlob: vi.fn(),
-    loadCompositorSession: vi.fn().mockResolvedValue(0),
-    toastAdd: vi.fn()
-  }))
+    loadCompositorSession: vi.fn().mockResolvedValue(0)
+  })
+)
 
 vi.mock(
   import('@/renderer/extensions/compositor/composables/compositorSession'),
@@ -31,9 +32,7 @@ vi.mock(
   })
 )
 vi.mock(import('@/base/common/downloadUtil'), () => ({ downloadBlob }))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -75,6 +74,10 @@ function makeSession(glOk = true) {
 
 const node = { id: toNodeId(5) } as unknown as LGraphNode
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
 describe('useCompositorPsdDownload', () => {
   beforeEach(() => {
     loadCompositorSession.mockResolvedValue(0)
@@ -100,7 +103,7 @@ describe('useCompositorPsdDownload', () => {
     )
     expect(session.dispose).toHaveBeenCalledTimes(1)
     expect(exporting.value).toBe(false)
-    expect(toastAdd).not.toHaveBeenCalled()
+    expect(vi.mocked(useToastStore().add)).not.toHaveBeenCalled()
   })
 
   it('reports an error and still disposes when WebGL is unavailable', async () => {
@@ -112,7 +115,7 @@ describe('useCompositorPsdDownload', () => {
     await downloadPsd(node)
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'layerEditor.webglUnavailable'
@@ -132,7 +135,7 @@ describe('useCompositorPsdDownload', () => {
 
     expect(buildSessionPsdBlob).not.toHaveBeenCalled()
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledTimes(1)
     expect(session.dispose).toHaveBeenCalledTimes(1)
   })
 
@@ -146,7 +149,7 @@ describe('useCompositorPsdDownload', () => {
     await downloadPsd(node)
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledTimes(1)
     expect(session.dispose).toHaveBeenCalledTimes(1)
     expect(exporting.value).toBe(false)
   })
@@ -159,7 +162,7 @@ describe('useCompositorPsdDownload', () => {
     await downloadPsd(node)
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledTimes(1)
     expect(exporting.value).toBe(false)
   })
 

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -1,6 +1,9 @@
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { getActivePinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -14,11 +17,8 @@ const mocks = vi.hoisted(() => ({
   dismiss: vi.fn(),
   beginTour: vi.fn(),
   loadTemplate: vi.fn(),
-  loadCatalog: vi.fn(),
-  isLoaded: true,
-  toastAdd: vi.fn(),
-  loadingTemplateId: { value: null as string | null },
-  catalog: [] as { name: string }[]
+
+  loadingTemplateId: { value: null as string | null }
 }))
 
 vi.mock<unknown>(import('./firstRunEntry'), () => ({
@@ -45,27 +45,6 @@ vi.mock<unknown>(
   }
 )
 
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
-  () => ({
-    useWorkflowTemplatesStore: () => ({
-      get isLoaded() {
-        return mocks.isLoaded
-      },
-      get enhancedTemplates() {
-        return mocks.catalog
-      },
-      loadWorkflowTemplates: mocks.loadCatalog,
-      getTemplateByName: (name: string) =>
-        mocks.catalog.find((template) => template.name === name)
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mocks.toastAdd })
-}))
-
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -82,8 +61,7 @@ async function renderScreen({
   stubFocusScope = false,
   withOpenDialog = false
 } = {}) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
   if (withOpenDialog) {
     useDialogStore().showDialog({ component: { template: '<div />' } })
   }
@@ -97,12 +75,26 @@ async function renderScreen({
   })
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+  vi.mocked(useWorkflowTemplatesStore().getTemplateByName).mockImplementation(
+    (name) =>
+      useWorkflowTemplatesStore().enhancedTemplates.find(
+        (template) => template.name === name
+      )
+  )
+})
+
 describe('GettingStartedScreen', () => {
   beforeEach(() => {
-    mocks.isLoaded = true
-    mocks.catalog = CURATED_TEMPLATE_IDS.map((name) => ({ name }))
+    useWorkflowTemplatesStore().isLoaded = true
+    Object.assign(useWorkflowTemplatesStore(), {
+      enhancedTemplates: CURATED_TEMPLATE_IDS.map((name) => ({ name }))
+    })
     mocks.loadTemplate.mockResolvedValue(true)
-    mocks.loadCatalog.mockResolvedValue(undefined)
+    vi.mocked(
+      useWorkflowTemplatesStore().loadWorkflowTemplates
+    ).mockResolvedValue(undefined)
     mocks.beginTour.mockResolvedValue(true)
     mocks.loadingTemplateId.value = null
   })
@@ -177,13 +169,15 @@ describe('GettingStartedScreen', () => {
 
   describe('grid', () => {
     it('fills from the catalog when no curated template survived a package skew', async () => {
-      mocks.catalog = [
-        { name: 'skew-a' },
-        { name: 'skew-b' },
-        { name: 'skew-c' },
-        { name: 'skew-d' },
-        { name: 'skew-e' }
-      ]
+      Object.assign(useWorkflowTemplatesStore(), {
+        enhancedTemplates: [
+          { name: 'skew-a' },
+          { name: 'skew-b' },
+          { name: 'skew-c' },
+          { name: 'skew-d' },
+          { name: 'skew-e' }
+        ]
+      })
 
       await renderScreen()
 
@@ -194,11 +188,13 @@ describe('GettingStartedScreen', () => {
     })
 
     it('keeps curated templates ahead of the ones it backfills', async () => {
-      mocks.catalog = [
-        { name: 'catalog-filler' },
-        { name: FALLBACK_TEMPLATE_IDS[0] },
-        { name: CURATED_TEMPLATE_IDS[1] }
-      ]
+      Object.assign(useWorkflowTemplatesStore(), {
+        enhancedTemplates: [
+          { name: 'catalog-filler' },
+          { name: FALLBACK_TEMPLATE_IDS[0] },
+          { name: CURATED_TEMPLATE_IDS[1] }
+        ]
+      })
 
       await renderScreen()
 
@@ -296,7 +292,9 @@ describe('GettingStartedScreen', () => {
 
       await pickFirstTemplate()
 
-      await waitFor(() => expect(mocks.toastAdd).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(vi.mocked(useToastStore().add)).toHaveBeenCalled()
+      )
       expect(
         mocks.dismiss,
         'A failed load must not dismiss the screen; the user would be left on a bare canvas'
@@ -305,7 +303,7 @@ describe('GettingStartedScreen', () => {
     })
 
     it('retries a catalog load that resolved without loading anything', async () => {
-      mocks.isLoaded = false
+      useWorkflowTemplatesStore().isLoaded = false
       await renderScreen()
 
       const retry = await screen.findByTestId(
@@ -315,14 +313,16 @@ describe('GettingStartedScreen', () => {
           timeout: 1000
         }
       )
-      mocks.loadCatalog.mockImplementation(() => {
-        mocks.isLoaded = true
+      vi.mocked(
+        useWorkflowTemplatesStore().loadWorkflowTemplates
+      ).mockImplementation(() => {
+        useWorkflowTemplatesStore().isLoaded = true
         return Promise.resolve(undefined)
       })
       await userEvent.click(retry)
 
       expect(
-        mocks.loadCatalog,
+        vi.mocked(useWorkflowTemplatesStore().loadWorkflowTemplates),
         'The store swallows fetch errors and resolves with isLoaded false, so a failed catalog must be detected without a rejection'
       ).toHaveBeenCalledTimes(2)
       await waitFor(() =>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -1,3 +1,6 @@
+import type * as VueUse from '@vueuse/core'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCommandStore } from '@/stores/commandStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
@@ -9,9 +12,7 @@ const mocks = vi.hoisted(() => ({
   subscriptionEnabled: true,
   isNewUser: true as boolean | null,
   tourFlag: true,
-  execute: vi.fn(),
-  settings: {} as Record<string, unknown>,
-  setSetting: vi.fn(),
+
   beginTour: vi.fn()
 }))
 
@@ -35,7 +36,8 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   breakpointsTailwind: {},
   createSharedComposable: sharedComposable.create,
   useBreakpoints: () => ({
@@ -70,17 +72,6 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({ execute: mocks.execute })
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) => mocks.settings[key],
-    set: mocks.setSetting
-  })
-}))
-
 vi.mock<unknown>(import('../tour/useFirstRunTourController'), () => ({
   useFirstRunTourController: () => ({ beginTour: mocks.beginTour })
 }))
@@ -89,6 +80,10 @@ import { useFirstRunEntry } from './firstRunEntry'
 
 type FirstRunEntry = ReturnType<typeof useFirstRunEntry>
 
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
+
 describe('useFirstRunEntry', () => {
   beforeEach(() => {
     mocks.isCloud = true
@@ -96,9 +91,9 @@ describe('useFirstRunEntry', () => {
     mocks.subscriptionEnabled = true
     mocks.isNewUser = true
     mocks.tourFlag = true
-    mocks.settings = {}
-    mocks.setSetting.mockImplementation((key: string, value: unknown) => {
-      mocks.settings[key] = value
+    useSettingStore().settingValues = {}
+    vi.mocked(useSettingStore().set).mockImplementation(async (key, value) => {
+      useSettingStore().settingValues[key] = value
     })
     sharedComposable.reset()
     // beginTour reports whether a tour actually started; default to the
@@ -125,7 +120,7 @@ describe('useFirstRunEntry', () => {
       await entry.handleStartupOutcome('fresh')
 
       expect(entry.gettingStartedVisible.value).toBe(true)
-      expect(mocks.execute).not.toHaveBeenCalled()
+      expect(useCommandStore().execute).not.toHaveBeenCalled()
     })
 
     it('shares first-run state across consumers during one boot', async () => {
@@ -149,7 +144,9 @@ describe('useFirstRunEntry', () => {
           entry.gettingStartedVisible.value,
           'A non-candidate must keep the existing template-browser flow'
         ).toBe(false)
-        expect(mocks.execute).toHaveBeenCalledWith('Comfy.BrowseTemplates')
+        expect(useCommandStore().execute).toHaveBeenCalledWith(
+          'Comfy.BrowseTemplates'
+        )
       }
     )
 
@@ -162,7 +159,7 @@ describe('useFirstRunEntry', () => {
         await entry.handleStartupOutcome('fresh')
 
         expect(
-          mocks.setSetting,
+          vi.mocked(useSettingStore().set),
           'Without this the browser reopens on every launch, forever'
         ).toHaveBeenCalledWith('Comfy.TutorialCompleted', true)
       }
@@ -177,7 +174,7 @@ describe('useFirstRunEntry', () => {
         await entry.handleStartupOutcome('fresh')
 
         expect(
-          mocks.setSetting,
+          vi.mocked(useSettingStore().set),
           'Comfy.TutorialCompleted is write-once and server-side; setting it here burns the tour for an account that was only ineligible this boot'
         ).not.toHaveBeenCalled()
       }
@@ -209,12 +206,12 @@ describe('useFirstRunEntry', () => {
       entry.gettingStartedVisible.value,
       'A share or template link is the user’s choice; onboarding must not cover it'
     ).toBe(false)
-    expect(mocks.execute).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
 
     await entry.handleUrlWorkflow('url-intent', 'image_z_image_turbo')
 
     expect(
-      mocks.setSetting,
+      vi.mocked(useSettingStore().set),
       'Without this the template browser reopens on every launch, as it did before this flow existed'
     ).toHaveBeenCalledWith('Comfy.TutorialCompleted', true)
   })
@@ -259,7 +256,7 @@ describe('useFirstRunEntry', () => {
         'the link is the user’s choice; onboarding must not cover it'
       ).toBe(false)
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'no tour ran, so the write-once flag that pays for one must stay unspent for the boot that can lift this'
       ).not.toHaveBeenCalled()
     }
@@ -275,7 +272,8 @@ describe('useFirstRunEntry', () => {
 
     mocks.isDesktopWidth = true
     // What `checkIsNewUser()` reads on the next launch.
-    mocks.isNewUser = !mocks.settings['Comfy.TutorialCompleted']
+    mocks.isNewUser =
+      !useSettingStore().settingValues['Comfy.TutorialCompleted']
     sharedComposable.reset()
     const laptop = useFirstRunEntry()
     await laptop.handleStartupOutcome('url-intent')
@@ -286,7 +284,7 @@ describe('useFirstRunEntry', () => {
       'opening a template link on a phone and returning on a laptop is ordinary behaviour'
     ).toHaveBeenCalledWith('image_z_image_turbo')
     expect(
-      mocks.settings['Comfy.TutorialCompleted'],
+      useSettingStore().settingValues['Comfy.TutorialCompleted'],
       'the flag is spent on the boot that finally delivered the tour, not before'
     ).toBe(true)
   })
@@ -301,7 +299,7 @@ describe('useFirstRunEntry', () => {
       'checkIsNewUser reads Comfy.TutorialCompleted, so a user who predates that setting looks new; only the outcome shows they had work to restore'
     ).toBe(false)
     expect(
-      mocks.execute,
+      useCommandStore().execute,
       'nor may the template browser cover their restored workflow'
     ).not.toHaveBeenCalled()
   })
@@ -331,8 +329,8 @@ describe('useFirstRunEntry', () => {
       expect(
         entry.gettingStartedVisible.value ||
           mocks.beginTour.mock.calls.length > 0 ||
-          mocks.setSetting.mock.calls.length > 0 ||
-          mocks.execute.mock.calls.length > 0,
+          vi.mocked(useSettingStore().set).mock.calls.length > 0 ||
+          vi.mocked(useCommandStore().execute).mock.calls.length > 0,
         'a startup that opened a blank canvas must offer onboarding, tour what the link loaded, record that it is done, or open the template browser; anything else strands the user with an empty screen'
       ).toBe(true)
     }
@@ -379,13 +377,13 @@ describe('useFirstRunEntry', () => {
     it('leaves the completion flag alone when the engine refused to start', async () => {
       const entry = useFirstRunEntry()
       await entry.handleStartupOutcome('url-intent')
-      mocks.setSetting.mockClear()
+      vi.mocked(useSettingStore().set).mockClear()
       mocks.beginTour.mockResolvedValue(false)
 
       await entry.handleUrlWorkflow('url-intent', 'image_z_image_turbo')
 
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'writing it here would mark onboarding done for a user whose tour never started, and postpone() exists to offer that user the tour again'
       ).not.toHaveBeenCalled()
     })
@@ -401,7 +399,7 @@ describe('useFirstRunEntry', () => {
         'there is no workflow on the canvas to tour'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'a dead link must not spend the one tour the account gets; the next boot has no URL to honour and offers Getting Started instead'
       ).not.toHaveBeenCalled()
     })
@@ -448,14 +446,14 @@ describe('useFirstRunEntry', () => {
   })
 
   it('leaves a completed user alone', async () => {
-    mocks.settings['Comfy.TutorialCompleted'] = true
+    useSettingStore().settingValues['Comfy.TutorialCompleted'] = true
     const entry = useFirstRunEntry()
 
     await entry.handleStartupOutcome('restored')
 
     expect(entry.gettingStartedVisible.value).toBe(false)
-    expect(mocks.execute).not.toHaveBeenCalled()
-    expect(mocks.setSetting).not.toHaveBeenCalled()
+    expect(useCommandStore().execute).not.toHaveBeenCalled()
+    expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalled()
   })
 
   it('keeps the screen up when eligibility changes underneath it', async () => {
@@ -477,14 +475,14 @@ describe('useFirstRunEntry', () => {
     await entry.handleStartupOutcome('fresh')
 
     expect(
-      mocks.setSetting,
+      vi.mocked(useSettingStore().set),
       'Showing the screen must not persist completion; the user has not chosen anything yet'
     ).not.toHaveBeenCalled()
 
     await entry.dismissGettingStarted()
 
     expect(entry.gettingStartedVisible.value).toBe(false)
-    expect(mocks.setSetting).toHaveBeenCalledWith(
+    expect(vi.mocked(useSettingStore().set)).toHaveBeenCalledWith(
       'Comfy.TutorialCompleted',
       true
     )

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -1,3 +1,5 @@
+import { useDialogStore } from '@/stores/dialogStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,7 +16,7 @@ const mocks = await vi.hoisted(async () => {
   return {
     nudgeArmed: ref(false),
     tourWasCompleted: ref(true),
-    openDialogs: ref<string[]>([]),
+
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
     }),
@@ -28,14 +30,6 @@ vi.mock<unknown>(import('../tour/useFirstRunTourController'), () => ({
     nudgeArmed: mocks.nudgeArmed,
     tourWasCompleted: mocks.tourWasCompleted,
     dismissNudge: mocks.dismissNudge
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    get dialogStack() {
-      return mocks.openDialogs.value
-    }
   })
 }))
 
@@ -70,7 +64,7 @@ describe('FirstRunTourNudge', () => {
   beforeEach(() => {
     mocks.nudgeArmed.value = false
     mocks.tourWasCompleted.value = true
-    mocks.openDialogs.value = []
+    useDialogStore().dialogStack = []
   })
 
   it('shows a nudge that came due before it mounted', async () => {
@@ -97,7 +91,7 @@ describe('FirstRunTourNudge', () => {
 
   it('waits out a dialog that is already open', async () => {
     mocks.nudgeArmed.value = true
-    mocks.openDialogs.value = ['some-dialog']
+    useDialogStore().dialogStack = [fromPartial({ key: 'some-dialog' })]
     renderNudge()
 
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
@@ -106,7 +100,7 @@ describe('FirstRunTourNudge', () => {
       'the nudge sits below the modal stack, so under a dialog it is invisible'
     ).toBeNull()
 
-    mocks.openDialogs.value = []
+    useDialogStore().dialogStack = []
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
     expect(
@@ -120,7 +114,7 @@ describe('FirstRunTourNudge', () => {
     renderNudge()
 
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS - 500)
-    mocks.openDialogs.value = ['some-dialog']
+    useDialogStore().dialogStack = [fromPartial({ key: 'some-dialog' })]
     await vi.advanceTimersByTimeAsync(500 + APPEAR_DELAY_MS)
 
     expect(
@@ -138,9 +132,9 @@ describe('FirstRunTourNudge', () => {
     renderNudge()
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
-    mocks.openDialogs.value = ['some-dialog']
+    useDialogStore().dialogStack = [fromPartial({ key: 'some-dialog' })]
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-    mocks.openDialogs.value = []
+    useDialogStore().dialogStack = []
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
     const shown = mocks.trackOnboardingTour.mock.calls.filter(

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
@@ -1,3 +1,5 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
@@ -24,19 +26,10 @@ function scaleFor(bounds: ReadOnlyRect, fill: number): number {
   )
 }
 
-const appState = vi.hoisted(() => ({ canvas: undefined as unknown }))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    get canvas() {
-      return appState.canvas
-    }
-  })
-}))
-
 const camera = {
   animateToBounds: vi.fn(),
   setDirty: vi.fn(),
-  ds: { fitToBounds: vi.fn(), offset: [0, 0], scale: 1 }
+  ds: { fitToBounds: vi.fn(), offset: [0, 0] as [number, number], scale: 1 }
 }
 
 let canvasRect = new DOMRect(0, 0, VIEWPORT.width, VIEWPORT.height)
@@ -48,11 +41,13 @@ function mountCanvas(): LGraphNode {
   node.size = [50, 60]
   graph.add(node)
   node.updateArea()
-  appState.canvas = {
+  useCanvasStore().canvas = fromPartial({
     ...camera,
     graph,
-    canvas: { getBoundingClientRect: () => canvasRect }
-  }
+    canvas: Object.assign(document.createElement('canvas'), {
+      getBoundingClientRect: () => canvasRect
+    })
+  })
   return node
 }
 
@@ -158,7 +153,7 @@ describe('frameNode', () => {
     camera.ds.fitToBounds.mockClear()
     camera.ds.offset = [0, 0]
     camera.ds.scale = 1
-    appState.canvas = undefined
+    useCanvasStore().canvas = null
   })
 
   it('skips the flight for a step already framed, as Back lands on', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as Litegraph from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 
 import { toNodeId } from '@/types/nodeId'
@@ -10,10 +13,7 @@ const { TITLE_HEIGHT } = vi.hoisted(() => ({ TITLE_HEIGHT: 30 }))
 
 const state = vi.hoisted(() => ({
   camera: null as Record<string, number> | null,
-  currentGraph: null as {
-    getNodeById: (id: unknown) => unknown
-    rootGraph: { id: ReturnType<typeof createUuidv4> }
-  } | null,
+
   collapsed: new Set<string>(),
   layout: null as { value: unknown } | null,
   layoutReads: vi.fn(),
@@ -22,18 +22,24 @@ const state = vi.hoisted(() => ({
 }))
 
 function graph(id: string) {
-  return {
+  return fromPartial<Litegraph.LGraph>({
     id,
     rootGraph: { id: createUuidv4() },
-    getNodeById: (nodeId: unknown) => ({
-      collapsed: state.collapsed.has(String(nodeId))
-    })
-  }
+    getNodeById: (nodeId: unknown) =>
+      fromPartial<Litegraph.LGraphNode>({
+        constructor: {},
+        collapsed: state.collapsed.has(String(nodeId))
+      })
+  })
 }
 
-vi.mock<unknown>(import('@/lib/litegraph/src/litegraph'), () => ({
-  LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
-}))
+vi.mock<unknown>(
+  import('@/lib/litegraph/src/litegraph'),
+  async (importOriginal) => ({
+    ...(await importOriginal<typeof Litegraph>()),
+    LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
+  })
+)
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
   async () => {
@@ -42,14 +48,7 @@ vi.mock<unknown>(
     return { useTransformState: () => ({ camera: state.camera }) }
   }
 )
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    canvas: { canvas: document.createElement('canvas') },
-    get currentGraph() {
-      return state.currentGraph
-    }
-  })
-}))
+
 vi.mock<unknown>(
   import('@/renderer/core/layout/store/layoutStore'),
   async () => {
@@ -84,9 +83,17 @@ function placeNode(bounds = { x: 100, y: 200, width: 80, height: 40 }) {
   state.layout!.value = { bounds }
 }
 
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({
+    graph: graph('root'),
+    canvas: document.createElement('canvas')
+  })
+  useCanvasStore().currentGraph = useCanvasStore().canvas!.graph
+})
+
 describe('canvasNodeTarget', () => {
   afterEach(() => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     state.collapsed.clear()
     state.canvasOffset = { left: 0, top: 0 }
     if (state.camera) Object.assign(state.camera, { x: 0, y: 0, z: 1 })
@@ -96,7 +103,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('releases what it watches when the tour drops it', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     const target = canvasNodeTarget(toNodeId(1))
     expect(state.releaseBounds).not.toHaveBeenCalled()
 
@@ -109,7 +116,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('places the rect over the node, title bar included', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode({ x: 100, y: 200, width: 80, height: 40 })
 
     expect(
@@ -119,7 +126,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('carries the node through pan and zoom', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode({ x: 100, y: 200, width: 80, height: 40 })
     Object.assign(state.camera!, { x: 10, y: 20, z: 2 })
     state.canvasOffset = { left: 5, top: 7 }
@@ -138,8 +145,8 @@ describe('canvasNodeTarget', () => {
   })
 
   it('withholds a rect until the node has a layout', () => {
-    state.currentGraph = graph('root')
-    const rootGraphId = state.currentGraph.rootGraph.id
+    useCanvasStore().currentGraph = graph('root')
+    const rootGraphId = useCanvasStore().currentGraph!.rootGraph.id
     const nodeId = toNodeId(6)
 
     expect(
@@ -150,12 +157,12 @@ describe('canvasNodeTarget', () => {
   })
 
   it('withholds a rect once the graph it resolved against is gone', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode()
     const target = canvasNodeTarget(toNodeId(6))
     expect(target.getRect()).not.toBeNull()
 
-    state.currentGraph = graph('another-workflow')
+    useCanvasStore().currentGraph = graph('another-workflow')
 
     expect(
       target.getRect(),
@@ -164,7 +171,7 @@ describe('canvasNodeTarget', () => {
   })
 
   it('withholds a rect for a collapsed node, which renders no widget', () => {
-    state.currentGraph = graph('root')
+    useCanvasStore().currentGraph = graph('root')
     placeNode()
     state.collapsed.add('6')
 

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -1,48 +1,42 @@
+import { useExecutionStore } from '@/stores/executionStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useOnboardingTourStore } from '@/platform/onboarding/onboardingTourStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import type { DetachedWindowAPI } from 'happy-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 import type { EffectScope, Ref } from 'vue'
 
 import type { TourEnding } from '@/platform/onboarding/onboardingTourStore'
+import type { WorkflowExecutionStatus } from '@/stores/executionStore'
 import type {
   CoachStep,
   SpotlightStep
 } from '@/platform/onboarding/onboardingTours'
 import type { OnboardingTourSkipReason } from '@/platform/telemetry/types'
 
-const TOUR_WORKFLOW = { path: 'tour.json' }
-const OTHER_WORKFLOW = { path: 'other.json' }
+const TOUR_WORKFLOW = fromPartial<
+  NonNullable<ReturnType<typeof useWorkflowStore>['activeWorkflow']>
+>({ path: 'tour.json' })
+const OTHER_WORKFLOW = fromPartial<
+  NonNullable<ReturnType<typeof useWorkflowStore>['activeWorkflow']>
+>({ path: 'other.json' })
 const INTRO_PREVIEW_MS = 500
 const OFFLINE_GRACE_MS = 20_000
 const ACCEPT_DEADLINE_MS = 15_000
 
 const mocks = vi.hoisted(() => {
-  const queuedJobs: { value: Record<string, { workflow?: unknown }> } = {
-    value: {}
-  }
   return {
     canRunWorkflows: { value: true },
     showSubscriptionDialog: vi.fn(),
-    workflowStatus: { value: new Map<unknown, string>() },
-    executionErrors: { hasNodeError: false, hasPromptError: false },
-    activeWorkflow: { value: null as { path: string } | null },
-    queuedJobs,
-    linearMode: { value: false },
-    vueNodesEnabled: true,
-    setSetting: vi.fn(),
+    workflowStatus: { value: new Map<unknown, WorkflowExecutionStatus>() },
+
     steps: [] as CoachStep[],
     runState: { value: 'idle' } as Ref<string>,
-    releaseFirstRunTargets: vi.fn(),
-    engine: {
-      activeTour: null as string | null,
-      lastEnding: null as TourEnding | null,
-      step: null as CoachStep | null,
-      isLast: false,
-      startTour: vi.fn(),
-      next: vi.fn(),
-      skip: vi.fn(),
-      postpone: vi.fn()
-    }
+    releaseFirstRunTargets: vi.fn()
   }
 })
 
@@ -53,66 +47,6 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-// Each factory runs on the first dynamic import, which lands mid-test for
-// whichever test runs first. Seed the new ref from the holder so that test's
-// setup survives instead of being discarded.
-vi.mock<unknown>(import('@/stores/executionStore'), async () => {
-  const { shallowRef } = await import('vue')
-  mocks.workflowStatus = shallowRef(new Map(mocks.workflowStatus.value))
-  mocks.queuedJobs = shallowRef(mocks.queuedJobs.value)
-  return {
-    useExecutionStore: () => ({
-      getWorkflowStatus: (workflow: unknown) =>
-        mocks.workflowStatus.value.get(workflow),
-      get queuedJobs() {
-        return mocks.queuedJobs.value
-      }
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), async () => {
-  const { reactive } = await import('vue')
-  mocks.executionErrors = reactive({ ...mocks.executionErrors })
-  return { useExecutionErrorStore: () => mocks.executionErrors }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  async () => {
-    const { shallowRef } = await import('vue')
-    mocks.activeWorkflow = shallowRef(mocks.activeWorkflow.value)
-    return {
-      useWorkflowStore: () => ({
-        get activeWorkflow() {
-          return mocks.activeWorkflow.value
-        }
-      })
-    }
-  }
-)
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), async () => {
-  const { shallowRef } = await import('vue')
-  mocks.linearMode = shallowRef(mocks.linearMode.value)
-  return {
-    useCanvasStore: () => ({
-      get linearMode() {
-        return mocks.linearMode.value
-      }
-    })
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => mocks.vueNodesEnabled,
-    // A spy, not a plain writer: a value that was flipped and put back reads
-    // the same as one that was never touched.
-    set: mocks.setSetting
-  })
-}))
-
 vi.mock<unknown>(import('./firstRunTourDefinition'), () => ({
   firstRunTourSteps: (_templateId: string, runState: Ref<string>) => {
     mocks.runState = runState
@@ -120,15 +54,6 @@ vi.mock<unknown>(import('./firstRunTourDefinition'), () => ({
   },
   releaseFirstRunTargets: mocks.releaseFirstRunTargets
 }))
-
-vi.mock<unknown>(
-  import('@/platform/onboarding/onboardingTourStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mocks.engine = reactive(mocks.engine)
-    return { useOnboardingTourStore: () => mocks.engine }
-  }
-)
 
 function runStep(): SpotlightStep {
   return {
@@ -146,7 +71,6 @@ let registeredTourHolds: () => boolean
 /** Scoped so each controller's document listener dies with its test. */
 async function freshController() {
   controllerScope?.stop()
-  vi.resetModules()
   controllerScope = effectScope()
   const tours = await import('@/platform/onboarding/onboardingTours')
   resolveRegisteredTour = async () => {
@@ -162,11 +86,11 @@ async function freshController() {
 /** A started tour sitting on its Run step, the state every run outcome acts on. */
 async function tourOnRunStep() {
   mocks.steps = [runStep()]
-  mocks.activeWorkflow.value = TOUR_WORKFLOW
-  mocks.engine.startTour.mockImplementation(async () => {
+  useWorkflowStore().activeWorkflow = TOUR_WORKFLOW
+  vi.mocked(useOnboardingTourStore().startTour).mockImplementation(async () => {
     await resolveRegisteredTour()
-    mocks.engine.activeTour = 'firstRun'
-    mocks.engine.step = runStep()
+    useOnboardingTourStore().activeTour = 'firstRun'
+    Object.assign(useOnboardingTourStore(), { step: runStep() })
     return true
   })
   const controller = await freshController()
@@ -179,9 +103,9 @@ async function tourOnRunStep() {
 
 /** The engine ending the tour and recording how, the way `finish()` leaves it. */
 function endTour(ending: TourEnding) {
-  mocks.engine.lastEnding = ending
-  mocks.engine.activeTour = null
-  mocks.engine.step = null
+  useOnboardingTourStore().lastEnding = ending
+  useOnboardingTourStore().activeTour = null
+  Object.assign(useOnboardingTourStore(), { step: null })
   return nextTick()
 }
 
@@ -208,30 +132,28 @@ const EVERY_ENDING: { named: string; ending: TourEnding }[] = [
 ]
 
 /** The queue storing a job, which is what acceptance actually looks like. */
-function acceptRun(workflow: unknown) {
-  mocks.queuedJobs.value = { 'job-1': { workflow } }
+function acceptRun(workflow: typeof TOUR_WORKFLOW) {
+  useExecutionStore().queuedJobs = { 'job-1': { workflow, nodes: {} } }
   return nextTick()
 }
 
 /** The queue letting a job go, which `resetExecutionState` does silently. */
 function removeRun() {
-  mocks.queuedJobs.value = {}
+  useExecutionStore().queuedJobs = {}
   return nextTick()
 }
 
-function finishRun(workflow: unknown, status: string) {
-  mocks.workflowStatus.value = new Map(mocks.workflowStatus.value).set(
-    workflow,
-    status
-  )
+function finishRun(
+  workflow: typeof TOUR_WORKFLOW,
+  status: WorkflowExecutionStatus
+) {
+  mocks.workflowStatus.value.set(workflow, status)
   return nextTick()
 }
 
 /** A user stop, which drops the status instead of reporting an outcome. */
 function dropRun(workflow: unknown) {
-  const next = new Map(mocks.workflowStatus.value)
-  next.delete(workflow)
-  mocks.workflowStatus.value = next
+  mocks.workflowStatus.value.delete(workflow)
   return nextTick()
 }
 
@@ -255,25 +177,43 @@ function mountRunButton(
   return button
 }
 
+beforeEach(() => {
+  Object.assign(useOnboardingTourStore(), {
+    activeTour:
+      ref<ReturnType<typeof useOnboardingTourStore>['activeTour']>(null),
+    lastEnding: ref<TourEnding | null>(null)
+  })
+  vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(true)
+  mocks.workflowStatus = ref(new Map())
+  vi.mocked(useExecutionStore().getWorkflowStatus).mockImplementation(
+    (workflow) => mocks.workflowStatus.value.get(workflow)
+  )
+  vi.mocked(useOnboardingTourStore().next).mockImplementation(() => undefined)
+  vi.mocked(useOnboardingTourStore().skip).mockImplementation(() => undefined)
+  vi.mocked(useOnboardingTourStore().postpone).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('useFirstRunTourController', () => {
   beforeEach(() => {
     mocks.canRunWorkflows = ref(true)
     mocks.workflowStatus.value = new Map()
-    mocks.queuedJobs.value = {}
-    mocks.executionErrors.hasNodeError = false
-    mocks.executionErrors.hasPromptError = false
-    mocks.activeWorkflow.value = null
-    mocks.linearMode.value = false
-    mocks.vueNodesEnabled = true
-    mocks.setSetting.mockImplementation((_key: string, value: boolean) => {
-      mocks.vueNodesEnabled = value
+    useExecutionStore().queuedJobs = {}
+    Object.assign(useExecutionErrorStore(), { hasNodeError: false })
+    Object.assign(useExecutionErrorStore(), { hasPromptError: false })
+    useWorkflowStore().activeWorkflow = null
+    useCanvasStore().linearMode = false
+    useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = true
+    vi.mocked(useSettingStore().set).mockImplementation(async (_key, value) => {
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = value
       return Promise.resolve()
     })
     mocks.steps = []
-    mocks.engine.activeTour = null
-    mocks.engine.lastEnding = null
-    mocks.engine.step = null
-    mocks.engine.isLast = false
+    useOnboardingTourStore().activeTour = null
+    useOnboardingTourStore().lastEnding = null
+    Object.assign(useOnboardingTourStore(), { step: null })
+    Object.assign(useOnboardingTourStore(), { isLast: false })
   })
 
   afterEach(() => {
@@ -284,9 +224,9 @@ describe('useFirstRunTourController', () => {
 
   describe('starting', () => {
     it('turns on the renderer whose nodes it spotlights', async () => {
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockResolvedValue(true)
+      vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(true)
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -294,15 +234,15 @@ describe('useFirstRunTourController', () => {
       await starting
 
       expect(
-        mocks.vueNodesEnabled,
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'a new user has no installed version, so Nodes 2.0 reads off and every step is blind'
       ).toBe(true)
     })
 
     it('hands back the renderer when the engine turns the start down', async () => {
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockResolvedValue(false)
+      vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(false)
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -310,15 +250,15 @@ describe('useFirstRunTourController', () => {
       await starting
 
       expect(
-        mocks.vueNodesEnabled,
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'a user who got no tour must not be left migrated by the one that never ran'
       ).toBe(false)
     })
 
     it('leaves a renderer the user already had switched on', async () => {
-      mocks.vueNodesEnabled = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = true
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockResolvedValue(false)
+      vi.mocked(useOnboardingTourStore().startTour).mockResolvedValue(false)
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -326,13 +266,13 @@ describe('useFirstRunTourController', () => {
       await starting
 
       expect(
-        mocks.vueNodesEnabled,
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'the tour only undoes the switch it threw itself'
       ).toBe(true)
     })
 
     it('starts nothing over a tour that is already running', async () => {
-      mocks.engine.activeTour = 'appMode'
+      useOnboardingTourStore().activeTour = 'appMode'
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -343,8 +283,12 @@ describe('useFirstRunTourController', () => {
         await starting,
         'the engine would refuse it anyway, so the side effects must not fire either'
       ).toBe(false)
-      expect(mocks.engine.startTour).not.toHaveBeenCalled()
-      expect(mocks.vueNodesEnabled).toBe(true)
+      expect(
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).not.toHaveBeenCalled()
+      expect(useSettingStore().settingValues['Comfy.VueNodes.Enabled']).toBe(
+        true
+      )
     })
 
     // Holds only ever end a tour that is already running, and only when they
@@ -352,8 +296,8 @@ describe('useFirstRunTourController', () => {
     // refused at the door. Asserted as "nothing opened" rather than as the
     // holds value: with no tour registered there is nothing to hold.
     it('refuses to open over the linear view, which hides the canvas', async () => {
-      mocks.linearMode.value = true
-      mocks.vueNodesEnabled = false
+      useCanvasStore().linearMode = true
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -365,18 +309,18 @@ describe('useFirstRunTourController', () => {
         '?template=X&mode=linear display:none-s the canvas, so every card would point at a node nobody can see'
       ).toBe(false)
       expect(
-        mocks.engine.startTour,
+        vi.mocked(useOnboardingTourStore().startTour),
         'the cards would sit over a hidden canvas until their targets timed out'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.setSetting,
+        vi.mocked(useSettingStore().set),
         'a tour that never opened must not touch the renderer setting at all'
       ).not.toHaveBeenCalledWith('Comfy.VueNodes.Enabled', true)
     })
 
     it('refuses to open on a viewport below the desktop layout', async () => {
       setViewportWidth(500)
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -387,15 +331,17 @@ describe('useFirstRunTourController', () => {
         await starting,
         'the spotlights are placed against a desktop layout, so below md they point nowhere'
       ).toBe(false)
-      expect(mocks.engine.startTour).not.toHaveBeenCalled()
-      expect(mocks.setSetting).not.toHaveBeenCalledWith(
+      expect(
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).not.toHaveBeenCalled()
+      expect(vi.mocked(useSettingStore().set)).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         true
       )
     })
 
     it('refuses to open when the canvas goes away during the intro preview', async () => {
-      mocks.vueNodesEnabled = false
+      useSettingStore().settingValues['Comfy.VueNodes.Enabled'] = false
       mocks.steps = [runStep()]
       const controller = await freshController()
 
@@ -404,16 +350,18 @@ describe('useFirstRunTourController', () => {
       // preview delay rather than while beginTour is still setting up. Only
       // the post-delay re-check can catch it from there.
       await vi.advanceTimersByTimeAsync(0)
-      mocks.linearMode.value = true
+      useCanvasStore().linearMode = true
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
 
       expect(
         await starting,
         'the holds watcher cannot catch this — there is no active tour to end yet'
       ).toBe(false)
-      expect(mocks.engine.startTour).not.toHaveBeenCalled()
       expect(
-        mocks.vueNodesEnabled,
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).not.toHaveBeenCalled()
+      expect(
+        useSettingStore().settingValues['Comfy.VueNodes.Enabled'],
         'the renderer switch thrown for a tour that never opened is handed back'
       ).toBe(false)
     })
@@ -425,20 +373,24 @@ describe('useFirstRunTourController', () => {
 
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS - 1)
       expect(
-        mocks.engine.startTour,
+        vi.mocked(useOnboardingTourStore().startTour),
         'a user who just picked a template deserves a look at it before the scrim'
       ).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(1)
-      expect(mocks.engine.startTour).toHaveBeenCalledWith('firstRun')
+      expect(
+        vi.mocked(useOnboardingTourStore().startTour)
+      ).toHaveBeenCalledWith('firstRun')
     })
 
     it('hands back the canvas targets when the engine turns the start down', async () => {
       mocks.steps = [runStep()]
-      mocks.engine.startTour.mockImplementation(async () => {
-        await resolveRegisteredTour()
-        return false
-      })
+      vi.mocked(useOnboardingTourStore().startTour).mockImplementation(
+        async () => {
+          await resolveRegisteredTour()
+          return false
+        }
+      )
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -694,7 +646,7 @@ describe('useFirstRunTourController', () => {
       await acceptRun(TOUR_WORKFLOW)
       await finishRun(TOUR_WORKFLOW, 'running')
 
-      mocks.executionErrors.hasPromptError = true
+      Object.assign(useExecutionErrorStore(), { hasPromptError: true })
       await removeRun()
 
       expect(
@@ -711,7 +663,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', () => {}).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'a run takes minutes; a tour parked on a button the user already pressed reads as broken'
       ).toHaveBeenCalled()
       expect(mocks.runState.value).toBe('generating')
@@ -719,12 +671,12 @@ describe('useFirstRunTourController', () => {
 
     it('hands the last step to the engine like any other', async () => {
       await tourOnRunStep()
-      mocks.engine.isLast = true
+      Object.assign(useOnboardingTourStore(), { isLast: true })
 
       mountRunButton('queue-button', () => {}).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'ending a tour is the engine’s call; the button only reports the click'
       ).toHaveBeenCalled()
     })
@@ -733,7 +685,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       expect(registeredTourHolds()).toBe(true)
 
-      mocks.activeWorkflow.value = OTHER_WORKFLOW
+      useWorkflowStore().activeWorkflow = OTHER_WORKFLOW
       await nextTick()
 
       expect(
@@ -757,7 +709,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       expect(registeredTourHolds()).toBe(true)
 
-      mocks.linearMode.value = true
+      useCanvasStore().linearMode = true
       await nextTick()
 
       expect(
@@ -768,7 +720,7 @@ describe('useFirstRunTourController', () => {
 
     it('ignores a run that finished for another workflow', async () => {
       await tourOnRunStep()
-      mocks.activeWorkflow.value = OTHER_WORKFLOW
+      useWorkflowStore().activeWorkflow = OTHER_WORKFLOW
 
       await finishRun(OTHER_WORKFLOW, 'failed')
 
@@ -825,7 +777,7 @@ describe('useFirstRunTourController', () => {
       await finishRun(TOUR_WORKFLOW, 'completed')
       expect(mocks.runState.value).toBe('succeeded')
 
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       expect(
@@ -864,7 +816,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
 
-      mocks.executionErrors.hasNodeError = true
+      Object.assign(useExecutionErrorStore(), { hasNodeError: true })
       await nextTick()
 
       expect(
@@ -877,7 +829,7 @@ describe('useFirstRunTourController', () => {
       await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
 
-      mocks.executionErrors.hasPromptError = true
+      Object.assign(useExecutionErrorStore(), { hasPromptError: true })
       await nextTick()
 
       expect(
@@ -889,7 +841,7 @@ describe('useFirstRunTourController', () => {
     it('leaves errors alone until the tour has run something', async () => {
       await tourOnRunStep()
 
-      mocks.executionErrors.hasPromptError = true
+      Object.assign(useExecutionErrorStore(), { hasPromptError: true })
       await nextTick()
 
       expect(
@@ -907,7 +859,7 @@ describe('useFirstRunTourController', () => {
         'a nudge fighting a live tour for the screen helps nobody'
       ).toBe(false)
 
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       expect(controller.nudgeArmed.value).toBe(true)
@@ -918,7 +870,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', () => {}).click()
       await finishRun(TOUR_WORKFLOW, 'failed')
 
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       expect(
@@ -929,7 +881,7 @@ describe('useFirstRunTourController', () => {
 
     it('takes an armed nudge off the screen when a second tour starts', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
       expect(controller.nudgeArmed.value).toBe(true)
 
@@ -981,16 +933,18 @@ describe('useFirstRunTourController', () => {
 
     it('congratulates nobody when the tour never appeared', async () => {
       mocks.steps = []
-      mocks.activeWorkflow.value = TOUR_WORKFLOW
-      mocks.engine.startTour.mockImplementation(async () => {
-        await resolveRegisteredTour()
-        // The store requests the run, resolves no steps and returns to idle, so
-        // nothing ever calls `finish()` and no ending is recorded.
-        mocks.engine.activeTour = 'firstRun'
-        await nextTick()
-        mocks.engine.activeTour = null
-        return false
-      })
+      useWorkflowStore().activeWorkflow = TOUR_WORKFLOW
+      vi.mocked(useOnboardingTourStore().startTour).mockImplementation(
+        async () => {
+          await resolveRegisteredTour()
+          // The store requests the run, resolves no steps and returns to idle, so
+          // nothing ever calls `finish()` and no ending is recorded.
+          useOnboardingTourStore().activeTour = 'firstRun'
+          await nextTick()
+          useOnboardingTourStore().activeTour = null
+          return false
+        }
+      )
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -1010,7 +964,7 @@ describe('useFirstRunTourController', () => {
 
     it('stops offering the nudge once it is waved away', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
+      useOnboardingTourStore().activeTour = null
       await nextTick()
 
       controller.dismissNudge()
@@ -1045,19 +999,21 @@ describe('useFirstRunTourController', () => {
         'opening it here too would replace the button reason with the tour own'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.engine.postpone,
+        vi.mocked(useOnboardingTourStore().postpone),
         'whoever subscribes off the back of this still has their first run ahead of them'
       ).toHaveBeenCalled()
-      expect(mocks.engine.skip).not.toHaveBeenCalled()
+      expect(vi.mocked(useOnboardingTourStore().skip)).not.toHaveBeenCalled()
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'nothing was queued, so there is no result to send the user to'
       ).not.toHaveBeenCalled()
     })
 
     it('keeps parking after the step renames its copy', async () => {
       await tourOnRunStep()
-      mocks.engine.step = { ...runStep(), name: 'run.cloud' }
+      Object.assign(useOnboardingTourStore(), {
+        step: { ...runStep(), name: 'run.cloud' }
+      })
       mocks.canRunWorkflows.value = false
       await nextTick()
       const underlyingHandler = vi.fn()
@@ -1065,19 +1021,21 @@ describe('useFirstRunTourController', () => {
       mountRunButton('subscribe-to-run-button', underlyingHandler).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'a translation key is copy, so renaming it must not walk the tour onto a run that never queued'
       ).not.toHaveBeenCalled()
-      expect(mocks.engine.postpone).toHaveBeenCalled()
+      expect(vi.mocked(useOnboardingTourStore().postpone)).toHaveBeenCalled()
     })
 
     it('leaves the Run button alone on a step the user can walk past', async () => {
       await tourOnRunStep()
-      mocks.engine.step = {
-        kind: 'spotlight',
-        name: 'result.image',
-        placement: 'auto'
-      }
+      Object.assign(useOnboardingTourStore(), {
+        step: {
+          kind: 'spotlight',
+          name: 'result.image',
+          placement: 'auto'
+        }
+      })
       await nextTick()
       const underlyingHandler = vi.fn()
 
@@ -1087,7 +1045,7 @@ describe('useFirstRunTourController', () => {
         underlyingHandler,
         'only the step whose sole way forward is running may intercept the run'
       ).toHaveBeenCalled()
-      expect(mocks.engine.next).not.toHaveBeenCalled()
+      expect(vi.mocked(useOnboardingTourStore().next)).not.toHaveBeenCalled()
     })
 
     it('lets a funded run through untouched', async () => {
@@ -1097,7 +1055,9 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', underlyingHandler).click()
 
       expect(underlyingHandler).toHaveBeenCalled()
-      expect(mocks.engine.postpone).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useOnboardingTourStore().postpone)
+      ).not.toHaveBeenCalled()
     })
 
     it('does not walk the tour on for a run it just refused', async () => {
@@ -1107,7 +1067,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('subscribe-to-run-button', () => {}).click()
 
       expect(
-        mocks.engine.next,
+        vi.mocked(useOnboardingTourStore().next),
         'nothing was queued, so there is no result to send the user to'
       ).not.toHaveBeenCalled()
     })
@@ -1119,7 +1079,7 @@ describe('useFirstRunTourController', () => {
       await nextTick()
 
       expect(
-        mocks.engine.postpone,
+        vi.mocked(useOnboardingTourStore().postpone),
         'the paywall is keyed to the click, so an active tour survives losing eligibility'
       ).not.toHaveBeenCalled()
     })

--- a/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
+++ b/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
@@ -1,3 +1,7 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
 import { render, screen, within } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,14 +20,13 @@ const {
   loadCompositorSession,
   saveLayerState,
   savePreview,
-  session,
-  toastAdd
+  session
 } = vi.hoisted(() => ({
   afterChange: vi.fn(),
   autoSaveStop: vi.fn(),
   beforeChange: vi.fn(),
   loadCompositorSession: vi.fn().mockResolvedValue(0),
-  toastAdd: vi.fn(),
+
   saveLayerState: vi.fn(() => true),
   savePreview: vi.fn().mockResolvedValue(undefined),
   session: {
@@ -74,26 +77,13 @@ vi.mock(
     useCompositorAutoSave: vi.fn(() => ({ stop: autoSaveStop }))
   })
 )
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: { changeTracker: { afterChange, beforeChange } }
-    })
-  })
-)
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
+
 vi.mock(
   import('@/renderer/extensions/compositor/composables/compositorSession'),
   () => ({
     loadCompositorSession
   })
 )
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({ getNodeImageUrls: () => [] })
-}))
 
 const i18n = createI18n({
   legacy: false,
@@ -138,6 +128,14 @@ function findRestoreButton() {
 async function waitForAutoSaveStart() {
   await vi.waitFor(() => expect(useCompositorAutoSave).toHaveBeenCalled())
 }
+
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { afterChange, beforeChange }
+  })
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+  vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([])
+})
 
 describe('LayerEditorContent', () => {
   beforeEach(() => {
@@ -224,7 +222,7 @@ describe('LayerEditorContent', () => {
     renderEditor('compositor')
 
     await vi.waitFor(() =>
-      expect(toastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'warn',
           detail: '2 layers failed to load'
@@ -237,13 +235,13 @@ describe('LayerEditorContent', () => {
   it('warns on close when edits could not be auto-saved', async () => {
     loadCompositorSession.mockResolvedValueOnce(2)
     const { unmount } = renderEditor('compositor')
-    await vi.waitFor(() => expect(toastAdd).toHaveBeenCalled())
+    await vi.waitFor(() => expect(useToastStore().add).toHaveBeenCalled())
     session.editor.history.canUndo.mockReturnValue(true)
 
     unmount()
 
     expect(saveLayerState).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(useToastStore().add).toHaveBeenCalledWith(
       expect.objectContaining({ detail: 'Failed to save composite' })
     )
   })
@@ -253,7 +251,7 @@ describe('LayerEditorContent', () => {
     renderEditor('compositor')
 
     await vi.waitFor(() =>
-      expect(toastAdd).toHaveBeenCalledWith(
+      expect(useToastStore().add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
     )

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
@@ -1,40 +1,37 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useDialogStore } from '@/stores/dialogStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
 import { useLayerEditor } from './useLayerEditor'
 
-const { showDialog, getNodeImageUrls, toastAdd } = vi.hoisted(() => ({
-  showDialog: vi.fn(),
-  getNodeImageUrls: vi.fn(),
-  toastAdd: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog })
-}))
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({ getNodeImageUrls })
-}))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+  vi.mocked(useNodeOutputStore().getNodeImageUrls).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('useLayerEditor', () => {
   it('does nothing without a node', () => {
     useLayerEditor().openLayerEditor(null)
-    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
   })
 
   it('toasts instead of opening when the node has fewer than 2 output images', () => {
     const node = {} as LGraphNode
-    getNodeImageUrls.mockReturnValue(['only-one.png'])
+    vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([
+      'only-one.png'
+    ])
     useLayerEditor().openLayerEditor(node)
-    expect(showDialog).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useDialogStore().showDialog)).not.toHaveBeenCalled()
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'info',
         detail: 'layerEditor.needsTwoImages'
@@ -44,9 +41,12 @@ describe('useLayerEditor', () => {
 
   it('opens the layer editor dialog for a node with multiple images', () => {
     const node = {} as LGraphNode
-    getNodeImageUrls.mockReturnValue(['a.png', 'b.png'])
+    vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue([
+      'a.png',
+      'b.png'
+    ])
     useLayerEditor().openLayerEditor(node)
-    expect(showDialog).toHaveBeenCalledWith(
+    expect(vi.mocked(useDialogStore().showDialog)).toHaveBeenCalledWith(
       expect.objectContaining({
         key: 'global-layer-editor',
         props: { node }

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 import { createApp, defineComponent, ref } from 'vue'
@@ -17,17 +18,14 @@ import type {
 import { useLayerEditorExport } from './useLayerEditorExport'
 import type { LayerEditorSession } from './useLayerEditorSession'
 
-const { writePsd, downloadBlob, toastAdd } = vi.hoisted(() => ({
+const { writePsd, downloadBlob } = vi.hoisted(() => ({
   writePsd: vi.fn((_psd: unknown) => new ArrayBuffer(4)),
-  downloadBlob: vi.fn(),
-  toastAdd: vi.fn()
+  downloadBlob: vi.fn()
 }))
 
 vi.mock(import('ag-psd'), () => ({ writePsd }))
 vi.mock(import('@/base/common/downloadUtil'), () => ({ downloadBlob }))
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: toastAdd })
-}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -173,6 +171,10 @@ function makeSession(nodes: RasterData[], glOk = true): LayerEditorSession {
   } as unknown as LayerEditorSession
 }
 
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
 describe('useLayerEditorExport', () => {
   it('writes a psd matching the layer tree and triggers a download', async () => {
     const session = makeSession([
@@ -206,7 +208,7 @@ describe('useLayerEditorExport', () => {
     expect(blob).toBeInstanceOf(Blob)
     expect(exporting.value).toBe(false)
     expect(session.requestRender).toHaveBeenCalled()
-    expect(toastAdd).not.toHaveBeenCalled()
+    expect(vi.mocked(useToastStore().add)).not.toHaveBeenCalled()
   })
 
   it('shows an error toast when writing fails', async () => {
@@ -219,7 +221,7 @@ describe('useLayerEditorExport', () => {
     await exportPsd()
 
     expect(downloadBlob).not.toHaveBeenCalled()
-    expect(toastAdd).toHaveBeenCalledWith(
+    expect(vi.mocked(useToastStore().add)).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'layerEditor.exportPsdFailed'

--- a/src/renderer/extensions/linearMode/LinearControls.test.ts
+++ b/src/renderer/extensions/linearMode/LinearControls.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen, within } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -114,11 +113,7 @@ function renderControls({
 } = {}) {
   billingMock.canRunWorkflows = canRunWorkflows
 
-  const pinia = createTestingPinia({
-    createSpy: vi.fn,
-    stubActions: false
-  })
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   useAppModeStore().selectedOutputs = [toNodeId(1)]
   if (hasError) {

--- a/src/renderer/extensions/linearMode/LinearWelcome.test.ts
+++ b/src/renderer/extensions/linearMode/LinearWelcome.test.ts
@@ -1,23 +1,10 @@
+import { useAppModeStore } from '@/stores/appModeStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import LinearWelcome from './LinearWelcome.vue'
-
-const { hasNodes, hasOutputs, enterBuilder } = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { ref } = require('vue')
-  return {
-    hasNodes: ref(false),
-    hasOutputs: ref(false),
-    enterBuilder: vi.fn()
-  }
-})
-
-vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
-  useAppMode: () => ({ setMode: vi.fn() })
-}))
 
 vi.mock<unknown>(
   import('@/composables/useWorkflowTemplateSelectorDialog'),
@@ -26,39 +13,26 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    hasNodes,
-    hasOutputs,
-    enterBuilder
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: null
-    })
-  })
-)
-
 const i18n = createI18n({ legacy: false, locale: 'en', missingWarn: false })
 
 function renderComponent(
   opts: { hasNodes?: boolean; hasOutputs?: boolean } = {}
 ) {
-  hasNodes.value = opts.hasNodes ?? false
-  hasOutputs.value = opts.hasOutputs ?? false
+  Object.assign(useAppModeStore(), { hasNodes: opts.hasNodes ?? false })
+  Object.assign(useAppModeStore(), { hasOutputs: opts.hasOutputs ?? false })
   return render(LinearWelcome, {
     global: { plugins: [i18n] }
   })
 }
 
+beforeEach(() => {
+  vi.mocked(useAppModeStore().enterBuilder).mockImplementation(() => undefined)
+})
+
 describe('LinearWelcome', () => {
   beforeEach(() => {
-    hasNodes.value = false
-    hasOutputs.value = false
+    Object.assign(useAppModeStore(), { hasNodes: false })
+    Object.assign(useAppModeStore(), { hasOutputs: false })
   })
 
   it('shows empty workflow text when there are no nodes', () => {
@@ -83,6 +57,6 @@ describe('LinearWelcome', () => {
     const user = userEvent.setup()
     renderComponent({ hasNodes: true, hasOutputs: false })
     await user.click(screen.getByTestId('linear-welcome-build-app'))
-    expect(enterBuilder).toHaveBeenCalled()
+    expect(useAppModeStore().enterBuilder).toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/linearMode/OutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistory.test.ts
@@ -1,3 +1,7 @@
+import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useQueueStore } from '@/stores/queueStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import type { RenderResult } from '@testing-library/vue'
@@ -21,29 +25,13 @@ const mediaRef = ref<AssetItem[]>([])
 const hasMoreRef = ref(false)
 const loadMoreFn = vi.fn()
 
-const selectedIdRef = ref<string | null>(null)
-const activeWorkflowInProgressItemsRef = ref<InProgressItem[]>([])
-
-const activeWorkflowPathRef = ref<string | undefined>('workflows/test.json')
-const hasOutputsRef = ref(false)
-
-const runningTasksRef = ref<Array<{ jobId: string }>>([])
-const pendingTasksRef = ref<Array<{ jobId: string }>>([])
-
 const selectFirstHistoryFn = vi.fn(() => {
   const first = mediaRef.value.at(0)
-  selectedIdRef.value = first ? `history:${first.id}:0` : null
+  useLinearOutputStore().selectedId = first ? `history:${first.id}:0` : null
 })
 const mayBeActiveWorkflowPendingRef = ref(false)
 
 const allOutputsFn = vi.fn((): AugmentedResultItem[] => [])
-
-const selectFn = vi.fn((id: string | null) => {
-  selectedIdRef.value = id
-})
-const selectAsLatestFn = vi.fn((id: string | null) => {
-  selectedIdRef.value = id
-})
 
 vi.mock<unknown>(import('@/lib/litegraph/src/CanvasPointer'), () => ({
   CanvasPointer: class {
@@ -69,55 +57,6 @@ vi.mock(import('@/renderer/extensions/linearMode/useOutputHistory'), () => ({
       mayBeActiveWorkflowPendingRef as ComputedRef<boolean>,
     isWorkflowActive: computed(() => false),
     cancelActiveWorkflowJobs: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/extensions/linearMode/linearOutputStore'),
-  () => ({
-    useLinearOutputStore: () => ({
-      get activeWorkflowInProgressItems() {
-        return activeWorkflowInProgressItemsRef.value
-      },
-      get selectedId() {
-        return selectedIdRef.value
-      },
-      set selectedId(v: string | null) {
-        selectedIdRef.value = v
-      },
-      select: selectFn,
-      selectAsLatest: selectAsLatestFn
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return activeWorkflowPathRef.value
-          ? { path: activeWorkflowPathRef.value }
-          : undefined
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    hasOutputs: hasOutputsRef
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    get runningTasks() {
-      return runningTasksRef.value
-    },
-    get pendingTasks() {
-      return pendingTasksRef.value
-    }
   })
 }))
 
@@ -206,12 +145,14 @@ describe('OutputHistory', () => {
   beforeEach(() => {
     mediaRef.value = []
     hasMoreRef.value = false
-    selectedIdRef.value = null
-    activeWorkflowInProgressItemsRef.value = []
-    activeWorkflowPathRef.value = 'workflows/test.json'
-    hasOutputsRef.value = false
-    runningTasksRef.value = []
-    pendingTasksRef.value = []
+    useLinearOutputStore().selectedId = null
+    Object.assign(useLinearOutputStore(), { activeWorkflowInProgressItems: [] })
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/test.json'
+    })
+    Object.assign(useAppModeStore(), { hasOutputs: false })
+    useQueueStore().runningTasks = []
+    useQueueStore().pendingTasks = []
     mayBeActiveWorkflowPendingRef.value = false
     allOutputsFn.mockReturnValue([])
   })
@@ -254,11 +195,11 @@ describe('OutputHistory', () => {
     })
 
     it('renders queue badge when queueCount > 1 and has active content', async () => {
-      runningTasksRef.value = [{ jobId: 'j1' }]
-      pendingTasksRef.value = [{ jobId: 'j2' }]
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'j1' }])
+      useQueueStore().pendingTasks = fromPartial([{ jobId: 'j2' }])
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
@@ -274,9 +215,9 @@ describe('OutputHistory', () => {
     })
 
     it('renders preview item for skeleton in-progress items', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
@@ -286,9 +227,11 @@ describe('OutputHistory', () => {
 
     it('renders history item for image in-progress items with output prop', async () => {
       const output = makeResult('out.png')
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'image', { output })
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          makeInProgressItem('ip1', 'image', { output })
+        ]
+      })
 
       mountComponent()
       await nextTick()
@@ -299,9 +242,9 @@ describe('OutputHistory', () => {
     })
 
     it('renders both active and history content when both exist', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('a1.png')])
 
@@ -328,9 +271,13 @@ describe('OutputHistory', () => {
       await userEvent.click(items[0])
       await nextTick()
 
-      expect(selectedIdRef.value).toBe('history:a1:0')
-      expect(selectFn).toHaveBeenCalledWith('history:a1:0')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenCalledWith(
+        'history:a1:0'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('history:a1:0')
       expect(lastEmission(result)).toMatchObject({
         asset,
         output: expect.objectContaining({ filename: 'a1.png' }),
@@ -341,9 +288,9 @@ describe('OutputHistory', () => {
     })
 
     it('selects in-progress item on click', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
@@ -353,9 +300,13 @@ describe('OutputHistory', () => {
 
       vi.clearAllMocks()
       await userEvent.click(slots[0])
-      expect(selectedIdRef.value).toBe('slot:ip1')
-      expect(selectFn).toHaveBeenCalledWith('slot:ip1')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('slot:ip1')
+      expect(useLinearOutputStore().selectedId).toBe('slot:ip1')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenCalledWith(
+        'slot:ip1'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('slot:ip1')
     })
 
     it('marks unselected items with tabindex=-1', async () => {
@@ -363,7 +314,7 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
 
       mountComponent()
       await nextTick()
@@ -378,7 +329,7 @@ describe('OutputHistory', () => {
 
     it('selects pending slot on click', async () => {
       mayBeActiveWorkflowPendingRef.value = true
-      runningTasksRef.value = [{ jobId: 'j1' }]
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'j1' }])
 
       mountComponent()
       await nextTick()
@@ -386,13 +337,13 @@ describe('OutputHistory', () => {
       const pendingPreview = screen.getByTestId('output-preview-item')
 
       await userEvent.click(pendingPreview)
-      expect(selectedIdRef.value).toBe('slot:pending')
+      expect(useLinearOutputStore().selectedId).toBe('slot:pending')
     })
   })
 
   describe('emit updateSelection', () => {
     it('emits canShowPreview:true when no selection', async () => {
-      selectedIdRef.value = null
+      useLinearOutputStore().selectedId = null
 
       const result = mountComponent()
       await nextTick()
@@ -401,10 +352,10 @@ describe('OutputHistory', () => {
     })
 
     it('emits showSkeleton for in-progress skeleton item', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       const result = mountComponent()
       await nextTick()
@@ -417,12 +368,14 @@ describe('OutputHistory', () => {
     })
 
     it('emits latentPreviewUrl for in-progress latent item', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'latent', {
-          latentPreviewUrl: 'blob:preview'
-        })
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          makeInProgressItem('ip1', 'latent', {
+            latentPreviewUrl: 'blob:preview'
+          })
+        ]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       const result = mountComponent()
       await nextTick()
@@ -436,10 +389,12 @@ describe('OutputHistory', () => {
 
     it('emits output for in-progress image item', async () => {
       const output = makeResult('out.png')
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'image', { output })
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          makeInProgressItem('ip1', 'image', { output })
+        ]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       const result = mountComponent()
       await nextTick()
@@ -456,12 +411,12 @@ describe('OutputHistory', () => {
       const output = makeResult('a1.png')
       mediaRef.value = [asset]
       allOutputsFn.mockReturnValue([output])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       const rendered = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
       await nextTick()
 
@@ -478,12 +433,12 @@ describe('OutputHistory', () => {
       const secondOutput = makeResult('second.png')
       mediaRef.value = [asset]
       allOutputsFn.mockReturnValue([firstOutput, secondOutput])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       const result = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'history:a1:1'
+      useLinearOutputStore().selectedId = 'history:a1:1'
       await nextTick()
       await nextTick()
 
@@ -499,12 +454,12 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       const result = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'history:a2:0'
+      useLinearOutputStore().selectedId = 'history:a2:0'
       await nextTick()
       await nextTick()
 
@@ -513,12 +468,12 @@ describe('OutputHistory', () => {
 
     it('emits skeleton for pending slot selection', async () => {
       mayBeActiveWorkflowPendingRef.value = true
-      runningTasksRef.value = [{ jobId: 'j1' }]
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'j1' }])
 
       const result = mountComponent()
       await nextTick()
 
-      selectedIdRef.value = 'slot:pending'
+      useLinearOutputStore().selectedId = 'slot:pending'
       await nextTick()
       await nextTick()
 
@@ -531,39 +486,43 @@ describe('OutputHistory', () => {
 
   describe('workflow tab switch', () => {
     it('selects first in-progress item on mount', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
 
       mountComponent()
       await nextTick()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith('slot:ip1')
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith('slot:ip1')
     })
 
     it('selects first history when no in-progress but outputs exist', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('a1.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
 
       expect(selectFirstHistoryFn).toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('clears selection when no outputs and no in-progress', async () => {
       mountComponent()
       await nextTick()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith(null)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith(null)
     })
 
     it('reselects when workflow path changes after mount', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('a1.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
@@ -571,11 +530,13 @@ describe('OutputHistory', () => {
       vi.clearAllMocks()
 
       // Simulate workflow tab switch
-      activeWorkflowPathRef.value = 'workflows/other.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/other.json'
+      })
       await nextTick()
 
       expect(selectFirstHistoryFn).toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('does not reselect when path becomes falsy', async () => {
@@ -584,20 +545,22 @@ describe('OutputHistory', () => {
 
       vi.clearAllMocks()
 
-      activeWorkflowPathRef.value = undefined
+      useWorkflowStore().activeWorkflow = null
       await nextTick()
 
-      expect(selectAsLatestFn).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalled()
       expect(selectFirstHistoryFn).not.toHaveBeenCalled()
     })
   })
 
   describe('media change watcher', () => {
     it('does not reselect when selection is a slot item', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
-      selectedIdRef.value = 'slot:ip1'
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
+      useLinearOutputStore().selectedId = 'slot:ip1'
 
       mountComponent()
       await nextTick()
@@ -618,11 +581,11 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
 
       vi.clearAllMocks()
@@ -638,11 +601,11 @@ describe('OutputHistory', () => {
       const oldFirst = makeAsset('old-first')
       mediaRef.value = [oldFirst]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:old-first:0'
+      useLinearOutputStore().selectedId = 'history:old-first:0'
       await nextTick()
 
       vi.clearAllMocks()
@@ -651,7 +614,7 @@ describe('OutputHistory', () => {
       await nextTick()
 
       expect(selectFirstHistoryFn).toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:new-first:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:new-first:0')
     })
 
     it('keeps older history selection stable when new assets arrive', async () => {
@@ -659,11 +622,11 @@ describe('OutputHistory', () => {
       const selectedOlder = makeAsset('selected-older')
       mediaRef.value = [currentFirst, selectedOlder]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:selected-older:0'
+      useLinearOutputStore().selectedId = 'history:selected-older:0'
       await nextTick()
 
       vi.clearAllMocks()
@@ -672,7 +635,7 @@ describe('OutputHistory', () => {
       await nextTick()
 
       expect(selectFirstHistoryFn).not.toHaveBeenCalled()
-      expect(selectedIdRef.value).toBe('history:selected-older:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:selected-older:0')
     })
   })
 
@@ -688,63 +651,71 @@ describe('OutputHistory', () => {
       const a2 = makeAsset('a2')
       mediaRef.value = [a1, a2]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
 
       // Set selection after mount (mount watcher may reset it)
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a2:0')
-      expect(selectFn).toHaveBeenLastCalledWith('history:a2:0')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('history:a2:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a2:0')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenLastCalledWith(
+        'history:a2:0'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('history:a2:0')
 
       pressKey('ArrowLeft')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
-      expect(selectFn).toHaveBeenLastCalledWith('history:a1:0')
-      expect(selectAsLatestFn).not.toHaveBeenCalledWith('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
+      expect(vi.mocked(useLinearOutputStore().select)).toHaveBeenLastCalledWith(
+        'history:a1:0'
+      )
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalledWith('history:a1:0')
 
       pressKey('ArrowDown')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a2:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a2:0')
 
       pressKey('ArrowUp')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('clamps to first and last items', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       await nextTick()
 
       pressKey('ArrowLeft')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('ignores key events from input elements', async () => {
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
-      hasOutputsRef.value = true
+      Object.assign(useAppModeStore(), { hasOutputs: true })
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = 'history:a1:0'
+      useLinearOutputStore().selectedId = 'history:a1:0'
       vi.clearAllMocks()
       await nextTick()
 
@@ -758,14 +729,14 @@ describe('OutputHistory', () => {
       )
       await nextTick()
 
-      expect(selectFn).not.toHaveBeenCalled()
+      expect(vi.mocked(useLinearOutputStore().select)).not.toHaveBeenCalled()
       document.body.removeChild(input)
     })
 
     it('navigates across in-progress and history items', async () => {
-      activeWorkflowInProgressItemsRef.value = [
-        makeInProgressItem('ip1', 'skeleton')
-      ]
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [makeInProgressItem('ip1', 'skeleton')]
+      })
       mediaRef.value = [makeAsset('a1')]
       allOutputsFn.mockReturnValue([makeResult('out.png')])
 
@@ -773,11 +744,11 @@ describe('OutputHistory', () => {
       await nextTick()
 
       // Mount watcher selects the in-progress item
-      expect(selectedIdRef.value).toBe('slot:ip1')
+      expect(useLinearOutputStore().selectedId).toBe('slot:ip1')
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
 
     it('selects first item when no current selection', async () => {
@@ -786,12 +757,12 @@ describe('OutputHistory', () => {
 
       mountComponent()
       await nextTick()
-      selectedIdRef.value = null
+      useLinearOutputStore().selectedId = null
       await nextTick()
 
       pressKey('ArrowRight')
       await nextTick()
-      expect(selectedIdRef.value).toBe('history:a1:0')
+      expect(useLinearOutputStore().selectedId).toBe('history:a1:0')
     })
   })
 })

--- a/src/renderer/extensions/linearMode/OutputHistoryActiveQueueItem.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistoryActiveQueueItem.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { useCommandStore } from '@/stores/commandStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { render, screen } from '@testing-library/vue'
@@ -8,15 +7,8 @@ import { render, screen } from '@testing-library/vue'
 import OutputHistoryActiveQueueItem from './OutputHistoryActiveQueueItem.vue'
 
 const i18n = createI18n({ legacy: false, locale: 'en' })
-setActivePinia(createTestingPinia({ stubActions: false }))
 
 vi.mock(import('@/platform/assets/composables/media/assetMappers'))
-
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: () => ({
-    execute: vi.fn()
-  })
-}))
 
 function renderComponent(queueCount: number) {
   return render(OutputHistoryActiveQueueItem, {
@@ -24,6 +16,10 @@ function renderComponent(queueCount: number) {
     global: { plugins: [i18n] }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+})
 
 describe('OutputHistoryActiveQueueItem', () => {
   it('hides badge when queueCount is 1', () => {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -1,15 +1,16 @@
+import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useJobPreviewStore } from '@/stores/jobPreviewStore'
+import { toNodeId } from '@/types/nodeId'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 
-const activeJobIdRef = ref<string | null>(null)
-const previewsRef = ref<Record<string, { url: string; nodeId?: string }>>({})
 const isAppModeRef = ref(true)
-const activeWorkflowPathRef = ref<string>('workflows/test-workflow.json')
-const jobIdToWorkflowPathRef = ref(new Map<string, string>())
-const selectedOutputsRef = ref<string[]>([])
 
 const { apiTarget } = vi.hoisted(() => ({
   apiTarget: new EventTarget()
@@ -19,45 +20,8 @@ vi.mock(import('@/platform/assets/composables/media/assetMappers'))
 
 vi.mock<unknown>(import('@/composables/useAppMode'), () => ({
   useAppMode: () => ({
-    isAppMode: isAppModeRef
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({
-    get selectedOutputs() {
-      return selectedOutputsRef.value
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    get activeJobId() {
-      return activeJobIdRef.value
-    },
-    get jobIdToSessionWorkflowPath() {
-      return jobIdToWorkflowPathRef.value
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return { path: activeWorkflowPathRef.value }
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/jobPreviewStore'), () => ({
-  useJobPreviewStore: () => ({
-    get nodePreviewsByPromptId() {
-      return previewsRef.value
-    }
+    isAppMode: isAppModeRef,
+    isBuilderMode: ref(false)
   })
 }))
 
@@ -68,9 +32,9 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 }))
 
 function setJobWorkflowPath(jobId: string, path: string) {
-  const next = new Map(jobIdToWorkflowPathRef.value)
+  const next = new Map(useExecutionStore().jobIdToSessionWorkflowPath)
   next.set(jobId, path)
-  jobIdToWorkflowPathRef.value = next
+  useExecutionStore().jobIdToSessionWorkflowPath = next
 }
 
 function makeExecutedDetail(
@@ -90,12 +54,14 @@ function makeExecutedDetail(
 
 describe('linearOutputStore', () => {
   beforeEach(() => {
-    activeJobIdRef.value = null
-    previewsRef.value = {}
+    useExecutionStore().activeJobId = null
+    useJobPreviewStore().clearAllPreviews()
     isAppModeRef.value = true
-    activeWorkflowPathRef.value = 'workflows/test-workflow.json'
-    jobIdToWorkflowPathRef.value = new Map()
-    selectedOutputsRef.value = []
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/test-workflow.json'
+    })
+    useExecutionStore().jobIdToSessionWorkflowPath = new Map()
+    useAppModeStore().selectedOutputs = []
   })
 
   it('creates a skeleton item when a job starts', () => {
@@ -346,16 +312,14 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     expect(store.inProgressItems).toHaveLength(1)
     expect(store.inProgressItems[0].state).toBe('skeleton')
 
     // Simulate jobPreviewStore update
-    previewsRef.value = {
-      'job-1': { url: 'blob:preview-1', nodeId: 'node-1' }
-    }
+    useJobPreviewStore().setPreviewUrl('job-1', 'blob:preview-1', 'node-1')
     await nextTick()
     vi.advanceTimersByTime(16)
 
@@ -368,14 +332,14 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
 
     // Direct transition: job-1 → job-2 (no null in between)
     setJobWorkflowPath('job-2', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-2'
+    useExecutionStore().activeJobId = 'job-2'
     await nextTick()
 
     // job-1 should have been completed
@@ -624,7 +588,7 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
@@ -632,7 +596,7 @@ describe('linearOutputStore', () => {
     // Switch away — job finishes while we're gone
     isAppModeRef.value = false
     await nextTick()
-    activeJobIdRef.value = null
+    useExecutionStore().activeJobId = null
     await nextTick()
 
     // Switch back — store should reconcile the stale tracked job
@@ -647,7 +611,7 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     // First node executes, consuming the skeleton
@@ -657,9 +621,11 @@ describe('linearOutputStore', () => {
     // Switch away — latent preview arrives for next node while gone
     isAppModeRef.value = false
     await nextTick()
-    previewsRef.value = {
-      'job-1': { url: 'blob:preview-while-away', nodeId: 'node-2' }
-    }
+    useJobPreviewStore().setPreviewUrl(
+      'job-1',
+      'blob:preview-while-away',
+      'node-2'
+    )
     await nextTick()
 
     // Switch back — should recover the latent preview
@@ -678,16 +644,22 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     // Job-1 submitted from workflow-a
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     setJobWorkflowPath('job-1', 'workflows/app-a.json')
     store.onJobStart('job-1')
 
     // User switches to workflow-b: job-1 should NOT appear
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
     expect(store.activeWorkflowInProgressItems).toHaveLength(0)
 
     // Back on workflow-a: job-1 should appear
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     expect(store.activeWorkflowInProgressItems).toHaveLength(1)
     expect(store.activeWorkflowInProgressItems[0].jobId).toBe('job-1')
   })
@@ -700,7 +672,9 @@ describe('linearOutputStore', () => {
     setJobWorkflowPath('job-2', 'workflows/app-a.json')
 
     // User switches to workflow-b before execution starts
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
 
     store.onJobStart('job-1')
     store.onJobStart('job-2')
@@ -709,7 +683,9 @@ describe('linearOutputStore', () => {
     expect(store.activeWorkflowInProgressItems).toHaveLength(0)
 
     // On workflow-a: both jobs should appear
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     expect(store.activeWorkflowInProgressItems).toHaveLength(2)
   })
 
@@ -717,14 +693,18 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     // Job-1 on workflow-a (dog)
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     setJobWorkflowPath('job-1', 'workflows/app-a.json')
     store.onJobStart('job-1')
     store.onLatentPreview('job-1', 'blob:dog')
     vi.advanceTimersByTime(16)
 
     // User switches to workflow-b, runs job-2
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
     setJobWorkflowPath('job-2', 'workflows/app-b.json')
 
     // Job-1 finishes, job-2 starts
@@ -741,7 +721,7 @@ describe('linearOutputStore', () => {
   })
 
   it('skips output items for nodes not in selectedOutputs', () => {
-    selectedOutputsRef.value = ['2']
+    useAppModeStore().selectedOutputs = [toNodeId('2')]
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
 
@@ -772,7 +752,9 @@ describe('linearOutputStore', () => {
     const store = useLinearOutputStore()
 
     // User is on workflow-b, following latest
-    activeWorkflowPathRef.value = 'workflows/app-b.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-b.json'
+    })
     store.selectAsLatest('history:asset-b:0')
 
     // Job from workflow-a starts
@@ -786,7 +768,9 @@ describe('linearOutputStore', () => {
   it('auto-selects for jobs belonging to the active workflow', () => {
     const store = useLinearOutputStore()
 
-    activeWorkflowPathRef.value = 'workflows/app-a.json'
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/app-a.json'
+    })
     store.selectAsLatest('history:asset-a:0')
 
     setJobWorkflowPath('job-1', 'workflows/app-a.json')
@@ -804,7 +788,7 @@ describe('linearOutputStore', () => {
     await nextTick()
 
     // Watcher-driven job start should be ignored
-    activeJobIdRef.value = 'job-1'
+    useExecutionStore().activeJobId = 'job-1'
     await nextTick()
 
     expect(store.inProgressItems).toHaveLength(0)
@@ -821,9 +805,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start job, produce 1 image + 1 latent
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -840,7 +826,9 @@ describe('linearOutputStore', () => {
       expect(latentsBefore).toHaveLength(1)
 
       // Switch to workflow B (graph mode)
-      activeWorkflowPathRef.value = 'workflows/graph-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/graph-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
 
@@ -853,7 +841,9 @@ describe('linearOutputStore', () => {
       )
 
       // Switch back to workflow A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = true
       await nextTick()
       vi.advanceTimersByTime(16)
@@ -869,9 +859,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start job, produce 1 image
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -880,19 +872,21 @@ describe('linearOutputStore', () => {
       ).toHaveLength(1)
 
       // Switch away
-      activeWorkflowPathRef.value = 'workflows/graph-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/graph-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
 
       // While away: node 2 executes (event missed — listener removed)
       // Node 3 starts sending latent previews (watcher guarded)
-      previewsRef.value = {
-        'job-a': { url: 'blob:node3-latent', nodeId: '3' }
-      }
+      useJobPreviewStore().setPreviewUrl('job-a', 'blob:node3-latent', '3')
       await nextTick()
 
       // Switch back
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = true
       await nextTick()
       vi.advanceTimersByTime(16)
@@ -913,21 +907,27 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start job
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Switch to workflow B
-      activeWorkflowPathRef.value = 'workflows/app-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-b.json'
+      })
 
       // Workflow A items should NOT appear for workflow B
       expect(store.activeWorkflowInProgressItems).toHaveLength(0)
 
       // Switch back to workflow A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
 
       // Workflow A items should reappear
       expect(store.activeWorkflowInProgressItems).toHaveLength(1)
@@ -939,25 +939,31 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: start and partially generate
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Switch to workflow B (graph mode)
-      activeWorkflowPathRef.value = 'workflows/graph-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/graph-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
 
       // While away: job A finishes, job B starts
       setJobWorkflowPath('job-b', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-b'
+      useExecutionStore().activeJobId = 'job-b'
       await nextTick()
 
       // Switch back to workflow A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = true
       await nextTick()
 
@@ -971,9 +977,11 @@ describe('linearOutputStore', () => {
     it('handles job finishing while away with no new job', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -983,7 +991,7 @@ describe('linearOutputStore', () => {
       await nextTick()
 
       // Job finishes, no new job
-      activeJobIdRef.value = null
+      useExecutionStore().activeJobId = null
       await nextTick()
 
       // Switch back
@@ -1002,9 +1010,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Workflow A: two images
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -1023,7 +1033,9 @@ describe('linearOutputStore', () => {
       ).toHaveLength(2)
 
       // Switch to workflow B (also app mode)
-      activeWorkflowPathRef.value = 'workflows/app-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-b.json'
+      })
 
       // Workflow B should see nothing from job-a
       expect(store.activeWorkflowInProgressItems).toHaveLength(0)
@@ -1037,9 +1049,11 @@ describe('linearOutputStore', () => {
     it('cleans up stale tracked job when leaving app mode after job finishes', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -1050,7 +1064,7 @@ describe('linearOutputStore', () => {
 
       // Now switch away — pendingResolve items stay (still-running case
       // doesn't apply, but items are kept for history absorption)
-      activeJobIdRef.value = null
+      useExecutionStore().activeJobId = null
       isAppModeRef.value = false
       await nextTick()
 
@@ -1084,16 +1098,18 @@ describe('linearOutputStore', () => {
     it('cleans up finished tracked job on exit when job ended while in app mode', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
 
       // Job ends, new job starts — all while in app mode
       setJobWorkflowPath('job-b', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-b'
+      useExecutionStore().activeJobId = 'job-b'
       await nextTick()
 
       // job-a completed via activeJobId watcher, now pending resolve
@@ -1130,9 +1146,11 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Tab A: queue "cat"
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-cat', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-cat'
+      useExecutionStore().activeJobId = 'job-cat'
       await nextTick()
 
       store.onNodeExecuted(
@@ -1143,14 +1161,16 @@ describe('linearOutputStore', () => {
       expect(store.activeWorkflowInProgressItems[0].jobId).toBe('job-cat')
 
       // Switch to tab B (different workflow, also app mode): queue "dog"
-      activeWorkflowPathRef.value = 'workflows/app-b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-b.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
       await nextTick()
 
       setJobWorkflowPath('job-dog', 'workflows/app-b.json')
-      activeJobIdRef.value = 'job-dog'
+      useExecutionStore().activeJobId = 'job-dog'
       await nextTick()
 
       // Tab B should see dog, not cat
@@ -1159,7 +1179,9 @@ describe('linearOutputStore', () => {
       ).toBe(true)
 
       // Switch back to tab A
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
@@ -1177,9 +1199,7 @@ describe('linearOutputStore', () => {
       apiTarget.dispatchEvent(event)
 
       // Dog's latent preview also arrives
-      previewsRef.value = {
-        'job-dog': { url: 'blob:dog-latent', nodeId: '2' }
-      }
+      useJobPreviewStore().setPreviewUrl('job-dog', 'blob:dog-latent', '2')
       await nextTick()
       vi.advanceTimersByTime(16)
 
@@ -1201,13 +1221,17 @@ describe('linearOutputStore', () => {
       const { store, nextTick } = await setup()
 
       // Run dog on dog tab
-      activeWorkflowPathRef.value = 'workflows/dog.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/dog.json'
+      })
       setJobWorkflowPath('job-dog', 'workflows/dog.json')
-      activeJobIdRef.value = 'job-dog'
+      useExecutionStore().activeJobId = 'job-dog'
       await nextTick()
 
       // Swap to cat tab, queue cat (dog still running)
-      activeWorkflowPathRef.value = 'workflows/cat.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/cat.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
@@ -1215,14 +1239,16 @@ describe('linearOutputStore', () => {
       setJobWorkflowPath('job-cat', 'workflows/cat.json')
 
       // Swap back to dog tab
-      activeWorkflowPathRef.value = 'workflows/dog.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/dog.json'
+      })
       isAppModeRef.value = false
       await nextTick()
       isAppModeRef.value = true
       await nextTick()
 
       // Dog finishes, cat starts (activeJobId transitions on dog tab)
-      activeJobIdRef.value = 'job-cat'
+      useExecutionStore().activeJobId = 'job-cat'
       await nextTick()
 
       // Dog tab must NOT show cat's skeleton
@@ -1238,9 +1264,11 @@ describe('linearOutputStore', () => {
     it('processes new executed events after switching back', async () => {
       const { store, nextTick } = await setup()
 
-      activeWorkflowPathRef.value = 'workflows/app-a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/app-a.json'
+      })
       setJobWorkflowPath('job-a', 'workflows/app-a.json')
-      activeJobIdRef.value = 'job-a'
+      useExecutionStore().activeJobId = 'job-a'
       await nextTick()
 
       store.onNodeExecuted('job-a', makeExecutedDetail('job-a', undefined, '1'))
@@ -1273,7 +1301,7 @@ describe('linearOutputStore', () => {
       const store = useLinearOutputStore()
 
       // activeJobId set before path mapping exists (WebSocket race)
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       // No skeleton yet — path mapping is missing
@@ -1293,7 +1321,7 @@ describe('linearOutputStore', () => {
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
 
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
@@ -1314,7 +1342,7 @@ describe('linearOutputStore', () => {
 
       // Path mapping set before activeJobId (normal case, no race)
       setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       expect(store.inProgressItems).toHaveLength(1)
@@ -1330,11 +1358,11 @@ describe('linearOutputStore', () => {
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
 
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       // Job changes before path mapping arrives
-      activeJobIdRef.value = null
+      useExecutionStore().activeJobId = null
       await nextTick()
 
       setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
@@ -1348,7 +1376,7 @@ describe('linearOutputStore', () => {
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
 
-      activeJobIdRef.value = 'job-1'
+      useExecutionStore().activeJobId = 'job-1'
       await nextTick()
 
       // Path maps to a different workflow than the active one

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -1,29 +1,18 @@
+import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useQueueStore } from '@/stores/queueStore'
+import { useAssetsStore } from '@/stores/assetsStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, toValue, ref } from 'vue'
+import { nextTick, toValue } from 'vue'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import type { InProgressItem } from '@/renderer/extensions/linearMode/linearModeTypes'
 import { useOutputHistory } from '@/renderer/extensions/linearMode/useOutputHistory'
 import { useAppModeStore } from '@/stores/appModeStore'
 import type { AugmentedResultItem } from '@/utils/resultItem'
 import { toNodeId } from '@/types/nodeId'
-
-const mediaRef = ref<AssetItem[]>([])
-const pendingResolveRef = ref(new Set<string>())
-const inProgressItemsRef = ref<InProgressItem[]>([])
-const activeWorkflowInProgressItemsRef = ref<InProgressItem[]>([])
-const selectedIdRef = ref<string | null>(null)
-const activeWorkflowPathRef = ref<string>('workflows/test.json')
-const jobIdToPathRef = ref(new Map<string, string>())
-const isActiveWorkflowRunningRef = ref(false)
-const runningTasksRef = ref<Array<{ jobId: string }>>([])
-const pendingTasksRef = ref<Array<{ jobId: string }>>([])
-
-const selectAsLatestFn = vi.fn()
-const resolveIfReadyFn = vi.fn()
-const resolvedOutputsCacheRef = new Map<string, AugmentedResultItem[]>()
 
 vi.mock(import('@/platform/assets/composables/media/assetMappers'), () => ({
   getAssetType: (tags?: string[]) =>
@@ -31,75 +20,6 @@ vi.mock(import('@/platform/assets/composables/media/assetMappers'), () => ({
   mapInputFileToAssetItem: vi.fn(),
   mapTaskOutputToAssetItem: vi.fn(),
   unflattenOutputAssets: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    outputAssets: {
-      hasMore: ref(false),
-      invalidate: vi.fn(),
-      isLoading: ref(false),
-      items: mediaRef,
-      loadMore: vi.fn(),
-      loadNew: vi.fn()
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/extensions/linearMode/linearOutputStore'),
-  () => ({
-    useLinearOutputStore: () => ({
-      get pendingResolve() {
-        return pendingResolveRef.value
-      },
-      get inProgressItems() {
-        return inProgressItemsRef.value
-      },
-      get activeWorkflowInProgressItems() {
-        return activeWorkflowInProgressItemsRef.value
-      },
-      get selectedId() {
-        return selectedIdRef.value
-      },
-      resolvedOutputsCache: resolvedOutputsCacheRef,
-      selectAsLatest: selectAsLatestFn,
-      resolveIfReady: resolveIfReadyFn
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return { path: activeWorkflowPathRef.value }
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    get jobIdToSessionWorkflowPath() {
-      return jobIdToPathRef.value
-    },
-    get isActiveWorkflowRunning() {
-      return isActiveWorkflowRunningRef.value
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: () => ({
-    get runningTasks() {
-      return runningTasksRef.value
-    },
-    get pendingTasks() {
-      return pendingTasksRef.value
-    }
-  })
 }))
 
 const { jobDetailResults } = vi.hoisted(() => ({
@@ -146,29 +66,47 @@ function makeResult(
   }
 }
 
+beforeEach(() => {
+  useAssetsStore().outputAssets.hasMore = false
+  vi.spyOn(useAssetsStore().outputAssets, 'loadMore').mockResolvedValue(
+    undefined
+  )
+  vi.mocked(useLinearOutputStore().selectAsLatest).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useLinearOutputStore().resolveIfReady).mockImplementation(
+    () => undefined
+  )
+})
+
 describe(useOutputHistory, () => {
   beforeEach(() => {
-    mediaRef.value = []
-    pendingResolveRef.value = new Set()
-    inProgressItemsRef.value = []
-    activeWorkflowInProgressItemsRef.value = []
-    selectedIdRef.value = null
-    activeWorkflowPathRef.value = 'workflows/test.json'
-    jobIdToPathRef.value = new Map()
-    isActiveWorkflowRunningRef.value = false
-    runningTasksRef.value = []
-    pendingTasksRef.value = []
-    resolvedOutputsCacheRef.clear()
+    useAssetsStore().outputAssets.items = []
+    useLinearOutputStore().pendingResolve = new Set()
+    useLinearOutputStore().inProgressItems = []
+    Object.assign(useLinearOutputStore(), { activeWorkflowInProgressItems: [] })
+    useLinearOutputStore().selectedId = null
+    useWorkflowStore().activeWorkflow = fromPartial({
+      path: 'workflows/test.json'
+    })
+    useExecutionStore().jobIdToSessionWorkflowPath = new Map()
+    Object.assign(useExecutionStore(), { isActiveWorkflowRunning: false })
+    useQueueStore().runningTasks = []
+    useQueueStore().pendingTasks = []
+    useLinearOutputStore().resolvedOutputsCache.clear()
     jobDetailResults.clear()
   })
 
   describe('sessionMedia filtering', () => {
     it('filters assets to match active workflow path', () => {
-      jobIdToPathRef.value = new Map([
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
         ['job-1', 'workflows/test.json'],
         ['job-2', 'workflows/other.json']
       ])
-      mediaRef.value = [makeAsset('a1', 'job-1'), makeAsset('a2', 'job-2')]
+      useAssetsStore().outputAssets.items = [
+        makeAsset('a1', 'job-1'),
+        makeAsset('a2', 'job-2')
+      ]
 
       const { outputs } = useOutputHistory()
 
@@ -177,9 +115,11 @@ describe(useOutputHistory, () => {
     })
 
     it('returns empty when no workflow is active', () => {
-      activeWorkflowPathRef.value = ''
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      mediaRef.value = [makeAsset('a1', 'job-1')]
+      useWorkflowStore().activeWorkflow = fromPartial({ path: '' })
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useAssetsStore().outputAssets.items = [makeAsset('a1', 'job-1')]
 
       const { outputs } = useOutputHistory()
 
@@ -187,19 +127,26 @@ describe(useOutputHistory, () => {
     })
 
     it('updates when active workflow changes', async () => {
-      jobIdToPathRef.value = new Map([
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
         ['job-1', 'workflows/a.json'],
         ['job-2', 'workflows/b.json']
       ])
-      mediaRef.value = [makeAsset('a1', 'job-1'), makeAsset('a2', 'job-2')]
+      useAssetsStore().outputAssets.items = [
+        makeAsset('a1', 'job-1'),
+        makeAsset('a2', 'job-2')
+      ]
 
-      activeWorkflowPathRef.value = 'workflows/a.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/a.json'
+      })
       const { outputs } = useOutputHistory()
 
       expect(toValue(outputs.items)).toHaveLength(1)
       expect(toValue(outputs.items)[0].id).toBe('a1')
 
-      activeWorkflowPathRef.value = 'workflows/b.json'
+      useWorkflowStore().activeWorkflow = fromPartial({
+        path: 'workflows/b.json'
+      })
       await nextTick()
 
       expect(toValue(outputs.items)).toHaveLength(1)
@@ -287,8 +234,8 @@ describe(useOutputHistory, () => {
 
     it('returns in-progress outputs for pending resolve jobs', () => {
       useAppModeStore().selectedOutputs.push(toNodeId('1'))
-      pendingResolveRef.value = new Set(['job-1'])
-      inProgressItemsRef.value = [
+      useLinearOutputStore().pendingResolve = new Set(['job-1'])
+      useLinearOutputStore().inProgressItems = [
         {
           id: 'item-1',
           jobId: 'job-1',
@@ -348,16 +295,22 @@ describe(useOutputHistory, () => {
         allOutputs: results,
         outputCount: 1
       })
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      pendingResolveRef.value = new Set(['job-1'])
-      mediaRef.value = [asset]
-      selectedIdRef.value = null
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useLinearOutputStore().pendingResolve = new Set(['job-1'])
+      useAssetsStore().outputAssets.items = [asset]
+      useLinearOutputStore().selectedId = null
 
       useOutputHistory()
       await nextTick()
 
-      expect(resolveIfReadyFn).toHaveBeenCalledWith('job-1', true)
-      expect(selectAsLatestFn).toHaveBeenCalledWith('history:a1:0')
+      expect(
+        vi.mocked(useLinearOutputStore().resolveIfReady)
+      ).toHaveBeenCalledWith('job-1', true)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith('history:a1:0')
     })
 
     it('does not select first history when a selection exists', async () => {
@@ -367,45 +320,59 @@ describe(useOutputHistory, () => {
         allOutputs: results,
         outputCount: 1
       })
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      pendingResolveRef.value = new Set(['job-1'])
-      mediaRef.value = [asset]
-      selectedIdRef.value = 'history:existing:0'
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useLinearOutputStore().pendingResolve = new Set(['job-1'])
+      useAssetsStore().outputAssets.items = [asset]
+      useLinearOutputStore().selectedId = 'history:existing:0'
 
       useOutputHistory()
       await nextTick()
 
-      expect(resolveIfReadyFn).toHaveBeenCalledWith('job-1', true)
-      expect(selectAsLatestFn).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useLinearOutputStore().resolveIfReady)
+      ).toHaveBeenCalledWith('job-1', true)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).not.toHaveBeenCalled()
     })
 
     it('skips jobs with no matching asset in media', async () => {
-      pendingResolveRef.value = new Set(['job-missing'])
-      mediaRef.value = []
+      useLinearOutputStore().pendingResolve = new Set(['job-missing'])
+      useAssetsStore().outputAssets.items = []
 
       useOutputHistory()
       await nextTick()
 
-      expect(resolveIfReadyFn).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useLinearOutputStore().resolveIfReady)
+      ).not.toHaveBeenCalled()
     })
   })
 
   describe('selectFirstHistory', () => {
     it('selects first media item', () => {
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
-      mediaRef.value = [makeAsset('a1', 'job-1')]
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
+      useAssetsStore().outputAssets.items = [makeAsset('a1', 'job-1')]
 
       const { selectFirstHistory } = useOutputHistory()
       selectFirstHistory()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith('history:a1:0')
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith('history:a1:0')
     })
 
     it('selects null when no media', () => {
       const { selectFirstHistory } = useOutputHistory()
       selectFirstHistory()
 
-      expect(selectAsLatestFn).toHaveBeenCalledWith(null)
+      expect(
+        vi.mocked(useLinearOutputStore().selectAsLatest)
+      ).toHaveBeenCalledWith(null)
     })
   })
 
@@ -416,43 +383,53 @@ describe(useOutputHistory, () => {
     })
 
     it('returns false when there are active in-progress items', () => {
-      activeWorkflowInProgressItemsRef.value = [
-        { id: 'item-1', jobId: 'job-1', state: 'skeleton' }
-      ]
-      runningTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
+      Object.assign(useLinearOutputStore(), {
+        activeWorkflowInProgressItems: [
+          { id: 'item-1', jobId: 'job-1', state: 'skeleton' }
+        ]
+      })
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)
     })
 
     it('returns true when a running task matches the active workflow', () => {
-      runningTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(true)
     })
 
     it('returns false when only pending tasks exist', () => {
-      pendingTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/test.json']])
+      useQueueStore().pendingTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/test.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)
     })
 
     it('returns false when tasks belong to another workflow', () => {
-      runningTasksRef.value = [{ jobId: 'job-1' }]
-      jobIdToPathRef.value = new Map([['job-1', 'workflows/other.json']])
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
+      useExecutionStore().jobIdToSessionWorkflowPath = new Map([
+        ['job-1', 'workflows/other.json']
+      ])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)
     })
 
     it('returns false when no workflow path is set', () => {
-      activeWorkflowPathRef.value = ''
-      runningTasksRef.value = [{ jobId: 'job-1' }]
+      useWorkflowStore().activeWorkflow = fromPartial({ path: '' })
+      useQueueStore().runningTasks = fromPartial([{ jobId: 'job-1' }])
 
       const { mayBeActiveWorkflowPending } = useOutputHistory()
       expect(mayBeActiveWorkflowPending.value).toBe(false)

--- a/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
@@ -1,3 +1,6 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 /**
  * Lifecycle tests for the minimap's change-detection interval, run against the
  * real `useIntervalFn` with fake timers. The main useMinimap test file mocks
@@ -6,6 +9,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
+import type {
+  LGraph,
+  LGraphNode,
+  LGraphCanvas
+} from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
 
 import {
   createMockCanvas2DContext,
@@ -13,24 +22,26 @@ import {
   createMockMinimapCanvas
 } from '@/utils/__tests__/litegraphTestUtils'
 
-const mockNodes = [
+const mockNodes = fromPartial<LGraphNode[]>([
   {
-    id: 'node1',
+    constructor: {},
+    id: toNodeId('node1'),
     pos: [0, 0],
     size: [100, 50],
     renderingSize: [100, 50],
     outputs: []
   },
   {
-    id: 'node2',
+    constructor: {},
+    id: toNodeId('node2'),
     pos: [200, 100],
     size: [150, 75],
     renderingSize: [150, 75],
     outputs: []
   }
-]
+])
 
-const mockGraph = {
+const mockGraph = fromPartial<LGraph>({
   id: 'root',
   rootGraph: { id: 'root' },
   _groups: [],
@@ -38,38 +49,25 @@ const mockGraph = {
   links: createMockLinks([]),
   getNodeById: vi.fn((id: string) => mockNodes.find((n) => n.id === id)),
   setDirtyCanvas: vi.fn(),
-  onNodeAdded: null,
-  onNodeRemoved: null,
-  onConnectionChange: null,
   events: {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   }
-}
+})
 
-const mockCanvas = {
+const canvasElement = document.createElement('canvas')
+canvasElement.width = 1000
+canvasElement.height = 800
+Object.defineProperties(canvasElement, {
+  clientWidth: { value: 1000 },
+  clientHeight: { value: 800 }
+})
+const mockCanvas = fromPartial<LGraphCanvas>({
   graph: mockGraph,
-  canvas: { width: 1000, height: 800, clientWidth: 1000, clientHeight: 800 },
+  canvas: canvasElement,
   ds: { scale: 1, offset: [0, 0] },
   setDirty: vi.fn()
-}
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => ({ canvas: mockCanvas }))
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn().mockReturnValue(true),
-    set: vi.fn().mockResolvedValue(undefined)
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({
-    completedActivePalette: { light_theme: false }
-  }))
-}))
+})
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -80,26 +78,24 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: { graph: mockGraph } }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({ activeSubgraph: null }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {},
-    nodeProgressStates: {}
-  }))
+  app: {
+    canvas: {
+      get graph() {
+        return mockGraph
+      }
+    }
+  }
 }))
 
 import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
 
 const POLL_MS = 100
+
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial(mockCanvas)
+  vi.mocked(useSettingStore().get).mockReturnValue(true)
+  vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+})
 
 describe('useMinimap change-detection interval', () => {
   let context: CanvasRenderingContext2D

--- a/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
@@ -1,11 +1,19 @@
+import type * as VueUse from '@vueuse/core'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useLinkStore } from '@/stores/linkStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, shallowRef } from 'vue'
+import { effectScope, nextTick, shallowRef } from 'vue'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+import type { LinkTopology } from '@/types/linkTopology'
 
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { MinimapDataSource } from '@/renderer/extensions/minimap/data/MinimapDataSource'
-import type { NodeProgressState } from '@/schemas/apiSchema'
 import { createMockCanvas2DContext } from '@/utils/__tests__/litegraphTestUtils'
 
 interface HarnessCounters {
@@ -31,9 +39,7 @@ interface HarnessCounters {
 
 const {
   counters,
-  defaultSettingStore,
-  mockCanvasStore,
-  progressStates,
+
   linkTopologies,
   apiListeners,
   pollControl
@@ -58,20 +64,12 @@ const {
     pollPauses: 0,
     pollResumes: 0
   }
-  const progressStates: Record<string, NodeProgressState> = {}
-  const canvasStore = (canvas: unknown) => ({ canvas })
   return {
     counters,
-    defaultSettingStore: {
-      visible: true,
-      get: vi.fn(() => true),
-      set: vi.fn().mockResolvedValue(undefined)
-    },
-    mockCanvasStore: canvasStore(null),
-    progressStates,
+
     linkTopologies: [] as Array<{
-      originNodeId: string
-      targetNodeId: string
+      originNodeId: NodeId
+      targetNodeId: NodeId
       originSlot: number
       targetSlot: number
     }>,
@@ -80,7 +78,8 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useDocumentVisibility: () => ({ value: 'visible' }),
   useIntervalFn: (callback: () => void) => {
     counters.pollRegistrations++
@@ -104,51 +103,6 @@ vi.mock<unknown>(import('@vueuse/core'), () => ({
     counters.throttleCallbacks++
     callback()
   }
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: () => defaultSettingStore.visible,
-    set: defaultSettingStore.set
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ activeSubgraph: null })
-  })
-)
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => mockCanvasStore
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: () => ({
-    nodeProgressStates: progressStates,
-    nodeLocationProgressStates: progressStates
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/linkStore'), () => ({
-  useLinkStore: () => ({
-    graphTopologies: () => {
-      counters.topologyReads++
-      return (function* () {
-        for (const topology of linkTopologies) {
-          counters.topologyEntries++
-          yield topology
-        }
-      })()
-    }
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: () => ({
-    completedActivePalette: { light_theme: false }
-  })
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -239,8 +193,8 @@ function createGraph(graphSize: number, edgeCount: number) {
     0,
     linkTopologies.length,
     ...Array.from({ length: edgeCount }, (_, index) => ({
-      originNodeId: '1',
-      targetNodeId: String((index % graphSize) + 1),
+      originNodeId: toNodeId('1'),
+      targetNodeId: toNodeId(String((index % graphSize) + 1)),
       originSlot: index,
       targetSlot: index
     }))
@@ -271,8 +225,9 @@ async function runCell(
 ): Promise<MatrixResult> {
   resetCounters()
   apiListeners.clear()
-  for (const key of Object.keys(progressStates)) delete progressStates[key]
-  progressStates['1'] = {
+  for (const key of Object.keys(useExecutionStore().nodeProgressStates))
+    delete useExecutionStore().nodeProgressStates[key]
+  useExecutionStore().nodeProgressStates['1'] = {
     state: 'running',
     value: 1,
     max: 2,
@@ -293,28 +248,38 @@ async function runCell(
     height: 200,
     getContext: (kind: string) => (kind === '2d' ? context : null)
   } as unknown as HTMLCanvasElement
-  mockCanvasStore.canvas = {
+  const graphCanvasElement = document.createElement('canvas')
+  graphCanvasElement.width = 1000
+  graphCanvasElement.height = 800
+  Object.defineProperties(graphCanvasElement, {
+    clientWidth: { value: 1000 },
+    clientHeight: { value: 800 }
+  })
+  useCanvasStore().canvas = fromPartial({
     graph,
-    canvas: {
-      width: 1000,
-      height: 800,
-      clientWidth: 1000,
-      clientHeight: 800
-    },
+    canvas: graphCanvasElement,
     ds: { scale: 1, offset: [0, 0] },
     setDirty: () => counters.dirtyRequests++
-  }
-  defaultSettingStore.visible = visible
+  })
+  useSettingStore().settingValues['Comfy.Minimap.Visible'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.ShowLinks'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.ShowGroups'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.NodeColors'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.RenderBypassState'] = visible
+  useSettingStore().settingValues['Comfy.Minimap.RenderErrorState'] = visible
 
   const getNodes = vi.spyOn(MinimapDataSource.prototype, 'getNodes')
   const getLinks = vi.spyOn(MinimapDataSource.prototype, 'getLinks')
   const getBounds = vi.spyOn(MinimapDataSource.prototype, 'getBounds')
-  const minimap = useMinimap({
-    canvasRefMaybe: shallowRef(canvasElement),
-    containerRefMaybe: shallowRef({
-      getBoundingClientRect: () => new DOMRect(0, 0, 250, 200)
-    } as HTMLDivElement)
-  })
+  const scope = effectScope()
+  const minimap = scope.run(() =>
+    useMinimap({
+      canvasRefMaybe: shallowRef(canvasElement),
+      containerRefMaybe: shallowRef({
+        getBoundingClientRect: () => new DOMRect(0, 0, 250, 200)
+      } as HTMLDivElement)
+    })
+  )!
   await minimap.init()
   await nextTick()
   await nextTick()
@@ -338,10 +303,12 @@ async function runCell(
   getBounds.mockClear()
 
   if (operation === 'equal-progress') {
-    progressStates['1'] = { ...progressStates['1'] }
+    useExecutionStore().nodeProgressStates['1'] = {
+      ...useExecutionStore().nodeProgressStates['1']
+    }
   } else if (operation === 'changed-progress') {
-    progressStates['1'] = {
-      ...progressStates['1'],
+    useExecutionStore().nodeProgressStates['1'] = {
+      ...useExecutionStore().nodeProgressStates['1'],
       state: 'finished'
     }
   } else if (operation === 'geometry') {
@@ -358,8 +325,8 @@ async function runCell(
       target_slot: 0
     })
     linkTopologies.push({
-      originNodeId: '1',
-      targetNodeId: String(Math.min(2, graphSize)),
+      originNodeId: toNodeId('1'),
+      targetNodeId: toNodeId(String(Math.min(2, graphSize))),
       originSlot: 0,
       targetSlot: 0
     })
@@ -382,6 +349,7 @@ async function runCell(
     ...counters
   }
   minimap.destroy()
+  scope.stop()
   result.pollRegistrations = lifecycleAtInit.pollRegistrations
   result.listenersAdded = lifecycleAtInit.listenersAdded
   result.listenersRemoved = counters.listenersRemoved
@@ -392,6 +360,20 @@ async function runCell(
   getBounds.mockRestore()
   return result
 }
+
+beforeEach(() => {
+  Object.assign(useExecutionStore(), {
+    nodeLocationProgressStates: useExecutionStore().nodeProgressStates
+  })
+  vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+  vi.mocked(useLinkStore().graphTopologies).mockImplementation(function* () {
+    counters.topologyReads++
+    for (const topology of linkTopologies) {
+      counters.topologyEntries++
+      yield fromPartial<LinkTopology>(topology)
+    }
+  })
+})
 
 describe('minimap progress performance baseline', () => {
   beforeEach(() => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -1,10 +1,12 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import type * as VueUse from '@vueuse/core'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref, shallowRef } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import { useLinkStore } from '@/stores/linkStore'
 import { toLinkId } from '@/types/linkId'
@@ -93,8 +95,10 @@ const mockIntervalResume = vi.fn()
 const rafCallbacks: Record<string, () => void> = {}
 let rafCallbackId = 0
 
-vi.mock<unknown>(import('@vueuse/core'), () => {
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
+  const { ref } = await import('vue')
   return {
+    ...(await importOriginal<typeof VueUse>()),
     useDocumentVisibility: vi.fn(() => ref('visible')),
     useRafFn: vi.fn((callback, options) => {
       const id = rafCallbackId++
@@ -217,35 +221,6 @@ const setupMocks = () => {
 
 setupMocks()
 
-const defaultCanvasStore: {
-  canvas: MockCanvas | null
-  getCanvas: () => MockCanvas | null
-} = {
-  canvas: moduleMockCanvas,
-  getCanvas: () => defaultCanvasStore.canvas
-}
-
-const defaultSettingStore = {
-  get: vi.fn().mockReturnValue(true),
-  set: vi.fn().mockResolvedValue(undefined)
-}
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn(() => defaultCanvasStore)
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => defaultSettingStore)
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: vi.fn(() => ({
-    completedActivePalette: {
-      light_theme: false
-    }
-  }))
-}))
-
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
     addEventListener: vi.fn(),
@@ -257,24 +232,11 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: {
-      graph: moduleMockGraph
+      get graph() {
+        return moduleMockGraph
+      }
     }
   }
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: vi.fn(() => ({
-      activeSubgraph: null
-    }))
-  })
-)
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {}
-  }))
 }))
 
 import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
@@ -299,7 +261,6 @@ describe('useMinimap', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     registerMockLink(1, 'node2')
 
     mockContext2D = createMockCanvas2DContext()
@@ -388,10 +349,18 @@ describe('useMinimap', () => {
       setDirty: vi.fn()
     }
 
-    defaultCanvasStore.canvas = moduleMockCanvas
+    const element = document.createElement('canvas')
+    element.width = 1000
+    element.height = 800
+    Object.defineProperties(element, {
+      clientWidth: { value: 1000, writable: true },
+      clientHeight: { value: 800, writable: true }
+    })
+    moduleMockCanvas.canvas = element
+    useCanvasStore().canvas = moduleMockCanvas as unknown as LGraphCanvas
 
-    defaultSettingStore.get = vi.fn().mockReturnValue(true)
-    defaultSettingStore.set = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useSettingStore().get).mockReturnValue(true)
+    vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
 
     Object.defineProperty(window, 'devicePixelRatio', {
       writable: true,
@@ -405,8 +374,8 @@ describe('useMinimap', () => {
 
   describe('initialization', () => {
     it('should initialize with default values', () => {
-      const originalCanvas = defaultCanvasStore.canvas
-      defaultCanvasStore.canvas = null
+      const originalCanvas = useCanvasStore().canvas
+      useCanvasStore().canvas = null
 
       const minimap = useMinimap()
 
@@ -415,7 +384,7 @@ describe('useMinimap', () => {
       expect(minimap.visible.value).toBe(true)
       expect(minimap.initialized.value).toBe(false)
 
-      defaultCanvasStore.canvas = originalCanvas
+      useCanvasStore().canvas = originalCanvas
     })
 
     it('should initialize minimap when canvas is available', async () => {
@@ -424,7 +393,7 @@ describe('useMinimap', () => {
       await minimap.init()
 
       expect(minimap.initialized.value).toBe(true)
-      expect(defaultSettingStore.get).toHaveBeenCalledWith(
+      expect(vi.mocked(useSettingStore().get)).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible'
       )
       expect(api.addEventListener).toHaveBeenCalledWith(
@@ -438,8 +407,8 @@ describe('useMinimap', () => {
     })
 
     it('should not initialize without canvas and graph', async () => {
-      const originalCanvas = defaultCanvasStore.canvas
-      defaultCanvasStore.canvas = null
+      const originalCanvas = useCanvasStore().canvas
+      useCanvasStore().canvas = null
 
       const minimap = useMinimap()
       await minimap.init()
@@ -447,7 +416,7 @@ describe('useMinimap', () => {
       expect(minimap.initialized.value).toBe(false)
       expect(api.addEventListener).not.toHaveBeenCalled()
 
-      defaultCanvasStore.canvas = originalCanvas
+      useCanvasStore().canvas = originalCanvas
     })
 
     it('should setup event listeners on graph', async () => {
@@ -461,7 +430,7 @@ describe('useMinimap', () => {
     })
 
     it('should handle visibility from settings', async () => {
-      defaultSettingStore.get.mockReturnValue(false)
+      vi.mocked(useSettingStore().get).mockReturnValue(false)
       const minimap = await createAndInitializeMinimap()
 
       await minimap.init()
@@ -521,7 +490,7 @@ describe('useMinimap', () => {
       await minimap.toggle()
 
       expect(minimap.visible.value).toBe(!initialVisibility)
-      expect(defaultSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible',
         !initialVisibility
       )
@@ -529,7 +498,7 @@ describe('useMinimap', () => {
       await minimap.toggle()
 
       expect(minimap.visible.value).toBe(initialVisibility)
-      expect(defaultSettingStore.set).toHaveBeenCalledWith(
+      expect(useSettingStore().set).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible',
         initialVisibility
       )
@@ -587,8 +556,8 @@ describe('useMinimap', () => {
       if (!renderingOccurred) {
         console.log('Minimap visible:', minimap.visible.value)
         console.log('Minimap initialized:', minimap.initialized.value)
-        console.log('Canvas exists:', !!defaultCanvasStore.canvas)
-        console.log('Graph exists:', !!defaultCanvasStore.canvas?.graph)
+        console.log('Canvas exists:', !!useCanvasStore().canvas)
+        console.log('Graph exists:', !!useCanvasStore().canvas?.graph)
         console.log(
           'clearRect calls:',
           vi.mocked(mockContext2D.clearRect).mock.calls.length

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -1,3 +1,5 @@
+import type * as VueUse from '@vueuse/core'
+import { useExecutionStore } from '@/stores/executionStore'
 import { useThrottleFn } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -20,18 +22,9 @@ import {
   createMockLinks
 } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useThrottleFn: vi.fn((fn) => fn)
-}))
-
-const { mockProgressStates } = vi.hoisted(() => ({
-  mockProgressStates: {} as Record<string, { state: string }>
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeProgressStates: mockProgressStates
-  }))
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -61,8 +54,8 @@ describe('useMinimapGraph', () => {
     })
 
     onGraphChangedMock = vi.fn()
-    for (const key of Object.keys(mockProgressStates)) {
-      delete mockProgressStates[key]
+    for (const key of Object.keys(useExecutionStore().nodeProgressStates)) {
+      delete useExecutionStore().nodeProgressStates[key]
     }
   })
 
@@ -500,11 +493,23 @@ describe('useMinimapGraph', () => {
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
 
-    mockProgressStates['1'] = { state: 'running' }
+    useExecutionStore().nodeProgressStates['1'] = {
+      state: 'running',
+      value: 1,
+      max: 2,
+      node_id: '1',
+      prompt_id: 'job-1'
+    }
     expect(graphManager.checkForChanges()).toBe(true)
     expect(graphManager.checkForChanges()).toBe(false)
 
-    mockProgressStates['1'] = { state: 'finished' }
+    useExecutionStore().nodeProgressStates['1'] = {
+      state: 'finished',
+      value: 2,
+      max: 2,
+      node_id: '1',
+      prompt_id: 'job-1'
+    }
     expect(graphManager.checkForChanges()).toBe(true)
   })
 

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
@@ -1,36 +1,22 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useMinimapSettings } from '@/renderer/extensions/minimap/composables/useMinimapSettings'
 
-type MockSettingStore = ReturnType<typeof useSettingStore>
-
-const mockUseColorPaletteStore = vi.hoisted(() => vi.fn())
-
-vi.mock(import('@/platform/settings/settingStore'))
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: mockUseColorPaletteStore
-}))
+beforeEach(() => {
+  useSettingStore().settingValues = {
+    'Comfy.Minimap.NodeColors': true,
+    'Comfy.Minimap.ShowLinks': false,
+    'Comfy.Minimap.ShowGroups': true,
+    'Comfy.Minimap.RenderBypassState': false,
+    'Comfy.Minimap.RenderErrorState': true
+  }
+})
 
 describe('useMinimapSettings', () => {
   it('should return all minimap settings as computed refs', () => {
-    const mockSettingStore = {
-      get: vi.fn((key: string) => {
-        const settings: Record<string, unknown> = {
-          'Comfy.Minimap.NodeColors': true,
-          'Comfy.Minimap.ShowLinks': false,
-          'Comfy.Minimap.ShowGroups': true,
-          'Comfy.Minimap.RenderBypassState': false,
-          'Comfy.Minimap.RenderErrorState': true
-        }
-        return settings[key]
-      })
-    }
-
-    vi.mocked(useSettingStore).mockReturnValue(
-      mockSettingStore as Partial<MockSettingStore> as MockSettingStore
-    )
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',
@@ -58,10 +44,7 @@ describe('useMinimapSettings', () => {
       }
     }
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      get: vi.fn()
-    } as Partial<MockSettingStore> as MockSettingStore)
-    mockUseColorPaletteStore.mockReturnValue(mockColorPaletteStore)
+    Object.assign(useColorPaletteStore(), mockColorPaletteStore)
 
     const settings = useMinimapSettings()
     const styles = settings.containerStyles.value
@@ -82,10 +65,7 @@ describe('useMinimapSettings', () => {
       }
     }
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      get: vi.fn()
-    } as Partial<MockSettingStore> as MockSettingStore)
-    mockUseColorPaletteStore.mockReturnValue(mockColorPaletteStore)
+    Object.assign(useColorPaletteStore(), mockColorPaletteStore)
 
     const settings = useMinimapSettings()
     const styles = settings.containerStyles.value
@@ -106,10 +86,7 @@ describe('useMinimapSettings', () => {
       }
     }
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      get: vi.fn()
-    } as Partial<MockSettingStore> as MockSettingStore)
-    mockUseColorPaletteStore.mockReturnValue(mockColorPaletteStore)
+    Object.assign(useColorPaletteStore(), mockColorPaletteStore)
 
     const settings = useMinimapSettings()
     const styles = settings.panelStyles.value
@@ -121,17 +98,7 @@ describe('useMinimapSettings', () => {
   })
 
   it('should create computed properties that call the store getter', () => {
-    const mockGet = vi.fn((key: string) => {
-      if (key === 'Comfy.Minimap.NodeColors') return true
-      if (key === 'Comfy.Minimap.ShowLinks') return false
-      return true
-    })
-    const mockSettingStore = { get: mockGet }
-
-    vi.mocked(useSettingStore).mockReturnValue(
-      mockSettingStore as Partial<MockSettingStore> as MockSettingStore
-    )
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',
@@ -147,7 +114,11 @@ describe('useMinimapSettings', () => {
     expect(settings.showLinks.value).toBe(false)
 
     // Verify the store getter was called with the correct keys
-    expect(mockGet).toHaveBeenCalledWith('Comfy.Minimap.NodeColors')
-    expect(mockGet).toHaveBeenCalledWith('Comfy.Minimap.ShowLinks')
+    expect(useSettingStore().get).toHaveBeenCalledWith(
+      'Comfy.Minimap.NodeColors'
+    )
+    expect(useSettingStore().get).toHaveBeenCalledWith(
+      'Comfy.Minimap.ShowLinks'
+    )
   })
 })

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
@@ -12,16 +12,11 @@ import {
 import { useMinimapViewport } from '@/renderer/extensions/minimap/composables/useMinimapViewport'
 import type { MinimapCanvas } from '@/renderer/extensions/minimap/types'
 
-vi.mock(import('@vueuse/core'))
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: vi.fn()
+vi.mock(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRafFn: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {}
-  }))
-}))
 vi.mock(import('@/renderer/core/spatial/boundsCalculator'), () => ({
   calculateNodeBounds: vi.fn(),
   calculateMinimapScale: vi.fn(),

--- a/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
+++ b/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
@@ -1,7 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
+import { useExecutionStore } from '@/stores/executionStore'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type {
@@ -19,12 +18,6 @@ import {
   createMockLGraph,
   createMockLGraphNode
 } from '@/utils/__tests__/litegraphTestUtils'
-
-const useExecutionStore = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore
-}))
 
 const ROOT_GRAPH_ID = '00000000-0000-0000-0000-000000000001'
 const SUBGRAPH_ID = '00000000-0000-0000-0000-000000000002'
@@ -67,8 +60,7 @@ function rootGraph(
 
 describe('MinimapDataSource', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    useExecutionStore.mockReturnValue({ nodeLocationProgressStates: {} })
+    Object.assign(useExecutionStore(), { nodeLocationProgressStates: {} })
   })
 
   it('uses graph position and rendered size', () => {
@@ -89,7 +81,7 @@ describe('MinimapDataSource', () => {
       rootGraph: rootGraph(),
       _nodes: [node]
     })
-    useExecutionStore.mockReturnValue({
+    Object.assign(useExecutionStore(), {
       nodeLocationProgressStates: {
         [createNodeLocatorId(SUBGRAPH_ID, node.id)]: { state: 'running' }
       }

--- a/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
+++ b/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
@@ -1,5 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -18,19 +17,8 @@ import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
 
-const mockUseColorPaletteStore = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/workspace/colorPaletteStore'), () => ({
-  useColorPaletteStore: mockUseColorPaletteStore
-}))
-
 vi.mock(import('@/utils/colorUtil'), () => ({
   adjustColor: vi.fn((color: string) => color + '_adjusted')
-}))
-
-vi.mock<unknown>(import('@/stores/executionStore'), () => ({
-  useExecutionStore: vi.fn(() => ({
-    nodeLocationProgressStates: {}
-  }))
 }))
 
 const GRAPH_ID: UUID = 'renderer-graph'
@@ -45,8 +33,6 @@ describe('minimapCanvasRenderer', () => {
   let mockGraph: LGraph
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-
     mockContext = {
       clearRect: vi.fn(),
       fillRect: vi.fn(),
@@ -95,7 +81,7 @@ describe('minimapCanvasRenderer', () => {
       getNodeById: vi.fn()
     })
 
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',
@@ -309,7 +295,7 @@ describe('minimapCanvasRenderer', () => {
   })
 
   it('should handle light theme colors', () => {
-    mockUseColorPaletteStore.mockReturnValue({
+    Object.assign(useColorPaletteStore(), {
       completedActivePalette: {
         id: 'test',
         name: 'Test Palette',

--- a/src/renderer/extensions/vueNodes/VideoPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/VideoPreview.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
@@ -49,7 +49,7 @@ describe('VideoPreview', () => {
         typeof VideoPreview
       >,
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           Skeleton: true
         }

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access */
 /* eslint-disable testing-library/prefer-user-event */
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen, fireEvent } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { getActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -68,12 +68,7 @@ describe('ImagePreview', () => {
     return render(ImagePreview, {
       props: { ...defaultProps, ...props },
       global: {
-        plugins: [
-          createTestingPinia({
-            createSpy: vi.fn
-          }),
-          i18n
-        ],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           'i-lucide:venetian-mask': true,
           'i-lucide:download': true,

--- a/src/renderer/extensions/vueNodes/components/InputSlot.test.ts
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import type { DirectiveBinding } from 'vue'
@@ -73,7 +73,7 @@ function renderInputSlot(
   dotOnly = false,
   standalone = dotOnly
 ) {
-  const pinia = createTestingPinia({ stubActions: false })
+  const pinia = getActivePinia()!
   const settingStore = useSettingStore(pinia)
   vi.spyOn(settingStore, 'get').mockImplementation(
     <K extends keyof Settings>(key: K): Settings[K] => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
@@ -1,9 +1,9 @@
 /**
  * Tests for NodeHeader subgraph functionality
  */
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { render, screen, fireEvent } from '@testing-library/vue'
+import type { Pinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -65,7 +65,7 @@ const i18n = createI18n({
 
 describe('Vue Node - Subgraph Functionality', () => {
   let rootGraph: LGraph
-  let pinia: ReturnType<typeof createTestingPinia>
+  let pinia: Pinia
 
   // Helper to setup common mocks
   const setupMocks = async (isSubgraph = true, hasGraph = true) => {
@@ -78,8 +78,7 @@ describe('Vue Node - Subgraph Functionality', () => {
   }
 
   beforeEach(() => {
-    pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
-    setActivePinia(pinia)
+    pinia = getActivePinia()!
     rootGraph = new LGraph()
   })
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.test.ts
@@ -1,16 +1,14 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
+import { useWidgetStore } from '@/stores/widgetStore'
+
 import { render, screen } from '@testing-library/vue'
 import { computed } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WidgetGridItem } from '@/renderer/extensions/vueNodes/types/widgetGrid'
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import LGraphNodePreview from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
 import { fromPartial } from '@total-typescript/shoehorn'
-
-vi.mock<unknown>(import('@/stores/widgetStore'), () => ({
-  useWidgetStore: () => ({ inputIsWidget: () => true })
-}))
 
 const WidgetGridProbe = {
   props: ['processedWidgets'],
@@ -50,7 +48,7 @@ function renderedWidgets(
   render(LGraphNodePreview, {
     props: { nodeDef: def, ...props },
     global: {
-      plugins: [createTestingPinia({ stubActions: false })],
+      plugins: [getActivePinia()!],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -70,12 +68,16 @@ function renderedComboWidget(
   return renderedWidgets(nodeDef, props).find((w) => w.name === 'ckpt_name')
 }
 
+beforeEach(() => {
+  vi.mocked(useWidgetStore().inputIsWidget).mockReturnValue(true)
+})
+
 describe('LGraphNodePreview', () => {
   it('does not synchronize preview geometry with the canvas layout', () => {
     render(LGraphNodePreview, {
       props: { nodeDef },
       global: {
-        plugins: [createTestingPinia({ stubActions: false })],
+        plugins: [getActivePinia()!],
         stubs: {
           NodeHeader: true,
           NodeSlots: {

--- a/src/renderer/extensions/vueNodes/components/LivePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LivePreview.test.ts
@@ -1,6 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { fireEvent, render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -30,12 +30,7 @@ describe('LivePreview', () => {
     return render(LivePreview, {
       props: { ...defaultProps, ...props },
       global: {
-        plugins: [
-          createTestingPinia({
-            createSpy: vi.fn
-          }),
-          i18n
-        ],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           'i-lucide:image-off': true
         }

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
@@ -1,7 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import { describe, expect, it, vi } from 'vitest'
@@ -33,8 +32,7 @@ const makeNodeData = (overrides: Partial<NodeState> = {}): NodeState => ({
 })
 
 const setupMockStores = () => {
-  const pinia = createTestingPinia({ stubActions: false })
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   const settingStore = useSettingStore()
   const nodeDefStore = useNodeDefStore()

--- a/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
@@ -1,5 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import type { RenderOptions } from '@testing-library/vue'
@@ -141,7 +140,7 @@ function createTrackingStub(
 function renderSlots(
   nodeData: NodeState,
   stubs: SlotComponentStubs = defaultSlotStubs,
-  pinia = createTestingPinia({ stubActions: false }),
+  pinia = getActivePinia()!,
   syncLayout = true
 ) {
   return render(NodeSlots, {
@@ -154,8 +153,7 @@ function renderSlots(
 }
 
 function createConnectedGraph() {
-  const pinia = createTestingPinia({ stubActions: false })
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   const graph = new LGraph()
   useCanvasStore().canvas = fromPartial<LGraphCanvas>({ graph })
@@ -231,8 +229,7 @@ describe('NodeSlots.vue', () => {
   beforeEach(() => layoutStore.resetForTests())
 
   it('stores slot offsets when the rendered element mounts', async () => {
-    const pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
     const graph = new LGraph()
     const canvasStore = useCanvasStore()
     canvasStore.canvas = fromPartial<LGraphCanvas>({ graph })
@@ -260,8 +257,7 @@ describe('NodeSlots.vue', () => {
   })
 
   it('does not store slot offsets when layout synchronization is disabled', async () => {
-    const pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
     const graph = new LGraph()
     const canvasStore = useCanvasStore()
     canvasStore.canvas = fromPartial<LGraphCanvas>({ graph })
@@ -289,8 +285,7 @@ describe('NodeSlots.vue', () => {
   })
 
   it('renders slots from nodeDataStore without resolving the live node', async () => {
-    const pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
 
     const graph = new LGraph()
     const canvasStore = useCanvasStore()
@@ -477,8 +472,7 @@ describe('NodeSlots.vue', () => {
     graph.add(subgraphNode)
     vi.spyOn(app, 'rootGraphOrUndefined', 'get').mockReturnValue(graph)
 
-    const pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
     useCanvasStore().currentGraph = subgraph
 
     const nodeData = makeNodeData({
@@ -518,8 +512,7 @@ describe('NodeSlots.vue', () => {
     graph.add(outerSubgraphNode)
     vi.spyOn(app, 'rootGraphOrUndefined', 'get').mockReturnValue(graph)
 
-    const pinia = createTestingPinia({ stubActions: false })
-    setActivePinia(pinia)
+    const pinia = getActivePinia()!
     useCanvasStore().currentGraph = innerSubgraph
 
     const nodeData = makeNodeData({
@@ -604,11 +597,7 @@ describe('NodeSlots.vue', () => {
   })
 
   describe('unified mode', () => {
-    function renderUnified(
-      nodeData: NodeState,
-      pinia = createTestingPinia({ stubActions: false })
-    ) {
-      setActivePinia(pinia)
+    function renderUnified(nodeData: NodeState, pinia = getActivePinia()!) {
       return render(NodeSlots, {
         global: {
           plugins: [i18n, pinia],

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,9 +1,9 @@
+import { getActivePinia } from 'pinia'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeState } from '@/types/nodeState'
 import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
@@ -16,12 +16,6 @@ import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-test'
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    rootGraphId: GRAPH_ID
-  })
-}))
 
 const WidgetStub = {
   name: 'WidgetStub',
@@ -85,8 +79,7 @@ function renderComponent({
   widgetIds?: readonly WidgetId[]
   setupStores?: () => void
 }) {
-  const pinia = createTestingPinia({ stubActions: false })
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
   setupStores?.()
 
   return render(NodeWidgets, {
@@ -106,6 +99,10 @@ function renderComponent({
     }
   })
 }
+
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
+})
 
 describe('NodeWidgets', () => {
   describe('node-type prop passing', () => {

--- a/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.test.ts
@@ -1,46 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed } from 'vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, effectScope } from 'vue'
 
-import type {
-  LGraph,
-  LGraphCanvas,
-  LGraphNode
-} from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
-import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables/useNodeEventHandlers'
+import { useNodeEventHandlers as createNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables/useNodeEventHandlers'
 import { toNodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 const ROOT_GRAPH_ID = vi.hoisted<UUID>(() => 'root-graph')
-const canvasSelectedItems = vi.hoisted(() => [] as Array<{ id?: string }>)
-const graphNode = vi.hoisted(() => ({
-  id: 'node-1',
+
+const graphNode = createMockLGraphNode({
+  id: toNodeId('node-1'),
   selected: false,
   flags: { pinned: false }
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => {
-  const canvas: Partial<LGraphCanvas> = {
-    select: vi.fn(),
-    deselect: vi.fn(),
-    deselectAll: vi.fn()
-  }
-  const updateSelectedItems = vi.fn()
-  const currentGraph: Partial<LGraph> = {
-    getNodeById: vi.fn(() => graphNode as Partial<LGraphNode> as LGraphNode)
-  }
-  const canvasStoreInstance = {
-    canvas: canvas as LGraphCanvas,
-    currentGraph: currentGraph as LGraph,
-    updateSelectedItems,
-    selectedItems: canvasSelectedItems,
-    rootGraphId: ROOT_GRAPH_ID
-  }
-  return {
-    useCanvasStore: vi.fn(() => canvasStoreInstance)
-  }
 })
 
 vi.mock<unknown>(
@@ -64,14 +39,40 @@ vi.mock<unknown>(
   }
 )
 
+let scope: ReturnType<typeof effectScope>
+
+function useNodeEventHandlers() {
+  return scope.run(createNodeEventHandlers)!
+}
+
+afterEach(() => scope.stop())
+
+beforeEach(() => {
+  const store = useCanvasStore()
+  const graph = fromPartial<NonNullable<typeof store.currentGraph>>({
+    getNodeById: vi.fn(() => graphNode)
+  })
+  store.canvas = fromPartial({
+    graph,
+    canvas: document.createElement('canvas'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    deselectAll: vi.fn()
+  })
+  store.currentGraph = graph
+  Object.assign(store, { rootGraphId: ROOT_GRAPH_ID })
+  vi.mocked(store.updateSelectedItems).mockImplementation(() => undefined)
+  scope = effectScope()
+})
+
 describe('useNodeEventHandlers', () => {
-  const mockNode = graphNode as Partial<LGraphNode> as LGraphNode
+  const mockNode = graphNode
   const mockLayoutMutations = useLayoutMutations(LayoutSource.Vue)
 
   const testNodeId = toNodeId('node-1')
 
   beforeEach(async () => {
-    canvasSelectedItems.length = 0
+    useCanvasStore().selectedItems.length = 0
   })
 
   describe('handleNodeSelect', () => {
@@ -206,7 +207,10 @@ describe('useNodeEventHandlers', () => {
       const { canvas } = useCanvasStore()
 
       mockNode.selected = true
-      canvasSelectedItems.push({ id: 'node-1' }, { id: 'node-2' })
+      useCanvasStore().selectedItems.push(
+        createMockLGraphNode({ id: toNodeId('node-1') }),
+        createMockLGraphNode({ id: toNodeId('node-2') })
+      )
 
       const event = new PointerEvent('pointerdown', {
         bubbles: true,
@@ -277,7 +281,10 @@ describe('useNodeEventHandlers', () => {
       const { canvas, updateSelectedItems } = useCanvasStore()
 
       mockNode.selected = true
-      canvasSelectedItems.push({ id: 'node-1' }, { id: 'node-2' })
+      useCanvasStore().selectedItems.push(
+        createMockLGraphNode({ id: toNodeId('node-1') }),
+        createMockLGraphNode({ id: toNodeId('node-2') })
+      )
 
       toggleNodeSelectionAfterPointerUp(testNodeId, false)
 
@@ -291,7 +298,9 @@ describe('useNodeEventHandlers', () => {
       const { canvas, updateSelectedItems } = useCanvasStore()
 
       mockNode.selected = true
-      canvasSelectedItems.push({ id: 'node-1' })
+      useCanvasStore().selectedItems.push(
+        createMockLGraphNode({ id: toNodeId('node-1') })
+      )
 
       toggleNodeSelectionAfterPointerUp(testNodeId, false)
 

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -1,12 +1,10 @@
-import { setActivePinia } from 'pinia'
 import { fromAny } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { nextTick, ref } from 'vue'
 
 import { useNodePointerInteractions } from '@/renderer/extensions/vueNodes/composables/useNodePointerInteractions'
 import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables/useNodeEventHandlers'
-import { createTestingPinia } from '@pinia/testing'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import type { NodeLayout } from '@/renderer/core/layout/types'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
@@ -120,10 +118,6 @@ const createMouseEvent = (
 }
 
 describe('useNodePointerInteractions', () => {
-  beforeEach(async () => {
-    setActivePinia(createTestingPinia())
-  })
-
   it('should only start drag on left-click', async () => {
     const { handleNodeSelect } = useNodeEventHandlers()
     const { startDrag } = useNodeDrag()

--- a/src/renderer/extensions/vueNodes/composables/useNodeZIndex.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeZIndex.test.ts
@@ -1,6 +1,8 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
@@ -12,16 +14,14 @@ vi.mock(import('@/renderer/core/layout/operations/layoutMutations'), () => ({
   useLayoutMutations: vi.fn()
 }))
 
-const CURRENT_GRAPH = fromPartial({ id: createUuidv4() })
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ currentGraph: CURRENT_GRAPH })
-}))
+const CURRENT_GRAPH = fromPartial<LGraph>({ id: createUuidv4() })
 
 const mockedUseLayoutMutations = vi.mocked(useLayoutMutations)
 
 describe('useNodeZIndex', () => {
   it('scopes the mutation to the viewed root graph, attributed to Vue', () => {
     const mockSetNodeOrder = vi.fn()
+    useCanvasStore().currentGraph = CURRENT_GRAPH
 
     mockedUseLayoutMutations.mockReturnValue(
       fromPartial({

--- a/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
@@ -1,5 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -15,11 +14,6 @@ import { toNodeId } from '@/types/nodeId'
 import { NodeBadgeMode } from '@/types/nodeSource'
 
 const NODE_ID = toNodeId(5)
-
-const settings = vi.hoisted(() => new Map<string, unknown>())
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => settings.get(key) })
-}))
 
 const getNodeDisplayPrice = vi.fn(() => '$0.05 x 3 Runs')
 vi.mock<unknown>(import('@/composables/node/useNodePricing'), () => ({
@@ -77,15 +71,13 @@ function nodeData(type: string): NodeState {
 
 describe('usePartitionedBadges', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-    settings.clear()
-    settings.set('Comfy.NodeBadge.NodeIdBadgeMode', NodeBadgeMode.ShowAll)
-    settings.set(
-      'Comfy.NodeBadge.NodeLifeCycleBadgeMode',
+    useSettingStore().settingValues['Comfy.NodeBadge.NodeIdBadgeMode'] =
       NodeBadgeMode.ShowAll
-    )
-    settings.set('Comfy.NodeBadge.NodeSourceBadgeMode', NodeBadgeMode.ShowAll)
-    settings.set('Comfy.NodeBadge.ShowApiPricing', true)
+    useSettingStore().settingValues['Comfy.NodeBadge.NodeLifeCycleBadgeMode'] =
+      NodeBadgeMode.ShowAll
+    useSettingStore().settingValues['Comfy.NodeBadge.NodeSourceBadgeMode'] =
+      NodeBadgeMode.ShowAll
+    useSettingStore().settingValues['Comfy.NodeBadge.ShowApiPricing'] = true
   })
 
   it('partitions derived rows into core chips and pricing entries', () => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -1,4 +1,3 @@
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { TooltipOptions } from 'primevue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
@@ -138,10 +137,6 @@ function processWidgets({
     ui: noopUi
   })
 }
-
-beforeEach(() => {
-  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
-})
 
 describe('widget slot ownership', () => {
   beforeEach(() => {})

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -1,6 +1,5 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { TooltipOptions } from 'primevue'
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
@@ -32,12 +31,6 @@ import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-test'
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    rootGraphId: GRAPH_ID
-  })
-}))
 
 function createMockWidget(
   overrides: Partial<IBaseWidget> & { widgetId?: WidgetId } = {}
@@ -146,10 +139,12 @@ function processWidgets({
   })
 }
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
+})
+
 describe('widget slot ownership', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   it('does not assign a non-widget input socket to a same-named custom widget', () => {
     const { graph, node } = createGraphWithNode([])
@@ -171,9 +166,7 @@ describe('widget slot ownership', () => {
 })
 
 describe('widget visibility', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   function visibilityOf(
     options: IBaseWidget['options'],
@@ -279,9 +272,7 @@ describe('widget visibility', () => {
 })
 
 describe('widget error state', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   function processWidgetNamed(name: string) {
     const id = widgetId(GRAPH_ID, toNodeId(1), name)
@@ -326,7 +317,6 @@ describe('promoted subgraph widgets', () => {
   const SOURCE_EXECUTION_ID = createNodeExecutionId([HOST_ID, INTERIOR_ID])
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     resetSubgraphFixtureState()
   })
 
@@ -605,9 +595,7 @@ describe('computeProcessedWidgets', () => {
 describe('createWidgetUpdateHandler (via computeProcessedWidgets)', () => {
   const NODE_ID = toNodeId(1)
 
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   function processUpdateWidgets(widgets: IBaseWidget[]) {
     const { graph } = createGraphWithNode(widgets, NODE_ID)
@@ -687,9 +675,7 @@ describe('createWidgetUpdateHandler (via computeProcessedWidgets)', () => {
 })
 
 describe('live widget update handler', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   it('forwards null (not undefined) to both the live widget value and callback', () => {
     const callback = vi.fn()

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
@@ -1,4 +1,3 @@
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -45,10 +44,6 @@ function renderedWidgetNames(graph: LGraph, node: LGraphNode): string[] {
     ui: noopUi
   }).map((w) => w.simplified.name)
 }
-
-beforeEach(() => {
-  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
-})
 
 describe('widget rename after registration (#15600)', () => {
   beforeEach(() => {})

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { computeProcessedWidgets } from '@/renderer/extensions/vueNodes/composables/useProcessedWidgets'
@@ -9,10 +8,6 @@ import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-widget-rename'
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ rootGraphId: GRAPH_ID })
-}))
 
 const noopUi = {
   getTooltipConfig: () => ({}),
@@ -51,10 +46,12 @@ function renderedWidgetNames(graph: LGraph, node: LGraphNode): string[] {
   }).map((w) => w.simplified.name)
 }
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: GRAPH_ID })
+})
+
 describe('widget rename after registration (#15600)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+  beforeEach(() => {})
 
   it('control: a widget that is never renamed renders', () => {
     const { graph, node } = setup('Original')

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import type * as VueUse from '@vueuse/core'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { toNodeId } from '@/types/nodeId'
@@ -58,10 +57,6 @@ vi.mock<unknown>(import('@/renderer/core/canvas/useAutoPan'), () => ({
       capturedAutoPan.current = this
     }
   }
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ isReadOnly: false })
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
@@ -206,7 +201,8 @@ vi.mock(import('@/renderer/core/canvas/links/linkDropOrchestrator'), () => ({
   resolveNodeSurfaceSlotCandidate: () => null
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
   useEventListener: (event: string, handler: (...args: unknown[]) => void) => {
     capturedHandlers[event] = handler
     return vi.fn()
@@ -217,10 +213,6 @@ vi.mock<unknown>(import('@vueuse/core'), () => ({
 vi.mock<unknown>(import('@/lib/litegraph/src/LLink'), () => ({
   LLink: { getReroutes: () => [] },
   slotFloatingLinks: () => []
-}))
-
-vi.mock<unknown>(import('@/lib/litegraph/src/types/globalEnums'), () => ({
-  LinkDirection: { LEFT: 0, RIGHT: 1, NONE: -1 }
 }))
 
 vi.mock<unknown>(import('@/utils/rafBatch'), () => ({
@@ -264,7 +256,6 @@ function startDrag() {
 
 describe('useSlotLinkInteraction auto-pan', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     capturedOnPan.current = null
     capturedAutoPan.current = null
     for (const k of Object.keys(capturedHandlers)) {

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -1,5 +1,9 @@
+import type * as VueUse from '@vueuse/core'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
+import type { ComfyApp } from '@/scripts/app'
 
 import { render, screen } from '@testing-library/vue'
 
@@ -48,8 +52,6 @@ const testState = vi.hoisted(() => {
   const contentSizes = new Map<string, { width: number; height: number }>()
 
   return {
-    linearMode: false,
-    rootGraphId: ROOT_GRAPH_ID,
     visibility: null as { value: 'visible' | 'hidden' } | null,
     nodeLayouts: new Map<NodeId, NodeLayout>(),
     contentSizes,
@@ -67,22 +69,23 @@ const testState = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('@vueuse/core'), () => ({
-  useDocumentVisibility: () => {
-    const visibility = ref<'visible' | 'hidden'>('visible')
-    testState.visibility = visibility
-    return visibility
-  },
-  createSharedComposable: <T>(fn: T) => fn
-}))
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({ canvas: {}, nodePreviewImages: {} }) }
+})
 
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    linearMode: testState.linearMode,
-    rootGraphId: testState.rootGraphId,
-    canvas: { setDirty: testState.setDirty }
-  })
-}))
+vi.mock(import('@vueuse/core'), async (importOriginal) => {
+  const { ref } = await import('vue')
+  return {
+    ...(await importOriginal<typeof VueUse>()),
+    useDocumentVisibility: () => {
+      const visibility = ref<'visible' | 'hidden'>('visible')
+      testState.visibility = visibility
+      return visibility
+    },
+    createSharedComposable: <T>(fn: T) => fn
+  }
+})
 
 vi.mock<unknown>(
   import('@/composables/element/useCanvasPositionConversion'),
@@ -188,10 +191,14 @@ function seedNodeLayout(options: {
   })
 }
 
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({ setDirty: testState.setDirty })
+})
+
 describe('useVueNodeResizeTracking', () => {
   beforeEach(() => {
-    testState.linearMode = false
-    testState.rootGraphId = ROOT_GRAPH_ID
+    useCanvasStore().linearMode = false
+    Object.assign(useCanvasStore(), { rootGraphId: ROOT_GRAPH_ID })
     if (testState.visibility) testState.visibility.value = 'visible'
     testState.nodeLayouts.clear()
     testState.contentSizes.clear()
@@ -227,7 +234,7 @@ describe('useVueNodeResizeTracking', () => {
 
     resizeObserverState.callback?.([entry], createObserverMock())
     vi.clearAllMocks()
-    testState.rootGraphId = SECOND_GRAPH_ID
+    Object.assign(useCanvasStore(), { rootGraphId: SECOND_GRAPH_ID })
 
     resizeObserverState.callback?.([entry], createObserverMock())
 
@@ -288,7 +295,7 @@ describe('useVueNodeResizeTracking', () => {
     })
     resizeObserverState.callback?.([entry], createObserverMock())
 
-    expect(testState.rootGraphId).toBe(ROOT_GRAPH_ID)
+    expect(useCanvasStore().rootGraphId).toBe(ROOT_GRAPH_ID)
     expect(testState.reportContentSize).toHaveBeenCalledWith(
       ROOT_GRAPH_ID,
       subgraphNodeId,

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -1,32 +1,19 @@
 import type { MockInstance } from 'vitest'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { MIN_NODE_WIDTH } from '@/renderer/core/layout/transform/graphRenderTransform'
 
+import { useNodeResize } from './useNodeResize'
 import type { ResizeCallbackPayload } from './useNodeResize'
 
 type ResizeCallback = (
   payload: ResizeCallbackPayload,
   element: HTMLElement
 ) => void
-
-// Capture pointermove/pointerup handlers registered via useEventListener
-const eventHandlers = vi.hoisted(() => ({
-  pointermove: null as ((e: PointerEvent) => void) | null,
-  pointerup: null as ((e: PointerEvent) => void) | null
-}))
-
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  useEventListener: vi.fn(
-    (eventName: string, handler: (...args: unknown[]) => void) => {
-      if (eventName === 'pointermove' || eventName === 'pointerup') {
-        eventHandlers[eventName] = handler
-      }
-      return vi.fn()
-    }
-  )
-}))
 
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
@@ -66,10 +53,6 @@ vi.mock(
     })
   })
 )
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({ rootGraphId: 'root-graph' })
-}))
 
 vi.mock<unknown>(import('@/renderer/core/layout/store/layoutStore'), () => ({
   layoutStore: {
@@ -157,7 +140,7 @@ function simulateMove(
     clientX: startX + deltaX,
     clientY: startY + deltaY
   })
-  eventHandlers.pointermove?.(moveEvent)
+  window.dispatchEvent(new PointerEvent('pointermove', moveEvent))
 }
 
 describe('useNodeResize', () => {
@@ -165,9 +148,14 @@ describe('useNodeResize', () => {
   let nodeElement: HTMLElement
   let handle: HTMLElement
 
-  beforeEach(async () => {
-    eventHandlers.pointermove = null
-    eventHandlers.pointerup = null
+  afterEach(() => {
+    window.dispatchEvent(new PointerEvent('pointercancel'))
+  })
+
+  beforeEach(() => {
+    useCanvasStore().currentGraph = fromPartial<LGraph>({
+      rootGraph: { id: 'root-graph' }
+    })
     snapState.shouldSnap = false
     snapState.applySnapToPosition = (pos) => pos
     snapState.applySnapToSize = (size) => size
@@ -176,8 +164,6 @@ describe('useNodeResize', () => {
     nodeElement = createMockNodeElement()
     handle = createMockHandle(nodeElement)
 
-    // Need fresh import after mocks are set up
-    const { useNodeResize } = await import('./useNodeResize')
     const { startResize } = useNodeResize(callback)
 
     // Store startResize for access in tests
@@ -325,12 +311,9 @@ describe('useNodeResize', () => {
 
     async function setupDynamic(getMinContentHeight: () => number) {
       vi.clearAllMocks()
-      eventHandlers.pointermove = null
-      eventHandlers.pointerup = null
       const cb = vi.fn<ResizeCallback>()
       const el = makeReflowingElement(300, 400, getMinContentHeight)
       const h = createMockHandle(el)
-      const { useNodeResize } = await import('./useNodeResize')
       const { startResize } = useNodeResize(cb)
       return { cb, el, handle: h, startResize }
     }
@@ -396,7 +379,7 @@ describe('useNodeResize', () => {
       const callsBeforeUp = cb.mock.calls.length
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      eventHandlers.pointerup?.(upEvent)
+      window.dispatchEvent(new PointerEvent('pointerup', upEvent))
 
       // Subsequent moves should be ignored after cleanup
       simulateMove(40, 40)
@@ -413,7 +396,9 @@ describe('useNodeResize', () => {
       simulateMove(10, 10)
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      expect(() => eventHandlers.pointerup?.(upEvent)).not.toThrow()
+      expect(() =>
+        window.dispatchEvent(new PointerEvent('pointerup', upEvent))
+      ).not.toThrow()
 
       // Further moves are ignored — cleanup still ran.
       const callsAfterUp = cb.mock.calls.length
@@ -496,7 +481,6 @@ describe('useNodeResize', () => {
       })()
       const cb = vi.fn<ResizeCallback>()
       const h = createMockHandle(breakpointAwareElement)
-      const { useNodeResize } = await import('./useNodeResize')
       const { startResize } = useNodeResize(cb)
 
       // Start at width=300 (still narrow side, but the breakpoint logic

--- a/src/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale.test.ts
@@ -1,8 +1,6 @@
 import { toGroupId } from '@/types/groupId'
-import { createTestingPinia } from '@pinia/testing'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphExtra } from '@/lib/litegraph/src/LGraph'
 import { LGraphGroup } from '@/lib/litegraph/src/litegraph'
@@ -70,10 +68,6 @@ function snapshotGeometry(nodes: MockNode[]) {
 }
 
 describe('ensureCorrectLayoutScale (legacy normalizer)', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('normalizes legacy Vue-scaled graph once', () => {
     const nodes = twoNodeLayout()
     const graph = createMockGraph(nodes, {

--- a/src/renderer/extensions/vueNodes/layout/nodeSizeReflow.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/nodeSizeReflow.test.ts
@@ -1,5 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -30,7 +28,6 @@ function setup() {
 
 describe('LGraphNode size reflow', () => {
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     layoutStore.resetForTests()
   })
 

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -1,14 +1,12 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import type * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
-import type { Ref } from 'vue'
 
 import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import type { NodeLayout } from '@/renderer/core/layout/types'
 import { toNodeId } from '@/types/nodeId'
-import type { NodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
 
 // TODO: Simplify test setup — use real layoutStore + createTestingPinia instead
@@ -17,8 +15,6 @@ const ROOT_GRAPH_ID = vi.hoisted<UUID>(() => 'root-graph')
 
 const testState = vi.hoisted(() => {
   return {
-    selectedNodeIds: null as unknown as Ref<Set<NodeId>>,
-    selectedItems: null as unknown as Ref<unknown[]>,
     nodeLayouts: new Map<string, Pick<NodeLayout, 'position' | 'size'>>(),
     mutationFns: {
       moveNode: vi.fn(),
@@ -55,26 +51,6 @@ vi.mock<unknown>(import('@/renderer/core/canvas/useAutoPan'), () => ({
       testState.capturedAutoPanInstance.current = this
     }
   }
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    rootGraphId: ROOT_GRAPH_ID,
-    selectedNodeIds: testState.selectedNodeIds,
-    selectedItems: testState.selectedItems,
-    canvas: {
-      ds: testState.mockDs,
-      auto_pan_speed: 10,
-      canvas: {
-        getBoundingClientRect: () => ({
-          left: 0,
-          top: 0,
-          right: 800,
-          bottom: 600
-        })
-      }
-    }
-  })
 }))
 
 vi.mock<unknown>(
@@ -138,8 +114,8 @@ function pointerEvent(clientX: number, clientY: number): PointerEvent {
 }
 
 beforeEach(() => {
-  testState.selectedNodeIds = ref(new Set<NodeId>())
-  testState.selectedItems = ref<unknown[]>([])
+  Object.assign(useCanvasStore(), { selectedNodeIds: new Set() })
+  useCanvasStore().selectedItems = []
   testState.nodeLayouts.clear()
   testState.nodeSnap.shouldSnap.mockReturnValue(false)
   testState.nodeSnap.applySnapToPosition.mockImplementation(
@@ -158,9 +134,20 @@ beforeEach(() => {
   vi.stubGlobal('cancelAnimationFrame', testState.cancelAnimationFrame)
 })
 
+beforeEach(() => {
+  Object.assign(useCanvasStore(), { rootGraphId: ROOT_GRAPH_ID })
+  useCanvasStore().canvas = fromPartial({
+    ds: testState.mockDs,
+    auto_pan_speed: 10,
+    canvas: { getBoundingClientRect: () => new DOMRect(0, 0, 800, 600) }
+  })
+})
+
 describe('useNodeDrag', () => {
   it('batches multi-node drag updates into one mutation call per frame', () => {
-    testState.selectedNodeIds.value = new Set([node1, toNodeId('2')])
+    Object.assign(useCanvasStore(), {
+      selectedNodeIds: new Set([node1, toNodeId('2')])
+    })
     testState.nodeLayouts.set('1', {
       position: { x: 100, y: 100 },
       size: { width: 200, height: 120 }
@@ -188,7 +175,7 @@ describe('useNodeDrag', () => {
   })
 
   it('uses the same batched mutation path for single-node drags', () => {
-    testState.selectedNodeIds.value = new Set([node1])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
     testState.nodeLayouts.set('1', {
       position: { x: 50, y: 80 },
       size: { width: 180, height: 110 }
@@ -213,8 +200,8 @@ describe('useNodeDrag', () => {
     selectedNode.pos = [300, 400]
     const selectedGroup = new LGraphGroup('selected')
     selectedGroup.pos = [500, 600]
-    testState.selectedNodeIds.value = new Set([node1])
-    testState.selectedItems.value = [selectedNode, selectedGroup]
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
+    useCanvasStore().selectedItems = [selectedNode, selectedGroup]
     testState.nodeLayouts.set('1', {
       position: { x: 100, y: 100 },
       size: { width: 200, height: 120 }
@@ -231,7 +218,7 @@ describe('useNodeDrag', () => {
   })
 
   it('cancels pending RAF and applies snap updates on endDrag', () => {
-    testState.selectedNodeIds.value = new Set([node1])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
     testState.nodeLayouts.set('1', {
       position: { x: 50, y: 80 },
       size: { width: 180, height: 110 }
@@ -271,8 +258,8 @@ describe('useNodeDrag', () => {
 
 describe('useNodeDrag auto-pan', () => {
   beforeEach(() => {
-    testState.selectedNodeIds = ref(new Set([node1]))
-    testState.selectedItems = ref<unknown[]>([])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
+    useCanvasStore().selectedItems = []
     testState.nodeLayouts.clear()
     testState.nodeLayouts.set('1', {
       position: { x: 100, y: 200 },
@@ -323,7 +310,9 @@ describe('useNodeDrag auto-pan', () => {
   })
 
   it('moves all selected nodes when auto-pan fires', () => {
-    testState.selectedNodeIds.value = new Set([node1, toNodeId('2')])
+    Object.assign(useCanvasStore(), {
+      selectedNodeIds: new Set([node1, toNodeId('2')])
+    })
     const drag = useNodeDrag()
 
     drag.startDrag(pointerEvent(750, 300), node1)
@@ -418,12 +407,12 @@ describe('useNodeDrag non-node positionables', () => {
         pos[1] += deltaY
       }
     }
-    testState.selectedItems.value = [group]
+    useCanvasStore().selectedItems = [fromPartial(group)]
     return group
   }
 
   function dragNodeBy(delta: number) {
-    testState.selectedNodeIds.value = new Set([node1])
+    Object.assign(useCanvasStore(), { selectedNodeIds: new Set([node1]) })
     testState.nodeLayouts.set('1', {
       position: { x: 0, y: 0 },
       size: { width: 100, height: 50 }

--- a/src/renderer/extensions/vueNodes/layout/useNodeLayout.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeLayout.test.ts
@@ -1,5 +1,6 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
@@ -32,16 +33,6 @@ function createNode(graphId: UUID, x: number): void {
   })
 }
 
-const state = vi.hoisted<{
-  canvasStore: { rootGraphId: UUID | undefined } | null
-}>(() => ({ canvasStore: null }))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), async () => {
-  const { reactive } = await import('vue')
-  state.canvasStore = reactive({ rootGraphId: undefined })
-  return { useCanvasStore: () => state.canvasStore }
-})
-
 const NodeLayoutHost = defineComponent({
   setup() {
     const { position } = useNodeLayout(NODE)
@@ -54,14 +45,14 @@ describe('useNodeLayout', () => {
     layoutStore.resetForTests()
     createNode(FIRST_WORKFLOW, 100)
     createNode(SECOND_WORKFLOW, 200)
-    state.canvasStore!.rootGraphId = FIRST_WORKFLOW
+    Object.assign(useCanvasStore(), { rootGraphId: FIRST_WORKFLOW })
   })
 
   it('follows layout changes when the workflow changes', async () => {
     const { container } = render(NodeLayoutHost)
     expect(container.textContent).toBe('100')
 
-    state.canvasStore!.rootGraphId = SECOND_WORKFLOW
+    Object.assign(useCanvasStore(), { rootGraphId: SECOND_WORKFLOW })
     await nextTick()
     expect(container.textContent).toBe('200')
 

--- a/src/renderer/extensions/vueNodes/utils/__tests__/nodeDataUtils.test.ts
+++ b/src/renderer/extensions/vueNodes/utils/__tests__/nodeDataUtils.test.ts
@@ -1,6 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -14,7 +11,7 @@ import {
   nonWidgetedInputs
 } from '@/renderer/extensions/vueNodes/utils/nodeDataUtils'
 import { useLinkStore } from '@/stores/linkStore'
-import { beforeEach, describe, it } from 'vitest'
+import { describe, it } from 'vitest'
 
 const GRAPH_ID = 'graph-test'
 const GRAPH_SCOPE = {
@@ -93,10 +90,6 @@ describe('nodeDataUtils', () => {
   })
 
   describe('linkedWidgetedInputs', () => {
-    beforeEach(() => {
-      setActivePinia(createTestingPinia({ stubActions: false }))
-    })
-
     it('returns nothing when no input slot is connected', () => {
       const inputs: INodeInputSlot[] = [
         makeFakeInputSlot('first'),

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable testing-library/no-node-access */
-import { createTestingPinia } from '@pinia/testing'
 import { fireEvent, render, screen } from '@testing-library/vue'
 import { fromAny } from '@total-typescript/shoehorn'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { getActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -74,7 +74,7 @@ function renderComponent(
 ) {
   return render(DisplayCarousel, {
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n]
+      plugins: [getActivePinia()!, i18n]
     },
     props: {
       widget,
@@ -467,7 +467,7 @@ describe('DisplayCarousel Grid Mode', () => {
     const widget = createGalleriaWidget([...TEST_IMAGES_SMALL])
     const { container, rerender } = render(DisplayCarousel, {
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn }), i18n]
+        plugins: [getActivePinia()!, i18n]
       },
       props: { widget, modelValue: images.value }
     })

--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
@@ -1,17 +1,12 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { ControlOptions } from '@/types/simplifiedWidget'
-
-const mockGet = vi.hoisted(() => vi.fn<(key: string) => string>())
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: mockGet })
-}))
 
 import ValueControlPopover from './ValueControlPopover.vue'
 
@@ -77,21 +72,25 @@ function renderPopover(modelValue: ControlOptions = 'randomize') {
 
 describe('ValueControlPopover', () => {
   beforeEach(() => {
-    mockGet.mockReturnValue('after')
+    useSettingStore().settingValues['Comfy.WidgetControlMode'] = 'after'
   })
 
   describe('Header text from setting store', () => {
     it('shows AFTER copy when Comfy.WidgetControlMode is "after"', () => {
       renderPopover()
-      expect(mockGet).toHaveBeenCalledWith('Comfy.WidgetControlMode')
+      expect(useSettingStore().get).toHaveBeenCalledWith(
+        'Comfy.WidgetControlMode'
+      )
       expect(screen.getByText('AFTER')).toBeInTheDocument()
       expect(screen.queryByText('BEFORE')).not.toBeInTheDocument()
     })
 
     it('shows BEFORE copy when Comfy.WidgetControlMode is "before"', () => {
-      mockGet.mockReturnValue('before')
+      useSettingStore().settingValues['Comfy.WidgetControlMode'] = 'before'
       renderPopover()
-      expect(mockGet).toHaveBeenCalledWith('Comfy.WidgetControlMode')
+      expect(useSettingStore().get).toHaveBeenCalledWith(
+        'Comfy.WidgetControlMode'
+      )
       expect(screen.getByText('BEFORE')).toBeInTheDocument()
       expect(screen.queryByText('AFTER')).not.toBeInTheDocument()
     })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
@@ -1,18 +1,8 @@
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const canvasMocks = vi.hoisted(() => ({
-  canvas: {
-    graph: {
-      getNodeById: vi.fn((): unknown => null)
-    }
-  },
-  linearMode: false
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => canvasMocks
-}))
 
 const resolveMock = vi.hoisted(() => vi.fn())
 vi.mock(
@@ -32,6 +22,13 @@ import { toNodeId } from '@/types/nodeId'
 import WidgetDOM from './WidgetDOM.vue'
 import { createMockWidget } from './widgetTestUtils'
 
+beforeEach(() => {
+  useCanvasStore().canvas = fromPartial({
+    canvas: document.createElement('canvas'),
+    graph: { getNodeById: vi.fn(() => null) }
+  })
+})
+
 describe('WidgetDOM', () => {
   beforeEach(() => {
     isDOMWidgetMock.mockReturnValue(true)
@@ -39,7 +36,9 @@ describe('WidgetDOM', () => {
 
   function mountWithWidget(domElement: HTMLElement | null) {
     if (domElement) {
-      canvasMocks.canvas.graph.getNodeById.mockReturnValue({ mock: true })
+      vi.mocked(
+        useCanvasStore().getCanvas().graph!.getNodeById
+      ).mockReturnValue(new LGraphNode('test'))
       resolveMock.mockReturnValue({
         node: { mock: true },
         widget: { element: domElement, name: 'dom' }
@@ -69,7 +68,9 @@ describe('WidgetDOM', () => {
   })
 
   it('renders an empty container when no host node is found', () => {
-    canvasMocks.canvas.graph.getNodeById.mockReturnValue(null)
+    vi.mocked(useCanvasStore().getCanvas().graph!.getNodeById).mockReturnValue(
+      null
+    )
     resolveMock.mockReturnValue(undefined)
 
     const { container } = render(WidgetDOM, {
@@ -94,7 +95,9 @@ describe('WidgetDOM', () => {
     const hosted = document.createElement('div')
     hosted.setAttribute('data-testid', 'hosted-dom')
 
-    canvasMocks.canvas.graph.getNodeById.mockReturnValue({ mock: true })
+    vi.mocked(useCanvasStore().getCanvas().graph!.getNodeById).mockReturnValue(
+      new LGraphNode('test')
+    )
     resolveMock.mockReturnValue({
       node: { mock: true },
       widget: { element: hosted, name: 'dom' }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -113,7 +113,7 @@ const ButtonStub = defineComponent({
 function renderWidget(props: { readonly?: boolean; nodeId?: NodeId } = {}) {
   return render(WidgetRecordAudio, {
     global: {
-      plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
+      plugins: [i18n, getActivePinia()!],
       stubs: { Button: ButtonStub }
     },
     props: { readonly: false, nodeId: toNodeId('n1'), ...props }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetResolutionPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetResolutionPreview.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -35,8 +34,7 @@ const i18n = createI18n({
 let pinia: Pinia
 
 beforeEach(() => {
-  pinia = createTestingPinia({ stubActions: false })
-  setActivePinia(pinia)
+  pinia = getActivePinia()!
   resolveNodeMock.mockReturnValue({
     id: NODE_ID,
     graph: { rootGraph: { id: GRAPH_ID } }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.asset-mode.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.asset-mode.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -59,7 +59,7 @@ describe('WidgetSelect asset mode', () => {
         nodeType: 'CheckpointLoaderSimple'
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia(), i18n],
+        plugins: [PrimeVue, getActivePinia()!, i18n],
         stubs
       }
     })
@@ -98,7 +98,7 @@ describe('WidgetSelect asset mode', () => {
         nodeType: 'ImageLoader'
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia(), i18n],
+        plugins: [PrimeVue, getActivePinia()!, i18n],
         stubs: {
           WidgetSelectDefault: stubs.WidgetSelectDefault,
           WidgetWithControl: stubs.WidgetWithControl

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelect.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen, fireEvent } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
@@ -55,7 +55,6 @@ const WidgetSelectDefaultStub = defineComponent({
 })
 
 const globalConfig = {
-  plugins: [createTestingPinia(), i18n],
   stubs: {
     WidgetSelectDropdown: WidgetSelectDropdownStub,
     WidgetSelectDefault: WidgetSelectDefaultStub,
@@ -107,7 +106,7 @@ describe('WidgetSelect Value Binding', () => {
         'onUpdate:modelValue': onModelUpdate,
         ...extraProps
       },
-      global: globalConfig
+      global: { ...globalConfig, plugins: [getActivePinia()!, i18n] }
     })
     return onModelUpdate
   }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -1,6 +1,7 @@
+import { getActivePinia } from 'pinia'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { computed, nextTick, ref } from 'vue'
@@ -16,19 +17,6 @@ import { createMockWidget } from './widgetTestUtils'
 
 const mockCheckState = vi.hoisted(() => vi.fn())
 const mockAssetsData = vi.hoisted(() => ({ items: [] as AssetItem[] }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: {
-          checkState: mockCheckState
-        }
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/api'))
 
@@ -120,6 +108,12 @@ const i18n = createI18n({
   messages: { en: {} }
 })
 
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { checkState: mockCheckState }
+  })
+})
+
 describe('WidgetSelectDropdown', () => {
   beforeEach(() => {
     mockMediaAssets.media.value = []
@@ -144,7 +138,7 @@ describe('WidgetSelectDropdown', () => {
         ...extraProps
       },
       global: {
-        plugins: [PrimeVue, createTestingPinia(), i18n]
+        plugins: [PrimeVue, getActivePinia()!, i18n]
       }
     })
   }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
@@ -1,11 +1,13 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { getActivePinia } from 'pinia'
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
 import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { NodeOutputWith, ResultItem } from '@/schemas/apiSchema'
@@ -13,6 +15,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { widgetId } from '@/types/widgetId'
 
@@ -20,7 +23,7 @@ import WidgetTextPreview from './WidgetTextPreview.vue'
 
 const GRAPH_ID = 'graph-1'
 const NODE_ID = toNodeId('7')
-const LOCATOR = 'loc-1'
+const LOCATOR = createNodeLocatorId(null, NODE_ID)
 
 // jsdom does not implement ResizeObserver (happy-dom does); stub it before
 // component modules construct their module-level observer at import time.
@@ -49,13 +52,6 @@ vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   resolveNode: () => ({})
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ nodeToNodeLocatorId: () => LOCATOR })
-  })
-)
-
 interface SavedFile {
   filename: string
   subfolder?: string
@@ -81,8 +77,7 @@ function renderPreview(
   text: string,
   opts: { markdown?: boolean; file?: SavedFile } = {}
 ) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   const canvasStore = useCanvasStore()
   canvasStore.canvas = fromPartial({ graph: { rootGraph: { id: GRAPH_ID } } })
@@ -113,6 +108,10 @@ function renderPreview(
     global: { plugins: [pinia, createTestI18n()] }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().nodeToNodeLocatorId).mockReturnValue(LOCATOR)
+})
 
 describe('WidgetTextPreview', () => {
   it('renders plaintext in a textarea by default', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.test.ts
@@ -1,6 +1,8 @@
+import { getActivePinia } from 'pinia'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia } from 'pinia'
+
 import PrimeVue from 'primevue/config'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -15,12 +17,6 @@ function createItem(id: string, name: string): FormDropdownItem {
 }
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    addAlert: vi.fn()
-  })
-}))
 
 const transformState = vi.hoisted(() => ({ camera: { x: 0, y: 0, z: 1 } }))
 
@@ -116,7 +112,7 @@ function mountDropdown(
       'onUpdate:isOpen': options.onUpdateIsOpen
     },
     global: {
-      plugins: [PrimeVue, i18n, createPinia()],
+      plugins: [PrimeVue, i18n, getActivePinia()!],
       stubs: {
         FormDropdownInput: MockFormDropdownInput,
         Popover: MockPopover,
@@ -146,6 +142,10 @@ async function openDropdown(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Open' }))
   await flushPromises()
 }
+
+beforeEach(() => {
+  vi.mocked(useToastStore().addAlert).mockImplementation(() => undefined)
+})
 
 describe('FormDropdown', () => {
   beforeEach(() => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.desktop.test.ts
@@ -1,3 +1,5 @@
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -5,25 +7,6 @@ import { useAssetWidgetData } from '@/renderer/extensions/vueNodes/widgets/compo
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
-}))
-
-const mockUpdateModelsForNodeType = vi.fn()
-const mockGetCategoryForNodeType = vi.fn()
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    getAssets: () => [],
-    isModelLoading: () => false,
-    getError: () => undefined,
-    hasAssetKey: () => false,
-    updateModelsForNodeType: mockUpdateModelsForNodeType
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getCategoryForNodeType: mockGetCategoryForNodeType
-  })
 }))
 
 describe('useAssetWidgetData (desktop/isCloud=false)', () => {
@@ -35,7 +18,7 @@ describe('useAssetWidgetData (desktop/isCloud=false)', () => {
     expect(assets.value).toEqual([])
     expect(isLoading.value).toBe(false)
     expect(error.value).toBeNull()
-    expect(mockUpdateModelsForNodeType).not.toHaveBeenCalled()
-    expect(mockGetCategoryForNodeType).not.toHaveBeenCalled()
+    expect(useAssetsStore().updateModelsForNodeType).not.toHaveBeenCalled()
+    expect(useModelToNodeStore().getCategoryForNodeType).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
@@ -1,3 +1,5 @@
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,24 +16,21 @@ const mockAssetsByKey = new Map<string, AssetItem[]>()
 const mockLoadingByKey = new Map<string, boolean>()
 const mockErrorByKey = new Map<string, Error | undefined>()
 const mockInitializedKeys = new Set<string>()
-const mockUpdateModelsForNodeType = vi.fn()
-const mockGetCategoryForNodeType = vi.fn()
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    getAssets: (key: string) => mockAssetsByKey.get(key) ?? [],
-    isModelLoading: (key: string) => mockLoadingByKey.get(key) ?? false,
-    getError: (key: string) => mockErrorByKey.get(key),
-    hasAssetKey: (key: string) => mockInitializedKeys.has(key),
-    updateModelsForNodeType: mockUpdateModelsForNodeType
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getCategoryForNodeType: mockGetCategoryForNodeType
-  })
-}))
+beforeEach(() => {
+  vi.mocked(useAssetsStore().getAssets).mockImplementation(
+    (key) => mockAssetsByKey.get(key) ?? []
+  )
+  vi.mocked(useAssetsStore().isModelLoading).mockImplementation(
+    (key) => mockLoadingByKey.get(key) ?? false
+  )
+  vi.mocked(useAssetsStore().getError).mockImplementation((key) =>
+    mockErrorByKey.get(key)
+  )
+  vi.mocked(useAssetsStore().hasAssetKey).mockImplementation((key) =>
+    mockInitializedKeys.has(key)
+  )
+})
 
 describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   beforeEach(() => {
@@ -39,12 +38,12 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
     mockLoadingByKey.clear()
     mockErrorByKey.clear()
     mockInitializedKeys.clear()
-    mockGetCategoryForNodeType.mockReturnValue(undefined)
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+      undefined
+    )
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (): Promise<AssetItem[]> => {
-        return []
-      }
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockResolvedValue(
+      undefined
     )
   })
 
@@ -75,14 +74,15 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       createMockAsset('asset-2', 'Model B', 'model_b.safetensors', '/preview/2')
     ]
 
-    mockGetCategoryForNodeType.mockReturnValue('checkpoints')
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+      'checkpoints'
+    )
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (_nodeType: string): Promise<AssetItem[]> => {
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+      async (_nodeType: string) => {
         mockInitializedKeys.add(_nodeType)
         mockAssetsByKey.set(_nodeType, mockAssets)
         mockLoadingByKey.set(_nodeType, false)
-        return mockAssets
       }
     )
 
@@ -92,9 +92,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
     await nextTick()
     await vi.waitFor(() => !isLoading.value)
 
-    expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith(
-      'CheckpointLoaderSimple'
-    )
+    expect(
+      vi.mocked(useAssetsStore().updateModelsForNodeType)
+    ).toHaveBeenCalledWith('CheckpointLoaderSimple')
     expect(category.value).toBe('checkpoints')
     expect(assets.value).toEqual(mockAssets)
     expect(assets.value).toHaveLength(2)
@@ -106,13 +106,12 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   it('handles API errors gracefully', async () => {
     const mockError = new Error('Network error')
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (_nodeType: string): Promise<AssetItem[]> => {
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+      async (_nodeType: string) => {
         mockInitializedKeys.add(_nodeType)
         mockErrorByKey.set(_nodeType, mockError)
         mockAssetsByKey.set(_nodeType, [])
         mockLoadingByKey.set(_nodeType, false)
-        return []
       }
     )
 
@@ -127,14 +126,15 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
   })
 
   it('returns empty for unknown node type', async () => {
-    mockGetCategoryForNodeType.mockReturnValue(undefined)
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+      undefined
+    )
 
-    mockUpdateModelsForNodeType.mockImplementation(
-      async (_nodeType: string): Promise<AssetItem[]> => {
+    vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+      async (_nodeType: string) => {
         mockInitializedKeys.add(_nodeType)
         mockAssetsByKey.set(_nodeType, [])
         mockLoadingByKey.set(_nodeType, false)
-        return []
       }
     )
 
@@ -153,13 +153,14 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
         createMockAsset('asset-1', 'Model A', 'model_a.safetensors')
       ]
 
-      mockGetCategoryForNodeType.mockReturnValue('checkpoints')
-      mockUpdateModelsForNodeType.mockImplementation(
-        async (_nodeType: string): Promise<AssetItem[]> => {
+      vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+        'checkpoints'
+      )
+      vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+        async (_nodeType: string) => {
           mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
-          return mockAssets
         }
       )
 
@@ -170,9 +171,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       await nextTick()
       await vi.waitFor(() => !isLoading.value)
 
-      expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith(
-        'CheckpointLoaderSimple'
-      )
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).toHaveBeenCalledWith('CheckpointLoaderSimple')
       expect(category.value).toBe('checkpoints')
       expect(assets.value).toEqual(mockAssets)
     })
@@ -182,13 +183,14 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
         createMockAsset('asset-1', 'Model A', 'model_a.safetensors')
       ]
 
-      mockGetCategoryForNodeType.mockReturnValue('loras')
-      mockUpdateModelsForNodeType.mockImplementation(
-        async (_nodeType: string): Promise<AssetItem[]> => {
+      vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+        'loras'
+      )
+      vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+        async (_nodeType: string) => {
           mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
-          return mockAssets
         }
       )
 
@@ -200,7 +202,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       await nextTick()
       await vi.waitFor(() => !isLoading.value)
 
-      expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith('LoraLoader')
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).toHaveBeenCalledWith('LoraLoader')
       expect(category.value).toBe('loras')
       expect(assets.value).toEqual(mockAssets)
     })
@@ -210,13 +214,14 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
         createMockAsset('asset-1', 'Model A', 'model_a.safetensors')
       ]
 
-      mockGetCategoryForNodeType.mockReturnValue('checkpoints')
-      mockUpdateModelsForNodeType.mockImplementation(
-        async (_nodeType: string): Promise<AssetItem[]> => {
+      vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
+        'checkpoints'
+      )
+      vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+        async (_nodeType: string) => {
           mockInitializedKeys.add(_nodeType)
           mockAssetsByKey.set(_nodeType, mockAssets)
           mockLoadingByKey.set(_nodeType, false)
-          return mockAssets
         }
       )
 
@@ -226,9 +231,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
       await nextTick()
       await vi.waitFor(() => !isLoading.value)
 
-      expect(mockUpdateModelsForNodeType).toHaveBeenCalledWith(
-        'CheckpointLoaderSimple'
-      )
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).toHaveBeenCalledWith('CheckpointLoaderSimple')
       expect(category.value).toBe('checkpoints')
       expect(assets.value).toEqual(mockAssets)
     })
@@ -239,7 +244,9 @@ describe('useAssetWidgetData (cloud mode, isCloud=true)', () => {
 
       await nextTick()
 
-      expect(mockUpdateModelsForNodeType).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useAssetsStore().updateModelsForNodeType)
+      ).not.toHaveBeenCalled()
       expect(category.value).toBeUndefined()
       expect(assets.value).toEqual([])
       expect(isLoading.value).toBe(false)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -1,4 +1,7 @@
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -24,49 +27,31 @@ function createMockAssetItem(overrides: Partial<AssetItem> = {}): AssetItem {
 }
 
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
-const mockLoadMore = vi.hoisted(() =>
-  vi.fn(() => {
-    mockAssetsStoreState.inputAssets.hasMore = false
-    return Promise.resolve()
-  })
-)
-const mockGetInputName = vi.hoisted(() => vi.fn((hash: string) => hash))
-const mockGetAssets = vi.hoisted(() => vi.fn(() => [] as AssetItem[]))
-const mockAssetsStoreState = vi.hoisted(() => ({
-  inputAssets: {
-    items: [] as AssetItem[],
-    isLoading: false,
-    hasMore: false,
-    loadMore: mockLoadMore
-  }
-}))
 
 vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidgets: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal()),
   get isCloud() {
     return mockDistributionState.isCloud
   }
 }))
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: vi.fn(() => ({
-    get inputAssets() {
-      return mockAssetsStoreState.inputAssets
-    },
-    getInputName: mockGetInputName,
-    getAssets: mockGetAssets
-  }))
-}))
-
-const mockSettingStoreGet = vi.fn(() => false)
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: mockSettingStoreGet
-  }))
-}))
+vi.mock(import('@/composables/useFeatureFlags'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useFeatureFlags: () => {
+      const featureFlags = actual.useFeatureFlags()
+      return {
+        ...featureFlags,
+        flags: { ...featureFlags.flags, assetsEnabled: false }
+      }
+    }
+  }
+})
 
 vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) =>
@@ -141,17 +126,27 @@ function createMockInputSpec(overrides: Partial<InputSpec> = {}): InputSpec {
   return inputSpec
 }
 
+beforeEach(() => {
+  vi.spyOn(useAssetsStore().inputAssets, 'loadMore').mockImplementation(
+    async () => {
+      useAssetsStore().inputAssets.hasMore = false
+    }
+  )
+})
+
 describe('useComboWidget', () => {
   beforeEach(() => {
-    mockSettingStoreGet.mockReturnValue(false)
-    mockGetInputName.mockImplementation((hash: string) => hash)
-    mockGetAssets.mockImplementation(() => [])
+    vi.mocked(useSettingStore().get).mockReturnValue(false)
+    vi.mocked(useAssetsStore().getInputName).mockImplementation(
+      (hash: string) => hash
+    )
+    vi.mocked(useAssetsStore().getAssets).mockImplementation(() => [])
     vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false)
     vi.mocked(assetService.shouldUseAssetBrowser).mockReturnValue(false)
     mockDistributionState.isCloud = false
-    mockAssetsStoreState.inputAssets.items = []
-    mockAssetsStoreState.inputAssets.isLoading = false
-    mockAssetsStoreState.inputAssets.hasMore = false
+    useAssetsStore().inputAssets.items = []
+    useAssetsStore().inputAssets.isLoading = false
+    useAssetsStore().inputAssets.hasMore = false
   })
 
   it('should handle undefined spec', () => {
@@ -177,7 +172,7 @@ describe('useComboWidget', () => {
 
   it('should create normal combo widget when asset API is disabled', () => {
     mockDistributionState.isCloud = true
-    mockSettingStoreGet.mockReturnValue(false)
+    vi.mocked(useSettingStore().get).mockReturnValue(false)
     vi.mocked(assetService.shouldUseAssetBrowser).mockReturnValue(false)
 
     const constructor = useComboWidget()
@@ -235,7 +230,7 @@ describe('useComboWidget', () => {
     }
 
     it('should create asset browser widget when API enabled', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'cloud_model.safetensors' })
       ])
 
@@ -256,7 +251,7 @@ describe('useComboWidget', () => {
     })
 
     it('should use first cloud asset as default instead of server combo options', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'cloud_model.safetensors' })
       ])
 
@@ -268,7 +263,7 @@ describe('useComboWidget', () => {
     })
 
     it('should fallback to assets[0] when inputSpec.default not in cloud assets', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'cloud_model.safetensors' })
       ])
 
@@ -280,7 +275,7 @@ describe('useComboWidget', () => {
     })
 
     it('should prefer inputSpec.default when it exists in cloud assets', () => {
-      mockGetAssets.mockReturnValue([
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([
         createMockAssetItem({ name: 'other_model.safetensors' }),
         createMockAssetItem({ name: 'fallback.safetensors' })
       ])
@@ -294,7 +289,7 @@ describe('useComboWidget', () => {
     })
 
     it('should create asset browser widget when default value provided without options', () => {
-      mockGetAssets.mockReturnValue([])
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([])
 
       const { mockNode } = setupCloudAssetWidget({
         // Note: no options array provided
@@ -305,7 +300,7 @@ describe('useComboWidget', () => {
     })
 
     it('should fallback to placeholder when cloud assets not loaded', () => {
-      mockGetAssets.mockReturnValue([])
+      vi.mocked(useAssetsStore().getAssets).mockReturnValue([])
 
       const { mockNode } = setupCloudAssetWidget({
         options: ['local_model.safetensors']
@@ -375,7 +370,7 @@ describe('useComboWidget', () => {
       inputAssets: AssetItem[] = []
     ) {
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = inputAssets
+      useAssetsStore().inputAssets.items = inputAssets
 
       const constructor = useComboWidget()
       const mockNode = createMockNode(scenario.nodeClass)
@@ -636,7 +631,9 @@ describe('useComboWidget', () => {
 
     it("should format option labels using store's getInputName function", () => {
       const scenario = cloudInputScenarios[0]
-      mockGetInputName.mockReturnValue('Beautiful Sunset.png')
+      vi.mocked(useAssetsStore().getInputName).mockReturnValue(
+        'Beautiful Sunset.png'
+      )
 
       const { mockNode } = setupCloudInputMappingWidget(
         scenario,
@@ -659,7 +656,9 @@ describe('useComboWidget', () => {
       }
 
       const result = options.getOptionLabel(scenario.assetHash)
-      expect(mockGetInputName).toHaveBeenCalledWith(scenario.assetHash)
+      expect(vi.mocked(useAssetsStore().getInputName)).toHaveBeenCalledWith(
+        scenario.assetHash
+      )
       expect(result).toBe('Beautiful Sunset.png')
     })
 
@@ -748,9 +747,9 @@ describe('useComboWidget', () => {
     it('should trigger lazy load for cloud input nodes', () => {
       const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = []
-      mockAssetsStoreState.inputAssets.isLoading = false
-      mockAssetsStoreState.inputAssets.hasMore = true
+      useAssetsStore().inputAssets.items = []
+      useAssetsStore().inputAssets.isLoading = false
+      useAssetsStore().inputAssets.hasMore = true
 
       const constructor = useComboWidget()
       const mockWidget = createMockWidget({ type: 'combo' })
@@ -763,24 +762,29 @@ describe('useComboWidget', () => {
 
       constructor(mockNode, inputSpec)
 
-      expect(mockLoadMore).toHaveBeenCalledTimes(1)
+      expect(
+        vi.mocked(useAssetsStore().inputAssets.loadMore)
+      ).toHaveBeenCalledTimes(1)
     })
 
     it('should keep empty cloud input value after lazy-loaded inputs resolve a default', async () => {
       const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = []
-      mockAssetsStoreState.inputAssets.isLoading = false
-      mockAssetsStoreState.inputAssets.hasMore = true
-      mockLoadMore.mockImplementationOnce(async () => {
-        mockAssetsStoreState.inputAssets.items = [
-          createMockAssetItem({
-            name: scenario.assetName,
-            hash: scenario.assetHash
-          })
-        ]
-        mockAssetsStoreState.inputAssets.hasMore = false
-      })
+      await nextTick()
+      useAssetsStore().inputAssets.items = []
+      useAssetsStore().inputAssets.isLoading = false
+      useAssetsStore().inputAssets.hasMore = true
+      vi.spyOn(useAssetsStore().inputAssets, 'loadMore').mockImplementationOnce(
+        async () => {
+          useAssetsStore().inputAssets.items = [
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+          useAssetsStore().inputAssets.hasMore = false
+        }
+      )
 
       const constructor = useComboWidget()
       const mockNode = createMockNode(scenario.nodeClass)
@@ -791,11 +795,14 @@ describe('useComboWidget', () => {
 
       const widget = constructor(mockNode, inputSpec)
 
-      expect(mockLoadMore).toHaveBeenCalledTimes(1)
+      expect(
+        vi.mocked(useAssetsStore().inputAssets.loadMore)
+      ).toHaveBeenCalledTimes(1)
       expect(getInputWidgetDefault(mockNode)).toBe('')
       expect(widget.value).toBe('')
 
-      await mockLoadMore.mock.results[0]?.value
+      await vi.mocked(useAssetsStore().inputAssets.loadMore).mock.results[0]
+        ?.value
 
       expect(getInputWidgetValues(mockNode)).toEqual([scenario.assetHash])
       expect(widget.value).toBe('')
@@ -804,14 +811,14 @@ describe('useComboWidget', () => {
     it('should not trigger lazy load if assets already loaded', () => {
       const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
-      mockAssetsStoreState.inputAssets.items = [
+      useAssetsStore().inputAssets.items = [
         createMockAssetItem({
           id: 'asset-123',
           name: scenario.assetName,
           hash: scenario.assetHash
         })
       ]
-      mockAssetsStoreState.inputAssets.isLoading = false
+      useAssetsStore().inputAssets.isLoading = false
 
       const constructor = useComboWidget()
       const mockWidget = createMockWidget({ type: 'combo' })
@@ -824,7 +831,9 @@ describe('useComboWidget', () => {
 
       constructor(mockNode, inputSpec)
 
-      expect(mockLoadMore).not.toHaveBeenCalled()
+      expect(
+        vi.mocked(useAssetsStore().inputAssets.loadMore)
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useFloatWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useFloatWidget.test.ts
@@ -7,12 +7,6 @@ vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidgets: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    settings: {}
-  })
-}))
-
 const { onFloatValueChange } = _for_testing
 
 describe('useFloatWidget', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -1,3 +1,5 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -6,25 +8,11 @@ import type { CanvasPointer, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { BaseWidget } from '@/lib/litegraph/src/widgets/BaseWidget'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 
-const mockSettingStore = vi.hoisted(() => ({
-  get: vi.fn(() => false)
-}))
-
 const mockCanvas = vi.hoisted(() => ({
   graph_mouse: [0, 0] as [number, number],
   pointer_is_down: false,
   canvas: { style: { cursor: '' } },
   setDirty: vi.fn()
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => mockSettingStore
-}))
-
-vi.mock<unknown>(import('@/renderer/core/canvas/canvasStore'), () => ({
-  useCanvasStore: () => ({
-    getCanvas: () => mockCanvas
-  })
 }))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
@@ -130,10 +118,14 @@ const defaultInputSpec = fromPartial<InputSpec>({
   type: 'CUSTOM'
 })
 
+beforeEach(() => {
+  vi.mocked(useCanvasStore().getCanvas).mockReturnValue(fromPartial(mockCanvas))
+})
+
 describe('useImagePreviewWidget', () => {
   beforeEach(() => {
     // clearAllMocks does not reset mockReturnValue — restore defaults explicitly
-    mockSettingStore.get.mockReturnValue(false)
+    useSettingStore().settingValues['Comfy.Node.AllowImageSizeDraw'] = false
     vi.mocked(is_all_same_aspect_ratio).mockReturnValue(true)
     mockCanvas.graph_mouse = [0, 0]
     mockCanvas.pointer_is_down = false
@@ -351,7 +343,7 @@ describe('useImagePreviewWidget', () => {
 
   describe('drawWidget — image size text', () => {
     it('draws image size text when setting is enabled', () => {
-      mockSettingStore.get.mockReturnValue(true)
+      useSettingStore().settingValues['Comfy.Node.AllowImageSizeDraw'] = true
 
       const constructor = useImagePreviewWidget()
       const img = createMockImage(512, 768)
@@ -375,7 +367,7 @@ describe('useImagePreviewWidget', () => {
     })
 
     it('does not draw image size text when setting is disabled', () => {
-      mockSettingStore.get.mockReturnValue(false)
+      useSettingStore().settingValues['Comfy.Node.AllowImageSizeDraw'] = false
 
       const constructor = useImagePreviewWidget()
       const img = createMockImage(512, 768)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
@@ -1,3 +1,5 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -18,21 +20,9 @@ type CapturedImageUploadOptions = {
 const mocks = vi.hoisted(() => ({
   capturedUploadOptions: undefined as CapturedImageUploadOptions | undefined,
   openFileSelection: vi.fn(),
-  setNodeOutputs: vi.fn(),
   showPreview: vi.fn(),
   captureCanvasState: vi.fn()
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: { captureCanvasState: mocks.captureCanvasState }
-      }
-    })
-  })
-)
 
 vi.mock(import('@/composables/node/useNodeImage'), () => ({
   useNodeImage: () => ({ showPreview: mocks.showPreview }),
@@ -51,12 +41,6 @@ vi.mock<unknown>(import('@/composables/node/useNodeImageUpload'), () => ({
 
 vi.mock(import('@/i18n'), () => ({
   t: (key: string) => key
-}))
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    setNodeOutputs: mocks.setNodeOutputs
-  })
 }))
 
 vi.mock(import('@/utils/litegraphUtil'), () => ({
@@ -116,6 +100,15 @@ const outputFolderCases: {
   }
 ]
 
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { captureCanvasState: mocks.captureCanvasState }
+  })
+  vi.mocked(useNodeOutputStore().setNodeOutputs).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('useImageUploadWidget', () => {
   beforeEach(() => {
     mocks.capturedUploadOptions = undefined
@@ -131,9 +124,13 @@ describe('useImageUploadWidget', () => {
     mocks.capturedUploadOptions?.onUploadComplete(['uploaded.png'])
 
     expect(fileComboWidget.value).toBe('uploaded.png')
-    expect(mocks.setNodeOutputs).toHaveBeenCalledWith(node, 'uploaded.png', {
-      isAnimated: false
-    })
+    expect(useNodeOutputStore().setNodeOutputs).toHaveBeenCalledWith(
+      node,
+      'uploaded.png',
+      {
+        isAnimated: false
+      }
+    )
     expect(onWidgetChanged).toHaveBeenCalledWith(
       'image',
       'uploaded.png',
@@ -150,9 +147,13 @@ describe('useImageUploadWidget', () => {
     construct(node)
     frame.mock.calls[0][0]()
 
-    expect(mocks.setNodeOutputs).toHaveBeenCalledWith(node, 'beach.jpg', {
-      isAnimated: false
-    })
+    expect(useNodeOutputStore().setNodeOutputs).toHaveBeenCalledWith(
+      node,
+      'beach.jpg',
+      {
+        isAnimated: false
+      }
+    )
   })
 
   it('does not preview a combo whose value is still unset', () => {
@@ -164,7 +165,7 @@ describe('useImageUploadWidget', () => {
     construct(node)
     frame.mock.calls[0][0]()
 
-    expect(mocks.setNodeOutputs).not.toHaveBeenCalled()
+    expect(useNodeOutputStore().setNodeOutputs).not.toHaveBeenCalled()
     expect(mocks.showPreview).toHaveBeenCalled()
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useIntWidget.test.ts
@@ -11,12 +11,6 @@ vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidget: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn(() => false)
-  })
-}))
-
 const { onValueChange } = _for_testing
 
 describe('useIntWidget', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
@@ -17,9 +17,6 @@ const { canvasMock } = vi.hoisted(() => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { id: 'root' }, canvas: canvasMock }
 }))
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => ({ getWidget: () => undefined })
-}))
 
 function createMarkdownWidget(node: LGraphNode, defaultValue = '') {
   const inputSpec: InputSpec = {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -1,5 +1,6 @@
+import { useAuthStore } from '@/stores/authStore'
 import axios from 'axios'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
@@ -19,13 +20,22 @@ function createMockWidget(overrides: Partial<IWidget> = {}): IWidget {
 
 const mockCloudAuth = vi.hoisted(() => ({
   isCloud: false,
-  authHeader: null as { Authorization: string } | null
+  authHeader: null as { Authorization: `Bearer ${string}` } | null
 }))
 
-vi.mock<unknown>(import('axios'), () => ({
-  default: {
-    get: vi.fn()
+vi.mock(import('axios'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    default: Object.assign(actual.default, { get: vi.fn() })
   }
+})
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => vi.fn()),
+  onIdTokenChanged: vi.fn(() => vi.fn())
 }))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
@@ -33,22 +43,6 @@ vi.mock(import('@/platform/distribution/types'), () => ({
     return mockCloudAuth.isCloud
   }
 }))
-
-vi.mock<unknown>(import('@/stores/authStore'), async () => {
-  return {
-    useAuthStore: vi.fn(() => ({
-      getAuthHeader: vi.fn(() => Promise.resolve(mockCloudAuth.authHeader))
-    }))
-  }
-})
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), async () => {
-  return {
-    useSettingStore: () => ({
-      settings: {}
-    })
-  }
-})
 
 const FIRST_BACKOFF = 1000 // backoff is 1s on first retry
 const DEFAULT_VALUE = 'Loading...'
@@ -100,6 +94,12 @@ async function getResolvedValue(hook: ReturnType<typeof useRemoteWidget>) {
   await responsePromise
   return hook.getCachedValue()
 }
+
+beforeEach(() => {
+  vi.mocked(useAuthStore().getAuthHeader).mockImplementation(
+    async () => mockCloudAuth.authHeader
+  )
+})
 
 describe('useRemoteWidget', () => {
   describe('initialization', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
@@ -1,3 +1,5 @@
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
 import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -18,34 +20,6 @@ const { canvasMock } = vi.hoisted(() => ({
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: { rootGraph: { id: 'root' }, canvas: canvasMock }
 }))
-const { widgetStoreMock } = vi.hoisted(() => {
-  const map = new Map<
-    string,
-    { type: string; value: unknown; options: unknown }
-  >()
-  return {
-    widgetStoreMock: {
-      map,
-      getWidget: (id: string) => map.get(id),
-      registerWidget: (
-        id: string,
-        init: { type: string; value: unknown; options: unknown }
-      ) => {
-        const existing = map.get(id)
-        if (existing) return existing
-        const state = { ...init }
-        map.set(id, state)
-        return state
-      }
-    }
-  }
-})
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => ({
-  useWidgetValueStore: () => widgetStoreMock
-}))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => false })
-}))
 
 function createStringWidget(node: LGraphNode) {
   const inputSpec: InputSpec = {
@@ -63,7 +37,6 @@ function createStringWidget(node: LGraphNode) {
 describe('useStringWidget (multiline)', () => {
   function setup() {
     vi.clearAllMocks()
-    widgetStoreMock.map.clear()
     const node = createMockDOMWidgetNode()
     const widget = createStringWidget(node)
     const callback = vi.fn<(value: string) => void>()
@@ -87,7 +60,7 @@ describe('useStringWidget (multiline)', () => {
     }
     options.setValue('from-execution')
 
-    const entries = [...widgetStoreMock.map.values()]
+    const entries = useWidgetValueStore().getNodeWidgets('root', toNodeId(1))
     expect(entries.some((s) => s.value === 'from-execution')).toBe(true)
     expect(entries.every((s) => s.type === 'customtext')).toBe(true)
   })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetRenderer.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetRenderer.test.ts
@@ -1,6 +1,4 @@
-import { setActivePinia } from 'pinia'
-import { createTestingPinia } from '@pinia/testing'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   getComponent,
@@ -19,23 +17,7 @@ const {
   WidgetToggleSwitch
 } = FOR_TESTING
 
-vi.mock<unknown>(import('@/stores/queueStore'), () => ({
-  useQueueStore: vi.fn(() => ({
-    historyTasks: []
-  }))
-}))
-
-// Mock the settings store for components that might use it
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn(() => 'before')
-  })
-}))
-
 describe('widgetRegistry', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia())
-  })
   describe('getComponent', () => {
     // Test number type mappings
     describe('number types', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -1,6 +1,7 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { computed, ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { FormDropdownItem } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions'
@@ -8,19 +9,6 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        changeTracker: {
-          captureCanvasState: mockCaptureCanvasState
-        }
-      }
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/api'))
 
@@ -32,6 +20,12 @@ function createItems(...names: string[]): FormDropdownItem[] {
     preview_url: ''
   }))
 }
+
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    changeTracker: { captureCanvasState: mockCaptureCanvasState }
+  })
+})
 
 describe('useWidgetSelectActions', () => {
   describe('updateSelectedItems', () => {

--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -1,6 +1,8 @@
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, shallowRef } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { createMockDOMWidgetNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
@@ -9,6 +11,7 @@ import { DEBOUNCE_MS } from '@/renderer/glsl/glslPreviewUtils'
 import { useGLSLPreview } from '@/renderer/glsl/useGLSLPreview'
 import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 /**
  * Guards the writer/reader store contract behind the GLSL live preview: the
@@ -45,32 +48,8 @@ vi.mock<unknown>(import('@/renderer/glsl/useGLSLRenderer'), () => ({
   useGLSLRenderer: (_config?: GLSLRendererConfig) => mockRenderer.create()
 }))
 
-const nodeOutputs = reactive<Record<string, unknown>>({})
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    setNodePreviewsByNodeId: vi.fn(),
-    setNodePreviewsByLocatorId: vi.fn(),
-    revokePreviewsByLocatorId: vi.fn(),
-    nodeOutputs
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeIdToNodeLocatorId: (id: string | number) => String(id),
-      nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
-    })
-  })
-)
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { rootGraph: { id: 'root', _nodes: [] } }
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: () => false })
+  app: { rootGraph: { id: 'root', _nodes: [] }, nodePreviewImages: {} }
 }))
 
 function seedShaderThroughWidget(nodeId: number, value: string): void {
@@ -102,15 +81,34 @@ function createGLSLNode(nodeId: number): LGraphNode {
   })
 }
 
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().nodeIdToNodeLocatorId).mockImplementation((id) =>
+    createNodeLocatorId(null, id)
+  )
+  vi.mocked(useWorkflowStore().nodeToNodeLocatorId).mockImplementation((node) =>
+    createNodeLocatorId(null, node.id)
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByNodeId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().revokePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+})
+
 describe('GLSL live preview reads the shader written by the customtext widget', () => {
   beforeEach(() => {
-    for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
+    for (const key of Object.keys(useNodeOutputStore().nodeOutputs))
+      delete useNodeOutputStore().nodeOutputs[key]
   })
 
   it('compiles the shader value written through the widget store path', async () => {
     const nodeId = 1
     seedShaderThroughWidget(nodeId, SHADER)
-    nodeOutputs[String(nodeId)] = {
+    useNodeOutputStore().nodeOutputs[String(nodeId)] = {
       images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
     }
 

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -1,6 +1,8 @@
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref, shallowRef } from 'vue'
+import { nextTick, ref, shallowRef } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -8,10 +10,7 @@ import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
 import { useGLSLPreview } from '@/renderer/glsl/useGLSLPreview'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { widgetId } from '@/types/widgetId'
-
-type WidgetValueStoreStub = {
-  _widgetMap: Map<string, { value: unknown }>
-}
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 const mockRendererFactory = vi.hoisted(() => {
   const init = vi.fn(() => true)
@@ -70,41 +69,6 @@ vi.mock<unknown>(import('@/renderer/glsl/useGLSLRenderer'), () => ({
     mockRendererFactory.create(config)
 }))
 
-const mockSetNodePreviewsByNodeId = vi.fn()
-const mockRevokePreviewsByLocatorId = vi.fn()
-const mockNodeOutputs = reactive<Record<string, unknown>>({})
-
-vi.mock<unknown>(import('@/stores/nodeOutputStore'), () => ({
-  useNodeOutputStore: () => ({
-    setNodePreviewsByNodeId: mockSetNodePreviewsByNodeId,
-    setNodePreviewsByLocatorId: vi.fn(),
-    revokePreviewsByLocatorId: mockRevokePreviewsByLocatorId,
-    getNodeImageUrls: vi.fn(() => undefined),
-    nodeOutputs: mockNodeOutputs
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/widgetValueStore'), () => {
-  const widgetMap = new Map<string, { value: unknown }>()
-  const getWidget = vi.fn((id: string) => widgetMap.get(id))
-  return {
-    useWidgetValueStore: () => ({
-      getWidget,
-      _widgetMap: widgetMap
-    })
-  }
-})
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeIdToNodeLocatorId: (id: string | number) => String(id),
-      nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
-    })
-  })
-)
-
 vi.mock(import('@/utils/objectUrlUtil'), () => ({
   createSharedObjectUrl: () => 'blob:test',
   releaseSharedObjectUrl: vi.fn()
@@ -134,6 +98,25 @@ function ensureImageBitmap(global: { ImageBitmap?: typeof ImageBitmap }): void {
   global.ImageBitmap ??= class ImageBitmap {} as unknown as typeof ImageBitmap
 }
 
+beforeEach(() => {
+  vi.mocked(useWorkflowStore().nodeIdToNodeLocatorId).mockImplementation((id) =>
+    createNodeLocatorId(null, id)
+  )
+  vi.mocked(useWorkflowStore().nodeToNodeLocatorId).mockImplementation((node) =>
+    createNodeLocatorId(null, node.id)
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByNodeId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().setNodePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().revokePreviewsByLocatorId).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useNodeOutputStore().getNodeImageUrls).mockReturnValue(undefined)
+})
+
 describe('useGLSLPreview', () => {
   beforeEach(() => {
     mockRendererFactory.lastConfig.value = undefined
@@ -150,14 +133,16 @@ describe('useGLSLPreview', () => {
 
   it('does not activate before first execution', () => {
     const node = createMockNode()
-    Object.keys(mockNodeOutputs).forEach((k) => delete mockNodeOutputs[k])
+    Object.keys(useNodeOutputStore().nodeOutputs).forEach(
+      (k) => delete useNodeOutputStore().nodeOutputs[k]
+    )
     const { isActive } = useGLSLPreview(wrapNode(node))
     expect(isActive.value).toBe(false)
   })
 
   it('activates for GLSLShader nodes with execution output', () => {
     const node = createMockNode()
-    mockNodeOutputs['1'] = {
+    useNodeOutputStore().nodeOutputs['1'] = {
       images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
     }
     const { isActive } = useGLSLPreview(wrapNode(node))
@@ -183,17 +168,13 @@ describe('useGLSLPreview', () => {
 
   describe('autogrow config extraction', () => {
     async function triggerRender(node: LGraphNode) {
-      mockNodeOutputs[String(node.id)] = {
+      useNodeOutputStore().nodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.set(
+      const store = useWidgetValueStore()
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'fragment_shader'),
-        {
-          value: 'void main() {}'
-        }
+        { type: 'customtext', options: {}, value: 'void main() {}' }
       )
 
       const nodeRef = shallowRef<LGraphNode | null>(null)
@@ -242,17 +223,13 @@ describe('useGLSLPreview', () => {
 
   describe('render pipeline', () => {
     async function setupAndRender(node: LGraphNode) {
-      mockNodeOutputs[String(node.id)] = {
+      useNodeOutputStore().nodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.set(
+      const store = useWidgetValueStore()
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'fragment_shader'),
-        {
-          value: 'void main() {}'
-        }
+        { type: 'customtext', options: {}, value: 'void main() {}' }
       )
 
       const nodeRef = shallowRef<LGraphNode | null>(null)
@@ -292,9 +269,9 @@ describe('useGLSLPreview', () => {
       expect(mockRendererFactory.init).toHaveBeenCalledTimes(1)
 
       mockRendererFactory.isContextLost.mockReturnValueOnce(true)
-      delete mockNodeOutputs['1']
+      delete useNodeOutputStore().nodeOutputs['1']
       await nextTick()
-      mockNodeOutputs['1'] = {
+      useNodeOutputStore().nodeOutputs['1'] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
       await nextTick()
@@ -344,14 +321,12 @@ describe('useGLSLPreview', () => {
         ],
         getInputNode: vi.fn((slot: number) => fromAny(slot === 0 ? up0 : up1))
       })
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.set(
+      const store = useWidgetValueStore()
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'fragment_shader'),
-        { value: 'void main() {}' }
+        { type: 'customtext', options: {}, value: 'void main() {}' }
       )
-      mockNodeOutputs['1'] = {
+      useNodeOutputStore().nodeOutputs['1'] = {
         images: [{ filename: 'a.png', subfolder: '', type: 'temp' }]
       }
 
@@ -367,9 +342,9 @@ describe('useGLSLPreview', () => {
 
       up0.imgs = []
       vi.clearAllMocks()
-      delete mockNodeOutputs['1']
+      delete useNodeOutputStore().nodeOutputs['1']
       await nextTick()
-      mockNodeOutputs['1'] = {
+      useNodeOutputStore().nodeOutputs['1'] = {
         images: [{ filename: 'a.png', subfolder: '', type: 'temp' }]
       }
       await nextTick()
@@ -401,7 +376,9 @@ describe('useGLSLPreview', () => {
       for (let i = 0; i < 5; i++) await nextTick()
 
       expect(hideExecutedOutput.value).toBe(false)
-      expect(mockRevokePreviewsByLocatorId).toHaveBeenCalledWith('1')
+      expect(
+        useNodeOutputStore().revokePreviewsByLocatorId
+      ).toHaveBeenCalledWith('1')
       expect(mockRendererFactory.compileFragment).not.toHaveBeenCalled()
     })
 
@@ -426,13 +403,9 @@ describe('useGLSLPreview', () => {
 
     it('skips render when shader source is unavailable', async () => {
       const node = createMockNode()
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
-      store._widgetMap.delete(
-        widgetId('test-graph-id', node.id, 'fragment_shader')
-      )
-      mockNodeOutputs[String(node.id)] = {
+      const store = useWidgetValueStore()
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'fragment_shader'))
+      useNodeOutputStore().nodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
       }
 
@@ -447,53 +420,45 @@ describe('useGLSLPreview', () => {
     })
 
     it('uses custom resolution when size_mode is custom', async () => {
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
+      const store = useWidgetValueStore()
 
       const node = createMockNode()
-      store._widgetMap.set(widgetId('test-graph-id', node.id, 'size_mode'), {
+      store.registerWidget(widgetId('test-graph-id', node.id, 'size_mode'), {
+        type: 'customtext',
+        options: {},
         value: 'custom'
       })
-      store._widgetMap.set(
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'size_mode.width'),
-        {
-          value: 800
-        }
+        { type: 'customtext', options: {}, value: 800 }
       )
-      store._widgetMap.set(
+      store.registerWidget(
         widgetId('test-graph-id', node.id, 'size_mode.height'),
-        {
-          value: 600
-        }
+        { type: 'customtext', options: {}, value: 600 }
       )
       await setupAndRender(node)
 
       expect(mockRendererFactory.setResolution).toHaveBeenCalledWith(800, 600)
 
-      store._widgetMap.delete(widgetId('test-graph-id', node.id, 'size_mode'))
-      store._widgetMap.delete(
-        widgetId('test-graph-id', node.id, 'size_mode.width')
-      )
-      store._widgetMap.delete(
-        widgetId('test-graph-id', node.id, 'size_mode.height')
-      )
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode'))
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode.width'))
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode.height'))
     })
 
     it('uses default resolution when size_mode is not custom', async () => {
-      const store = fromAny<WidgetValueStoreStub, unknown>(
-        useWidgetValueStore()
-      )
+      const store = useWidgetValueStore()
 
       const node = createMockNode()
-      store._widgetMap.set(widgetId('test-graph-id', node.id, 'size_mode'), {
+      store.registerWidget(widgetId('test-graph-id', node.id, 'size_mode'), {
+        type: 'customtext',
+        options: {},
         value: 'from_input'
       })
       await setupAndRender(node)
 
       expect(mockRendererFactory.setResolution).toHaveBeenCalledWith(512, 512)
 
-      store._widgetMap.delete(widgetId('test-graph-id', node.id, 'size_mode'))
+      store.deleteWidget(widgetId('test-graph-id', node.id, 'size_mode'))
     })
 
     it('disposes renderer and cancels debounce on cleanup', async () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Replace the renderer domain of #17222 plus local-instance removal from #17223 with global testing Pinia.

## Changes

- 90 files including the identical four-file shared lifecycle prerequisite. Targets main and can merge independently.
- Real store actions unless explicitly stubbed. Preserve scenario state and fixtures, including non-Pinia layoutStore mocks.
- Enforcement and documentation remain deferred to #17223.

## Review Focus

- All 86 domain paths are byte-identical to the corresponding files in [the immutable source](https://github.com/Comfy-Org/ComfyUI_frontend/commit/beb2e861ef0a168b0e0bd06edde4d80c050005c2).
- Includes the same two `isAssetWidget` Knip-tag removals as #17229 in `src/lib/litegraph/src/litegraph.ts` and `src/lib/litegraph/src/widgets/widgetMap.ts`. Renderer imports make both tags redundant: Knip fails with them and passes without them. This metadata-only overlap lets either PR merge first.
- `pnpm test:unit` with all 84 changed domain test paths plus three shared tests: 87 files and 1,099 tests passed.
- Passed: `pnpm typecheck`, `pnpm typecheck:scripts`, scoped ESLint, type-aware Oxlint, cleanup audit, formatting, `pnpm knip`, and `git diff --check`.

<details>
<summary>Common lifecycle prerequisite</summary>

- `vitest.setup.ts`
- `scripts/testingPinia.test.ts`
- `src/components/node/NodePreview.test.ts`
- `src/renderer/extensions/vueNodes/components/LGraphNode.test.ts`

</details>
