### PR TITLE
test: clean up global Pinia component tests

### DIFF
--- a/src/components/common/CustomizationDialog.test.ts
+++ b/src/components/common/CustomizationDialog.test.ts
@@ -1,18 +1,9 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
-import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
-
 import CustomizationDialog from './CustomizationDialog.vue'
-
-beforeEach(() => {
-  Object.assign(useNodeBookmarkStore(), {
-    defaultBookmarkIcon: DEFAULT_ICON,
-    defaultBookmarkColor: DEFAULT_COLOR
-  })
-})
 
 const DEFAULT_ICON = 'pi-bookmark-fill'
 const DEFAULT_COLOR = '#a1a1aa'

--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
@@ -11,7 +11,6 @@ import TopUpCreditsDialogContentLegacy from './TopUpCreditsDialogContentLegacy.v
 const mockPurchaseCreditsDirect = vi.fn()
 const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
-
 const mockTrackTopUpPurchase = vi.fn()
 const mockTrackBillingEvent = vi.fn()
 const mockIsSubscriptionEnabled = vi.fn(() => true)

--- a/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
+++ b/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
@@ -12,7 +12,6 @@ import MissingPackGroupRow from './MissingPackGroupRow.vue'
 
 const mockInstallAllPacks = vi.fn()
 const mockIsInstalling = ref(false)
-
 const mockShouldShowManagerButtons = { value: false }
 const mockOpenManager = vi.fn()
 const mockMissingNodePacks = ref<Array<{ id: string; name: string }>>([])

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
@@ -320,10 +320,10 @@ describe('ModelLibrarySidebarTab', () => {
       const user = userEvent.setup()
       renderComponent()
       await nextTick()
-      for (let i = 0; i < 520; i++) {
-        Object.assign(useModelStore(), {
-          models: [
-            ...useModelStore().models,
+      Object.assign(useModelStore(), {
+        models: [
+          ...useModelStore().models,
+          ...Array.from({ length: 520 }, (_, i) =>
             fromPartial<ComfyModelDef>({
               key: `checkpoints/bulk-${i}.safetensors`,
               file_name: `bulk-${i}.safetensors`,
@@ -332,9 +332,9 @@ describe('ModelLibrarySidebarTab', () => {
               directory: 'checkpoints',
               searchable: `checkpoints/bulk-${i}.safetensors`
             })
-          ]
-        })
-      }
+          )
+        ]
+      })
 
       await user.type(screen.getByTestId('search-input'), 'bulk')
       await nextTick()


### PR DESCRIPTION
## Summary

Applies Austin’s follow-up test cleanup after #17231 merged unchanged.

## Changes

- Remove redundant bookmark-default setup ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17231#discussion_r3971467101)).
- Remove two stray blank lines ([TopUp comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17231#discussion_r3971481428), [MissingPack comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17231#discussion_r3971528101)).
- Build the 520-model fixture once and override the testing getter once ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17231#discussion_r3971747546)).

## Review Focus

This PR is based on `main` after #17231.