### PR TITLE
test(errors): cover execution-error workflow scoping and rename

### DIFF
--- a/browser_tests/fixtures/helpers/ErrorsTabHelper.ts
+++ b/browser_tests/fixtures/helpers/ErrorsTabHelper.ts
@@ -33,6 +33,20 @@ export async function loadWorkflowAndOpenErrorsTab(
   await expect(errorOverlay).toBeHidden()
 }
 
+/** Queue a workflow that fails at runtime and open its Errors tab. */
+export async function queueWorkflowAndOpenExecutionErrors(
+  comfyPage: ComfyPage,
+  workflow = 'nodes/execution_error'
+) {
+  await comfyPage.workflow.loadWorkflow(workflow)
+  await comfyPage.command.executeCommand('Comfy.QueuePrompt')
+
+  const errorOverlay = comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
+  await expect(errorOverlay).toBeVisible()
+  await errorOverlay.getByTestId(TestIds.dialogs.errorOverlaySeeErrors).click()
+  await expect(errorOverlay).toBeHidden()
+}
+
 export async function openErrorsTab(comfyPage: ComfyPage) {
   const panel = new PropertiesPanelHelper(comfyPage.page)
   await panel.open(comfyPage.actionbar.propertiesButton)

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@e2e/fixtures/helpers/ErrorsTabHelper'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
 const webSocketTest = mergeTests(test, webSocketFixture)
@@ -81,6 +82,11 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
 
     await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
     await expect(runtimePanel).toBeHidden()
+
+    const panel = new PropertiesPanelHelper(comfyPage.page)
+    await panel.open(comfyPage.actionbar.propertiesButton)
+    await expect(panel.root).toBeVisible()
+    await expect(panel.errorsTab).toBeHidden()
 
     await workflowsTab.switchToWorkflow('execution_error')
     await openErrorsTab(comfyPage)

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -48,6 +48,16 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
     await expect(runtimePanel).toBeVisible()
     await expect(runtimePanel).toContainText('Error log')
   })
+})
+
+test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting(
+      'Comfy.RightSidePanel.ShowErrorsTab',
+      true
+    )
+  })
 
   test('Should keep an execution error on the workflow that produced it', async ({
     comfyPage
@@ -57,23 +67,15 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
     const runtimePanel = comfyPage.page.getByTestId(
       TestIds.dialogs.runtimeErrorPanel
     )
-    const queueButtonIcon = comfyPage.page.getByTestId(
-      TestIds.topbar.queueButtonIcon
-    )
     await expect(runtimePanel).toBeVisible()
-    await expect(queueButtonIcon).toHaveClass(/icon-\[lucide--triangle-alert\]/)
 
     await comfyPage.menu.workflowsTab.open()
     await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
-
     await expect(runtimePanel).toBeHidden()
-    await expect(queueButtonIcon).toHaveClass(/icon-\[lucide--play\]/)
 
     await comfyPage.menu.workflowsTab.switchToWorkflow('execution_error')
     await openErrorsTab(comfyPage)
-
     await expect(runtimePanel).toBeVisible()
-    await expect(queueButtonIcon).toHaveClass(/icon-\[lucide--triangle-alert\]/)
   })
 
   test('Should keep an execution error after the workflow is renamed', async ({
@@ -99,11 +101,7 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
       .toContain('execution-error-after-rename')
 
     await openErrorsTab(comfyPage)
-
     await expect(runtimePanel).toBeVisible()
-    await expect(
-      comfyPage.page.getByTestId(TestIds.topbar.queueButtonIcon)
-    ).toHaveClass(/icon-\[lucide--triangle-alert\]/)
   })
 })
 

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -77,12 +77,9 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
     const workflowsTab = comfyPage.menu.workflowsTab
     await expect
       .poll(() => workflowsTab.getOpenedWorkflowNames())
-      .toContain('execution_error')
+      .toContain('*execution_error')
 
     await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
-    await expect
-      .poll(() => workflowsTab.getOpenedWorkflowNames())
-      .toHaveLength(2)
     await expect(runtimePanel).toBeHidden()
 
     await workflowsTab.switchToWorkflow('execution_error')

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -57,6 +57,11 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
       'Comfy.RightSidePanel.ShowErrorsTab',
       true
     )
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Sidebar'
+    )
+    await comfyPage.menu.workflowsTab.open()
   })
 
   test('Should keep an execution error on the workflow that produced it', async ({
@@ -70,7 +75,6 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
     await expect(runtimePanel).toBeVisible()
 
     const workflowsTab = comfyPage.menu.workflowsTab
-    await workflowsTab.open()
     await expect
       .poll(() => workflowsTab.getOpenedWorkflowNames())
       .toContain('execution_error')
@@ -100,7 +104,6 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
     await expect(comfyPage.page.getByTestId('dialog-overlay')).toBeHidden()
 
     const workflowsTab = comfyPage.menu.workflowsTab
-    await workflowsTab.open()
     await expect
       .poll(() => workflowsTab.getOpenedWorkflowNames())
       .toContain('execution-error-before-rename')

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -71,13 +71,9 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
 
     const workflowsTab = comfyPage.menu.workflowsTab
     await workflowsTab.open()
-    const erroredWorkflow = (await workflowsTab.getOpenedWorkflowNames()).find(
-      (name) => name.includes('execution_error')
-    )
-    expect(
-      erroredWorkflow,
-      'the errored workflow should be listed as an open workflow'
-    ).toBeDefined()
+    await expect
+      .poll(() => workflowsTab.getOpenedWorkflowNames())
+      .toContain('execution_error')
 
     await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
     await expect
@@ -85,7 +81,7 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
       .toHaveLength(2)
     await expect(runtimePanel).toBeHidden()
 
-    await workflowsTab.switchToWorkflow(erroredWorkflow!)
+    await workflowsTab.switchToWorkflow('execution_error')
     await openErrorsTab(comfyPage)
     await expect(runtimePanel).toBeVisible()
   })
@@ -101,6 +97,7 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
     await expect(runtimePanel).toBeVisible()
 
     await comfyPage.menu.topbar.saveWorkflowAs('execution-error-before-rename')
+    await expect(comfyPage.page.getByTestId('dialog-overlay')).toBeHidden()
 
     const workflowsTab = comfyPage.menu.workflowsTab
     await workflowsTab.open()

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -1,10 +1,13 @@
 import { mergeTests } from '@playwright/test'
 
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
+import {
+  openErrorsTab,
+  queueWorkflowAndOpenExecutionErrors
+} from '@e2e/fixtures/helpers/ErrorsTabHelper'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { webSocketFixture } from '@e2e/fixtures/ws'
@@ -21,24 +24,10 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
     await comfyPage.setup()
   })
 
-  async function openExecutionErrorTab(comfyPage: ComfyPage) {
-    await comfyPage.workflow.loadWorkflow('nodes/execution_error')
-    await comfyPage.command.executeCommand('Comfy.QueuePrompt')
-
-    const errorOverlay = comfyPage.page.getByTestId(
-      TestIds.dialogs.errorOverlay
-    )
-    await expect(errorOverlay).toBeVisible()
-    await errorOverlay
-      .getByTestId(TestIds.dialogs.errorOverlaySeeErrors)
-      .click()
-    await expect(errorOverlay).toBeHidden()
-  }
-
   test('Should show Find on GitHub and Copy buttons in error card', async ({
     comfyPage
   }) => {
-    await openExecutionErrorTab(comfyPage)
+    await queueWorkflowAndOpenExecutionErrors(comfyPage)
 
     await expect(
       comfyPage.page.getByTestId(TestIds.dialogs.errorCardFindOnGithub)
@@ -51,13 +40,70 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
   test('Should show runtime error log in the execution error group', async ({
     comfyPage
   }) => {
-    await openExecutionErrorTab(comfyPage)
+    await queueWorkflowAndOpenExecutionErrors(comfyPage)
 
     const runtimePanel = comfyPage.page.getByTestId(
       TestIds.dialogs.runtimeErrorPanel
     )
     await expect(runtimePanel).toBeVisible()
     await expect(runtimePanel).toContainText('Error log')
+  })
+
+  test('Should keep an execution error on the workflow that produced it', async ({
+    comfyPage
+  }) => {
+    await queueWorkflowAndOpenExecutionErrors(comfyPage)
+
+    const runtimePanel = comfyPage.page.getByTestId(
+      TestIds.dialogs.runtimeErrorPanel
+    )
+    const queueButtonIcon = comfyPage.page.getByTestId(
+      TestIds.topbar.queueButtonIcon
+    )
+    await expect(runtimePanel).toBeVisible()
+    await expect(queueButtonIcon).toHaveClass(/icon-\[lucide--triangle-alert\]/)
+
+    await comfyPage.menu.workflowsTab.open()
+    await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
+
+    await expect(runtimePanel).toBeHidden()
+    await expect(queueButtonIcon).toHaveClass(/icon-\[lucide--play\]/)
+
+    await comfyPage.menu.workflowsTab.switchToWorkflow('execution_error')
+    await openErrorsTab(comfyPage)
+
+    await expect(runtimePanel).toBeVisible()
+    await expect(queueButtonIcon).toHaveClass(/icon-\[lucide--triangle-alert\]/)
+  })
+
+  test('Should keep an execution error after the workflow is renamed', async ({
+    comfyPage
+  }) => {
+    await queueWorkflowAndOpenExecutionErrors(comfyPage)
+
+    const runtimePanel = comfyPage.page.getByTestId(
+      TestIds.dialogs.runtimeErrorPanel
+    )
+    await expect(runtimePanel).toBeVisible()
+
+    await comfyPage.menu.topbar.saveWorkflowAs('execution-error-before-rename')
+
+    const workflowsTab = comfyPage.menu.workflowsTab
+    await workflowsTab.open()
+    await workflowsTab.renameWorkflow(
+      workflowsTab.getOpenedItem('execution-error-before-rename'),
+      'execution-error-after-rename'
+    )
+    await expect
+      .poll(() => workflowsTab.getOpenedWorkflowNames())
+      .toContain('execution-error-after-rename')
+
+    await openErrorsTab(comfyPage)
+
+    await expect(runtimePanel).toBeVisible()
+    await expect(
+      comfyPage.page.getByTestId(TestIds.topbar.queueButtonIcon)
+    ).toHaveClass(/icon-\[lucide--triangle-alert\]/)
   })
 })
 

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -69,11 +69,23 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
     )
     await expect(runtimePanel).toBeVisible()
 
-    await comfyPage.menu.workflowsTab.open()
+    const workflowsTab = comfyPage.menu.workflowsTab
+    await workflowsTab.open()
+    const erroredWorkflow = (await workflowsTab.getOpenedWorkflowNames()).find(
+      (name) => name.includes('execution_error')
+    )
+    expect(
+      erroredWorkflow,
+      'the errored workflow should be listed as an open workflow'
+    ).toBeDefined()
+
     await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
+    await expect
+      .poll(() => workflowsTab.getOpenedWorkflowNames())
+      .toHaveLength(2)
     await expect(runtimePanel).toBeHidden()
 
-    await comfyPage.menu.workflowsTab.switchToWorkflow('execution_error')
+    await workflowsTab.switchToWorkflow(erroredWorkflow!)
     await openErrorsTab(comfyPage)
     await expect(runtimePanel).toBeVisible()
   })
@@ -92,6 +104,10 @@ test.describe('Errors tab - Execution error lifecycle', { tag: '@ui' }, () => {
 
     const workflowsTab = comfyPage.menu.workflowsTab
     await workflowsTab.open()
+    await expect
+      .poll(() => workflowsTab.getOpenedWorkflowNames())
+      .toContain('execution-error-before-rename')
+
     await workflowsTab.renameWorkflow(
       workflowsTab.getOpenedItem('execution-error-before-rename'),
       'execution-error-after-rename'


### PR DESCRIPTION
## Summary

Adds browser coverage for two error-lifecycle fixes that shipped in 1.54 with no test behind them: execution errors staying scoped to the workflow that produced them, and surviving a workflow rename.

## Changes

- **What**: two tests in `errorsTabExecution.spec.ts`, plus `queueWorkflowAndOpenExecutionErrors` lifted out of that spec into `ErrorsTabHelper` (the two existing call sites repointed, no behaviour change).

## Review Focus

`errorsTabExecution.spec.ts` asserted only the error card contents and the runtime log. Per-workflow scoping *is* covered for missing **nodes**, by `errorsTabModeAware.spec.ts` → "Restores missing nodes in errors tab when switching back to workflow" — but not for execution errors, which are a separate path. So today nothing fails if an execution error leaks onto a neighbouring workflow, or disappears when the workflow is renamed.

The two fixes:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15361 — keep execution errors scoped to the workflow that produced them
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/16766 — keep execution errors after workflow rename

Both tests assert the queue button icon alongside the errors panel, since that badge is how a user actually notices a workflow is in an error state — the panel alone would pass even if the topbar went stale.

Worth a look at the rename test's setup: it saves the workflow first (`saveWorkflowAs`) because `renameWorkflow` operates on a persisted item, so the flow is run-error → save → rename rather than run-error → rename.

Found by auditing the 1.53 → 1.54 QA test plan against the suite rather than against a grep, which is also how #16807's early-execution-error case turned out to be already covered and got dropped from the plan.
