### PR TITLE
[backport cloud/1.54] fix: stop resetting subgraph IDs on clear()

### DIFF
--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -2324,6 +2324,31 @@ describe('Zero UUID handling in configure', () => {
     const subgraph = graph.createSubgraph(subgraphData)
     expect(subgraph.id).toBe(zeroUuid)
   })
+
+  it('keeps a subgraph registered under its own ID across clear()', () => {
+    const graph = new LGraph()
+    const subgraph = graph.createSubgraph(createTestSubgraphData())
+    const { id } = subgraph
+
+    subgraph.clear()
+
+    expect(subgraph.id).toBe(id)
+    expect(graph.subgraphs.get(id)).toBe(subgraph)
+    expect(graph.subgraphs.has(zeroUuid)).toBe(false)
+  })
+
+  it('creates a subgraph exposing IO without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const graph = new LGraph()
+
+    graph.createSubgraph(
+      createTestSubgraphData({
+        inputs: [{ id: createUuidv4(), name: 'value', type: 'INT' }]
+      })
+    )
+
+    expect(warn).not.toHaveBeenCalled()
+  })
 })
 
 describe('node layout registration', () => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -794,7 +794,7 @@ export class LGraph
     this._nodes_executable = null
     this._groups = []
 
-    this.id = this.isRootGraph ? createUuidv4() : zeroUuid
+    if (this.isRootGraph) this.id = createUuidv4()
     this.revision = 0
 
     this.state = createLGraphState()


### PR DESCRIPTION
Backport of merged fix https://github.com/Comfy-Org/ComfyUI_frontend/pull/17268 to the `cloud/1.54` release branch.

- One-line change in `LGraph.clear()` plus regression tests for zero-UUID handling in `configure`.
- Cherry-picked cleanly; no conflicts. Typecheck and `LGraph.test.ts` pass locally on this branch.
- The fix merged to main after the 1.54 branches were cut, so 1.54 was missing it (1.53 backports already merged).

<details><summary>Full context for agent readers</summary>

Source: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17268 (merge commit `f761da981e9d5c865daccbe9f64672841d4f0503`), authored by Christian directly. 1.53 backports: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17277 and https://github.com/Comfy-Org/ComfyUI_frontend/pull/17278 (merged). Verified via `git merge-base --is-ancestor` that the merge commit is not on `cloud/1.54`; opened this manual cherry-pick under Christian's standing backport authorization (bbc #520 answer 2).

Files: `src/lib/litegraph/src/LGraph.ts`, `src/lib/litegraph/src/LGraph.test.ts`.

Local verification: `CI=true pnpm install --frozen-lockfile`, `pnpm typecheck` (clean), `pnpm vitest run src/lib/litegraph/src/LGraph.test.ts` (117 passed, 1 expected fail — same as branch baseline).

<!-- authored-by:agent w3-520-followup -->
</details>
