### PR TITLE
fix(billing): one verb for un-cancelling — Resume subscription everywhere

### DIFF
--- a/browser_tests/tests/dialogs/endedSubscription.spec.ts
+++ b/browser_tests/tests/dialogs/endedSubscription.spec.ts
@@ -82,7 +82,7 @@ test.describe('Inactive Team subscription billing', { tag: '@cloud' }, () => {
       content.getByRole('heading', { name: 'Inactive team subscription' })
     ).toBeVisible()
     await expect(
-      content.getByRole('button', { name: 'Reactivate plan' })
+      content.getByRole('button', { name: 'Resume subscription' })
     ).toBeVisible()
     await content.getByRole('button', { name: 'Billing & invoices' }).click()
     await expect

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3237,7 +3237,7 @@
       },
       "ending": {
         "title": "Your team plan ends on {date}",
-        "body": "Members keep full access until then. Reactivate to keep your shared credits and seats.",
+        "body": "Members keep full access until then. Resume your subscription to keep your shared credits and seats.",
         "reactivate": "Resume subscription"
       },
       "planChange": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2830,8 +2830,8 @@
     "cancelPlan": "Cancel plan",
     "canceled": "Canceled",
     "resubscribe": "Resubscribe",
-    "reactivatePlan": "Reactivate plan",
-    "resubscribeTo": "Resubscribe to {plan}",
+    "reactivatePlan": "Resume subscription",
+    "resubscribeTo": "Resume {plan}",
     "resubscribeSuccess": "Subscription reactivated successfully",
     "resubscribeFailed": "Failed to reactivate subscription",
     "subscribeFailed": "Failed to subscribe",
@@ -3238,7 +3238,7 @@
       "ending": {
         "title": "Your team plan ends on {date}",
         "body": "Members keep full access until then. Reactivate to keep your shared credits and seats.",
-        "reactivate": "Reactivate plan"
+        "reactivate": "Resume subscription"
       },
       "planChange": {
         "title": "Your plan changes to {plan} on {date}",

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -845,7 +845,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.queryByRole('button', { name: 'Change plan' })
     ).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Reactivate plan' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Resume subscription' })
+    )
     expect(mockResubscribe).toHaveBeenCalledOnce()
     expect(mockShowSubscriptionDialog).not.toHaveBeenCalled()
   })
@@ -905,7 +907,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByRole('button', { name: 'Billing & invoices' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Reactivate plan' })
+      screen.getByRole('button', { name: 'Resume subscription' })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'More Options' })
@@ -930,7 +932,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('Role-based permissions')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Reactivate plan' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Resume subscription' })
+    )
 
     expect(mockShowSubscriptionDialog).toHaveBeenCalledWith({
       reason: 'settings_billing_panel'
@@ -988,14 +992,14 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Reactivate plan' })
+      screen.getByRole('button', { name: 'Resume subscription' })
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Subscribe Now' })
     ).not.toBeInTheDocument()
   })
 
-  it('hides Reactivate plan when the server denies reactivation to a client-side owner', () => {
+  it('hides Resume subscription when the server denies reactivation to a client-side owner', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockHasTeamPlan.value = false
     Object.assign(useTeamWorkspaceStore(), { isWorkspaceSubscribed: false })
@@ -1007,7 +1011,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
+      screen.queryByRole('button', { name: 'Resume subscription' })
     ).not.toBeInTheDocument()
   })
 

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -485,7 +485,7 @@ describe('UnifiedPricingTable outside Cloud', () => {
     const { emitted } = renderComponent()
 
     const cta = screen.getByRole('button', {
-      name: 'Resubscribe to Creator Yearly'
+      name: 'Resume Creator Yearly'
     })
     expect(cta).toBeEnabled()
     await user.click(cta)

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -154,7 +154,7 @@ const i18n = createI18n({
           ending: {
             title: 'Your team plan ends on {date}',
             body: 'Members keep full access until then. Reactivate to keep your shared credits and seats.',
-            reactivate: 'Reactivate plan'
+            reactivate: 'Resume subscription'
           },
           planChange: {
             title: 'Your plan changes to {plan} on {date}',
@@ -434,7 +434,7 @@ describe('BillingStatusBanner', () => {
       'Your team plan ends on'
     )
     await userEvent.click(
-      screen.getByRole('button', { name: 'Reactivate plan' })
+      screen.getByRole('button', { name: 'Resume subscription' })
     )
     expect(state.handleResubscribe).toHaveBeenCalledTimes(1)
   })
@@ -454,7 +454,7 @@ describe('BillingStatusBanner', () => {
     renderBanner()
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Reactivate plan' })
+      screen.getByRole('button', { name: 'Resume subscription' })
     )
     expect(state.handleResubscribe).toHaveBeenCalledTimes(1)
   })
@@ -473,7 +473,7 @@ describe('BillingStatusBanner', () => {
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
+      screen.queryByRole('button', { name: 'Resume subscription' })
     ).not.toBeInTheDocument()
   })
 
@@ -493,7 +493,7 @@ describe('BillingStatusBanner', () => {
       'Your team plan ends on'
     )
     expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
+      screen.queryByRole('button', { name: 'Resume subscription' })
     ).not.toBeInTheDocument()
   })
 

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -153,7 +153,7 @@ const i18n = createI18n({
           },
           ending: {
             title: 'Your team plan ends on {date}',
-            body: 'Members keep full access until then. Reactivate to keep your shared credits and seats.',
+            body: 'Members keep full access until then. Resume your subscription to keep your shared credits and seats.',
             reactivate: 'Resume subscription'
           },
           planChange: {


### PR DESCRIPTION
Implements the rename decided on [DES-1019](https://linear.app/comfyorg/issue/DES-1019/cancel-plan-reflects-an-already-cancelled-subscription).

Un-cancelling a subscription wore three names across three surfaces: **Reactivate plan** (settings panel CTA), **Reactivate plan** (ending banner action), and **Resubscribe to {plan}** (pricing table). One action, one verb: the panel and banner now read **Resume subscription**; the table keeps its verb-plus-plan label convention as **Resume {plan}**.

Copy-only — en locale values and the test assertions that pin them; no keys renamed, no behavior touched. Non-en locales follow via the translation pipeline.

Context from the same ticket, deliberately not in this PR: the hide-Cancel-plan-when-cancelled guard already ships (`canCancelPlan` excludes cancelled); the remaining FE investigation is why the stale menu item was observed on staging post-cancellation (suspected client-state staleness after the cancel completes) — separate change once pinned.

┆ Linear: DES-1019