### PR TITLE
test(agent): guard bound-canvas read path keeps populated draft (QAF-38/GM-12)

### DIFF
--- a/browser_tests/tests/agent/boundCanvasReadPath.spec.ts
+++ b/browser_tests/tests/agent/boundCanvasReadPath.spec.ts
@@ -1,0 +1,162 @@
+import type { WebSocketRoute } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
+
+import { webSocketFixture } from '@e2e/fixtures/ws'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import type { AgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
+
+import { MESSAGE_DONE_EVENT, agentTest } from '@e2e/tests/agent/agentPanelMocks'
+
+const test = mergeTests(agentTest, webSocketFixture)
+
+const OPEN_AGENT_LABEL = enMessages.agent.askComfyAgent
+
+/** Must match WORKFLOW_ID in agentPanelMocks (the id the turn ack binds). */
+const BOUND_WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
+
+function pushEvent(ws: WebSocketRoute, event: AgentWsEvent): void {
+  ws.send(JSON.stringify(event))
+}
+
+interface PostedMessageBody {
+  workflow_id?: string
+  current_tab?: string
+  open_tabs?: { workflow_id: string; name: string }[]
+  draft?: { content?: { nodes?: unknown[] } }
+}
+
+function parsePosted(raw: string | undefined): PostedMessageBody {
+  expect(raw, 'a message body must have been POSTed').toBeTruthy()
+  return JSON.parse(raw ?? '{}') as PostedMessageBody
+}
+
+/**
+ * Regression coverage for the "focused canvas is empty" read-path failure
+ * (QA sweep GM-12): a populated workflow whose tab has been bound to a cloud
+ * workflow id by the first turn ack must be sent on the next turn with both
+ * the binding and a populated draft, otherwise the agent reads an empty graph.
+ */
+test.describe('Agent bound-canvas read path', { tag: '@cloud' }, () => {
+  test.use({ connectWebSocketToServer: false })
+
+  test.beforeEach(async ({ comfyPage }) => {
+    // Cloud workflow index used to resolve saved tabs to ids; none saved here.
+    await comfyPage.page.route('**/api/agent/workflows**', (route) =>
+      route.fulfill(
+        jsonRoute({
+          data: [],
+          pagination: { has_more: false, limit: 100, offset: 0, total: 0 }
+        })
+      )
+    )
+  })
+
+  test('second turn on a bound populated tab carries the binding and a populated draft', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket
+  }) => {
+    test.setTimeout(45_000)
+
+    const page = comfyPage.page
+    const nodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+    expect(
+      nodeCount,
+      'fixture canvas must be populated'
+    ).toBeGreaterThanOrEqual(3)
+
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+    const panel = page.locator('#agent-panel-root')
+    await expect(panel).toBeVisible()
+
+    const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+    const sendButton = panel.getByRole('button', { name: 'Send' })
+    const ws = await getWebSocket()
+
+    // Turn 1: unbound temporary tab. The 202 ack binds the tab to
+    // BOUND_WORKFLOW_ID (AgentPanelRoot.onWorkflowAdopted).
+    await composer.fill('What is on my canvas?')
+    await sendButton.click()
+    await expect.poll(() => postedMessages.length).toBe(1)
+    const first = parsePosted(postedMessages[0])
+    expect(first.workflow_id).toBeUndefined()
+    expect(
+      first.draft?.content?.nodes?.length,
+      'turn 1 draft must carry the populated graph'
+    ).toBeGreaterThanOrEqual(3)
+
+    pushEvent(ws, MESSAGE_DONE_EVENT)
+    await expect(composer).toHaveValue('')
+
+    // Turn 2: same thread, same (now bound) tab, canvas unchanged.
+    await composer.fill('Describe the focused canvas.')
+    await expect(sendButton).toBeEnabled()
+    await sendButton.click()
+    await expect.poll(() => postedMessages.length).toBe(2)
+    const second = parsePosted(postedMessages[1])
+
+    expect(second.workflow_id, 'binding from turn 1 ack must be sent').toBe(
+      BOUND_WORKFLOW_ID
+    )
+    expect(second.current_tab, 'current_tab must point at the bound id').toBe(
+      BOUND_WORKFLOW_ID
+    )
+    expect(
+      second.open_tabs?.map((t) => t.workflow_id),
+      'open_tabs must include the bound id'
+    ).toContain(BOUND_WORKFLOW_ID)
+    expect(
+      second.draft?.content?.nodes?.length,
+      'turn 2 draft must still carry the populated graph (GM-12: reads empty)'
+    ).toBeGreaterThanOrEqual(nodeCount)
+  })
+
+  test('switching to a new tab and back keeps the bound tab populated on the next turn', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket
+  }) => {
+    test.setTimeout(45_000)
+
+    const page = comfyPage.page
+    const nodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+    expect(nodeCount).toBeGreaterThanOrEqual(3)
+
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+    const panel = page.locator('#agent-panel-root')
+    const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+    const sendButton = panel.getByRole('button', { name: 'Send' })
+    const ws = await getWebSocket()
+
+    await composer.fill('What is on my canvas?')
+    await sendButton.click()
+    await expect.poll(() => postedMessages.length).toBe(1)
+    pushEvent(ws, MESSAGE_DONE_EVENT)
+    await expect(composer).toHaveValue('')
+
+    // Open a fresh (empty, unbound) tab, then return to the bound one.
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+      .toBeLessThan(nodeCount)
+    await comfyPage.menu.topbar.getTab(0).click()
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+      .toBe(nodeCount)
+
+    await composer.fill('Describe the focused canvas.')
+    await expect(sendButton).toBeEnabled()
+    await sendButton.click()
+    await expect.poll(() => postedMessages.length).toBe(2)
+    const second = parsePosted(postedMessages[1])
+
+    expect(second.workflow_id).toBe(BOUND_WORKFLOW_ID)
+    expect(second.current_tab).toBe(BOUND_WORKFLOW_ID)
+    expect(
+      second.draft?.content?.nodes?.length,
+      'draft after tab switch must reflect the bound populated tab'
+    ).toBeGreaterThanOrEqual(nodeCount)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `@cloud` Playwright regression guard for the agent panel's bound-canvas read path (QA sweep finding GM-12 / program row QAF-38: "focused canvas reads empty on the second turn").

Two tests in `browser_tests/tests/agent/boundCanvasReadPath.spec.ts`:
1. Turn 1 on an unbound populated tab → 202 ack binds the tab → turn 2 must POST `workflow_id`/`current_tab` = bound id, `open_tabs` containing it, and a `draft` whose node count ≥ the canvas node count.
2. Same, but with a new-tab / switch-back detour between turns.

**Both tests pass on current `main` (`928cd4a5e56f0848a4e971b532e1db95a5f53c44`)**: GM-12 does not reproduce against the FE with the mocked agent backend. The residual QAF-38 concern is therefore on the cloud agent-service read path, not the FE payload. This PR keeps the FE side guarded.

<details><summary>Full context for agent readers</summary>

### Why a PR when the tests pass
The seam GM-12 describes (`AgentPanelRoot.cloudIdFor` / `openTabsSnapshot` / `onWorkflowAdopted` + `useAgentSession.shouldSendDraft`) has changed recently (#16840, #16699) and had no direct coverage of the second-turn payload after binding. A plausible wrong implementation (dropping `draft` once `workflow_id` is set, or sending the previous tab's snapshot after a tab switch) fails these tests.

### Local run recipe (cloud project)
Vite cloud dev cannot be used against a `--multi-user` backend (the `/api/users` proxy bypass in `vite.config.mts` is method-agnostic), so this mirrors CI:
```
VITE_USE_LEGACY_DEFAULT_GRAPH=true pnpm build:cloud
docker run -d --name comfyui-hp-cloud -p 127.0.0.1:8199:8188 \
  -v $PWD/tools/devtools:/ComfyUI/custom_nodes/ComfyUI_devtools:ro \
  -v $PWD/dist:/frontend-dist:ro ghcr.io/comfy-org/comfyui-ci-container:0.0.22 \
  bash -lc 'cd /ComfyUI && exec python3 main.py --cpu --multi-user --listen 0.0.0.0 --front-end-root /frontend-dist'
DISTRIBUTION=cloud PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://127.0.0.1:8199 \
  pnpm exec playwright test --project=cloud browser_tests/tests/agent/boundCanvasReadPath.spec.ts
```

### Possible follow-ups (not in this PR)
- Make the vite cloud `/api/users` proxy bypass GET-only so `pnpm dev:cloud` works with `--multi-user`.
- Document the cloud Playwright recipe above in `docs/guidance/playwright.md`.

</details>

## Evidence
- `2 passed (6.9s)` — `boundCanvasReadPath.spec.ts` on the cloud project against `main` `928cd4a5e56f0848a4e971b532e1db95a5f53c44` (container recipe above).
- Control `agentPanel.spec.ts` "shows the greeting" passes in the same environment.
- `pnpm typecheck`, `pnpm typecheck:browser`, oxlint, oxfmt, eslint clean (lint-staged on commit `c63aa115c00a9d3042c1f61560bd75f4e3234082`).

Program tracking: christian-byrne/in-app-agent-program rows QAF-38, qaf38-1.

<!-- authored-by:agent role-hard-problem -->
