### PR TITLE
fix: stop resetting subgraph IDs on clear()

### DIFF
--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -2317,6 +2317,31 @@ describe('Zero UUID handling in configure', () => {
     const subgraph = graph.createSubgraph(subgraphData)
     expect(subgraph.id).toBe(zeroUuid)
   })
+
+  it('keeps a subgraph registered under its own ID across clear()', () => {
+    const graph = new LGraph()
+    const subgraph = graph.createSubgraph(createTestSubgraphData())
+    const { id } = subgraph
+
+    subgraph.clear()
+
+    expect(subgraph.id).toBe(id)
+    expect(graph.subgraphs.get(id)).toBe(subgraph)
+    expect(graph.subgraphs.has(zeroUuid)).toBe(false)
+  })
+
+  it('creates a subgraph exposing IO without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const graph = new LGraph()
+
+    graph.createSubgraph(
+      createTestSubgraphData({
+        inputs: [{ id: createUuidv4(), name: 'value', type: 'INT' }]
+      })
+    )
+
+    expect(warn).not.toHaveBeenCalled()
+  })
 })
 
 describe('node layout registration', () => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -807,7 +807,7 @@ export class LGraph
     this._nodes_executable = null
     this._groups = []
 
-    this.id = this.isRootGraph ? createUuidv4() : zeroUuid
+    if (this.isRootGraph) this.id = createUuidv4()
     this.revision = 0
 
     this.state = createLGraphState()


### PR DESCRIPTION
## Summary

Loading a workflow template logs `Cannot change the ID of populated graph <uuid>` once per subgraph; `resetAfterClear()` was assigning `zeroUuid` to graphs that are about to be reassigned the same ID anyway.

## Changes

- **What**: `resetAfterClear()` now remints an ID only for root graphs. Subgraphs keep theirs.

`LGraph.createNormalizedSubgraphs` constructs each `Subgraph` (which populates `inputs`/`outputs`/`widgets` via `_configureSubgraph`) and then calls `configure()` on it. `configure()` → `clear()` → `resetAfterClear()`, which set `this.id = zeroUuid` for non-root graphs — but `clear()` never empties a subgraph's `inputs`/`outputs`/`widgets`, and those three are exactly what the `populated` check in `set id` looks at. So any subgraph exposing an input, output, or promoted widget warns on every load, and `_configureBase` reassigns the identical ID immediately afterwards.

For a subgraph with no exposed IO the guard does not fire, and the assignment goes through: `set id` rekeys the root's `_subgraphs` registry to `zeroUuid` and migrates its `graphMetadataStore` entry, only for `configure()` to move both back one step later.

Neither outcome is useful. Root graphs still remint, which is what `clear()` on the root graph needs.

## Review Focus

The `populated` guard in `set id` is load-bearing now that the setter rekeys the subgraph registry — the fix is at the caller, not the guard.

Regression tests in `LGraph.test.ts` ("Zero UUID handling in configure"): both fail on `main` — the registration test with `expected '00000000-0000-0000-0000-000000000000' to be '<real id>'`, the warning test with one unexpected `console.warn`.
