### PR TITLE
feat(nodes): show what a running node is doing beside its progress bar

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2486,6 +2486,10 @@
   "nodeBadge": {
     "partnerNodesCount": "Partner Nodes x {count}"
   },
+  "nodeActivity": {
+    "loading": "Loading",
+    "downloading": "Downloading"
+  },
   "nodeErrors": {
     "render": "Node Render Error",
     "content": "Node Content Error",

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -164,7 +164,11 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
     global: {
       plugins: [getActivePinia()!, i18n],
       stubs: {
-        NodeHeader: true,
+        NodeHeader: {
+          props: ['activity'],
+          template:
+            '<div data-testid="node-header" :data-activity="activity" />'
+        },
         NodeSlots: true,
         NodeWidgets: {
           props: ['nodeData', 'widgetIds'],
@@ -323,8 +327,9 @@ describe('LGraphNode', () => {
 
     renderLGraphNode({ nodeData: mockNodeData })
 
-    expect(screen.getByTestId('node-activity-badge')).toHaveTextContent(
-      'Loading'
+    expect(screen.getByTestId('node-header')).toHaveAttribute(
+      'data-activity',
+      'loading'
     )
   })
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -109,6 +109,7 @@ vi.mock(
       executing: computed(() => mockData.mockExecuting),
       progress: computed(() => undefined),
       progressPercentage: computed(() => undefined),
+      activity: computed(() => undefined),
       progressState: computed(() => undefined),
       executionState: computed(() => 'idle' as const)
     }))

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -27,6 +27,7 @@ import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
 const mockData = vi.hoisted(() => ({
   mockExecuting: false,
+  mockActivity: undefined as string | undefined,
   mockLgraphNode: null as Record<string, unknown> | null
 }))
 
@@ -109,7 +110,7 @@ vi.mock(
       executing: computed(() => mockData.mockExecuting),
       progress: computed(() => undefined),
       progressPercentage: computed(() => undefined),
-      activity: computed(() => undefined),
+      activity: computed(() => mockData.mockActivity),
       progressState: computed(() => undefined),
       executionState: computed(() => 'idle' as const)
     }))
@@ -201,6 +202,7 @@ const mockRerouteNodeData: NodeState = {
 describe('LGraphNode', () => {
   beforeEach(() => {
     mockData.mockExecuting = false
+    mockData.mockActivity = undefined
     mockData.mockLgraphNode = null
 
     const canvasStore = useCanvasStore()
@@ -313,6 +315,17 @@ describe('LGraphNode', () => {
 
     const overlay = screen.getByTestId('node-state-outline-overlay')
     expect(overlay).toHaveClass('border-node-stroke-executing')
+  })
+
+  it('passes a reported activity through to the node header', () => {
+    mockData.mockExecuting = true
+    mockData.mockActivity = 'loading'
+
+    renderLGraphNode({ nodeData: mockNodeData })
+
+    expect(screen.getByTestId('node-activity-badge')).toHaveTextContent(
+      'Loading'
+    )
   })
 
   it('hides a linked core LoadImage input preview', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -107,6 +107,7 @@
           :node-data
           :collapsed="isCollapsed"
           :price-badges="badges.pricing"
+          :activity
           @collapse="handleCollapse"
           @update:title="handleHeaderTitleUpdate"
         />
@@ -350,7 +351,8 @@ const isSelected = computed(() => {
 const nodeLocatorId = computed(
   () => locatorIdFromState(nodeData, canvasStore.rootGraphId) ?? undefined
 )
-const { executing, progress } = useNodeExecutionState(nodeLocatorId)
+const { executing, progress, activity } =
+  useNodeExecutionState(nodeLocatorId)
 const hasAnyError = computed(() =>
   nodeHasError(nodeData, canvasStore.rootGraphId, lgraphNode.value)
 )

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -351,8 +351,7 @@ const isSelected = computed(() => {
 const nodeLocatorId = computed(
   () => locatorIdFromState(nodeData, canvasStore.rootGraphId) ?? undefined
 )
-const { executing, progress, activity } =
-  useNodeExecutionState(nodeLocatorId)
+const { executing, progress, activity } = useNodeExecutionState(nodeLocatorId)
 const hasAnyError = computed(() =>
   nodeHasError(nodeData, canvasStore.rootGraphId, lgraphNode.value)
 )

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
@@ -138,6 +138,28 @@ describe('NodeHeader.vue', () => {
     expect(onCollapse).toHaveBeenCalled()
   })
 
+  it('shows a known activity as a word', () => {
+    renderHeader({ activity: 'loading' })
+
+    expect(screen.getByTestId('node-activity-badge')).toHaveTextContent(
+      'Loading'
+    )
+  })
+
+  it('shows an activity it has no word for as sent', () => {
+    renderHeader({ activity: 'warming' })
+
+    expect(screen.getByTestId('node-activity-badge')).toHaveTextContent(
+      'warming'
+    )
+  })
+
+  it('shows no activity badge when the node reports none', () => {
+    renderHeader()
+
+    expect(screen.queryByTestId('node-activity-badge')).toBeNull()
+  })
+
   it('shows the current node title and updates when prop changes', async () => {
     const { rerender } = renderHeader({
       nodeData: makeNodeData({ title: 'Original' })

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -61,6 +61,11 @@
         :text="badge.required"
         :rest="badge.rest"
       />
+      <NodeBadge
+        v-if="activityLabel"
+        :text="activityLabel"
+        data-testid="node-activity-badge"
+      />
       <NodeBadge v-if="statusBadge" v-bind="statusBadge" />
       <i
         v-if="isPinned"
@@ -92,9 +97,10 @@ interface NodeHeaderProps {
   nodeData?: NodeState
   collapsed?: boolean
   priceBadges?: { required: string; rest?: string }[]
+  activity?: string
 }
 
-const { nodeData, collapsed } = defineProps<NodeHeaderProps>()
+const { nodeData, collapsed, activity } = defineProps<NodeHeaderProps>()
 
 const emit = defineEmits<{
   collapse: []
@@ -147,6 +153,10 @@ const statusBadge = computed((): NodeBadgeProps | undefined =>
     : bypassed.value
       ? { text: 'Bypassed', cssIcon: 'icon-[lucide--redo-dot]' }
       : undefined
+)
+
+const activityLabel = computed(() =>
+  activity ? st(`nodeActivity.${activity}`, activity) : undefined
 )
 
 const isPinned = computed(() => Boolean(nodeData?.flags.pinned))

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -64,6 +64,8 @@
       <NodeBadge
         v-if="activityLabel"
         :text="activityLabel"
+        fg-color="var(--color-node-stroke-executing)"
+        css-icon="icon-[lucide--loader-circle] motion-safe:animate-spin"
         data-testid="node-activity-badge"
       />
       <NodeBadge v-if="statusBadge" v-bind="statusBadge" />

--- a/src/renderer/extensions/vueNodes/execution/useNodeExecutionState.ts
+++ b/src/renderer/extensions/vueNodes/execution/useNodeExecutionState.ts
@@ -35,6 +35,10 @@ export const useNodeExecutionState = (
     return state && state.max > 0 ? state.value / state.max : undefined
   })
 
+  const activity = computed(() =>
+    executing.value ? progressState.value?.activity : undefined
+  )
+
   const progressPercentage = computed(() => {
     const prog = progress.value
     return prog !== undefined ? Math.round(prog * 100) : undefined
@@ -50,6 +54,7 @@ export const useNodeExecutionState = (
     executing,
     progress,
     progressPercentage,
+    activity,
     progressState,
     executionState
   }

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -65,6 +65,7 @@ const zNodeProgressState = z.object({
   value: z.number(),
   max: z.number(),
   state: z.enum(['pending', 'running', 'finished', 'error']),
+  activity: z.string().optional(),
   node_id: zNodeId,
   prompt_id: zJobId,
   display_node_id: zNodeId.optional(),

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -284,6 +284,51 @@ describe('useExecutionStore - nodeLocationProgressStates caching', () => {
     ).toBeDefined()
   })
 
+  it('carries the running node activity onto its subgraph locator', () => {
+    const mockSubgraph = {
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      nodes: []
+    }
+    const mockNode = createMockLGraphNode({
+      id: 123,
+      isSubgraphNode: () => true,
+      subgraph: mockSubgraph
+    })
+    vi.mocked(app.rootGraph.getNodeById).mockReturnValue(mockNode)
+    const parentLocator = createNodeLocatorId(null, toNodeId(123))
+
+    const finishedSibling: NodeProgressState = {
+      display_node_id: '123:455',
+      state: 'finished',
+      value: 1,
+      max: 1,
+      prompt_id: 'test',
+      node_id: 'node0'
+    }
+    const loadingNode: NodeProgressState = {
+      display_node_id: '123:456',
+      state: 'running',
+      activity: 'loading',
+      value: 0,
+      max: 0,
+      prompt_id: 'test',
+      node_id: 'node1'
+    }
+
+    store.nodeProgressStates = { node0: finishedSibling, node1: loadingNode }
+    expect(store.nodeLocationProgressStates[parentLocator].activity).toBe(
+      'loading'
+    )
+
+    store.nodeProgressStates = {
+      node0: finishedSibling,
+      node1: { ...loadingNode, activity: undefined }
+    }
+    expect(
+      store.nodeLocationProgressStates[parentLocator].activity
+    ).toBeUndefined()
+  })
+
   it('should not re-traverse graph for same execution IDs across progress updates', () => {
     const mockSubgraph = {
       id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -360,6 +360,7 @@ export const useExecutionStore = defineStore('execution', () => {
         mergedState.max = newState.max
       }
       mergedState.state = 'running'
+      mergedState.activity = newState.activity
     }
 
     return mergedState


### PR DESCRIPTION
## Summary

A running node that reports an `activity` (today: `loading` while weights move to VRAM) shows that word as a header badge, so a sampler sitting at 0% for minutes says why.

## Changes

- **What**: `progress_state` node entries may carry an optional `activity` string (typed in `apiSchema.ts`, carried through the subgraph merge in `executionStore.ts`). Vue nodes show it as a `NodeBadge` in the header while the node is running; absent means no badge and no layout change. The value never touches the progress bar.
- Known values map through `nodeActivity.*` strings; an unknown value is shown as sent.
- Classic canvas nodes (`LGraphNode.ts`) are untouched.

## Review Focus

- Producer: Comfy-Org/ComfyUI#16202 (draft). Until it merges the field is absent on every message and this PR changes nothing visible. Merging this first is safe; it gives #16202 a reader.
- The risk grader will mark this R3 because `src/schemas/apiSchema.ts` changed; the change there is one optional field.
- Linear: FE-2146 (task 2 of CORE-424).

## Screenshots

<img width="331" height="182" alt="image" src="https://github.com/user-attachments/assets/8b3d8b4e-ece8-4d30-9f8f-e396b0e0693a" />

