### PR TITLE
test: use global Pinia in platform service tests

### DIFF
--- a/scripts/testingPinia.test.ts
+++ b/scripts/testingPinia.test.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { expect, it, vi } from 'vitest'
+import { onScopeDispose, ref, watch } from 'vue'
+
+it('disposes the global Pinia after the test', ({ onTestFinished }) => {
+  const value = ref(0)
+  const changed = vi.fn()
+  const disposed = vi.fn()
+  const useStore = defineStore('testing-pinia-lifecycle', () => {
+    watch(value, changed, { flush: 'sync' })
+    onScopeDispose(disposed)
+    return {}
+  })
+  useStore()
+
+  value.value++
+  expect(changed).toHaveBeenCalledOnce()
+  expect(disposed).not.toHaveBeenCalled()
+
+  onTestFinished(() => {
+    value.value++
+    expect(changed).toHaveBeenCalledOnce()
+    expect(disposed).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
-import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
@@ -26,7 +25,6 @@ vi.hoisted(() => {
 
 describe('NodePreview', () => {
   let i18n: ReturnType<typeof createI18n>
-  let pinia: ReturnType<typeof createPinia>
 
   beforeAll(() => {
     // Create a Vue app instance for PrimeVue
@@ -45,9 +43,6 @@ describe('NodePreview', () => {
         }
       }
     })
-
-    // Create pinia instance
-    pinia = createPinia()
   })
 
   const mockNodeDef: ComfyNodeDefV2 = {
@@ -71,7 +66,7 @@ describe('NodePreview', () => {
   function renderComponent(nodeDef: ComfyNodeDefV2 = mockNodeDef) {
     return render(NodePreview, {
       global: {
-        plugins: [PrimeVue, i18n, pinia],
+        plugins: [PrimeVue, i18n],
         stubs: {}
       },
       props: {

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -1,24 +1,20 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type { ComfyApp } from '@/scripts/app'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockGetIdToken = vi.fn()
-const mockGetAuthHeader = vi.fn()
-const mockAuthState = vi.hoisted(() => ({
-  currentUser: { uid: 'user-a' } as { uid: string } | null
-}))
+const mockGetIdToken = vi.fn<ReturnType<typeof useAuthStore>['getIdToken']>(
+  async () => undefined
+)
+const mockGetAuthHeader = vi.fn<
+  ReturnType<typeof useAuthStore>['getAuthHeader']
+>(async () => null)
 const originalFetch = globalThis.fetch
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: true
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: () => ({
-    getIdToken: mockGetIdToken,
-    getAuthHeader: mockGetAuthHeader,
-    get currentUser() {
-      return mockAuthState.currentUser
-    }
-  })
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -27,15 +23,20 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-const mockReportError = vi.fn()
+const mockReportError = vi.hoisted(() => vi.fn())
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
   reportError: mockReportError
 }))
 
+beforeEach(() => {
+  vi.mocked(useAuthStore().getIdToken).mockImplementation(mockGetIdToken)
+  vi.mocked(useAuthStore().getAuthHeader).mockImplementation(mockGetAuthHeader)
+})
+
 describe('useSessionCookie', () => {
   beforeEach(() => {
     vi.resetModules()
-    mockAuthState.currentUser = { uid: 'user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-a' })
     globalThis.fetch = vi.fn()
   })
 
@@ -59,14 +60,14 @@ describe('useSessionCookie', () => {
       method: 'POST',
       credentials: 'include',
       headers: {
-        Authorization: 'Bearer firebase-id-token',
+        Authorization: 'Bearer firebase-id-token' as const,
         'Content-Type': 'application/json'
       }
     })
   })
 
   it('createSessionOrThrow fails fast without a Firebase token', async () => {
-    mockGetIdToken.mockResolvedValue(null)
+    mockGetIdToken.mockResolvedValue(undefined)
     const { useSessionCookie } =
       await import('@/platform/auth/session/useSessionCookie')
 
@@ -150,7 +151,7 @@ describe('useSessionCookie', () => {
 
   it('serializes strict session creation after the previous user response', async () => {
     mockGetIdToken.mockImplementation(() =>
-      Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
+      Promise.resolve(`firebase-${useAuthStore().currentUser?.uid}`)
     )
     let resolveFirstFetch: (value: Response) => void = () => {}
     vi.mocked(globalThis.fetch)
@@ -166,7 +167,7 @@ describe('useSessionCookie', () => {
     const first = useSessionCookie().createSession()
     await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
 
-    mockAuthState.currentUser = { uid: 'user-b' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-b' })
     const second = useSessionCookie().createSessionOrThrow()
     await Promise.resolve()
     await Promise.resolve()
@@ -189,7 +190,7 @@ describe('useSessionCookie', () => {
 
   it('reconfirms a cached owner after another owner mutates the cookie', async () => {
     mockGetIdToken.mockImplementation(() =>
-      Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
+      Promise.resolve(`firebase-${useAuthStore().currentUser?.uid}`)
     )
     let resolveUserB: (value: Response) => void = () => {}
     vi.mocked(globalThis.fetch)
@@ -204,11 +205,11 @@ describe('useSessionCookie', () => {
       await import('@/platform/auth/session/useSessionCookie')
 
     await useSessionCookie().ensureSessionCookie()
-    mockAuthState.currentUser = { uid: 'user-b' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-b' })
     const userBSession = useSessionCookie().createSession()
     await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2))
 
-    mockAuthState.currentUser = { uid: 'user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'user-a' })
     const userASession = useSessionCookie().ensureSessionCookie()
     await Promise.resolve()
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
@@ -285,3 +286,14 @@ describe('useSessionCookie', () => {
     )
   })
 })
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -1,3 +1,5 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { AxiosAdapter } from 'axios'
 import axios, { AxiosError } from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,13 +21,6 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/workspaceAuthStore'),
-  () => ({
-    useWorkspaceAuthStore: () => ({ remintUnifiedOnce: mockRemint })
-  })
-)
-
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({
     flags: {
@@ -38,7 +33,16 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
 
 // The axios interceptor gates on shouldRemintCloudRequest(), which is a no-op
 // off-cloud; the unit env is not a cloud build, so force it on.
-vi.mock(import('@/platform/distribution/types'), () => ({ isCloud: true }))
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
+  isCloud: true
+}))
+
+beforeEach(() => {
+  vi.mocked(useWorkspaceAuthStore().remintUnifiedOnce).mockImplementation(
+    mockRemint
+  )
+})
 
 describe('fetchWithUnifiedRemint', () => {
   const ok = { status: 200 } as Response
@@ -57,7 +61,9 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer tokenA', 'Comfy-User': 'u1' } },
+      {
+        headers: { Authorization: 'Bearer tokenA' as const, 'Comfy-User': 'u1' }
+      },
       true
     )
 
@@ -85,7 +91,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer tokenA' } },
+      { headers: { Authorization: 'Bearer tokenA' as const } },
       true
     )
 
@@ -105,7 +111,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer tokenA' } },
+      { headers: { Authorization: 'Bearer tokenA' as const } },
       false
     )
 
@@ -121,7 +127,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer t' } },
+      { headers: { Authorization: 'Bearer t' as const } },
       true
     )
 
@@ -136,7 +142,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer t' } },
+      { headers: { Authorization: 'Bearer t' as const } },
       true
     )
 
@@ -155,7 +161,7 @@ describe('fetchWithUnifiedRemint', () => {
     mockFetch.mockResolvedValueOnce(unauthorized).mockResolvedValueOnce(ok)
     mockRemint.mockResolvedValue('tokenB')
     const request = new Request('https://cloud/x', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
 
     const result = await fetchWithUnifiedRemint(request, {}, true)
@@ -171,7 +177,7 @@ describe('fetchWithUnifiedRemint', () => {
     const request = new Request('https://cloud/x', {
       method: 'POST',
       body,
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
     mockFetch
       .mockImplementationOnce(async (input: Request) => {
@@ -215,7 +221,7 @@ describe('fetchWithUnifiedRemint', () => {
 
     const result = await fetchWithUnifiedRemint(
       'https://cloud/x',
-      { headers: { Authorization: 'Bearer t' } },
+      { headers: { Authorization: 'Bearer t' as const } },
       true
     )
 
@@ -233,7 +239,7 @@ describe('fetchWithUnifiedRemint', () => {
       {
         method: 'POST',
         body: new ReadableStream<Uint8Array>(),
-        headers: { Authorization: 'Bearer tokenA' }
+        headers: { Authorization: 'Bearer tokenA' as const }
       },
       true
     )
@@ -252,7 +258,7 @@ describe('fetchWithUnifiedRemint', () => {
   it.for([
     {
       shape: 'object',
-      headers: { Authorization: 'Bearer tokenA', 'Comfy-User': 'u1' }
+      headers: { Authorization: 'Bearer tokenA' as const, 'Comfy-User': 'u1' }
     },
     {
       shape: 'array of tuples',
@@ -264,7 +270,7 @@ describe('fetchWithUnifiedRemint', () => {
     {
       shape: 'Headers',
       headers: new Headers({
-        Authorization: 'Bearer tokenA',
+        Authorization: 'Bearer tokenA' as const,
         'Comfy-User': 'u1'
       })
     }
@@ -336,7 +342,7 @@ describe('attachUnifiedRemintInterceptor', () => {
     mockRemint.mockResolvedValue('tokenB')
 
     const res = await client.get('https://cloud/x', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
 
     expect(res.status).toBe(200)
@@ -359,7 +365,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     await expect(
       client.get('https://cloud/x', {
-        headers: { Authorization: 'Bearer tokenA' }
+        headers: { Authorization: 'Bearer tokenA' as const }
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
 
@@ -379,7 +385,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     await expect(
       client.get('https://cloud/x', {
-        headers: { Authorization: 'Bearer tokenA' }
+        headers: { Authorization: 'Bearer tokenA' as const }
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
 
@@ -394,7 +400,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     await expect(
       client.post('https://cloud/invites/x/accept', null, {
-        headers: { Authorization: 'Bearer firebase' },
+        headers: { Authorization: 'Bearer firebase' as const },
         __skipUnifiedRemint: true
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
@@ -418,7 +424,9 @@ describe('attachUnifiedRemintInterceptor', () => {
     const { client } = makeClient([500])
 
     await expect(
-      client.get('https://cloud/x', { headers: { Authorization: 'Bearer t' } })
+      client.get('https://cloud/x', {
+        headers: { Authorization: 'Bearer t' as const }
+      })
     ).rejects.toMatchObject({ response: { status: 500 } })
 
     expect(mockRemint).not.toHaveBeenCalled()
@@ -431,7 +439,7 @@ describe('attachUnifiedRemintInterceptor', () => {
     const res = await client.post(
       'https://cloud/topup',
       { amount: 5 },
-      { headers: { Authorization: 'Bearer tokenA' } }
+      { headers: { Authorization: 'Bearer tokenA' as const } }
     )
 
     expect(res.status).toBe(200)
@@ -473,10 +481,10 @@ describe('attachUnifiedRemintInterceptor', () => {
     mockRemint.mockResolvedValue('tokenB')
 
     const a = await client.get('https://cloud/a', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
     const b = await client.get('https://cloud/b', {
-      headers: { Authorization: 'Bearer tokenA' }
+      headers: { Authorization: 'Bearer tokenA' as const }
     })
 
     expect(a.status).toBe(200)

--- a/src/platform/keybindings/keybindingService.canvas.test.ts
+++ b/src/platform/keybindings/keybindingService.canvas.test.ts
@@ -1,20 +1,9 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => [])
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: vi.fn(() => ({
-    dialogStack: []
-  }))
-}))
 
 function createTestKeyboardEvent(
   key: string,
@@ -50,6 +39,11 @@ function createTestKeyboardEvent(
   return event
 }
 
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+  useDialogStore().dialogStack = []
+})
+
 describe('keybindingService - Canvas Keybindings', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
   let canvasContainer: HTMLDivElement
@@ -59,11 +53,7 @@ describe('keybindingService - Canvas Keybindings', () => {
     const commandStore = useCommandStore()
     commandStore.execute = vi.fn()
 
-    vi.mocked(useDialogStore).mockReturnValue({
-      dialogStack: []
-    } as Partial<ReturnType<typeof useDialogStore>> as ReturnType<
-      typeof useDialogStore
-    >)
+    Object.assign(useDialogStore(), { dialogStack: [] })
 
     canvasContainer = document.createElement('div')
     canvasContainer.id = 'graph-canvas-container'

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -1,4 +1,5 @@
-import { markRaw, reactive } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
@@ -21,24 +22,15 @@ function createTestDialogInstance(
   }
 }
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => [])
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => {
-  const dialogStack = reactive<DialogInstance[]>([])
-  return {
-    useDialogStore: () => ({ dialogStack })
-  }
-})
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: null
   }
 }))
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+})
 
 describe('keybindingService - dialog gate', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
@@ -46,8 +38,8 @@ describe('keybindingService - dialog gate', () => {
 
   beforeEach(() => {
     const commandStore = useCommandStore()
-    mockCommandExecute = vi.fn()
-    commandStore.execute = mockCommandExecute
+    mockCommandExecute = commandStore.execute
+    vi.mocked(mockCommandExecute).mockResolvedValue(undefined)
 
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -1,5 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { markRaw, reactive } from 'vue'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CORE_KEYBINDINGS } from '@/platform/keybindings/defaults'
@@ -26,24 +26,15 @@ function createTestDialogInstance(
   }
 }
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => [])
-  }))
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => {
-  const dialogStack = reactive<DialogInstance[]>([])
-  return {
-    useDialogStore: () => ({ dialogStack })
-  }
-})
-
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
     canvas: null
   }
 }))
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+})
 
 describe('keybindingService - Escape key handling', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
@@ -51,8 +42,8 @@ describe('keybindingService - Escape key handling', () => {
 
   beforeEach(() => {
     const commandStore = useCommandStore()
-    mockCommandExecute = vi.fn()
-    commandStore.execute = mockCommandExecute
+    mockCommandExecute = commandStore.execute
+    vi.mocked(mockCommandExecute).mockResolvedValue(undefined)
 
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0
@@ -167,7 +158,9 @@ describe('keybindingService - Escape key handling', () => {
   })
 
   it('should still close legacy modals on Escape when no keybinding matched', async () => {
-    setActivePinia(createPinia())
+    useKeybindingStore().removeAllKeybindingsForCommand(
+      'Comfy.Graph.ExitSubgraph'
+    )
     keybindingService = useKeybindingService()
 
     const mockModal = document.createElement('div')

--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -1,3 +1,4 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
@@ -5,21 +6,12 @@ import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useCommandStore } from '@/stores/commandStore'
 
-const settings = vi.hoisted(() => ({
-  values: {} as Record<string, unknown>
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => settings.values[key] ?? [])
-  }))
-}))
-
 describe('keybindingService - registerUserKeybindings', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    settings.values = {}
+    useSettingStore().settingValues['Comfy.Keybinding.NewBindings'] = []
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = []
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -30,7 +22,7 @@ describe('keybindingService - registerUserKeybindings', () => {
   it('does not warn when unset binding targets a command that no longer exists', () => {
     // A command removed from the app (e.g. ConvertSelectedNodesToGroupNode,
     // removed in #12931) can still linger in the persisted UnsetBindings.
-    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = [
       {
         commandId: 'ConvertSelectedNodesToGroupNode',
         combo: { key: 'g', ctrl: true, alt: false, shift: false }
@@ -57,7 +49,7 @@ describe('keybindingService - registerUserKeybindings', () => {
       new KeybindingImpl({ commandId: 'Comfy.Test.Registered', combo })
     )
 
-    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = [
       { commandId: 'Comfy.Test.Registered', combo }
     ]
 

--- a/src/platform/keybindings/presetService.test.ts
+++ b/src/platform/keybindings/presetService.test.ts
@@ -1,3 +1,8 @@
+import type * as I18nModule from '@/i18n'
+import type { ComfyApp } from '@/scripts/app'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useDialogStore } from '@/stores/dialogStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
@@ -24,7 +29,9 @@ const mockShowSmallLayoutDialog = vi.hoisted(() =>
     onResult?.(true)
   })
 )
-const mockSettingSet = vi.hoisted(() => vi.fn())
+const mockSettingSet = vi.hoisted(() =>
+  vi.fn<ReturnType<typeof useSettingStore>['set']>(async () => undefined)
+)
 const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockPersistUserKeybindings = vi.hoisted(() =>
   vi.fn(async () => undefined)
@@ -50,19 +57,6 @@ vi.mock<unknown>(import('@/services/dialogService'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    set: mockSettingSet,
-    get: vi.fn(() => 'default')
-  })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: mockToastAdd
-  })
-}))
-
 vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: () => ({
     wrapWithErrorHandling: <T extends (...args: unknown[]) => unknown>(fn: T) =>
@@ -80,17 +74,21 @@ vi.mock<unknown>(import('@/platform/keybindings/keybindingService'), () => ({
   })
 }))
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    showDialog: vi.fn(),
-    closeDialog: vi.fn(),
-    dialogStack: []
-  })
-}))
-
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: (key: string) => key
 }))
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => undefined)
+  useDialogStore().dialogStack = []
+})
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().set).mockImplementation(mockSettingSet)
+  vi.mocked(useSettingStore().get).mockImplementation(() => 'default')
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+})
 
 describe('useKeybindingPresetService', () => {
   let store: ReturnType<typeof useKeybindingStore>
@@ -800,4 +798,9 @@ describe('useKeybindingPresetService', () => {
       )
     })
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/missingMedia/missingMediaPipeline.test.ts
+++ b/src/platform/missingMedia/missingMediaPipeline.test.ts
@@ -1,3 +1,4 @@
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -11,23 +12,17 @@ import { runMissingMediaPipeline } from '@/platform/missingMedia/missingMediaPip
 import * as missingMediaScan from '@/platform/missingMedia/missingMediaScan'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
-import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
 
-const { activeWorkflow } = vi.hoisted(() => {
-  const activeWorkflow: Pick<ComfyWorkflow, 'pendingWarnings'> = {
-    pendingWarnings: null
-  }
-  return { activeWorkflow }
-})
-
-// The real store reaches authStore -> firebase setPersistence, which has no
-// config under vitest. Mirrors missingModelPipeline.test.ts.
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({ workflow: { activeWorkflow } })
-}))
+let activeWorkflow: ComfyWorkflow
 
 beforeEach(() => {
-  activeWorkflow.pendingWarnings = null
+  activeWorkflow = new ComfyWorkflow({
+    path: 'test.json',
+    modified: 0,
+    size: 0
+  })
+  Object.assign(useWorkflowStore(), { activeWorkflow })
 })
 
 async function startPendingWorkflowLoadMediaVerification(
@@ -120,3 +115,10 @@ describe('runMissingMediaPipeline', () => {
     expect(activeWorkflow.pendingWarnings).toBeNull()
   })
 })
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 
@@ -6,14 +6,6 @@ import { useMissingMediaStore } from './missingMediaStore'
 import type { MissingMediaCandidate } from './types'
 
 // Mock dependencies
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-  () => ({
-    useCanvasStore: () => ({
-      currentGraph: null
-    })
-  })
-)
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -124,12 +124,7 @@ function mountCard(
   onLocateModel?: (nodeId: string) => void,
   initialGatedRepoUrls: Record<string, string> = {}
 ) {
-  const pinia = createTestingPinia({
-    createSpy: vi.fn,
-    initialState: {
-      missingModel: { gatedRepoUrls: initialGatedRepoUrls }
-    }
-  })
+  useMissingModelStore().gatedRepoUrls = initialGatedRepoUrls
   return render(MissingModelCard, {
     props: {
       missingModelGroups: [makeGroup()],
@@ -137,7 +132,7 @@ function mountCard(
       ...(onLocateModel ? { onLocateModel } : {})
     },
     global: {
-      plugins: [pinia, PrimeVue, i18n]
+      plugins: [getActivePinia()!, PrimeVue, i18n]
     }
   })
 }

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -163,8 +163,7 @@ function renderRow(
   directory: string | null = 'checkpoints',
   canCloudImport = true
 ) {
-  const pinia = createPinia()
-  setActivePinia(pinia)
+  const pinia = getActivePinia()!
 
   render(MissingModelRow, {
     props: {

--- a/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
@@ -1,3 +1,8 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import type { App } from 'vue'
@@ -10,13 +15,21 @@ const mockGetNodeByExecutionId = vi.fn()
 const mockResolveNodeDisplayName = vi.fn()
 const mockTrackDownload = vi.fn()
 const mockInvalidateModelsForCategory = vi.fn()
-const mockUpdateModelsForNodeType = vi.fn()
-const mockGetAllNodeProviders = vi.fn()
+const mockUpdateModelsForNodeType = vi.fn<
+  ReturnType<typeof useAssetsStore>['updateModelsForNodeType']
+>(async () => undefined)
+const mockGetAllNodeProviders = vi.fn<
+  ReturnType<typeof useModelToNodeStore>['getAllNodeProviders']
+>(() => [])
 const mockDownloadList = vi.fn(
-  (): Array<{ taskId: string; status: string }> => []
+  (): Pick<
+    ReturnType<typeof useAssetDownloadStore>['downloadList'][number],
+    'taskId' | 'status'
+  >[] => []
 )
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
 
@@ -34,37 +47,6 @@ vi.mock(import('@/utils/graphTraversalUtil'), () => ({
 vi.mock(import('@/utils/nodeTitleUtil'), () => ({
   resolveNodeDisplayName: (...args: unknown[]) =>
     mockResolveNodeDisplayName(...args)
-}))
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  () => ({
-    useCanvasStore: () => ({})
-  })
-)
-
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    updateModelsForNodeType: mockUpdateModelsForNodeType,
-    invalidateModelsForCategory: mockInvalidateModelsForCategory,
-    updateModelsForTag: vi.fn()
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/assetDownloadStore'), () => ({
-  useAssetDownloadStore: () => ({
-    get downloadList() {
-      return mockDownloadList()
-    },
-    trackDownload: mockTrackDownload
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => ({
-    getAllNodeProviders: mockGetAllNodeProviders
-  })
 }))
 
 import { app } from '@/scripts/app'
@@ -88,6 +70,31 @@ function makeCandidate(
     ...overrides
   }
 }
+
+beforeEach(() => {
+  vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+    mockUpdateModelsForNodeType
+  )
+  vi.mocked(useAssetsStore().invalidateModelsForCategory).mockImplementation(
+    mockInvalidateModelsForCategory
+  )
+  vi.mocked(useAssetsStore().updateModelsForTag).mockResolvedValue(undefined)
+  vi.spyOn(useAssetDownloadStore(), 'downloadList', 'get').mockImplementation(
+    () => {
+      return mockDownloadList().map((download) =>
+        fromPartial<
+          ReturnType<typeof useAssetDownloadStore>['downloadList'][number]
+        >(download)
+      )
+    }
+  )
+  vi.mocked(useAssetDownloadStore().trackDownload).mockImplementation(
+    mockTrackDownload
+  )
+  vi.mocked(useModelToNodeStore().getAllNodeProviders).mockImplementation(
+    mockGetAllNodeProviders
+  )
+})
 
 describe('useMissingModelInteractions', () => {
   const mountedApps: App<Element>[] = []
@@ -124,9 +131,7 @@ describe('useMissingModelInteractions', () => {
   }
 
   beforeEach(() => {
-    mockDownloadList.mockImplementation(
-      (): Array<{ taskId: string; status: string }> => []
-    )
+    mockDownloadList.mockReturnValue([])
     ;(app as { rootGraph: unknown }).rootGraph = null
   })
 
@@ -274,7 +279,7 @@ describe('useMissingModelInteractions', () => {
       ;(app as { rootGraph: unknown }).rootGraph = {}
       mockGetNodeByExecutionId.mockReturnValue(null)
       mockGetAllNodeProviders.mockReturnValue([
-        { nodeDef: { name: 'CheckpointLoaderSimple' } }
+        fromPartial({ nodeDef: { name: 'CheckpointLoaderSimple' } })
       ])
 
       const store = useMissingModelStore()

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -10,41 +13,37 @@ import {
   toBrowsableUrl
 } from './missingModelDownload'
 
-const { fetchMock, mockIsDesktop, mockSidebarTabStore, mockStartDownload } =
-  vi.hoisted(() => ({
-    fetchMock: vi.fn(),
-    mockIsDesktop: { value: false },
-    mockSidebarTabStore: { activeSidebarTabId: null as string | null },
-    mockStartDownload: vi.fn()
-  }))
+const { fetchMock, mockIsDesktop, mockStartDownload } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  mockIsDesktop: { value: false },
+  mockStartDownload: vi.fn()
+}))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isDesktop() {
     return mockIsDesktop.value
   }
 }))
 
-vi.mock<unknown>(import('@/stores/electronDownloadStore'), () => ({
-  useElectronDownloadStore: () => ({
-    start: mockStartDownload
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => mockSidebarTabStore
-}))
-
 beforeEach(() => {
+  mockIsDesktop.value = false
   vi.stubGlobal('fetch', fetchMock)
   clearMetadataCache()
   delete window.__comfyDesktop2Remote
   delete window.__comfyDesktop2
 })
 
+beforeEach(() => {
+  vi.mocked(useElectronDownloadStore().start).mockImplementation(
+    mockStartDownload
+  )
+})
+
 describe('fetchModelMetadata', () => {
   beforeEach(() => {
     mockIsDesktop.value = false
-    mockSidebarTabStore.activeSidebarTabId = null
+    useSidebarTabStore().activeSidebarTabId = null
   })
 
   it('fetches file size via HEAD for non-Civitai URLs', async () => {
@@ -469,7 +468,7 @@ describe('isModelDownloadable', () => {
 describe('downloadModel', () => {
   beforeEach(() => {
     mockIsDesktop.value = false
-    mockSidebarTabStore.activeSidebarTabId = null
+    useSidebarTabStore().activeSidebarTabId = null
   })
 
   it.for([
@@ -550,7 +549,7 @@ describe('downloadModel', () => {
 
   it('does not dispatch blocked localhost URLs through Electron', () => {
     mockIsDesktop.value = true
-    mockSidebarTabStore.activeSidebarTabId = 'node-library'
+    useSidebarTabStore().activeSidebarTabId = 'node-library'
 
     downloadModel(
       {
@@ -562,7 +561,7 @@ describe('downloadModel', () => {
     )
 
     expect(mockStartDownload).not.toHaveBeenCalled()
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('node-library')
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('node-library')
   })
 
   it('uses the Desktop2 bridge directly instead of the browser fallback', () => {
@@ -750,7 +749,7 @@ describe('downloadModel', () => {
       { checkpoints: ['/models/checkpoints'] }
     )
 
-    expect(mockSidebarTabStore.activeSidebarTabId).toBe('model-library')
+    expect(useSidebarTabStore().activeSidebarTabId).toBe('model-library')
     expect(mockStartDownload).toHaveBeenCalledWith({
       url: 'https://huggingface.co/org/model/resolve/main/model.safetensors',
       savePath: '/models/checkpoints',

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -1,3 +1,11 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import type * as DistributionModule from '@/platform/distribution/types'
+import type { ComfyApp } from '@/scripts/app'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useMissingModelStore } from './missingModelStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useModelToNodeStore } from '@/stores/modelToNodeStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -29,25 +37,6 @@ const { mockHandles } = vi.hoisted(() => {
   return {
     mockHandles: {
       state,
-      missingModelStore: {
-        missingModelCandidates: null as MissingModelCandidate[] | null,
-        createVerificationAbortController: vi.fn(() => new AbortController()),
-        setFolderPaths: vi.fn(),
-        setFileSize: vi.fn(),
-        setGatedRepoUrl: vi.fn()
-      },
-      workspaceWorkflow: {
-        activeWorkflow: null as {
-          activeState?: Pick<ComfyWorkflowJSON, 'models'> | null
-          pendingWarnings?: unknown
-        } | null
-      },
-      executionErrorStore: {
-        surfaceMissingModels: vi.fn()
-      },
-      modelToNodeStore: {
-        getCategoryForNodeType: vi.fn()
-      },
       scanAllModelCandidates: vi.fn(
         (
           _graph: LGraph,
@@ -67,9 +56,6 @@ const { mockHandles } = vi.hoisted(() => {
           _signal: AbortSignal
         ) => undefined
       ),
-      toastStore: {
-        add: vi.fn()
-      },
       assetService: {
         shouldUseAssetBrowser: vi.fn()
       },
@@ -86,7 +72,8 @@ const { mockHandles } = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
 
@@ -97,19 +84,12 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/stores/workspaceStore'), () => ({
-  useWorkspaceStore: () => ({
-    workflow: mockHandles.workspaceWorkflow
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
-  useExecutionErrorStore: () => mockHandles.executionErrorStore
-}))
-
-vi.mock<unknown>(import('@/stores/modelToNodeStore'), () => ({
-  useModelToNodeStore: () => mockHandles.modelToNodeStore
-}))
+beforeEach(() => {
+  vi.mocked(useExecutionErrorStore().surfaceMissingModels).mockImplementation(
+    () => undefined
+  )
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
 
 vi.mock<unknown>(import('@/platform/missingModel/missingModelScan'), () => ({
   scanAllModelCandidates: (
@@ -126,10 +106,6 @@ vi.mock<unknown>(import('@/platform/missingModel/missingModelScan'), () => ({
     candidates: readonly MissingModelCandidate[],
     signal: AbortSignal
   ) => mockHandles.verifyAssetSupportedCandidates(candidates, signal)
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => mockHandles.toastStore
 }))
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
@@ -173,12 +149,12 @@ function createGraph(graphData = createWorkflowGraphData()): LGraph {
 describe('missingModelPipeline', () => {
   beforeEach(() => {
     mockHandles.state.enrichedCandidates = []
-    mockHandles.missingModelStore.missingModelCandidates = null
-    mockHandles.workspaceWorkflow.activeWorkflow = null
-    mockHandles.missingModelStore.createVerificationAbortController.mockImplementation(
-      () => new AbortController()
-    )
-    mockHandles.modelToNodeStore.getCategoryForNodeType.mockReturnValue(
+    useMissingModelStore().missingModelCandidates = null
+    useWorkflowStore().activeWorkflow = null
+    vi.mocked(
+      useMissingModelStore().createVerificationAbortController
+    ).mockImplementation(() => new AbortController())
+    vi.mocked(useModelToNodeStore().getCategoryForNodeType).mockReturnValue(
       undefined
     )
     mockHandles.scanAllModelCandidates.mockReturnValue([])
@@ -220,7 +196,7 @@ describe('missingModelPipeline', () => {
       const refreshPromise = refreshMissingModelPipeline({
         graph,
         reloadNodeDefs,
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(order).toEqual(['reload:start'])
@@ -233,7 +209,7 @@ describe('missingModelPipeline', () => {
     it('scans the current graph when node definition reload is omitted', async () => {
       await refreshMissingModelPipeline({
         graph: createGraph(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(mockHandles.scanAllModelCandidates).toHaveBeenCalled()
@@ -247,11 +223,11 @@ describe('missingModelPipeline', () => {
           directory: 'checkpoints'
         }
       ]
-      mockHandles.workspaceWorkflow.activeWorkflow = {
+      useWorkflowStore().activeWorkflow = fromPartial({
         activeState: { models: activeModels },
         pendingWarnings: null
-      }
-      mockHandles.missingModelStore.missingModelCandidates = [
+      })
+      useMissingModelStore().missingModelCandidates = [
         {
           nodeId: '1',
           nodeType: 'CheckpointLoaderSimple',
@@ -267,7 +243,7 @@ describe('missingModelPipeline', () => {
       await refreshMissingModelPipeline({
         graph: createGraph(),
         reloadNodeDefs: vi.fn(),
-        missingModelStore: mockHandles.missingModelStore,
+        missingModelStore: useMissingModelStore(),
         silent: false
       })
 
@@ -276,12 +252,12 @@ describe('missingModelPipeline', () => {
         expect.objectContaining({ models: activeModels })
       )
       expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).toHaveBeenCalledWith([], { silent: false })
     })
 
     it('falls back to current missing model metadata when workflow state has no models', async () => {
-      mockHandles.missingModelStore.missingModelCandidates = [
+      useMissingModelStore().missingModelCandidates = [
         {
           nodeId: '1',
           nodeType: 'CheckpointLoaderSimple',
@@ -308,7 +284,7 @@ describe('missingModelPipeline', () => {
       await refreshMissingModelPipeline({
         graph: createGraph(),
         reloadNodeDefs: vi.fn(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(mockHandles.enrichWithEmbeddedMetadata).toHaveBeenCalledWith(
@@ -326,7 +302,7 @@ describe('missingModelPipeline', () => {
         })
       )
       expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).toHaveBeenCalledWith([], { silent: true })
     })
 
@@ -336,7 +312,7 @@ describe('missingModelPipeline', () => {
       await refreshMissingModelPipeline({
         graph: createGraph(graphData),
         reloadNodeDefs: vi.fn(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(mockHandles.enrichWithEmbeddedMetadata).toHaveBeenCalledWith(
@@ -352,7 +328,7 @@ describe('missingModelPipeline', () => {
         refreshMissingModelPipeline({
           graph: createGraph(),
           reloadNodeDefs: vi.fn().mockRejectedValue(error),
-          missingModelStore: mockHandles.missingModelStore
+          missingModelStore: useMissingModelStore()
         })
       ).rejects.toThrow(error)
 
@@ -380,19 +356,19 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: null
       }
       mockHandles.state.enrichedCandidates = [
         confirmedCandidate,
         installedCandidate
       ]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
 
       const result = await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore,
+        missingModelStore: useMissingModelStore(),
         missingNodeTypes: ['MissingCustomNode']
       })
       await vi.dynamicImportSettled()
@@ -430,7 +406,7 @@ describe('missingModelPipeline', () => {
       const result = await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(result).toEqual({
@@ -469,7 +445,7 @@ describe('missingModelPipeline', () => {
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
@@ -477,7 +453,7 @@ describe('missingModelPipeline', () => {
       expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
         'https://example.com/downloadable.safetensors'
       )
-      expect(mockHandles.missingModelStore.setFileSize).toHaveBeenCalledWith(
+      expect(useMissingModelStore().setFileSize).toHaveBeenCalledWith(
         'https://example.com/downloadable.safetensors',
         1024
       )
@@ -502,17 +478,15 @@ describe('missingModelPipeline', () => {
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
-      expect(
-        mockHandles.missingModelStore.setGatedRepoUrl
-      ).toHaveBeenCalledWith(
+      expect(useMissingModelStore().setGatedRepoUrl).toHaveBeenCalledWith(
         'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors',
         'https://huggingface.co/bfl/FLUX.1'
       )
-      expect(mockHandles.missingModelStore.setFileSize).not.toHaveBeenCalled()
+      expect(useMissingModelStore().setFileSize).not.toHaveBeenCalled()
     })
 
     it('does not store gated repo URLs after verification is aborted', async () => {
@@ -527,9 +501,9 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       mockHandles.state.enrichedCandidates = [downloadableCandidate]
-      mockHandles.missingModelStore.createVerificationAbortController.mockReturnValueOnce(
-        controller
-      )
+      vi.mocked(
+        useMissingModelStore().createVerificationAbortController
+      ).mockReturnValueOnce(controller)
       mockHandles.fetchModelMetadata.mockResolvedValue({
         fileSize: null,
         gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
@@ -539,16 +513,14 @@ describe('missingModelPipeline', () => {
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
       expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
         'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors'
       )
-      expect(
-        mockHandles.missingModelStore.setGatedRepoUrl
-      ).not.toHaveBeenCalled()
+      expect(useMissingModelStore().setGatedRepoUrl).not.toHaveBeenCalled()
     })
 
     it('clears surfaced and cached missing models when no candidates are confirmed missing', async () => {
@@ -561,7 +533,7 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: {
           missingModelCandidates: [
             {
@@ -578,16 +550,16 @@ describe('missingModelPipeline', () => {
         }
       }
       mockHandles.state.enrichedCandidates = [installedCandidate]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
 
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).toHaveBeenCalledWith([], { silent: false })
       expect(activeWorkflow.pendingWarnings).toBeNull()
     })
@@ -612,7 +584,7 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       } satisfies MissingModelCandidate
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: null
       }
       const graph = createGraph()
@@ -620,7 +592,7 @@ describe('missingModelPipeline', () => {
         activeCandidate,
         inactiveCandidate
       ]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
       mockHandles.isAncestorPathActive.mockImplementation(
         (_graph: LGraph, nodeId: string) => nodeId !== '2'
       )
@@ -628,7 +600,7 @@ describe('missingModelPipeline', () => {
       const result = await runMissingModelPipeline({
         graph,
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(result.confirmedCandidates).toEqual([activeCandidate])
@@ -651,12 +623,12 @@ describe('missingModelPipeline', () => {
         isAssetSupported: true
       }
       const activeWorkflow = {
-        activeState: null,
+        activeState: createWorkflowGraphData(),
         pendingWarnings: null
       }
       const graph = createGraph()
       mockHandles.state.enrichedCandidates = [promotedCandidate]
-      mockHandles.workspaceWorkflow.activeWorkflow = activeWorkflow
+      useWorkflowStore().activeWorkflow = fromPartial(activeWorkflow)
       mockHandles.isAncestorPathActive.mockImplementation(
         (_graph: LGraph, nodeId: string) => nodeId !== '65:77:42'
       )
@@ -664,7 +636,7 @@ describe('missingModelPipeline', () => {
       const result = await runMissingModelPipeline({
         graph,
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       expect(result.confirmedCandidates).toEqual([])
@@ -689,15 +661,15 @@ describe('missingModelPipeline', () => {
         }
       )
       mockHandles.state.enrichedCandidates = [confirmedCandidate]
-      mockHandles.missingModelStore.createVerificationAbortController.mockReturnValueOnce(
-        controller
-      )
+      vi.mocked(
+        useMissingModelStore().createVerificationAbortController
+      ).mockReturnValueOnce(controller)
       mockHandles.api.getFolderPaths.mockReturnValueOnce(folderPathsPromise)
 
       await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
-        missingModelStore: mockHandles.missingModelStore
+        missingModelStore: useMissingModelStore()
       })
 
       controller.abort()
@@ -707,12 +679,22 @@ describe('missingModelPipeline', () => {
       await Promise.resolve()
       await Promise.resolve()
 
+      expect(useMissingModelStore().setFolderPaths).not.toHaveBeenCalled()
       expect(
-        mockHandles.missingModelStore.setFolderPaths
-      ).not.toHaveBeenCalled()
-      expect(
-        mockHandles.executionErrorStore.surfaceMissingModels
+        useExecutionErrorStore().surfaceMissingModels
       ).not.toHaveBeenCalled()
     })
   })
 })
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
+
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
+}))

--- a/src/platform/missingModel/missingModelScan.test.ts
+++ b/src/platform/missingModel/missingModelScan.test.ts
@@ -1,5 +1,8 @@
+import type * as I18nModule from '@/i18n'
+import { useAssetsStore } from '@/stores/assetsStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
@@ -253,6 +256,17 @@ function makeNestedPromotedModelGraph({
 }
 
 const noAssetSupport = () => false
+
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(() => undefined)
+})
+
+beforeEach(() => {
+  vi.mocked(useAssetsStore().updateModelsForNodeType).mockImplementation(
+    mockUpdateModelsForNodeType
+  )
+  vi.mocked(useAssetsStore().getAssets).mockImplementation(mockGetAssets)
+})
 
 describe('isModelFileName', () => {
   it('should return true for common model extensions', () => {
@@ -1727,20 +1741,8 @@ const { mockUpdateModelsForNodeType, mockGetAssets } = vi.hoisted(() => ({
   mockGetAssets: vi.fn().mockReturnValue([])
 }))
 
-vi.mock<unknown>(import('@/stores/assetsStore'), () => ({
-  useAssetsStore: () => ({
-    updateModelsForNodeType: mockUpdateModelsForNodeType,
-    getAssets: mockGetAssets
-  })
-}))
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({
-    add: vi.fn()
-  })
-}))
-
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: (_key: string, fallback: string) => fallback
 }))
 

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeExecutionId } from '@/types/nodeIdentification'
@@ -12,23 +15,16 @@ const mockNodeLocatorIdToNodeExecutionId = vi.hoisted(() =>
   vi.fn((nodeLocatorId: string) => nodeLocatorId)
 )
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   t: vi.fn((key: string) => `translated:${key}`),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      nodeLocatorIdToNodeExecutionId: mockNodeLocatorIdToNodeExecutionId
-    })
-  })
-)
 
 import { useMissingModelStore } from './missingModelStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -57,6 +53,14 @@ function makeModelCandidate(
     isMissing: true
   }
 }
+
+beforeEach(() => {
+  vi.mocked(
+    useWorkflowStore().nodeLocatorIdToNodeExecutionId
+  ).mockImplementation((id) =>
+    createNodeExecutionId(mockNodeLocatorIdToNodeExecutionId(id).split(':'))
+  )
+})
 
 describe('missingModelStore', () => {
   beforeEach(() => {

--- a/src/platform/nodeReplacement/components/SwapNodeGroupRow.test.ts
+++ b/src/platform/nodeReplacement/components/SwapNodeGroupRow.test.ts
@@ -1,4 +1,4 @@
-import { createTestingPinia } from '@pinia/testing'
+import { getActivePinia } from 'pinia'
 import { fromAny } from '@total-typescript/shoehorn'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
@@ -61,7 +61,7 @@ function renderRow(
       ...props
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue, i18n],
+      plugins: [getActivePinia()!, PrimeVue, i18n],
       stubs: {
         TransitionCollapse: { template: '<div><slot /></div>' }
       }

--- a/src/platform/nodeReplacement/components/SwapNodesCard.test.ts
+++ b/src/platform/nodeReplacement/components/SwapNodesCard.test.ts
@@ -1,6 +1,6 @@
+import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -45,7 +45,7 @@ function mountCard(
       ...(callbacks?.onReplace ? { onReplace: callbacks.onReplace } : {})
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue]
+      plugins: [getActivePinia()!, PrimeVue]
     }
   })
 }

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -27,18 +30,14 @@ vi.mock(import('@/platform/nodeReplacement/cnrIdUtil'), () => ({
   getCnrIdFromNode: vi.fn(() => undefined)
 }))
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: vi.fn(() => true)
-  })
 }))
 
 import {
@@ -76,6 +75,10 @@ function getMissingNodesError(
   if (!error) throw new Error('Expected missingNodesError to be defined')
   return error
 }
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => true)
+})
 
 describe('scanMissingNodes (via rescanAndSurfaceMissingNodes)', () => {
   beforeEach(() => {

--- a/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
+++ b/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
@@ -1,24 +1,29 @@
-import { describe, expect, it, vi } from 'vitest'
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false
 }))
 
 const mockShowErrorsTab = vi.hoisted(() => ({ value: false }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn(() => mockShowErrorsTab.value)
-  }))
-}))
-
 import { useMissingNodesErrorStore } from './missingNodesErrorStore'
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(
+    () => mockShowErrorsTab.value
+  )
+})
 
 describe('missingNodesErrorStore', () => {
   describe('setMissingNodeTypes', () => {

--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -1,6 +1,6 @@
 import type { NodeReplacementResponse } from './types'
+import type { ComfyApp } from '@/scripts/app'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ServerFeatureFlag } from '@/composables/useFeatureFlags'
@@ -8,10 +8,6 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { fetchNodeReplacements } from './nodeReplacementService'
 import { useNodeReplacementStore } from './nodeReplacementStore'
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn()
-}))
 
 vi.mock(import('./nodeReplacementService'), () => ({
   fetchNodeReplacements: vi.fn()
@@ -23,21 +19,10 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-function mockSettingStore(enabled: boolean) {
-  vi.mocked(useSettingStore, { partial: true }).mockReturnValue({
-    get: vi.fn().mockImplementation((key: string) => {
-      if (key === 'Comfy.NodeReplacement.Enabled') {
-        return enabled
-      }
-      return false
-    }),
-    load: vi.fn().mockResolvedValue(undefined)
-  })
-}
-
 function createStore(settingEnabled = true, serverFeatureEnabled = true) {
-  setActivePinia(createPinia())
-  mockSettingStore(settingEnabled)
+  useSettingStore().settingValues['Comfy.NodeReplacement.Enabled'] =
+    settingEnabled
+  vi.mocked(useSettingStore().load).mockResolvedValue(undefined)
   vi.mocked(api.getServerFeature).mockImplementation(
     (flag: string, defaultValue?: unknown) => {
       if (flag === ServerFeatureFlag.NODE_REPLACEMENTS) {
@@ -269,4 +254,9 @@ describe('useNodeReplacementStore', () => {
       expect(fetchNodeReplacements).toHaveBeenCalledOnce()
     })
   })
+})
+
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
 })

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -1,4 +1,7 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { fromPartial, fromAny } from '@total-typescript/shoehorn'
+import type * as I18nModule from '@/i18n'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -10,7 +13,6 @@ import {
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
-import type { PendingWarnings } from '@/platform/workflow/management/stores/comfyWorkflow'
 import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -55,42 +57,11 @@ vi.mock(import('@/utils/graphTraversalUtil'), () => ({
 
 const { mockToastAdd } = vi.hoisted(() => ({ mockToastAdd: vi.fn() }))
 
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: vi.fn(() => ({
-    add: mockToastAdd
-  }))
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    ComfyWorkflow: class {},
-    useWorkflowStore: vi.fn(() => workflowMocks)
-  })
-)
-
-vi.mock<unknown>(import('@/i18n'), () => ({
+vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: (_key: string, fallback: string) => fallback,
   t: (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key
-}))
-
-interface ActiveWorkflowMock {
-  pendingWarnings: PendingWarnings | null
-  changeTracker: {
-    beforeChange: () => void
-    afterChange: () => void
-  }
-}
-
-const workflowMocks = vi.hoisted(() => ({
-  activeWorkflow: {
-    pendingWarnings: null,
-    changeTracker: {
-      beforeChange: vi.fn(),
-      afterChange: vi.fn()
-    }
-  } as ActiveWorkflowMock | null
 }))
 
 import { app } from '@/scripts/app'
@@ -99,13 +70,13 @@ import { collectAllNodes } from '@/utils/graphTraversalUtil'
 import { useNodeReplacement } from './useNodeReplacement'
 
 beforeEach(() => {
-  workflowMocks.activeWorkflow = {
+  useWorkflowStore().activeWorkflow = fromPartial({
     pendingWarnings: null,
     changeTracker: {
       beforeChange: vi.fn(),
       afterChange: vi.fn()
     }
-  }
+  })
 })
 
 function createMockLink(
@@ -262,7 +233,7 @@ function makeMissingNodeType(
 }
 
 function getActiveWorkflowMock() {
-  const activeWorkflow = workflowMocks.activeWorkflow
+  const activeWorkflow = useWorkflowStore().activeWorkflow
   if (!activeWorkflow) throw new Error('Expected an active workflow')
   return activeWorkflow
 }
@@ -271,6 +242,10 @@ function seedMissingNodeTypes(types: MissingNodeType[]): void {
   getActiveWorkflowMock().pendingWarnings = { missingNodeTypes: types }
   useMissingNodesErrorStore().setMissingNodeTypes(types)
 }
+
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockToastAdd)
+})
 
 describe('useNodeReplacement', () => {
   describe('replaceNodesInPlace', () => {
@@ -1577,7 +1552,7 @@ describe('useNodeReplacement', () => {
         oldNodeType,
         'OtherNode'
       ])
-      workflowMocks.activeWorkflow = null
+      useWorkflowStore().activeWorkflow = null
 
       const { replaceGroup } = useNodeReplacement()
       replaceGroup({

--- a/src/platform/onboarding/TourOverlay.test.ts
+++ b/src/platform/onboarding/TourOverlay.test.ts
@@ -1,8 +1,7 @@
-import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { defineComponent, h } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -10,29 +9,6 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import TourOverlay from './TourOverlay.vue'
 import type { CoachStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
-
-vi.mock<unknown>(import('./onboardingTourStore'), () => ({
-  useOnboardingTourStore: vi.fn()
-}))
-
-function makeTourState() {
-  return {
-    step: ref<CoachStep | null>(null),
-    title: ref('Canvas title'),
-    body: ref('Canvas body'),
-    isLast: ref(false),
-    canGoBack: ref(true),
-    primaryLabel: ref('Next'),
-    skipLabel: ref('Skip'),
-    backLabel: ref('Back'),
-    countedStepIdx: ref(0),
-    countedStepsTotal: ref(0),
-    waitingForTarget: ref(false),
-    next: vi.fn(),
-    back: vi.fn(),
-    skip: vi.fn()
-  }
-}
 
 // Stubbed so the suite covers only TourOverlay's branching and intent wiring.
 vi.mock(import('./TourSpotlight.vue'), () => ({
@@ -55,7 +31,7 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-let s: ReturnType<typeof makeTourState>
+let s: ReturnType<typeof useOnboardingTourStore>
 
 const spotlightStep: CoachStep = {
   kind: 'spotlight',
@@ -73,8 +49,27 @@ function renderOverlay() {
 
 describe('TourOverlay', () => {
   beforeEach(() => {
-    s = makeTourState()
-    vi.mocked(useOnboardingTourStore).mockReturnValue(fromPartial(reactive(s)))
+    const store = useOnboardingTourStore()
+    Object.assign(store, {
+      step: null,
+      title: 'Canvas title',
+      body: 'Canvas body',
+      isLast: false,
+      canGoBack: true,
+      primaryLabel: 'Next',
+      skipLabel: 'Skip',
+      backLabel: 'Back',
+      countedStepIdx: 0,
+      countedStepsTotal: 0,
+      waitingForTarget: false
+    })
+    vi.mocked(store.next).mockResolvedValue(undefined)
+    vi.mocked(store.back).mockResolvedValue(undefined)
+    vi.mocked(store.skip).mockImplementation(() => undefined)
+    s = store
+    vi.spyOn(s, 'step', 'get').mockReturnValue(null)
+    vi.spyOn(s, 'primaryLabel', 'get').mockReturnValue('Next')
+    vi.spyOn(s, 'skipLabel', 'get').mockReturnValue('Skip')
   })
 
   it('renders nothing when no tour step is active', () => {
@@ -85,7 +80,7 @@ describe('TourOverlay', () => {
 
   it('renders the spotlight for a non-landing step and wires its intents', async () => {
     const user = userEvent.setup()
-    s.step.value = spotlightStep
+    vi.spyOn(s, 'step', 'get').mockReturnValue(spotlightStep)
     renderOverlay()
 
     expect(screen.getByTestId('spotlight')).toBeTruthy()
@@ -102,8 +97,8 @@ describe('TourOverlay', () => {
 
   it('renders the landing step and starts the tour on its primary action', async () => {
     const user = userEvent.setup()
-    s.step.value = landingStep()
-    s.primaryLabel.value = 'Start tutorial'
+    vi.spyOn(s, 'step', 'get').mockReturnValue(landingStep())
+    vi.spyOn(s, 'primaryLabel', 'get').mockReturnValue('Start tutorial')
     renderOverlay()
 
     await user.click(
@@ -113,9 +108,9 @@ describe('TourOverlay', () => {
   })
 
   it('disables the landing primary action while waiting for a deferred target', async () => {
-    s.step.value = landingStep()
-    s.primaryLabel.value = 'Start tutorial'
-    s.waitingForTarget.value = true
+    vi.spyOn(s, 'step', 'get').mockReturnValue(landingStep())
+    vi.spyOn(s, 'primaryLabel', 'get').mockReturnValue('Start tutorial')
+    vi.spyOn(s, 'waitingForTarget', 'get').mockReturnValue(true)
     renderOverlay()
 
     expect(
@@ -125,7 +120,7 @@ describe('TourOverlay', () => {
 
   it('ends the tour when the landing is dismissed', async () => {
     const user = userEvent.setup()
-    s.step.value = landingStep()
+    vi.spyOn(s, 'step', 'get').mockReturnValue(landingStep())
     renderOverlay()
 
     await user.click(await screen.findByRole('button', { name: 'Skip' }))

--- a/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
@@ -1,6 +1,6 @@
-import { createPinia, disposePinia, setActivePinia } from 'pinia'
-import type { Pinia } from 'pinia'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAppModeStore } from '@/stores/appModeStore'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
 
@@ -11,18 +11,6 @@ import { TOUR_SEEN_SETTING, registerTour } from './onboardingTours'
 import type { SpotlightStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
-const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
-    set: (key: string, value: unknown) => {
-      settings.store.set(key, value)
-      return Promise.resolve()
-    }
-  })
-}))
-
 const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
@@ -30,13 +18,24 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 
 const appModeMock = vi.hoisted(() => ({ mode: null as Ref<AppMode> | null }))
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
-  const { ref } = await import('vue')
+  const { ref, computed } = await import('vue')
   appModeMock.mode = ref<AppMode>('graph')
-  return { useAppMode: () => ({ mode: appModeMock.mode }) }
+  return {
+    useAppMode: () => ({
+      mode: appModeMock.mode,
+      isAppMode: computed(() => appModeMock.mode?.value === 'app'),
+      isBuilderMode: computed(() =>
+        appModeMock.mode?.value.startsWith('builder:')
+      ),
+      isSelectMode: computed(
+        () =>
+          appModeMock.mode?.value === 'builder:inputs' ||
+          appModeMock.mode?.value === 'builder:outputs'
+      ),
+      setMode: vi.fn()
+    })
+  }
 })
-vi.mock<unknown>(import('@/stores/appModeStore'), () => ({
-  useAppModeStore: () => ({ hasOutputs: false })
-}))
 
 function step(
   name: string,
@@ -49,20 +48,24 @@ function stages(): string[] {
   return telemetry.track.mock.calls.map(([stage]) => stage)
 }
 
-let pinia: Pinia | undefined
-
 function mountStore() {
-  pinia = createPinia()
-  setActivePinia(pinia)
   return useOnboardingTourStore()
 }
 
+beforeEach(() => {
+  useSettingStore().settingValues[TOUR_SEEN_SETTING] = []
+  vi.mocked(useSettingStore().set).mockImplementation(
+    (key: string, value: unknown) => {
+      Object.assign(useSettingStore().settingValues, { [key]: value })
+      return Promise.resolve()
+    }
+  )
+  Object.assign(useAppModeStore(), { hasOutputs: false })
+})
+
 describe('onboardingTourStore — runtime-resolved tours', () => {
   afterEach(() => {
-    if (pinia) disposePinia(pinia)
-    pinia = undefined
     clearCoachmarks()
-    settings.store.clear()
     telemetry.track.mockClear()
   })
 
@@ -70,8 +73,6 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
     vi.resetModules()
     const { useOnboardingTourStore: freshStore } =
       await import('./onboardingTourStore')
-    pinia = createPinia()
-    setActivePinia(pinia)
     const store = freshStore()
 
     await expect(store.startTour('firstRun')).resolves.toBe(false)
@@ -94,7 +95,7 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
   })
 
   it('tells a repeat user apart from a coverage failure', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['firstRun'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['firstRun']
     registerTour('firstRun', () => Promise.resolve([]))
     const store = mountStore()
 
@@ -151,7 +152,7 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
   })
 
   it('counts a user once however often the trigger re-fires', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['firstRun'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['firstRun']
     const store = mountStore()
 
     await store.startTour('firstRun')

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -1,6 +1,6 @@
+import { useAppModeStore } from '@/stores/appModeStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { DetachedWindowAPI } from 'happy-dom'
-import { createPinia, disposePinia, setActivePinia } from 'pinia'
-import type { Pinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import type { Ref } from 'vue'
@@ -18,46 +18,34 @@ import { TOUR_SEEN_SETTING, tourDefinition } from './onboardingTours'
 import type { CoachId, CoachStep } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
-const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: (key: string) =>
-      settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
-    set: (key: string, value: unknown) => {
-      settings.store.set(key, value)
-      return Promise.resolve()
-    }
-  })
-}))
-
 const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
 }))
 
-const appModeMock = vi.hoisted(
-  (): { mode: Ref<AppMode> | null; hasOutputs: Ref<boolean> | null } => ({
-    mode: null,
-    hasOutputs: null
-  })
-)
+const appModeMock = vi.hoisted((): { mode: Ref<AppMode> | null } => ({
+  mode: null
+}))
 vi.mock<unknown>(import('@/composables/useAppMode'), async () => {
-  const { ref: r } = await import('vue')
+  const { ref: r, computed } = await import('vue')
   appModeMock.mode = r<AppMode>('graph')
-  return { useAppMode: () => ({ mode: appModeMock.mode }) }
-})
-vi.mock<unknown>(import('@/stores/appModeStore'), async () => {
-  const { ref: r } = await import('vue')
-  appModeMock.hasOutputs = r(false)
-  const hasOutputs = appModeMock.hasOutputs
   return {
-    useAppModeStore: () => ({
-      get hasOutputs() {
-        return hasOutputs.value
-      }
+    useAppMode: () => ({
+      mode: appModeMock.mode,
+      isAppMode: computed(() => appModeMock.mode?.value === 'app'),
+      isBuilderMode: computed(() =>
+        appModeMock.mode?.value.startsWith('builder:')
+      ),
+      isSelectMode: computed(
+        () =>
+          appModeMock.mode?.value === 'builder:inputs' ||
+          appModeMock.mode?.value === 'builder:outputs'
+      ),
+      setMode: vi.fn()
     })
   }
 })
+
 const APP_MODE_TARGETS: CoachId[] = [
   'inputs-list',
   'app-run-button',
@@ -66,7 +54,7 @@ const APP_MODE_TARGETS: CoachId[] = [
 ]
 
 function seenTours(): string[] {
-  return (settings.store.get(TOUR_SEEN_SETTING) as string[] | undefined) ?? []
+  return useSettingStore().get(TOUR_SEEN_SETTING)
 }
 
 function setViewport(viewport: { width: number; height: number }) {
@@ -78,11 +66,7 @@ function setViewport(viewport: { width: number; height: number }) {
   happyDOM.setViewport(viewport)
 }
 
-let pinia: Pinia | undefined
-
 function mountStore() {
-  pinia = createPinia()
-  setActivePinia(pinia)
   return useOnboardingTourStore()
 }
 
@@ -102,23 +86,33 @@ function shownCount(coachId?: CoachId) {
   ).length
 }
 
+beforeEach(() => {
+  useSettingStore().settingValues[TOUR_SEEN_SETTING] = []
+  vi.mocked(useSettingStore().set).mockImplementation(
+    (key: string, value: unknown) => {
+      Object.assign(useSettingStore().settingValues, { [key]: value })
+      return Promise.resolve()
+    }
+  )
+})
+
+beforeEach(() => {
+  Object.assign(useAppModeStore(), { hasOutputs: false })
+})
+
 describe('onboardingTourStore', () => {
   // Removed in teardown even when a test throws before its own cleanup.
   const appendedTargets: HTMLElement[] = []
   const restoreOnEnter: (() => void)[] = []
 
   afterEach(() => {
-    if (pinia) disposePinia(pinia)
-    pinia = undefined
     clearCoachmarks()
     restoreOnEnter.forEach((restore) => restore())
     restoreOnEnter.length = 0
     appendedTargets.forEach((el) => el.remove())
     appendedTargets.length = 0
-    settings.store.clear()
     setViewport({ width: 1024, height: 768 })
     if (appModeMock.mode) appModeMock.mode.value = 'graph'
-    if (appModeMock.hasOutputs) appModeMock.hasOutputs.value = false
     telemetry.track.mockClear()
   })
 
@@ -140,11 +134,9 @@ describe('onboardingTourStore', () => {
 
   function enterApp(mode: AppMode, hasOutputs: boolean) {
     const modeRef = appModeMock.mode
-    const outputsRef = appModeMock.hasOutputs
-    if (!modeRef || !outputsRef)
-      throw new Error('app mode mock not initialised')
+    if (!modeRef) throw new Error('app mode mock not initialised')
     modeRef.value = mode
-    outputsRef.value = hasOutputs
+    Object.assign(useAppModeStore(), { hasOutputs })
   }
 
   beforeEach(() => enterApp('app', false))
@@ -186,7 +178,7 @@ describe('onboardingTourStore', () => {
   })
 
   it('does not auto-open a populated app once the tour has been dismissed', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
     mountStore()
     enterApp('app', true)
     await nextTick()
@@ -194,7 +186,7 @@ describe('onboardingTourStore', () => {
   })
 
   it('replays a seen tour when explicitly requested', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
     const store = mountStore()
     store.replayTour('appMode')
     await nextTick()
@@ -202,7 +194,7 @@ describe('onboardingTourStore', () => {
   })
 
   it('dismisses a replayed tour without the seen-flag when the user leaves its mode', async () => {
-    settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+    useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
     const store = mountStore()
     enterApp('app', false)
     await nextTick()
@@ -292,7 +284,7 @@ describe('onboardingTourStore', () => {
     })
 
     it('records a tour that lost the context its steps point at', async () => {
-      settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+      useSettingStore().settingValues[TOUR_SEEN_SETTING] = ['appMode']
       const store = mountStore()
       enterApp('app', false)
       await nextTick()

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -1,22 +1,8 @@
 import { render } from '@testing-library/vue'
-import { nextTick, reactive } from 'vue'
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useQueuePolling } from '@/platform/remote/comfyui/useQueuePolling'
-
-vi.mock<unknown>(import('@/stores/queueStore'), () => {
-  const state = reactive({
-    activeJobsCount: 0,
-    isLoading: false,
-    update: vi.fn()
-  })
-
-  return {
-    useQueueStore: () => state
-  }
-})
-
-// Re-import to get the mock instance for assertions
 import { useQueueStore } from '@/stores/queueStore'
 
 function mountUseQueuePolling() {
@@ -30,17 +16,13 @@ function mountUseQueuePolling() {
 }
 
 describe('useQueuePolling', () => {
-  const store = useQueueStore() as Partial<
-    ReturnType<typeof useQueueStore>
-  > as {
-    activeJobsCount: number
-    isLoading: boolean
-    update: ReturnType<typeof vi.fn>
-  }
+  let store: ReturnType<typeof useQueueStore>
 
   beforeEach(() => {
-    store.activeJobsCount = 0
+    store = useQueueStore()
+    Object.assign(store, { activeJobsCount: 0 })
     store.isLoading = false
+    vi.mocked(store.update).mockResolvedValue(undefined)
   })
 
   it('does not call update on creation', () => {
@@ -51,7 +33,7 @@ describe('useQueuePolling', () => {
   it('polls when activeJobsCount is exactly 1', async () => {
     mountUseQueuePolling()
 
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     await vi.advanceTimersByTimeAsync(8_000)
 
     expect(store.update).toHaveBeenCalledOnce()
@@ -60,24 +42,24 @@ describe('useQueuePolling', () => {
   it('does not poll when activeJobsCount > 1', async () => {
     mountUseQueuePolling()
 
-    store.activeJobsCount = 2
+    Object.assign(store, { activeJobsCount: 2 })
     await vi.advanceTimersByTimeAsync(16_000)
 
     expect(store.update).not.toHaveBeenCalled()
   })
 
   it('stops polling when activeJobsCount drops to 0', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
-    store.activeJobsCount = 0
+    Object.assign(store, { activeJobsCount: 0 })
     await vi.advanceTimersByTimeAsync(16_000)
 
     expect(store.update).not.toHaveBeenCalled()
   })
 
   it('resets timer when loading completes', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // Advance 5s toward the 8s timeout
@@ -100,7 +82,7 @@ describe('useQueuePolling', () => {
   })
 
   it('applies exponential backoff on successive polls', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // First poll at 8s
@@ -121,7 +103,7 @@ describe('useQueuePolling', () => {
   })
 
   it('skips poll when an update is already in-flight', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // Simulate an external update starting before the timer fires
@@ -138,7 +120,7 @@ describe('useQueuePolling', () => {
   })
 
   it('resets backoff when activeJobsCount changes', async () => {
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     mountUseQueuePolling()
 
     // First poll at 8s (backs off delay to 12s)
@@ -152,12 +134,12 @@ describe('useQueuePolling', () => {
     await nextTick()
 
     // Count changes — backoff should reset to 8s
-    store.activeJobsCount = 0
+    Object.assign(store, { activeJobsCount: 0 })
     await nextTick()
-    store.activeJobsCount = 1
+    Object.assign(store, { activeJobsCount: 1 })
     await nextTick()
 
-    store.update.mockClear()
+    vi.mocked(store.update).mockClear()
     await vi.advanceTimersByTimeAsync(8_000)
     expect(store.update).toHaveBeenCalledOnce()
   })

--- a/src/platform/secrets/components/SecretsPanel.test.ts
+++ b/src/platform/secrets/components/SecretsPanel.test.ts
@@ -1,3 +1,4 @@
+import { useDialogStore } from '@/stores/dialogStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -32,12 +33,6 @@ vi.mock<unknown>(import('@/platform/secrets/composables/useSecrets'), () => ({
     fetchSecrets: mockFetchSecrets,
     fetchProviders: mockFetchProviders,
     deleteSecret: mockDeleteSecret
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({
-    closeDialog: mockCloseDialog
   })
 }))
 
@@ -111,6 +106,10 @@ function renderPanel() {
     }
   })
 }
+
+beforeEach(() => {
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(mockCloseDialog)
+})
 
 describe('SecretsPanel', () => {
   beforeEach(() => {

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -1,16 +1,13 @@
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { render } from '@testing-library/vue'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SecretMetadata } from '../types'
 import { useSecrets as useSecretsComposable } from './useSecrets'
 
 const mockAdd = vi.fn()
-
-vi.mock<unknown>(import('@/platform/updates/common/toastStore'), () => ({
-  useToastStore: () => ({ add: mockAdd })
-}))
 
 const mockListSecrets = vi.fn()
 const mockListSecretProviders = vi.fn()
@@ -63,6 +60,10 @@ function createMockSecret(
     ...overrides
   }
 }
+
+beforeEach(() => {
+  vi.mocked(useToastStore().add).mockImplementation(mockAdd)
+})
 
 describe('useSecrets', () => {
   describe('fetchSecrets', () => {

--- a/src/platform/settings/components/SettingItem.test.ts
+++ b/src/platform/settings/components/SettingItem.test.ts
@@ -1,3 +1,4 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { render } from '@testing-library/vue'
 import { defineComponent } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,13 +11,9 @@ const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
 const mockGet = vi.fn()
-const mockSet = vi.fn()
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({
-    get: mockGet,
-    set: mockSet
-  })
-}))
+const mockSet = vi.fn<ReturnType<typeof useSettingStore>['set']>(
+  async () => undefined
+)
 
 let emitFormValue: ((value: unknown) => void) | null = null
 
@@ -31,6 +28,11 @@ const FormItemUpdateStub = defineComponent({
     return {}
   },
   template: '<div data-testid="form-item-stub" />'
+})
+
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(mockGet)
+  vi.mocked(useSettingStore().set).mockImplementation(mockSet)
 })
 
 describe('SettingItem', () => {

--- a/src/platform/settings/composables/useLitegraphSettings.reactiveEdge.test.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.reactiveEdge.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { effectScope, nextTick } from 'vue'
 import { expect, it, vi } from 'vitest'
 
@@ -21,7 +20,6 @@ const createCanvas = (draw: () => void) => {
 }
 
 it('contains CanvasInfo draws to its explicit sources', async () => {
-  setActivePinia(createPinia())
   const node = new LGraphNode('test')
   const slot = node.addInput('input', 'STRING')
   const firstCanvas = createCanvas(() => {

--- a/src/platform/settings/composables/useLitegraphSettings.test.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.test.ts
@@ -6,33 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
-
-const testState = vi.hoisted(
-  (): { canvasStore: { canvas: LGraphCanvas | null } | null } => ({
-    canvasStore: null
-  })
-)
-
-vi.mock<unknown>(
-  import('@/renderer/core/canvas/canvasStore'), // eslint-disable-line import-x/no-restricted-paths
-
-  async () => {
-    const { reactive } = await import('vue')
-    testState.canvasStore = reactive({ canvas: null })
-    return { useCanvasStore: () => testState.canvasStore }
-  }
-)
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
 
 import { useLitegraphSettings } from './useLitegraphSettings'
 
 function createCanvas(draw: () => void): LGraphCanvas {
   return fromPartial<LGraphCanvas>({ draw, setDirty: vi.fn() })
-}
-
-function getCanvasStore(): { canvas: LGraphCanvas | null } {
-  if (!testState.canvasStore)
-    throw new Error('Canvas store was not initialized')
-  return testState.canvasStore
 }
 
 describe('useLitegraphSettings', () => {
@@ -49,7 +28,7 @@ describe('useLitegraphSettings', () => {
     const node = new LGraphNode('test')
     const slot = node.addInput('input', '*')
     const draw = vi.fn(() => slot.pos)
-    getCanvasStore().canvas = createCanvas(draw)
+    useCanvasStore().canvas = createCanvas(draw)
 
     scope.run(useLitegraphSettings)
 
@@ -64,7 +43,7 @@ describe('useLitegraphSettings', () => {
   it('redraws when CanvasInfo or the canvas changes', async () => {
     const firstDraw = vi.fn()
     const secondDraw = vi.fn()
-    const canvasStore = getCanvasStore()
+    const canvasStore = useCanvasStore()
     const settingStore = useSettingStore()
     canvasStore.canvas = createCanvas(firstDraw)
 

--- a/src/platform/settings/composables/useSettingSearch.test.ts
+++ b/src/platform/settings/composables/useSettingSearch.test.ts
@@ -1,64 +1,49 @@
+import type * as I18nModule from '@/i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { st } from '@/i18n'
 import { useSettingSearch } from '@/platform/settings/composables/useSettingSearch'
-import {
-  getSettingInfo,
-  useSettingStore
-} from '@/platform/settings/settingStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingTreeNode } from '@/platform/settings/settingStore'
-
-// Test-specific type for mock settings
-interface MockSettingParams {
-  id: string
-  name: string
-  type: string
-  defaultValue: unknown
-  category?: string[]
-  deprecated?: boolean
-}
+import type { SettingParams } from '@/platform/settings/types'
 
 // Mock dependencies
-vi.mock(import('@/i18n'), () => ({
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   st: vi.fn((_: string, fallback: string) => fallback)
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(),
-  getSettingInfo: vi.fn()
 }))
 
 describe('useSettingSearch', () => {
   let mockSettingStore: ReturnType<typeof useSettingStore>
-  let mockSettings: Record<string, MockSettingParams>
+  let mockSettings: Record<string, SettingParams>
 
   beforeEach(() => {
     // Mock settings data
     mockSettings = {
       'Category.Setting1': {
-        id: 'Category.Setting1',
+        id: 'Category.Setting1' as SettingParams['id'],
         name: 'Setting One',
         type: 'text',
         defaultValue: 'default',
         category: ['Category', 'Basic']
       },
       'Category.Setting2': {
-        id: 'Category.Setting2',
+        id: 'Category.Setting2' as SettingParams['id'],
         name: 'Setting Two',
         type: 'boolean',
         defaultValue: false,
         category: ['Category', 'Advanced']
       },
       'Category.HiddenSetting': {
-        id: 'Category.HiddenSetting',
+        id: 'Category.HiddenSetting' as SettingParams['id'],
         name: 'Hidden Setting',
         type: 'hidden',
         defaultValue: 'hidden',
         category: ['Category', 'Basic']
       },
       'Category.DeprecatedSetting': {
-        id: 'Category.DeprecatedSetting',
+        id: 'Category.DeprecatedSetting' as SettingParams['id'],
         name: 'Deprecated Setting',
         type: 'text',
         defaultValue: 'deprecated',
@@ -66,28 +51,18 @@ describe('useSettingSearch', () => {
         category: ['Category', 'Advanced']
       },
       'Other.Setting3': {
-        id: 'Other.Setting3',
+        id: 'Other.Setting3' as SettingParams['id'],
         name: 'Other Setting',
-        type: 'select',
+        type: 'combo',
+        options: ['option1', 'option2'],
         defaultValue: 'option1',
         category: ['Other', 'SubCategory']
       }
     }
 
     // Mock setting store
-    mockSettingStore = {
-      settingsById: mockSettings
-    } as ReturnType<typeof useSettingStore>
-    vi.mocked(useSettingStore).mockReturnValue(mockSettingStore)
-
-    // Mock getSettingInfo function
-    vi.mocked(getSettingInfo).mockImplementation((setting) => {
-      const parts = setting.category || setting.id.split('.')
-      return {
-        category: parts[0] ?? 'Other',
-        subCategory: parts[1] ?? 'Other'
-      }
-    })
+    mockSettingStore = useSettingStore()
+    mockSettingStore.settingsById = mockSettings
 
     // Mock st function to return fallback value
     vi.mocked(st).mockImplementation((_: string, fallback: string) => fallback)
@@ -345,14 +320,14 @@ describe('useSettingSearch', () => {
       // Simulates the "badge" scenario: same term matches settings in
       // multiple categories (e.g. LiteGraph and Comfy)
       mockSettings['LiteGraph.BadgeSetting'] = {
-        id: 'LiteGraph.BadgeSetting',
+        id: 'LiteGraph.BadgeSetting' as SettingParams['id'],
         name: 'Node source badge mode',
         type: 'combo',
         defaultValue: 'default',
         category: ['LiteGraph', 'Node']
       }
       mockSettings['Comfy.BadgeSetting'] = {
-        id: 'Comfy.BadgeSetting',
+        id: 'Comfy.BadgeSetting' as SettingParams['id'],
         name: 'Show API node pricing badge',
         type: 'boolean',
         defaultValue: true,
@@ -388,7 +363,7 @@ describe('useSettingSearch', () => {
 
       // Add another setting to Basic subcategory
       mockSettings['Category.Setting4'] = {
-        id: 'Category.Setting4',
+        id: 'Category.Setting4' as SettingParams['id'],
         name: 'Setting Four',
         type: 'text',
         defaultValue: 'default',
@@ -496,7 +471,7 @@ describe('useSettingSearch', () => {
 
     it('handles settings with undefined category', () => {
       mockSettings['NoCategorySetting'] = {
-        id: 'NoCategorySetting',
+        id: 'NoCategorySetting' as SettingParams['id'],
         name: 'No Category',
         type: 'text',
         defaultValue: 'default'

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -1,12 +1,13 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { fromPartial } from '@total-typescript/shoehorn'
+
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import {
-  getSettingInfo,
-  useSettingStore
-} from '@/platform/settings/settingStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingTreeNode } from '@/platform/settings/settingStore'
 
 import { useSettingUI as useSettingUIComposable } from './useSettingUI'
@@ -57,7 +58,8 @@ vi.mock<unknown>(import('@/composables/useVueFeatureFlags'), () => ({
   useVueFeatureFlags: () => ({ shouldRenderVueNodes: ref(false) })
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return env.state.isCloud
   },
@@ -66,30 +68,11 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: vi.fn(),
-  getSettingInfo: vi.fn()
-}))
-
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),
   () => ({
     useWorkspaceUI: () => ({
       workspaceRole: env.fakeRef('workspaceRole')
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workspace/stores/partnerNodeGovernanceStore'),
-  () => ({
-    usePartnerNodeGovernanceStore: () => ({
-      get status() {
-        return env.state.partnerNodeGovernanceStatus
-      },
-      get providers() {
-        return env.state.partnerNodeGovernanceProviders
-      }
     })
   })
 )
@@ -122,6 +105,25 @@ function useSettingUI(
   render(Wrapper, { global: { plugins: [i18n] } })
   return result
 }
+
+beforeEach(() => {
+  vi.spyOn(usePartnerNodeGovernanceStore(), 'status', 'get').mockImplementation(
+    () => {
+      return env.state.partnerNodeGovernanceStatus
+    }
+  )
+  vi.spyOn(
+    usePartnerNodeGovernanceStore(),
+    'providers',
+    'get'
+  ).mockImplementation(() => {
+    return env.state.partnerNodeGovernanceProviders.map((provider) =>
+      fromPartial<
+        ReturnType<typeof usePartnerNodeGovernanceStore>['providers'][number]
+      >(provider)
+    )
+  })
+})
 
 describe('useSettingUI', () => {
   const mockSettings: Record<string, MockSettingParams> = {
@@ -157,17 +159,7 @@ describe('useSettingUI', () => {
       partnerNodeGovernanceProviders: []
     })
 
-    vi.mocked(useSettingStore).mockReturnValue({
-      settingsById: mockSettings
-    } as ReturnType<typeof useSettingStore>)
-
-    vi.mocked(getSettingInfo).mockImplementation((setting) => {
-      const parts = setting.category || setting.id.split('.')
-      return {
-        category: parts[0] ?? 'Other',
-        subCategory: parts[1] ?? 'Other'
-      }
-    })
+    Object.assign(useSettingStore(), { settingsById: mockSettings })
   })
 
   function findCategory(

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -1,3 +1,6 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as I18nModule from '@/i18n'
+import { useDialogStore } from '@/stores/dialogStore'
 /**
  * Settings dialog migration regression net: `useSettingsDialog().show()` must
  * open the Reka-renderer path with sizing that matches the previous
@@ -9,17 +12,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const showDialog = vi.hoisted(() => vi.fn())
 const isCloudRef = vi.hoisted(() => ({ value: false }))
 
-vi.mock<unknown>(import('@/stores/dialogStore'), () => ({
-  useDialogStore: () => ({ showDialog, closeDialog: vi.fn() })
-}))
-
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isCloud() {
     return isCloudRef.value
   }
 }))
 
-vi.mock(import('@/i18n'), () => ({ t: (k: string) => k }))
+vi.mock(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
+  t: (k: string) => k
+}))
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackEvent: vi.fn() })
@@ -34,6 +37,11 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
 }))
 
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+
+beforeEach(() => {
+  useDialogStore().showDialog = showDialog
+  vi.mocked(useDialogStore().closeDialog).mockImplementation(() => undefined)
+})
 
 describe('useSettingsDialog', () => {
   beforeEach(() => {

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -1,6 +1,6 @@
-import { defineStore } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 
 const trackFeatureUsed = vi.hoisted(() => vi.fn())
 
@@ -11,20 +11,11 @@ vi.mock<unknown>(import('./useSurveyFeatureTracking'), () => ({
   })
 }))
 
-const useFakeExecutionErrorStore = defineStore('fakeExecutionError', () => {
-  const hasAnyError = ref(false)
-  return { hasAnyError }
-})
-
-vi.mock<unknown>(import('@/stores/executionErrorStore'), () => ({
-  useExecutionErrorStore: () => useFakeExecutionErrorStore()
-}))
-
 import { useErrorSurveyTracking } from './useErrorSurveyTracking'
 
 describe('useErrorSurveyTracking', () => {
   let scope: ReturnType<typeof effectScope>
-  let store: ReturnType<typeof useFakeExecutionErrorStore>
+  let store: ReturnType<typeof useExecutionErrorStore>
 
   function setup() {
     scope = effectScope()
@@ -32,7 +23,8 @@ describe('useErrorSurveyTracking', () => {
   }
 
   beforeEach(() => {
-    store = useFakeExecutionErrorStore()
+    store = useExecutionErrorStore()
+    Object.assign(store, { hasAnyError: false })
   })
 
   afterEach(() => {
@@ -41,14 +33,14 @@ describe('useErrorSurveyTracking', () => {
 
   it('counts false → true transition once', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
   })
 
   it('counts initial true state on mount', async () => {
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     setup()
     await nextTick()
 
@@ -64,9 +56,9 @@ describe('useErrorSurveyTracking', () => {
 
   it('does not count true → false transition', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
-    store.hasAnyError = false
+    Object.assign(store, { hasAnyError: false })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
@@ -74,11 +66,11 @@ describe('useErrorSurveyTracking', () => {
 
   it('counts a fresh error after clear as a second use', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
-    store.hasAnyError = false
+    Object.assign(store, { hasAnyError: false })
     await nextTick()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(2)
@@ -86,9 +78,9 @@ describe('useErrorSurveyTracking', () => {
 
   it('does not double-count when state stays true', async () => {
     setup()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
-    store.hasAnyError = true
+    Object.assign(store, { hasAnyError: true })
     await nextTick()
 
     expect(trackFeatureUsed).toHaveBeenCalledTimes(1)

--- a/src/platform/telemetry/hostUserIdSync.test.ts
+++ b/src/platform/telemetry/hostUserIdSync.test.ts
@@ -1,24 +1,14 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as VueModule from 'vue'
 import { nextTick } from 'vue'
+import { useAuthStore } from '@/stores/authStore'
 
-type MockAuthStore = {
-  isInitialized: boolean
-  currentUser: { uid: string } | null
-}
-
-const hoisted = vi.hoisted(() => ({
-  authStore: null as unknown as MockAuthStore
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn()
 }))
-
-vi.mock<unknown>(import('@/stores/authStore'), async () => {
-  const { reactive } = await vi.importActual<typeof VueModule>('vue')
-  hoisted.authStore = reactive<MockAuthStore>({
-    isInitialized: false,
-    currentUser: null
-  })
-  return { useAuthStore: () => hoisted.authStore }
-})
 
 import { syncHostUserIdWithFirebaseAuth } from './hostUserIdSync'
 
@@ -43,8 +33,8 @@ function startSync(): void {
 
 describe('host user ID sync', () => {
   beforeEach(() => {
-    hoisted.authStore.isInitialized = false
-    hoisted.authStore.currentUser = null
+    useAuthStore().isInitialized = false
+    useAuthStore().currentUser = null
   })
 
   afterEach(() => {
@@ -61,12 +51,12 @@ describe('host user ID sync', () => {
       status: 'pending'
     })
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
 
-    hoisted.authStore.isInitialized = true
+    useAuthStore().isInitialized = true
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
@@ -77,8 +67,8 @@ describe('host user ID sync', () => {
 
   it('reports a restored Firebase session immediately', () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
 
     startSync()
 
@@ -90,7 +80,7 @@ describe('host user ID sync', () => {
 
   it('reports an initially signed-out Firebase session', () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.isInitialized = true
+    useAuthStore().isInitialized = true
 
     startSync()
 
@@ -106,7 +96,7 @@ describe('host user ID sync', () => {
 
     expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
 
-    hoisted.authStore.isInitialized = true
+    useAuthStore().isInitialized = true
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
@@ -116,11 +106,11 @@ describe('host user ID sync', () => {
 
   it('reports account switches, logout, and subsequent login', async () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
     startSync()
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-b' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-b' })
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
@@ -128,14 +118,14 @@ describe('host user ID sync', () => {
       userId: 'firebase-user-b'
     })
 
-    hoisted.authStore.currentUser = null
+    useAuthStore().currentUser = null
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
       status: 'signed_out'
     })
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-c' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-c' })
     await nextTick()
 
     expect(reportFirebaseAuthState.mock.calls).toEqual([
@@ -149,11 +139,11 @@ describe('host user ID sync', () => {
 
   it('does not report again when Firebase replaces the user object with the same UID', async () => {
     const { reportFirebaseAuthState } = installTelemetryBridge()
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
     startSync()
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
     await nextTick()
 
     expect(reportFirebaseAuthState.mock.calls).toEqual([
@@ -170,8 +160,8 @@ describe('host user ID sync', () => {
 
     expect(() => startSync()).not.toThrow()
 
-    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
-    hoisted.authStore.isInitialized = true
+    useAuthStore().currentUser = fromPartial({ uid: 'firebase-user-a' })
+    useAuthStore().isInitialized = true
     await nextTick()
 
     expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
@@ -1,45 +1,25 @@
 import { createHash } from 'node:crypto'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { User } from 'firebase/auth'
+import { getActivePinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-type MockApiKeyUser = {
-  id: string
-  email?: string
-} | null
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useAuthStore } from '@/stores/authStore'
 
-type MockAuthUser = {
-  uid: string
-  email?: string | null
-} | null
-
-const {
-  mockCaptureCheckoutAttributionFromSearch,
-  mockUseApiKeyAuthStore,
-  mockUseAuthStore,
-  mockApiKeyAuthStore,
-  mockAuthStore
-} = vi.hoisted(() => ({
-  mockCaptureCheckoutAttributionFromSearch: vi.fn(),
-  mockUseApiKeyAuthStore: vi.fn(),
-  mockUseAuthStore: vi.fn(),
-  mockApiKeyAuthStore: {
-    isAuthenticated: false,
-    currentUser: null as MockApiKeyUser
-  },
-  mockAuthStore: {
-    currentUser: null as MockAuthUser
-  }
+const { mockCaptureCheckoutAttributionFromSearch } = vi.hoisted(() => ({
+  mockCaptureCheckoutAttributionFromSearch: vi.fn()
 }))
 
 vi.mock(import('@/platform/telemetry/utils/checkoutAttribution'), () => ({
   captureCheckoutAttributionFromSearch: mockCaptureCheckoutAttributionFromSearch
 }))
 
-vi.mock<unknown>(import('@/stores/apiKeyAuthStore'), () => ({
-  useApiKeyAuthStore: mockUseApiKeyAuthStore
-}))
-
-vi.mock<unknown>(import('@/stores/authStore'), () => ({
-  useAuthStore: mockUseAuthStore
+vi.mock(import('firebase/auth'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn(),
+  setPersistence: vi.fn()
 }))
 
 import { ImpactTelemetryProvider } from './ImpactTelemetryProvider'
@@ -61,12 +41,12 @@ function toUint8Array(data: BufferSource): Uint8Array {
 }
 
 describe('ImpactTelemetryProvider', () => {
+  let apiKeyAuthStore: ReturnType<typeof useApiKeyAuthStore>
+  let authStore: ReturnType<typeof useAuthStore>
+
   beforeEach(() => {
-    mockApiKeyAuthStore.isAuthenticated = false
-    mockApiKeyAuthStore.currentUser = null
-    mockAuthStore.currentUser = null
-    mockUseApiKeyAuthStore.mockReturnValue(mockApiKeyAuthStore)
-    mockUseAuthStore.mockReturnValue(mockAuthStore)
+    apiKeyAuthStore = useApiKeyAuthStore()
+    authStore = useAuthStore()
 
     const queueFn: NonNullable<Window['ire']> = (...args: unknown[]) => {
       ;(queueFn.a ??= []).push(args)
@@ -84,10 +64,10 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('captures attribution and invokes identify with hashed email', async () => {
-    mockAuthStore.currentUser = {
+    authStore.currentUser = fromPartial<User>({
       uid: 'user-123',
       email: ' User@Example.com '
-    }
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(
@@ -119,16 +99,18 @@ describe('ImpactTelemetryProvider', () => {
     })
   })
 
-  it('falls back to current URL search and empty identify values when user is unresolved', async () => {
-    mockUseApiKeyAuthStore.mockImplementation(() => {
-      throw new Error('No active pinia')
-    })
+  it('falls back to current URL search and empty identify values when Pinia is unavailable', async () => {
     window.history.pushState({}, '', '/?im_ref=fallback-123')
 
     const provider = new ImpactTelemetryProvider()
-    provider.trackPageView('home')
-
-    await flushAsyncWork()
+    const pinia = getActivePinia()
+    setActivePinia(undefined)
+    try {
+      provider.trackPageView('home')
+      await flushAsyncWork()
+    } finally {
+      setActivePinia(pinia)
+    }
 
     expect(mockCaptureCheckoutAttributionFromSearch).toHaveBeenCalledWith(
       '?im_ref=fallback-123'
@@ -144,10 +126,10 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('invokes identify on each page view even with identical identity payloads', async () => {
-    mockAuthStore.currentUser = {
+    authStore.currentUser = fromPartial<User>({
       uid: 'user-123',
       email: 'user@example.com'
-    }
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(async () => new Uint8Array([16, 32, 48]).buffer)
@@ -175,15 +157,14 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('prefers firebase identity when both firebase and API key identity are available', async () => {
-    mockApiKeyAuthStore.isAuthenticated = true
-    mockApiKeyAuthStore.currentUser = {
+    apiKeyAuthStore.currentUser = fromPartial({
       id: 'api-key-user-123',
       email: 'apikey@example.com'
-    }
-    mockAuthStore.currentUser = {
+    })
+    authStore.currentUser = fromPartial<User>({
       uid: 'firebase-user-123',
       email: 'firebase@example.com'
-    }
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(
@@ -214,12 +195,10 @@ describe('ImpactTelemetryProvider', () => {
   })
 
   it('falls back to API key identity when firebase user is unavailable', async () => {
-    mockApiKeyAuthStore.isAuthenticated = true
-    mockApiKeyAuthStore.currentUser = {
+    apiKeyAuthStore.currentUser = fromPartial({
       id: 'api-key-user-123',
       email: 'apikey@example.com'
-    }
-    mockAuthStore.currentUser = null
+    })
     vi.stubGlobal('crypto', {
       subtle: {
         digest: vi.fn(

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
@@ -1,3 +1,5 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ExecutionContext, ShellLayoutMetadata } from '../../types'
@@ -44,17 +46,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
   })
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      activeWorkflow: {
-        isModified: mocks.workflowIsModified
-      }
-    })
-  })
-)
-
 vi.mock(import('../../utils/getExecutionContext'), () => ({
   getExecutionContext: () => mocks.executionContext
 }))
@@ -69,6 +60,12 @@ const shellLayout: ShellLayoutMetadata = {
   bottom_panel_open: true,
   open_workflow_tabs: 2
 }
+
+beforeEach(() => {
+  useWorkflowStore().activeWorkflow = fromPartial({
+    isModified: mocks.workflowIsModified
+  })
+})
 
 describe('SentryTelemetryProvider', () => {
   beforeEach(() => {

--- a/src/platform/telemetry/utils/getExecutionContext.test.ts
+++ b/src/platform/telemetry/utils/getExecutionContext.test.ts
@@ -1,52 +1,16 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { NodeSourceType } from '@/types/nodeSource'
 
 const hoisted = vi.hoisted(() => ({
   mockNodeDefsByName: {} as Partial<Record<string, Record<string, unknown>>>,
-  mockNodes: [] as Pick<LGraphNode, 'type' | 'isSubgraphNode'>[],
-  mockActiveWorkflow: null as null | {
-    filename: string
-    fullFilename: string
-  },
-  mockKnownTemplateNames: new Set<string>(),
-  mockTemplateByName: null as null | { sourceModule?: string }
+  mockNodes: [] as Pick<LGraphNode, 'type' | 'isSubgraphNode'>[]
 }))
-
-vi.mock<unknown>(import('@/stores/nodeDefStore'), () => ({
-  useNodeDefStore: () => ({
-    fromLGraphNode: (node: Pick<LGraphNode, 'type'>) => {
-      const nodeDef = hoisted.mockNodeDefsByName[node.type]
-      return nodeDef
-        ? { nodeSource: { type: 'unknown' }, ...nodeDef }
-        : undefined
-    }
-  })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({
-      get activeWorkflow() {
-        return hoisted.mockActiveWorkflow
-      }
-    })
-  })
-)
-
-vi.mock<unknown>(
-  import('@/platform/workflow/templates/repositories/workflowTemplatesStore'),
-  () => ({
-    useWorkflowTemplatesStore: () => ({
-      get knownTemplateNames() {
-        return hoisted.mockKnownTemplateNames
-      },
-      getTemplateByName: (_name: string) => hoisted.mockTemplateByName,
-      getEnglishMetadata: () => null
-    })
-  })
-)
 
 function mockNode(
   type: string,
@@ -74,15 +38,35 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 
 import { getExecutionContext } from './getExecutionContext'
 
+beforeEach(() => {
+  vi.mocked(useNodeDefStore().fromLGraphNode).mockImplementation(
+    (node: Pick<LGraphNode, 'type'>) => {
+      const nodeDef = hoisted.mockNodeDefsByName[node.type]
+      return nodeDef
+        ? fromPartial({
+            nodeSource: { type: NodeSourceType.Unknown },
+            ...nodeDef
+          })
+        : null
+    }
+  )
+})
+
+beforeEach(() => {
+  vi.mocked(useWorkflowTemplatesStore().getTemplateByName).mockReturnValue(
+    fromPartial({ sourceModule: 'default' })
+  )
+  vi.mocked(useWorkflowTemplatesStore().getEnglishMetadata).mockImplementation(
+    () => null
+  )
+})
+
 describe('getExecutionContext', () => {
   beforeEach(() => {
     hoisted.mockNodes.length = 0
     for (const key of Object.keys(hoisted.mockNodeDefsByName)) {
       delete hoisted.mockNodeDefsByName[key]
     }
-    hoisted.mockActiveWorkflow = null
-    hoisted.mockKnownTemplateNames = new Set()
-    hoisted.mockTemplateByName = null
   })
 
   it('returns has_toolkit_nodes false when no toolkit nodes are present', () => {
@@ -173,12 +157,13 @@ describe('getExecutionContext', () => {
 
   describe('template detection', () => {
     it('detects a regular template by name', () => {
-      hoisted.mockKnownTemplateNames = new Set(['flux-dev'])
-      hoisted.mockTemplateByName = { sourceModule: 'default' }
-      hoisted.mockActiveWorkflow = {
+      Object.assign(useWorkflowTemplatesStore(), {
+        knownTemplateNames: new Set(['flux-dev'])
+      })
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'flux-dev',
         fullFilename: 'flux-dev.json'
-      }
+      })
 
       const context = getExecutionContext()
 
@@ -187,16 +172,15 @@ describe('getExecutionContext', () => {
     })
 
     it('detects an app mode template whose name ends with .app', () => {
-      hoisted.mockKnownTemplateNames = new Set([
-        'templates-qwen_multiangle.app'
-      ])
-      hoisted.mockTemplateByName = { sourceModule: 'default' }
+      Object.assign(useWorkflowTemplatesStore(), {
+        knownTemplateNames: new Set(['templates-qwen_multiangle.app'])
+      })
       // getFilenameDetails strips ".app.json" as a compound extension, yielding
       // filename = "templates-qwen_multiangle" — the previous code would fail here.
-      hoisted.mockActiveWorkflow = {
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'templates-qwen_multiangle',
         fullFilename: 'templates-qwen_multiangle.app.json'
-      }
+      })
 
       const context = getExecutionContext()
 
@@ -205,11 +189,13 @@ describe('getExecutionContext', () => {
     })
 
     it('does not flag a non-template workflow as a template', () => {
-      hoisted.mockKnownTemplateNames = new Set(['flux-dev'])
-      hoisted.mockActiveWorkflow = {
+      Object.assign(useWorkflowTemplatesStore(), {
+        knownTemplateNames: new Set(['flux-dev'])
+      })
+      useWorkflowStore().activeWorkflow = fromPartial({
         filename: 'my-custom-workflow',
         fullFilename: 'my-custom-workflow.json'
-      }
+      })
 
       const context = getExecutionContext()
 

--- a/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
+++ b/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
@@ -1,49 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const state = vi.hoisted(() => ({
-  settings: {} as Record<string, unknown>,
-  activeSidebarTabId: null as string | null,
-  rightSidePanelOpen: false,
-  bottomPanelVisible: false,
-  openWorkflows: [] as unknown[]
-}))
-
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: () => ({ get: (key: string) => state.settings[key] })
-}))
-
-vi.mock<unknown>(
-  import('@/platform/workflow/management/stores/workflowStore'),
-  () => ({
-    useWorkflowStore: () => ({ openWorkflows: state.openWorkflows })
-  })
-)
-
-vi.mock<unknown>(import('@/stores/workspace/bottomPanelStore'), () => ({
-  useBottomPanelStore: () => ({
-    bottomPanelVisible: state.bottomPanelVisible
-  })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/rightSidePanelStore'), () => ({
-  useRightSidePanelStore: () => ({ isOpen: state.rightSidePanelOpen })
-}))
-
-vi.mock<unknown>(import('@/stores/workspace/sidebarTabStore'), () => ({
-  useSidebarTabStore: () => ({
-    activeSidebarTabId: state.activeSidebarTabId
-  })
-}))
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
+import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
+import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { getShellLayoutSnapshot } from './getShellLayoutSnapshot'
 
 describe('getShellLayoutSnapshot', () => {
   beforeEach(() => {
-    state.settings = { 'Comfy.UseNewMenu': 'Top' }
-    state.activeSidebarTabId = null
-    state.rightSidePanelOpen = false
-    state.bottomPanelVisible = false
-    state.openWorkflows = []
+    useSettingStore().settingValues = { 'Comfy.UseNewMenu': 'Top' }
+    useSidebarTabStore().activeSidebarTabId = null
+    useRightSidePanelStore().isOpen = false
+    useBottomPanelStore().bottomPanelVisible = false
+    Object.assign(useWorkflowStore(), { openWorkflows: [] })
   })
 
   it('captures the default layout', () => {
@@ -63,10 +33,10 @@ describe('getShellLayoutSnapshot', () => {
 
   it('captures a customized layout', () => {
     localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
-    state.activeSidebarTabId = 'node-library'
-    state.rightSidePanelOpen = true
-    state.bottomPanelVisible = true
-    state.openWorkflows = [{}, {}, {}]
+    useSidebarTabStore().activeSidebarTabId = 'node-library'
+    useRightSidePanelStore().isOpen = true
+    useBottomPanelStore().bottomPanelVisible = true
+    Object.assign(useWorkflowStore(), { openWorkflows: [{}, {}, {}] })
 
     expect(
       getShellLayoutSnapshot({ view_mode: 'app', is_app_mode: true })

--- a/src/platform/updates/common/releaseStore.test.ts
+++ b/src/platform/updates/common/releaseStore.test.ts
@@ -1,15 +1,18 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import type * as VueUseModule from '@vueuse/core'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { until } from '@vueuse/core'
 import { compare } from 'semver'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import type { Ref } from 'vue'
 
-import type { EntryPath } from '@/platform/onboarding/onboardingTours'
+import { useOnboardingTourStore } from '@/platform/onboarding/onboardingTourStore'
 import type { ReleaseNote } from '@/platform/updates/common/releaseService'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useReleaseStore } from '@/platform/updates/common/releaseStore'
 import { useReleaseService } from '@/platform/updates/common/releaseService'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
-import type { SystemStats } from '@/types'
 
 // Mock the dependencies
 vi.mock(import('semver'), () => ({
@@ -19,7 +22,8 @@ vi.mock(import('semver'), () => ({
 
 const mockData = vi.hoisted(() => ({ isDesktop: true, isCloud: false }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   get isDesktop() {
     return mockData.isDesktop
   },
@@ -41,79 +45,34 @@ vi.mock(import('@/platform/updates/common/releaseService'), () => {
   }
 })
 
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => {
-  const get = vi.fn((key: string) => {
-    if (key === 'Comfy.Notification.ShowVersionUpdates') return true
-    return null
-  })
-  const set = vi.fn()
-  const setMany = vi.fn()
-  return {
-    useSettingStore: () => ({ get, set, setMany })
-  }
-})
-
-const mockSystemStatsState = vi.hoisted(() => ({
-  systemStats: {
-    system: {
-      comfyui_version: '1.0.0',
-      argv: []
-    }
-  } satisfies {
-    system: Partial<SystemStats['system']>
-  },
-  isInitialized: true,
-  reset() {
-    this.systemStats = {
-      system: {
-        comfyui_version: '1.0.0',
-        argv: []
-      } satisfies Partial<SystemStats['system']>
-    }
-    this.isInitialized = true
-  }
-}))
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => {
-  const refetchSystemStats = vi.fn()
-  const getFormFactor = vi.fn(() => 'git-windows')
-  return {
-    useSystemStatsStore: () => ({
-      get systemStats() {
-        return mockSystemStatsState.systemStats
-      },
-      set systemStats(val) {
-        mockSystemStatsState.systemStats = val
-      },
-      get isInitialized() {
-        return mockSystemStatsState.isInitialized
-      },
-      set isInitialized(val) {
-        mockSystemStatsState.isInitialized = val
-      },
-      refetchSystemStats,
-      getFormFactor
-    })
-  }
-})
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUseModule>()),
   until: vi.fn(() => Promise.resolve()),
   useStorage: vi.fn(() => ({ value: {} })),
   createSharedComposable: vi.fn((fn) => fn)
 }))
 
-const mocks = vi.hoisted(() => ({
-  tour: { activeTour: null as EntryPath | null }
-}))
-vi.mock<unknown>(
-  import('@/platform/onboarding/onboardingTourStore'),
-  async () => {
-    const { reactive } = await import('vue')
-    mocks.tour = reactive(mocks.tour)
-    return { useOnboardingTourStore: () => mocks.tour }
-  }
-)
+beforeEach(() => {
+  const get = vi.fn((key: string) => {
+    if (key === 'Comfy.Notification.ShowVersionUpdates') return true
+    return null
+  })
+  vi.mocked(useSettingStore().get).mockImplementation(get)
+  vi.mocked(useSettingStore().set).mockResolvedValue(undefined)
+  vi.mocked(useSettingStore().setMany).mockResolvedValue(undefined)
+  const getFormFactor = vi.fn(() => 'git-windows')
+  useSystemStatsStore().systemStats = fromPartial({
+    system: { comfyui_version: '1.0.0', argv: [] }
+  })
+  useSystemStatsStore().isInitialized = true
+  vi.mocked(useSystemStatsStore().refetchSystemStats).mockResolvedValue(null)
+  vi.mocked(useSystemStatsStore().getFormFactor).mockImplementation(
+    getFormFactor
+  )
+})
 
 describe('useReleaseStore', () => {
+  let activeTour: Ref<ReturnType<typeof useOnboardingTourStore>['activeTour']>
   const mockRelease = {
     id: 1,
     project: 'comfyui' as const,
@@ -124,9 +83,11 @@ describe('useReleaseStore', () => {
   }
 
   beforeEach(() => {
-    mockSystemStatsState.reset()
     mockData.isCloud = false
-    mocks.tour.activeTour = null
+    activeTour = ref(null)
+    vi.spyOn(useOnboardingTourStore(), 'activeTour', 'get').mockImplementation(
+      () => activeTour.value
+    )
   })
 
   describe('initial state', () => {
@@ -667,10 +628,10 @@ describe('useReleaseStore', () => {
 
       store.releases = [mockRelease]
 
-      mocks.tour.activeTour = 'firstRun'
+      activeTour.value = 'firstRun'
       expect(store.shouldShowPopup).toBe(false)
 
-      mocks.tour.activeTour = null
+      activeTour.value = null
       expect(store.shouldShowPopup).toBe(true)
     })
 
@@ -686,7 +647,7 @@ describe('useReleaseStore', () => {
       vi.mocked(compare).mockReturnValue(0)
 
       store.releases = [mockRelease]
-      mocks.tour.activeTour = 'appMode'
+      activeTour.value = 'appMode'
 
       expect(store.shouldShowPopup).toBe(true)
     })

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -1,8 +1,11 @@
+import type * as VueUseModule from '@vueuse/core'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { until } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 
 vi.mock<unknown>(import('@/config'), () => ({
   default: {
@@ -10,62 +13,41 @@ vi.mock<unknown>(import('@/config'), () => ({
   }
 }))
 
-const mockUseSystemStatsStore = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/stores/systemStatsStore'), () => ({
-  useSystemStatsStore: mockUseSystemStatsStore
-}))
-
-const mockUseSettingStore = vi.hoisted(() => vi.fn())
-vi.mock<unknown>(import('@/platform/settings/settingStore'), () => ({
-  useSettingStore: mockUseSettingStore
-}))
-
-// Mock useStorage and until from VueUse
-const mockDismissalStorage = ref({} as Record<string, number>)
-vi.mock<unknown>(import('@vueuse/core'), () => ({
+const { mockDismissalStorage } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return { mockDismissalStorage: ref({} as Record<string, number>) }
+})
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUseModule>()),
   useStorage: vi.fn(() => mockDismissalStorage),
   until: vi.fn(() => Promise.resolve())
 }))
 
-type MockSystemStatsStore = {
-  systemStats: unknown
-  isInitialized: boolean
-  refetchSystemStats: ReturnType<typeof vi.fn>
-}
-
 describe('useVersionCompatibilityStore', () => {
   let store: ReturnType<typeof useVersionCompatibilityStore>
-  let mockSystemStatsStore: MockSystemStatsStore
-  let mockSettingStore: { get: ReturnType<typeof vi.fn> }
+  let mockSystemStatsStore: ReturnType<typeof useSystemStatsStore>
+  let mockSettingStore: ReturnType<typeof useSettingStore>
 
   beforeEach(() => {
     // Clear the mock dismissal storage
     mockDismissalStorage.value = {}
 
-    mockSystemStatsStore = {
-      systemStats: null,
-      isInitialized: false,
-      refetchSystemStats: vi.fn()
-    }
-
-    mockSettingStore = {
-      get: vi.fn(() => false) // Default to warnings enabled
-    }
-
-    mockUseSystemStatsStore.mockReturnValue(mockSystemStatsStore)
-    mockUseSettingStore.mockReturnValue(mockSettingStore)
+    mockSystemStatsStore = useSystemStatsStore()
+    vi.mocked(mockSystemStatsStore.refetchSystemStats).mockResolvedValue(null)
+    mockSettingStore = useSettingStore()
+    vi.mocked(mockSettingStore.get).mockReturnValue(false)
 
     store = useVersionCompatibilityStore()
   })
 
   describe('version compatibility detection', () => {
     it('should detect frontend is outdated when required version is higher', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -78,12 +60,12 @@ describe('useVersionCompatibilityStore', () => {
     it('should not warn when frontend is newer than backend', async () => {
       // Frontend: 1.24.0, Backend: 1.23.0, Required: 1.23.0
       // Frontend meets required version, no warning needed
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.23.0',
           required_frontend_version: '1.23.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -94,12 +76,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not detect mismatch when versions are compatible', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -110,12 +92,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should handle missing version information gracefully', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '',
           required_frontend_version: ''
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -126,12 +108,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not detect mismatch when versions are not valid semver', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '080e6d4af809a46852d1c4b7ed85f06e8a3a72be', // git hash
           required_frontend_version: 'not-a-version' // invalid semver format
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -143,12 +125,12 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should not warn when frontend exceeds required version', async () => {
       // Frontend: 1.24.0 (from mock config)
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.22.0', // Backend is older
           required_frontend_version: '1.23.0' // Required is 1.23.0, frontend 1.24.0 meets this
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -163,12 +145,12 @@ describe('useVersionCompatibilityStore', () => {
     it('should show warning when there is a version mismatch and not dismissed', async () => {
       // No dismissals in storage
       mockDismissalStorage.value = {}
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -183,12 +165,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': futureTime
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -197,12 +179,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not show warning when no version mismatch', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -212,15 +194,15 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should not show warning when disabled via setting', async () => {
       // Enable the disable setting
-      mockSettingStore.get.mockReturnValue(true)
+      vi.mocked(mockSettingStore.get).mockReturnValue(true)
 
       // Set up version mismatch that would normally show warning
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -234,12 +216,12 @@ describe('useVersionCompatibilityStore', () => {
 
   describe('warning messages', () => {
     it('should generate outdated message when frontend is outdated', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -252,12 +234,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should return null when no mismatch', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -270,12 +252,12 @@ describe('useVersionCompatibilityStore', () => {
     it('should save dismissal to reactive storage with expiration', async () => {
       const now = Date.now()
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -293,12 +275,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': futureTime
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -312,12 +294,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': pastTime
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -332,12 +314,12 @@ describe('useVersionCompatibilityStore', () => {
         '1.24.0-1.25.0-1.25.0': futureTime // Different version was dismissed
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.26.0',
           required_frontend_version: '1.26.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -357,12 +339,12 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should not fetch system stats if already available', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.initialize()
@@ -373,7 +355,7 @@ describe('useVersionCompatibilityStore', () => {
 
   describe('comfy package version warnings', () => {
     it('should detect outdated comfy packages and skip comfyui-frontend-package', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -395,7 +377,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -419,7 +401,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should ignore packages with missing or invalid versions', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -436,7 +418,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -446,7 +428,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should detect outdated PEP 440 versions via coerce', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -463,7 +445,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -476,7 +458,7 @@ describe('useVersionCompatibilityStore', () => {
     it('should include outdated packages in dismissal key', async () => {
       const now = Date.now()
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
@@ -488,7 +470,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()
@@ -512,26 +494,26 @@ describe('useVersionCompatibilityStore', () => {
         required: '0.9.5'
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
           comfy_package_versions: [packageA, packageB]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
       await store.checkVersionCompatibility()
       store.dismissWarning()
       const firstKey = Object.keys(mockDismissalStorage.value)[0]
 
       mockDismissalStorage.value = {}
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.24.0',
           required_frontend_version: '1.24.0',
           comfy_package_versions: [packageB, packageA]
         }
-      }
+      })
       await store.checkVersionCompatibility()
       store.dismissWarning()
       const secondKey = Object.keys(mockDismissalStorage.value)[0]
@@ -547,12 +529,12 @@ describe('useVersionCompatibilityStore', () => {
         'still-valid-key': now + 5000
       }
 
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '1.25.0',
           required_frontend_version: '1.25.0'
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
       await store.checkVersionCompatibility()
       store.dismissWarning()
@@ -563,7 +545,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should allow dismissal when only package warnings are present', async () => {
-      mockSystemStatsStore.systemStats = {
+      mockSystemStatsStore.systemStats = fromPartial({
         system: {
           comfyui_version: '',
           required_frontend_version: '',
@@ -575,7 +557,7 @@ describe('useVersionCompatibilityStore', () => {
             }
           ]
         }
-      }
+      })
       mockSystemStatsStore.isInitialized = true
 
       await store.checkVersionCompatibility()

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -1,3 +1,16 @@
+import type * as DistributionModule from '@/platform/distribution/types'
+import { useReleaseStore } from '../common/releaseStore'
+beforeEach(() => {
+  Object.assign(useReleaseStore(), {
+    recentRelease: null as ReleaseNote | null
+  })
+  Object.assign(useReleaseStore(), { shouldShowToast: false })
+  vi.mocked(useReleaseStore().handleSkipRelease).mockResolvedValue(undefined)
+  vi.mocked(useReleaseStore().handleShowChangelog).mockResolvedValue(undefined)
+  Object.assign(useReleaseStore(), { releases: [] })
+  vi.mocked(useReleaseStore().fetchReleases).mockResolvedValue(undefined)
+})
+import { useCommandStore } from '@/stores/commandStore'
 // @vitest-environment jsdom
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
@@ -24,14 +37,17 @@ vi.hoisted(() => {
 const mockData = vi.hoisted(() => ({ isDesktop: false }))
 
 const { commandExecuteMock } = vi.hoisted(() => ({
-  commandExecuteMock: vi.fn()
+  commandExecuteMock: vi.fn<ReturnType<typeof useCommandStore>['execute']>(
+    async () => undefined
+  )
 }))
 
 const { toastErrorHandlerMock } = vi.hoisted(() => ({
   toastErrorHandlerMock: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
   isCloud: false,
   isNightly: false,
   get isDesktop() {
@@ -59,12 +75,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   }))
 }))
 
-vi.mock<unknown>(import('@/stores/commandStore'), () => ({
-  useCommandStore: vi.fn(() => ({
-    execute: commandExecuteMock
-  }))
-}))
-
 vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
   useExternalLink: vi.fn(() => ({
     buildDocsUrl: vi.fn((path: string) => `https://docs.comfy.org${path}`),
@@ -74,18 +84,10 @@ vi.mock<unknown>(import('@/composables/useExternalLink'), () => ({
 }))
 
 // Mock release store
-const mockReleaseStore = {
-  recentRelease: null as ReleaseNote | null,
-  shouldShowToast: false,
-  handleSkipRelease: vi.fn(),
-  handleShowChangelog: vi.fn(),
-  releases: [],
-  fetchReleases: vi.fn()
-}
 
-vi.mock<unknown>(import('../common/releaseStore'), () => ({
-  useReleaseStore: vi.fn(() => mockReleaseStore)
-}))
+beforeEach(() => {
+  vi.mocked(useCommandStore().execute).mockImplementation(commandExecuteMock)
+})
 
 describe('ReleaseNotificationToast', () => {
   const renderComponent = (props = {}) => {
@@ -103,25 +105,29 @@ describe('ReleaseNotificationToast', () => {
 
   beforeEach(() => {
     mockData.isDesktop = false
-    mockReleaseStore.recentRelease = null
-    mockReleaseStore.shouldShowToast = true
+    Object.assign(useReleaseStore(), { recentRelease: null })
+    Object.assign(useReleaseStore(), { shouldShowToast: true })
   })
 
   it('renders correctly when shouldShow is true', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release\n\nSome content'
+      } as ReleaseNote
+    })
 
     renderComponent()
     expect(screen.getByText('New update is out!')).toBeInTheDocument()
   })
 
   it('stays hidden while node selection mode is active', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release\n\nSome content'
+      } as ReleaseNote
+    })
     useAgentNodeSelectionStore().isActive = true
 
     renderComponent()
@@ -129,10 +135,12 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('displays rocket icon', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const { container } = renderComponent()
     /* eslint-disable testing-library/no-container, testing-library/no-node-access */
@@ -143,34 +151,40 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('displays release version', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
     expect(screen.getByText('1.2.3')).toBeInTheDocument()
   })
 
   it('calls handleSkipRelease when skip button is clicked', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
     const user = userEvent.setup()
 
     await user.click(screen.getByRole('button', { name: /skip/i }))
 
-    expect(mockReleaseStore.handleSkipRelease).toHaveBeenCalledWith('1.2.3')
+    expect(useReleaseStore().handleSkipRelease).toHaveBeenCalledWith('1.2.3')
   })
 
   it('opens update URL when update button is clicked', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const mockWindowOpen = vi.fn()
     Object.defineProperty(window, 'open', {
@@ -191,10 +205,12 @@ describe('ReleaseNotificationToast', () => {
 
   it('executes desktop updater flow when running on desktop', async () => {
     mockData.isDesktop = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     commandExecuteMock.mockResolvedValueOnce(undefined)
 
@@ -218,10 +234,12 @@ describe('ReleaseNotificationToast', () => {
 
   it('shows an error toast if the desktop updater flow fails on desktop', async () => {
     mockData.isDesktop = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const error = new Error('Command Comfy-Desktop.CheckForUpdates not found')
     commandExecuteMock.mockRejectedValueOnce(error)
@@ -242,24 +260,28 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('calls handleShowChangelog when learn more link is clicked', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
     const user = userEvent.setup()
 
     await user.click(screen.getByRole('link', { name: /what's new/i }))
 
-    expect(mockReleaseStore.handleShowChangelog).toHaveBeenCalledWith('1.2.3')
+    expect(useReleaseStore().handleShowChangelog).toHaveBeenCalledWith('1.2.3')
   })
 
   it('generates correct changelog URL', () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -279,10 +301,12 @@ describe('ReleaseNotificationToast', () => {
     )
     mockMarkdownRenderer.mockReturnValue('<div>Content without title</div>')
 
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release Title\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release Title\n\nSome content'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -290,19 +314,21 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('fetches releases on mount when not already loaded', () => {
-    mockReleaseStore.releases = []
+    useReleaseStore().releases = []
 
     renderComponent()
 
-    expect(mockReleaseStore.fetchReleases).toHaveBeenCalled()
+    expect(useReleaseStore().fetchReleases).toHaveBeenCalled()
   })
 
   it('handles missing release content gracefully', () => {
-    mockReleaseStore.shouldShowToast = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: ''
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowToast: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: ''
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -310,10 +336,12 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('auto-hides after timeout', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -326,10 +354,12 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('clears auto-hide timer when manually dismissed', async () => {
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
 
@@ -340,6 +370,6 @@ describe('ReleaseNotificationToast', () => {
     await user.click(screen.getByRole('button', { name: /skip/i }))
 
     expect(vi.getTimerCount()).toBe(0)
-    expect(mockReleaseStore.handleSkipRelease).toHaveBeenCalled()
+    expect(useReleaseStore().handleSkipRelease).toHaveBeenCalled()
   })
 })

--- a/src/platform/updates/components/WhatsNewPopup.test.ts
+++ b/src/platform/updates/components/WhatsNewPopup.test.ts
@@ -1,4 +1,16 @@
 // @vitest-environment jsdom
+import type * as I18nModule from '@/i18n'
+import type { ComfyApp } from '@/scripts/app'
+import { useReleaseStore } from '../common/releaseStore'
+beforeEach(() => {
+  Object.assign(useReleaseStore(), {
+    recentRelease: null as ReleaseNote | null
+  })
+  Object.assign(useReleaseStore(), { shouldShowPopup: false })
+  vi.mocked(useReleaseStore().handleWhatsNewSeen).mockResolvedValue(undefined)
+  Object.assign(useReleaseStore(), { releases: [] as ReleaseNote[] })
+  vi.mocked(useReleaseStore().fetchReleases).mockResolvedValue(undefined)
+})
 // dompurify is inert under happy-dom — see the tripwire note in
 // vitest.setup.ts (capricorn86/happy-dom#2182, FE-1189).
 import { render, screen } from '@testing-library/vue'
@@ -11,6 +23,14 @@ import { createI18n } from 'vue-i18n'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import type { ReleaseNote } from '../common/releaseService'
 import WhatsNewPopup from './WhatsNewPopup.vue'
+
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
 
 // Mock dependencies
 const mockTranslations: Record<string, string> = {
@@ -25,7 +45,8 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-vi.mock<unknown>(import('@/i18n'), () => ({
+vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
+  ...(await importOriginal<typeof I18nModule>()),
   i18n: {
     global: {
       locale: {
@@ -49,18 +70,12 @@ vi.mock(import('@/utils/markdownRendererUtil'), () => ({
   renderMarkdownToHtml: vi.fn((content: string) => `<div>${content}</div>`)
 }))
 
-// Mock release store
-const mockReleaseStore = {
-  recentRelease: null as ReleaseNote | null,
-  shouldShowPopup: false,
-  handleWhatsNewSeen: vi.fn(),
-  releases: [] as ReleaseNote[],
-  fetchReleases: vi.fn()
-}
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({}) }
+})
 
-vi.mock<unknown>(import('../common/releaseStore'), () => ({
-  useReleaseStore: vi.fn(() => mockReleaseStore)
-}))
+// Mock release store
 
 describe('WhatsNewPopup', () => {
   const renderComponent = (props = {}) => {
@@ -78,19 +93,21 @@ describe('WhatsNewPopup', () => {
   }
 
   beforeEach(() => {
-    mockReleaseStore.recentRelease = null
-    mockReleaseStore.shouldShowPopup = false
-    mockReleaseStore.releases = []
-    mockReleaseStore.handleWhatsNewSeen = vi.fn()
-    mockReleaseStore.fetchReleases = vi.fn()
+    Object.assign(useReleaseStore(), { recentRelease: null })
+    Object.assign(useReleaseStore(), { shouldShowPopup: false })
+    useReleaseStore().releases = []
+    useReleaseStore().handleWhatsNewSeen = vi.fn()
+    useReleaseStore().fetchReleases = vi.fn()
   })
 
   it('renders correctly when shouldShow is true', () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release\n\nSome content'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release\n\nSome content'
+      } as ReleaseNote
+    })
 
     const { container } = renderComponent()
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -98,33 +115,37 @@ describe('WhatsNewPopup', () => {
   })
 
   it('does not render when shouldShow is false', () => {
-    mockReleaseStore.shouldShowPopup = false
+    Object.assign(useReleaseStore(), { shouldShowPopup: false })
     const { container } = renderComponent()
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('.whats-new-popup')).toBeNull()
   })
 
   it('calls handleWhatsNewSeen when close button is clicked', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const user = userEvent.setup()
     renderComponent()
 
     await user.click(screen.getByRole('button', { name: /close/i }))
 
-    expect(mockReleaseStore.handleWhatsNewSeen).toHaveBeenCalledWith('1.2.3')
+    expect(useReleaseStore().handleWhatsNewSeen).toHaveBeenCalledWith('1.2.3')
   })
 
   it('generates correct changelog URL', () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     renderComponent()
 
@@ -135,11 +156,13 @@ describe('WhatsNewPopup', () => {
   })
 
   it('handles missing release content gracefully', () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: ''
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: ''
+      } as ReleaseNote
+    })
 
     const { container } = renderComponent()
 
@@ -148,11 +171,13 @@ describe('WhatsNewPopup', () => {
   })
 
   it('emits whats-new-dismissed event when popup is closed', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Test Release'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Test Release'
+      } as ReleaseNote
+    })
 
     const onDismissed = vi.fn()
     const user = userEvent.setup()
@@ -164,21 +189,21 @@ describe('WhatsNewPopup', () => {
   })
 
   it('fetches releases on mount when not already loaded', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.releases = []
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    useReleaseStore().releases = []
 
     renderComponent()
 
-    expect(mockReleaseStore.fetchReleases).toHaveBeenCalled()
+    expect(useReleaseStore().fetchReleases).toHaveBeenCalled()
   })
 
   it('does not fetch releases when already loaded', async () => {
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.releases = [{ version: '1.0.0' } as ReleaseNote]
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    useReleaseStore().releases = [{ version: '1.0.0' } as ReleaseNote]
 
     renderComponent()
 
-    expect(mockReleaseStore.fetchReleases).not.toHaveBeenCalled()
+    expect(useReleaseStore().fetchReleases).not.toHaveBeenCalled()
   })
 
   it('processes markdown content correctly', async () => {
@@ -190,11 +215,13 @@ describe('WhatsNewPopup', () => {
     )
     mockMarkdownRenderer.mockReturnValue('<h1>Processed Content</h1>')
 
-    mockReleaseStore.shouldShowPopup = true
-    mockReleaseStore.recentRelease = {
-      version: '1.2.3',
-      content: '# Original Title\n\nContent'
-    } as ReleaseNote
+    Object.assign(useReleaseStore(), { shouldShowPopup: true })
+    Object.assign(useReleaseStore(), {
+      recentRelease: {
+        version: '1.2.3',
+        content: '# Original Title\n\nContent'
+      } as ReleaseNote
+    })
 
     renderComponent()
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -1,6 +1,5 @@
-import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
+import { getActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromAny } from '@total-typescript/shoehorn'
@@ -153,11 +152,6 @@ const i18n = createI18n({
   }
 })
 
-const pinia = createTestingPinia({
-  createSpy: vi.fn,
-  stubActions: false
-})
-
 function getNodeRoot(container: Element): HTMLElement {
   return container.firstElementChild as HTMLElement
 }
@@ -166,7 +160,7 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
   return render(LGraphNode, {
     props,
     global: {
-      plugins: [pinia, i18n],
+      plugins: [getActivePinia()!, i18n],
       stubs: {
         NodeHeader: true,
         NodeSlots: true,
@@ -208,11 +202,10 @@ describe('LGraphNode', () => {
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 
-    setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
     canvasStore.currentGraph = null
-    const settingStore = useSettingStore(pinia)
+    const settingStore = useSettingStore()
     useNodeOutputStore().nodeOutputs = {}
     useWidgetValueStore().clearGraph('graph-test')
     vi.mocked(settingStore.get).mockImplementation((key) => {
@@ -240,7 +233,7 @@ describe('LGraphNode', () => {
     const { container } = render(LGraphNode, {
       props: { nodeData: mockNodeData },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           NodeSlots: true,
           NodeWidgets: true,
@@ -278,7 +271,7 @@ describe('LGraphNode', () => {
         nodeData: { ...mockNodeData, graphId: 'graph-test' }
       },
       global: {
-        plugins: [pinia, i18n],
+        plugins: [getActivePinia()!, i18n],
         stubs: {
           AsyncComponentWrapper: {
             props: ['modelValue'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
+import { disposePinia, getActivePinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, vi } from 'vitest'
 import 'vue'
 import DOMPurify from 'dompurify'
@@ -13,6 +13,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  const pinia = getActivePinia()
+  if (pinia) disposePinia(pinia)
   clearRegisteredLiteGraphTypes()
 })
 


### PR DESCRIPTION
## Summary

Use the global testing Pinia in platform service tests, replacing this domain's migration from #17222 and local-instance cleanup from #17223.

## Changes

- 48 files: 44 domain tests plus the identical four-file shared lifecycle prerequisite.
- Preserves real-store state/action setup, independent effect scopes, and non-Pinia layout-store mocks.
- Independently targets main from the shared lifecycle prerequisite; no other domain branch is required. Rule enforcement and documentation remain deferred to #17223.

## Review Focus

- All 44 domain file blobs match the immutable source commit from #17223.
- Passed all 47 selected test files, 809 tests, including all three shared tests.
- Passed `pnpm typecheck`, `pnpm typecheck:scripts`, scoped ESLint, type-aware Oxlint, cleanup audit, formatting, `pnpm knip`, and `git diff --check`.
- Real commit hooks passed, including full lint and typecheck.
