### PR TITLE
fix(billing): re-read billing state when returning from the Stripe portal

### DIFF
--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -55,7 +55,7 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   WorkspaceApiError: mockWorkspaceApiError
 }))
 
-const mockCapabilitiesRefresh = vi.hoisted(() => vi.fn())
+const mockCapabilitiesRefresh = vi.hoisted(() => vi.fn(async () => undefined))
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useBillingCapabilities'),
   () => ({
@@ -903,7 +903,10 @@ describe('useWorkspaceBilling', () => {
     })
 
     it('re-reads billing state once when the tab regains visibility after opening the portal', async () => {
-      vi.stubGlobal('open', vi.fn())
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
       mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
         url: 'https://billing.example/portal'
       })
@@ -923,6 +926,121 @@ describe('useWorkspaceBilling', () => {
       // One-shot: switching tabs later must not keep refetching.
       document.dispatchEvent(new Event('visibilitychange'))
       expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-reads billing state when focus returns without a visibility change', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockWorkspaceApi.getBillingBalance.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      window.dispatchEvent(new Event('focus'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledTimes(1)
+      expect(mockCapabilitiesRefresh).toHaveBeenCalledTimes(1)
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores hidden transitions and refreshes on the visible return', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+      const visibilitySpy = vi.spyOn(document, 'visibilityState', 'get')
+      visibilitySpy.mockReturnValue('hidden')
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+
+      visibilitySpy.mockReturnValue('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('replaces pending return listeners on repeated portal opens', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockWorkspaceApi.getBillingBalance.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      window.dispatchEvent(new Event('focus'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledTimes(1)
+      expect(mockCapabilitiesRefresh).toHaveBeenCalledTimes(1)
+    })
+
+    it('removes pending return listeners when its scope is disposed', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+      scope?.stop()
+      scope = undefined
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+      expect(mockCapabilitiesRefresh).not.toHaveBeenCalled()
+    })
+
+    it('does not watch for a return when the portal window is blocked', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => null)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+      expect(mockCapabilitiesRefresh).not.toHaveBeenCalled()
     })
 
     it('does not watch for a return when no portal was opened', async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -55,6 +55,14 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   WorkspaceApiError: mockWorkspaceApiError
 }))
 
+const mockCapabilitiesRefresh = vi.hoisted(() => vi.fn())
+vi.mock<unknown>(
+  import('@/platform/workspace/composables/useBillingCapabilities'),
+  () => ({
+    useBillingCapabilities: () => ({ refresh: mockCapabilitiesRefresh })
+  })
+)
+
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useBillingPlans'),
   () => ({
@@ -892,6 +900,44 @@ describe('useWorkspaceBilling', () => {
 
       await expect(billing.manageSubscription()).rejects.toThrow('portal down')
       expect(billing.error.value).toBe('portal down')
+    })
+
+    it('re-reads billing state once when the tab regains visibility after opening the portal', async () => {
+      vi.stubGlobal('open', vi.fn())
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockWorkspaceApi.getBillingBalance.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledTimes(1)
+      expect(mockCapabilitiesRefresh).toHaveBeenCalledTimes(1)
+
+      // One-shot: switching tabs later must not keep refetching.
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not watch for a return when no portal was opened', async () => {
+      vi.stubGlobal('open', vi.fn())
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({ url: '' })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+      expect(mockCapabilitiesRefresh).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -1,4 +1,11 @@
-import { computed, ref, shallowRef, watch } from 'vue'
+import {
+  computed,
+  getCurrentScope,
+  onScopeDispose,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
 
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
@@ -19,6 +26,7 @@ import {
   WorkspaceApiError,
   workspaceApi
 } from '@/platform/workspace/api/workspaceApi'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
@@ -366,6 +374,38 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     }
   }
 
+  // A cancellation or card change made in the portal tab never pushes back to
+  // this one — status has no focus refetch and capability reads are paced —
+  // so the next return to the app re-reads everything the portal could have
+  // changed.
+  let portalReturnRefresh: (() => void) | null = null
+  function refreshOnPortalReturn() {
+    if (portalReturnRefresh) {
+      document.removeEventListener('visibilitychange', portalReturnRefresh)
+    }
+    const onReturn = () => {
+      if (document.visibilityState !== 'visible') return
+      document.removeEventListener('visibilitychange', onReturn)
+      portalReturnRefresh = null
+      void Promise.allSettled([
+        fetchStatus(),
+        fetchBalance(),
+        useBillingCapabilities().refresh()
+      ])
+    }
+    portalReturnRefresh = onReturn
+    document.addEventListener('visibilitychange', onReturn)
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (portalReturnRefresh) {
+        document.removeEventListener('visibilitychange', portalReturnRefresh)
+        portalReturnRefresh = null
+      }
+    })
+  }
+
   async function manageSubscription(): Promise<void> {
     isLoading.value = true
     error.value = null
@@ -374,6 +414,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       const response = await workspaceApi.getPaymentPortalUrl(returnUrl)
       if (response.url) {
         window.open(response.url, '_blank')
+        refreshOnPortalReturn()
       }
     } catch (err) {
       error.value =

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -374,35 +374,41 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     }
   }
 
-  // A cancellation or card change made in the portal tab never pushes back to
-  // this one — status has no focus refetch and capability reads are paced —
-  // so the next return to the app re-reads everything the portal could have
-  // changed.
-  let portalReturnRefresh: (() => void) | null = null
+  // A cancellation or card change made in the portal tab or window never
+  // pushes back to this one — status has no return refetch and capability
+  // reads are paced — so the next return to the app re-reads everything the
+  // portal could have changed.
+  let stopPortalReturnRefresh: (() => void) | null = null
   function refreshOnPortalReturn() {
-    if (portalReturnRefresh) {
-      document.removeEventListener('visibilitychange', portalReturnRefresh)
-    }
-    const onReturn = () => {
-      if (document.visibilityState !== 'visible') return
+    stopPortalReturnRefresh?.()
+
+    const stopListening = () => {
       document.removeEventListener('visibilitychange', onReturn)
-      portalReturnRefresh = null
+      window.removeEventListener('focus', onReturn)
+      stopPortalReturnRefresh = null
+    }
+    const onReturn = (event: Event) => {
+      if (
+        event.type === 'visibilitychange' &&
+        document.visibilityState !== 'visible'
+      ) {
+        return
+      }
+      stopListening()
       void Promise.allSettled([
         fetchStatus(),
         fetchBalance(),
         useBillingCapabilities().refresh()
       ])
     }
-    portalReturnRefresh = onReturn
+    stopPortalReturnRefresh = stopListening
     document.addEventListener('visibilitychange', onReturn)
+    window.addEventListener('focus', onReturn)
   }
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
-      if (portalReturnRefresh) {
-        document.removeEventListener('visibilitychange', portalReturnRefresh)
-        portalReturnRefresh = null
-      }
+      stopPortalReturnRefresh?.()
     })
   }
 
@@ -413,8 +419,8 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       const returnUrl = window.location.href
       const response = await workspaceApi.getPaymentPortalUrl(returnUrl)
       if (response.url) {
-        window.open(response.url, '_blank')
-        refreshOnPortalReturn()
+        const portalWindow = window.open(response.url, '_blank')
+        if (portalWindow) refreshOnPortalReturn()
       }
     } catch (err) {
       error.value =


### PR DESCRIPTION
A cancellation (or card change) made in the Stripe portal tab never reaches the app tab: `/billing/status` has no focus refetch, capability reads are paced by `expires_at`, and revision invalidation only rides this client's own API responses. So after cancelling in the portal, **Cancel plan** stayed offered on an already-cancelled subscription — clicking it landed in the `ALREADY_CANCELED` recovery as a no-op (the QA repro on FE-2162).

`manageSubscription()` now registers a one-shot visibility listener when it opens the portal: the next return to the tab re-reads status, balance, and capabilities together. Same pattern the outstanding-payment recovery rail already uses (`refreshStatusOnFocus`).

- One-shot and deduped: repeated portal opens replace the pending listener; scope disposal removes it.
- No portal opened (blank URL) → nothing registered.

Tests: refresh fires exactly once on return and covers all three reads; later tab switches don't refetch; the no-portal path stays quiet.

- Fixes the staleness half of FE-2162 (the rename half shipped in #17318)

## Path notes

- The refresh is best-effort `Promise.allSettled` — a failed read logs through the existing per-read failure handling and does not surface a new error state.
- Webhook-driven changes (Stripe retries converging, etc.) with the tab never hidden remain invisible until the paced capability refresh; that push channel is a bigger contract question than this fix.
