### PR TITLE
fix: accept output media listed in widget options

### DIFF
--- a/browser_tests/assets/missing/missing_media_remote_output_option.json
+++ b/browser_tests/assets/missing/missing_media_remote_output_option.json
@@ -1,0 +1,68 @@
+{
+  "last_node_id": 3,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadImageOutput",
+      "pos": [50, 120],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImageOutput"
+      },
+      "widgets_values": [
+        "ComfyUI_00001_.png [output]",
+        false,
+        "refresh",
+        "image"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "LoadAudio",
+      "pos": [500, 120],
+      "size": [400, 200],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": ["sound.wav [output]", null, ""]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '@e2e/fixtures/assetApiFixture'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { WidgetSelectDropdownFixture } from '@e2e/fixtures/components/WidgetSelectDropdown'
 import type { WorkspaceStore } from '@e2e/types/globals'
 import {
   routeObjectInfoFromSetupApi,
@@ -28,8 +29,10 @@ import {
   jobsRouteFixture
 } from '@e2e/fixtures/jobsRouteFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { mockViewFiles } from '@e2e/fixtures/utils/viewFileMocks'
 import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
 import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
+import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { toNodeId } from '@/types/nodeId'
 
 const ossTest = mergeTests(test, jobsRouteFixture)
@@ -501,6 +504,167 @@ ossTest.describe(
 
         await delayedUpload.finishUpload()
         await expect(getErrorOverlay(comfyPage)).toBeHidden()
+      }
+    )
+  }
+)
+
+ossTest.describe(
+  'Errors tab - OSS output media widget options',
+  { tag: ['@ui', '@vue-nodes'] },
+  () => {
+    ossTest.beforeEach(async ({ page, jobsRoutes }) => {
+      await routeObjectInfoFromSetupApi(page, (objectInfo) => {
+        setComboInputOptions(objectInfo, 'LoadImage', 'image', [
+          'ComfyUI_00001_.png [output]'
+        ])
+        setComboInputOptions(objectInfo, 'LoadVideo', 'file', ['clip.mp4'])
+        setComboInputOptions(objectInfo, 'LoadAudio', 'audio', ['other.wav'])
+      })
+      await jobsRoutes.mockJobsHistory([])
+      await jobsRoutes.mockJobsQueue([])
+    })
+
+    ossTest.beforeEach(async ({ comfyPage }) => {
+      await enableErrorsTab(comfyPage)
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    })
+
+    ossTest(
+      'keeps an exact output option selectable with empty history and warns for absent outputs',
+      async ({ comfyPage }) => {
+        await loadWorkflowAndOpenErrorsTab(
+          comfyPage,
+          'missing/missing_media_output_annotations'
+        )
+
+        const missingMediaRows = comfyPage.page.getByTestId(
+          TestIds.dialogs.missingMediaRow
+        )
+        await expect(
+          missingMediaRows.getByRole('button', {
+            name: 'Load Video - file',
+            exact: true
+          })
+        ).toBeVisible()
+        await expect(
+          missingMediaRows.getByRole('button', {
+            name: 'Load Audio - audio',
+            exact: true
+          })
+        ).toBeVisible()
+        await expect(missingMediaRows).toHaveCount(2)
+
+        const panel = new PropertiesPanelHelper(comfyPage.page)
+        await panel.close()
+        await comfyPage.vueNodes.waitForNodes(3)
+        const dropdown = new WidgetSelectDropdownFixture(
+          comfyPage.vueNodes.getWidgetRowByLabel('Load Image', 'image')
+        )
+        await expect(dropdown.selection).toHaveText(
+          'ComfyUI_00001_.png [output]'
+        )
+        await dropdown.selectOption('ComfyUI_00001_.png [output]')
+        await expect(dropdown.selection).toHaveText(
+          'ComfyUI_00001_.png [output]'
+        )
+      }
+    )
+  }
+)
+
+ossTest.describe(
+  'Errors tab - OSS remote output media options',
+  { tag: ['@ui', '@vue-nodes'] },
+  () => {
+    ossTest.beforeEach(async ({ page, jobsRoutes }) => {
+      await routeObjectInfoFromSetupApi(page, (objectInfo) => {
+        setComboInputOptions(objectInfo, 'LoadAudio', 'audio', ['other.wav'])
+      })
+      await page.route('**/internal/files/output**', async (route) => {
+        if (route.request().method() !== 'GET') {
+          await route.fallback()
+          return
+        }
+
+        const outputOptions: ComboInputSpec['options'] = [
+          'ComfyUI_00001_.png [output]'
+        ]
+        await route.fulfill({ json: outputOptions })
+      })
+      await mockViewFiles(page, { 'ComfyUI_00001_.png': {} })
+      await jobsRoutes.mockJobsHistory([])
+      await jobsRoutes.mockJobsQueue([])
+    })
+
+    ossTest.beforeEach(async ({ comfyPage }) => {
+      await enableErrorsTab(comfyPage)
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    })
+
+    ossTest(
+      'resolves a saved LoadImageOutput selection on reload with cached remote options and empty history',
+      async ({ comfyPage }) => {
+        const outputOptionsResponse = comfyPage.page.waitForResponse(
+          (response) =>
+            response.url().includes('/internal/files/output') &&
+            response.status() === 200
+        )
+
+        await loadWorkflowAndOpenErrorsTab(
+          comfyPage,
+          'missing/missing_media_remote_output_option'
+        )
+        await (await outputOptionsResponse).finished()
+        await expect
+          .poll(() =>
+            comfyPage.page.evaluate((nodeId) => {
+              const widget = window
+                .app!.graph.getNodeById(nodeId)
+                ?.widgets?.find((candidate) => candidate.name === 'image')
+              const values = widget?.options.values
+              return Array.isArray(values) ? values : []
+            }, toNodeId(1))
+          )
+          .toEqual(['ComfyUI_00001_.png [output]'])
+
+        const outputNode = await comfyPage.nodeOps.getNodeRefById('1')
+        const imageWidget = await outputNode.getWidgetByName('image')
+        await expect
+          .poll(() => imageWidget.getValue())
+          .toBe('ComfyUI_00001_.png [output]')
+
+        await loadWorkflowAndOpenErrorsTab(
+          comfyPage,
+          'missing/missing_media_remote_output_option'
+        )
+
+        const missingMediaRows = comfyPage.page.getByTestId(
+          TestIds.dialogs.missingMediaRow
+        )
+        await expect(
+          missingMediaRows.getByRole('button', {
+            name: 'Load Audio - audio',
+            exact: true
+          })
+        ).toBeVisible()
+        await expect(missingMediaRows).toHaveCount(1)
+
+        const panel = new PropertiesPanelHelper(comfyPage.page)
+        await panel.close()
+        const dropdown = new WidgetSelectDropdownFixture(
+          comfyPage.vueNodes.getWidgetRowByLabel(
+            'Load Image (from Outputs)',
+            'image'
+          )
+        )
+        await expect(dropdown.selection).toHaveText(
+          'ComfyUI_00001_.png [output]'
+        )
+        await dropdown.selectOption('ComfyUI_00001_.png [output]')
+        await expect(dropdown.selection).toHaveText(
+          'ComfyUI_00001_.png [output]'
+        )
       }
     )
   }

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -391,7 +391,7 @@ describe('scanNodeMediaCandidates', () => {
       const node = makeMediaNode(
         1,
         nodeType,
-        [makeMediaCombo(widgetName, value, ['other-file.png', value])],
+        [makeMediaCombo(widgetName, value, ['other-file.png'])],
         0
       )
       const graph = makeGraph([node])
@@ -670,6 +670,83 @@ describe('verifyMediaCandidates', () => {
       limit: 200,
       hasMore: false
     })
+  })
+
+  it.for([
+    { nodeType: 'LoadImage', widgetName: 'image', filename: 'photo.png' },
+    { nodeType: 'LoadVideo', widgetName: 'file', filename: 'clip.mp4' },
+    { nodeType: 'LoadAudio', widgetName: 'audio', filename: 'sound.wav' }
+  ])(
+    'resolves OSS $nodeType output from exact widget options without history',
+    async ({ nodeType, widgetName, filename }) => {
+      const value = `subfolder/${filename} [output]`
+      const node = makeMediaNode(1, nodeType, [
+        makeMediaCombo(widgetName, value, [value])
+      ])
+      const candidates = scanNodeMediaCandidates(makeGraph([node]), node, false)
+
+      await verifyMediaCandidates(candidates, { isCloud: false })
+
+      expect(candidates).toEqual([
+        expect.objectContaining({ name: value, isMissing: false })
+      ])
+      expect(mockFetchHistoryPage).not.toHaveBeenCalled()
+    }
+  )
+
+  it.for([
+    { option: 'other.png', hasHistory: true, isMissing: false },
+    { option: 'other.png', hasHistory: false, isMissing: true },
+    { option: 'subfolder/photo.png', hasHistory: false, isMissing: true },
+    {
+      option: 'subfolder/photo.png [input]',
+      hasHistory: false,
+      isMissing: true
+    },
+    {
+      option: 'other/photo.png [output]',
+      hasHistory: false,
+      isMissing: true
+    }
+  ])(
+    'verifies OSS output with option $option and history present $hasHistory',
+    async ({ option, hasHistory, isMissing }) => {
+      const value = 'subfolder/photo.png [output]'
+      const node = makeMediaNode(1, 'LoadImage', [
+        makeMediaCombo('image', value, [option])
+      ])
+      const candidates = scanNodeMediaCandidates(makeGraph([node]), node, false)
+      const jobs = hasHistory
+        ? [makeHistoryJob('photo.png', { subfolder: 'subfolder' })]
+        : []
+      mockFetchHistoryPage.mockResolvedValue({
+        jobs,
+        total: jobs.length,
+        offset: 0,
+        limit: 200,
+        hasMore: false
+      })
+
+      await verifyMediaCandidates(candidates, { isCloud: false })
+
+      expect(candidates).toEqual([
+        expect.objectContaining({ name: value, isMissing })
+      ])
+    }
+  )
+
+  it('does not trust backend output options when Cloud assets are missing', async () => {
+    const value = 'photo.png [output]'
+    const node = makeMediaNode(1, 'LoadImage', [
+      makeMediaCombo('image', value, [value])
+    ])
+    const candidates = scanNodeMediaCandidates(makeGraph([node]), node, true)
+
+    await verifyMediaCandidates(candidates, { isCloud: true })
+
+    expect(candidates).toEqual([
+      expect.objectContaining({ name: value, isMissing: true })
+    ])
   })
 
   it('matches candidates by available input asset name or hash', async () => {

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -118,11 +118,11 @@ export function scanNodeMediaCandidates(
     if (isCloud) {
       isMissing = undefined
     } else {
+      const options = resolveComboValues(widget)
       const type = getAnnotatedMediaPathTypeForDetection(value)
       if (type === 'output') {
-        isMissing = undefined
+        isMissing = options.includes(value) ? false : undefined
       } else {
-        const options = resolveComboValues(widget)
         const detectionNames = getMediaPathDetectionNames(value)
         const existsInOptions = detectionNames.some((name) =>
           options.includes(name)


### PR DESCRIPTION
## ELI5

A local output image can be listed in its node's selector even when it is absent from job history. Missing-media detection now accepts either source, so a valid selectable file is not incorrectly marked missing.

## Summary

Local scans now check widget options before falling back to generated history. An exact output option is accepted immediately; an absent option still uses the existing history verification.

## Changes

- Accept output-annotated image, video and audio values present in widget options, including when history is empty.
- Preserve history-only selections, missing-file warnings, input/output path identity and Cloud asset validation.
- Check that valid output selections remain selectable in Vue node popovers, including LoadImageOutput's remote options.

## Review Focus

An input option named `photo.png` must not validate `photo.png [output]`. Remote options are allowed to settle before the direct LoadImageOutput rescan; cold remote initialization is a separate concern.

The existing "not in options" fixture now omits the selected value, matching its stated purpose; separate new cases assert that an exact option is valid.

## Red-green proof

| Phase | Commit | Unit | E2E |
| --- | --- | --- | --- |
| Red | [fd1f809a36](https://github.com/Comfy-Org/ComfyUI_frontend/commit/fd1f809a3634659226e78b38ba33692a67a04d8c) | [3 regression failures](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34328633650/job/102391769657) | [2 regression failures](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34328633912/job/102392632172) |
| Green | [4bcbae8ec8](https://github.com/Comfy-Org/ComfyUI_frontend/commit/4bcbae8ec8888f1924e188a360af75bc43e5f518) | [20,555 passed](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34331275748/job/102400243503) | [122 passed in regression shard](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34331275891/job/102401133953) |

RED failures were limited to the new output-option cases. GREEN passes the same unchanged tests, all other E2E shards, and the remaining CI checks.

## Provenance

- **Authored by:** interactive session.
- **Verified:** 112 targeted unit tests and 3 Chromium E2E tests passed with one worker, including history-only fallback. Restoring the old production code reproduced exactly 3 unit and 2 E2E failures; restoring the fix passed all 115 again. Tests are unchanged from the RED commit. `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint`, `pnpm format:check` and `pnpm knip` passed. Independent final review found no issues. Both complete CI workflows passed at the GREEN commit, and all other checks passed or were skipped.
- **Deviations:** none.


## Cache freshness boundary

An exact loader option, including its `[output]` annotation, is accepted as the best available evidence that an OSS output is present. This avoids falsely rejecting a valid file solely because generated history does not contain it. It is not a fresh disk-existence check: after a successful fetch, a deleted file can remain in cached options until refresh, including while the option endpoint is unavailable. Input options already have the same freshness limitation, and history itself does not verify disk existence.

Shared refresh/invalidation and unavailable-endpoint policy for input and output are tracked in #17815. Cloud asset verification and the history fallback when no exact output option exists remain unchanged.
