### PR TITLE
[backport cloud/1.53] fix: preserve legacy numeric widget rendering

### DIFF
--- a/src/lib/litegraph/src/utils/widget.test.ts
+++ b/src/lib/litegraph/src/utils/widget.test.ts
@@ -7,6 +7,7 @@ import {
   getWidgetStep,
   resolveNodeRootGraphId
 } from '@/lib/litegraph/src/litegraph'
+import { formatNumericWidgetValue } from '@/lib/litegraph/src/utils/widget'
 
 describe('getWidgetStep', () => {
   test('should return step2 when available', () => {
@@ -45,6 +46,15 @@ describe('getWidgetStep', () => {
     }
 
     expect(getWidgetStep(optionsWithZeroStep)).toBe(1)
+  })
+})
+
+describe('formatNumericWidgetValue', () => {
+  test.for<[string, unknown]>([
+    ['symbol', Symbol('legacy')],
+    ['object without primitive conversion', Object.create(null)]
+  ])('formats %s coercion failures as NaN', ([_label, value]) => {
+    expect(formatNumericWidgetValue(value)).toBe('NaN')
   })
 })
 

--- a/src/lib/litegraph/src/utils/widget.ts
+++ b/src/lib/litegraph/src/utils/widget.ts
@@ -18,6 +18,28 @@ export function getWidgetStep(options: IWidgetOptions<unknown>): number {
   return options.step2 || (options.step || 10) * 0.1
 }
 
+/**
+ * Coerces a numeric widget value for legacy canvas rendering.
+ *
+ * Persisted workflows and extension-provided widgets can contain values that do
+ * not match the current numeric widget type. Keep coercion at this runtime
+ * boundary so an invalid value cannot throw and stop the canvas render loop.
+ */
+export function coerceNumericWidgetValue(value: unknown): number {
+  try {
+    return Number(value)
+  } catch {
+    return Number.NaN
+  }
+}
+
+export function formatNumericWidgetValue(
+  value: unknown,
+  precision = 3
+): string {
+  return coerceNumericWidgetValue(value).toFixed(precision)
+}
+
 export function evaluateInput(input: string): number | undefined {
   const result = evaluateMathExpression(input)
   if (result !== undefined) {

--- a/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
@@ -1,6 +1,7 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { IGradientSliderWidget } from '@/lib/litegraph/src/types/widgets'
+import { coerceNumericWidgetValue } from '@/lib/litegraph/src/utils/widget'
 
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -23,8 +24,9 @@ export class GradientSliderWidget
     ctx.fillStyle = this.background_color
     ctx.fillRect(margin, y, width - margin * 2, height)
 
+    const value = coerceNumericWidgetValue(this.value)
     const range = this.options.max - this.options.min
-    let nvalue = (this.value - this.options.min) / range
+    let nvalue = (value - this.options.min) / range
     nvalue = clamp(nvalue, 0, 1)
 
     ctx.fillStyle = '#678'
@@ -38,7 +40,7 @@ export class GradientSliderWidget
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = Number(this.value).toFixed(this.options.precision ?? 3)
+      const fixedValue = value.toFixed(this.options.precision ?? 3)
       ctx.fillText(
         `${this.label || this.name}  ${fixedValue}`,
         width * 0.5,

--- a/src/lib/litegraph/src/widgets/KnobWidget.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.ts
@@ -1,7 +1,10 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { IKnobWidget } from '@/lib/litegraph/src/types/widgets'
-import { getWidgetStep } from '@/lib/litegraph/src/utils/widget'
+import {
+  coerceNumericWidgetValue,
+  getWidgetStep
+} from '@/lib/litegraph/src/utils/widget'
 
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -113,8 +116,9 @@ export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
     ctx.stroke()
     ctx.closePath()
 
+    const value = coerceNumericWidgetValue(this.value)
     const range = this.options.max - this.options.min
-    let nvalue = (this.value - this.options.min) / range
+    let nvalue = (value - this.options.min) / range
     nvalue = clamp(nvalue, 0, 1)
 
     // Draw value
@@ -169,7 +173,7 @@ export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = Number(this.value).toFixed(this.options.precision ?? 3)
+      const fixedValue = value.toFixed(this.options.precision ?? 3)
       ctx.fillText(
         `${this.label || this.name}\n${fixedValue}`,
         width * 0.5,
@@ -227,8 +231,10 @@ export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
         : step
 
     const deltaValue = adjustment * step_with_shift_modifier
+    const currentValue = coerceNumericWidgetValue(this.value)
     const newValue = clamp(
-      this.value + deltaValue,
+      (Number.isNaN(currentValue) ? this.options.min : currentValue) +
+        deltaValue,
       this.options.min,
       this.options.max
     )

--- a/src/lib/litegraph/src/widgets/NumberWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { NumberWidget } from '@/lib/litegraph/src/widgets/NumberWidget'
+
+function createWidget(): { node: LGraphNode; widget: NumberWidget } {
+  const node = new LGraphNode('TestNode')
+  const widget = new NumberWidget(
+    {
+      type: 'number',
+      name: 'test',
+      value: 1,
+      options: { precision: 3 },
+      y: 0
+    },
+    node
+  )
+  node.addCustomWidget(widget)
+  return { node, widget }
+}
+
+function persistedNode(value: TWidgetValue): ISerialisedNode {
+  return {
+    id: 1,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    widgets_values: [value]
+  }
+}
+
+describe('NumberWidget', () => {
+  describe('_displayValue', () => {
+    it.for<[TWidgetValue, string]>([
+      ['both', 'NaN'],
+      [true, '1.000'],
+      ['', '0.000']
+    ])(
+      'coerces persisted non-number value %j before formatting without mutating it',
+      ([value, expected]) => {
+        const { node, widget } = createWidget()
+        node.configure(persistedNode(value))
+
+        expect(widget._displayValue).toBe(expected)
+        expect(widget.value).toBe(value)
+      }
+    )
+
+    it('preserves numeric formatting', () => {
+      const { widget } = createWidget()
+
+      expect(widget._displayValue).toBe('1.000')
+      expect(widget.value).toBe(1)
+    })
+  })
+})

--- a/src/lib/litegraph/src/widgets/NumberWidget.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.ts
@@ -1,5 +1,9 @@
 import type { INumericWidget } from '@/lib/litegraph/src/types/widgets'
-import { evaluateInput, getWidgetStep } from '@/lib/litegraph/src/utils/widget'
+import {
+  evaluateInput,
+  formatNumericWidgetValue,
+  getWidgetStep
+} from '@/lib/litegraph/src/utils/widget'
 
 import { BaseSteppedWidget } from './BaseSteppedWidget'
 import type { WidgetEventOptions } from './BaseWidget'
@@ -12,7 +16,8 @@ export class NumberWidget
 
   override get _displayValue() {
     if (this.computedDisabled) return ''
-    return Number(this.value).toFixed(
+    return formatNumericWidgetValue(
+      this.value,
       this.options.precision !== undefined ? this.options.precision : 3
     )
   }

--- a/src/lib/litegraph/src/widgets/NumericWidgetRendering.test.ts
+++ b/src/lib/litegraph/src/widgets/NumericWidgetRendering.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type {
+  IBaseWidget,
+  TWidgetValue
+} from '@/lib/litegraph/src/types/widgets'
+import { GradientSliderWidget } from '@/lib/litegraph/src/widgets/GradientSliderWidget'
+import { KnobWidget } from '@/lib/litegraph/src/widgets/KnobWidget'
+import { SliderWidget } from '@/lib/litegraph/src/widgets/SliderWidget'
+import {
+  createMockCanvas,
+  createMockCanvasPointerEvent,
+  createMockCanvasRenderingContext2D
+} from '@/utils/__tests__/litegraphTestUtils'
+
+function createKnob(node: LGraphNode) {
+  return new KnobWidget(
+    {
+      type: 'knob',
+      name: 'test',
+      value: 1,
+      options: { min: 0, max: 10, step2: 1 },
+      y: 0
+    },
+    node
+  )
+}
+
+function restoreWidgetValue(
+  node: LGraphNode,
+  widget: IBaseWidget,
+  value: TWidgetValue
+) {
+  node.addCustomWidget(widget)
+  node.configure({
+    id: 1,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    widgets_values: [value]
+  } satisfies ISerialisedNode)
+}
+
+const cases = [
+  {
+    name: 'slider',
+    create: (node: LGraphNode) =>
+      new SliderWidget(
+        {
+          type: 'slider',
+          name: 'test',
+          value: 1,
+          options: { min: 0, max: 10, step2: 1 },
+          y: 0
+        },
+        node
+      )
+  },
+  {
+    name: 'gradient slider',
+    create: (node: LGraphNode) =>
+      new GradientSliderWidget(
+        {
+          type: 'gradientslider',
+          name: 'test',
+          value: 1,
+          options: { min: 0, max: 10, step2: 1 },
+          y: 0
+        },
+        node
+      )
+  },
+  {
+    name: 'knob',
+    create: createKnob
+  }
+]
+
+const valueCases: [TWidgetValue, string][] = [
+  [Object.create(null), 'NaN'],
+  [null, '0.000']
+]
+
+describe('numeric widget rendering', () => {
+  it.for(cases)('$name tolerates malformed values', ({ create }) => {
+    for (const [value, expected] of valueCases) {
+      const node = new LGraphNode('TestNode')
+      const widget = create(node)
+      restoreWidgetValue(node, widget, value)
+
+      const gradient = { addColorStop: vi.fn() }
+      const ctx = createMockCanvasRenderingContext2D({
+        createRadialGradient: vi.fn(() => gradient),
+        createConicGradient: vi.fn(() => gradient)
+      })
+
+      expect(() => widget.drawWidget(ctx, { width: 200 })).not.toThrow()
+      expect(ctx.fillText).toHaveBeenCalledWith(
+        expect.stringContaining(expected),
+        expect.any(Number),
+        expect.any(Number)
+      )
+    }
+  })
+
+  it('recovers from a malformed knob value when dragged', () => {
+    const node = new LGraphNode('TestNode')
+    const widget = createKnob(node)
+    restoreWidgetValue(node, widget, Object.create(null))
+
+    expect(() =>
+      widget.onDrag({
+        e: createMockCanvasPointerEvent(0, 0, {
+          movementX: 16,
+          movementY: 0,
+          shiftKey: false
+        }),
+        node,
+        canvas: createMockCanvas()
+      })
+    ).not.toThrow()
+    expect(widget.value).toBe(1)
+  })
+})

--- a/src/lib/litegraph/src/widgets/SliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.ts
@@ -1,6 +1,7 @@
 import { clamp } from 'es-toolkit/compat'
 
 import type { ISliderWidget } from '@/lib/litegraph/src/types/widgets'
+import { coerceNumericWidgetValue } from '@/lib/litegraph/src/utils/widget'
 
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -33,8 +34,9 @@ export class SliderWidget
     ctx.fillRect(margin, y, width - margin * 2, height)
 
     // Calculate normalized value
+    const value = coerceNumericWidgetValue(this.value)
     const range = this.options.max - this.options.min
-    let nvalue = (this.value - this.options.min) / range
+    let nvalue = (value - this.options.min) / range
     nvalue = clamp(nvalue, 0, 1)
 
     // Draw slider bar
@@ -59,7 +61,7 @@ export class SliderWidget
     if (showText) {
       ctx.textAlign = 'center'
       ctx.fillStyle = this.text_color
-      const fixedValue = Number(this.value).toFixed(this.options.precision ?? 3)
+      const fixedValue = value.toFixed(this.options.precision ?? 3)
       ctx.fillText(
         `${this.label || this.name}  ${fixedValue}`,
         width * 0.5,


### PR DESCRIPTION
Manual backport of https://github.com/Comfy-Org/ComfyUI_frontend/pull/17099 to `cloud/1.53`. The backport workflow did not open one for this branch.

<details><summary>Full context for agent readers</summary>

- Source: merge commit https://github.com/Comfy-Org/ComfyUI_frontend/commit/242d9a60a89fba220c8cecf7b1c464b56c79bac1 (fix: preserve legacy numeric widget rendering), cherry-picked onto `origin/cloud/1.53`. 8 files, +247/−10, widget sources identical to upstream.
- The one-line `e.deltaX ?? 0` difference in NumberWidget.ts relative to main is a pre-existing branch delta on 1.53, not part of this change.
- Verified on the branch: `pnpm install --frozen-lockfile` clean; vitest for NumericWidgetRendering, NumberWidget and utils/widget: 33/33 pass; `pnpm typecheck` clean.
- Sibling backport for the other 1.53 branch opened alongside this one.

<!-- authored-by:agent w3-520-ingest -->
</details>
