### PR TITLE
refactor(agent): renderer-provided layout port for agent materializer (ADR CRDT-FOLLOWER-0031)

### DIFF
--- a/docs/adr/CRDT-FOLLOWER-0031-renderer-provided-layout-port-for-agent-materializer.md
+++ b/docs/adr/CRDT-FOLLOWER-0031-renderer-provided-layout-port-for-agent-materializer.md
@@ -1,0 +1,123 @@
+# ADR-CRDT-FOLLOWER-0031: Renderer-Provided Layout Port for the Agent Materializer
+
+Date: 2026-09-10
+
+## Status
+
+Proposed
+
+<!-- [Proposed | Accepted | Rejected | Deprecated | Superseded by [ADR-IDENTIFIER](IDENTIFIER-title.md)] -->
+
+## Context
+
+The in-app agent follower ([CRDT-FOLLOWER-0025](CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md))
+integrates agent-authored Y.Doc updates into frontend state. Its semantic layer,
+`src/core/graph/graphMutations.ts`, materializes nodes and links into the graph
+document and never writes position or size into the shared follower Y.Doc. Layout is
+renderer state owned by `layoutStore` ([CRDT-LAYOUT-0003](CRDT-LAYOUT-0003-crdt-layout-intent-and-local-measurement.md)).
+
+Node materialization still needs a layout write: a node the agent creates must get a
+`createNode` layout operation with `LayoutSource.AgentRemote`, and a deleted node must
+have its layout removed. Two placements were discussed for that write:
+
+1. Let `graphMutations.ts` import `layoutStore` directly and perform the write inline.
+2. Keep `graphMutations.ts` renderer-free and have the caller supply the layout write
+   through a port.
+
+The follower already took option 2 in shape: `GraphMutationsDeps['layout']` declares a
+`SemanticLayoutMutationPort` with `createNode` and `deleteNodes`. What was left
+unrecorded was _who constructs the port_. Until now the only implementation was an
+inline object literal inside `AgentPanelRoot.vue`, which required the workbench
+extension to import `LayoutSource` from the renderer and duplicated layout-operation
+construction in a UI component.
+
+A parallel discussion (XC-157, tracked in the program repo) asked whether the
+frontend Node-API exception/whitelist policy should also decide this boundary. That
+policy governs which litegraph and renderer APIs custom-node extensions may reach; it
+does not decide how the agent follower is composed. This ADR records that the
+follower keeps its own boundary regardless of the whitelist outcome.
+
+The related refactor [#16908](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16908)
+splits the follower layers; it does not move the layout write and is compatible with
+this decision.
+
+## Decision
+
+The renderer owns the layout port implementation. The follower core does not import
+the renderer.
+
+- `src/renderer/core/layout/agentLayoutPort.ts` exports
+  `createAgentLayoutPort(): GraphMutationsDeps['layout']`. It is the only code that
+  translates a semantic `createNode` / `deleteNodes` call into `layoutStore`
+  operations tagged `LayoutSource.AgentRemote`, carrying the remote actor and opId.
+- The port shape stays owned by `src/core/graph/graphMutations.ts`
+  (`GraphMutationsDeps['layout']`). The renderer adapts to the semantic contract, not
+  the reverse.
+- The composition root (`src/workbench/extensions/agent/AgentPanelRoot.vue`) wires
+  `layout: createAgentLayoutPort()` into `createGraphMutations`, mirroring the
+  mint-port seam in `crdt/mintPortWiring.ts`.
+- `src/core/graph/graphMutations.ts` and `src/workbench/extensions/agent/crdt/**`
+  (non-test files) must not import `@/renderer/`. The unit test
+  `src/workbench/extensions/agent/crdt/rendererBoundary.test.ts` scans those paths
+  and fails on any such import.
+
+```text
+┌──────────────────────────────┐   Y.Doc update    ┌──────────────────────────────┐
+│ agent doc-host (server)      │──────────────────▶│ follower core                │
+└──────────────────────────────┘                   │ workbench/extensions/agent/  │
+                                                   │   crdt/**                    │
+                                                   │ core/graph/graphMutations.ts │
+                                                   │   (no @/renderer imports)    │
+                                                   └──────────────┬───────────────┘
+                                                                  │ GraphMutationsDeps['layout']
+                                                                  │ (port shape owned here)
+                       composition root                           ▼
+┌──────────────────────────────┐  createAgentLayoutPort()  ┌──────────────────────────────┐
+│ AgentPanelRoot.vue           │──────────────────────────▶│ renderer/core/layout/        │
+│ wires deps into              │                           │   agentLayoutPort.ts         │
+│ createGraphMutations()       │                           │ → layoutStore.applyOperation │
+└──────────────────────────────┘                           │   source: AgentRemote        │
+                                                           └──────────────────────────────┘
+```
+
+## Consequences
+
+### Positive
+
+- The op layer stays pure and portable: `graphMutations.ts` can be unit-tested and
+  reused (for example in a headless doc-host) without a renderer.
+- One place builds agent layout operations, so `LayoutSource.AgentRemote`, actor, and
+  opId tagging cannot drift between UI components.
+- The boundary is machine-checked, not just documented.
+- The whitelist/exception policy for custom nodes (XC-157) can evolve independently.
+
+### Negative
+
+- Any new renderer capability the materializer needs must be added to the port
+  interface first, then to the renderer factory. This is two edits instead of one.
+- `AgentPanelRoot.vue` still imports the renderer (`layoutStore`, `ACTOR_CONFIG`,
+  `createAgentLayoutPort`) under `eslint-disable` for `import-x/no-restricted-paths`.
+  That is accepted for the composition root; the guard test covers the layers below it.
+- `src/core/**` outside `graphMutations.ts` is not renderer-clean today; the guard is
+  deliberately scoped to the follower and does not claim a wider invariant.
+
+## Notes
+
+- Related: [CRDT-FOLLOWER-0025](CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md),
+  [CRDT-LAYOUT-0003](CRDT-LAYOUT-0003-crdt-layout-intent-and-local-measurement.md),
+  [GRAPH-DOCUMENT-0024](GRAPH-DOCUMENT-0024-graph-activation-and-document-objects-for-in-app-agent-targets.md),
+  [GRAPH-DOCUMENT-0026](GRAPH-DOCUMENT-0026-frontend-document-model.md),
+  [ECS-0008](ECS-0008-entity-component-system.md), PR [#16908](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16908).
+- Glossary:
+  - **Follower**: the frontend side of the agent CRDT flow; integrates updates, does
+    not author semantic ops.
+  - **Materializer**: the follower step that turns semantic Y.Doc nodes/links into
+    graph-document state.
+  - **Port**: an interface the core declares and the outer layer implements
+    (`GraphMutationsDeps['layout']`).
+  - **Composition root**: the single place dependencies are constructed and wired
+    (`AgentPanelRoot.vue`).
+  - **LayoutSource.AgentRemote**: layout-operation tag marking writes originating from
+    the agent rather than the local user.
+  - **XC-157**: program-repo cross-cutting item on the Node-API exception/whitelist
+    policy.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [CANVAS-GESTURE-0029](CANVAS-GESTURE-0029-pointer-gesture-state-machine.md)                                      | Pointer Gesture State Machine                                   | Proposed | 2026-09-06 |
 | [CANVAS-SELECTION-0028](CANVAS-SELECTION-0028-single-selection-store.md)                                         | Single Selection Store                                          | Proposed | 2026-09-04 |
 | [CRDT-FOLLOWER-0025](CRDT-FOLLOWER-0025-in-app-agent-crdt-follower-and-distribution-resolved-boundaries.md)      | In-App Agent CRDT Follower and Distribution-Resolved Boundaries | Proposed | 2026-08-21 |
+| [CRDT-FOLLOWER-0031](CRDT-FOLLOWER-0031-renderer-provided-layout-port-for-agent-materializer.md)                 | Renderer-Provided Layout Port for the Agent Materializer        | Proposed | 2026-09-10 |
 | [CRDT-LAYOUT-0003](CRDT-LAYOUT-0003-crdt-layout-intent-and-local-measurement.md)                                 | CRDT Layout Intent and Local Measurement                        | Proposed | 2025-08-27 |
 | [CRDT-MINT-0018](CRDT-MINT-0018-merge-identity-for-node-transfers.md)                                            | Merge Identity for Node Transfers                               | Proposed | 2026-08-25 |
 | [DEPS-DESIGN-SYSTEM-0004](DEPS-DESIGN-SYSTEM-0004-fork-primevue.md)                                              | Fork PrimeVue                                                   | Rejected | 2025-08-27 |

--- a/src/renderer/core/layout/agentLayoutPort.ts
+++ b/src/renderer/core/layout/agentLayoutPort.ts
@@ -1,0 +1,56 @@
+import type { GraphMutationsDeps } from '@/core/graph/graphMutations'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { LayoutSource } from '@/renderer/core/layout/types'
+
+/**
+ * Renderer-owned layout port for the in-app agent CRDT materializer.
+ *
+ * The follower core (`src/core/graph/graphMutations.ts` and
+ * `src/workbench/extensions/agent/crdt/**`) never imports the renderer; the
+ * composition root (`AgentPanelRoot.vue`) injects this port, mirroring the
+ * mint-port seam in `crdt/mintPortWiring.ts`. The port shape is owned by
+ * `GraphMutationsDeps['layout']`, so the renderer adapts to the semantic
+ * contract rather than the other way round.
+ *
+ * See docs/adr/CRDT-FOLLOWER-0031-renderer-provided-layout-port-for-agent-materializer.md
+ */
+export function createAgentLayoutPort(): GraphMutationsDeps['layout'] {
+  return {
+    createNode(scope, nodeId, layout, context) {
+      const { position, size } = layout
+      layoutStore.applyOperation({
+        type: 'createNode',
+        graphId: scope.rootGraphId,
+        ownerGraphId: scope.owningGraphId,
+        nodeId,
+        layout: {
+          id: nodeId,
+          position,
+          size,
+          bounds: { x: position.x, y: position.y, ...size },
+          zIndex: layoutStore.allocateZIndex(),
+          visible: true
+        },
+        source: LayoutSource.AgentRemote,
+        actor: context.actor,
+        opId: context.opId,
+        timestamp: Date.now()
+      })
+    },
+    deleteNodes(scope, nodeIds, context) {
+      const timestamp = Date.now()
+      layoutStore.applyOperations(
+        nodeIds.map((nodeId) => ({
+          type: 'deleteNode',
+          graphId: scope.rootGraphId,
+          ownerGraphId: scope.owningGraphId,
+          nodeId,
+          source: LayoutSource.AgentRemote,
+          actor: context.actor,
+          opId: context.opId,
+          timestamp
+        }))
+      )
+    }
+  }
+}

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -44,7 +44,7 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 // eslint-disable-next-line import-x/no-restricted-paths
 import { ACTOR_CONFIG } from '@/renderer/core/layout/constants'
 // eslint-disable-next-line import-x/no-restricted-paths
-import { LayoutSource } from '@/renderer/core/layout/types'
+import { createAgentLayoutPort } from '@/renderer/core/layout/agentLayoutPort'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
@@ -174,44 +174,7 @@ const graphMutations = (workflowId: string) => {
           }
         : null
     },
-    layout: {
-      createNode(scope, nodeId, layout, context) {
-        const { position, size } = layout
-        layoutStore.applyOperation({
-          type: 'createNode',
-          graphId: scope.rootGraphId,
-          ownerGraphId: scope.owningGraphId,
-          nodeId,
-          layout: {
-            id: nodeId,
-            position,
-            size,
-            bounds: { x: position.x, y: position.y, ...size },
-            zIndex: layoutStore.allocateZIndex(),
-            visible: true
-          },
-          source: LayoutSource.AgentRemote,
-          actor: context.actor,
-          opId: context.opId,
-          timestamp: Date.now()
-        })
-      },
-      deleteNodes(scope, nodeIds, context) {
-        const timestamp = Date.now()
-        layoutStore.applyOperations(
-          nodeIds.map((nodeId) => ({
-            type: 'deleteNode',
-            graphId: scope.rootGraphId,
-            ownerGraphId: scope.owningGraphId,
-            nodeId,
-            source: LayoutSource.AgentRemote,
-            actor: context.actor,
-            opId: context.opId,
-            timestamp
-          }))
-        )
-      }
-    }
+    layout: createAgentLayoutPort()
   })
   graphMutationsByWorkflow.set(workflowId, mutations)
   return mutations

--- a/src/workbench/extensions/agent/crdt/rendererBoundary.test.ts
+++ b/src/workbench/extensions/agent/crdt/rendererBoundary.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards the follower boundary from
+ * ADR CRDT-FOLLOWER-0031: the agent CRDT follower core and the semantic
+ * graph-mutation layer must not import the renderer. Renderer access is
+ * injected by the composition root (`AgentPanelRoot.vue`) through ports
+ * such as `createAgentLayoutPort()`.
+ */
+
+const SRC_ROOT = join(__dirname, '..', '..', '..', '..')
+const GUARDED_DIRS = [
+  join(SRC_ROOT, 'workbench', 'extensions', 'agent', 'crdt')
+]
+const GUARDED_FILES = [join(SRC_ROOT, 'core', 'graph', 'graphMutations.ts')]
+const RENDERER_IMPORT = /from\s+['"]@\/renderer\//
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      return entry === '__fixtures__' ? [] : listSourceFiles(full)
+    }
+    if (!entry.endsWith('.ts') || entry.endsWith('.test.ts')) return []
+    return [full]
+  })
+}
+
+describe('agent follower renderer boundary', () => {
+  const files = [...GUARDED_DIRS.flatMap(listSourceFiles), ...GUARDED_FILES]
+
+  it('scans the follower core', () => {
+    expect(files.length).toBeGreaterThan(5)
+  })
+
+  it('does not import @/renderer from follower core or graphMutations', () => {
+    const offenders = files
+      .filter((file) => RENDERER_IMPORT.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(SRC_ROOT, file))
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Move the `AgentPanelRoot.vue` inline layout mutations (`createNode` / `deleteNodes` against `useLayoutMutations` with `LayoutSource.AgentRemote`) into a renderer-owned factory `createAgentLayoutPort(): GraphMutationsDeps['layout']` at `src/renderer/core/layout/agentLayoutPort.ts`. The agent CRDT follower (`src/workbench/extensions/agent/crdt/**`) and `src/core/graph/graphMutations.ts` now depend only on the layout port type and never import `@/renderer/` directly; the composition root wires the concrete port.

Documents the seam as ADR `CRDT-FOLLOWER-0031` and adds a boundary test that fs-scans the follower + `graphMutations.ts` for `@/renderer/` imports.

Related: #16908 (`agent/fer-1-split-follower`) — compatible; this PR only moves the already-existing renderer coupling behind the same `GraphMutationsDeps['layout']` port that PR keeps.

## Changes

- `src/renderer/core/layout/agentLayoutPort.ts` (new) — `createAgentLayoutPort()`; same behavior as the removed inline code (actor/opId, `Date.now()`, `LayoutSource.AgentRemote`).
- `src/workbench/extensions/agent/AgentPanelRoot.vue` — `layout: createAgentLayoutPort()` (+2 / −39).
- `src/workbench/extensions/agent/crdt/rendererBoundary.test.ts` (new) — asserts zero `@/renderer/` imports in `crdt/**` non-test `.ts` (skips `__fixtures__`) and in `graphMutations.ts`; asserts >5 files scanned so a broken glob cannot pass vacuously.
- `docs/adr/CRDT-FOLLOWER-0031-renderer-provided-layout-port-for-agent-materializer.md` (new) + `docs/adr/README.md` index row.

## Evidence

- Commit `902d02f44e03c6d1fcdd2dcd2ff3556efe0a1c7b` on `christian-byrne/agent-materializer-layout-port`, based on `main` `dffad2da6df769bf15d7e3c64b7987e5b2a771f2`.
- `pnpm exec vitest run src/core/graph/graphMutations.test.ts src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts src/workbench/extensions/agent/crdt/rendererBoundary.test.ts` → 3 files, 53/53 passed.
- `pnpm typecheck` (`vue-tsc --noEmit`) → exit 0 (also ran in the pre-commit hook).
- `pnpm exec oxlint` on the 3 code files → 0 warnings / 0 errors; `pnpm exec eslint` on the same + `graphMutations.ts` → exit 0 (`import-x/no-restricted-paths` satisfied; composition-root import uses the existing disable-comment pattern).
- `pnpm adr:check` → "ADR naming and index validation passed".
- `pnpm exec oxfmt --write` on the 5 touched files → no diff after commit.

## Review notes / decisions to veto

- Boundary test scope is `crdt/**` + `graphMutations.ts` only, not all of `src/core` (kept narrow to the agent follower; widen in a follow-up if wanted).
- ADR numbered `CRDT-FOLLOWER-0031` (next free in the CRDT-FOLLOWER series); status Proposed.
- Draft until a roster reviewer confirms the seam matches the #16908 direction.

<!-- authored-by:agent role-hard-problem -->
