### PR TITLE
fix: check out available lockfile repair action

### DIFF
--- a/.github/workflows/ci-lockfile-repair.yaml
+++ b/.github/workflows/ci-lockfile-repair.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Checkout pull request


### PR DESCRIPTION
## Summary

Check out the live trusted base branch before invoking the local lockfile repair action, so long-lived PR events whose recorded base SHA predates the action can still run.

## Changes

- **What**: Use the pull request base ref for action lookup while retaining the exact event base SHA as the merge input.

## Review Focus

Confirm the checkout remains trusted and [the failing long-lived PR run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34427400862/job/102715447773) can find `.github/actions/prepare-lockfile-merge`.