### PR TITLE
test: quarantine unavailable Prompt Combinator source

### DIFF
--- a/browser_tests/fixtures/data/cloud/packQuarantine.json
+++ b/browser_tests/fixtures/data/cloud/packQuarantine.json
@@ -1,4 +1,11 @@
 {
+  "ComfyUI-Prompt-Combinator": {
+    "class": "unfetchable-ref",
+    "evidence": "GitHub's repository API returns HTTP 404 for lquesada/ComfyUI-Prompt-Combinator, and clean CI runners cannot fetch its pinned 3576ace3f2776918c1046b6674fbe345a46dba2f source.",
+    "reason": "the repository pinned by the live Cloud supported_nodes.yaml is no longer publicly available",
+    "since": "2026-09-09",
+    "upstreamFix": "restore the public repository at the pinned commit or remove or replace the entry in Cloud supported_nodes.yaml"
+  },
   "ComfyUI-LivePortraitKJ": {
     "class": "unfetchable-ref",
     "evidence": "deployRef @4d9dc6205b79e50f81c0e6d245a2e0e5e53d5ecd returns HTTP 422 'No commit found'; a full clone across all 6 branches and 134 commits does not contain it. The first 12 characters match the repository's real HEAD (4d9dc6205b793ffd0fb319816136d9b8c0dbfdff) and then diverge, which is a short sha expanded wrongly rather than a force-push.",

--- a/scripts/customNodeQuarantine.ts
+++ b/scripts/customNodeQuarantine.ts
@@ -35,6 +35,7 @@ import {
 import { ROUNDTRIP_NODE_LOSS_EXPECTATIONS_LITEGRAPH } from '../browser_tests/fixtures/customNode/valueDrift'
 import {
   provesRefIsMissing,
+  provesRepositoryIsUnavailable,
   provesRequirementIsUnsatisfiable
 } from './customNodeQuarantineProbe'
 
@@ -69,6 +70,29 @@ async function dryRunPython(): Promise<string> {
 async function refStillMissing(deployRef: string): Promise<boolean> {
   const [url, sha] = deployRef.split(/@(?=[^@]*$)/)
   if (!url || !sha) throw new Error(`invalid git deployRef: ${deployRef}`)
+  const slug = url.match(
+    /^https:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/
+  )?.[1]
+  if (slug) {
+    const repositoryStatus = await run(
+      'curl',
+      [
+        '-sS',
+        '-o',
+        '/dev/null',
+        '-w',
+        '%{http_code}',
+        '--max-time',
+        '30',
+        `https://api.github.com/repos/${slug}`
+      ],
+      { timeout: 35_000 }
+    ).then(
+      ({ stdout }) => stdout,
+      () => ''
+    )
+    if (provesRepositoryIsUnavailable(repositoryStatus)) return true
+  }
   const dir = mkdtempSync(join(tmpdir(), 'cnq-'))
   await run('git', ['init', '-q', dir], { timeout: 30_000 })
   await run('git', ['-C', dir, 'remote', 'add', 'origin', url])
@@ -98,7 +122,7 @@ async function requirementsStillUnsatisfiable(
   failurePattern: string
 ): Promise<boolean> {
   const [url, sha] = deployRef.split(/@(?=[^@]*$)/)
-  const slug = url?.split('github.com/')[1]
+  const slug = url.split('github.com/')[1]
   if (!slug || !sha) throw new Error(`invalid git deployRef: ${deployRef}`)
   let body: string
   try {

--- a/scripts/customNodeQuarantineProbe.test.ts
+++ b/scripts/customNodeQuarantineProbe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   provesRefIsMissing,
+  provesRepositoryIsUnavailable,
   provesRequirementIsUnsatisfiable
 } from './customNodeQuarantineProbe'
 
@@ -15,6 +16,12 @@ describe('custom-node quarantine probes', () => {
     expect(
       provesRefIsMissing({ stderr: 'Could not resolve host: github.com' })
     ).toBe(false)
+  })
+
+  test('accepts a missing repository but not transient API failures', () => {
+    expect(provesRepositoryIsUnavailable('404')).toBe(true)
+    expect(provesRepositoryIsUnavailable('200')).toBe(false)
+    expect(provesRepositoryIsUnavailable('403')).toBe(false)
   })
 
   test('requires both the declared requirement and a resolver verdict', () => {

--- a/scripts/customNodeQuarantineProbe.ts
+++ b/scripts/customNodeQuarantineProbe.ts
@@ -13,6 +13,10 @@ export function provesRefIsMissing(error: unknown): boolean {
   )
 }
 
+export function provesRepositoryIsUnavailable(status: string): boolean {
+  return status.trim() === '404'
+}
+
 export function provesRequirementIsUnsatisfiable(
   error: unknown,
   expectedRequirement: string


### PR DESCRIPTION
## Summary

Keep the custom-node gate deterministic after the repository pinned by the live Cloud manifest became unavailable.

## Changes

- **What**: Exclude only `ComfyUI-Prompt-Combinator` as an explicit whole-pack skip while GitHub returns 404 for its repository. Recheck repository availability on every quarantine report so restored source makes the ledger stale and fails until coverage is restored.

## Review Focus

The Cloud manifest still pins `lquesada/ComfyUI-Prompt-Combinator@3576ace3...`, but GitHub now returns 404 and clean CI runners cannot fetch it. HTTP 403 and network failures remain inconclusive; only 404 proves this exclusion. The Actions summary reports that no S-tier ran and names the removal condition.