### PR TITLE
test: cover properties panel button callbacks

### DIFF
--- a/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
+++ b/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
@@ -1,50 +1,50 @@
 import { expect } from '@playwright/test'
 
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
 
 const NODE_TYPE = 'DevToolsRemoteWidgetNodeWithRefreshButton'
+const CHECKPOINTS_ROUTE = '**/api/models/checkpoints**'
+
+async function setupButtonWidget(comfyPage: ComfyPage) {
+  await comfyPage.page.route(CHECKPOINTS_ROUTE, async (route) => {
+    await route.fulfill({
+      body: JSON.stringify(['checkpoint.safetensors']),
+      status: 200
+    })
+  })
+  await comfyPage.nodeOps.clearGraph()
+  const initialRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
+  const node = await comfyPage.nodeOps.addNode(NODE_TYPE)
+  await initialRequest
+  await node.click('title')
+
+  const panel = new PropertiesPanelHelper(comfyPage.page)
+  await comfyPage.actionbar.propertiesButton.click()
+  await expect(panel.root).toBeVisible()
+  return panel
+}
 
 test.describe(
   'Properties panel - Button widget callbacks',
-  { tag: ['@ui', '@widget', '@node'] },
+  { tag: ['@ui', '@widget', '@node', '@vue-nodes'] },
   () => {
-    let panel: PropertiesPanelHelper
-    let requestCount: number
-
-    test.beforeEach(async ({ comfyPage }) => {
-      requestCount = 0
-      await comfyPage.page.route(
-        '**/api/models/checkpoints**',
-        async (route) => {
-          requestCount++
-          await route.fulfill({
-            body: JSON.stringify(['checkpoint.safetensors']),
-            status: 200
-          })
-        }
-      )
-      panel = new PropertiesPanelHelper(comfyPage.page)
-      await comfyPage.nodeOps.clearGraph()
-      const node = await comfyPage.nodeOps.addNode(NODE_TYPE)
-      await node.click('title')
-      await comfyPage.actionbar.propertiesButton.click()
-      await expect(panel.root).toBeVisible()
-      await expect.poll(() => requestCount).toBe(1)
-    })
-
-    test('invokes the callback from node Parameters', async () => {
+    test('invokes the callback from node Parameters', async ({ comfyPage }) => {
+      const panel = await setupButtonWidget(comfyPage)
+      const refreshRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
       await panel.contentArea
         .getByRole('button', { name: 'refresh', exact: true })
         .click()
 
-      await expect.poll(() => requestCount).toBe(2)
+      await refreshRequest
     })
 
     test('invokes the callback from Favorited Inputs', async ({
       comfyPage
     }) => {
+      const panel = await setupButtonWidget(comfyPage)
       const refreshRow = panel.root.locator('.widget-item', {
         has: comfyPage.page.getByRole('button', {
           name: 'refresh',
@@ -61,11 +61,12 @@ test.describe(
 
       await comfyPage.page.evaluate(() => window.app!.canvas.deselectAll())
       await comfyPage.nextFrame()
+      const refreshRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
       await panel.contentArea
         .getByRole('button', { name: 'refresh', exact: true })
         .click()
 
-      await expect.poll(() => requestCount).toBe(2)
+      await refreshRequest
     })
   }
 )

--- a/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
+++ b/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+
+const NODE_TYPE = 'DevToolsRemoteWidgetNodeWithRefreshButton'
+
+test.describe(
+  'Properties panel - Button widget callbacks',
+  { tag: ['@ui', '@widget', '@node'] },
+  () => {
+    let panel: PropertiesPanelHelper
+    let requestCount: number
+
+    test.beforeEach(async ({ comfyPage }) => {
+      requestCount = 0
+      await comfyPage.page.route(
+        '**/api/models/checkpoints**',
+        async (route) => {
+          requestCount++
+          await route.fulfill({
+            body: JSON.stringify(['checkpoint.safetensors']),
+            status: 200
+          })
+        }
+      )
+      panel = new PropertiesPanelHelper(comfyPage.page)
+      await comfyPage.nodeOps.clearGraph()
+      const node = await comfyPage.nodeOps.addNode(NODE_TYPE)
+      await node.click('title')
+      await comfyPage.actionbar.propertiesButton.click()
+      await expect(panel.root).toBeVisible()
+      await expect.poll(() => requestCount).toBe(1)
+    })
+
+    test('invokes the callback from node Parameters', async () => {
+      await panel.contentArea
+        .getByRole('button', { name: 'refresh', exact: true })
+        .click()
+
+      await expect.poll(() => requestCount).toBe(2)
+    })
+
+    test('invokes the callback from Favorited Inputs', async ({
+      comfyPage
+    }) => {
+      const refreshRow = panel.root.locator('.widget-item', {
+        has: comfyPage.page.getByRole('button', {
+          name: 'refresh',
+          exact: true
+        })
+      })
+      await refreshRow
+        .getByTestId(TestIds.subgraphEditor.widgetActionsMenuButton)
+        .click()
+      await comfyPage.page
+        .getByTestId(TestIds.menu.moreMenuContent)
+        .getByText('Favorite', { exact: true })
+        .click()
+
+      await comfyPage.page.evaluate(() => window.app!.canvas.deselectAll())
+      await comfyPage.nextFrame()
+      await panel.contentArea
+        .getByRole('button', { name: 'refresh', exact: true })
+        .click()
+
+      await expect.poll(() => requestCount).toBe(2)
+    })
+  }
+)

--- a/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
+++ b/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
@@ -17,7 +17,10 @@ async function setupButtonWidget(comfyPage: ComfyPage) {
   })
   await comfyPage.nodeOps.clearGraph()
   const initialRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
-  const node = await comfyPage.nodeOps.addNode(NODE_TYPE)
+  const node = await comfyPage.nodeOps.addNode(NODE_TYPE, undefined, {
+    x: 300,
+    y: 200
+  })
   await initialRequest
   await comfyPage.vueNodes.selectNode(String(node.id))
 

--- a/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
+++ b/browser_tests/tests/propertiesPanel/buttonWidgetCallbacks.spec.ts
@@ -19,11 +19,14 @@ async function setupButtonWidget(comfyPage: ComfyPage) {
   const initialRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
   const node = await comfyPage.nodeOps.addNode(NODE_TYPE)
   await initialRequest
-  await node.click('title')
+  await comfyPage.vueNodes.selectNode(String(node.id))
 
   const panel = new PropertiesPanelHelper(comfyPage.page)
   await comfyPage.actionbar.propertiesButton.click()
   await expect(panel.root).toBeVisible()
+  await expect(panel.panelTitle).toContainText(
+    'Remote Widget Node With Refresh Button'
+  )
   return panel
 }
 
@@ -33,12 +36,12 @@ test.describe(
   () => {
     test('invokes the callback from node Parameters', async ({ comfyPage }) => {
       const panel = await setupButtonWidget(comfyPage)
-      const refreshRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
-      await panel.contentArea
-        .getByRole('button', { name: 'refresh', exact: true })
-        .click()
-
-      await refreshRequest
+      await Promise.all([
+        comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE),
+        panel.contentArea
+          .getByRole('button', { name: 'refresh', exact: true })
+          .click()
+      ])
     })
 
     test('invokes the callback from Favorited Inputs', async ({
@@ -61,12 +64,13 @@ test.describe(
 
       await comfyPage.page.evaluate(() => window.app!.canvas.deselectAll())
       await comfyPage.nextFrame()
-      const refreshRequest = comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE)
-      await panel.contentArea
-        .getByRole('button', { name: 'refresh', exact: true })
-        .click()
-
-      await refreshRequest
+      await expect(panel.panelTitle).toContainText('Workflow Overview')
+      await Promise.all([
+        comfyPage.page.waitForRequest(CHECKPOINTS_ROUTE),
+        panel.contentArea
+          .getByRole('button', { name: 'refresh', exact: true })
+          .click()
+      ])
     })
   }
 )


### PR DESCRIPTION
## Summary

Add Playwright coverage for button widget callbacks in node Parameters and Favorited Inputs.

## Changes

- **What**: Use the existing DevTools remote-widget refresh button and verify each panel action issues a model-options refresh request.

## Review Focus

Each test registers its own route and awaits a request created immediately before the click, with no shared mutable state. Both cases failed before #17334 because no refresh request occurred and pass after #17334.

Follow-up to #17334.