### PR TITLE
fix: report invalid subgraph unpack mappings

### DIFF
--- a/src/core/graph/subgraph/adoptPromotedWidgetValue.ts
+++ b/src/core/graph/subgraph/adoptPromotedWidgetValue.ts
@@ -12,16 +12,13 @@ import { useWidgetValueStore } from '@/stores/widgetValueStore'
 export function adoptPromotedWidgetValue(
   hostInput: INodeInputSlot,
   targetNode: LGraphNode,
-  targetSlot: number
+  targetInput: INodeInputSlot
 ): void {
   const { widgetId } = hostInput
   if (!widgetId) return
 
   const value = useWidgetValueStore().getWidget(widgetId)?.value
   if (value === undefined || !isWidgetValue(value)) return
-
-  if (targetSlot < 0 || targetSlot >= targetNode.inputs.length) return
-  const targetInput = targetNode.inputs[targetSlot]
 
   const widget = targetNode.getWidgetFromSlot(targetInput)
   if (!widget) return

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2542,7 +2542,10 @@ export class LGraph
           )
         : undefined
       if (link.origin_id === SUBGRAPH_INPUT_ID && !hostInput) {
-        console.error('Missing host input when unpacking subgraph')
+        reportError(new Error('Missing host input when unpacking subgraph'), {
+          errorType: 'subgraph_unpack_missing_host_input',
+          context: { linkId: link.id, subgraphNodeId: subgraphNode.id }
+        })
         continue
       }
       const outerLink =
@@ -2552,7 +2555,25 @@ export class LGraph
       if (link.origin_id === SUBGRAPH_INPUT_ID && !outerLink) {
         const interiorNode = this.getNodeById(nodeIdMap.get(link.target_id))
         if (hostInput && interiorNode) {
-          adoptPromotedWidgetValue(hostInput, interiorNode, link.target_slot)
+          if (
+            link.target_slot < 0 ||
+            link.target_slot >= interiorNode.inputs.length
+          ) {
+            reportError(
+              new Error('Missing target input when unpacking subgraph'),
+              {
+                errorType: 'subgraph_unpack_missing_target_input',
+                context: {
+                  linkId: link.id,
+                  targetNodeId: interiorNode.id,
+                  targetSlot: link.target_slot
+                }
+              }
+            )
+            continue
+          }
+          const targetInput = interiorNode.inputs[link.target_slot]
+          adoptPromotedWidgetValue(hostInput, interiorNode, targetInput)
         }
         continue
       }

--- a/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
@@ -29,8 +29,14 @@ import {
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock(import('@/platform/telemetry/reportError'), () => ({
+  reportError: mockReportError
+}))
+
 beforeEach(() => {
   resetSubgraphFixtureState()
+  mockReportError.mockClear()
 })
 
 describe('SubgraphConversion', () => {
@@ -357,22 +363,31 @@ describe('SubgraphConversion', () => {
 
       it('Should not report a missing link for a promoted widget input', () => {
         const { graph, subgraphNode } = createPromotedWidgetSubgraph()
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
         graph.unpackSubgraph(subgraphNode)
 
-        expect(errorSpy).not.toHaveBeenCalled()
+        expect(mockReportError).not.toHaveBeenCalled()
       })
 
       it('Should report a missing host input and continue unpacking', () => {
         const { graph, subgraphNode } = createPromotedWidgetSubgraph()
+        const [link] = subgraphNode.subgraph.links.values()
+        assert(link)
         subgraphNode.removeInput(0)
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
         graph.unpackSubgraph(subgraphNode)
 
-        expect(errorSpy).toHaveBeenCalledWith(
-          'Missing host input when unpacking subgraph'
+        expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            message: 'Missing host input when unpacking subgraph'
+          }),
+          {
+            errorType: 'subgraph_unpack_missing_host_input',
+            context: {
+              linkId: link.id,
+              subgraphNodeId: subgraphNode.id
+            }
+          }
         )
         expect(graph.nodes.length).toBe(1)
       })
@@ -401,15 +416,40 @@ describe('SubgraphConversion', () => {
         assert(secondWidgetId)
         useWidgetValueStore().setValue(secondWidgetId, 'second host')
         subgraphNode.removeInput(0)
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
         graph.unpackSubgraph(subgraphNode)
 
-        expect(errorSpy).toHaveBeenCalledTimes(1)
+        expect(mockReportError).toHaveBeenCalledTimes(1)
         expect(readUnpackedWidgetValues(graph)).toEqual([
           'interior 0',
           'second host'
         ])
+      })
+
+      it('Should report a missing interior target input and continue unpacking', () => {
+        const { graph, subgraphNode } = createPromotedWidgetSubgraph()
+        const [link] = subgraphNode.subgraph.links.values()
+        assert(link)
+        link.target_slot = 1
+
+        graph.unpackSubgraph(subgraphNode)
+        const [targetNode] = graph.nodes
+        assert(targetNode)
+
+        expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            message: 'Missing target input when unpacking subgraph'
+          }),
+          {
+            errorType: 'subgraph_unpack_missing_target_input',
+            context: {
+              linkId: link.id,
+              targetNodeId: targetNode.id,
+              targetSlot: 1
+            }
+          }
+        )
+        expect(graph.nodes.length).toBe(1)
       })
 
       it('Should hand the promoted host value to the interior widget', () => {
@@ -455,11 +495,10 @@ describe('SubgraphConversion', () => {
 
         const inner = createTestNode(subgraph, ['number'])
         subgraph.inputNode.slots[0].connect(inner.inputs[0], inner)
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
         graph.unpackSubgraph(subgraphNode)
 
-        expect(errorSpy).not.toHaveBeenCalled()
+        expect(mockReportError).not.toHaveBeenCalled()
         expect(graph.nodes.length).toBe(1)
       })
     })


### PR DESCRIPTION
## Summary

Follow up on #15002 by reporting malformed subgraph unpack mappings without treating valid unconnected inputs as errors.

## Changes

- **What**: Route missing host-input mappings through structured telemetry, preserving stable host-slot ID matching and continued unpacking.

## Review Focus

Confirm telemetry is limited to missing host-input mappings; promoted widget values and ordinary unconnected inputs remain silent.

Depends on #15002.