### PR TITLE
fix(website): preserve localized Markdown output and text indexes

### DIFF
--- a/apps/website/src/integrations/markdown-twins.test.ts
+++ b/apps/website/src/integrations/markdown-twins.test.ts
@@ -1,0 +1,59 @@
+import type { AstroIntegrationLogger } from 'astro'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { expect, it, onTestFinished, vi } from 'vitest'
+
+import { markdownTwins } from './markdown-twins'
+
+it('preserves listed pages and discovers eligible localized pages after the build', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'markdown-build-'))
+  onTestFinished(() => rm(root, { recursive: true, force: true }))
+  const page = (title: string) =>
+    `<html><head><title>${title}</title></head><body><main><h1>${title}</h1></main></body></html>`
+  await mkdir(join(root, 'zh-CN', 'cli'), { recursive: true })
+  await mkdir(join(root, 'ja', 'cli'), { recursive: true })
+  await mkdir(join(root, 'redirect'), { recursive: true })
+  await mkdir(join(root, 'empty'))
+  await writeFile(join(root, 'index.html'), page('Home'))
+  await writeFile(join(root, '404.html'), page('Not found'))
+  await writeFile(join(root, 'zh-CN/cli/index.html'), page('Chinese CLI'))
+  await writeFile(join(root, 'ja/cli/index.html'), page('Unpublished CLI'))
+  await writeFile(
+    join(root, 'redirect/index.html'),
+    '<html><head><meta http-equiv="refresh" content="0;url=/"></head></html>'
+  )
+  const logger: AstroIntegrationLogger = {
+    label: 'test',
+    options: { level: 'silent', destination: { write: vi.fn() } },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    flush: vi.fn(),
+    close: vi.fn(),
+    fork() {
+      return this
+    }
+  }
+  const hook = markdownTwins().hooks['astro:build:done']
+  if (!hook) throw new Error('Missing build hook')
+  await hook({
+    dir: pathToFileURL(`${root}/`),
+    pages: [{ pathname: '' }, { pathname: '404' }],
+    assets: new Map(),
+    logger
+  })
+
+  expect(await readFile(join(root, '404.md'), 'utf8')).toContain('# Not found')
+  expect(await readFile(join(root, 'zh-CN/cli.md'), 'utf8')).toContain(
+    '# Chinese CLI'
+  )
+  expect(existsSync(join(root, 'redirect.md'))).toBe(false)
+  expect(existsSync(join(root, 'ja/cli.md'))).toBe(false)
+  const fullText = await readFile(join(root, 'llms-full.txt'), 'utf8')
+  expect(fullText.match(/# Home/g)).toHaveLength(1)
+  expect(fullText).not.toContain('Chinese CLI')
+})

--- a/apps/website/src/integrations/markdown-twins.ts
+++ b/apps/website/src/integrations/markdown-twins.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegration } from 'astro'
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { access, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -103,6 +103,13 @@ export async function writeMarkdownTwins(
       report.skipped.push(twinPath)
       continue
     }
+    // A redirect stub is a meta-refresh, not content. Astro's own page list
+    // left these out; reading the built site off disk finds them, so they are
+    // filtered on what the page IS rather than on a config listing them.
+    if (html.includes('http-equiv="refresh"')) {
+      report.skipped.push(twinPath)
+      continue
+    }
     const page = htmlToTwin(html, new URL(route, site).href)
     await mkdir(dirname(target), { recursive: true })
     await writeFile(target, renderTwin(page), 'utf8')
@@ -111,16 +118,42 @@ export async function writeMarkdownTwins(
   return report
 }
 
+/** Every built page, as Astro would have named it: `about/`, `zh-CN/pricing/`. */
+async function builtPages(root: string): Promise<string[]> {
+  const found: string[] = []
+
+  async function walk(dir: string, prefix: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        await walk(join(dir, entry.name), `${prefix}${entry.name}/`)
+      } else if (entry.name === 'index.html') {
+        found.push(prefix)
+      }
+    }
+  }
+
+  await walk(root, '')
+  return found.sort()
+}
+
 export function markdownTwins(): AstroIntegration {
   return {
     name: 'comfy:markdown-twins',
     hooks: {
-      'astro:build:done': async ({ dir, pages, logger }) => {
+      'astro:build:done': async ({ dir, logger }) => {
         const root = fileURLToPath(dir)
-        const report = await writeMarkdownTwins(
-          root,
-          pages.map((page) => page.pathname)
-        )
+        // Read the pages off DISK rather than from Astro's `pages` list.
+        //
+        // That list omits routes produced by the i18n fallback, which is every
+        // localized page once a locale is served from the English file. It cost
+        // Japanese all 560 of its twins without a word, and deleting the Chinese
+        // page files would have taken all 144 Chinese twins with them and shrunk
+        // llms-full.txt to match.
+        //
+        // `isExcludedFromSitemap` still decides what deserves a twin, so a
+        // held-back locale gains none: Japanese pages are built but unpublished,
+        // and a twin of an English page at a /ja/ URL is not content.
+        const report = await writeMarkdownTwins(root, await builtPages(root))
         // Section indexes and llms-full.txt need every twin that actually
         // exists on disk, not just the ones this build freshly wrote — a
         // twin a page endpoint already wrote (report.existing) is just as

--- a/apps/website/src/integrations/markdown-twins.ts
+++ b/apps/website/src/integrations/markdown-twins.ts
@@ -140,20 +140,15 @@ export function markdownTwins(): AstroIntegration {
   return {
     name: 'comfy:markdown-twins',
     hooks: {
-      'astro:build:done': async ({ dir, logger }) => {
+      'astro:build:done': async ({ dir, pages, logger }) => {
         const root = fileURLToPath(dir)
-        // Read the pages off DISK rather than from Astro's `pages` list.
-        //
-        // That list omits routes produced by the i18n fallback, which is every
-        // localized page once a locale is served from the English file. It cost
-        // Japanese all 560 of its twins without a word, and deleting the Chinese
-        // page files would have taken all 144 Chinese twins with them and shrunk
-        // llms-full.txt to match.
-        //
-        // `isExcludedFromSitemap` still decides what deserves a twin, so a
-        // held-back locale gains none: Japanese pages are built but unpublished,
-        // and a twin of an English page at a /ja/ URL is not content.
-        const report = await writeMarkdownTwins(root, await builtPages(root))
+        const pathnames = [
+          ...new Set([
+            ...pages.map((page) => page.pathname),
+            ...(await builtPages(root))
+          ])
+        ]
+        const report = await writeMarkdownTwins(root, pathnames)
         // Section indexes and llms-full.txt need every twin that actually
         // exists on disk, not just the ones this build freshly wrote — a
         // twin a page endpoint already wrote (report.existing) is just as

--- a/apps/website/src/lib/section-index.test.ts
+++ b/apps/website/src/lib/section-index.test.ts
@@ -18,6 +18,7 @@ async function seed() {
   const root = await mkdtemp(join(tmpdir(), 'index-'))
   await mkdir(join(root, 'learning', 'vfx'), { recursive: true })
   await mkdir(join(root, 'zh-CN'), { recursive: true })
+  await mkdir(join(root, 'ja'), { recursive: true })
   await writeFile(
     join(root, 'index.md'),
     twin('Comfy', 'Home.', '# Comfy\n\nHome body.', 'https://comfy.org/')
@@ -44,6 +45,20 @@ async function seed() {
     join(root, 'zh-CN', 'cli.md'),
     twin('Comfy CLI 中文', 'CLI.', '# CLI 中文')
   )
+  await writeFile(
+    join(root, 'ja', 'cli.md'),
+    twin('Comfy CLI 日本語', 'CLI.', '# CLI 日本語')
+  )
+  // A locale's HOME page twin is `/zh-CN.md`, not `/zh-CN/index.md`, so it does
+  // not sit under the locale directory and a prefix+slash test never sees it.
+  await writeFile(
+    join(root, 'zh-CN.md'),
+    twin('Comfy 首页', 'Home.', '# Comfy 首页')
+  )
+  await writeFile(
+    join(root, 'ja.md'),
+    twin('Comfy ホーム', 'Home.', '# Comfy ホーム')
+  )
   await writeFile(join(root, '404.md'), twin('Not found', '', '# 404'))
   return root
 }
@@ -55,6 +70,9 @@ const twins = [
   '/learning/vfx/sky-replacement.md',
   '/cli.md',
   '/zh-CN/cli.md',
+  '/ja/cli.md',
+  '/zh-CN.md',
+  '/ja.md',
   '/404.md'
 ]
 
@@ -98,6 +116,13 @@ describe('writeFullText', () => {
     expect(full).toContain('# Comfy\n\n> Home.\n\nHome body.')
     expect(full).toContain('# Sky Replacement\n\nSteps.')
     expect(full).not.toContain('CLI 中文')
+    // Every locale, not just Chinese. The filter named only /zh-CN/, so once
+    // /ja/ existed its pages leaked into what is meant to be the English corpus.
+    expect(full).not.toContain('CLI 日本語')
+    // And every locale's HOME page, whose twin is /zh-CN.md rather than
+    // /zh-CN/index.md. Both of these were shipping inside llms-full.txt.
+    expect(full).not.toContain('Comfy 首页')
+    expect(full).not.toContain('Comfy ホーム')
     expect(full).not.toContain('# 404')
   })
 

--- a/apps/website/src/lib/section-index.ts
+++ b/apps/website/src/lib/section-index.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
+import { LOCALE_PREFIXES } from '../config/locales'
+
 const SITE_INDEX_URL = 'https://comfy.org/llms.txt'
 
 export interface SectionSpec {
@@ -130,7 +132,15 @@ export async function writeFullText(
   const english = twinPaths
     .filter(
       (path) =>
-        !path.startsWith('/zh-CN/') &&
+        // Every locale, via the same `belongsTo` the section indexes use, which
+        // already knows a prefix owns both `/zh-CN.md` and `/zh-CN/...`.
+        //
+        // This was a literal `!path.startsWith('/zh-CN/')`, which missed two
+        // things: every Japanese page once /ja/ existed, and BOTH locales' home
+        // pages in every build before that, since a locale home's twin is
+        // `/zh-CN.md` rather than `/zh-CN/index.md`. All of them were being
+        // concatenated into what is meant to be the English corpus.
+        !LOCALE_PREFIXES.some((prefix) => belongsTo(path, prefix)) &&
         path !== '/404.md' &&
         path !== '/p/supported-models.md' &&
         !path.startsWith('/p/supported-models/')


### PR DESCRIPTION
## Summary

Keep generated Markdown available when localized pages come from shared templates, and prevent translated pages from entering the English full-text index.

Part 3/8 of native stack #17294, continuing #17129. Original implementation by Mobeen Abdullah, preserved with co-author attribution. Reconciled with main at 16f4d3a2be.

## Changes

- **What**: Discover built HTML recursively, skip redirect stubs, and exclude every localized prefix and localized homepage from the English text index.

## Review Focus

Filesystem discovery must retain the existing Markdown output while respecting publication exclusions. The page-rendering migration remains in #17208.

Validation: 26 focused tests; root and website type checks; lint/format hooks; Knip. The regression test runs the real build-completion hook against generated files, covering flat HTML, discovered localized pages, redirects, and publication exclusions. A browser test cannot isolate pages omitted from Astro’s build metadata.
