### PR TITLE
fix: stop resetting subgraph IDs on clear() (backport to cloud 1.53)

### DIFF
--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -2106,6 +2106,31 @@ describe('Zero UUID handling in configure', () => {
     const subgraph = graph.createSubgraph(subgraphData)
     expect(subgraph.id).toBe(zeroUuid)
   })
+
+  it('keeps a subgraph registered under its own ID across clear()', () => {
+    const graph = new LGraph()
+    const subgraph = graph.createSubgraph(createTestSubgraphData())
+    const { id } = subgraph
+
+    subgraph.clear()
+
+    expect(subgraph.id).toBe(id)
+    expect(graph.subgraphs.get(id)).toBe(subgraph)
+    expect(graph.subgraphs.has(zeroUuid)).toBe(false)
+  })
+
+  it('creates a subgraph exposing IO without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const graph = new LGraph()
+
+    graph.createSubgraph(
+      createTestSubgraphData({
+        inputs: [{ id: createUuidv4(), name: 'value', type: 'INT' }]
+      })
+    )
+
+    expect(warn).not.toHaveBeenCalled()
+  })
 })
 
 describe('node layout registration', () => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -752,7 +752,7 @@ export class LGraph
     this._nodes_executable = null
     this._groups = []
 
-    this.id = this.isRootGraph ? createUuidv4() : zeroUuid
+    if (this.isRootGraph) this.id = createUuidv4()
     this.revision = 0
 
     this.state = createLGraphState()


### PR DESCRIPTION
Backport of merged fix https://github.com/Comfy-Org/ComfyUI_frontend/pull/17268 to the 1.53 release branch.

- One-line change in `LGraph.clear()` plus regression tests for zero-UUID handling in `configure`.
- Cherry-picked cleanly; no conflicts.
- Original PR had no backport labels; labels were added retroactively so both 1.53 branches get the fix.

<details><summary>Full context for agent readers</summary>

Source: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17268 (merge commit `f761da981e9d5c865daccbe9f64672841d4f0503`), authored by Christian directly. It merged without `needs-backport` / release-branch labels; the ECS operator lane added `needs-backport`, `core/1.53`, `cloud/1.53` and opened this manual cherry-pick under the standing backport authorization. Christian may close this if the fix was intentionally main-only.

Files: `src/lib/litegraph/src/LGraph.ts` (bug line verified identical on both 1.53 branches before cherry-pick), `src/lib/litegraph/src/LGraph.test.ts` (25 new lines, "Zero UUID handling in configure").

Tests not run locally: the throwaway worktree lacked matching dependencies (a stale `node_modules` link from a main-branch checkout made the vitest setup file fail before any test body ran). CI on this PR is the verification.

<!-- authored-by:agent w3-w35 -->
</details>
