### PR TITLE
test: assert usage output and subscription state transitions

### DIFF
--- a/src/components/dialog/content/setting/UsageLogsTable.test.ts
+++ b/src/components/dialog/content/setting/UsageLogsTable.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import { render, screen, waitFor } from '@testing-library/vue'
+import { render, screen, waitFor, within } from '@testing-library/vue'
 
 import type { AuditLog } from '@/services/customerEventsService'
 import { EventType } from '@/services/customerEventsService'
@@ -177,7 +177,8 @@ describe('UsageLogsTable', () => {
       }
     )
     mockCustomerEventsService.formatDate.mockImplementation(
-      (dateString: string) => new Date(dateString).toLocaleDateString()
+      (dateString: string) =>
+        new Date(dateString).toLocaleDateString('en-US', { timeZone: 'UTC' })
     )
     mockCustomerEventsService.hasAdditionalInfo.mockImplementation(
       (event: AuditLog) => {
@@ -290,15 +291,38 @@ describe('UsageLogsTable', () => {
     it('renders event type badges', async () => {
       await renderLoaded()
 
-      expect(mockCustomerEventsService.formatEventType).toHaveBeenCalled()
-      expect(mockCustomerEventsService.getEventSeverity).toHaveBeenCalled()
+      const creditRow = screen.getByRole('row', { name: /Added \$10\.00/ })
+      const usageRow = screen.getByRole('row', { name: /Image Generation/ })
+
+      expect(within(creditRow).getByText('Credits Added')).toBeInTheDocument()
+      expect(within(usageRow).getByText('API Usage')).toBeInTheDocument()
     })
 
     it('renders credit added details with formatted amount', async () => {
+      mockCustomerEventsService.getMyEvents.mockResolvedValue(
+        makeEventsResponse([
+          {
+            event_id: 'credit-1',
+            event_type: EventType.CREDIT_ADDED,
+            params: { amount: 2735 },
+            createdAt: '2024-01-01T10:00:00Z'
+          },
+          {
+            event_id: 'credit-2',
+            event_type: EventType.CREDIT_ADDED,
+            params: { amount: 408 },
+            createdAt: '2024-01-02T10:00:00Z'
+          }
+        ])
+      )
+
       await renderLoaded()
 
-      expect(screen.getByText(/Added \$/)).toBeInTheDocument()
-      expect(mockCustomerEventsService.formatAmount).toHaveBeenCalled()
+      const firstRow = screen.getByRole('row', { name: /1\/1\/2024/ })
+      const secondRow = screen.getByRole('row', { name: /1\/2\/2024/ })
+
+      expect(within(firstRow).getByText('Added $27.35')).toBeInTheDocument()
+      expect(within(secondRow).getByText('Added $4.08')).toBeInTheDocument()
     })
 
     it('renders API usage details with api name and model', async () => {
@@ -330,7 +354,11 @@ describe('UsageLogsTable', () => {
     it('renders formatted dates', async () => {
       await renderLoaded()
 
-      expect(mockCustomerEventsService.formatDate).toHaveBeenCalled()
+      const creditRow = screen.getByRole('row', { name: /Added \$10\.00/ })
+      const usageRow = screen.getByRole('row', { name: /Image Generation/ })
+
+      expect(within(creditRow).getByText('1/1/2024')).toBeInTheDocument()
+      expect(within(usageRow).getByText('1/2/2024')).toBeInTheDocument()
     })
 
     it('renders info buttons for events with additional info', async () => {
@@ -489,24 +517,6 @@ describe('UsageLogsTable', () => {
   })
 
   describe('EventType integration', () => {
-    it('renders credit_added event with correct detail template', async () => {
-      mockCustomerEventsService.getMyEvents.mockResolvedValue(
-        makeEventsResponse([
-          {
-            event_id: 'event-1',
-            event_type: EventType.CREDIT_ADDED,
-            params: { amount: 1000 },
-            createdAt: '2024-01-01T10:00:00Z'
-          }
-        ])
-      )
-
-      await renderLoaded()
-
-      expect(screen.getByText(/Added \$/)).toBeInTheDocument()
-      expect(mockCustomerEventsService.formatAmount).toHaveBeenCalled()
-    })
-
     it('renders api_usage_completed event with correct detail template', async () => {
       mockCustomerEventsService.getMyEvents.mockResolvedValue(
         makeEventsResponse([

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -315,7 +315,7 @@ describe('useSubscription', () => {
 
       await fetchStatus()
 
-      expect(subscriptionStatus.value).toMatchObject({
+      expect(subscriptionStatus.value).toEqual({
         is_active: false,
         has_funds: true
       })

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -256,23 +256,14 @@ describe('useSubscription', () => {
       mockGetBillingStatus.mockResolvedValue({
         is_active: true,
         has_funds: true,
-        renewal_date: '2025-11-16T12:00:00Z'
+        renewal_date: '2025-11-16T12:00:00'
       })
 
       mockIsLoggedIn.value = true
       const { formattedRenewalDate, fetchStatus } = useSubscriptionWithScope()
 
       await fetchStatus()
-      // The date format may vary based on timezone, so we just check it's a valid date string
-      expect(formattedRenewalDate.value).toMatch(/^[A-Za-z]{3} \d{1,2}, \d{4}$/)
-      expect(formattedRenewalDate.value).toContain('2025')
-      expect(formattedRenewalDate.value).toContain('Nov')
-    })
-
-    it('should return empty string when renewal date is not available', () => {
-      const { formattedRenewalDate } = useSubscriptionWithScope()
-
-      expect(formattedRenewalDate.value).toBe('')
+      expect(formattedRenewalDate.value).toBe('Nov 16, 2025')
     })
 
     it('should return subscription tier from status', async () => {
@@ -290,10 +281,50 @@ describe('useSubscription', () => {
       expect(subscriptionTier.value).toBe('CREATOR')
     })
 
-    it('should return null when subscription tier is not available', () => {
-      const { subscriptionTier } = useSubscriptionWithScope()
+    it('clears plan details when a refreshed status has no subscription', async () => {
+      mockGetBillingStatus
+        .mockResolvedValueOnce({
+          is_active: true,
+          has_funds: false,
+          subscription_tier: 'CREATOR',
+          subscription_duration: 'ANNUAL',
+          renewal_date: '2025-11-16T12:00:00',
+          cancel_at: '2025-12-01T12:00:00'
+        })
+        .mockResolvedValueOnce({ is_active: false, has_funds: true })
 
+      const {
+        fetchStatus,
+        subscriptionStatus,
+        subscriptionTier,
+        subscriptionDuration,
+        isYearlySubscription,
+        formattedRenewalDate,
+        isCancelled,
+        formattedEndDate
+      } = useSubscriptionWithScope()
+
+      await fetchStatus()
+
+      expect(subscriptionTier.value).toBe('CREATOR')
+      expect(subscriptionDuration.value).toBe('ANNUAL')
+      expect(isYearlySubscription.value).toBe(true)
+      expect(formattedRenewalDate.value).toBe('Nov 16, 2025')
+      expect(isCancelled.value).toBe(true)
+      expect(formattedEndDate.value).toBe('Dec 1, 2025')
+
+      await fetchStatus()
+
+      expect(subscriptionStatus.value).toMatchObject({
+        is_active: false,
+        has_funds: true
+      })
       expect(subscriptionTier.value).toBeNull()
+      expect(subscriptionDuration.value).toBeNull()
+      expect(isYearlySubscription.value).toBe(false)
+      expect(formattedRenewalDate.value).toBe('')
+      expect(isCancelled.value).toBe(false)
+      expect(formattedEndDate.value).toBe('')
     })
 
     it('derives cancellation state and end date from cancel_at', async () => {
@@ -313,24 +344,6 @@ describe('useSubscription', () => {
   })
 
   describe('fetchStatus', () => {
-    it('should fetch subscription status successfully', async () => {
-      const mockStatus = {
-        is_active: true,
-        has_funds: true,
-        renewal_date: '2025-11-16',
-        team_credit_stop: null
-      }
-
-      mockGetBillingStatus.mockResolvedValue(mockStatus)
-
-      mockIsLoggedIn.value = true
-      const { fetchStatus } = useSubscriptionWithScope()
-
-      await fetchStatus()
-
-      expect(mockGetBillingStatus).toHaveBeenCalledOnce()
-    })
-
     it('should handle fetch errors gracefully', async () => {
       mockGetBillingStatus.mockRejectedValue(
         new Error('Subscription not found')


### PR DESCRIPTION
## Summary

Assert the usage output and subscription state that callers receive instead of only checking formatting/service calls.

## Changes

- Check event badges, distinct formatted amounts, and dates in their corresponding rendered rows.
- Check that refreshing from an annual plan to no subscription clears the exposed plan and cancellation details, using asymmetric active/funds inputs.
- Replace default-only checks and remove redundant mock-only cases while preserving request-coalescing and billing-rail assertions.

## Review Focus

Fixes #17254. Only the two test files change; production behavior is unchanged.

Validation: 57 focused tests passed, plus typecheck, lint, knip, scoped formatting, and git diff --check. Four temporary mutations to badge/amount/date rendering and stale subscription state each failed the corresponding improved test. A behavior-preserving formatter refactor passed. All temporary production changes were then removed.