### PR TITLE
fix(billing): pay waits for the payment element to actually paint

### DIFF
--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -140,7 +140,7 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
             template: '<p>subscription.preview.termsNote</p>'
           },
           UnifiedStripePaymentSelector: {
-            emits: ['providerUnreachableChange'],
+            emits: ['providerUnreachableChange', 'elementReadyChange'],
             template: `<div>
               <button @click="$emit('providerUnreachableChange', true)">
                 report unreachable
@@ -148,12 +148,21 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
               <button @click="$emit('providerUnreachableChange', false)">
                 report recovered
               </button>
+              <button @click="$emit('elementReadyChange', true)">
+                report element ready
+              </button>
             </div>`
           }
         }
       }
     })
 
+    // Nothing to agree to until the payment element has actually painted.
+    expect(screen.queryByText('subscription.preview.termsNote')).toBeNull()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'report element ready' })
+    )
     expect(screen.getByText('subscription.preview.termsNote')).toBeTruthy()
 
     // With no way to pay there is nothing to agree to.
@@ -162,9 +171,13 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
     expect(screen.queryByText('subscription.preview.termsNote')).toBeNull()
 
-    // A successful retry brings the form - and the agreement - back.
+    // A successful retry brings the form - and the agreement - back once the
+    // remounted element paints.
     await userEvent.click(
       screen.getByRole('button', { name: 'report recovered' })
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'report element ready' })
     )
     expect(screen.getByText('subscription.preview.termsNote')).toBeTruthy()
   })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -293,6 +293,7 @@
         :can-submit="quoteIsCurrent"
         @submitting-change="stripeSubmissionPending = $event"
         @provider-unreachable-change="providerUnreachable = $event"
+        @element-ready-change="paymentElementReady = $event"
         @confirm="confirmPayment"
       />
 
@@ -341,9 +342,13 @@
       </Button>
 
       <!-- Terms Agreement (below the pay action, like Stripe checkout).
-           Hidden while the payment provider is unreachable: with no way to
-           pay, there is nothing to agree to. -->
-      <SubscriptionTermsNote v-if="!providerUnreachableActive" class="mt-2" />
+           Hidden while the payment provider is unreachable or the payment
+           element hasn't painted yet: with no way to pay, there is nothing
+           to agree to. -->
+      <SubscriptionTermsNote
+        v-if="!providerUnreachableActive && !awaitingPaymentElement"
+        class="mt-2"
+      />
     </div>
   </div>
 </template>
@@ -498,6 +503,16 @@ const stripeSubmissionPending = ref(false)
 const providerUnreachable = ref(false)
 const providerUnreachableActive = computed(
   () => captureMode.value && quoteReady.value && providerUnreachable.value
+)
+const paymentElementReady = ref(false)
+// True exactly while the capture selector is mounted but its element hasn't
+// painted; the terms note waits for it the same way the pay CTA does.
+const awaitingPaymentElement = computed(
+  () =>
+    captureMode.value &&
+    quoteReady.value &&
+    !parkedCheckoutRecovery &&
+    !paymentElementReady.value
 )
 const interactionLocked = computed(
   () => isLoading || isApplyingPromotionCode || stripeSubmissionPending.value

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.test.ts
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.test.ts
@@ -79,6 +79,24 @@ function renderSelector(
   })
 }
 
+function fireElementReady() {
+  const readyHandler = stripeMocks.on.mock.calls.find(
+    ([event]) => event === 'ready'
+  )?.[1]
+  expect(readyHandler).toBeTypeOf('function')
+  readyHandler()
+}
+
+async function mountAndReady() {
+  await waitFor(() => expect(stripeMocks.mount).toHaveBeenCalledTimes(1))
+  fireElementReady()
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: 'Pay and subscribe' })
+    ).toBeEnabled()
+  )
+}
+
 describe('UnifiedStripePaymentSelector', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_STRIPE_PUBLISHABLE_KEY', 'pk_test_example')
@@ -125,6 +143,12 @@ describe('UnifiedStripePaymentSelector', () => {
     expect(stripeMocks.mount).toHaveBeenCalledTimes(1)
     expect(screen.queryByText("We can't take payments right now")).toBeNull()
 
+    fireElementReady()
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Pay and subscribe' })
+      ).toBeEnabled()
+    )
     await user.click(
       screen.getByRole('button', {
         name: 'Pay and subscribe'
@@ -145,7 +169,7 @@ describe('UnifiedStripePaymentSelector', () => {
     })
     const { emitted } = renderSelector()
 
-    await waitFor(() => expect(stripeMocks.mount).toHaveBeenCalledTimes(1))
+    await mountAndReady()
     await user.click(
       screen.getByRole('button', {
         name: 'Pay and subscribe'
@@ -166,7 +190,7 @@ describe('UnifiedStripePaymentSelector', () => {
     })
     const { emitted } = renderSelector()
 
-    await waitFor(() => expect(stripeMocks.mount).toHaveBeenCalledTimes(1))
+    await mountAndReady()
     await user.click(
       screen.getByRole('button', {
         name: 'Pay and subscribe'
@@ -189,10 +213,45 @@ describe('UnifiedStripePaymentSelector', () => {
   ])('blocks paying when $description', async ({ props }) => {
     renderSelector(66500, 'pmc_test', props)
     await waitFor(() => expect(stripeMocks.mount).toHaveBeenCalledTimes(1))
+    fireElementReady()
 
     expect(
       screen.getByRole('button', { name: 'Pay and subscribe' })
     ).toBeDisabled()
+  })
+
+  it('keeps Pay disabled until the payment element reports ready', async () => {
+    const { emitted } = renderSelector()
+    await waitFor(() => expect(stripeMocks.mount).toHaveBeenCalledTimes(1))
+
+    expect(
+      screen.getByRole('button', { name: 'Pay and subscribe' })
+    ).toBeDisabled()
+    expect(emitted().elementReadyChange).toEqual([[false]])
+
+    fireElementReady()
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Pay and subscribe' })
+      ).toBeEnabled()
+    )
+    expect(emitted().elementReadyChange).toEqual([[false], [true]])
+  })
+
+  it('drops back to disabled when the element fails after ready', async () => {
+    renderSelector()
+    await mountAndReady()
+
+    const loaderrorHandler = stripeMocks.on.mock.calls.find(
+      ([event]) => event === 'loaderror'
+    )?.[1]
+    loaderrorHandler({ error: { type: 'invalid_request_error' } })
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Pay and subscribe' })
+      ).toBeDisabled()
+    )
   })
 
   it('shows unavailable state when Stripe configuration is missing', async () => {
@@ -244,9 +303,13 @@ describe('UnifiedStripePaymentSelector', () => {
     expect(stripeMocks.loadStripe).toHaveBeenCalledTimes(2)
     expect(screen.queryByText("We can't take payments right now")).toBeNull()
     expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull()
-    expect(
-      screen.getByRole('button', { name: 'Pay and subscribe' })
-    ).toBeEnabled()
+
+    fireElementReady()
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Pay and subscribe' })
+      ).toBeEnabled()
+    )
   })
 
   it('keeps the unreachable state when the retry fails again', async () => {

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -60,7 +60,9 @@
       :variant="verificationPending ? 'tertiary' : 'inverted'"
       size="lg"
       class="w-full rounded-lg"
-      :disabled="!stripeElements || !canSubmit || verificationPending"
+      :disabled="
+        !stripeElements || !elementReady || !canSubmit || verificationPending
+      "
       :loading="isLoading || isSubmitting"
     >
       {{ $t('subscription.preview.payAndSubscribe') }}
@@ -118,6 +120,7 @@ const emit = defineEmits<{
   confirm: [confirmationToken: string]
   submittingChange: [submitting: boolean]
   providerUnreachableChange: [unreachable: boolean]
+  elementReadyChange: [ready: boolean]
 }>()
 
 const { t } = useI18n()
@@ -125,6 +128,10 @@ const paymentElementTarget = ref<HTMLDivElement>()
 const stripeElements = ref<StripeElements>()
 const configurationError = ref('')
 const providerUnreachable = ref(false)
+// The pay CTA waits for the element's iframe to actually paint (Stripe's
+// `ready` event), not merely for Elements to be constructed — the gap between
+// the two is the cold-load window where Pay was clickable over a blank form.
+const elementReady = ref(false)
 const isRetryingLoad = ref(false)
 const isSubmitting = ref(false)
 const selectedMethodType = ref('')
@@ -135,6 +142,7 @@ let isUnmounted = false
 onMounted(initializeStripe)
 
 async function initializeStripe() {
+  elementReady.value = false
   const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
   if (!publishableKey) {
     configurationError.value = t('subscription.preview.stripeUnavailable')
@@ -242,6 +250,9 @@ function createAndMountPaymentElement(stripe: Stripe, target: HTMLDivElement) {
     terms: { card: 'never' }
   })
   paymentElement.mount(target)
+  paymentElement.on('ready', () => {
+    if (!isUnmounted) elementReady.value = true
+  })
   // Method-specific notes (e.g. the Alipay auto-renewal disclosure) key off
   // whichever payment method the user has selected inside the element.
   paymentElement.on('change', (event) => {
@@ -271,6 +282,7 @@ function markConfigurationFailed() {
   paymentElement = undefined
   stripeElements.value = undefined
   selectedMethodType.value = ''
+  elementReady.value = false
   configurationError.value = t('subscription.preview.stripeUnavailable')
 }
 
@@ -279,6 +291,7 @@ function markProviderUnreachable() {
   paymentElement = undefined
   stripeElements.value = undefined
   selectedMethodType.value = ''
+  elementReady.value = false
   providerUnreachable.value = true
 }
 
@@ -299,6 +312,10 @@ watch(
   (unreachable) => emit('providerUnreachableChange', unreachable),
   { immediate: true }
 )
+
+watch(elementReady, (ready) => emit('elementReadyChange', ready), {
+  immediate: true
+})
 
 watch([() => amountCents, () => currency], ([amount, nextCurrency]) => {
   if (!stripeElements.value || amount <= 0) return


### PR DESCRIPTION
On a cold load, **Pay and subscribe** enabled the moment Stripe Elements was constructed — before the payment element's iframe painted — so a fast click landed on a blank form region. The button now waits for Stripe's own `ready` event, and the legal fine print below it waits the same way (nothing to pay with, nothing to agree to).

- The selector tracks `ready` from the mounted element and folds it into the pay CTA's disabled state; failure cleanups and retries reset it, so a remounted element re-earns the enabled state.
- A new `elementReadyChange` emit lets the host hold `SubscriptionTermsNote` until the form is real — closing the during-load window flagged in review on #16846 and deliberately scoped to this change.
- Amount changes flow through `elements.update()` without a remount, so `ready` survives re-quotes.

Tests: pay stays disabled until `ready` and drops back on element failure; the retry path re-earns enabled; the terms note follows ready/unreachable through the full round trip.

Stacked on #16846 (same file, same lifecycle); diff is against that branch.

## Path notes

- Ready gating applies only to the selector's own CTA. Saved-method and zero-dollar paths render their own pay controls in the host and mount no element — unchanged.
- `UnifiedStripePaymentSelector` has exactly one host today (`SubscriptionAddPaymentPreviewWorkspace`); the new emit is additive for any future host.
