### PR TITLE
[backport cloud/1.54] fix: keep edited dynamic-combo child values across option toggles

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -1,6 +1,6 @@
 import { setActivePinia } from 'pinia'
 import { createTestingPinia } from '@pinia/testing'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   addAutogrow,
   addDynamicCombo
@@ -11,6 +11,11 @@ import { useLinkStore } from '@/stores/linkStore'
 
 setActivePinia(createTestingPinia({ stubActions: false }))
 beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
+const originalNamedValuesRestore = LiteGraph.namedValuesRestore
+afterEach(() => {
+  LiteGraph.namedValuesRestore = originalNamedValuesRestore
+})
 type TestAutogrowNode = LGraphNode & {
   comfyDynamic: { autogrow: Record<string, unknown> }
 }
@@ -172,6 +177,56 @@ describe('Dynamic Combos', () => {
     expect.soft(node.widgets[1].tooltip).toBe('0')
     node.widgets[0].value = '1'
     expect.soft(node.widgets[1].tooltip).toBe('1')
+  })
+  test('An edited nested value survives toggling the combo away and back after load (#16006)', () => {
+    LiteGraph.namedValuesRestore = true
+    const node = testNode()
+    node.serialize_widgets = true
+    addDynamicCombo(node, [['INT'], ['INT']])
+
+    node.widgets[0].value = '1'
+    node.widgets[1].value = 0.8
+    const serialized = node.serialize()
+
+    const reloaded = testNode()
+    addDynamicCombo(reloaded, [['INT'], ['INT']])
+    reloaded.configure(serialized)
+    expect(reloaded.widgets[1].value).toBe(0.8)
+
+    reloaded.widgets[1].value = 0.3
+
+    reloaded.widgets[0].value = '0'
+    reloaded.widgets[0].value = '1'
+
+    expect(reloaded.widgets[1].value).toBe(0.3)
+  })
+  test('Same-name children keep separate values across options', () => {
+    const node = testNode()
+    addDynamicCombo(node, [['INT'], ['INT']])
+
+    node.widgets[1].value = 3
+    node.widgets[0].value = '1'
+    expect(node.widgets[1].value).not.toBe(3)
+    node.widgets[1].value = 7
+
+    node.widgets[0].value = '0'
+    expect(node.widgets[1].value).toBe(3)
+    node.widgets[0].value = '1'
+    expect(node.widgets[1].value).toBe(7)
+    node.widgets[0].value = '0'
+    expect(node.widgets[1].value).toBe(3)
+  })
+  test('Nested child keeps its value when its parent option is recreated', () => {
+    const node = testNode()
+    addDynamicCombo(node, [[[[], ['INT']]], ['INT']])
+    node.widgets[1].value = '1'
+    node.widgets[2].value = 7
+
+    node.widgets[0].value = '1'
+    node.widgets[0].value = '0'
+
+    expect(node.widgets[1].value).toBe('1')
+    expect(node.widgets[2].value).toBe(7)
   })
 })
 describe('Autogrow', () => {

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -30,6 +30,7 @@ import type { InputLayoutSnapshot } from '@/lib/litegraph/src/node/slotLinks'
 import { useLinkStore } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 import { widgetId } from '@/types/widgetId'
 
 function setCanvasDirty(canvas: typeof app.canvas | undefined) {
@@ -120,17 +121,61 @@ function dynamicComboWidget(
     appArg,
     widgetName
   )
+  const removedWidgetValues = new Map<
+    string | undefined,
+    Map<string, { type: string; value: WidgetValue }>
+  >()
+  let activeOption = widget.value as string | undefined
   function isInGroup(e: { name: string }): boolean {
     return e.name.startsWith(inputName + '.')
+  }
+  function restoreRemovedValues(
+    value: string | undefined,
+    widgetNames: string[]
+  ) {
+    const widgets = node.widgets
+    if (!widgets) return
+    const graphId = resolveNodeRootGraphId(node)
+    const removedValues = removedWidgetValues.get(value)
+    const names = new Set(widgetNames)
+    for (const name of removedValues?.keys() ?? []) names.add(name)
+    for (const name of names) {
+      const addedWidget = widgets.find((widget) => widget.name === name)
+      if (!addedWidget) continue
+      const removed = removedValues?.get(name)
+      const positionalIndex = widgets
+        .filter((widget) => widget.serialize !== false)
+        .indexOf(addedWidget)
+      const restored =
+        graphId && positionalIndex >= 0
+          ? useWidgetValueStore().getRestoredWidgetValue(
+              graphId,
+              node.id,
+              name,
+              positionalIndex
+            )
+          : undefined
+      if (!restored && removed?.type === addedWidget.type) {
+        addedWidget.value = removed.value
+      }
+    }
   }
   const updateWidgets = (value?: string) => {
     if (!node.widgets) throw new Error('Not Reachable')
     const newSpec = value ? options[value] : undefined
+    const removedOption = activeOption
+    activeOption = value
 
     const previous = captureInputLayout(node)
     const inputLinks = new Map(previous.links)
     const removedInputs = remove(node.inputs, isInGroup)
     for (const widget of remove(node.widgets, isInGroup)) {
+      const optionValues = removedWidgetValues.get(removedOption) ?? new Map()
+      optionValues.set(widget.name, {
+        type: widget.type,
+        value: widget.value
+      })
+      removedWidgetValues.set(removedOption, optionValues)
       widget.onRemove?.()
       if (widget.widgetId) deleteWidget(widget.widgetId)
     }
@@ -167,6 +212,7 @@ function dynamicComboWidget(
     const inputInsertionPoint =
       node.inputs.findIndex((i) => i.name === widget.name) + 1
     const addedWidgets = node.widgets.splice(startingLength)
+    const addedWidgetNames = addedWidgets.map(({ name }) => name)
     node.widgets.splice(insertionPoint, 0, ...addedWidgets)
     syncNodeWidgetOrder(node)
     if (inputInsertionPoint === 0) {
@@ -178,6 +224,7 @@ function dynamicComboWidget(
         throw new Error('Failed to find input socket for ' + widget.name)
       const result = commitMutatedInputs(node, previous, inputLinks)
       if (!result.ok) return
+      restoreRemovedValues(value, addedWidgetNames)
       return
     }
     const addedInputs = node.inputs
@@ -203,6 +250,7 @@ function dynamicComboWidget(
     for (const { input, link, slot } of result.replacements) {
       node.onConnectionsChange?.(LiteGraph.INPUT, slot, true, link, input)
     }
+    restoreRemovedValues(value, addedWidgetNames)
 
     if (!node.graph) return
     node._setConcreteSlots()


### PR DESCRIPTION
Backport of merged fix https://github.com/Comfy-Org/ComfyUI_frontend/pull/16508 to the `cloud/1.54` release branch.

- Keeps user-edited dynamic-combo child values when the parent option is toggled away and back.
- One test-file conflict in the imports/setup header (both sides added setup helpers); resolved by keeping both. Typecheck and `dynamicWidgets.test.ts` (23 passed) are green locally.
- Fix merged to main after the 1.54 branches were cut; 1.53 backports already merged.

<details><summary>Full context for agent readers</summary>

Source: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16508 (merge commit `3e43e3e7a51e77c93185feb6a499f45fb939b7f8`). 1.53 backports: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17296 and https://github.com/Comfy-Org/ComfyUI_frontend/pull/17297 (merged). Manual cherry-pick opened under Christian's standing backport authorization (bbc #520 answer 2).

Files: `src/core/graph/widgets/dynamicWidgets.ts`, `src/core/graph/widgets/dynamicWidgets.test.ts`.

Conflict detail: `dynamicWidgets.test.ts` header. Branch HEAD had pinia imports plus `setActivePinia` in `beforeEach`; the cherry-picked commit added an `afterEach` import and an `afterEach` that restores `LiteGraph.namedValuesRestore`. Both hunks were kept; no test logic was altered.

Local verification: `CI=true pnpm install --frozen-lockfile`, pre-commit (oxfmt/oxlint/eslint + `pnpm typecheck`) passed, `pnpm vitest run src/core/graph/widgets/dynamicWidgets.test.ts` = 23 passed.

<!-- authored-by:agent w3-520-followup -->
</details>
