### PR TITLE
feat(load3d): read the 3D save and preview nodes' standard 3d output …

### DIFF
--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -1663,6 +1663,49 @@ describe('useLoad3d', () => {
       )
     })
 
+    it('skips thumbnail persistence for a temp preview', async () => {
+      const { isAssetPreviewSupported, persistThumbnail } =
+        await import('@/platform/assets/utils/assetPreviewUtil')
+      vi.mocked(isAssetPreviewSupported).mockReturnValue(true)
+      mockNode.widgets = [
+        { name: 'model_file', value: 'preview.glb' } as unknown as IWidget
+      ]
+      mockNode.properties['Last Time Model Folder'] = 'temp'
+
+      const { handler } = await getModelReadyHandler()
+      handler()
+
+      expect(mockLoad3d.captureThumbnail).not.toHaveBeenCalled()
+      await expect
+        .poll(() => vi.mocked(persistThumbnail).mock.calls.length)
+        .toBe(0)
+    })
+
+    it('persists the thumbnail of a model loaded from the output folder', async () => {
+      const { isAssetPreviewSupported, persistThumbnail } =
+        await import('@/platform/assets/utils/assetPreviewUtil')
+      vi.mocked(isAssetPreviewSupported).mockReturnValue(true)
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue([
+        '3d',
+        'saved.glb'
+      ] as unknown as ReturnType<typeof Load3dUtils.splitFilePath>)
+      mockNode.widgets = [
+        { name: 'model_file', value: '3d/saved.glb' } as unknown as IWidget
+      ]
+      mockNode.properties['Last Time Model Folder'] = 'output'
+
+      const { handler } = await getModelReadyHandler()
+      handler()
+
+      expect(mockLoad3d.captureThumbnail).toHaveBeenCalledWith(256, 256)
+      await vi.waitFor(() =>
+        expect(persistThumbnail).toHaveBeenCalledWith(
+          'saved.glb',
+          expect.any(Blob)
+        )
+      )
+    })
+
     it('skips persistence when the model widget has no value', async () => {
       const { isAssetPreviewSupported, persistThumbnail } =
         await import('@/platform/assets/utils/assetPreviewUtil')

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -964,6 +964,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       if (!load3d || !isAssetPreviewSupported()) return
 
       const node = nodeRef.value
+      if (node?.properties['Last Time Model Folder'] === 'temp') return
       const modelWidget = node?.widgets?.find(
         (w) => w.name === 'model_file' || w.name === 'image'
       )

--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -5,6 +5,8 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 const {
   capture,
@@ -697,6 +699,29 @@ describe('Comfy.Save3DAdvanced.onNodeOutputsUpdated', () => {
     )
   })
 
+  it('restores the saved model from a standard 3d output item', () => {
+    const node = makePreview3DAdvancedNode({ comfyClass: 'Save3DAdvanced' })
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    save3DAdvancedExt.onNodeOutputsUpdated!({
+      [createNodeLocatorId(null, toNodeId(7))]: {
+        '3d': [
+          { filename: 'ComfyUI_00001.glb', subfolder: '3d', type: 'output' }
+        ],
+        camera_info: [null],
+        model_3d_info: []
+      }
+    })
+
+    expect(node.properties['Last Time Model File']).toBe('3d/ComfyUI_00001.glb')
+    expect(node.properties['Last Time Model Folder']).toBe('output')
+    expect(configureForSaveMeshMock).toHaveBeenCalledWith(
+      'output',
+      '3d/ComfyUI_00001.glb',
+      expect.objectContaining({ silentOnNotFound: true })
+    )
+  })
+
   it('skips nodes whose comfyClass is not Save3DAdvanced', async () => {
     const node = makePreview3DAdvancedNode({ comfyClass: 'Preview3DAdvanced' })
     getNodeByLocatorIdMock.mockReturnValue(node)
@@ -706,6 +731,24 @@ describe('Comfy.Save3DAdvanced.onNodeOutputsUpdated', () => {
     } as never)
 
     expect(configureForSaveMeshMock).not.toHaveBeenCalled()
+  })
+
+  it('restores a persisted temp preview on startup instead of its output default', async () => {
+    const node = makePreview3DAdvancedNode({
+      comfyClass: 'Save3DAdvanced',
+      properties: {
+        'Last Time Model File': 'preview3d_advanced_1.glb',
+        'Last Time Model Folder': 'temp'
+      }
+    })
+
+    await save3DAdvancedExt.nodeCreated!(node, app)
+
+    expect(configureForSaveMeshMock).toHaveBeenCalledWith(
+      'temp',
+      'preview3d_advanced_1.glb',
+      { silentOnNotFound: true }
+    )
   })
 })
 
@@ -739,6 +782,23 @@ describe('Comfy.Preview3DAdvanced.nodeCreated', () => {
     expect(configureForSaveMeshMock).toHaveBeenCalledWith(
       'temp',
       'prev/model.glb',
+      { silentOnNotFound: true }
+    )
+  })
+
+  it('restores from the persisted output folder instead of its temp default', async () => {
+    const node = makePreview3DAdvancedNode({
+      properties: {
+        'Last Time Model File': '3d/kept.glb',
+        'Last Time Model Folder': 'output'
+      }
+    })
+
+    await preview3DAdvancedExt.nodeCreated!(node, app)
+
+    expect(configureForSaveMeshMock).toHaveBeenCalledWith(
+      'output',
+      '3d/kept.glb',
       { silentOnNotFound: true }
     )
   })
@@ -867,7 +927,12 @@ describe('Comfy.Preview3DAdvanced.nodeCreated', () => {
     waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
       cb(load3d)
     )
-    const cameraState = { position: [1, 2, 3] }
+    const cameraState = {
+      position: { x: 1, y: 2, z: 3 },
+      target: { x: 0, y: 0, z: 0 },
+      zoom: 1,
+      cameraType: 'perspective'
+    }
     const node = makePreview3DAdvancedNode()
 
     await preview3DAdvancedExt.nodeCreated!(node, app)

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -25,6 +25,8 @@ import {
   SUPPORTED_EXTENSIONS_ACCEPT
 } from '@/extensions/core/load3d/constants'
 import { snapshotLoad3dState } from '@/extensions/core/load3d/load3dSerialize'
+import type { Model3DOutput } from '@/extensions/core/load3d/model3dOutput'
+import { readModel3DOutput } from '@/extensions/core/load3d/model3dOutput'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -39,9 +41,6 @@ import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 type Matrix = number[][]
 type Load3dPreviewOutput = NodeOutputWith<{
   result?: [string?, CameraState?, string?, Matrix?, Matrix?]
-}>
-type Preview3DAdvancedOutput = NodeOutputWith<{
-  result?: [string?, CameraState?, Model3DInfo?]
 }>
 import type { CustomInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { api } from '@/scripts/api'
@@ -688,23 +687,21 @@ useExtensionService().registerExtension({
 function applyPreview3DAdvancedResult(
   node: LGraphNode,
   load3d: Load3d,
-  result: NonNullable<Preview3DAdvancedOutput['result']>,
+  reported: Model3DOutput,
   loadFolder: LoadFolder,
   comfyClass: string
 ): void {
-  const filePath = result[0]
-  if (!filePath) return
-
-  const normalizedPath = filePath.replaceAll('\\', '/')
+  const normalizedPath = reported.filePath.replaceAll('\\', '/')
+  const folder = reported.folder ?? loadFolder
   node.properties['Last Time Model File'] = normalizedPath
+  node.properties['Last Time Model Folder'] = folder
 
   const config = new Load3DConfiguration(load3d, node.properties)
-  config.configureForSaveMesh(loadFolder, normalizedPath, {
+  config.configureForSaveMesh(folder, normalizedPath, {
     silentOnNotFound: true
   })
 
-  const cameraState = result[1]
-  const modelTransform = result[2]?.[0]
+  const { cameraState, modelTransform } = reported
   if (!cameraState && !modelTransform) return
 
   const targetGeneration = load3d.currentLoadGeneration
@@ -735,8 +732,8 @@ function createPreview3DAdvancedExtension(
       nodeOutputs: Record<NodeLocatorId, NodeExecutionOutput>
     ) {
       for (const [locatorId, output] of Object.entries(nodeOutputs)) {
-        const result = (output as Preview3DAdvancedOutput).result
-        if (!result?.[0]) continue
+        const reported = readModel3DOutput(output)
+        if (!reported) continue
 
         const node = getNodeByLocatorId(app.rootGraph, locatorId)
         if (!node || node.constructor.comfyClass !== comfyClass) continue
@@ -745,7 +742,7 @@ function createPreview3DAdvancedExtension(
           applyPreview3DAdvancedResult(
             node,
             load3d,
-            result,
+            reported,
             loadFolder,
             comfyClass
           )
@@ -780,8 +777,14 @@ function createPreview3DAdvancedExtension(
         const lastTimeModelFile = node.properties['Last Time Model File']
         if (!lastTimeModelFile) return
 
+        const lastTimeModelFolder = node.properties['Last Time Model Folder']
+        const folder =
+          lastTimeModelFolder === 'temp' || lastTimeModelFolder === 'output'
+            ? lastTimeModelFolder
+            : loadFolder
+
         const config = new Load3DConfiguration(load3d, node.properties)
-        config.configureForSaveMesh(loadFolder, lastTimeModelFile as string, {
+        config.configureForSaveMesh(folder, lastTimeModelFile as string, {
           silentOnNotFound: true
         })
 
@@ -859,11 +862,11 @@ function createPreview3DAdvancedExtension(
           }
         }
 
-        node.onExecuted = function (output: Preview3DAdvancedOutput) {
+        node.onExecuted = function (output: NodeExecutionOutput) {
           onExecuted?.call(this, output)
 
-          const result = output.result
-          if (!result?.[0]) {
+          const reported = readModel3DOutput(output)
+          if (!reported) {
             const msg = t('toastMessages.unableToGetModelFilePath')
             console.error(msg)
             useToastStore().addAlert(msg)
@@ -873,7 +876,7 @@ function createPreview3DAdvancedExtension(
           applyPreview3DAdvancedResult(
             node,
             resolveLoad3d(),
-            result,
+            reported,
             loadFolder,
             comfyClass
           )

--- a/src/extensions/core/load3d/model3dOutput.test.ts
+++ b/src/extensions/core/load3d/model3dOutput.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+
+import { readModel3DOutput } from '@/extensions/core/load3d/model3dOutput'
+
+const camera = {
+  position: { x: 1, y: 2, z: 3 },
+  target: { x: 0, y: 0, z: 0 },
+  zoom: 1,
+  cameraType: 'perspective'
+}
+const transform = {
+  position: { x: 0, y: 0, z: 0 },
+  quaternion: { x: 0, y: 0, z: 0, w: 1 },
+  scale: { x: 1, y: 1, z: 1 }
+}
+
+describe('readModel3DOutput', () => {
+  it('reads the file, folder and viewer state from a 3d item', () => {
+    const reported = readModel3DOutput({
+      '3d': [
+        { filename: 'ComfyUI_00001.glb', subfolder: '3d', type: 'output' }
+      ],
+      camera_info: [camera],
+      model_3d_info: [transform]
+    })
+
+    expect(reported).toEqual({
+      filePath: '3d/ComfyUI_00001.glb',
+      folder: 'output',
+      cameraState: camera,
+      modelTransform: transform
+    })
+  })
+
+  it('keeps a temp preview in the temp folder without a subfolder prefix', () => {
+    const reported = readModel3DOutput({
+      '3d': [{ filename: 'preview.glb', subfolder: '', type: 'temp' }],
+      camera_info: [null],
+      model_3d_info: []
+    })
+
+    expect(reported).toEqual({
+      filePath: 'preview.glb',
+      folder: 'temp',
+      cameraState: undefined,
+      modelTransform: undefined
+    })
+  })
+
+  it('falls back to the positional result of older backends', () => {
+    const reported = readModel3DOutput({
+      result: ['3d/ComfyUI_00001.glb', camera, [transform]]
+    })
+
+    expect(reported).toEqual({
+      filePath: '3d/ComfyUI_00001.glb',
+      cameraState: camera,
+      modelTransform: transform
+    })
+  })
+
+  it('prefers the 3d item when both forms are present', () => {
+    const reported = readModel3DOutput({
+      '3d': [{ filename: 'new.glb', subfolder: '', type: 'output' }],
+      result: ['old.glb']
+    })
+
+    expect(reported?.filePath).toBe('new.glb')
+  })
+
+  it('returns null when no file is reported', () => {
+    expect(readModel3DOutput(undefined)).toBeNull()
+    expect(readModel3DOutput(null)).toBeNull()
+    expect(readModel3DOutput('3d/model.glb')).toBeNull()
+    expect(readModel3DOutput({})).toBeNull()
+    expect(readModel3DOutput({ '3d': [] })).toBeNull()
+    expect(readModel3DOutput({ '3d': [{}] })).toBeNull()
+    expect(readModel3DOutput({ result: [] })).toBeNull()
+    expect(readModel3DOutput({ result: ['', camera] })).toBeNull()
+  })
+
+  it('rejects a file reference that is not a string', () => {
+    expect(readModel3DOutput({ '3d': [{ filename: 42 }] })).toBeNull()
+    expect(readModel3DOutput({ '3d': [{ filename: ['a.glb'] }] })).toBeNull()
+    expect(readModel3DOutput({ result: [{ path: 'a.glb' }] })).toBeNull()
+  })
+
+  it.each([
+    ['position', { target: camera.target, zoom: 1, cameraType: 'perspective' }],
+    [
+      'target',
+      { position: camera.position, zoom: 1, cameraType: 'perspective' }
+    ],
+    [
+      'zoom',
+      {
+        position: camera.position,
+        target: camera.target,
+        cameraType: 'perspective'
+      }
+    ],
+    [
+      'cameraType',
+      { position: camera.position, target: camera.target, zoom: 1 }
+    ]
+  ])('drops a camera state missing %s', (_field, partialCamera) => {
+    const reported = readModel3DOutput({
+      '3d': [{ filename: 'a.glb', subfolder: '', type: 'output' }],
+      camera_info: [partialCamera]
+    })
+
+    expect(reported?.cameraState).toBeUndefined()
+  })
+
+  it.each([
+    ['quaternion', 'invalid'],
+    ['customUp', { x: 0, y: 1 }],
+    ['useCustomUp', 'yes'],
+    ['fov', '35']
+  ])('drops a camera state whose optional %s is malformed', (field, value) => {
+    const reported = readModel3DOutput({
+      '3d': [{ filename: 'a.glb', subfolder: '', type: 'output' }],
+      camera_info: [{ ...camera, [field]: value }]
+    })
+
+    expect(reported?.cameraState).toBeUndefined()
+  })
+
+  it('keeps well-formed optional camera fields', () => {
+    const quaternion = { x: 0, y: 0, z: 0, w: 1 }
+    const reported = readModel3DOutput({
+      '3d': [{ filename: 'a.glb', subfolder: '', type: 'output' }],
+      camera_info: [{ ...camera, quaternion, useCustomUp: true }]
+    })
+
+    expect(reported?.cameraState).toMatchObject({
+      quaternion,
+      useCustomUp: true
+    })
+  })
+
+  it('drops viewer state that does not have the expected shape', () => {
+    const reported = readModel3DOutput({
+      '3d': [{ filename: 'a.glb', subfolder: '', type: 'input' }],
+      camera_info: [{ position: { x: 1, y: 2, z: 3 } }],
+      model_3d_info: [{ scale: { x: 1, y: 1, z: 1 } }]
+    })
+
+    expect(reported).toEqual({
+      filePath: 'a.glb',
+      folder: undefined,
+      cameraState: undefined,
+      modelTransform: undefined
+    })
+  })
+
+  it('rejects a file item whose fields are malformed', () => {
+    expect(
+      readModel3DOutput({ '3d': [{ filename: 'a.glb', subfolder: 7 }] })
+    ).toBeNull()
+    expect(
+      readModel3DOutput({ '3d': [{ filename: 'a.glb', type: 'nowhere' }] })
+    ).toBeNull()
+  })
+})

--- a/src/extensions/core/load3d/model3dOutput.ts
+++ b/src/extensions/core/load3d/model3dOutput.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+
+import type {
+  CameraState,
+  LoadFolder,
+  Model3DInfo
+} from '@/extensions/core/load3d/interfaces'
+import { zResultItem } from '@/schemas/apiSchema'
+
+export interface Model3DOutput {
+  filePath: string
+  folder?: LoadFolder
+  cameraState?: CameraState
+  modelTransform?: Model3DInfo[number]
+}
+
+const zVector3 = z.object({ x: z.number(), y: z.number(), z: z.number() })
+
+const zQuaternion = zVector3.extend({ w: z.number() })
+
+const zCameraShape = z.object({
+  position: zVector3,
+  target: zVector3,
+  zoom: z.number(),
+  cameraType: z.enum(['perspective', 'orthographic']),
+  quaternion: zQuaternion.optional(),
+  useCustomUp: z.boolean().optional(),
+  customUp: zVector3.optional(),
+  fov: z.number().optional(),
+  aspect: z.number().optional(),
+  near: z.number().optional(),
+  far: z.number().optional(),
+  frustum: z
+    .object({
+      left: z.number(),
+      right: z.number(),
+      top: z.number(),
+      bottom: z.number()
+    })
+    .optional()
+})
+
+const zCameraState = z.custom<CameraState>(
+  (value) => zCameraShape.safeParse(value).success
+)
+
+const zModelTransform = z.object({
+  position: zVector3,
+  quaternion: zQuaternion,
+  scale: zVector3
+})
+
+const zLoadFolder = z.enum(['output', 'temp'])
+
+const zModel3DNodeOutput = z.object({
+  '3d': z.array(zResultItem).optional(),
+  camera_info: z.array(z.unknown()).optional(),
+  model_3d_info: z.array(z.unknown()).optional(),
+  result: z.array(z.unknown()).optional()
+})
+
+function parseOptional<T>(schema: z.ZodType<T>, value: unknown): T | undefined {
+  const parsed = schema.safeParse(value)
+  return parsed.success ? parsed.data : undefined
+}
+
+export function readModel3DOutput(output: unknown): Model3DOutput | null {
+  const parsed = zModel3DNodeOutput.safeParse(output)
+  if (!parsed.success) return null
+  const { '3d': items, camera_info, model_3d_info, result } = parsed.data
+
+  const item = items?.[0]
+  if (item?.filename) {
+    return {
+      filePath: item.subfolder
+        ? `${item.subfolder}/${item.filename}`
+        : item.filename,
+      folder: parseOptional(zLoadFolder, item.type),
+      cameraState: parseOptional(zCameraState, camera_info?.[0]),
+      modelTransform: parseOptional(zModelTransform, model_3d_info?.[0])
+    }
+  }
+
+  const [filePath, cameraInfo, modelInfo] = result ?? []
+  if (typeof filePath !== 'string' || !filePath) return null
+  return {
+    filePath,
+    cameraState: parseOptional(zCameraState, cameraInfo),
+    modelTransform: parseOptional(
+      zModelTransform,
+      Array.isArray(modelInfo) ? modelInfo[0] : undefined
+    )
+  }
+}

--- a/src/extensions/core/load3dPreviewExtensions.test.ts
+++ b/src/extensions/core/load3dPreviewExtensions.test.ts
@@ -191,6 +191,58 @@ describe('load3dPreviewExtensions module registration', () => {
       expect.objectContaining({ silentOnNotFound: true })
     )
   })
+
+  it('loads a standard 3d item and remembers the folder it names', () => {
+    const node = makePreviewNode()
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    splatExt.onNodeOutputsUpdated!({
+      [createNodeLocatorId(null, toNodeId(4))]: {
+        '3d': [
+          { filename: 'preview_splat_1.spz', subfolder: '', type: 'temp' }
+        ],
+        camera_info: [null],
+        model_3d_info: []
+      }
+    })
+
+    expect(node.properties['Last Time Model File']).toBe('preview_splat_1.spz')
+    expect(node.properties['Last Time Model Folder']).toBe('temp')
+    expect(configureForSaveMeshMock).toHaveBeenCalledWith(
+      'temp',
+      'preview_splat_1.spz',
+      expect.objectContaining({ silentOnNotFound: true })
+    )
+  })
+
+  it('restores from the persisted folder instead of the extension default', async () => {
+    const previewNode = makePreviewNode({
+      properties: {
+        'Last Time Model File': '3d/kept.spz',
+        'Last Time Model Folder': 'output'
+      }
+    })
+    await splatExt.nodeCreated!(previewNode, app)
+    expect(configureForSaveMeshMock).toHaveBeenLastCalledWith(
+      'output',
+      '3d/kept.spz',
+      expect.objectContaining({ silentOnNotFound: true })
+    )
+
+    const saveNode = makePreviewNode({
+      comfyClass: 'SaveGaussianSplat',
+      properties: {
+        'Last Time Model File': 'preview_splat_1.spz',
+        'Last Time Model Folder': 'temp'
+      }
+    })
+    await saveSplatExt.nodeCreated!(saveNode, app)
+    expect(configureForSaveMeshMock).toHaveBeenLastCalledWith(
+      'temp',
+      'preview_splat_1.spz',
+      expect.objectContaining({ silentOnNotFound: true })
+    )
+  })
 })
 
 describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
@@ -232,7 +284,8 @@ describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
     const cameraState = {
       position: { x: 1, y: 2, z: 3 },
       target: { x: 0, y: 0, z: 0 },
-      zoom: 1
+      zoom: 1,
+      cameraType: 'perspective'
     }
 
     await splatExt.nodeCreated!(node, app)
@@ -271,7 +324,11 @@ describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
       cb(load3d)
     )
     const node = makePreviewNode({ comfyClass: 'SaveGaussianSplat' })
-    const transform = { position: { x: 1, y: 2, z: 3 } }
+    const transform = {
+      position: { x: 1, y: 2, z: 3 },
+      quaternion: { x: 0, y: 0, z: 0, w: 1 },
+      scale: { x: 1, y: 1, z: 1 }
+    }
 
     await saveSplatExt.nodeCreated!(node, app)
     node.onExecuted!({ result: ['scene.ply', undefined, [transform]] })

--- a/src/extensions/core/load3dPreviewExtensions.ts
+++ b/src/extensions/core/load3dPreviewExtensions.ts
@@ -4,17 +4,18 @@ import { nodeToLoad3dMap, useLoad3d } from '@/composables/useLoad3d'
 import { createExportMenuItems } from '@/extensions/core/load3d/exportMenuHelper'
 import type {
   CameraConfig,
-  CameraState,
   LoadFolder,
   Model3DInfo
 } from '@/extensions/core/load3d/interfaces'
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
+import type { Model3DOutput } from '@/extensions/core/load3d/model3dOutput'
+import { readModel3DOutput } from '@/extensions/core/load3d/model3dOutput'
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import type { NodeExecutionOutput, NodeOutputWith } from '@/schemas/apiSchema'
+import type { NodeExecutionOutput } from '@/schemas/apiSchema'
 import { app } from '@/scripts/app'
 import { useExtensionService } from '@/services/extensionService'
 import { useLoad3dService } from '@/services/load3dService'
@@ -22,20 +23,17 @@ import type { ComfyExtension } from '@/types/comfy'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 
-type PreviewOutput = NodeOutputWith<{
-  result?: [string?, CameraState?, Model3DInfo?]
-}>
-
 function applyResultToLoad3d(
   node: LGraphNode,
   load3d: Load3d,
-  filePath: string,
-  cameraState: CameraState | undefined,
-  modelTransform: Model3DInfo[number] | undefined,
+  reported: Model3DOutput,
   loadFolder: LoadFolder
 ): void {
-  const normalizedPath = filePath.replaceAll('\\', '/')
+  const { cameraState, modelTransform } = reported
+  const normalizedPath = reported.filePath.replaceAll('\\', '/')
+  const folder = reported.folder ?? loadFolder
   node.properties['Last Time Model File'] = normalizedPath
+  node.properties['Last Time Model Folder'] = folder
   if (cameraState) {
     const existing = node.properties['Camera Config'] as
       | CameraConfig
@@ -49,7 +47,7 @@ function applyResultToLoad3d(
   }
 
   const config = new Load3DConfiguration(load3d, node.properties)
-  config.configureForSaveMesh(loadFolder, normalizedPath, {
+  config.configureForSaveMesh(folder, normalizedPath, {
     silentOnNotFound: true
   })
 
@@ -69,22 +67,10 @@ function createPreview3DExtension(
 ): ComfyExtension {
   const applyPreviewOutput = (
     node: LGraphNode,
-    result: NonNullable<PreviewOutput['result']>
+    reported: Model3DOutput
   ): void => {
-    const filePath = result[0]
-    const cameraState = result[1]
-    const modelTransform = result[2]?.[0]
-    if (!filePath) return
-
     useLoad3d(node).waitForLoad3d((load3d) => {
-      applyResultToLoad3d(
-        node,
-        load3d,
-        filePath,
-        cameraState,
-        modelTransform,
-        loadFolder
-      )
+      applyResultToLoad3d(node, load3d, reported, loadFolder)
     })
   }
 
@@ -95,13 +81,13 @@ function createPreview3DExtension(
       nodeOutputs: Record<NodeLocatorId, NodeExecutionOutput>
     ) {
       for (const [locatorId, output] of Object.entries(nodeOutputs)) {
-        const result = (output as PreviewOutput).result
-        if (!result?.[0]) continue
+        const reported = readModel3DOutput(output)
+        if (!reported) continue
 
         const node = getNodeByLocatorId(app.rootGraph, locatorId)
         if (!node || node.constructor.comfyClass !== comfyClass) continue
 
-        applyPreviewOutput(node, result)
+        applyPreviewOutput(node, reported)
       }
     },
 
@@ -131,8 +117,14 @@ function createPreview3DExtension(
         const lastTimeModelFile = node.properties['Last Time Model File']
         if (!lastTimeModelFile) return
 
+        const lastTimeModelFolder = node.properties['Last Time Model Folder']
+        const folder =
+          lastTimeModelFolder === 'temp' || lastTimeModelFolder === 'output'
+            ? lastTimeModelFolder
+            : loadFolder
+
         const config = new Load3DConfiguration(load3d, node.properties)
-        config.configureForSaveMesh(loadFolder, lastTimeModelFile as string, {
+        config.configureForSaveMesh(folder, lastTimeModelFile as string, {
           silentOnNotFound: true
         })
 
@@ -201,27 +193,18 @@ function createPreview3DExtension(
           }
         }
 
-        node.onExecuted = function (output: PreviewOutput) {
+        node.onExecuted = function (output: NodeExecutionOutput) {
           onExecuted?.call(this, output)
 
-          const result = output.result
-          const filePath = result?.[0]
-
-          if (!filePath) {
+          const reported = readModel3DOutput(output)
+          if (!reported) {
             const msg = t('toastMessages.unableToGetModelFilePath')
             console.error(msg)
             useToastStore().addAlert(msg)
             return
           }
 
-          applyResultToLoad3d(
-            node,
-            resolveLoad3d(),
-            filePath,
-            result?.[1],
-            result?.[2]?.[0],
-            loadFolder
-          )
+          applyResultToLoad3d(node, resolveLoad3d(), reported, loadFolder)
         }
       })
     }


### PR DESCRIPTION
…item

## Summary
The Save 3D (Advanced), Preview 3D (Advanced), Gaussian splat and point cloud nodes report their model as a bare path in the first slot of a positional `result` list, a shape nothing but the viewer extension understands: core does not register it as a job output and the media panel never groups it. The backend is moving these nodes onto the shape SaveGLB already uses, a `3d` file item plus `camera_info` and `model_3d_info` keys.

Both extensions now read that form first through one readModel3DOutput, falling back to `result` for older backends. The folder the item names is persisted as `Last Time Model Folder` and honoured on restore, and a temp preview no longer triggers thumbnail persistence.

Need BE change https://github.com/Comfy-Org/ComfyUI/pull/16200