### PR TITLE
test: mock custom-node startup dependencies

### DIFF
--- a/browser_tests/fixtures/networkIsolationFixture.ts
+++ b/browser_tests/fixtures/networkIsolationFixture.ts
@@ -104,6 +104,15 @@ export const networkIsolationFixture = base.extend<{
     await context.route('https://apis.google.com/js/api.js**', (route) =>
       route.fulfill({ status: 503, body: '' })
     )
+    await context.route(
+      'https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js',
+      (route) =>
+        route.fulfill({
+          contentType: 'application/javascript',
+          headers: { 'access-control-allow-origin': '*' },
+          body: ''
+        })
+    )
     await context.route('https://cloud.comfy.org/cdn-cgi/trace', (route) =>
       route.fulfill({ contentType: 'text/plain', body: 'loc=US\n' })
     )
@@ -122,6 +131,14 @@ export const networkIsolationFixture = base.extend<{
     await context.route(
       'https://{api,stagingapi}.comfy.org/nodes{,?*}',
       (route) => route.fulfill({ status: 404, body: '' })
+    )
+    await context.route(
+      'https://{api,stagingapi}.comfy.org/releases{,?*}',
+      (route) =>
+        route.fulfill({
+          headers: { 'access-control-allow-origin': '*' },
+          json: []
+        })
     )
 
     await use(context)

--- a/browser_tests/tests/infrastructure/networkIsolation.spec.ts
+++ b/browser_tests/tests/infrastructure/networkIsolation.spec.ts
@@ -38,6 +38,28 @@ test.describe('Network isolation', { tag: '@smoke' }, () => {
     await expect(popup).toHaveURL('https://network-test.invalid/popup')
   })
 
+  test('serves deterministic startup dependencies in secondary pages', async ({
+    context
+  }) => {
+    const page = await context.newPage()
+    const frontend = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+    await page.goto(`${frontend}/api/users`)
+
+    await expect(
+      page.evaluate(async () => {
+        const releases = await fetch(
+          'https://stagingapi.comfy.org/releases'
+        ).then((response) => response.json())
+        const modelViewer = await fetch(
+          'https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js'
+        ).then((response) => response.text())
+        return { releases, modelViewer }
+      })
+    ).resolves.toEqual({ releases: [], modelViewer: '' })
+
+    await page.close()
+  })
+
   test('keeps real backend WebSocket messages', async ({ page }) => {
     const backend =
       process.env.PLAYWRIGHT_SETUP_API_URL ||


### PR DESCRIPTION
## Summary

Keep browser network isolation deterministic for secondary custom-node pages and the pinned Impact pack.

## Changes

- **What**: Serve the product release poll from an exact context-level mock so pages created after `ComfyPage.setup()` cannot reach staging.
- **What**: Serve the pinned model-viewer 4.0.0 script URL as an empty local module, matching the existing Impact telemetry stub pattern.
- **What**: Cover both dependencies from a secondary page while the default-deny fixture remains active.
- **Dependencies**: None.

## Review Focus

The September 9 custom-node nightly failed otherwise-passing tests on `GET https://stagingapi.comfy.org/releases`; cloud shard 4 failed all 30 tests after the pinned pack requested `https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js`. Both are exact known startup resources. All other external HTTP and WebSocket traffic remains a teardown failure.

Local verification: browser and application typechecks, ESLint, oxlint, formatting, and commit hooks passed.