### PR TITLE
feat(billing): show scheduled plan change in pricing table

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3022,6 +3022,8 @@
     "teamHeaderLearnMore": "Learn more",
     "personalHeader": "Personal plans are for individual use only. {action}",
     "personalHeaderAction": "To add teammates, subscribe to the team plan.",
+    "scheduledChangeNotice": "Your plan changes to {plan} on {date}.",
+    "scheduledForDate": "Scheduled for {date}",
     "everythingInPlus": "Everything in {plan}, plus:",
     "monthlyCredits": "monthly credits",
     "yearlyCredits": "credits per year",

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -1,4 +1,7 @@
-import type { SubscriptionTier } from '@comfyorg/ingest-types'
+import type {
+  ScheduledPlanChange,
+  SubscriptionTier
+} from '@comfyorg/ingest-types'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -39,7 +42,7 @@ interface MockSubscription {
   tier: SubscriptionTier | null
   isCancelled?: boolean
   duration?: string
-  scheduledChange?: { plan_slug: string; effective_at: string }
+  scheduledChange?: ScheduledPlanChange
 }
 
 interface MockTeamStop {
@@ -265,7 +268,8 @@ describe('UnifiedPricingTable scheduled plan change', () => {
       duration: 'ANNUAL',
       scheduledChange: {
         plan_slug: 'standard-monthly',
-        effective_at: '2026-10-01T00:00:00Z'
+        effective_at: '2026-10-01T00:00:00Z',
+        team_credit_stop: null
       }
     }
     mockSubscriptionStatus.value = null
@@ -332,7 +336,8 @@ describe('UnifiedPricingTable scheduled plan change', () => {
       duration: 'MONTHLY',
       scheduledChange: {
         plan_slug: 'creator-annual',
-        effective_at: '2026-10-01T00:00:00Z'
+        effective_at: '2026-10-01T00:00:00Z',
+        team_credit_stop: null
       }
     }
     mockCurrentPlanSlug.value = 'creator-monthly'
@@ -343,7 +348,7 @@ describe('UnifiedPricingTable scheduled plan change', () => {
       screen.getByRole('button', { name: 'Scheduled for Oct 1, 2026' })
     ).toBeDisabled()
 
-    await user.click(screen.getByTestId('cycle-monthly'))
+    await user.click(screen.getByRole('button', { name: 'Monthly' }))
     await nextTick()
 
     expect(screen.getByRole('button', { name: 'Current Plan' })).toBeDisabled()
@@ -366,7 +371,8 @@ describe('UnifiedPricingTable scheduled plan change', () => {
       duration: 'ANNUAL',
       scheduledChange: {
         plan_slug: 'standard-monthly',
-        effective_at: '2026-10-01T00:00:00Z'
+        effective_at: '2026-10-01T00:00:00Z',
+        team_credit_stop: null
       },
       isCancelled: true
     }
@@ -770,7 +776,7 @@ describe('UnifiedPricingTable credit allotment copy', () => {
     const user = userEvent.setup()
     renderWithCycleToggle()
 
-    await user.click(screen.getByTestId('cycle-monthly'))
+    await user.click(screen.getByRole('button', { name: 'Monthly' }))
     await nextTick()
 
     expect(screen.getAllByText('monthly credits')).toHaveLength(3)
@@ -788,7 +794,7 @@ describe('UnifiedPricingTable credit allotment copy', () => {
     expect(screen.getByText('1,772,400')).toBeTruthy()
     expect(screen.getByText('Generates ~160,860 5s videos*')).toBeTruthy()
 
-    await user.click(screen.getByTestId('cycle-monthly'))
+    await user.click(screen.getByRole('button', { name: 'Monthly' }))
     await nextTick()
 
     expect(screen.getByText('monthly credits')).toBeTruthy()

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -295,16 +295,23 @@ describe('UnifiedPricingTable scheduled plan change', () => {
     ]
   })
 
-  it('shows the destination and current plan while disabling plan actions', () => {
-    renderComponent()
+  it('shows a scheduled monthly destination only on the monthly cycle', async () => {
+    const user = userEvent.setup()
+    renderWithCycleToggle()
+
+    expect(screen.getByRole('button', { name: 'Current Plan' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /Scheduled for/ })).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Change to Pro Yearly' })
+    ).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Monthly' }))
+    await nextTick()
 
     expect(
       screen.getByRole('button', { name: 'Scheduled for Oct 1, 2026' })
     ).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Current Plan' })).toBeDisabled()
-    expect(
-      screen.getByRole('button', { name: 'Change to Pro Yearly' })
-    ).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Current Plan' })).toBeNull()
   })
 
   it('replaces the footnote with a link-less status notice', () => {

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -1,5 +1,5 @@
 import type { SubscriptionTier } from '@comfyorg/ingest-types'
-import { render, screen } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, ref } from 'vue'
@@ -39,6 +39,7 @@ interface MockSubscription {
   tier: SubscriptionTier | null
   isCancelled?: boolean
   duration?: string
+  scheduledChange?: { plan_slug: string; effective_at: string }
 }
 
 interface MockTeamStop {
@@ -254,6 +255,127 @@ describe('UnifiedPricingTable plan CTA labels', () => {
       screen.queryByRole('button', { name: 'Change to Standard Yearly' })
     ).toBeNull()
     expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
+  })
+})
+
+describe('UnifiedPricingTable scheduled plan change', () => {
+  beforeEach(() => {
+    mockSubscription.value = {
+      tier: 'CREATOR',
+      duration: 'ANNUAL',
+      scheduledChange: {
+        plan_slug: 'standard-monthly',
+        effective_at: '2026-10-01T00:00:00Z'
+      }
+    }
+    mockSubscriptionStatus.value = null
+    mockCurrentPlanSlug.value = null
+    mockCurrentTeamCreditStop.value = null
+    mockIsTeamPlan.value = false
+    mockCanManageSubscription.value = false
+    mockCanDowngradeToPersonal.value = false
+    mockCanChangeSeats.value = false
+    mockRawCanReactivate.value = false
+    mockSnapshotAuthoritative.value = true
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockDistributionTypes.isCloud = true
+    mockApiPlans.value = [
+      apiPlan('STANDARD', 'MONTHLY', 42_000),
+      apiPlan('STANDARD', 'ANNUAL', 504_000),
+      apiPlan('CREATOR', 'MONTHLY', 74_000),
+      apiPlan('CREATOR', 'ANNUAL', 888_000)
+    ]
+  })
+
+  it('shows the destination and current plan while disabling plan actions', () => {
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Scheduled for Oct 1, 2026' })
+    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Current Plan' })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Change to Pro Yearly' })
+    ).toBeDisabled()
+  })
+
+  it('replaces the footnote with a link-less status notice', () => {
+    renderComponent()
+
+    const notice = screen.getByRole('status')
+    expect(notice).toHaveTextContent(
+      'Your plan changes to Standard on Oct 1, 2026.'
+    )
+    expect(within(notice).queryByRole('button')).toBeNull()
+    expect(screen.queryByText(/Based on this template/)).toBeNull()
+  })
+
+  it('shows the notice and disables the team action on the team tab', () => {
+    renderComponent({ initialPlanMode: 'team' })
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Your plan changes to Standard on Oct 1, 2026.'
+    )
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
+    ).toBeDisabled()
+  })
+
+  it('shows a cadence change only when viewing its destination cycle', async () => {
+    const user = userEvent.setup()
+    mockSubscription.value = {
+      tier: 'CREATOR',
+      duration: 'MONTHLY',
+      scheduledChange: {
+        plan_slug: 'creator-annual',
+        effective_at: '2026-10-01T00:00:00Z'
+      }
+    }
+    mockCurrentPlanSlug.value = 'creator-monthly'
+
+    renderWithCycleToggle()
+
+    expect(
+      screen.getByRole('button', { name: 'Scheduled for Oct 1, 2026' })
+    ).toBeDisabled()
+
+    await user.click(screen.getByTestId('cycle-monthly'))
+    await nextTick()
+
+    expect(screen.getByRole('button', { name: 'Current Plan' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /Scheduled for/ })).toBeNull()
+  })
+
+  it('suppresses an incomplete scheduled change', () => {
+    mockApiPlans.value = []
+
+    renderComponent()
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByText(/Based on this template/)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Scheduled for/ })).toBeNull()
+  })
+
+  it('suppresses a scheduled change on a cancelled subscription', () => {
+    mockSubscription.value = {
+      tier: 'CREATOR',
+      duration: 'ANNUAL',
+      scheduledChange: {
+        plan_slug: 'standard-monthly',
+        effective_at: '2026-10-01T00:00:00Z'
+      },
+      isCancelled: true
+    }
+
+    renderComponent()
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByText(/Based on this template/)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Scheduled for/ })).toBeNull()
   })
 })
 

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -902,10 +902,7 @@ const isCurrentPlan = (tierKey: CheckoutTierKey): boolean => {
 function isScheduledDestination(tierKey: CheckoutTierKey): boolean {
   const slug = scheduledPlanChange.scheduledChange.value?.plan_slug
   if (!slug) return false
-  return (
-    getApiPlanForTier(tierKey, 'monthly')?.slug === slug ||
-    getApiPlanForTier(tierKey, 'yearly')?.slug === slug
-  )
+  return getApiPlanForTier(tierKey, currentBillingCycle.value)?.slug === slug
 }
 
 const getButtonLabel = (tier: PricingTierConfig): string => {

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -355,53 +355,73 @@
       </div>
     </div>
 
-    <!-- Footnote: template caveat + contact / pricing links -->
-    <I18nT
-      keypath="subscription.pricingBlurb"
-      tag="p"
-      class="m-0 mt-auto pt-4 text-center text-sm text-text-secondary"
-    >
-      <template #seeDetails>
-        <a
-          :href="VIDEO_TEMPLATE_URL"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
-        >
-          {{ t('subscription.pricingBlurbSeeDetails') }}
-        </a>
-      </template>
-      <template #questions>
-        <a
-          :href="QUESTIONS_URL"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
-        >
-          {{ t('subscription.pricingBlurbQuestions') }}
-        </a>
-      </template>
-      <template #enterpriseDiscussions>
-        <a
-          :href="ENTERPRISE_URL"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
-        >
-          {{ t('subscription.pricingBlurbEnterprise') }}
-        </a>
-      </template>
-      <template #clickHere>
-        <a
-          :href="PRICING_URL"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
-        >
-          {{ t('subscription.pricingBlurbClickHere') }}
-        </a>
-      </template>
-    </I18nT>
+    <div class="mt-auto flex min-h-14 items-center justify-center pt-4">
+      <div
+        v-if="showScheduledPlanChange"
+        role="status"
+        class="flex items-center gap-2 rounded-full bg-base-foreground px-3 py-1.5 text-sm text-base-background"
+      >
+        <i
+          class="icon-[lucide--info] size-4 shrink-0 bg-base-background"
+          aria-hidden="true"
+        />
+        <span>
+          {{
+            t('subscription.scheduledChangeNotice', {
+              plan: scheduledPlanChange.planName.value,
+              date: scheduledPlanChange.formattedDate.value
+            })
+          }}
+        </span>
+      </div>
+      <I18nT
+        v-else
+        keypath="subscription.pricingBlurb"
+        tag="p"
+        class="m-0 text-center text-sm text-text-secondary"
+      >
+        <template #seeDetails>
+          <a
+            :href="VIDEO_TEMPLATE_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
+          >
+            {{ t('subscription.pricingBlurbSeeDetails') }}
+          </a>
+        </template>
+        <template #questions>
+          <a
+            :href="QUESTIONS_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
+          >
+            {{ t('subscription.pricingBlurbQuestions') }}
+          </a>
+        </template>
+        <template #enterpriseDiscussions>
+          <a
+            :href="ENTERPRISE_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
+          >
+            {{ t('subscription.pricingBlurbEnterprise') }}
+          </a>
+        </template>
+        <template #clickHere>
+          <a
+            :href="PRICING_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="cursor-pointer text-sm text-base-foreground no-underline hover:text-muted-foreground"
+          >
+            {{ t('subscription.pricingBlurbClickHere') }}
+          </a>
+        </template>
+      </I18nT>
+    </div>
   </div>
 </template>
 
@@ -438,6 +458,7 @@ import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscript
 import { isCloud } from '@/platform/distribution/types'
 import type { Plan } from '@/platform/workspace/api/workspaceApi'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
+import { useScheduledPlanChange } from '@/platform/workspace/composables/useScheduledPlanChange'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
@@ -671,6 +692,10 @@ watch(
 const { teamCreditStops } = useBillingPlans()
 
 const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+const scheduledPlanChange = useScheduledPlanChange()
+const showScheduledPlanChange = computed(
+  () => scheduledPlanChange.isDisplayable.value && !isCancelled.value
+)
 
 // An ended subscription still reports its plan slug and tier, so the plan it
 // held must not read as current — it is buyable again.
@@ -874,6 +899,15 @@ const isCurrentPlan = (tierKey: CheckoutTierKey): boolean => {
   )
 }
 
+function isScheduledDestination(tierKey: CheckoutTierKey): boolean {
+  const slug = scheduledPlanChange.scheduledChange.value?.plan_slug
+  if (!slug) return false
+  return (
+    getApiPlanForTier(tierKey, 'monthly')?.slug === slug ||
+    getApiPlanForTier(tierKey, 'yearly')?.slug === slug
+  )
+}
+
 const getButtonLabel = (tier: PricingTierConfig): string => {
   const planName =
     currentBillingCycle.value === 'yearly'
@@ -884,6 +918,12 @@ const getButtonLabel = (tier: PricingTierConfig): string => {
     return isCancelled.value
       ? t('subscription.resubscribeTo', { plan: planName })
       : t('subscription.currentPlan')
+  }
+
+  if (showScheduledPlanChange.value && isScheduledDestination(tier.key)) {
+    return t('subscription.scheduledForDate', {
+      date: scheduledPlanChange.formattedDate.value
+    })
   }
 
   return hasActivePaidPlan(currentAccountTier.value)


### PR DESCRIPTION
## Summary

Show a scheduled plan change directly in the pricing table so customers can see the destination plan and effective date before the change takes effect.

## Changes

- **What**: Labels the destination card `Scheduled for {date}` while preserving `Current Plan` on the active card.
- **What**: Replaces the pricing footnote with a link-less scheduled-change status notice on both Personal and Teams tabs.
- **What**: Keeps CTA disabling on the existing server capability union; cloud#8417 will close the actions with `subscription_change_in_progress`.
- **Breaking**: None.
- **Dependencies**: Display uses the existing `/billing/status.scheduled_change` contract. CTA disabling depends on Comfy-Org/cloud#8417.

## Review Focus

- Built independently from the latest `main`; this is not stacked on or cherry-picked from #17301. The settled DES-1023 design is the visual reference only.
- Current-plan labeling wins for cadence-only changes, while the destination cycle shows the scheduled date.
- Cancelled or incomplete scheduled changes fall back to the existing pricing footnote.
- `Stay on {plan}` remains out of scope until BE-10873 provides the revert endpoint and capability.

Linear: FE-2152
Design: https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=6865-29850

## Verification

- `pnpm test:unit src/platform/workspace/components/UnifiedPricingTable.test.ts` (41 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm format:check`
- `pnpm locale:check`
- `pnpm knip`

## Screenshots

### AS IS

Scheduled change is not reflected in the destination card or footer.

![AS IS pricing table](https://github.com/user-attachments/assets/ca4d1f65-2de7-436a-a6dc-f9cccb81df0b)

### TO BE

The destination card shows the effective date and the footer explains the scheduled change.

![TO BE pricing table](https://github.com/user-attachments/assets/1e744f7c-50a1-4a5a-ad21-578269eb8d2a)