### PR TITLE
test: clean up composable fixtures

### DIFF
--- a/src/composables/maskeditor/useCanvasHistory.test.ts
+++ b/src/composables/maskeditor/useCanvasHistory.test.ts
@@ -1,4 +1,5 @@
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { useCanvasHistory } from '@/composables/maskeditor/useCanvasHistory'
@@ -18,8 +19,36 @@ if (typeof globalThis.ImageBitmap === 'undefined') {
   }
 }
 
+function createImageData(): ImageData {
+  if (typeof ImageData !== 'undefined') {
+    return new ImageData(100, 100)
+  }
+
+  return {
+    colorSpace: 'srgb',
+    data: new Uint8ClampedArray(100 * 100 * 4),
+    width: 100,
+    height: 100
+  }
+}
+
+function createContext(): CanvasRenderingContext2D {
+  return createMockCanvasRenderingContext2D({
+    getImageData: vi.fn(createImageData),
+    putImageData: vi.fn(),
+    drawImage: vi.fn()
+  })
+}
+
+function createCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = 100
+  canvas.height = 100
+  return canvas
+}
+
 describe('useCanvasHistory', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockRefs = useMaskEditorStore()
     let rafCallCount = 0
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
@@ -31,54 +60,15 @@ describe('useCanvasHistory', () => {
       }
     )
 
-    const createMockImageData = (): ImageData => {
-      return {
-        data: new Uint8ClampedArray(100 * 100 * 4),
-        width: 100,
-        height: 100
-      } as ImageData
-    }
+    mockRefs.maskCanvas = createCanvas()
+    mockRefs.rgbCanvas = createCanvas()
+    mockRefs.imgCanvas = createCanvas()
 
-    // Mock contexts using explicit partial-cast pattern
-    mockRefs.maskCtx = {
-      getImageData: vi.fn(() => createMockImageData()),
-      putImageData: vi.fn(),
-      clearRect: vi.fn(),
-      drawImage: vi.fn()
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
+    await nextTick()
 
-    mockRefs.rgbCtx = {
-      getImageData: vi.fn(() => createMockImageData()),
-      putImageData: vi.fn(),
-      clearRect: vi.fn(),
-      drawImage: vi.fn()
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
-
-    mockRefs.imgCtx = {
-      getImageData: vi.fn(() => createMockImageData()),
-      putImageData: vi.fn(),
-      clearRect: vi.fn(),
-      drawImage: vi.fn()
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
-
-    // Mock canvases using explicit partial-cast pattern
-    mockRefs.maskCanvas = {
-      getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
-      width: 100,
-      height: 100
-    } as Partial<HTMLCanvasElement> as HTMLCanvasElement
-
-    mockRefs.rgbCanvas = {
-      getContext: vi.fn().mockImplementation(() => mockRefs.rgbCtx),
-      width: 100,
-      height: 100
-    } as Partial<HTMLCanvasElement> as HTMLCanvasElement
-
-    mockRefs.imgCanvas = {
-      getContext: vi.fn().mockImplementation(() => mockRefs.imgCtx),
-      width: 100,
-      height: 100
-    } as Partial<HTMLCanvasElement> as HTMLCanvasElement
+    mockRefs.maskCtx = createContext()
+    mockRefs.rgbCtx = createContext()
+    mockRefs.imgCtx = createContext()
   })
 
   describe('initialization', () => {
@@ -109,24 +99,16 @@ describe('useCanvasHistory', () => {
     it('should wait for canvas to be ready', () => {
       const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
 
-      mockRefs.maskCanvas = {
-        getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
-        // oxlint-disable-next-line no-misused-spread
-        ...mockRefs.maskCanvas,
-        width: 0,
-        height: 0
-      } as Partial<HTMLCanvasElement> as HTMLCanvasElement
+      mockRefs.maskCanvas!.width = 0
+      mockRefs.maskCanvas!.height = 0
 
       const history = useCanvasHistory()
       history.saveInitialState()
 
       expect(rafSpy).toHaveBeenCalled()
 
-      mockRefs.maskCanvas = {
-        getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
-        width: 100,
-        height: 100
-      } as Partial<HTMLCanvasElement> as HTMLCanvasElement
+      mockRefs.maskCanvas!.width = 100
+      mockRefs.maskCanvas!.height = 100
     })
 
     it('should wait for context to be ready', () => {
@@ -139,20 +121,7 @@ describe('useCanvasHistory', () => {
 
       expect(rafSpy).toHaveBeenCalled()
 
-      const createMockImageData = (): ImageData => {
-        return {
-          data: new Uint8ClampedArray(100 * 100 * 4),
-          width: 100,
-          height: 100
-        } as ImageData
-      }
-
-      mockRefs.maskCtx = {
-        getImageData: vi.fn(() => createMockImageData()),
-        putImageData: vi.fn(),
-        clearRect: vi.fn(),
-        drawImage: vi.fn()
-      } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
+      mockRefs.maskCtx = createContext()
     })
   })
 
@@ -567,13 +536,8 @@ describe('useCanvasHistory', () => {
     })
 
     it('should handle zero-sized canvas', () => {
-      if (mockRefs.maskCanvas) {
-        mockRefs.maskCanvas = {
-          getContext: vi.fn().mockImplementation(() => mockRefs.maskCtx),
-          width: 0,
-          height: 0
-        } as Partial<HTMLCanvasElement> as HTMLCanvasElement
-      }
+      mockRefs.maskCanvas!.width = 0
+      mockRefs.maskCanvas!.height = 0
 
       const history = useCanvasHistory()
 

--- a/src/composables/useBrowserTabTitle.test.ts
+++ b/src/composables/useBrowserTabTitle.test.ts
@@ -31,10 +31,12 @@ describe('useBrowserTabTitle', () => {
     workflowStore = useWorkflowStore()
     workspaceStore = useWorkspaceStore()
     // reset execution store
-    Object.assign(executionStore, { isIdle: true })
-    Object.assign(executionStore, { executionProgress: 0 })
-    Object.assign(executionStore, { executingNode: null })
-    Object.assign(executionStore, { executingNodeProgress: 0 })
+    Object.assign(executionStore, {
+      isIdle: true,
+      executionProgress: 0,
+      executingNode: null,
+      executingNodeProgress: 0
+    })
     executionStore.nodeProgressStates = {}
 
     // reset setting and workflow stores


### PR DESCRIPTION
## Summary

Follow up on #17236 without blocking its merge by replacing unsafe canvas fixture casts and consolidating execution-store setup.

## Changes

- **What**: Use real canvas elements, typed image data, and the existing canvas context fixture in `useCanvasHistory.test.ts`; combine the consecutive execution-store assignments in `useBrowserTabTitle.test.ts`.

## Review Focus

Addresses [canvas fixture feedback](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17236#discussion_r3972627298) and [store setup feedback](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17236#discussion_r3972668429). This follow-up was kept separate so #17236 could merge unchanged, then rebased onto `main` after the parent merged.

Validation: 5 targeted test files / 80 tests passed; `pnpm typecheck`, scoped ESLint, type-aware Oxlint and Vitest cleanup audit, scoped format check, `pnpm knip`, `git diff --check`, commit hooks, and pre-push hooks passed.