### PR TITLE
fix(pricing): match the team card copy and slider ticks to the yearly grant

### DIFF
--- a/apps/website/src/components/pricing/PricingSection.test.ts
+++ b/apps/website/src/components/pricing/PricingSection.test.ts
@@ -65,7 +65,7 @@ describe('PricingSection credit allotment copy', () => {
     await user.click(screen.getByRole('button', { name: /^Yearly/ }))
     await nextTick()
 
-    for (const label of ['506.4K', '1M', '1.8M', '3.5M', '6.3M']) {
+    for (const label of ['506.4K', '1M', '1.7M', '3.5M', '6.3M']) {
       expect(screen.getByText(label)).toBeTruthy()
     }
     expect(screen.queryByText('147.7K')).toBeNull()

--- a/apps/website/src/components/pricing/PricingSection.test.ts
+++ b/apps/website/src/components/pricing/PricingSection.test.ts
@@ -54,6 +54,23 @@ describe('PricingSection credit allotment copy', () => {
     expect(screen.getByText('Generates ~160,860 5s videos*')).toBeTruthy()
   })
 
+  it('scales the team slider tick labels with the billing cycle', async () => {
+    const user = userEvent.setup()
+    render(PricingSection, { props: { defaultBillingCycle: 'monthly' } })
+
+    for (const label of ['42.2K', '84.4K', '147.7K', '295.4K', '527.5K']) {
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+
+    await user.click(screen.getByRole('button', { name: /^Yearly/ }))
+    await nextTick()
+
+    for (const label of ['506.4K', '1M', '1.8M', '3.5M', '6.3M']) {
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+    expect(screen.queryByText('147.7K')).toBeNull()
+  })
+
   it('keeps every yearly figure at twelve times its monthly counterpart', () => {
     const annualPlans = pricingPlans.flatMap((plan) => {
       const { creditsKey, yearlyCreditsKey, estimateKey, yearlyEstimateKey } =

--- a/apps/website/src/components/pricing/PricingSection.test.ts
+++ b/apps/website/src/components/pricing/PricingSection.test.ts
@@ -61,6 +61,7 @@ describe('PricingSection credit allotment copy', () => {
     for (const label of ['42.2K', '84.4K', '147.7K', '295.4K', '527.5K']) {
       expect(screen.getByText(label)).toBeTruthy()
     }
+    expect(screen.getByLabelText('Team monthly credit commitment')).toBeTruthy()
 
     await user.click(screen.getByRole('button', { name: /^Yearly/ }))
     await nextTick()
@@ -69,6 +70,7 @@ describe('PricingSection credit allotment copy', () => {
       expect(screen.getByText(label)).toBeTruthy()
     }
     expect(screen.queryByText('147.7K')).toBeNull()
+    expect(screen.getByLabelText('Team annual credit commitment')).toBeTruthy()
   })
 
   it('keeps every yearly figure at twelve times its monthly counterpart', () => {

--- a/apps/website/src/components/pricing/PricingTeamCard.vue
+++ b/apps/website/src/components/pricing/PricingTeamCard.vue
@@ -5,11 +5,10 @@ import { computed, ref } from 'vue'
 
 import { Coins as CreditsIcon } from '@lucide/vue'
 
+import { formatCreditsCompact } from '@comfyorg/shared-frontend-utils/creditsUtil'
+
 import { subscribeUrl } from '../../data/pricingPlans'
-import {
-  formatTeamCreditsShort,
-  teamCreditTiers
-} from '../../data/teamCreditTiers'
+import { teamCreditTiers } from '../../data/teamCreditTiers'
 import { t } from '../../i18n/translations'
 import Button from '../ui/button/Button.vue'
 import Slider from '../ui/slider/Slider.vue'
@@ -64,7 +63,7 @@ const teamSliderLabel = computed(() =>
 
 const tickCreditLabels = computed(() =>
   teamCreditTiers.map((tier) =>
-    formatTeamCreditsShort(amountForBillingPeriod(tier.credits))
+    formatCreditsCompact(amountForBillingPeriod(tier.credits))
   )
 )
 

--- a/apps/website/src/components/pricing/PricingTeamCard.vue
+++ b/apps/website/src/components/pricing/PricingTeamCard.vue
@@ -53,6 +53,20 @@ const teamCreditsLabel = computed(() =>
     locale
   )
 )
+const teamSliderLabel = computed(() =>
+  t(
+    billingPeriod === 'yearly'
+      ? 'pricing.team.sliderLabelYearly'
+      : 'pricing.team.sliderLabel',
+    locale
+  )
+)
+
+const tickCreditLabels = computed(() =>
+  teamCreditTiers.map((tier) =>
+    formatTeamCreditsShort(amountForBillingPeriod(tier.credits))
+  )
+)
 
 function fmtPrice(n: number): string {
   return `$${n.toLocaleString('en-US')}`
@@ -131,7 +145,7 @@ const ctaHref = computed(() =>
             :max="teamCreditTiers.length - 1"
             :step="1"
             :ticks="teamCreditTiers.length"
-            :thumb-label="t('pricing.team.sliderLabel', locale)"
+            :thumb-label="teamSliderLabel"
             :thumb-value-text="`${teamCredits.toLocaleString('en-US')} ${teamCreditsLabel}, ${fmtPrice(selectedTeamPrice)} ${t('pricing.plan.period', locale)}`"
           >
             <template #tick="{ index, active }">
@@ -150,7 +164,7 @@ const ctaHref = computed(() =>
                   active ? 'text-primary-warm-white' : 'text-primary-warm-gray'
                 "
               >
-                {{ formatTeamCreditsShort(teamCreditTiers[index].credits) }}
+                {{ tickCreditLabels[index] }}
               </span>
             </template>
           </Slider>

--- a/apps/website/src/data/teamCreditTiers.ts
+++ b/apps/website/src/data/teamCreditTiers.ts
@@ -56,7 +56,12 @@ export const teamCreditTiers: readonly TeamCreditTier[] = [
   }
 ]
 
+// Yearly totals reach seven figures, where a K unit stops abbreviating
+// ("1772.4K"), so the unit follows the magnitude — the same compact formatting
+// the in-app slider uses, so the two surfaces read identically.
 export function formatTeamCreditsShort(n: number): string {
-  const k = n / 1000
-  return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1
+  }).format(n)
 }

--- a/apps/website/src/data/teamCreditTiers.ts
+++ b/apps/website/src/data/teamCreditTiers.ts
@@ -55,13 +55,3 @@ export const teamCreditTiers: readonly TeamCreditTier[] = [
     videos: 47875
   }
 ]
-
-// Yearly totals reach seven figures, where a K unit stops abbreviating
-// ("1772.4K"), so the unit follows the magnitude — the same compact formatting
-// the in-app slider uses, so the two surfaces read identically.
-export function formatTeamCreditsShort(n: number): string {
-  return new Intl.NumberFormat('en-US', {
-    notation: 'compact',
-    maximumFractionDigits: 1
-  }).format(n)
-}

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1733,6 +1733,10 @@ Enterprise`
     en: 'Team monthly credit commitment',
     'zh-CN': '团队每月积分承诺'
   },
+  'pricing.team.sliderLabelYearly': {
+    en: 'Team annual credit commitment',
+    'zh-CN': '团队年度积分承诺'
+  },
   'pricing.team.description': {
     en: 'Built for teams collaborating on workflows together.',
     'zh-CN': '为协作开发工作流的团队打造。'

--- a/packages/shared-frontend-utils/src/creditsUtil.test.ts
+++ b/packages/shared-frontend-utils/src/creditsUtil.test.ts
@@ -8,6 +8,7 @@ import {
   creditsToCents,
   creditsToUsd,
   formatCredits,
+  formatCreditsCompact,
   formatCreditsFromCents,
   formatCreditsFromUsd,
   formatUsd,
@@ -68,5 +69,22 @@ describe('comfyCredits helpers', () => {
     expect(clampUsd(0.5)).toBe(1)
     expect(clampUsd(2000)).toBe(1000)
     expect(clampUsd(NaN)).toBe(0)
+  })
+
+  test('formatCreditsCompact abbreviates with the unit the magnitude calls for', () => {
+    expect(formatCreditsCompact(42_200)).toBe('42.2K')
+    expect(formatCreditsCompact(506_400)).toBe('506.4K')
+    expect(formatCreditsCompact(1_012_800)).toBe('1M')
+    expect(formatCreditsCompact(6_330_000)).toBe('6.3M')
+  })
+
+  test('formatCreditsCompact truncates, so it never overstates the amount', () => {
+    expect(formatCreditsCompact(1_772_400)).toBe('1.7M')
+    expect(formatCreditsCompact(10_550)).toBe('10.5K')
+  })
+
+  test('formatCreditsCompact leaves amounts below a thousand unabbreviated', () => {
+    expect(formatCreditsCompact(0)).toBe('0')
+    expect(formatCreditsCompact(999)).toBe('999')
   })
 })

--- a/packages/shared-frontend-utils/src/creditsUtil.ts
+++ b/packages/shared-frontend-utils/src/creditsUtil.ts
@@ -98,8 +98,7 @@ export const formatCreditsFromUsd = ({
  * than the amount it stands for. Engines without Intl NumberFormat V3 ignore
  * `roundingMode` and round to nearest instead.
  *
- * Always English, matching the exact figure the pricing surfaces print beside
- * the abbreviation.
+ * Formatted in English regardless of the active locale.
  */
 export const formatCreditsCompact = (credits: number): string =>
   new Intl.NumberFormat('en-US', {

--- a/packages/shared-frontend-utils/src/creditsUtil.ts
+++ b/packages/shared-frontend-utils/src/creditsUtil.ts
@@ -92,6 +92,18 @@ export const formatCreditsFromUsd = ({
     numberOptions
   })
 
+/**
+ * Abbreviates a credit amount to one fraction digit ("42.2K", "1.7M"),
+ * truncating rather than rounding so the short form never claims more credits
+ * than the amount it stands for.
+ */
+export const formatCreditsCompact = (credits: number): string =>
+  new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+    roundingMode: 'trunc'
+  }).format(credits)
+
 export const formatUsd = ({
   value,
   locale,

--- a/packages/shared-frontend-utils/src/creditsUtil.ts
+++ b/packages/shared-frontend-utils/src/creditsUtil.ts
@@ -95,7 +95,11 @@ export const formatCreditsFromUsd = ({
 /**
  * Abbreviates a credit amount to one fraction digit ("42.2K", "1.7M"),
  * truncating rather than rounding so the short form never claims more credits
- * than the amount it stands for.
+ * than the amount it stands for. Engines without Intl NumberFormat V3 ignore
+ * `roundingMode` and round to nearest instead.
+ *
+ * Always English, matching the exact figure the pricing surfaces print beside
+ * the abbreviation.
  */
 export const formatCreditsCompact = (credits: number): string =>
   new Intl.NumberFormat('en-US', {

--- a/src/components/ui/credit-slider/CreditSlider.test.ts
+++ b/src/components/ui/credit-slider/CreditSlider.test.ts
@@ -18,7 +18,9 @@ const i18n = createI18n({
         usdPerMonth: 'USD / mo',
         billedYearly: '{total} Billed yearly',
         billedMonthly: 'Billed monthly',
-        creditSliderSave: 'Save {percent}% ({amount})'
+        creditSliderSave: 'Save {percent}% ({amount})',
+        monthlyCredits: 'monthly credits',
+        yearlyCredits: 'credits per year'
       }
     }
   }
@@ -164,7 +166,7 @@ describe('CreditSlider', () => {
     renderSlider({ modelValue: 700 })
     await flush()
 
-    const stops = within(screen.getByTestId('credit-slider-stops'))
+    const stops = within(screen.getByRole('list', { name: 'credits per year' }))
     for (const label of ['506.4K', '1M', '1.7M', '3.5M', '6.3M']) {
       expect(stops.getByText(label)).toBeInTheDocument()
     }
@@ -175,7 +177,7 @@ describe('CreditSlider', () => {
     renderSlider({ modelValue: 700, cycle: 'monthly' })
     await flush()
 
-    const stops = within(screen.getByTestId('credit-slider-stops'))
+    const stops = within(screen.getByRole('list', { name: 'monthly credits' }))
     for (const label of ['42.2K', '84.4K', '147.7K', '295.4K', '527.5K']) {
       expect(stops.getByText(label)).toBeInTheDocument()
     }

--- a/src/components/ui/credit-slider/CreditSlider.test.ts
+++ b/src/components/ui/credit-slider/CreditSlider.test.ts
@@ -165,7 +165,7 @@ describe('CreditSlider', () => {
     await flush()
 
     const stops = within(screen.getByTestId('credit-slider-stops'))
-    for (const label of ['506.4K', '1M', '1.8M', '3.5M', '6.3M']) {
+    for (const label of ['506.4K', '1M', '1.7M', '3.5M', '6.3M']) {
       expect(stops.getByText(label)).toBeInTheDocument()
     }
     expect(stops.queryByText('147.7K')).not.toBeInTheDocument()
@@ -179,6 +179,20 @@ describe('CreditSlider', () => {
     for (const label of ['42.2K', '84.4K', '147.7K', '295.4K', '527.5K']) {
       expect(stops.getByText(label)).toBeInTheDocument()
     }
+  })
+
+  it('re-labels the stops when the cycle changes after mount', async () => {
+    const { rerender } = renderSlider({ modelValue: 700, cycle: 'monthly' })
+    await flush()
+
+    const stops = within(screen.getByTestId('credit-slider-stops'))
+    expect(stops.getByText('147.7K')).toBeInTheDocument()
+
+    await rerender({ modelValue: 700, cycle: 'yearly' })
+    await flush()
+
+    expect(stops.getByText('1.7M')).toBeInTheDocument()
+    expect(stops.queryByText('147.7K')).not.toBeInTheDocument()
   })
 
   it('renders stops + default index supplied via props (BE-sourced override)', async () => {

--- a/src/components/ui/credit-slider/CreditSlider.test.ts
+++ b/src/components/ui/credit-slider/CreditSlider.test.ts
@@ -160,8 +160,19 @@ describe('CreditSlider', () => {
     expect(screen.queryByTestId('credit-slider-save')).not.toBeInTheDocument()
   })
 
-  it('renders all five fixed credit stop labels', async () => {
+  it('labels the five fixed stops with the year they grant on the yearly cycle', async () => {
     renderSlider({ modelValue: 700 })
+    await flush()
+
+    const stops = within(screen.getByTestId('credit-slider-stops'))
+    for (const label of ['506.4K', '1M', '1.8M', '3.5M', '6.3M']) {
+      expect(stops.getByText(label)).toBeInTheDocument()
+    }
+    expect(stops.queryByText('147.7K')).not.toBeInTheDocument()
+  })
+
+  it('labels the five fixed stops with the monthly grant when cycle=monthly', async () => {
+    renderSlider({ modelValue: 700, cycle: 'monthly' })
     await flush()
 
     const stops = within(screen.getByTestId('credit-slider-stops'))
@@ -195,9 +206,9 @@ describe('CreditSlider', () => {
 
     // Only the prop's labels render — none of the DES-197 defaults.
     const labels = within(screen.getByTestId('credit-slider-stops'))
-    expect(labels.getByText('10.6K')).toBeInTheDocument()
-    expect(labels.getByText('21.1K')).toBeInTheDocument()
-    expect(labels.queryByText('147.7K')).not.toBeInTheDocument()
+    expect(labels.getByText('126.6K')).toBeInTheDocument()
+    expect(labels.getByText('253.2K')).toBeInTheDocument()
+    expect(labels.queryByText('1.8M')).not.toBeInTheDocument()
   })
 
   it('keeps every credit amount equal to usdToCredits(usd) (guards rate drift)', () => {

--- a/src/components/ui/credit-slider/CreditSlider.test.ts
+++ b/src/components/ui/credit-slider/CreditSlider.test.ts
@@ -222,7 +222,7 @@ describe('CreditSlider', () => {
     const labels = within(screen.getByTestId('credit-slider-stops'))
     expect(labels.getByText('126.6K')).toBeInTheDocument()
     expect(labels.getByText('253.2K')).toBeInTheDocument()
-    expect(labels.queryByText('1.8M')).not.toBeInTheDocument()
+    expect(labels.queryByText('1.7M')).not.toBeInTheDocument()
   })
 
   it('keeps every credit amount equal to usdToCredits(usd) (guards rate drift)', () => {

--- a/src/components/ui/credit-slider/CreditSlider.vue
+++ b/src/components/ui/credit-slider/CreditSlider.vue
@@ -16,6 +16,7 @@ import {
   TEAM_PLAN_CREDIT_STOPS,
   getStopDiscountedMonthlyUsd
 } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
+import { amountForBillingCycle } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { CreditStop } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 
 const {
@@ -135,6 +136,14 @@ const formatCreditsCompact = (value: number) =>
     maximumFractionDigits: 1
   }).format(value)
 
+const stopCreditLabels = computed(() =>
+  stops.map((stop) =>
+    formatCreditsCompact(
+      amountForBillingCycle(stop.credits, cycle === 'yearly')
+    )
+  )
+)
+
 const { t } = useI18n()
 </script>
 
@@ -229,7 +238,7 @@ const { t } = useI18n()
           "
           aria-hidden="true"
         />
-        {{ formatCreditsCompact(stop.credits) }}
+        {{ stopCreditLabels[i] }}
       </li>
     </ol>
   </div>

--- a/src/components/ui/credit-slider/CreditSlider.vue
+++ b/src/components/ui/credit-slider/CreditSlider.vue
@@ -10,6 +10,7 @@ import { useI18n } from 'vue-i18n'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
+import { formatCreditsCompact } from '@/base/credits/comfyCredits'
 import Slider from '@/components/ui/slider/Slider.vue'
 import {
   DEFAULT_TEAM_PLAN_STOP_INDEX,
@@ -130,11 +131,6 @@ const sliderModel = computed<number[]>({
 const lastIndex = computed(() => Math.max(stops.length - 1, 0))
 
 const formatUsd = (value: number) => `$${value.toLocaleString('en-US')}`
-const formatCreditsCompact = (value: number) =>
-  new Intl.NumberFormat('en-US', {
-    notation: 'compact',
-    maximumFractionDigits: 1
-  }).format(value)
 
 const stopCreditLabels = computed(() =>
   stops.map((stop) =>

--- a/src/components/ui/credit-slider/CreditSlider.vue
+++ b/src/components/ui/credit-slider/CreditSlider.vue
@@ -132,13 +132,8 @@ const lastIndex = computed(() => Math.max(stops.length - 1, 0))
 
 const formatUsd = (value: number) => `$${value.toLocaleString('en-US')}`
 
-const stopCreditLabels = computed(() =>
-  stops.map((stop) =>
-    formatCreditsCompact(
-      amountForBillingCycle(stop.credits, cycle === 'yearly')
-    )
-  )
-)
+const creditLabelFor = (stop: CreditStop) =>
+  formatCreditsCompact(amountForBillingCycle(stop.credits, cycle === 'yearly'))
 
 const { t } = useI18n()
 </script>
@@ -234,7 +229,7 @@ const { t } = useI18n()
           "
           aria-hidden="true"
         />
-        {{ stopCreditLabels[i] }}
+        {{ creditLabelFor(stop) }}
       </li>
     </ol>
   </div>

--- a/src/components/ui/credit-slider/CreditSlider.vue
+++ b/src/components/ui/credit-slider/CreditSlider.vue
@@ -135,6 +135,12 @@ const formatUsd = (value: number) => `$${value.toLocaleString('en-US')}`
 const creditLabelFor = (stop: CreditStop) =>
   formatCreditsCompact(amountForBillingCycle(stop.credits, cycle === 'yearly'))
 
+const creditsLabelKey = computed(() =>
+  cycle === 'yearly'
+    ? 'subscription.yearlyCredits'
+    : 'subscription.monthlyCredits'
+)
+
 const { t } = useI18n()
 </script>
 
@@ -205,6 +211,7 @@ const { t } = useI18n()
     <!-- Credit stop labels; the selected stop is emphasized -->
     <ol
       data-testid="credit-slider-stops"
+      :aria-label="t(creditsLabelKey)"
       class="m-0 flex list-none justify-between p-0"
     >
       <li

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3030,6 +3030,7 @@
     "teamPlan": {
       "name": "Team Plan",
       "tagline": "Choose your own credit subscription. Get a larger discount with a larger credit subscription.",
+      "taglineYearly": "Choose your own annual credit subscription. Get a larger discount with a larger credit subscription.",
       "detailsTitle": "Details",
       "perkInviteMembers": "Invite team members",
       "perkConcurrentRuns": "Members can run workflows concurrently",

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -673,6 +673,20 @@ describe('UnifiedPricingTable credit allotment copy', () => {
     expect(screen.getByText('147,700')).toBeTruthy()
     expect(screen.getByText('Generates ~13,405 5s videos*')).toBeTruthy()
   })
+
+  it('calls the team subscription by the cycle it is bought on', async () => {
+    const user = userEvent.setup()
+    renderWithCycleToggle({ initialPlanMode: 'team' })
+
+    expect(
+      screen.getByText(/Choose your own annual credit subscription/)
+    ).toBeTruthy()
+
+    await user.click(screen.getByTestId('cycle-monthly'))
+    await nextTick()
+
+    expect(screen.getByText(/Choose your own credit subscription/)).toBeTruthy()
+  })
 })
 
 // INC-128. The server answers per workspace, not per plan card, so the table

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -226,7 +226,7 @@
                   {{ t('subscription.teamPlan.name') }}
                 </span>
                 <span class="text-sm text-muted-foreground">
-                  {{ t('subscription.teamPlan.tagline') }}
+                  {{ t(teamTaglineKey) }}
                 </span>
               </div>
 
@@ -691,6 +691,12 @@ const amountForCurrentCycle = (monthlyAmount: number) =>
 
 const creditsLabelKey = computed(() =>
   isYearly.value ? 'subscription.yearlyCredits' : 'subscription.monthlyCredits'
+)
+
+const teamTaglineKey = computed(() =>
+  isYearly.value
+    ? 'subscription.teamPlan.taglineYearly'
+    : 'subscription.teamPlan.tagline'
 )
 
 // Team credit stops: backend-sourced when the API supplies them, otherwise the


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Follow-up to #16099, which relabelled annual plans with the year's total grant. Alex Tov's review there (#frontend-code-reviews) flagged two spots on the Team Plan card the merge left on a monthly footing; both are fixed here, on the in-app **Choose a Plan** table and on `/cloud/pricing`.

Origin report: [FE-1448: Bug: Team/Personal pricing modal — credit slider, Save% badge, and /mo vs /year labeling issues](https://linear.app/comfyorg/issue/FE-1448/bug-teampersonal-pricing-modal-credit-slider-savepercent-badge-and-mo) — its source thread already asked for credits granted to be "reflected on team plan credit slider too", which is the half still outstanding.

## Slider ticks now carry the allotment the stop buys

The ticks read monthly (42.2K → 527.5K) while the grant line under them read the annual total, so the thumb sat against a scale twelve times off what it bought — 147.7K selected, `1,772,400 credits per year` granted. Both surfaces now scale the ticks by the same cycle factor as the grant line and abbreviate the seven-figure totals, so the label under the thumb and the figure beneath it are the same number:

| Yearly | before | after |
|---|---|---|
| ticks | `42.2K 84.4K 147.7K 295.4K 527.5K` | `506.4K 1M 1.7M 3.5M 6.3M` |
| grant | `1,772,400 credits per year` | unchanged |

Monthly is untouched — every shipped stop is a round hundred, so it renders the same five strings byte-for-byte.

## Tagline and slider name follow the selected cycle

- In-app: adds `subscription.teamPlan.taglineYearly` ("Choose your own **annual** credit subscription…"), selected on Yearly. **The English `tagline` was already cycle-neutral** — #16099 dropped the word "monthly" from it — so this is the annual half it never gained, not a contradiction that was live in English. The 14 non-English locales *do* still carry the monthly-worded `tagline`, and they now stop showing it on Yearly. The existing key is left in place so Monthly keeps its translations.
- Website: `pricing.team.sliderLabel` ("Team **monthly** credit commitment") was the one literal monthly string on that surface. It reaches the page only as the slider's `aria-label`, so it had no visual symptom — now paired with `sliderLabelYearly` and covered by a test.
- The in-app tick row had no accessible name at all, so a screen reader heard a bare list of numbers whose scale silently changed 12× on Yearly. It now announces the same period label the grant line shows, reusing the existing `monthlyCredits` / `yearlyCredits` strings.

## Two notes for review

1. **`1.7M`, not `1.8M`.** `1,772,400 / 1e6 = 1.7724`, so rounding gives `1.8M` — which would claim more credits than the exact figure printed directly beneath it. The shared formatter truncates instead, matching what Alex asked for verbatim. This is the only one of the ten labels where the two differ.
2. **Truncation also reaches monthly labels for backend-supplied stops.** `TEAM_PLAN_CREDIT_STOPS` is only the OSS/pre-deploy fallback; live stops come from `GET /api/billing/plans`. Any stop that is not a multiple of 100 now truncates (a 10,550 stop reads `10.5K`, was `10.6K`). Nothing observable changes today, and the direction never overstates a grant — flagging it since the change is framed as yearly-only.

The abbreviation is built once in `shared-frontend-utils/creditsUtil` and used by both surfaces. Previously each had its own: the website's was K-only, so above a million it produced `1772.4K` where the in-app one produced `1.8M` — they could not have agreed.

## Verification

`pnpm typecheck` (both apps), `lint`, `format:check`, `knip`, `build` (both apps) all exit 0. Unit tests: 184 in-app/shared across the touched suites, full website suite 1193/1193. Four in-app full-suite failures (`AgentPanelRoot` ×3, `useFirstRunTourController`) reproduce on an untouched `main` — pre-existing.

Rendered in a real browser on both cycles, both surfaces (screenshots below): the highlighted tick and the grant line now agree, and Monthly is unchanged.

The `pricing-tiers-*` visual baselines need no regeneration — I measured the tick row at 1128–2418px below the viewport top after the spec's scroll, outside every captured viewport (800–1024px tall).

`subscription.teamPlan.taglineYearly` is a new en-only key pending the release translation run, per `src/locales/CONTRIBUTING.md`; `pricing.team.sliderLabelYearly` ships with its `zh-CN` string, as that file's entries do.

cc @comfydesigner @comfyui-wiki


## Screenshots

![In-app Team Plan card, Monthly: unchanged - ticks 42.2K to 527.5K with '147,700 monthly credits'](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/52aa12acfc8c62c887fb10f2f5bbd77acc06c98e5ed7a664546187eae54bb921/pr-images/1788944814129-363d30ec-c95c-4b15-a77f-8c601d722566.png)

![comfy.org/cloud/pricing Team card, Yearly: ticks 506.4K / 1M / 1.7M / 3.5M / 6.3M above '1,772,400 credits per year'](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/52aa12acfc8c62c887fb10f2f5bbd77acc06c98e5ed7a664546187eae54bb921/pr-images/1788944816081-9af303e1-23b6-48a5-ac47-5434782c3e05.png)

![comfy.org/cloud/pricing Team card, Monthly: unchanged - ticks 42.2K to 527.5K with '147,700 monthly credits'](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/52aa12acfc8c62c887fb10f2f5bbd77acc06c98e5ed7a664546187eae54bb921/pr-images/1788944816842-40515681-1b2e-4666-ad58-ed1b8ef6dc1b.png)