### PR TITLE
[backport cloud/1.54] fix: refresh slot labels after rename with ECS node state

### DIFF
--- a/src/core/graph/nodeShell/slotLabelReactivity.regression.test.ts
+++ b/src/core/graph/nodeShell/slotLabelReactivity.regression.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { computed, isReactive } from 'vue'
+
+import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+describe('slot label reactivity (regression #16642)', () => {
+  test('plain-object output written by index is upgraded and reactive', () => {
+    const node = new LGraphNode('Plain')
+    node.addOutput('out', 'STRING')
+
+    const outLabel = computed(() => node.outputs[0].label)
+    expect(outLabel.value).toBeUndefined()
+
+    const output: INodeOutputSlot = {
+      name: 'out',
+      type: 'STRING',
+      links: [],
+      boundingRect: new Float64Array(4)
+    }
+    node.outputs[0] = output
+    expect(outLabel.value).toBeUndefined()
+
+    node.outputs[0].label = 'c'
+
+    expect(outLabel.value).toBe('c')
+    expect(isReactive(node.outputs[0])).toBe(true)
+  })
+})

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -63,6 +63,7 @@ import {
 } from './node/slotLinks'
 import {
   createInputSlotView,
+  createOutputSlotView,
   resolveInputSlotView
 } from './node/slotDescriptorView'
 import { initializeWidgetsView } from './node/widgetsView'
@@ -1047,6 +1048,7 @@ export class LGraphNode
       type,
       this.title_mode
     )
+    this._state.outputs = createOutputSlotView(this, this._state.outputs)
     this._inputs = this._state.inputs
     this._outputs = this._state.outputs
     for (const property of [

--- a/src/lib/litegraph/src/node/slotDescriptorView.test.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.test.ts
@@ -60,6 +60,22 @@ describe('slot identity', () => {
     expect(node._state.inputs[0]).toBe(node.inputs[0])
   })
 
+  it('upgrades extension-assigned outputs when they are written', () => {
+    const node = new LGraphNode('Node')
+    const output = {
+      name: 'output',
+      type: 'INT',
+      links: [],
+      boundingRect: new Float64Array(4)
+    }
+
+    node.outputs = [output]
+
+    expect(node._state.outputs).toBe(node.outputs)
+    expect(node.outputs[0]).toBeInstanceOf(NodeOutputSlot)
+    expect(node._state.outputs[0]).toBe(node.outputs[0])
+  })
+
   it('preserves native indexOf behavior for arbitrary values', () => {
     const node = new LGraphNode('Node')
     node.addInput('slot', 'INT')

--- a/src/lib/litegraph/src/node/slotDescriptorView.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.ts
@@ -1,6 +1,10 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
+import type {
+  INodeInputSlot,
+  INodeOutputSlot
+} from '@/lib/litegraph/src/interfaces'
 import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
+import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
 import { toClass } from '@/lib/litegraph/src/utils/type'
 
 const assignedInputViews = new WeakMap<
@@ -28,6 +32,21 @@ export function createInputSlotView(
   return view
 }
 
+export function createOutputSlotView(
+  node: LGraphNode,
+  outputs: INodeOutputSlot[]
+): INodeOutputSlot[] {
+  return new Proxy(outputs, {
+    set(target, property, value: unknown, receiver) {
+      const output =
+        isArrayIndex(property) && isOutputSlot(value)
+          ? toClass(NodeOutputSlot, value, node)
+          : value
+      return Reflect.set(target, property, output, receiver)
+    }
+  })
+}
+
 export function resolveInputSlotView(
   inputs: INodeInputSlot[],
   input: INodeInputSlot
@@ -47,6 +66,15 @@ function isArrayIndex(property: string | symbol): property is string {
 }
 
 function isInputSlot(value: unknown): value is INodeInputSlot {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'name' in value &&
+    'type' in value
+  )
+}
+
+function isOutputSlot(value: unknown): value is INodeOutputSlot {
   return (
     value !== null &&
     typeof value === 'object' &&


### PR DESCRIPTION
Backport of #17319 to 1.54. Clean cherry-pick of `928cd4a5e5`; typecheck and the two slot-label tests green locally.

- Slot labels now refresh after a rename when the node is in ECS state.
- No conflicts; same diff as main.
- 1.53 backport is blocked: it depends on #16510, which was never backported to 1.53.

<details><summary>Full context for agent readers</summary>

- Source PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17319 (merge commit `928cd4a5e5`).
- Cherry-picked with `-x`; `pnpm typecheck` exit 0; `pnpm vitest run src/lib/litegraph/src/node/slotDescriptorView.test.ts src/core/graph/nodeShell/slotLabelReactivity.regression.test.ts` → 6/6 pass.
- 1.53 status: `slotDescriptorView.ts` on core/1.53 and cloud/1.53 lacks the `assignedInputViews` plumbing introduced by https://github.com/Comfy-Org/ComfyUI_frontend/pull/16510 (`risk:xhigh`, no backport labels, no backport PRs). Cherry-picking #17319 onto 1.53 conflicts; a decision on backporting #16510 first (or skipping 1.53) is pending with Christian.
- Program tracker: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973

<!-- authored-by:agent supreme-operator w3-w37 -->
</details>
