### PR TITLE
fix: un-ignore src/scripts in eslint.config.ts and fix the surfaced lint findings

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -177,7 +177,6 @@ export default defineConfig([
       'scripts/registry-census/detection-proof/**',
       'src/__ecs_matrix__/**',
       'src/extensions/core/*',
-      'src/scripts/*',
       'src/types/generatedManagerTypes.ts',
       'src/types/vue-shim.d.ts',
       'packages/design-system/src/css/lucideStrokePlugin.js',

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -17,24 +17,11 @@ import type {
   ModelFolderInfo
 } from '@/platform/assets/schemas/assetSchema'
 import { isCloud } from '@/platform/distribution/types'
-import * as Sentry from '@sentry/vue'
+import { addBreadcrumb } from '@sentry/vue'
 import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import type { ShareableAssetsResponse } from '@/schemas/apiSchema'
-import {
-  zEmbeddingsResponse,
-  zShareableAssetsResponse
-} from '@/schemas/apiSchema'
 import type {
-  TemplateIncludeOnDistributionEnum,
-  WorkflowTemplates
-} from '@/platform/workflow/templates/types/template'
-import type {
-  ComfyApiWorkflow,
-  ComfyWorkflowJSON
-} from '@/platform/workflow/validation/schemas/workflowSchema'
-import type { SerializedNodeId } from '@/types/nodeId'
-import type {
+  ShareableAssetsResponse,
   AssetDownloadWsMessage,
   AssetExportWsMessage,
   CustomNodesI18n,
@@ -63,6 +50,19 @@ import type {
   User,
   UserDataFullInfo
 } from '@/schemas/apiSchema'
+import {
+  zEmbeddingsResponse,
+  zShareableAssetsResponse
+} from '@/schemas/apiSchema'
+import type {
+  TemplateIncludeOnDistributionEnum,
+  WorkflowTemplates
+} from '@/platform/workflow/templates/types/template'
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
+} from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { SerializedNodeId } from '@/types/nodeId'
 import type {
   JobAssetsResult,
   JobDetail,
@@ -298,7 +298,7 @@ type ApiToEventType<T = ApiCalls> = {
 }
 
 /** Dictionary of types used in the detail for a custom event */
-type ApiEventTypes = ApiToEventType<ApiCalls>
+type ApiEventTypes = ApiToEventType
 
 /** Dictionary of API events: `[name]: CustomEvent<Type>` */
 type ApiEvents = AsCustomEvents<ApiEventTypes>
@@ -585,7 +585,7 @@ export class ComfyApi extends EventTarget {
           const method = (requestOptions.method ?? 'GET').toUpperCase()
           const routeTemplate = getFetchRouteTemplate(route)
 
-          Sentry.addBreadcrumb({
+          addBreadcrumb({
             category: 'fetch',
             message: `Timeout on ${method} ${routeTemplate}`,
             level: 'warning',
@@ -788,7 +788,7 @@ export class ComfyApi extends EventTarget {
     const generation = ++this.socketGeneration
 
     let opened = false
-    let existingSession = window.name
+    const existingSession = window.name
 
     // Build WebSocket URL with query parameters
     const params = new URLSearchParams()
@@ -921,7 +921,7 @@ export class ComfyApi extends EventTarget {
               }
               break
             }
-            case 1:
+            case 1: {
               const imageType = view.getUint32(4)
               const imageData = event.data.slice(8)
               switch (imageType) {
@@ -938,7 +938,8 @@ export class ComfyApi extends EventTarget {
               })
               this.dispatchCustomEvent('b_preview', imageBlob)
               break
-            case 4:
+            }
+            case 4: {
               // PREVIEW_IMAGE_WITH_METADATA
               const decoder4 = new TextDecoder()
               const metadataLength = view.getUint32(4)
@@ -946,7 +947,7 @@ export class ComfyApi extends EventTarget {
               const metadata = JSON.parse(decoder4.decode(metadataBytes))
               const imageData4 = event.data.slice(8 + metadataLength)
 
-              let imageMime4 = metadata.image_type
+              const imageMime4 = metadata.image_type
 
               const imageBlob4 = new Blob([imageData4], {
                 type: imageMime4
@@ -965,6 +966,7 @@ export class ComfyApi extends EventTarget {
               // Also dispatch legacy b_preview for backward compatibility
               this.dispatchCustomEvent('b_preview', imageBlob4)
               break
+            }
             default:
               console.error(
                 `Unknown binary websocket message of type ${eventType}`
@@ -1618,7 +1620,7 @@ export class ComfyApi extends EventTarget {
     if (!subgraph?.data) {
       throw new Error(`Global subgraph '${id}' returned empty data`)
     }
-    return subgraph.data as string
+    return subgraph.data
   }
   async getGlobalSubgraphs(): Promise<Record<string, GlobalSubgraphData>> {
     const resp = await api.fetchApi('/global_subgraphs')

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1,8 +1,6 @@
 import { useEventListener, useResizeObserver } from '@vueuse/core'
 import _ from 'es-toolkit/compat'
-import type { ToastMessageOptions } from 'primevue/toast'
-import { reactive, unref } from 'vue'
-import { shallowRef } from 'vue'
+import { reactive, unref, shallowRef } from 'vue'
 
 import { partnerRunGateBlocksAutoQueue } from '@/composables/billing/usePartnerNodesRunGate'
 import { useCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
@@ -71,16 +69,10 @@ import type {
   NodeExecutionOutput,
   ResultItem
 } from '@/schemas/apiSchema'
-import {
-  type ComfyNodeDef as ComfyNodeDefV1,
-  isComboInputSpecV1,
-  isComboInputSpecV2
-} from '@/schemas/nodeDefSchema'
-import {
-  type BaseDOMWidget,
-  ComponentWidgetImpl,
-  DOMWidgetImpl
-} from '@/scripts/domWidget'
+import { isComboInputSpecV1, isComboInputSpecV2 } from '@/schemas/nodeDefSchema'
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import { ComponentWidgetImpl, DOMWidgetImpl } from '@/scripts/domWidget'
+import type { BaseDOMWidget } from '@/scripts/domWidget'
 import { useAccountPreconditionDialog } from '@/platform/cloud/subscription/composables/useAccountPreconditionDialog'
 import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -129,6 +121,8 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { runMissingMediaPipeline } from '@/platform/missingMedia/missingMediaPipeline'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 
+type ToastMessage = Parameters<ReturnType<typeof useToastStore>['add']>[0]
+
 import { getWorkflowMode } from '@/utils/appMode'
 import { anyItemOverlapsRect } from '@/utils/mathUtil'
 import { ensureNonZeroUuid } from '@/utils/uuid'
@@ -155,13 +149,15 @@ import {
 } from '@/utils/migration/migrateReroute'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
-import { type ComfyApi, PromptExecutionError, api } from './api'
+import { PromptExecutionError, api } from './api'
+import type { ComfyApi } from './api'
 import { defaultGraph } from './defaultGraph'
 import { importA1111 } from './pnginfo'
 import { applyPromotedWidgetControl } from './promotedWidgetControl'
 import { $el, ComfyUI } from './ui'
 import { ComfyAppMenu } from './ui/menu/index'
 import { clone } from './utils'
+import type * as WidgetsModule from './widgets'
 import type { CustomComfyWidgetConstructor } from './widgets'
 import { ensureCorrectLayoutScale } from '@/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale'
 import {
@@ -191,7 +187,7 @@ function isMeshModelFile(file: File): boolean {
 }
 
 export function sanitizeNodeName(string: string) {
-  let entityMap = {
+  const entityMap = {
     '&': '',
     '<': '',
     '>': '',
@@ -426,7 +422,7 @@ export class ComfyApp {
    * @deprecated Use useWidgetStore().widgets instead
    */
   get widgets(): Record<string, CustomComfyWidgetConstructor> &
-    typeof import('./widgets').ComfyWidgets {
+    typeof WidgetsModule.ComfyWidgets {
     const widgetStore = useWidgetStore()
     return Object.assign(
       Object.fromEntries(widgetStore.widgets.entries()),
@@ -528,7 +524,7 @@ export class ComfyApp {
    * force the server to load the output file as an image.
    */
   getPreviewFormatParam() {
-    let preview_format = useSettingStore().get('Comfy.PreviewFormat')
+    const preview_format = useSettingStore().get('Comfy.PreviewFormat')
     if (preview_format) return `&preview=${preview_format}`
     else return ''
   }
@@ -549,7 +545,7 @@ export class ComfyApp {
   }
 
   static copyToClipspace(node: LGraphNode) {
-    var widgets = null
+    let widgets = null
     if (node.widgets) {
       widgets = node.widgets.map(({ type, name, value }) => ({
         type,
@@ -558,8 +554,8 @@ export class ComfyApp {
       }))
     }
 
-    var imgs = undefined
-    var orig_imgs = undefined
+    let imgs = undefined
+    let orig_imgs = undefined
     if (node.imgs != undefined) {
       imgs = []
       orig_imgs = []
@@ -571,7 +567,7 @@ export class ComfyApp {
       }
     }
 
-    var selectedIndex = 0
+    let selectedIndex = 0
     if (node.imageIndex) {
       selectedIndex = node.imageIndex
     }
@@ -1022,10 +1018,7 @@ export class ComfyApp {
 
         const widgetStore = useDomWidgetStore()
 
-        const activeWidgets: Record<
-          string,
-          BaseDOMWidget<object | string>
-        > = Object.fromEntries(
+        const activeWidgets: Record<string, BaseDOMWidget> = Object.fromEntries(
           newGraph.nodes
             .flatMap((node) => node.widgets ?? [])
             .filter(
@@ -1130,7 +1123,7 @@ export class ComfyApp {
         output_node: false,
         python_module: 'custom_nodes.frontend_only',
         description: node.description ?? `Frontend only node for ${name}`
-      } as ComfyNodeDefV1
+      }
     }
 
     const allNodeDefs = {
@@ -1293,7 +1286,7 @@ export class ComfyApp {
       silentAssetErrors = false,
       workflowNavigationId
     } = options
-    useWorkflowService().beforeLoadNewGraph(clean !== false)
+    useWorkflowService().beforeLoadNewGraph(clean)
     await useExtensionService().invokeExtensionsAsync('beforeLoadGraph')
 
     if (skipAssetScans) {
@@ -1310,7 +1303,7 @@ export class ComfyApp {
       useMissingMediaStore().clearMissingMedia()
     }
 
-    if (clean !== false) {
+    if (clean) {
       // Reset canvas context before configuring a new graph so subgraph UI
       // state from the previous workflow cannot leak into the newly loaded
       // one, and so `clean()` can clear the root graph even when the user is
@@ -1382,7 +1375,7 @@ export class ComfyApp {
         )
         return
       }
-      for (let n of nodes) {
+      for (const n of nodes) {
         if (!(n.type in LiteGraph.registered_node_types)) {
           // Always sanitize so configure() can handle unregistered types,
           // but only report as missing if the node is active.
@@ -1514,7 +1507,7 @@ export class ComfyApp {
         if (node.widgets) {
           // If you break something in the backend and want to patch workflows in the frontend
           // This is the place to do this
-          for (let widget of node.widgets) {
+          for (const widget of node.widgets) {
             if (node.type == 'KSampler' || node.type == 'KSamplerAdvanced') {
               if (widget.name == 'sampler_name') {
                 if (
@@ -2102,9 +2095,8 @@ export class ComfyApp {
     // Check workflow first - it should take priority over parameters
     // when both are present (e.g., in ComfyUI-generated PNGs)
     if (workflow) {
-      let workflowObj: ComfyWorkflowJSON | undefined = undefined
       try {
-        workflowObj =
+        const workflowObj: ComfyWorkflowJSON | undefined =
           typeof workflow === 'string'
             ? parseJsonWithNonFinite<ComfyWorkflowJSON>(workflow)
             : (workflow as ComfyWorkflowJSON)
@@ -2591,7 +2583,7 @@ export class ComfyApp {
    * Refresh combo list on whole nodes
    */
   async refreshComboInNodes() {
-    const requestToastMessage: ToastMessageOptions = {
+    const requestToastMessage: ToastMessage = {
       severity: 'info',
       summary: t('g.update'),
       detail: t('toastMessages.updateRequested')

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -1,5 +1,5 @@
-import _ from 'es-toolkit/compat'
-import { type Component, toRaw } from 'vue'
+import { toRaw } from 'vue'
+import type { Component } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 // LegacyWidget is imported from its own module, not the barrel: the barrel
@@ -194,7 +194,7 @@ abstract class BaseDOMWidgetImpl<V extends object | string>
   }
 
   override createCopyForNode(node: LGraphNode): this {
-    // @ts-expect-error
+    // @ts-expect-error: `typeof this` is not constructible in TS, but every concrete subclass shares this constructor signature
     const cloned: this = new (this.constructor as typeof this)({
       node: node,
       name: this.name,
@@ -227,7 +227,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
   }
 
   override createCopyForNode(node: LGraphNode): this {
-    // @ts-expect-error
+    // @ts-expect-error: `typeof this` is not constructible in TS, but every concrete subclass shares this constructor signature
     const cloned: this = new (this.constructor as typeof this)({
       node: node,
       name: this.name,
@@ -243,7 +243,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
   }
 
   /** Extract DOM widget size info */
-  override computeLayoutSize(node: LGraphNode) {
+  override computeLayoutSize(_node: LGraphNode) {
     if (this.type === 'hidden') {
       return {
         minHeight: 0,
@@ -256,7 +256,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
     let minHeight =
       this.options.getMinHeight?.() ??
       parseInt(styles.getPropertyValue('--comfy-widget-min-height'))
-    let maxHeight =
+    const maxHeight =
       this.options.getMaxHeight?.() ??
       parseInt(styles.getPropertyValue('--comfy-widget-max-height'))
 
@@ -264,11 +264,7 @@ export class DOMWidgetImpl<T extends HTMLElement, V extends object | string>
       this.options.getHeight?.() ??
       styles.getPropertyValue('--comfy-widget-height')
 
-    if (typeof prefHeight === 'string' && prefHeight.endsWith?.('%')) {
-      prefHeight =
-        node.size[1] *
-        (parseFloat(prefHeight.substring(0, prefHeight.length - 1)) / 100)
-    } else {
+    if (typeof prefHeight !== 'string' || !prefHeight.endsWith?.('%')) {
       prefHeight =
         typeof prefHeight === 'number' ? prefHeight : parseInt(prefHeight)
 
@@ -329,7 +325,7 @@ export class ComponentWidgetImpl<
   }
 }
 
-export const addWidget = <W extends BaseDOMWidget<object | string>>(
+export const addWidget = <W extends BaseDOMWidget>(
   node: LGraphNode,
   widget: W
 ) => {
@@ -371,7 +367,7 @@ LGraphNode.prototype.addDOMWidget = function <
     options: { hideOnZoom: true, ...options }
   })
   // Note: Before `LGraphNode.configure` is called, `this.id` is always `-1`.
-  addWidget(this, widget as unknown as BaseDOMWidget<object | string>)
+  addWidget(this, widget as unknown as BaseDOMWidget)
 
   // Workaround for https://github.com/Comfy-Org/ComfyUI_frontend/issues/2493
   // Some custom nodes are explicitly expecting getter and setter of `value`

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -2,13 +2,13 @@ import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
-import {
-  type AvifIinfBox,
-  type AvifIlocBox,
-  type AvifInfeBox,
-  type ComfyMetadata,
-  ComfyMetadataTags,
-  type IsobmffBoxContentRange
+import { ComfyMetadataTags } from '@/types/metadataTypes'
+import type {
+  AvifIinfBox,
+  AvifIlocBox,
+  AvifInfeBox,
+  ComfyMetadata,
+  IsobmffBoxContentRange
 } from '@/types/metadataTypes'
 import { readFileAsArrayBuffer } from '@/utils/fileUtil'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
@@ -337,7 +337,7 @@ function parseExifData(exifData) {
   // Function to read 16-bit and 32-bit integers from binary data
   // @ts-expect-error fixme ts strict error
   function readInt(offset, isLittleEndian, length) {
-    let arr = exifData.slice(offset, offset + length)
+    const arr = exifData.slice(offset, offset + length)
     if (length === 2) {
       return new DataView(arr.buffer, arr.byteOffset, arr.byteLength).getUint16(
         0,

--- a/src/scripts/metadata/ebml.ts
+++ b/src/scripts/metadata/ebml.ts
@@ -1,14 +1,14 @@
-import {
-  type ComfyApiWorkflow,
-  type ComfyWorkflowJSON
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
-import {
-  type ComfyMetadata,
-  ComfyMetadataTags,
-  type EbmlElementRange,
-  type EbmlTagPosition,
-  type TextRange,
-  type VInt
+import { ComfyMetadataTags } from '@/types/metadataTypes'
+import type {
+  ComfyMetadata,
+  EbmlElementRange,
+  EbmlTagPosition,
+  TextRange,
+  VInt
 } from '@/types/metadataTypes'
 import { readFileAsArrayBuffer } from '@/utils/fileUtil'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'

--- a/src/scripts/metadata/gltf.ts
+++ b/src/scripts/metadata/gltf.ts
@@ -1,15 +1,13 @@
-import {
-  type ComfyApiWorkflow,
-  type ComfyWorkflowJSON
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
-import {
-  ASCII,
-  type ComfyMetadata,
-  ComfyMetadataTags,
-  type GltfChunkHeader,
-  type GltfHeader,
-  type GltfJsonData,
-  GltfSizeBytes
+import { ASCII, ComfyMetadataTags, GltfSizeBytes } from '@/types/metadataTypes'
+import type {
+  ComfyMetadata,
+  GltfChunkHeader,
+  GltfHeader,
+  GltfJsonData
 } from '@/types/metadataTypes'
 import { readFileAsArrayBuffer } from '@/utils/fileUtil'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'

--- a/src/scripts/metadata/isobmff.ts
+++ b/src/scripts/metadata/isobmff.ts
@@ -1,12 +1,11 @@
-import {
-  type ComfyApiWorkflow,
-  type ComfyWorkflowJSON
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
-import {
-  ASCII,
-  type ComfyMetadata,
-  ComfyMetadataTags,
-  type IsobmffBoxContentRange
+import { ASCII, ComfyMetadataTags } from '@/types/metadataTypes'
+import type {
+  ComfyMetadata,
+  IsobmffBoxContentRange
 } from '@/types/metadataTypes'
 import { readFileAsArrayBuffer } from '@/utils/fileUtil'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
@@ -195,10 +194,13 @@ const parseIlstBox = (
 }
 
 const findUserDataBox = (data: Uint8Array): IsobmffBoxContentRange => {
-  let userDataBox: IsobmffBoxContentRange = null
-
   // Metadata can be in 'udta' at top level or inside 'moov'
-  userDataBox = findIsobmffBoxByType(data, 0, data.length, BOX_TYPES.USER_DATA)
+  let userDataBox: IsobmffBoxContentRange = findIsobmffBoxByType(
+    data,
+    0,
+    data.length,
+    BOX_TYPES.USER_DATA
+  )
 
   if (!userDataBox) {
     const moovBox = findIsobmffBoxByType(data, 0, data.length, BOX_TYPES.MOVIE)

--- a/src/scripts/metadata/json.ts
+++ b/src/scripts/metadata/json.ts
@@ -17,7 +17,7 @@ export function getDataFromJSON(
           reader.result
         )
         if (jsonContent?.templates) {
-          resolve({ templates: jsonContent.templates as object })
+          resolve({ templates: jsonContent.templates })
           return
         }
         if (isApiJson(jsonContent)) {

--- a/src/scripts/metadata/mp3.ts
+++ b/src/scripts/metadata/mp3.ts
@@ -35,7 +35,8 @@ export async function getMp3Metadata(file: File) {
   }
   let workflow: ComfyWorkflowJSON | undefined
   let prompt: ComfyApiWorkflow | undefined
-  let prompt_s = header.match(/prompt\u0000(\{.*?\})\u0000/s)?.[1]
+  // eslint-disable-next-line no-control-regex -- NUL-delimited binary field
+  const prompt_s = header.match(/prompt\u0000(\{.*?\})\u0000/s)?.[1]
   if (prompt_s) {
     try {
       prompt = parseJsonWithNonFinite<ComfyApiWorkflow>(prompt_s)
@@ -43,7 +44,8 @@ export async function getMp3Metadata(file: File) {
       console.error('Failed to parse MP3 prompt metadata', e)
     }
   }
-  let workflow_s = header.match(/workflow\u0000(\{.*?\})\u0000/s)?.[1]
+  // eslint-disable-next-line no-control-regex -- NUL-delimited binary field
+  const workflow_s = header.match(/workflow\u0000(\{.*?\})\u0000/s)?.[1]
   if (workflow_s) {
     try {
       workflow = parseJsonWithNonFinite<ComfyWorkflowJSON>(workflow_s)

--- a/src/scripts/metadata/ogg.ts
+++ b/src/scripts/metadata/ogg.ts
@@ -32,7 +32,8 @@ export async function getOggMetadata(file: File) {
   }
   let workflow: ComfyWorkflowJSON | undefined
   let prompt: ComfyApiWorkflow | undefined
-  let prompt_s = header
+  const prompt_s = header
+    // eslint-disable-next-line no-control-regex -- NUL-delimited binary field
     .match(/prompt=(\{.*?(\}.*?\u0000))/s)?.[1]
     ?.match(/\{.*\}/)?.[0]
   if (prompt_s) {
@@ -42,7 +43,8 @@ export async function getOggMetadata(file: File) {
       console.error('Failed to parse Ogg prompt metadata', e)
     }
   }
-  let workflow_s = header
+  const workflow_s = header
+    // eslint-disable-next-line no-control-regex -- NUL-delimited binary field
     .match(/workflow=(\{.*?(\}.*?\u0000))/s)?.[1]
     ?.match(/\{.*\}/)?.[0]
   if (workflow_s) {

--- a/src/scripts/metadata/svg.ts
+++ b/src/scripts/metadata/svg.ts
@@ -1,4 +1,4 @@
-import { type ComfyMetadata } from '@/types/metadataTypes'
+import type { ComfyMetadata } from '@/types/metadataTypes'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
 
 export async function getSvgMetadata(file: File): Promise<ComfyMetadata> {

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -1,4 +1,5 @@
-import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 import { api } from './api'
@@ -29,7 +30,7 @@ function parseExifData(exifData: Uint8Array) {
     isLittleEndian: boolean,
     length: 2 | 4
   ): number {
-    let arr = exifData.slice(offset, offset + length)
+    const arr = exifData.slice(offset, offset + length)
     if (length === 2) {
       return new DataView(arr.buffer, arr.byteOffset, arr.byteLength).getUint16(
         0,

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -6,14 +6,15 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { runMintPortsIntentionalClear } from '@/workbench/extensions/agent/crdt/mintPortWiring'
 import { useTelemetry } from '@/platform/telemetry'
 import { WORKFLOW_ACCEPT_STRING } from '@/platform/workflow/core/types/formats'
-import { type StatusWsMessageStatus } from '@/schemas/apiSchema'
+import type { StatusWsMessageStatus } from '@/schemas/apiSchema'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 import { api } from './api'
-import { ComfyApp, app } from './app'
+import type { ComfyApp } from './app'
+import { app } from './app'
 import { ComfyDialog as _ComfyDialog } from './ui/dialog'
 import { ComfySettingsDialog } from './ui/settings'
 import { toggleSwitch } from './ui/toggleSwitch'
@@ -61,13 +62,7 @@ export function $el<TTag extends string>(
     if (Array.isArray(propsOrChildren)) {
       element.append(...propsOrChildren)
     } else {
-      const {
-        parent,
-        $: cb,
-        dataset,
-        style,
-        ...rest
-      } = propsOrChildren as Props
+      const { parent, $: cb, dataset, style, ...rest } = propsOrChildren
 
       if (rest.for) {
         element.setAttribute('for', rest.for)
@@ -100,7 +95,7 @@ export function $el<TTag extends string>(
 
 // @ts-expect-error fixme ts strict error
 function dragElement(dragEl): () => void {
-  var posDiffX = 0,
+  let posDiffX = 0,
     posDiffY = 0,
     posStartX = 0,
     posStartY = 0,
@@ -459,7 +454,7 @@ export class ComfyUI {
     autoQueueModeEl.style.display = 'none'
 
     api.addEventListener('autoQueueGraphChanged', () => {
-      if (this.autoQueueMode === 'change' && this.autoQueueEnabled === true) {
+      if (this.autoQueueMode === 'change' && this.autoQueueEnabled) {
         if (this.lastQueueSize === 0) {
           this.graphHasChanged = false
           app.queuePrompt(0, this.batchCount, {
@@ -725,7 +720,7 @@ export class ComfyUI {
 
     this.restoreMenuPosition = dragElement(this.menuContainer)
 
-    // @ts-expect-error
+    // @ts-expect-error: placeholder status carries a string queue_remaining to size the element before the first real update
     this.setStatus({ exec_info: { queue_remaining: 'X' } })
   }
 

--- a/src/scripts/ui/components/button.ts
+++ b/src/scripts/ui/components/button.ts
@@ -1,10 +1,11 @@
-import { type Settings } from '@/schemas/apiSchema'
+import type { Settings } from '@/schemas/apiSchema'
 import type { ComfyApp } from '@/scripts/app'
 
 import type { ComfyComponent } from '.'
 import { $el } from '../../ui'
 import { prop } from '../../utils'
-import { type ClassList, applyClasses, toggleElement } from '../utils'
+import { applyClasses, toggleElement } from '../utils'
+import type { ClassList } from '../utils'
 import type { ComfyPopup } from './popup'
 
 type ComfyButtonProps = {
@@ -20,7 +21,7 @@ type ComfyButtonProps = {
   app?: ComfyApp
 }
 
-export class ComfyButton implements ComfyComponent<HTMLElement> {
+export class ComfyButton implements ComfyComponent {
   private _over = 0
   private _popupOpen = false
   isOver = false

--- a/src/scripts/ui/components/buttonGroup.ts
+++ b/src/scripts/ui/components/buttonGroup.ts
@@ -1,6 +1,6 @@
 import { $el } from '../../ui'
 import { prop } from '../../utils'
-import { ComfyButton } from './button'
+import type { ComfyButton } from './button'
 
 export class ComfyButtonGroup {
   element = $el('div.comfyui-button-group')

--- a/src/scripts/ui/components/popup.ts
+++ b/src/scripts/ui/components/popup.ts
@@ -1,6 +1,7 @@
 import { $el } from '../../ui'
 import { prop } from '../../utils'
-import { type ClassList, applyClasses } from '../utils'
+import { applyClasses } from '../utils'
+import type { ClassList } from '../utils'
 
 export class ComfyPopup extends EventTarget {
   element = $el('div.comfyui-popup')

--- a/src/scripts/ui/imagePreview.ts
+++ b/src/scripts/ui/imagePreview.ts
@@ -18,8 +18,8 @@ export function calculateImageGrid(
   shiftX: number
 } {
   let best = 0
-  let w = imgs[0].naturalWidth
-  let h = imgs[0].naturalHeight
+  const w = imgs[0].naturalWidth
+  const h = imgs[0].naturalHeight
   const numImages = imgs.length
 
   let cellWidth, cellHeight, cols, rows, shiftX
@@ -58,8 +58,8 @@ export function createImageHost(node: LGraphNode) {
   let first = true
 
   function updateSize() {
-    let w = null
-    let h = null
+    let w: number | string
+    let h: number | string
 
     // @ts-expect-error fixme ts strict error
     if (currentImgs) {

--- a/src/scripts/ui/toggleSwitch.ts
+++ b/src/scripts/ui/toggleSwitch.ts
@@ -17,9 +17,6 @@ export function toggleSwitch(name, items, e?) {
   // @ts-expect-error fixme ts strict error
   let selectedIndex
   // @ts-expect-error fixme ts strict error
-  let elements
-
-  // @ts-expect-error fixme ts strict error
   function updateSelected(index) {
     // @ts-expect-error fixme ts strict error
     if (selectedIndex != null) {
@@ -32,12 +29,11 @@ export function toggleSwitch(name, items, e?) {
       prev: selectedIndex == null ? undefined : items[selectedIndex]
     })
     selectedIndex = index
-    // @ts-expect-error fixme ts strict error
     elements[selectedIndex].classList.add('comfy-toggle-selected')
   }
 
   // @ts-expect-error fixme ts strict error
-  elements = items.map((item, i) => {
+  const elements = items.map((item, i) => {
     if (typeof item === 'string') item = { text: item }
     if (!item.value) item.value = item.text
 

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -1,5 +1,6 @@
 import { t } from '@/i18n'
-import { type LGraphNode, isComboWidget } from '@/lib/litegraph/src/litegraph'
+import { isComboWidget } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type {
   IBaseWidget,
   IComboWidget,


### PR DESCRIPTION
## ELI-5

`src/scripts/` (70 source files, the oldest core of the frontend: `app.ts`, `api.ts`, `widgets.ts`, the metadata parsers) was invisible to ESLint because one line in `eslint.config.ts` ignored it. This deletes that line and fixes every error that showed up, so the lint gate now actually covers that code.

## Description

Removes `'src/scripts/*'` from the top-level `ignores` array in `eslint.config.ts`. ESLint flat config treats `dir/*` as ignoring the whole subtree, so `metadata/` and `ui/` were dark too. With the line gone, `eslint src` surfaced **74 problems (53 errors, 21 warnings)** across the subtree; 25 were auto-fixable, the remaining 28 errors are hand-fixed here.

Auto-fixed (`eslint --fix` + `oxfmt`): `prefer-const`, `no-var`, `@typescript-eslint/consistent-type-imports`, `unused-imports/no-unused-imports`, `import/consistent-type-specifier-style`, `import/no-duplicates`.

Hand-fixed:

- **`no-case-declarations` ×10** — `src/scripts/api.ts`, the binary-websocket `switch`: `case 1:` and `case 4:` bodies wrapped in `{ … }`. No control-flow change.
- **`no-useless-assignment` ×5** — each was a genuine dead store: `workflowObj` in `app.ts` (moved into the `try` as a `const`, it was never read after the block), `userDataBox` in `metadata/isobmff.ts` (`= null` immediately overwritten, folded into the declaration), `w`/`h` in `ui/imagePreview.ts` (`= null` initialisers overwritten before any read, now bare typed declarations), `prefHeight` in `domWidget.ts` (see the note below).
- **`no-control-regex` ×4** — `metadata/mp3.ts` and `metadata/ogg.ts`. The `` is intentional (NUL-delimited binary tag fields), so each gets a line-level `// eslint-disable-next-line no-control-regex -- NUL-delimited binary field`. The parsers are untouched. These four are the only suppressions added.
- **`@typescript-eslint/ban-ts-comment` ×3** — `domWidget.ts` ×2, `ui.ts` ×1: each `@ts-expect-error` now carries a `: <reason>` description.
- **`@typescript-eslint/consistent-type-imports` (`import()` annotations) ×1** — `app.ts`: `typeof import('./widgets').ComfyWidgets` replaced by a top-level `import type * as WidgetsModule`.
- **`prefer-const` ×1** — `ui/toggleSwitch.ts`: `let elements` + a later single assignment collapsed into `const elements = items.map(…)`, with the `@ts-expect-error` moved to the declaration.
- **`no-restricted-imports` ×1** — `api.ts` imported `* as Sentry from '@sentry/vue'`, which the rule rejects because the namespace exposes the banned `captureException`. The file only ever calls `Sentry.addBreadcrumb`, so this is now a named `import { addBreadcrumb }`. `addBreadcrumb` is not restricted; `reportError()` is the replacement for `captureException`, which this file never used.
- **`primevue-removal/no-imports` ×1** — `app.ts` imported `type { ToastMessageOptions } from 'primevue/toast'` for one local annotation. Replaced with a local alias derived from the store it is handed to: `type ToastMessage = Parameters<ReturnType<typeof useToastStore>['add']>[0]`. Structurally the same type, no new PrimeVue reference, and no edit outside `src/scripts/**` (`toastStore.ts` is already on the PrimeVue allowlist).

### Behaviour note: a latent dead branch in `domWidget.ts`

`BaseDOMWidgetImpl.computeLayoutSize` computed a percentage-relative `prefHeight` (`node.size[1] * pct`) and then never read it — only the non-percentage branch feeds `minHeight`. So percentage `--comfy-widget-height` values have never influenced the computed layout. The condition is inverted and the dead branch dropped, which is **behaviour-identical** (the discarded computation is pure). Deleting it also left `node` unused, now `_node`, which is independent confirmation that the parameter existed only for that dead branch. Making percentage heights actually work is a real behaviour change and is deliberately not done here.

The 7 remaining `no-restricted-syntax` apiSchema-deprecation findings in the subtree are warnings and do not fail the gate; they are left alone.

## Residual

**The oxlint half of the ticket is not done: `"src/scripts/*"` is still in `ignorePatterns` in `.oxlintrc.json`.** Only the ESLint ignore is removed. Removing the oxlint entry as well was measured, not skipped blindly — with it removed, `oxlint --type-aware src/scripts` reports **242 findings**, of which **151 survive the auto-fixer** (`oxlint --type-aware --fix`). Post-autofix breakdown:

| count | rule |
| --- | --- |
| 112 | `typescript/no-unnecessary-condition` (70 "unnecessary optional chain on a non-nullish value", 22 "always truthy", 16 "always falsy", 2 literal comparisons, 2 no-overlap) |
| 15 | `typescript/no-floating-promises` |
| 5 | `vitest/valid-expect` (warning) |
| 4 | `vitest/consistent-each-for` |
| 4 | `typescript/no-unnecessary-type-parameters` |
| 4 | `typescript/no-explicit-any` |
| 3 | `typescript/no-unnecessary-type-assertion` |
| 1 each | `unicorn/no-thenable` (warning), `typescript/no-unnecessary-type-conversion`, `typescript/no-misused-spread`, `eslint/no-console` |

The blocker is the 112 `no-unnecessary-condition` findings, and they are **not** mechanical. They land overwhelmingly in runtime code, not tests — `app.ts` 31, `metadata/parser.ts` 16, `ui.ts` 10, `widgets.ts` 8, `metadata/ply.ts` 8, `api.ts` 6, `pnginfo.ts` 4 — and 70 of them ask for an `?.` to become `.` because the *declared* type is non-nullish. This subtree is exactly where declared types are least trustworthy: it is dense with `// @ts-expect-error fixme ts strict error` and it parses untyped data off the wire and out of image files. Each `?.` removal is a judgment call about whether the type is telling the truth at runtime, on the frontend's hottest path. Doing 112 of those unattended, in the same PR as a mechanical lint sweep, is how a silent `TypeError` regression ships.

Follow-up work, actionable on its own: delete `"src/scripts/*"` from `ignorePatterns` in `.oxlintrc.json`, run `pnpm exec oxlint --type-aware --fix src/scripts`, and then triage the ~112 `no-unnecessary-condition` sites one file at a time, starting with the test files and the leaf metadata parsers (`ply.ts`, `parser.ts`) before touching `app.ts` / `api.ts`. For any site where the declared type is not trustworthy at runtime, the correct fix is to widen the declared type to admit `undefined` rather than to delete the guard.

Also unaddressed, and deliberately so: `eslint.config.ts` still lists `'src/scripts/**'` in the per-rule `ignores` of the `comfy/no-new-error-throw` config block. That is a separate, rule-scoped exclusion (its sibling `'src/extensions/core/**'` is right beside it), not part of the top-level ignore list this PR clears, and the ticket scoped this change to the top-level entry only.

Verification caveat: `pnpm exec eslint --print-config src/scripts/metadata/png.ts` prints `undefined` on this branch — but so does every other resolution attempt against that subtree, and `--print-config` on a file *outside* it prints a full config, so this is a `--print-config` quirk in this repo's flat config rather than evidence the tree is still ignored. Reachability is instead confirmed directly, both ways: with the ignore line restored, `eslint src/scripts/metadata/png.ts` emits the "file ignored" warning; with it removed, it lints the file and reports 0 problems. Before the change the subtree produced no findings at all; after it, 74.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `pnpm lint` — exit 0 (0 errors, 225 warnings, all pre-existing `no-restricted-syntax` deprecation warnings repo-wide); `pnpm typecheck` — exit 0; `pnpm exec vitest run src/scripts` — 30 files, 407 passed, 1 skipped, 0 failed; `pnpm exec eslint src/scripts` — 0 errors; pre-commit `lint-staged` re-ran `pnpm lint` and `pnpm typecheck` green on the staged tree.
- **Deviations:** the oxlint `ignorePatterns` entry is intentionally retained; see `## Residual` for the measurement and the reason.
