### PR TITLE
fix(website): prepare canonical metadata for shared localized pages

### DIFF
--- a/apps/website/src/config/indexing.test.ts
+++ b/apps/website/src/config/indexing.test.ts
@@ -57,3 +57,94 @@ describe('indexing policy', () => {
     ).toBe(true)
   })
 })
+
+describe('localized pages the site is not ready to expose', () => {
+  /**
+   * Astro's i18n fallback builds a page for EVERY route in a fallback locale,
+   * so /ja/ went from one page to 560 the moment it was enabled. The pages
+   * themselves behave: they canonical to English and leave ja out of their
+   * hreflang cluster. The sitemap did not, because it knew nothing about
+   * INDEXABLE_PAGES, and listed 43 Japanese URLs the site does not advertise.
+   *
+   * A sitemap disagreeing with a page's own tags is the defect Phase 0 fixed.
+   * One predicate, every surface.
+   */
+  it('keeps a fallback page out of the sitemap', () => {
+    expect(isExcludedFromSitemap('https://comfy.org/ja/pricing/')).toBe(true)
+    expect(isExcludedFromSitemap('https://comfy.org/ja/cli/')).toBe(true)
+  })
+
+  it('keeps the one Japanese page that IS ready', () => {
+    expect(isExcludedFromSitemap('https://comfy.org/ja/')).toBe(false)
+  })
+
+  it('leaves Chinese alone, since it is complete', () => {
+    expect(isExcludedFromSitemap('https://comfy.org/zh-CN/pricing/')).toBe(
+      false
+    )
+  })
+
+  it('leaves English alone', () => {
+    expect(isExcludedFromSitemap('https://comfy.org/pricing/')).toBe(false)
+  })
+})
+
+describe('localized copies of English-only routes', () => {
+  /**
+   * P3-9 gives Chinese a fallback so its 47 page files can be deleted. Astro's
+   * fallback is per-locale with no route granularity, so it also mints Chinese
+   * URLs for the 401 routes that are deliberately English-only — the model
+   * catalogue, Enterprise, the legal documents. Chinese is marked 'all' in
+   * INDEXABLE_PAGES, so without this they would enter the sitemap the moment
+   * they exist, advertising Chinese pages that are English content.
+   *
+   * hreflang already refuses to cluster them. This is the same answer on the
+   * sitemap surface.
+   */
+  it.for([
+    'https://comfy.org/zh-CN/p/supported-models/grok-imagine/',
+    'https://comfy.org/zh-CN/enterprise/',
+    'https://comfy.org/zh-CN/enterprise-msa/',
+    'https://comfy.org/zh-CN/pixal3d-trellis2/',
+    'https://comfy.org/ja/p/supported-models/grok-imagine/'
+  ])('keeps %s out of the sitemap', (url) => {
+    expect(isExcludedFromSitemap(url)).toBe(true)
+  })
+
+  it('still lists the English original', () => {
+    expect(
+      isExcludedFromSitemap(
+        'https://comfy.org/p/supported-models/grok-imagine/'
+      )
+    ).toBe(false)
+    expect(isExcludedFromSitemap('https://comfy.org/enterprise/')).toBe(false)
+  })
+
+  it('still lists a Chinese page that is genuinely served', () => {
+    expect(isExcludedFromSitemap('https://comfy.org/zh-CN/pricing/')).toBe(
+      false
+    )
+  })
+})
+
+describe('the not-found page, in every locale', () => {
+  /**
+   * Astro keeps /404 out of the sitemap itself, but only the exact route. Once
+   * Chinese gained a fallback, /zh-CN/404 was generated and sailed past both
+   * guards: Astro did not recognise it, and Chinese is 'all' in
+   * INDEXABLE_PAGES. Japanese never hit this because its allowlist holds
+   * everything back.
+   */
+  it.for(['https://comfy.org/zh-CN/404/', 'https://comfy.org/ja/404/'])(
+    'keeps %s out of the sitemap',
+    (url) => {
+      expect(isExcludedFromSitemap(url)).toBe(true)
+    }
+  )
+
+  it('leaves the English 404 to Astro, which already omits it', () => {
+    // This predicate also decides which pages get a markdown twin. Excluding
+    // the English 404 here would delete /404.md as a side effect.
+    expect(isExcludedFromSitemap('https://comfy.org/404/')).toBe(false)
+  })
+})

--- a/apps/website/src/config/indexing.ts
+++ b/apps/website/src/config/indexing.ts
@@ -1,10 +1,26 @@
-import { LOCALE_CODES, localePrefix } from './locales'
+import {
+  DEFAULT_LOCALE,
+  LOCALE_CODES,
+  isPageIndexable,
+  localePrefix
+} from './locales'
+import type { Locale } from './locales'
+import { isLocaleInvariantPath } from './routes'
 import { models } from './models'
 import { isWorkshopInBuild, isWorkshopRoute } from './workshop-release'
 
 const PAYMENT_STATUSES = ['success', 'failed'] as const
 const PLACEHOLDER_PATHNAMES = ['/case-studies', '/videos', '/demos'] as const
 
+/**
+ * Every locale's prefix, the default's empty one included.
+ *
+ * This list used to be declared here and named only `en` and `zh-CN`, so it
+ * never learned about Japanese. Nothing broke while `/ja/` was a single page,
+ * but the noindex set below is built from it: the moment P3 generates
+ * `/ja/privacy-policy` and the rest, they would have been indexable. Deriving
+ * it from `LOCALES` is what makes that impossible to forget again.
+ */
 const LOCALE_PREFIXES = LOCALE_CODES.map(localePrefix)
 
 const NOINDEX_PATHNAMES = new Set([
@@ -39,11 +55,62 @@ export function isNoindexPathname(pathname: string): boolean {
   return NOINDEX_PATHNAMES.has(normalizePathname(pathname))
 }
 
+/**
+ * The locale a URL belongs to, and the English route underneath it.
+ *
+ * `/ja/pricing` -> `ja`, `/pricing`. Matched on a whole path segment, so a route
+ * that merely starts with a locale's letters is not mistaken for that locale.
+ */
+function splitLocale(pathname: string): { locale: Locale; route: string } {
+  for (const locale of LOCALE_CODES) {
+    if (locale === DEFAULT_LOCALE) continue
+    const prefix = localePrefix(locale)
+    if (pathname === prefix) return { locale, route: '/' }
+    if (pathname.startsWith(`${prefix}/`)) {
+      return { locale, route: pathname.slice(prefix.length) }
+    }
+  }
+  return { locale: DEFAULT_LOCALE, route: pathname }
+}
+
 export function isExcludedFromSitemap(page: string): boolean {
   const pathname = normalizePathname(new URL(page).pathname)
-  return (
+  if (
     isNoindexPathname(pathname) ||
     MODEL_REDIRECT_PATHNAMES.has(pathname) ||
     (!isWorkshopInBuild() && isWorkshopRoute(pathname))
-  )
+  ) {
+    return true
+  }
+
+  // Astro's i18n fallback builds a page for every route in a fallback locale,
+  // so /ja/ became 560 pages the moment it was enabled. Those pages already
+  // canonical to English and leave themselves out of their own hreflang
+  // cluster; without this the sitemap advertised them anyway. `isPageIndexable`
+  // is the same predicate the hreflang emitter reads, so the two cannot
+  // disagree — which is the defect Phase 0 existed to fix.
+  const { locale, route } = splitLocale(pathname)
+  const englishRoute = route === '' ? '/' : route
+
+  // Astro keeps /404 out of the sitemap itself, but only the exact route. The
+  // i18n fallback generates /zh-CN/404 and /ja/404 too, and the Chinese one
+  // sailed past both guards: Astro did not recognise it and Chinese is 'all'
+  // in INDEXABLE_PAGES.
+  //
+  // Localized copies only. English /404 is Astro's to handle, and this predicate
+  // also decides which pages get a markdown twin — excluding it here would
+  // silently delete /404.md, which `markdown-twin.test.ts` pins.
+  if (locale !== DEFAULT_LOCALE && englishRoute === '/404') return true
+
+  // A locale-invariant route exists once, in English. Astro's fallback is
+  // per-locale with no route granularity, so giving Chinese a fallback in P3-9
+  // also mints /zh-CN/p/supported-models/* and the rest; Chinese is 'all' in
+  // INDEXABLE_PAGES, so without this they would enter the sitemap and advertise
+  // Chinese pages that are English content. hreflang already refuses to cluster
+  // them — this is the same answer on this surface.
+  if (locale !== DEFAULT_LOCALE && isLocaleInvariantPath(englishRoute)) {
+    return true
+  }
+
+  return !isPageIndexable(locale, englishRoute)
 }

--- a/apps/website/src/config/llms-txt.test.ts
+++ b/apps/website/src/config/llms-txt.test.ts
@@ -11,7 +11,7 @@ import {
   parseLlmsTxtLinks
 } from '../lib/llms-txt'
 import { isNoindexPathname } from './indexing'
-import { LOCALE_PREFIXES, LOCALIZED_CODES, localePrefix } from './locales'
+import { LOCALE_PREFIXES } from './locales'
 import { getRoutes } from './routes'
 
 const websiteRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -149,10 +149,7 @@ describe('llms.txt', () => {
    * llms.txt as pointing at nothing.
    */
   const byLocalePrefix = new Map(
-    LOCALIZED_CODES.map((code) => [
-      localePrefix(code),
-      { static: staticPages, dynamic }
-    ])
+    LOCALE_PREFIXES.map((prefix) => [prefix, { static: staticPages, dynamic }])
   )
 
   it('follows the llms.txt shape: one H1, a summary blockquote, Optional last', () => {

--- a/apps/website/src/config/llms-txt.test.ts
+++ b/apps/website/src/config/llms-txt.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
@@ -11,6 +11,7 @@ import {
   parseLlmsTxtLinks
 } from '../lib/llms-txt'
 import { isNoindexPathname } from './indexing'
+import { LOCALE_PREFIXES, LOCALIZED_CODES, localePrefix } from './locales'
 import { getRoutes } from './routes'
 
 const websiteRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -94,6 +95,11 @@ function pageMatchers(root: string): {
 } {
   const staticPages = new Set<string>()
   const dynamic: RegExp[] = []
+  // A locale can be registered in LOCALES before its pages are generated, which
+  // is the normal state between adding a language and building its shells. That
+  // is not this test's complaint to make: return no routes so the assertions
+  // below report the real problem instead of an ENOENT stack.
+  if (!existsSync(root)) return { static: staticPages, dynamic }
   const entries = readdirSync(root, { recursive: true, withFileTypes: true })
   for (const entry of entries) {
     if (!entry.isFile() || !/\.(astro|ts)$/.test(entry.name)) continue
@@ -103,7 +109,14 @@ function pageMatchers(root: string): {
       .split(sep)
       .join('/')
       .replace(/\.(astro|ts)$/, '')
-    if (root === pagesDir && relative.startsWith('/zh-CN/')) continue
+    // Skip every locale directory, not just Chinese. Naming only /zh-CN/ here
+    // meant /ja counted as an English page, which is why the ja launch broke
+    // this file's coverage test.
+    if (
+      root === pagesDir &&
+      LOCALE_PREFIXES.some((prefix) => relative.startsWith(`${prefix}/`))
+    )
+      continue
     const route = relative.replace(/\/index$/, '') || '/'
     if (route.includes('[')) {
       const pattern = route
@@ -126,7 +139,21 @@ describe('llms.txt', () => {
   const links = parseLlmsTxtLinks(llmsTxt)
   const internalPaths = internalLinks(links).map(({ path }) => path)
   const { static: staticPages, dynamic } = pageMatchers(pagesDir)
-  const zhCN = pageMatchers(join(pagesDir, 'zh-CN'))
+  /**
+   * One matcher per localized locale, keyed by its URL prefix.
+   *
+   * Every locale reuses the ENGLISH matchers. Localized pages have no files of
+   * their own since P3-9: Astro's i18n fallback serves /zh-CN/pricing from
+   * pricing.astro, so a localized path is served exactly when its English route
+   * is. Reading `src/pages/zh-CN/` instead reported all 20 Chinese links in
+   * llms.txt as pointing at nothing.
+   */
+  const byLocalePrefix = new Map(
+    LOCALIZED_CODES.map((code) => [
+      localePrefix(code),
+      { static: staticPages, dynamic }
+    ])
+  )
 
   it('follows the llms.txt shape: one H1, a summary blockquote, Optional last', () => {
     const lines = llmsTxt.split('\n')
@@ -159,11 +186,16 @@ describe('llms.txt', () => {
       if (path.includes('/workflows')) {
         return !WORKFLOW_APP_ROUTES.some((route) => route.test(path))
       }
-      if (path.startsWith('/zh-CN')) {
-        const base = normalizePath(path.slice('/zh-CN'.length))
+      const prefix = LOCALE_PREFIXES.find(
+        (candidate) => path === candidate || path.startsWith(`${candidate}/`)
+      )
+      if (prefix !== undefined) {
+        const matchers = byLocalePrefix.get(prefix)
+        if (matchers === undefined) return true
+        const base = normalizePath(path.slice(prefix.length))
         return (
-          !zhCN.static.has(base) &&
-          !zhCN.dynamic.some((matcher) => matcher.test(base))
+          !matchers.static.has(base) &&
+          !matchers.dynamic.some((matcher) => matcher.test(base))
         )
       }
       return (

--- a/apps/website/src/lib/hreflang.test.ts
+++ b/apps/website/src/lib/hreflang.test.ts
@@ -11,6 +11,7 @@ import { redirects } from '../config/redirects'
 import { routeOf } from '../utils/hreflangRoutes'
 import type { Alternate } from './hreflang'
 import {
+  canonicalPath,
   hreflangAlternates,
   ogLocale,
   ogLocaleAlternate,
@@ -286,5 +287,43 @@ describe('a page whose own locale is held back', () => {
         (a) => a.hreflang
       )
     ).toEqual(['en', 'zh-CN', 'x-default'])
+  })
+})
+
+describe('canonicalPath', () => {
+  /**
+   * THE most dangerous line in the localization work.
+   *
+   * Deleting the Chinese page files makes every /zh-CN/ URL a rewritten
+   * fallback render, and Astro reports the ENGLISH pathname during those. A
+   * canonical built from that pathname told Google the English page was the
+   * original for a fully translated Chinese page. Shipped across all 47 files
+   * it would have de-indexed the entire Chinese site.
+   *
+   * The canonical must follow whether the page is PUBLISHED in its locale, not
+   * whatever path Astro happens to report.
+   */
+  it('points a published Chinese page at itself', () => {
+    expect(canonicalPath('/pricing/', 'zh-CN')).toBe('/zh-CN/pricing/')
+  })
+
+  it('still points a published Chinese page at itself when Astro reports the localized path', () => {
+    expect(canonicalPath('/zh-CN/pricing/', 'zh-CN')).toBe('/zh-CN/pricing/')
+  })
+
+  it('points a held-back Japanese page at the English original', () => {
+    expect(canonicalPath('/pricing/', 'ja')).toBe('/pricing/')
+  })
+
+  it('points the published Japanese home page at itself', () => {
+    expect(canonicalPath('/ja/', 'ja')).toBe('/ja/')
+  })
+
+  it('points a Chinese copy of an English-only route at English', () => {
+    expect(canonicalPath('/enterprise/', 'zh-CN')).toBe('/enterprise/')
+  })
+
+  it('leaves English alone', () => {
+    expect(canonicalPath('/pricing/', 'en')).toBe('/pricing/')
   })
 })

--- a/apps/website/src/lib/hreflang.ts
+++ b/apps/website/src/lib/hreflang.ts
@@ -8,7 +8,7 @@ import {
   isLocale
 } from '../config/locales'
 import type { Locale } from '../config/locales'
-import { isLocaleInvariantPath } from '../config/routes'
+import { isLocaleInvariantPath, localizeHref } from '../config/routes'
 
 export interface Alternate {
   hreflang: Locale | 'x-default'
@@ -81,6 +81,30 @@ export function hreflangAlternates(
   }))
   alternates.push({ hreflang: 'x-default', href: enHref })
   return alternates
+}
+
+/**
+ * The canonical path for a page, given the locale it is rendering for.
+ *
+ * Cannot be taken from the pathname Astro reports. Once a locale is served by
+ * the i18n fallback, Astro reports the ENGLISH path during the render, so a
+ * canonical built from it declares the English page the original — correct for
+ * a held-back locale, catastrophic for a translated one. Chinese is fully
+ * translated, and deleting its page files turns every /zh-CN/ URL into a
+ * fallback render, so this decides whether the Chinese site keeps its identity
+ * in search.
+ *
+ * The rule is the same predicate everything else reads: a page published in its
+ * locale is its own original; one that is held back points at English.
+ */
+export function canonicalPath(pathname: string, pageLocale: Locale): string {
+  const en = englishPath(pathname)
+  const path = isPageIndexable(pageLocale, en)
+    ? localizeHref(en, pageLocale)
+    : en
+  // The site canonicalises with a trailing slash everywhere. Returning the bare
+  // path here would rewrite the canonical of all 1,291 pages.
+  return withSlash(trimSlash(path))
 }
 
 /** `xhtml:link` alternates for one sitemap entry, or nothing for English-only pages. */

--- a/apps/website/src/utils/jsonLd.test.ts
+++ b/apps/website/src/utils/jsonLd.test.ts
@@ -41,10 +41,35 @@ describe('pageContext', () => {
     expect(pageContext(site, '/about/', undefined)).toEqual({
       siteUrl,
       locale: 'en',
-      url: 'https://comfy.org/about/'
+      url: 'https://comfy.org/about/',
+      canonicalUrl: 'https://comfy.org/about/',
+      canonicalLocale: 'en'
     })
     expect(pageContext(site, '/zh-CN/', 'zh-CN').locale).toBe('zh-CN')
     expect(pageContext(site, '/ja/', 'ja').locale).toBe('ja')
+  })
+
+  /**
+   * `url` is where the reader actually is; `canonicalUrl` is what the page
+   * claims to be. They diverge exactly when a locale is served by the i18n
+   * fallback but held back from indexing — and getting that backwards would
+   * have told Google the English page is the original for every Chinese page.
+   */
+  it('keeps a published localized page as its own original', () => {
+    const context = pageContext(site, '/zh-CN/pricing/', 'zh-CN')
+
+    expect(context.url).toBe('https://comfy.org/zh-CN/pricing/')
+    expect(context.canonicalUrl).toBe('https://comfy.org/zh-CN/pricing/')
+    expect(context.canonicalLocale).toBe('zh-CN')
+  })
+
+  it('points a held-back page at the English original', () => {
+    // Japanese serves only `/`, so every other route is built but unpublished.
+    const context = pageContext(site, '/ja/pricing/', 'ja')
+
+    expect(context.url).toBe('https://comfy.org/ja/pricing/')
+    expect(context.canonicalUrl).toBe('https://comfy.org/pricing/')
+    expect(context.canonicalLocale).toBe('en')
   })
 })
 

--- a/apps/website/src/utils/jsonLd.ts
+++ b/apps/website/src/utils/jsonLd.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_LOCALE, isLocale, localePrefix } from '../config/locales'
+import type { Locale } from '../config/locales'
 import { externalLinks } from '../config/routes'
-import type { Locale } from '../i18n/translations'
+import { canonicalPath } from '../lib/hreflang'
 
 export type JsonLdNode = Record<string, unknown> & { '@type': string }
 
@@ -54,13 +56,42 @@ export function pageContext(
   site: URL | undefined,
   pathname: string,
   currentLocale: string | undefined
-): PageContext & { url: string } {
+): PageContext & {
+  url: string
+  canonicalUrl: string
+  canonicalLocale: Locale
+} {
+  const locale = isLocale(currentLocale) ? currentLocale : DEFAULT_LOCALE
   return {
     siteUrl: siteUrlFrom(site),
-    locale:
-      currentLocale === 'zh-CN' || currentLocale === 'ja'
-        ? currentLocale
-        : 'en',
+    /**
+     * The canonical URL, which is NOT always this page's own.
+     *
+     * A locale served by the i18n fallback but held back from indexing points
+     * its canonical at the English original. Structured-data ids have to follow
+     * that, or the graph describes a different page than the canonical claims.
+     * `url` stays the page's real address, which is what analytics needs.
+     */
+    canonicalUrl: absoluteUrl(site, canonicalPath(pathname, locale)),
+    /**
+     * The locale the canonical belongs to, which is English for a page held
+     * back from indexing.
+     *
+     * Breadcrumbs and other structured-data URLs follow this rather than the
+     * rendering locale: a held-back Japanese page canonicals to English, so a
+     * breadcrumb pointing at /ja/ would describe a different site section than
+     * the canonical claims the page belongs to.
+     */
+    canonicalLocale: canonicalPath(pathname, locale).startsWith(
+      `${localePrefix(locale)}/`
+    )
+      ? locale
+      : DEFAULT_LOCALE,
+    // Any locale this site serves, not a hardcoded pair. This is what BaseLayout
+    // calls to decide a page's locale, so an unrecognised value here made the
+    // page declare itself English in JSON-LD, in `<html lang>` and in the
+    // canonical. A new locale used to be unrecognised by default.
+    locale,
     url: absoluteUrl(site, pathname)
   }
 }


### PR DESCRIPTION
## Summary

Prepare canonical URLs and publication checks for rendering translated routes from shared page files.

Part 2/8 of native stack #17294, continuing #17129. Original implementation by Mobeen Abdullah, preserved with co-author attribution. Reconciled with main at 16f4d3a2be.

## Changes

- **What**: Canonical URL and locale helpers, sitemap exclusions for unpublished or English-only localized routes, and link-validation tests that recognize shared page implementations.

## Review Focus

Published translations keep their localized canonical URLs; held-back translations point to English and stay out of the sitemap. This adds the supporting helpers and checks; shared rendering is enabled later in #17208. Preserves the newer noindex and link-validation rules from main.

Validation: 105 focused tests; website build and hreflang audit; lint and root/website type checks.


Review feedback carried from #17205; this split does not resolve it:

- [apps/website/src/config/llms-txt.test.ts](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17205#discussion_r3963333619)
