### PR TITLE
feat: EDU promo pricing for the cloud subscription surfaces

### DIFF
--- a/src/components/ui/credit-slider/CreditSlider.test.ts
+++ b/src/components/ui/credit-slider/CreditSlider.test.ts
@@ -205,4 +205,15 @@ describe('CreditSlider', () => {
       expect(stop.credits).toBe(usdToCredits(stop.usd))
     }
   })
+
+  it('stacks an extra discount percent into the price and save badge', async () => {
+    // team_700 yearly: 10% volume + 5% EDU = $595 shown, 15% ($105) saved.
+    renderSlider({ modelValue: 700, extraDiscountPercent: 5 })
+    await flush()
+
+    expect(screen.getByTestId('credit-slider-price')).toHaveTextContent('$595')
+    expect(screen.getByTestId('credit-slider-save')).toHaveTextContent(
+      'Save 15% ($105)'
+    )
+  })
 })

--- a/src/components/ui/credit-slider/CreditSlider.vue
+++ b/src/components/ui/credit-slider/CreditSlider.vue
@@ -23,7 +23,8 @@ const {
   class: rootClass,
   stops = TEAM_PLAN_CREDIT_STOPS,
   defaultStopIndex = DEFAULT_TEAM_PLAN_STOP_INDEX,
-  cycle = 'yearly'
+  cycle = 'yearly',
+  extraDiscountPercent = 0
 } = defineProps<{
   disabled?: boolean
   class?: HTMLAttributes['class']
@@ -45,6 +46,8 @@ const {
    * halved": yearly 0/5/10/15/20% → monthly 0/2.5/5/7.5/10%).
    */
   cycle?: 'monthly' | 'yearly'
+  /** Extra percent of list stacked on the stop's cycle discount (team EDU promo). */
+  extraDiscountPercent?: number
 }>()
 
 const emit = defineEmits<{
@@ -78,13 +81,14 @@ const current = computed<CreditStop>(() => stops[selectedIndex.value])
 // `discountPercentYearly`; monthly halves it (PRD: GA Team Billing). The card
 // shows the discounted monthly price, the struck pre-discount price, the
 // saving, and — for yearly — the annual total.
-const effectiveDiscountPercent = computed(() =>
-  cycle === 'monthly'
-    ? current.value.discountPercentYearly / 2
-    : current.value.discountPercentYearly
+const effectiveDiscountPercent = computed(
+  () =>
+    (cycle === 'monthly'
+      ? current.value.discountPercentYearly / 2
+      : current.value.discountPercentYearly) + extraDiscountPercent
 )
 const discountedMonthly = computed(() =>
-  getStopDiscountedMonthlyUsd(current.value, cycle)
+  getStopDiscountedMonthlyUsd(current.value, cycle, extraDiscountPercent)
 )
 const saveAmount = computed(() => current.value.usd - discountedMonthly.value)
 const hasDiscount = computed(() => effectiveDiscountPercent.value > 0)

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -45,7 +45,8 @@ export enum ServerFeatureFlag {
   CHURNKEY_APP_ID = 'churnkey_app_id',
   SIGNUP_TURNSTILE = 'signup_turnstile',
   SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags',
-  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled'
+  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled',
+  EDU_PRICING_ENABLED = 'edu_pricing_enabled'
 }
 
 function reportFeatureFlagEvaluation<T>(flagKey: string, value: T): T {
@@ -294,6 +295,14 @@ export function useFeatureFlags() {
     },
     get assetsEnabled() {
       return isCloud || resolveFlag('assets', undefined, false)
+    },
+    /** EDU promo pricing display; the customer must also carry is_edu (cloud#8725). */
+    get eduPricingEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.EDU_PRICING_ENABLED,
+        remoteConfig.value.edu_pricing_enabled,
+        false
+      )
     }
   })
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2801,6 +2801,7 @@
   },
   "subscription": {
     "plansForWorkspace": "Plans for {workspace}",
+    "eduPromoHeader": "Education discount: up to {percent}% off for eligible students and educators",
     "personalWorkspace": "Personal Workspace",
     "teamWorkspace": "Team Workspace",
     "soloUseOnly": "Solo use only",

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -9,6 +9,7 @@ import { createI18n } from 'vue-i18n'
 import PricingTable from '@/platform/cloud/subscription/components/PricingTable.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { IngestSubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
+import { applyEduDiscount } from '@/platform/cloud/subscription/constants/tierPricing'
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 
 async function flushPromises() {
@@ -89,6 +90,17 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
     )
   })
 }))
+
+const mockIsEduPricingActive = ref(false)
+
+vi.mock<unknown>(
+  import('@/platform/cloud/subscription/composables/useEduPricing'),
+  () => ({
+    useEduPricing: () => ({
+      isEduPricingActive: computed(() => mockIsEduPricingActive.value)
+    })
+  })
+)
 
 vi.mock<unknown>(import('@/composables/auth/useAuthActions'), () => ({
   useAuthActions: () => ({
@@ -242,6 +254,7 @@ describe('PricingTable', () => {
     mockCanAccessSubscriptionFeatures.value = false
     mockSubscriptionTier.value = null
     mockSubscriptionDuration.value = 'MONTHLY'
+    mockIsEduPricingActive.value = false
     Object.assign(useAuthStore(), { userId: 'user-123' })
     mockAccessBillingPortal.mockResolvedValue(true)
     mockLocalStorage.__reset()
@@ -559,6 +572,47 @@ describe('PricingTable', () => {
       await userEvent.click(teamLink!)
 
       expect(onChooseTeamWorkspace).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('EDU pricing', () => {
+    // Display must match the coupon charge: monthly 10% off list, yearly
+    // 6.25% off the yearly price (= 25% off the monthly list).
+    it.for([
+      ['standard', 'monthly', '$18', '$20', null],
+      ['creator', 'monthly', '$31.50', '$35', null],
+      ['pro', 'monthly', '$90', '$100', null],
+      ['standard', 'yearly', '$15', '$20', 'Billed yearly ($180)'],
+      ['creator', 'yearly', '$26.25', '$35', 'Billed yearly ($315)'],
+      ['pro', 'yearly', '$75', '$100', 'Billed yearly ($900)']
+    ] as const)('discounts %s %s in its own card', async (testCase) => {
+      const [tierKey, cycle, price, struck, billed] = testCase
+      mockIsEduPricingActive.value = true
+      renderComponent()
+      await flushPromises()
+
+      if (cycle === 'monthly') {
+        await userEvent.click(screen.getByText('Monthly'))
+        await flushPromises()
+      }
+
+      const card = screen.getByTestId(`pricing-tier-${tierKey}`)
+      expect(card.textContent).toContain(price)
+      expect(card.textContent).toContain(struck)
+      if (billed) expect(card.textContent).toContain(billed)
+    })
+
+    it('keeps list prices when inactive', async () => {
+      renderComponent()
+      await flushPromises()
+
+      expect(screen.getByText('Billed yearly ($192)')).toBeInTheDocument()
+      expect(screen.queryByText('Billed yearly ($180)')).toBeNull()
+    })
+
+    it('rounds discounted prices to cents deterministically', () => {
+      expect(applyEduDiscount(16, 'standard', 'yearly')).toBe(15)
+      expect(applyEduDiscount(35, 'creator', 'monthly')).toBe(31.5)
     })
   })
 })

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -48,6 +48,7 @@
             tier.isPopular ? 'border-muted-foreground' : ''
           )
         "
+        :data-testid="`pricing-tier-${tier.key}`"
       >
         <div class="flex flex-col gap-4 p-6 pb-0">
           <div class="flex flex-row items-center justify-between gap-2">
@@ -69,12 +70,12 @@
                 <span
                   class="font-inter text-[28px] leading-normal font-semibold text-base-foreground tabular-nums"
                 >
-                  ${{ getPrice(tier) }}
+                  ${{ formatTierPriceValue(getPrice(tier)) }}
                   <span
-                    v-show="currentBillingCycle === 'yearly'"
+                    v-if="getStruckPrice(tier) !== null"
                     class="text-2xl text-muted-foreground line-through"
                   >
-                    ${{ tier.pricing.monthly }}
+                    ${{ formatTierPriceValue(getStruckPrice(tier)!) }}
                   </span>
                 </span>
                 <span class="font-inter text-xl/normal text-base-foreground">
@@ -268,9 +269,12 @@ import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useErrorHandling } from '@/composables/useErrorHandling'
+import { useEduPricing } from '@/platform/cloud/subscription/composables/useEduPricing'
 import {
   TIER_PRICING,
   amountForBillingCycle,
+  applyEduDiscount,
+  formatTierPriceValue,
   toTierKey
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
@@ -450,11 +454,29 @@ const getButtonTextClass = (tier: PricingTierConfig): string =>
     ? 'font-inter text-sm font-bold leading-normal text-base-background'
     : 'font-inter text-sm font-bold leading-normal text-primary-foreground'
 
-const getPrice = (tier: PricingTierConfig): number =>
-  tier.pricing[currentBillingCycle.value]
+const { isEduPricingActive } = useEduPricing()
 
-const getAnnualTotal = (tier: PricingTierConfig): number =>
-  tier.pricing.yearly * 12
+const getPrice = (tier: PricingTierConfig): number => {
+  const base = tier.pricing[currentBillingCycle.value]
+  return isEduPricingActive.value
+    ? applyEduDiscount(base, tier.key, currentBillingCycle.value)
+    : base
+}
+
+// Monthly list price rendered struck through next to the active price, so the
+// EDU yearly card shows the full 25%-off-list story (mirrors stock yearly).
+const getStruckPrice = (tier: PricingTierConfig): number | null => {
+  if (isEduPricingActive.value || currentBillingCycle.value === 'yearly')
+    return tier.pricing.monthly
+  return null
+}
+
+const getAnnualTotal = (tier: PricingTierConfig): number => {
+  const total = tier.pricing.yearly * 12
+  return isEduPricingActive.value
+    ? applyEduDiscount(total, tier.key, 'yearly')
+    : total
+}
 
 const isYearly = computed(() => currentBillingCycle.value === 'yearly')
 

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -31,6 +31,16 @@
           </span>
         </template>
       </i18n-t>
+      <div
+        v-if="isEduPricingActive"
+        class="flex items-center rounded-full bg-primary-background px-3 py-1 text-sm font-medium text-white"
+      >
+        {{
+          $t('subscription.eduPromoHeader', {
+            percent: EDU_MAX_DISCOUNT_PERCENT
+          })
+        }}
+      </div>
     </div>
 
     <PricingTable
@@ -155,6 +165,8 @@ import CloudBadge from '@/components/topbar/CloudBadge.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { MONTHLY_SUBSCRIPTION_PRICE } from '@/config/subscriptionPricesConfig'
 import PricingTable from '@/platform/cloud/subscription/components/PricingTable.vue'
+import { useEduPricing } from '@/platform/cloud/subscription/composables/useEduPricing'
+import { EDU_MAX_DISCOUNT_PERCENT } from '@/platform/cloud/subscription/constants/tierPricing'
 import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeButton.vue'
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
@@ -174,6 +186,7 @@ const emit = defineEmits<{
 }>()
 
 const { canAccessSubscriptionFeatures } = useBillingContext()
+const { isEduPricingActive } = useEduPricing()
 
 const isSubscriptionEnabled = (): boolean =>
   Boolean(isCloud && window.__CONFIG__?.subscription_required)

--- a/src/platform/cloud/subscription/composables/useEduPricing.test.ts
+++ b/src/platform/cloud/subscription/composables/useEduPricing.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { computed, reactive, ref } from 'vue'
+
+import { useEduPricing } from '@/platform/cloud/subscription/composables/useEduPricing'
+
+// Plain (non-reactive) hoisted holder: `useEduPricing` pulls in the real
+// teamWorkspaceStore, whose transitive authStore import reads `isCloud` at
+// module-evaluation time — before a normal top-level `const` would exist.
+// `vi.hoisted` runs before that import graph, but its factory can't call into
+// `vue`, so this stays a plain object; `isCloud` is read fresh inside the
+// computed each time regardless of its own reactivity.
+const { mockIsCloud } = vi.hoisted(() => ({
+  mockIsCloud: { value: true }
+}))
+// Real reactivity primitives: `flags` is a `reactive()` object in production
+// (mirrored here so `flags.eduPricingEnabled` registers as a tracked
+// dependency even when short-circuit evaluation skips later operands), and
+// `isEduCustomer` backs a `computed()` inside the mocked useSubscription.
+const mockFlags = reactive({ eduPricingEnabled: false })
+const mockIsEduCustomer = ref(false)
+
+vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
+  useFeatureFlags: () => ({
+    flags: mockFlags
+  })
+}))
+
+vi.mock<unknown>(
+  import('@/platform/cloud/subscription/composables/useSubscription'),
+  () => ({
+    useSubscription: () => ({
+      isEduCustomer: computed(() => mockIsEduCustomer.value)
+    })
+  })
+)
+
+vi.mock(import('@/platform/distribution/types'), () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+describe('useEduPricing', () => {
+  afterEach(() => {
+    localStorage.removeItem('ff:edu_customer')
+    mockIsCloud.value = true
+    mockFlags.eduPricingEnabled = false
+    mockIsEduCustomer.value = false
+  })
+
+  describe('isEduPricingActive', () => {
+    it('is inactive unless both the flag and the customer marker are set', () => {
+      const { isEduPricingActive } = useEduPricing()
+
+      mockFlags.eduPricingEnabled = false
+      mockIsEduCustomer.value = true
+      expect(isEduPricingActive.value).toBe(false)
+
+      mockFlags.eduPricingEnabled = true
+      mockIsEduCustomer.value = false
+      expect(isEduPricingActive.value).toBe(false)
+
+      mockFlags.eduPricingEnabled = true
+      mockIsEduCustomer.value = true
+      expect(isEduPricingActive.value).toBe(true)
+    })
+
+    it('is inactive off cloud builds', () => {
+      mockIsCloud.value = false
+      mockFlags.eduPricingEnabled = true
+      mockIsEduCustomer.value = true
+
+      const { isEduPricingActive } = useEduPricing()
+      expect(isEduPricingActive.value).toBe(false)
+    })
+
+    it('dev override fakes the customer marker', () => {
+      mockFlags.eduPricingEnabled = true
+      mockIsEduCustomer.value = false
+      localStorage.setItem('ff:edu_customer', 'true')
+
+      const { isEduPricingActive } = useEduPricing()
+      expect(isEduPricingActive.value).toBe(true)
+    })
+  })
+
+  describe('isTeamEduEligible', () => {
+    // The backing field (a workspace member's is_edu) isn't exposed by any
+    // API yet — a separate, not-yet-shipped backend PR — so with the real
+    // store's default empty member list this reads as false even with the
+    // flag on. teamWorkspaceStore.test.ts pins the member-mapping half of the
+    // wiring (`fetchMembers updates active workspace members`), and
+    // UnifiedPricingTable.test.ts exercises the true branch once eligible.
+    it('is false by default (flag on, no active-workspace member data)', async () => {
+      mockFlags.eduPricingEnabled = true
+      const { useTeamWorkspaceStore } =
+        await import('@/platform/workspace/stores/teamWorkspaceStore')
+      expect(useTeamWorkspaceStore().members).toEqual([])
+
+      const { isTeamEduEligible } = useEduPricing()
+      expect(isTeamEduEligible.value).toBe(false)
+    })
+
+    it('is false when the flag is off', () => {
+      mockFlags.eduPricingEnabled = false
+
+      const { isTeamEduEligible } = useEduPricing()
+      expect(isTeamEduEligible.value).toBe(false)
+    })
+
+    it('is false off cloud builds', () => {
+      mockIsCloud.value = false
+      mockFlags.eduPricingEnabled = true
+
+      const { isTeamEduEligible } = useEduPricing()
+      expect(isTeamEduEligible.value).toBe(false)
+    })
+  })
+})

--- a/src/platform/cloud/subscription/composables/useEduPricing.ts
+++ b/src/platform/cloud/subscription/composables/useEduPricing.ts
@@ -1,0 +1,39 @@
+import { computed } from 'vue'
+
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { isCloud } from '@/platform/distribution/types'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { getDevOverride } from '@/utils/devFeatureFlagOverride'
+
+/**
+ * Gate for EDU promo pricing: cloud only, remote-config flag AND the personal
+ * customer's is_edu marker (cloud#8725). Also surfaces team/workspace
+ * eligibility for the unified pricing table's team tab.
+ */
+export function useEduPricing() {
+  const { flags } = useFeatureFlags()
+  const { isEduCustomer } = useSubscription()
+  const workspaceStore = useTeamWorkspaceStore()
+
+  // Dev-only: localStorage.setItem('ff:edu_customer', 'true') fakes the marker locally.
+  const isEduPricingActive = computed(
+    () =>
+      isCloud &&
+      flags.eduPricingEnabled &&
+      (getDevOverride<boolean>('edu_customer') ?? isEduCustomer.value)
+  )
+
+  // Team/workspace eligibility (any current member carrying is_edu). The
+  // backend field this reads isn't exposed on any member-list response yet —
+  // that's a separate, not-yet-shipped backend PR — so this reads as false
+  // today and starts reporting true once a loaded member carries it.
+  const isTeamEduEligible = computed(
+    () =>
+      isCloud &&
+      flags.eduPricingEnabled &&
+      workspaceStore.members.some((member) => member.isEdu === true)
+  )
+
+  return { isEduPricingActive, isTeamEduEligible }
+}

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -310,6 +310,25 @@ describe('useSubscription', () => {
       expect(isCancelled.value).toBe(true)
       expect(formattedEndDate.value).toBe('Dec 1, 2025')
     })
+
+    it('reads isEduCustomer from the status response is_edu marker', async () => {
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        is_edu: true
+      })
+
+      const { isEduCustomer, fetchStatus } = useSubscriptionWithScope()
+      await fetchStatus()
+
+      expect(isEduCustomer.value).toBe(true)
+    })
+
+    it('defaults isEduCustomer to false when is_edu is absent', () => {
+      const { isEduCustomer } = useSubscriptionWithScope()
+
+      expect(isEduCustomer.value).toBe(false)
+    })
   })
 
   describe('fetchStatus', () => {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -104,6 +104,10 @@ function useSubscriptionInternal() {
     () => subscriptionDuration.value === 'ANNUAL'
   )
 
+  const isEduCustomer = computed(
+    () => subscriptionStatus.value?.is_edu === true
+  )
+
   const subscriptionTierName = computed(() => {
     const tier = subscriptionTier.value
     if (!tier) return ''
@@ -515,6 +519,7 @@ function useSubscriptionInternal() {
     isFreeTier,
     subscriptionDuration,
     isYearlySubscription,
+    isEduCustomer,
     subscriptionTierName,
     subscriptionStatus,
 

--- a/src/platform/cloud/subscription/constants/teamPlanCreditStops.test.ts
+++ b/src/platform/cloud/subscription/constants/teamPlanCreditStops.test.ts
@@ -74,3 +74,29 @@ describe('getTeamPlanSlug', () => {
     expect(getTeamPlanSlug('yearly')).toBe('team_per_credit_annual')
   })
 })
+
+describe('getStopDiscountedMonthlyUsd with an extra discount', () => {
+  // Team EDU: +5 percentage points of list on top of the stop's own cycle
+  // discount (cloud#8724).
+  it.for([
+    [{ usd: 200, discountPercentYearly: 0 }, 'monthly', 190],
+    [{ usd: 200, discountPercentYearly: 0 }, 'yearly', 190],
+    [{ usd: 400, discountPercentYearly: 5 }, 'monthly', 370],
+    [{ usd: 700, discountPercentYearly: 10 }, 'yearly', 595],
+    // Monthly halves the volume discount (5%) but the EDU extra stays a flat 5%.
+    [{ usd: 700, discountPercentYearly: 10 }, 'monthly', 630],
+    [{ usd: 2500, discountPercentYearly: 20 }, 'yearly', 1875]
+  ] as const)('discounts %s', (testCase) => {
+    const [stop, cycle, expected] = testCase
+    expect(getStopDiscountedMonthlyUsd(stop, cycle, 5)).toBe(expected)
+  })
+
+  it('defaults to no extra discount', () => {
+    expect(
+      getStopDiscountedMonthlyUsd(
+        { usd: 700, discountPercentYearly: 10 },
+        'yearly'
+      )
+    ).toBe(630)
+  })
+})

--- a/src/platform/cloud/subscription/constants/teamPlanCreditStops.ts
+++ b/src/platform/cloud/subscription/constants/teamPlanCreditStops.ts
@@ -94,17 +94,19 @@ export function mapApiTeamCreditStops(
 
 /**
  * Discounted monthly price for a credit stop, applying the billing-cycle
- * discount (yearly = full `discountPercentYearly`; monthly halves it). Shared by
- * the slider display and the checkout confirm step so the two never drift, and
- * it reads the stop's own discount so backend-driven stops are honored.
+ * discount (yearly = full `discountPercentYearly`; monthly halves it) plus a
+ * flat `extraDiscountPercent` of list (team EDU, cloud#8724). Shared by the
+ * slider display and the checkout confirm step so the two never drift, and it
+ * reads the stop's own discount so backend-driven stops are honored.
  */
 export function getStopDiscountedMonthlyUsd(
   stop: Pick<CreditStop, 'usd' | 'discountPercentYearly'>,
-  cycle: 'monthly' | 'yearly'
+  cycle: 'monthly' | 'yearly',
+  extraDiscountPercent = 0
 ): number {
   const percent =
-    cycle === 'monthly'
+    (cycle === 'monthly'
       ? stop.discountPercentYearly / 2
-      : stop.discountPercentYearly
+      : stop.discountPercentYearly) + extraDiscountPercent
   return Math.round(stop.usd * (1 - percent / 100))
 }

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import type { IngestSubscriptionTier } from './tierPricing'
 import {
+  applyEduDiscount,
+  formatTierPriceValue,
   hasActivePaidPlan,
   isEnterprisePlanSlug,
   isSalesManagedTier,
@@ -101,5 +103,35 @@ describe('isSalesManagedTier', () => {
     expect(isSalesManagedTier('PRO')).toBe(false)
     expect(isSalesManagedTier('TEAM')).toBe(false)
     expect(isSalesManagedTier(null)).toBe(false)
+  })
+})
+
+describe('applyEduDiscount', () => {
+  // cloud#8724: monthly 10% off list, yearly 6.25% off the yearly price (=
+  // 25% off the monthly list, compounding with the existing 20% yearly bundle).
+  it.for([
+    ['standard', 'monthly', 20, 18],
+    ['creator', 'monthly', 35, 31.5],
+    ['pro', 'monthly', 100, 90],
+    ['standard', 'yearly', 16, 15],
+    ['creator', 'yearly', 28, 26.25],
+    ['pro', 'yearly', 80, 75]
+  ] as const)('discounts %s %s list price %d to %d', (testCase) => {
+    const [tierKey, cycle, price, expected] = testCase
+    expect(applyEduDiscount(price, tierKey, cycle)).toBe(expected)
+  })
+
+  it('rounds to cents deterministically', () => {
+    expect(applyEduDiscount(19.99, 'standard', 'monthly')).toBe(17.99)
+    // Half-cent rounds up: 0.15 * 0.9 = 0.135 -> 0.14.
+    expect(applyEduDiscount(0.15, 'standard', 'monthly')).toBe(0.14)
+  })
+})
+
+describe('formatTierPriceValue', () => {
+  it('renders whole dollars bare and fractional prices with cents', () => {
+    expect(formatTierPriceValue(18)).toBe('18')
+    expect(formatTierPriceValue(31.5)).toBe('31.50')
+    expect(formatTierPriceValue(26.25)).toBe('26.25')
   })
 })

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -41,6 +41,46 @@ export const TIER_PRICING: Record<
   pro: { monthly: 100, yearly: 80, credits: 21100, videoEstimate: 1915 }
 }
 
+export type PaidTierKey = Exclude<TierKey, 'free' | 'founder'>
+export type BillingCycleKey = 'monthly' | 'yearly'
+
+/**
+ * Coupon percent applied to the CYCLE price; must mirror the backend Stripe
+ * coupons exactly (cloud#8724) — the display promises what the coupon
+ * charges. Yearly 6.25% compounds with the 20% yearly bundle to 25% off the
+ * monthly list. Values are identical across tiers today; keyed per tier to
+ * mirror the backend slots.
+ */
+export const EDU_DISCOUNT_PERCENTS: Record<
+  PaidTierKey,
+  Record<BillingCycleKey, number>
+> = {
+  standard: { monthly: 10, yearly: 6.25 },
+  creator: { monthly: 10, yearly: 6.25 },
+  pro: { monthly: 10, yearly: 6.25 }
+}
+
+/** Team EDU adds 5 percentage points of list on top of the volume discount (cloud#8724). */
+export const TEAM_EDU_EXTRA_PERCENT = 5
+
+/** Marketing max: total off the monthly list (yearly EDU = 25%), not a coupon percent. */
+export const EDU_MAX_DISCOUNT_PERCENT = 25
+
+/** Whole dollars render bare ($18); fractional prices always show cents ($31.50). */
+export function formatTierPriceValue(price: number): string {
+  return Number.isInteger(price) ? String(price) : price.toFixed(2)
+}
+
+/** Display-only EDU price; the backend coupon applies the same cut at checkout. */
+export function applyEduDiscount(
+  price: number,
+  tierKey: PaidTierKey,
+  cycle: BillingCycleKey
+): number {
+  const percent = EDU_DISCOUNT_PERCENTS[tierKey][cycle]
+  return Math.round(price * (1 - percent / 100) * 100) / 100
+}
+
 const MONTHS_PER_YEAR = 12
 
 // Annual plans grant the whole year up front (catalog `*-annual` credit_grant

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -136,6 +136,7 @@ export type RemoteConfig = {
   // Always funnel it through normalizeTurnstileMode before trusting it as a
   // TurnstileMode — that resolver is the single narrowing boundary.
   signup_turnstile?: string
+  edu_pricing_enabled?: boolean
 }
 
 /**

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -6,7 +6,7 @@ import type {
   BillingOpStatusResponse,
   BillingPlansResponse,
   BillingStatus,
-  BillingStatusResponse,
+  BillingStatusResponse as GeneratedBillingStatusResponse,
   CancelSubscriptionRequest,
   CancelSubscriptionResponse,
   ChurnkeyAuthResponse,
@@ -58,6 +58,12 @@ import { workspaceApiUrl } from './workspaceApiUrl'
 
 export type WorkspaceType = 'personal' | 'team'
 export type WorkspaceRole = 'owner' | 'member'
+
+export type BillingStatusResponse = GeneratedBillingStatusResponse & {
+  /** EDU marker from cloud#8725; drop the augmentation once ingest-types regenerates. */
+  is_edu?: boolean
+}
+
 export type BillingRail = NonNullable<BillingStatusResponse['billing_rail']>
 
 export type Member = GeneratedMember & {
@@ -65,6 +71,8 @@ export type Member = GeneratedMember & {
   // neither usage nor limit yet; persistence and real usage land in FE-1278.
   credits_used_this_month?: number
   monthly_credit_limit?: number | null
+  /** EDU marker for team-eligibility pricing; not exposed by any API yet (FE-1356). */
+  is_edu?: boolean
 }
 
 export interface ListMembersParams {
@@ -114,7 +122,6 @@ export type BillingSubscriptionStatus = NonNullable<
 >
 
 export type { BillingStatus }
-export type { BillingStatusResponse }
 export type { ScheduledPlanChange }
 
 export type { BillingBalanceResponse }

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -18,6 +18,18 @@ const mockPreviewData = ref<Record<string, unknown> | null>(null)
 const mockSelectedTeamStop = ref<Record<string, unknown> | null>(null)
 const mockSelectedSavedPaymentMethodId = ref<string | null>('pm_default')
 const mockSavedPaymentMethods = ref<Record<string, unknown>[]>([])
+const mockIsEduPricingActive = ref(false)
+const mockIsTeamEduEligible = ref(false)
+
+vi.mock<unknown>(
+  import('@/platform/cloud/subscription/composables/useEduPricing'),
+  () => ({
+    useEduPricing: () => ({
+      isEduPricingActive: computed(() => mockIsEduPricingActive.value),
+      isTeamEduEligible: computed(() => mockIsTeamEduEligible.value)
+    })
+  })
+)
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useSubscriptionCheckout'),
@@ -64,7 +76,10 @@ const i18n = createI18n({
   messages: {
     en: {
       g: { back: 'Back', close: 'Close' },
-      subscription: { descriptionWorkspace: 'Choose your plan' }
+      subscription: {
+        descriptionWorkspace: 'Choose your plan',
+        eduPromoHeader: 'Education discount: up to {percent}% off'
+      }
     }
   }
 })
@@ -127,6 +142,8 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
     mockSelectedTeamStop.value = null
     mockSelectedSavedPaymentMethodId.value = 'pm_default'
     mockSavedPaymentMethods.value = []
+    mockIsEduPricingActive.value = false
+    mockIsTeamEduEligible.value = false
   })
 
   // The team checkout mounts the payment element against the quote's amount, so
@@ -282,4 +299,23 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
       expect(mockHandleBackToPricing).toHaveBeenCalled()
     }
   )
+
+  describe('EDU promo pill', () => {
+    it('is hidden by default', () => {
+      renderComponent()
+      expect(screen.queryByText(/Education discount/)).toBeNull()
+    })
+
+    it('shows when the requesting customer is EDU-eligible', () => {
+      mockIsEduPricingActive.value = true
+      renderComponent()
+      expect(screen.getByText(/Education discount/)).toBeInTheDocument()
+    })
+
+    it('shows when the team is EDU-eligible', () => {
+      mockIsTeamEduEligible.value = true
+      renderComponent()
+      expect(screen.getByText(/Education discount/)).toBeInTheDocument()
+    })
+  })
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -46,6 +46,16 @@
       <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
         {{ $t('subscription.descriptionWorkspace') }}
       </h2>
+      <div
+        v-if="isEduPricingActive || isTeamEduEligible"
+        class="flex items-center rounded-full bg-primary-background px-3 py-1 text-sm font-medium text-white"
+      >
+        {{
+          $t('subscription.eduPromoHeader', {
+            percent: EDU_MAX_DISCOUNT_PERCENT
+          })
+        }}
+      </div>
     </div>
 
     <div v-if="reason === 'out_of_credits'" class="text-center">
@@ -181,6 +191,8 @@ import { useEventListener } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
+import { useEduPricing } from '@/platform/cloud/subscription/composables/useEduPricing'
+import { EDU_MAX_DISCOUNT_PERCENT } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
@@ -253,6 +265,8 @@ const {
   invalidateQuote,
   handleResubscribe
 } = useSubscriptionCheckout(emit, reason, { embeddedCheckoutEnabled })
+
+const { isEduPricingActive, isTeamEduEligible } = useEduPricing()
 
 const savedMethodsForConfirm = computed(() =>
   collectingNewPaymentMethod.value || !selectedSavedPaymentMethodId.value

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -64,6 +64,18 @@ const mockPermissions = ref({
 })
 const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
 const mockApiPlans = vi.hoisted(() => ({ value: [] as Plan[] }))
+const mockIsEduPricingActive = ref(false)
+const mockIsTeamEduEligible = ref(false)
+
+vi.mock<unknown>(
+  import('@/platform/cloud/subscription/composables/useEduPricing'),
+  () => ({
+    useEduPricing: () => ({
+      isEduPricingActive: computed(() => mockIsEduPricingActive.value),
+      isTeamEduEligible: computed(() => mockIsTeamEduEligible.value)
+    })
+  })
+)
 
 vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   useBillingContext: () => ({
@@ -107,7 +119,19 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-function renderComponent(props: Record<string, unknown> = {}) {
+// Interactive toggle stub: renders a button per option so EDU tests can flip
+// the billing cycle. The default `<div />` stub keeps existing tests inert.
+const InteractiveSelectButton = {
+  template:
+    '<div><button v-for="option in options" :key="option.value" type="button" @click="$emit(\'update:modelValue\', option.value)">{{ option.label }}</button></div>',
+  props: ['modelValue', 'options'],
+  emits: ['update:modelValue']
+}
+
+function renderComponent(
+  props: Record<string, unknown> = {},
+  stubOverrides: Record<string, unknown> = {}
+) {
   return render(UnifiedPricingTable, {
     props,
     global: {
@@ -121,7 +145,8 @@ function renderComponent(props: Record<string, unknown> = {}) {
           template:
             '<button data-testid="team-slider" @click="$emit(\'update:modelValue\', 200)" />',
           emits: ['update:modelValue']
-        }
+        },
+        ...stubOverrides
       }
     }
   })
@@ -129,6 +154,8 @@ function renderComponent(props: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   mockApiPlans.value = []
+  mockIsEduPricingActive.value = false
+  mockIsTeamEduEligible.value = false
 })
 
 describe('UnifiedPricingTable plan CTA labels', () => {
@@ -829,5 +856,104 @@ describe('UnifiedPricingTable plan-scope availability', () => {
     expect(
       screen.queryByRole('button', { name: 'Change to Standard Yearly' })
     ).toBeNull()
+  })
+})
+
+describe('UnifiedPricingTable EDU pricing', () => {
+  const withToggle = { SelectButton: InteractiveSelectButton }
+
+  beforeEach(() => {
+    mockSubscription.value = null
+    mockCurrentPlanSlug.value = null
+    mockCurrentTeamCreditStop.value = null
+    mockIsTeamPlan.value = false
+    mockCanManageSubscription.value = true
+    mockCanDowngradeToPersonal.value = true
+    mockApiPlans.value = []
+    mockIsEduPricingActive.value = false
+    mockIsTeamEduEligible.value = false
+  })
+
+  // Display must match the coupon charge: monthly 10% off list, yearly 6.25%
+  // off the yearly price (= 25% off the monthly list). Yearly strikes the
+  // monthly list.
+  it.for([
+    ['standard', 'monthly', '$18', '$20'],
+    ['creator', 'monthly', '$31.50', '$35'],
+    ['pro', 'monthly', '$90', '$100'],
+    ['standard', 'yearly', '$15', '$20'],
+    ['creator', 'yearly', '$26.25', '$35'],
+    ['pro', 'yearly', '$75', '$100']
+  ] as const)(
+    'discounts %s %s against the struck monthly list',
+    async ([tierKey, cycle, price, struck]) => {
+      mockIsEduPricingActive.value = true
+      renderComponent({}, withToggle)
+
+      if (cycle === 'monthly') {
+        await userEvent.click(screen.getByRole('button', { name: 'Monthly' }))
+      }
+
+      const card = screen.getByTestId(`pricing-tier-${tierKey}`)
+      expect(card.textContent).toContain(price)
+      expect(card.textContent).toContain(struck)
+    }
+  )
+
+  it('keeps list prices when EDU is inactive', () => {
+    renderComponent()
+
+    const card = screen.getByTestId('pricing-tier-standard')
+    expect(card.textContent).toContain('$16')
+    expect(card.textContent).toContain('$20')
+    expect(card.textContent).not.toContain('$15')
+  })
+
+  it('applies the discount to the API-derived price, not just the static fallback', () => {
+    mockIsEduPricingActive.value = true
+    mockApiPlans.value = [
+      { ...apiPlan('STANDARD', 'MONTHLY', 4200), price_cents: 3000 },
+      { ...apiPlan('STANDARD', 'ANNUAL', 50400), price_cents: 24000 }
+    ]
+    renderComponent()
+
+    // API monthly $30 struck; API yearly-equivalent $20 -> EDU $18.75.
+    const card = screen.getByTestId('pricing-tier-standard')
+    expect(card.textContent).toContain('$18.75')
+    expect(card.textContent).toContain('$30')
+  })
+
+  // Team eligibility (any current member carrying is_edu) is a currently
+  // always-false stub pending a separate backend PR; this pins the wiring so
+  // it activates the moment that field ships. Default $700 stop, yearly:
+  // 10% volume discount, +5pp EDU once eligible.
+  it('stacks the team-eligibility extra discount once eligible', async () => {
+    const user = userEvent.setup()
+    mockIsTeamEduEligible.value = true
+
+    const { emitted } = renderComponent({ initialPlanMode: 'team' })
+    await user.click(
+      screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
+    )
+
+    const [teamPayload] = emitted().subscribeTeam[0] as [
+      { stop: { discountedUsd: number } }
+    ]
+    expect(teamPayload.stop.discountedUsd).toBe(595)
+  })
+
+  it('does not stack the team extra discount while ineligible', async () => {
+    const user = userEvent.setup()
+    mockIsTeamEduEligible.value = false
+
+    const { emitted } = renderComponent({ initialPlanMode: 'team' })
+    await user.click(
+      screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
+    )
+
+    const [teamPayload] = emitted().subscribeTeam[0] as [
+      { stop: { discountedUsd: number } }
+    ]
+    expect(teamPayload.stop.discountedUsd).toBe(630)
   })
 })

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -97,6 +97,7 @@
           v-for="tier in tiers"
           :key="tier.id"
           class="flex flex-col rounded-2xl border border-border-default bg-base-background shadow-[0_0_12px_rgba(0,0,0,0.1)] xl:w-80"
+          :data-testid="`pricing-tier-${tier.key}`"
         >
           <div class="flex flex-1 flex-col gap-4 p-6 pb-0">
             <div class="flex flex-row items-center justify-between gap-2">
@@ -117,12 +118,12 @@
                 <span
                   class="font-inter text-[28px] leading-normal font-semibold text-base-foreground tabular-nums"
                 >
-                  ${{ getPrice(tier) }}
+                  ${{ formatTierPriceValue(getPrice(tier)) }}
                   <span
-                    v-show="currentBillingCycle === 'yearly'"
+                    v-if="getStruckPrice(tier) !== null"
                     class="text-2xl text-muted-foreground line-through"
                   >
-                    ${{ getMonthlyPrice(tier) }}
+                    ${{ formatTierPriceValue(getStruckPrice(tier)!) }}
                   </span>
                 </span>
                 <span class="font-inter text-sm/normal text-base-foreground">
@@ -237,6 +238,7 @@
                 :stops="teamStops"
                 :default-stop-index="teamDefaultStopIndex"
                 :cycle="currentBillingCycle"
+                :extra-discount-percent="teamEduExtraPercent"
               />
 
               <!-- Selected credit grant + template-based video estimate -->
@@ -418,7 +420,10 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import {
   TIER_PRICING,
   amountForBillingCycle,
+  applyEduDiscount,
+  formatTierPriceValue,
   hasActivePaidPlan,
+  TEAM_EDU_EXTRA_PERCENT,
   toTierKey
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
@@ -427,6 +432,7 @@ import type {
   TierPricing
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
+import { useEduPricing } from '@/platform/cloud/subscription/composables/useEduPricing'
 import {
   DEFAULT_TEAM_PLAN_STOP_INDEX,
   TEAM_PLAN_CREDIT_STOPS,
@@ -914,17 +920,39 @@ const getButtonTextClass = (tier: PricingTierConfig): string =>
     ? 'font-inter text-sm font-bold leading-normal text-base-background'
     : 'font-inter text-sm font-bold leading-normal text-primary-foreground'
 
-const getPrice = (tier: PricingTierConfig): number =>
-  getPriceFromApi(tier) ?? tier.pricing[currentBillingCycle.value]
+const { isEduPricingActive, isTeamEduEligible } = useEduPricing()
+const teamEduExtraPercent = computed(() =>
+  isTeamEduEligible.value ? TEAM_EDU_EXTRA_PERCENT : 0
+)
+
+// Personal tiers only: the coupon cut applies to the API-derived price (or the
+// static fallback).
+const getPrice = (tier: PricingTierConfig): number => {
+  const base = getPriceFromApi(tier) ?? tier.pricing[currentBillingCycle.value]
+  return isEduPricingActive.value
+    ? applyEduDiscount(base, tier.key, currentBillingCycle.value)
+    : base
+}
 
 const getMonthlyPrice = (tier: PricingTierConfig): number => {
   const plan = getApiPlanForTier(tier.key, 'monthly')
   return plan ? plan.price_cents / 100 : tier.pricing.monthly
 }
 
+// Struck monthly list price: shown on yearly (the bundle saving) and whenever
+// EDU is active, so the EDU yearly card reads 25% off the monthly list.
+const getStruckPrice = (tier: PricingTierConfig): number | null => {
+  if (isEduPricingActive.value || currentBillingCycle.value === 'yearly')
+    return getMonthlyPrice(tier)
+  return null
+}
+
 const getAnnualTotal = (tier: PricingTierConfig): number => {
   const plan = getApiPlanForTier(tier.key, 'yearly')
-  return plan ? plan.price_cents / 100 : tier.pricing.yearly * 12
+  const total = plan ? plan.price_cents / 100 : tier.pricing.yearly * 12
+  return isEduPricingActive.value
+    ? applyEduDiscount(total, tier.key, 'yearly')
+    : total
 }
 
 function handleSubscribe(tierKey: CheckoutTierKey) {
@@ -959,7 +987,8 @@ function handleSubscribeTeam() {
       credits: stop.credits,
       discountedUsd: getStopDiscountedMonthlyUsd(
         stop,
-        currentBillingCycle.value
+        currentBillingCycle.value,
+        teamEduExtraPercent.value
       )
     },
     billingCycle: currentBillingCycle.value,

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -1177,7 +1177,8 @@ describe('useTeamWorkspaceStore', () => {
           joined_at: '2024-01-01T00:00:00Z',
           role: 'member' as const,
           credits_used_this_month: 0,
-          monthly_credit_limit: null
+          monthly_credit_limit: null,
+          is_edu: true
         },
         {
           id: 'user-2',
@@ -1208,8 +1209,12 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members[0].name).toBe('User One')
       expect(store.members[0].creditsUsedThisMonth).toBe(0)
       expect(store.members[0].monthlyCreditLimit).toBeNull()
+      // EDU marker for team-eligibility pricing (FE-1356); not exposed by the
+      // real API yet, so this pins the mapping for when it ships.
+      expect(store.members[0].isEdu).toBe(true)
       expect(store.members[1].creditsUsedThisMonth).toBeUndefined()
       expect(store.members[1].monthlyCreditLimit).toBeUndefined()
+      expect(store.members[1].isEdu).toBeUndefined()
       expect(mockWorkspaceApi.listMembers).toHaveBeenCalledWith({ limit: 100 })
     })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -32,6 +32,8 @@ export interface WorkspaceMember {
   isOriginalOwner: boolean
   creditsUsedThisMonth?: number
   monthlyCreditLimit?: number | null
+  /** EDU marker; not exposed by any member-list API yet (FE-1356). */
+  isEdu?: boolean
 }
 
 export interface WorkspacePendingInvite {
@@ -62,7 +64,8 @@ function mapApiMemberToWorkspaceMember(member: Member): WorkspaceMember {
     role: member.role,
     isOriginalOwner: member.is_original_owner,
     creditsUsedThisMonth: member.credits_used_this_month,
-    monthlyCreditLimit: member.monthly_credit_limit
+    monthlyCreditLimit: member.monthly_credit_limit,
+    isEdu: member.is_edu
   }
 }
 


### PR DESCRIPTION
## Summary

Education-marked cloud customers see the existing subscription modal (both the legacy per-user dialog and the unified workspace pricing table) with discounted prices; checkout is untouched — the backend coupon adjusts the actual charge. Supersedes #13876, which targeted the closed/abandoned backend PR Comfy-Org/cloud#5314 and won't be landed as-is; this re-applies its correct pricing logic against current `main`, reconciled with what's shipped since (billing status now flows through `/api/billing/status` rather than the legacy `/customers/cloud-subscription-status` endpoint), and extends eligibility to team/workspace members per FE-1356.

## Changes

- **`useEduPricing`**: gate on `edu_pricing_enabled` (cloud#8723, via `useFeatureFlags`) AND `is_edu` (cloud#8725) from the personal subscription status. Dev-only `ff:edu_customer` localStorage override for local testing.
- **Individual pricing**: `applyEduDiscount`/`EDU_DISCOUNT_PERCENTS` in `tierPricing.ts` — monthly 10% off list, yearly 6.25% off the yearly price (compounds with the existing 20% yearly bundle to 25% off monthly list), matching cloud#8724's coupon ladder to the cent. Wired into `PricingTable.vue` (legacy) and the personal tab of `UnifiedPricingTable.vue`.
- **Promo pill**: `subscription.eduPromoHeader` shown on both `SubscriptionRequiredDialogContent.vue` and `SubscriptionRequiredDialogContentUnified.vue` when EDU pricing (personal or team) is active. Copy is generic ("Education discount…"), not "individual"-specific, since team members can also qualify.
- **Team eligibility (new vs. #13876)**: any workspace where a loaded member carries `is_edu` also qualifies for the team EDU ladder (+5 percentage points on the volume discount, `TEAM_EDU_EXTRA_PERCENT`, stacked via `CreditSlider`'s new `extraDiscountPercent` prop and `getStopDiscountedMonthlyUsd`'s new parameter). **This is stubbed**: no API exposes a team-member `is_edu` field yet (a separate, not-yet-built backend PR), so `Member`/`WorkspaceMember` carry a `is_edu?`/`isEdu?` type augmentation (matching the existing `credits_used_this_month` augmentation pattern already in `workspaceApi.ts`) that reads as `undefined` today, keeping `isTeamEduEligible` always `false` in practice until that field ships.
- `is_edu` is likewise a type augmentation on `BillingStatusResponse` (`/api/billing/status`, ingest-types) since cloud#8725 currently only adds it to the older `/customers/cloud-subscription-status` (comfy-api) response, not the ingest endpoint the frontend actually calls today for subscription status. Flagging this explicitly: a small backend follow-up will need to surface `is_edu` on `/api/billing/status` (or the frontend will need a dedicated read) before this can go live for personal accounts either.

## Review Focus

- Ship dark: `edu_pricing_enabled` defaults false and is not flipped on anywhere; no remote-config/rollout values touched.
- Display-only — `useSubscription.ts`/`useSubscriptionCheckout.ts` checkout mechanics are untouched.
- The `BillingStatusResponse`/`is_edu` endpoint mismatch noted above (see "Changes") is worth a second look from whoever owns the billing-status unification.

## Companion PRs

- Backend: Comfy-Org/cloud#8725, Comfy-Org/cloud#8723, Comfy-Org/cloud#8724 (in review, CI green, not yet merged)

## Supersedes

- #13876 (targeted the closed Comfy-Org/cloud#5314; left untouched as historical reference)