### PR TITLE
ci: unblock website content PRs from screenshot diffs and blanket R2 risk

### DIFF
--- a/.github/risk.json
+++ b/.github/risk.json
@@ -234,8 +234,44 @@
     {
       "class": "website",
       "tier": "R2",
-      "why": "the marketing site is production and had no rule at all \u2014 but it is copy and layout, so it cannot corrupt a saved workflow or move money",
-      "paths": ["apps/website/**"]
+      "why": "the marketing site is production and had no rule at all \u2014 but it is copy and layout, so it cannot corrupt a saved workflow or move money. Excludes src/content/** and src/i18n/** (see the website-content class): grading is worst(...)-over-matches with no negation, so those paths must be carved out here rather than merely added elsewhere, or this rule's R2 would still win.",
+      "paths": [
+        "apps/website/README.md",
+        "apps/website/astro.config.ts",
+        "apps/website/components.json",
+        "apps/website/design/**",
+        "apps/website/e2e/**",
+        "apps/website/package.json",
+        "apps/website/playwright.config.ts",
+        "apps/website/public/**",
+        "apps/website/scripts/**",
+        "apps/website/tsconfig.json",
+        "apps/website/tsconfig.stories.json",
+        "apps/website/vercel.json",
+        "apps/website/vitest.config.ts",
+        "apps/website/src/assets/**",
+        "apps/website/src/components/**",
+        "apps/website/src/composables/**",
+        "apps/website/src/config/**",
+        "apps/website/src/content.config.ts",
+        "apps/website/src/data/**",
+        "apps/website/src/env.d.ts",
+        "apps/website/src/integrations/**",
+        "apps/website/src/layouts/**",
+        "apps/website/src/lib/**",
+        "apps/website/src/pages/**",
+        "apps/website/src/scripts/**",
+        "apps/website/src/styles/**",
+        "apps/website/src/templates/**",
+        "apps/website/src/test/**",
+        "apps/website/src/utils/**"
+      ]
+    },
+    {
+      "class": "website-content",
+      "tier": "R1",
+      "why": "Astro content collections and translation copy under apps/website ship to users but are schema-validated prose/data \u2014 they cannot corrupt a saved workflow, move money, or change build/routing behaviour the way the rest of the website tree can",
+      "paths": ["apps/website/src/content/**", "apps/website/src/i18n/**"]
     },
     {
       "class": "docs",

--- a/.github/risk.json
+++ b/.github/risk.json
@@ -234,45 +234,8 @@
     {
       "class": "website",
       "tier": "R2",
-      "why": "the marketing site is production and had no rule at all \u2014 but it is copy and layout, so it cannot corrupt a saved workflow or move money. Excludes src/content/** and src/i18n/** (see the website-content class): grading is worst(...)-over-matches with no negation, so those paths must be carved out here rather than merely added elsewhere, or this rule's R2 would still win.",
-      "paths": [
-        "apps/website/README.md",
-        "apps/website/.gitignore",
-        "apps/website/astro.config.ts",
-        "apps/website/components.json",
-        "apps/website/design/**",
-        "apps/website/e2e/**",
-        "apps/website/package.json",
-        "apps/website/playwright.config.ts",
-        "apps/website/public/**",
-        "apps/website/scripts/**",
-        "apps/website/tsconfig.json",
-        "apps/website/tsconfig.stories.json",
-        "apps/website/vercel.json",
-        "apps/website/vitest.config.ts",
-        "apps/website/src/assets/**",
-        "apps/website/src/components/**",
-        "apps/website/src/composables/**",
-        "apps/website/src/config/**",
-        "apps/website/src/content.config.ts",
-        "apps/website/src/data/**",
-        "apps/website/src/env.d.ts",
-        "apps/website/src/integrations/**",
-        "apps/website/src/layouts/**",
-        "apps/website/src/lib/**",
-        "apps/website/src/pages/**",
-        "apps/website/src/scripts/**",
-        "apps/website/src/styles/**",
-        "apps/website/src/templates/**",
-        "apps/website/src/test/**",
-        "apps/website/src/utils/**"
-      ]
-    },
-    {
-      "class": "website-content",
-      "tier": "R1",
-      "why": "Astro content collections and translation copy under apps/website ship to users but are schema-validated prose/data \u2014 they cannot corrupt a saved workflow, move money, or change build/routing behaviour the way the rest of the website tree can",
-      "paths": ["apps/website/src/content/**", "apps/website/src/i18n/**"]
+      "why": "the marketing site is production and had no rule at all \u2014 but it is copy and layout, so it cannot corrupt a saved workflow or move money. A prior attempt to carve out a lower R1 tier for apps/website/src/content/** and src/i18n/** swept in real code (Zod schemas, i18n resolver logic), and the grader has no exclusion syntax to express that split safely against this blanket rule regardless \u2014 reverted pending a properly scoped follow-up.",
+      "paths": ["apps/website/**"]
     },
     {
       "class": "docs",

--- a/.github/risk.json
+++ b/.github/risk.json
@@ -237,6 +237,7 @@
       "why": "the marketing site is production and had no rule at all \u2014 but it is copy and layout, so it cannot corrupt a saved workflow or move money. Excludes src/content/** and src/i18n/** (see the website-content class): grading is worst(...)-over-matches with no negation, so those paths must be carved out here rather than merely added elsewhere, or this rule's R2 would still win.",
       "paths": [
         "apps/website/README.md",
+        "apps/website/.gitignore",
         "apps/website/astro.config.ts",
         "apps/website/components.json",
         "apps/website/design/**",

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -66,6 +66,9 @@ jobs:
       # server instead of failing to bind an already-occupied port.
       - name: Run e2e tests
         id: e2e
+        # This container's default run-block shell is sh, not bash — the
+        # /dev/tcp readiness probe below is a bash-ism.
+        shell: bash
         run: |
           set +e
           pnpm --filter @comfyorg/website preview &
@@ -128,6 +131,7 @@ jobs:
           ${{
             always() &&
             !cancelled() &&
+            (steps.e2e.outputs.visual-outcome == 'success' || steps.e2e.outputs.visual-outcome == 'failure') &&
             (
               github.event_name != 'pull_request' ||
               github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -34,25 +34,13 @@ jobs:
     permissions:
       contents: read
     outputs:
-      functional-outcome: ${{ steps.functional.outcome }}
-      visual-outcome: ${{ steps.visual.outcome }}
-      screenshots-updated: ${{ steps.commit-screenshots.outputs.has-changes }}
+      functional-outcome: ${{ steps.e2e.outputs.functional-outcome }}
+      visual-outcome: ${{ steps.e2e.outputs.visual-outcome }}
       report-url: ${{ steps.deploy.outputs.url }}
       # Evaluated at job level (not from a step) — static expression.
       is-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
     steps:
       - uses: actions/checkout@v7
-        with:
-          # The PR's actual branch tip, not GitHub's synthetic merge commit —
-          # so a later auto-update push (below) lands on the ref we just
-          # built and tested, not a ref that doesn't otherwise exist.
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-          token: >-
-            ${{
-              (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
-              && secrets.PR_GH_TOKEN
-              || secrets.GITHUB_TOKEN
-            }}
 
       - name: Install pnpm
         run: corepack enable && corepack prepare
@@ -68,17 +56,56 @@ jobs:
           PUBLIC_CUSTOMERIO_WRITE_KEY: test-e2e-write-key
         run: pnpm --filter @comfyorg/website build
 
-      # Functional and visual run as separate Playwright invocations (not one
-      # combined run classified after the fact) so "did this block merge"
-      # reduces to plain step pass/fail — no per-test error-message parsing
-      # that can misclassify a real failure as screenshot-only.
-      - name: Run functional e2e tests
-        id: functional
-        run: pnpm --filter @comfyorg/website test:e2e:functional
+      # Functional and visual run as separate Playwright invocations, in one
+      # script, so "did this block merge" reduces to a plain exit code with
+      # no per-test error-message parsing that can misclassify a real
+      # failure as screenshot-only. Both share ONE preview server we start
+      # and poll for ourselves — playwright.config.ts's webServer only skips
+      # spawning its own when PLAYWRIGHT_REUSE_SERVER=1, which is what lets
+      # a second `playwright test` invocation attach to the first one's
+      # server instead of failing to bind an already-occupied port.
+      - name: Run e2e tests
+        id: e2e
+        run: |
+          set +e
+          pnpm --filter @comfyorg/website preview &
+          PREVIEW_PID=$!
 
-      - name: Run visual e2e tests
-        id: visual
-        run: pnpm --filter @comfyorg/website test:visual
+          READY=0
+          for i in $(seq 1 30); do
+            (echo > /dev/tcp/127.0.0.1/4321) >/dev/null 2>&1 && { READY=1; break; }
+            sleep 1
+          done
+          if [ "$READY" -ne 1 ]; then
+            echo "::error::Preview server never became reachable on :4321"
+            echo "functional-outcome=failure" >> "$GITHUB_OUTPUT"
+            echo "visual-outcome=skipped" >> "$GITHUB_OUTPUT"
+            kill "$PREVIEW_PID" 2>/dev/null
+            exit 1
+          fi
+
+          PLAYWRIGHT_REUSE_SERVER=1 \
+          PLAYWRIGHT_HTML_REPORT=playwright-report/functional \
+          PLAYWRIGHT_JSON_OUTPUT_NAME=results-functional.json \
+            pnpm --filter @comfyorg/website test:e2e:functional
+          FUNCTIONAL_EXIT=$?
+          echo "functional-outcome=$([ "$FUNCTIONAL_EXIT" -eq 0 ] && echo success || echo failure)" >> "$GITHUB_OUTPUT"
+
+          if [ "$FUNCTIONAL_EXIT" -ne 0 ]; then
+            echo "visual-outcome=skipped" >> "$GITHUB_OUTPUT"
+            kill "$PREVIEW_PID" 2>/dev/null
+            exit 1
+          fi
+
+          PLAYWRIGHT_REUSE_SERVER=1 \
+          PLAYWRIGHT_HTML_REPORT=playwright-report/visual \
+          PLAYWRIGHT_JSON_OUTPUT_NAME=results-visual.json \
+            pnpm --filter @comfyorg/website test:visual
+          VISUAL_EXIT=$?
+          echo "visual-outcome=$([ "$VISUAL_EXIT" -eq 0 ] && echo success || echo failure)" >> "$GITHUB_OUTPUT"
+
+          kill "$PREVIEW_PID" 2>/dev/null
+          exit "$VISUAL_EXIT"
 
       - name: Upload test report
         uses: actions/upload-artifact@v6
@@ -87,10 +114,14 @@ jobs:
           name: website-playwright-report
           path: |
             apps/website/playwright-report/
-            apps/website/results.json
+            apps/website/results-functional.json
+            apps/website/results-visual.json
             apps/website/test-results/
           retention-days: 30
 
+      # Visual, not functional: it's the one a reviewer needs the interactive
+      # screenshot-diff viewer for. A functional failure is self-explanatory
+      # from the failed step's own log output.
       - name: Deploy report to Cloudflare
         id: deploy
         if: >-
@@ -111,7 +142,7 @@ jobs:
           DEPLOY_OK=false
           for i in 1 2 3; do
             echo "Deployment attempt $i of 3..."
-            OUTPUT=$(pnpx wrangler@^4.0.0 pages deploy apps/website/playwright-report \
+            OUTPUT=$(pnpx wrangler@^4.0.0 pages deploy apps/website/playwright-report/visual \
               --project-name=comfyui-website-e2e \
               --branch="$BRANCH" 2>&1) && { DEPLOY_OK=true; break; } || echo "$OUTPUT"
             [ $i -lt 3 ] && sleep 10
@@ -124,58 +155,17 @@ jobs:
           URL=$(echo "$OUTPUT" | grep -oE 'https://[a-zA-Z0-9.-]+\.pages\.dev\S*' | head -1)
           echo "url=${URL}" >> $GITHUB_OUTPUT
 
-      # Reached only when visual failed and functional did not (a functional
-      # failure already stopped the job above). Mirrors the safety property
-      # pr-update-website-screenshots.yaml already relies on: this commits
-      # only if regenerating screenshots itself completes cleanly, so a page
-      # that's actually broken (crash, nav error) can't get its broken state
-      # committed as the new "expected" baseline — it just fails here too,
-      # leaving the run blocking with nothing auto-pushed.
-      - name: Auto-update screenshots
-        id: auto-update
-        if: >-
-          ${{
-            failure() &&
-            steps.visual.conclusion == 'failure' &&
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.fork == false
-          }}
-        continue-on-error: true
-        run: pnpm --filter @comfyorg/website test:visual:update
-
-      - name: Commit and push updated screenshots
-        id: commit-screenshots
-        if: always() && steps.auto-update.outcome == 'success'
-        run: |
-          git config --global --add safe.directory "$(pwd)"
-          git config --global user.name 'github-actions'
-          git config --global user.email 'github-actions@github.com'
-
-          CHANGED=$(git status --porcelain=v1 --untracked-files=all -- apps/website/e2e/ | wc -l)
-          if [ "$CHANGED" -eq 0 ]; then
-            echo "No screenshot changes to commit"
-            echo "has-changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "has-changes=true" >> "$GITHUB_OUTPUT"
-          git add apps/website/e2e/
-          git commit -m "[automated] Update website screenshot expectations"
-          git push origin "HEAD:refs/heads/${{ github.head_ref }}"
-
       - name: Write job summary
         if: always() && !cancelled()
         uses: actions/github-script@v9
         env:
-          FUNCTIONAL_OUTCOME: ${{ steps.functional.outcome }}
-          VISUAL_OUTCOME: ${{ steps.visual.outcome }}
-          SCREENSHOTS_UPDATED: ${{ steps.commit-screenshots.outputs.has-changes }}
+          FUNCTIONAL_OUTCOME: ${{ steps.e2e.outputs.functional-outcome }}
+          VISUAL_OUTCOME: ${{ steps.e2e.outputs.visual-outcome }}
           REPORT_URL: ${{ steps.deploy.outputs.url }}
         with:
           script: |
             const functionalPassed = process.env.FUNCTIONAL_OUTCOME === 'success'
             const visualPassed = process.env.VISUAL_OUTCOME === 'success'
-            const screenshotsUpdated = process.env.SCREENSHOTS_UPDATED === 'true'
             const reportUrl = process.env.REPORT_URL
 
             const lines = ['## 🌐 Website E2E', '']
@@ -184,15 +174,13 @@ jobs:
               lines.push('> [!TIP]', '> All tests passed.')
             } else if (!functionalPassed) {
               lines.push('> [!CAUTION]', '> Functional tests failed — this blocks merge.')
-            } else if (screenshotsUpdated) {
-              lines.push('> [!WARNING]', '> Screenshot diffs found — pushed an automated commit with updated expectations. Review the new screenshots before approving.')
             } else {
-              lines.push('> [!CAUTION]', '> Screenshot diffs found and could not be auto-updated — this blocks merge.')
+              lines.push('> [!CAUTION]', '> Screenshot diffs found — this blocks merge. Use the "Update Website Screenshots" checkbox below to refresh expectations.')
             }
 
             const rows = [
               ['Functional tests', functionalPassed ? '✅ Passed' : '❌ Failed'],
-              ['Visual tests', visualPassed ? '✅ Passed' : (screenshotsUpdated ? '⚠️ Diffs found (auto-updated)' : '❌ Failed')],
+              ['Visual tests', visualPassed ? '✅ Passed' : '❌ Failed'],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
             lines.push(
@@ -253,13 +241,11 @@ jobs:
         env:
           FUNCTIONAL_OUTCOME: ${{ needs.website-e2e.outputs.functional-outcome }}
           VISUAL_OUTCOME: ${{ needs.website-e2e.outputs.visual-outcome }}
-          SCREENSHOTS_UPDATED: ${{ needs.website-e2e.outputs.screenshots-updated }}
           REPORT_URL: ${{ needs.website-e2e.outputs.report-url }}
         with:
           script: |
             const functionalPassed = process.env.FUNCTIONAL_OUTCOME === 'success'
             const visualPassed = process.env.VISUAL_OUTCOME === 'success'
-            const screenshotsUpdated = process.env.SCREENSHOTS_UPDATED === 'true'
             const reportUrl = process.env.REPORT_URL
 
             const lines = ['## 🌐 Website E2E', '<!-- WEBSITE_E2E_STATUS -->', '']
@@ -268,15 +254,13 @@ jobs:
               lines.push('> [!TIP]', '> All tests passed.')
             } else if (!functionalPassed) {
               lines.push('> [!CAUTION]', '> Functional tests failed — this blocks merge.')
-            } else if (screenshotsUpdated) {
-              lines.push('> [!WARNING]', '> Screenshot diffs found — pushed an automated commit with updated expectations. Review the new screenshots before approving.')
             } else {
-              lines.push('> [!CAUTION]', '> Screenshot diffs found and could not be auto-updated — this blocks merge.')
+              lines.push('> [!CAUTION]', '> Screenshot diffs found — this blocks merge.')
             }
 
             const rows = [
               ['Functional tests', functionalPassed ? '✅ Passed' : '❌ Failed'],
-              ['Visual tests', visualPassed ? '✅ Passed' : (screenshotsUpdated ? '⚠️ Diffs found (auto-updated)' : '❌ Failed')],
+              ['Visual tests', visualPassed ? '✅ Passed' : '❌ Failed'],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
             lines.push(
@@ -286,7 +270,7 @@ jobs:
               ...rows.map(([k, v]) => `| **${k}** | ${v} |`)
             )
 
-            if (!visualPassed && !screenshotsUpdated) {
+            if (!visualPassed) {
               lines.push('', '- [ ] Update website screenshots')
             }
 

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -169,7 +169,9 @@ jobs:
         with:
           script: |
             const functionalPassed = process.env.FUNCTIONAL_OUTCOME === 'success'
-            const visualPassed = process.env.VISUAL_OUTCOME === 'success'
+            const visualOutcome = process.env.VISUAL_OUTCOME
+            const visualPassed = visualOutcome === 'success'
+            const visualFailed = visualOutcome === 'failure'
             const reportUrl = process.env.REPORT_URL
 
             const lines = ['## 🌐 Website E2E', '']
@@ -184,7 +186,7 @@ jobs:
 
             const rows = [
               ['Functional tests', functionalPassed ? '✅ Passed' : '❌ Failed'],
-              ['Visual tests', visualPassed ? '✅ Passed' : '❌ Failed'],
+              ['Visual tests', visualPassed ? '✅ Passed' : visualFailed ? '❌ Failed' : '⏭️ Skipped'],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
             lines.push(
@@ -249,7 +251,9 @@ jobs:
         with:
           script: |
             const functionalPassed = process.env.FUNCTIONAL_OUTCOME === 'success'
-            const visualPassed = process.env.VISUAL_OUTCOME === 'success'
+            const visualOutcome = process.env.VISUAL_OUTCOME
+            const visualPassed = visualOutcome === 'success'
+            const visualFailed = visualOutcome === 'failure'
             const reportUrl = process.env.REPORT_URL
 
             const lines = ['## 🌐 Website E2E', '<!-- WEBSITE_E2E_STATUS -->', '']
@@ -264,7 +268,7 @@ jobs:
 
             const rows = [
               ['Functional tests', functionalPassed ? '✅ Passed' : '❌ Failed'],
-              ['Visual tests', visualPassed ? '✅ Passed' : '❌ Failed'],
+              ['Visual tests', visualPassed ? '✅ Passed' : visualFailed ? '❌ Failed' : '⏭️ Skipped'],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
             lines.push(
@@ -274,7 +278,7 @@ jobs:
               ...rows.map(([k, v]) => `| **${k}** | ${v} |`)
             )
 
-            if (!visualPassed) {
+            if (visualFailed) {
               lines.push('', '- [ ] Update website screenshots')
             }
 

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -66,17 +66,18 @@ jobs:
       # server instead of failing to bind an already-occupied port.
       - name: Run e2e tests
         id: e2e
-        # This container's default run-block shell is sh, not bash — the
-        # /dev/tcp readiness probe below is a bash-ism.
-        shell: bash
         run: |
           set +e
           pnpm --filter @comfyorg/website preview &
           PREVIEW_PID=$!
 
+          # Not bash's /dev/tcp: Debian/Ubuntu bash is built with that
+          # feature disabled, so it silently never connects on this image
+          # regardless of shell. Node is guaranteed present here already.
           READY=0
           for i in $(seq 1 30); do
-            (echo > /dev/tcp/127.0.0.1/4321) >/dev/null 2>&1 && { READY=1; break; }
+            node -e "require('net').connect(4321,'127.0.0.1').on('connect',s=>{s.end();process.exit(0)}).on('error',()=>process.exit(1))" \
+              && { READY=1; break; }
             sleep 1
           done
           if [ "$READY" -ne 1 ]; then

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -74,16 +74,25 @@ jobs:
           # Not bash's /dev/tcp: Debian/Ubuntu bash is built with that
           # feature disabled, so it silently never connects on this image
           # regardless of shell. Node is guaranteed present here already.
-          # Connect to 'localhost' (not a literal 127.0.0.1) to match
-          # whatever address astro's own "Local http://localhost:4321/"
-          # actually bound.
+          # A literal 127.0.0.1 probe got a clean, immediate, and permanent
+          # ECONNREFUSED here despite astro logging ready — this image binds
+          # the server to IPv6 loopback only, refusing IPv4 outright. Try
+          # both families instead of assuming either.
           READY=0
           LAST_ERR=""
           for i in $(seq 1 30); do
             LAST_ERR=$(node -e "
-              const s = require('net').connect(4321, 'localhost')
-              s.on('connect', () => { s.end(); process.exit(0) })
-              s.on('error', (e) => { console.error(e.message); process.exit(1) })
+              const net = require('net')
+              const tryHost = (host) => new Promise((resolve) => {
+                const s = net.connect(4321, host)
+                s.on('connect', () => { s.end(); resolve(true) })
+                s.on('error', (e) => resolve(e.message))
+              })
+              Promise.all([tryHost('127.0.0.1'), tryHost('::1')]).then((results) => {
+                if (results.some((r) => r === true)) process.exit(0)
+                console.error(results.join('; '))
+                process.exit(1)
+              })
             " 2>&1) && { READY=1; break; }
             sleep 1
           done

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -34,14 +34,25 @@ jobs:
     permissions:
       contents: read
     outputs:
-      required-passed: ${{ steps.gate.outputs.required-passed }}
+      functional-outcome: ${{ steps.functional.outcome }}
+      visual-outcome: ${{ steps.visual.outcome }}
+      screenshots-updated: ${{ steps.commit-screenshots.outputs.has-changes }}
       report-url: ${{ steps.deploy.outputs.url }}
-      screenshot-failures: ${{ steps.failures.outputs.screenshot }}
-      other-failures: ${{ steps.failures.outputs.other }}
       # Evaluated at job level (not from a step) — static expression.
       is-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The PR's actual branch tip, not GitHub's synthetic merge commit —
+          # so a later auto-update push (below) lands on the ref we just
+          # built and tested, not a ref that doesn't otherwise exist.
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+          token: >-
+            ${{
+              (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+              && secrets.PR_GH_TOKEN
+              || secrets.GITHUB_TOKEN
+            }}
 
       - name: Install pnpm
         run: corepack enable && corepack prepare
@@ -57,13 +68,17 @@ jobs:
           PUBLIC_CUSTOMERIO_WRITE_KEY: test-e2e-write-key
         run: pnpm --filter @comfyorg/website build
 
-      - name: Run Playwright tests
-        id: tests
-        # A screenshot-only failure must not fail this step outright — the
-        # gate step below decides pass/fail from the visual/other split so
-        # content PRs aren't blocked by pixel diffs alone.
-        continue-on-error: true
-        run: pnpm --filter @comfyorg/website test:e2e
+      # Functional and visual run as separate Playwright invocations (not one
+      # combined run classified after the fact) so "did this block merge"
+      # reduces to plain step pass/fail — no per-test error-message parsing
+      # that can misclassify a real failure as screenshot-only.
+      - name: Run functional e2e tests
+        id: functional
+        run: pnpm --filter @comfyorg/website test:e2e:functional
+
+      - name: Run visual e2e tests
+        id: visual
+        run: pnpm --filter @comfyorg/website test:visual
 
       - name: Upload test report
         uses: actions/upload-artifact@v6
@@ -109,108 +124,77 @@ jobs:
           URL=$(echo "$OUTPUT" | grep -oE 'https://[a-zA-Z0-9.-]+\.pages\.dev\S*' | head -1)
           echo "url=${URL}" >> $GITHUB_OUTPUT
 
-      - name: Categorize failures
-        id: failures
-        if: always() && !cancelled() && steps.tests.outcome != 'success'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs')
-            const report = JSON.parse(fs.readFileSync('apps/website/results.json', 'utf8'))
+      # Reached only when visual failed and functional did not (a functional
+      # failure already stopped the job above). Mirrors the safety property
+      # pr-update-website-screenshots.yaml already relies on: this commits
+      # only if regenerating screenshots itself completes cleanly, so a page
+      # that's actually broken (crash, nav error) can't get its broken state
+      # committed as the new "expected" baseline — it just fails here too,
+      # leaving the run blocking with nothing auto-pushed.
+      - name: Auto-update screenshots
+        id: auto-update
+        if: >-
+          ${{
+            failure() &&
+            steps.visual.conclusion == 'failure' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.fork == false
+          }}
+        continue-on-error: true
+        run: pnpm --filter @comfyorg/website test:visual:update
 
-            function isFailed(t) { return t.status === 'unexpected' || t.status === 'flaky' }
-            // Classified per FAILING TEST from its own result, not the spec
-            // file's path or any other test in the same file — a functional
-            // failure sitting next to a screenshot test must still block.
-            function isScreenshotFailure(t) {
-              return t.results?.some(r => r.error?.message?.includes('toHaveScreenshot'))
-            }
-            function specsOf(suite) {
-              return [
-                ...(suite.specs || []),
-                ...(suite.suites || []).flatMap(specsOf)
-              ]
-            }
-
-            const failed = specsOf(report).flatMap(spec => (spec.tests || []).filter(isFailed))
-
-            const screenshotFailures = failed.filter(isScreenshotFailure).length
-            core.setOutput('screenshot', screenshotFailures)
-            core.setOutput('other', failed.length - screenshotFailures)
-
-      # Screenshot-only failures don't block merge (there's a one-click fix:
-      # the "Update Website Screenshots" checkbox below); only a non-visual
-      # e2e failure, or the run being cancelled outright, fails this required
-      # check. This is the step whose exit code decides the job's conclusion,
-      # since "Run Playwright tests" above no longer can (continue-on-error).
-      - name: Determine required gate result
-        id: gate
-        if: always() && !cancelled()
-        env:
-          TEST_OUTCOME: ${{ steps.tests.outcome }}
-          CATEGORIZE_OUTCOME: ${{ steps.failures.outcome }}
-          OTHER_FAILURES: ${{ steps.failures.outputs.other }}
+      - name: Commit and push updated screenshots
+        id: commit-screenshots
+        if: always() && steps.auto-update.outcome == 'success'
         run: |
-          if [ "$TEST_OUTCOME" = "success" ]; then
-            echo "required-passed=true" >> "$GITHUB_OUTPUT"
+          git config --global --add safe.directory "$(pwd)"
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+
+          CHANGED=$(git status --porcelain=v1 --untracked-files=all -- apps/website/e2e/ | wc -l)
+          if [ "$CHANGED" -eq 0 ]; then
+            echo "No screenshot changes to commit"
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # The screenshot-only exception requires the tests to have actually
-          # run and failed AND categorization to have completed cleanly.
-          # Anything else (cancelled, skipped because an earlier step like
-          # "Build website" failed, or "Categorize failures" itself erroring
-          # on a missing/malformed results.json) fails closed rather than
-          # defaulting a missing OTHER_FAILURES to 0.
-          if [ "$TEST_OUTCOME" != "failure" ] || [ "$CATEGORIZE_OUTCOME" != "success" ]; then
-            echo "required-passed=false" >> "$GITHUB_OUTPUT"
-            echo "::error::Website e2e did not complete cleanly (test outcome: ${TEST_OUTCOME}, failure categorization: ${CATEGORIZE_OUTCOME}) — blocking merge."
-            exit 1
-          fi
-          OTHER="${OTHER_FAILURES:-0}"
-          if [ "$OTHER" -gt 0 ]; then
-            echo "required-passed=false" >> "$GITHUB_OUTPUT"
-            echo "::error::${OTHER} non-screenshot e2e failure(s) — these block merge."
-            exit 1
-          fi
-          echo "required-passed=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::Only screenshot diffs failed; not blocking merge. Use the 'Update Website Screenshots' checkbox to refresh expectations."
+
+          echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          git add apps/website/e2e/
+          git commit -m "[automated] Update website screenshot expectations"
+          git push origin "HEAD:refs/heads/${{ github.head_ref }}"
 
       - name: Write job summary
         if: always() && !cancelled()
         uses: actions/github-script@v9
         env:
-          REQUIRED_PASSED: ${{ steps.gate.outputs.required-passed }}
+          FUNCTIONAL_OUTCOME: ${{ steps.functional.outcome }}
+          VISUAL_OUTCOME: ${{ steps.visual.outcome }}
+          SCREENSHOTS_UPDATED: ${{ steps.commit-screenshots.outputs.has-changes }}
           REPORT_URL: ${{ steps.deploy.outputs.url }}
-          SCREENSHOT_FAILURES: ${{ steps.failures.outputs.screenshot }}
-          OTHER_FAILURES: ${{ steps.failures.outputs.other }}
         with:
           script: |
-            const requiredPassed = process.env.REQUIRED_PASSED === 'true'
+            const functionalPassed = process.env.FUNCTIONAL_OUTCOME === 'success'
+            const visualPassed = process.env.VISUAL_OUTCOME === 'success'
+            const screenshotsUpdated = process.env.SCREENSHOTS_UPDATED === 'true'
             const reportUrl = process.env.REPORT_URL
-            const screenshotFailures = parseInt(process.env.SCREENSHOT_FAILURES) || 0
-            const otherFailures = parseInt(process.env.OTHER_FAILURES) || 0
-            const hasScreenshotDiffs = screenshotFailures > 0
 
             const lines = ['## 🌐 Website E2E', '']
 
-            if (requiredPassed && !hasScreenshotDiffs) {
+            if (functionalPassed && visualPassed) {
               lines.push('> [!TIP]', '> All tests passed.')
-            } else if (requiredPassed) {
-              lines.push('> [!WARNING]', '> Functional tests passed. Screenshot diffs found — non-blocking, but review before merging.')
-            } else {
+            } else if (!functionalPassed) {
               lines.push('> [!CAUTION]', '> Functional tests failed — this blocks merge.')
+            } else if (screenshotsUpdated) {
+              lines.push('> [!WARNING]', '> Screenshot diffs found — pushed an automated commit with updated expectations. Review the new screenshots before approving.')
+            } else {
+              lines.push('> [!CAUTION]', '> Screenshot diffs found and could not be auto-updated — this blocks merge.')
             }
 
             const rows = [
-              ['Status', requiredPassed ? (hasScreenshotDiffs ? '⚠️ Passed (screenshot diffs)' : '✅ Passed') : '❌ Failed'],
+              ['Functional tests', functionalPassed ? '✅ Passed' : '❌ Failed'],
+              ['Visual tests', visualPassed ? '✅ Passed' : (screenshotsUpdated ? '⚠️ Diffs found (auto-updated)' : '❌ Failed')],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
-            if (hasScreenshotDiffs || otherFailures > 0) {
-              rows.push(
-                ['Screenshot diffs', String(screenshotFailures)],
-                ['Other failures', String(otherFailures)]
-              )
-            }
             lines.push(
               '',
               '| | |',
@@ -267,38 +251,34 @@ jobs:
         id: content
         uses: actions/github-script@v9
         env:
-          REQUIRED_PASSED: ${{ needs.website-e2e.outputs.required-passed }}
+          FUNCTIONAL_OUTCOME: ${{ needs.website-e2e.outputs.functional-outcome }}
+          VISUAL_OUTCOME: ${{ needs.website-e2e.outputs.visual-outcome }}
+          SCREENSHOTS_UPDATED: ${{ needs.website-e2e.outputs.screenshots-updated }}
           REPORT_URL: ${{ needs.website-e2e.outputs.report-url }}
-          SCREENSHOT_FAILURES: ${{ needs.website-e2e.outputs.screenshot-failures }}
-          OTHER_FAILURES: ${{ needs.website-e2e.outputs.other-failures }}
         with:
           script: |
-            const requiredPassed = process.env.REQUIRED_PASSED === 'true'
+            const functionalPassed = process.env.FUNCTIONAL_OUTCOME === 'success'
+            const visualPassed = process.env.VISUAL_OUTCOME === 'success'
+            const screenshotsUpdated = process.env.SCREENSHOTS_UPDATED === 'true'
             const reportUrl = process.env.REPORT_URL
-            const screenshotFailures = parseInt(process.env.SCREENSHOT_FAILURES) || 0
-            const otherFailures = parseInt(process.env.OTHER_FAILURES) || 0
-            const hasScreenshotDiffs = screenshotFailures > 0
 
             const lines = ['## 🌐 Website E2E', '<!-- WEBSITE_E2E_STATUS -->', '']
 
-            if (requiredPassed && !hasScreenshotDiffs) {
+            if (functionalPassed && visualPassed) {
               lines.push('> [!TIP]', '> All tests passed.')
-            } else if (requiredPassed) {
-              lines.push('> [!WARNING]', '> Functional tests passed. Screenshot diffs found — non-blocking, but review before merging.')
-            } else {
+            } else if (!functionalPassed) {
               lines.push('> [!CAUTION]', '> Functional tests failed — this blocks merge.')
+            } else if (screenshotsUpdated) {
+              lines.push('> [!WARNING]', '> Screenshot diffs found — pushed an automated commit with updated expectations. Review the new screenshots before approving.')
+            } else {
+              lines.push('> [!CAUTION]', '> Screenshot diffs found and could not be auto-updated — this blocks merge.')
             }
 
             const rows = [
-              ['Status', requiredPassed ? (hasScreenshotDiffs ? '⚠️ Passed (screenshot diffs)' : '✅ Passed') : '❌ Failed'],
+              ['Functional tests', functionalPassed ? '✅ Passed' : '❌ Failed'],
+              ['Visual tests', visualPassed ? '✅ Passed' : (screenshotsUpdated ? '⚠️ Diffs found (auto-updated)' : '❌ Failed')],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
-            if (hasScreenshotDiffs || otherFailures > 0) {
-              rows.push(
-                ['Screenshot diffs', String(screenshotFailures)],
-                ['Other failures', String(otherFailures)]
-              )
-            }
             lines.push(
               '',
               '| | |',
@@ -306,9 +286,8 @@ jobs:
               ...rows.map(([k, v]) => `| **${k}** | ${v} |`)
             )
 
-            if (screenshotFailures > 0) {
-              const s = screenshotFailures === 1 ? '' : 's'
-              lines.push('', `- [ ] Update website screenshots (${screenshotFailures} screenshot diff${s})`)
+            if (!visualPassed && !screenshotsUpdated) {
+              lines.push('', '- [ ] Update website screenshots')
             }
 
             core.setOutput('section-content', lines.join('\n'))

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -119,9 +119,11 @@ jobs:
             const report = JSON.parse(fs.readFileSync('apps/website/results.json', 'utf8'))
 
             function isFailed(t) { return t.status === 'unexpected' || t.status === 'flaky' }
-            function isVisual(spec) {
-              return spec.file?.includes('visual') ||
-                spec.tests?.some(t => t.results?.some(r => r.error?.message?.includes('toHaveScreenshot')))
+            // Classified per FAILING TEST from its own result, not the spec
+            // file's path or any other test in the same file — a functional
+            // failure sitting next to a screenshot test must still block.
+            function isScreenshotFailure(t) {
+              return t.results?.some(r => r.error?.message?.includes('toHaveScreenshot'))
             }
             function specsOf(suite) {
               return [
@@ -130,14 +132,9 @@ jobs:
               ]
             }
 
-            // True:  Visual
-            // False: Other
-            const failed = specsOf(report)
-              .flatMap(spec => (spec.tests || [])
-              .filter(isFailed)
-              .map(() => isVisual(spec)))
+            const failed = specsOf(report).flatMap(spec => (spec.tests || []).filter(isFailed))
 
-            const screenshotFailures = failed.filter(Boolean).length
+            const screenshotFailures = failed.filter(isScreenshotFailure).length
             core.setOutput('screenshot', screenshotFailures)
             core.setOutput('other', failed.length - screenshotFailures)
 
@@ -151,15 +148,22 @@ jobs:
         if: always() && !cancelled()
         env:
           TEST_OUTCOME: ${{ steps.tests.outcome }}
+          CATEGORIZE_OUTCOME: ${{ steps.failures.outcome }}
           OTHER_FAILURES: ${{ steps.failures.outputs.other }}
         run: |
           if [ "$TEST_OUTCOME" = "success" ]; then
             echo "required-passed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$TEST_OUTCOME" = "cancelled" ]; then
+          # The screenshot-only exception requires the tests to have actually
+          # run and failed AND categorization to have completed cleanly.
+          # Anything else (cancelled, skipped because an earlier step like
+          # "Build website" failed, or "Categorize failures" itself erroring
+          # on a missing/malformed results.json) fails closed rather than
+          # defaulting a missing OTHER_FAILURES to 0.
+          if [ "$TEST_OUTCOME" != "failure" ] || [ "$CATEGORIZE_OUTCOME" != "success" ]; then
             echo "required-passed=false" >> "$GITHUB_OUTPUT"
-            echo "::error::Website E2E run was cancelled."
+            echo "::error::Website e2e did not complete cleanly (test outcome: ${TEST_OUTCOME}, failure categorization: ${CATEGORIZE_OUTCOME}) — blocking merge."
             exit 1
           fi
           OTHER="${OTHER_FAILURES:-0}"

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      test-outcome: ${{ steps.tests.outcome }}
+      required-passed: ${{ steps.gate.outputs.required-passed }}
       report-url: ${{ steps.deploy.outputs.url }}
       screenshot-failures: ${{ steps.failures.outputs.screenshot }}
       other-failures: ${{ steps.failures.outputs.other }}
@@ -59,6 +59,10 @@ jobs:
 
       - name: Run Playwright tests
         id: tests
+        # A screenshot-only failure must not fail this step outright — the
+        # gate step below decides pass/fail from the visual/other split so
+        # content PRs aren't blocked by pixel diffs alone.
+        continue-on-error: true
         run: pnpm --filter @comfyorg/website test:e2e
 
       - name: Upload test report
@@ -137,34 +141,67 @@ jobs:
             core.setOutput('screenshot', screenshotFailures)
             core.setOutput('other', failed.length - screenshotFailures)
 
+      # Screenshot-only failures don't block merge (there's a one-click fix:
+      # the "Update Website Screenshots" checkbox below); only a non-visual
+      # e2e failure, or the run being cancelled outright, fails this required
+      # check. This is the step whose exit code decides the job's conclusion,
+      # since "Run Playwright tests" above no longer can (continue-on-error).
+      - name: Determine required gate result
+        id: gate
+        if: always() && !cancelled()
+        env:
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+          OTHER_FAILURES: ${{ steps.failures.outputs.other }}
+        run: |
+          if [ "$TEST_OUTCOME" = "success" ]; then
+            echo "required-passed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$TEST_OUTCOME" = "cancelled" ]; then
+            echo "required-passed=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Website E2E run was cancelled."
+            exit 1
+          fi
+          OTHER="${OTHER_FAILURES:-0}"
+          if [ "$OTHER" -gt 0 ]; then
+            echo "required-passed=false" >> "$GITHUB_OUTPUT"
+            echo "::error::${OTHER} non-screenshot e2e failure(s) — these block merge."
+            exit 1
+          fi
+          echo "required-passed=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Only screenshot diffs failed; not blocking merge. Use the 'Update Website Screenshots' checkbox to refresh expectations."
+
       - name: Write job summary
         if: always() && !cancelled()
         uses: actions/github-script@v9
         env:
-          TEST_OUTCOME: ${{ steps.tests.outcome }}
+          REQUIRED_PASSED: ${{ steps.gate.outputs.required-passed }}
           REPORT_URL: ${{ steps.deploy.outputs.url }}
           SCREENSHOT_FAILURES: ${{ steps.failures.outputs.screenshot }}
           OTHER_FAILURES: ${{ steps.failures.outputs.other }}
         with:
           script: |
-            const passed = process.env.TEST_OUTCOME === 'success'
+            const requiredPassed = process.env.REQUIRED_PASSED === 'true'
             const reportUrl = process.env.REPORT_URL
             const screenshotFailures = parseInt(process.env.SCREENSHOT_FAILURES) || 0
             const otherFailures = parseInt(process.env.OTHER_FAILURES) || 0
+            const hasScreenshotDiffs = screenshotFailures > 0
 
             const lines = ['## 🌐 Website E2E', '']
 
-            if (passed) {
+            if (requiredPassed && !hasScreenshotDiffs) {
               lines.push('> [!TIP]', '> All tests passed.')
+            } else if (requiredPassed) {
+              lines.push('> [!WARNING]', '> Functional tests passed. Screenshot diffs found — non-blocking, but review before merging.')
             } else {
-              lines.push('> [!CAUTION]', '> Some tests failed.')
+              lines.push('> [!CAUTION]', '> Functional tests failed — this blocks merge.')
             }
 
             const rows = [
-              ['Status', passed ? '✅ Passed' : '❌ Failed'],
+              ['Status', requiredPassed ? (hasScreenshotDiffs ? '⚠️ Passed (screenshot diffs)' : '✅ Passed') : '❌ Failed'],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
-            if (!passed) {
+            if (hasScreenshotDiffs || otherFailures > 0) {
               rows.push(
                 ['Screenshot diffs', String(screenshotFailures)],
                 ['Other failures', String(otherFailures)]
@@ -226,30 +263,33 @@ jobs:
         id: content
         uses: actions/github-script@v9
         env:
-          TEST_OUTCOME: ${{ needs.website-e2e.outputs.test-outcome }}
+          REQUIRED_PASSED: ${{ needs.website-e2e.outputs.required-passed }}
           REPORT_URL: ${{ needs.website-e2e.outputs.report-url }}
           SCREENSHOT_FAILURES: ${{ needs.website-e2e.outputs.screenshot-failures }}
           OTHER_FAILURES: ${{ needs.website-e2e.outputs.other-failures }}
         with:
           script: |
-            const passed = process.env.TEST_OUTCOME === 'success'
+            const requiredPassed = process.env.REQUIRED_PASSED === 'true'
             const reportUrl = process.env.REPORT_URL
             const screenshotFailures = parseInt(process.env.SCREENSHOT_FAILURES) || 0
             const otherFailures = parseInt(process.env.OTHER_FAILURES) || 0
+            const hasScreenshotDiffs = screenshotFailures > 0
 
             const lines = ['## 🌐 Website E2E', '<!-- WEBSITE_E2E_STATUS -->', '']
 
-            if (passed) {
+            if (requiredPassed && !hasScreenshotDiffs) {
               lines.push('> [!TIP]', '> All tests passed.')
+            } else if (requiredPassed) {
+              lines.push('> [!WARNING]', '> Functional tests passed. Screenshot diffs found — non-blocking, but review before merging.')
             } else {
-              lines.push('> [!CAUTION]', '> Some tests failed.')
+              lines.push('> [!CAUTION]', '> Functional tests failed — this blocks merge.')
             }
 
             const rows = [
-              ['Status', passed ? '✅ Passed' : '❌ Failed'],
+              ['Status', requiredPassed ? (hasScreenshotDiffs ? '⚠️ Passed (screenshot diffs)' : '✅ Passed') : '❌ Failed'],
               ['Report', reportUrl ? `[View Report](${reportUrl})` : '_unavailable_']
             ]
-            if (!passed) {
+            if (hasScreenshotDiffs || otherFailures > 0) {
               rows.push(
                 ['Screenshot diffs', String(screenshotFailures)],
                 ['Other failures', String(otherFailures)]
@@ -265,13 +305,6 @@ jobs:
             if (screenshotFailures > 0) {
               const s = screenshotFailures === 1 ? '' : 's'
               lines.push('', `- [ ] Update website screenshots (${screenshotFailures} screenshot diff${s})`)
-            }
-            if (otherFailures > 0) {
-              lines.push(
-                '',
-                '> [!WARNING]',
-                `> ${otherFailures} non-screenshot failure${otherFailures === 1 ? '' : 's'} — these require manual review.`
-              )
             }
 
             core.setOutput('section-content', lines.join('\n'))

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -74,14 +74,21 @@ jobs:
           # Not bash's /dev/tcp: Debian/Ubuntu bash is built with that
           # feature disabled, so it silently never connects on this image
           # regardless of shell. Node is guaranteed present here already.
+          # Connect to 'localhost' (not a literal 127.0.0.1) to match
+          # whatever address astro's own "Local http://localhost:4321/"
+          # actually bound.
           READY=0
+          LAST_ERR=""
           for i in $(seq 1 30); do
-            node -e "require('net').connect(4321,'127.0.0.1').on('connect',s=>{s.end();process.exit(0)}).on('error',()=>process.exit(1))" \
-              && { READY=1; break; }
+            LAST_ERR=$(node -e "
+              const s = require('net').connect(4321, 'localhost')
+              s.on('connect', () => { s.end(); process.exit(0) })
+              s.on('error', (e) => { console.error(e.message); process.exit(1) })
+            " 2>&1) && { READY=1; break; }
             sleep 1
           done
           if [ "$READY" -ne 1 ]; then
-            echo "::error::Preview server never became reachable on :4321"
+            echo "::error::Preview server never became reachable on :4321 (last error: ${LAST_ERR})"
             echo "functional-outcome=failure" >> "$GITHUB_OUTPUT"
             echo "visual-outcome=skipped" >> "$GITHUB_OUTPUT"
             kill "$PREVIEW_PID" 2>/dev/null

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,6 +12,7 @@
     "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:functional": "playwright test --project desktop --project mobile",
     "test:e2e:local": "cross-env PLAYWRIGHT_LOCAL=1 playwright test",
     "test:visual": "playwright test --project visual",
     "test:visual:update": "playwright test --project visual --update-snapshots",

--- a/apps/website/playwright.config.ts
+++ b/apps/website/playwright.config.ts
@@ -35,7 +35,12 @@ export default defineConfig({
   webServer: {
     command: 'pnpm preview',
     port: 4321,
-    reuseExistingServer: !process.env.CI
+    // CI runs functional and visual as two separate `playwright test`
+    // invocations against one preview server it starts itself — the second
+    // invocation must attach to that server rather than insist on its own
+    // (and fail immediately, since the port's already taken).
+    reuseExistingServer:
+      process.env.PLAYWRIGHT_REUSE_SERVER === '1' || !process.env.CI
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

Website E2E ran functional and visual checks as one combined suite, so a screenshot diff on a routine content change failed the whole required check the same as a real functional bug. Screenshot diffs stay blocking (per Alex's review — they're real functional checks, and merging without updating the baseline leaves later PRs comparing against a stale, unattributed "before"); what changes is how "did this block merge" gets decided.

## Changes

- **What**: Splits `website-e2e`'s functional (`desktop`+`mobile`) and visual (`visual` project) Playwright runs so merge-blocking is a plain exit code, not per-test error-message parsing that can misclassify a real failure as screenshot-only. Both invocations run against one preview server the job starts and polls for itself (`playwright.config.ts` gained a `PLAYWRIGHT_REUSE_SERVER` escape hatch), each writing its own report/JSON path so the second run doesn't silently overwrite the first's.
- **Breaking**: None — required check name (`website-e2e`) is unchanged.
- **Reverted from this PR's earlier commits**: the risk-map R1 content carve-out (swept in real code, and the grader can't express the exclusion safely) and an automated screenshot-commit-and-push (Alex found it exposed a write PAT to `pull_request`-triggered, PR-controlled code — moving the token to only the last step doesn't fix that either, since the whole workflow YAML is sourced from the PR's own branch for that event). Screenshot diffs now report clearly and rely on the existing manual "Update Website Screenshots" checkbox, same as before this PR existed.

## Review Focus

- Alex's review caught a live CI failure from an earlier commit in this PR: `playwright.config.ts`'s `webServer` always starts its own server in CI, so a second `playwright test` invocation failed immediately once the first's server was left up ("Another astro preview server is already running"), which the reporting logic misdiagnosed as a screenshot diff. Fixed by managing one shared server explicitly rather than two independent invocations each trying to own it.
- The checkout is back to GitHub's default (no custom `ref:`) — an earlier commit's override broke fork PRs outright (`github.head_ref` names a branch that only exists in the fork, not the base repo) and changed what non-fork PRs actually tested (branch tip vs. merge commit).

## Screenshots (if applicable)

N/A — CI/config only.