### PR TITLE
fix: gate model metadata requests behind download actions

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
@@ -107,25 +107,26 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
       await expect(copyUrlButton.first()).toBeVisible()
     })
 
-    test('Should probe and show Download for the devtools model fixture', async ({
+    test('Should probe the devtools model fixture after Download', async ({
       comfyPage
     }) => {
-      await Promise.all([
-        comfyPage.page.waitForResponse(
-          (response) =>
-            response.request().method() === 'HEAD' &&
-            response.url() ===
-              'http://localhost:8188/api/devtools/fake_model.safetensors' &&
-            response.ok()
-        ),
-        loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
-      ])
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
 
       const downloadButton = comfyPage.page.getByTestId(
         TestIds.dialogs.missingModelDownload
       )
       await expect(downloadButton.first()).toBeVisible()
       await expect(downloadButton.first()).toHaveText('Download')
+
+      await Promise.all([
+        comfyPage.page.waitForRequest(
+          (request) =>
+            request.method() === 'HEAD' &&
+            request.url() ===
+              'http://localhost:8188/api/devtools/fake_model.safetensors'
+        ),
+        downloadButton.first().click()
+      ])
     })
 
     test('Should render Download all and Refresh actions for one downloadable model', async ({
@@ -200,6 +201,10 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
       })
 
       test('Should classify a 403 model as gated', async ({ comfyPage }) => {
+        await comfyPage.page
+          .getByTestId(TestIds.dialogs.missingModelDownload)
+          .click()
+
         await expect(
           comfyPage.page.getByTestId(TestIds.dialogs.missingModelGatedAccess)
         ).toBeVisible()
@@ -211,10 +216,6 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
       test('Should keep Download available for a gated model', async ({
         comfyPage
       }) => {
-        await expect(
-          comfyPage.page.getByTestId(TestIds.dialogs.missingModelGatedAccess)
-        ).toBeVisible()
-
         const downloadButton = comfyPage.page.getByTestId(
           TestIds.dialogs.missingModelDownload
         )
@@ -222,15 +223,28 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
         await expect(downloadButton).toBeVisible()
         await expect(downloadButton).toBeEnabled()
         await expect(downloadButton).toHaveText('Download')
+
+        await downloadButton.click()
+        await expect(
+          comfyPage.page.getByTestId(TestIds.dialogs.missingModelGatedAccess)
+        ).toBeVisible()
+        await expect(downloadButton).toBeEnabled()
       })
 
       test('Should open the gated repository with the browser fallback', async ({
         comfyPage
       }) => {
-        const pagePromise = comfyPage.page.context().waitForEvent('page')
         await comfyPage.page
-          .getByTestId(TestIds.dialogs.missingModelGatedAccess)
+          .getByTestId(TestIds.dialogs.missingModelDownload)
           .click()
+
+        const gatedAccess = comfyPage.page.getByTestId(
+          TestIds.dialogs.missingModelGatedAccess
+        )
+        await expect(gatedAccess).toBeVisible()
+
+        const pagePromise = comfyPage.page.context().waitForEvent('page')
+        await gatedAccess.click()
         const accessPage = await pagePromise
 
         await expect(accessPage).toHaveURL(GATED_MODEL_REPO_URL)

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -221,19 +221,6 @@ describe('MissingModelRow', () => {
     expect(mockFetchModelMetadata).not.toHaveBeenCalled()
   })
 
-  it('prefetches metadata for allowlisted URLs outside cloud', () => {
-    mockIsCloud.value = false
-    const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
-    model.representative.url =
-      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
-
-    renderRow(model)
-
-    expect(mockFetchModelMetadata).toHaveBeenCalledWith(
-      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
-    )
-  })
-
   it('opens the model import dialog from the cloud row', async () => {
     const user = userEvent.setup()
     renderRow(makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }]))
@@ -667,9 +654,13 @@ describe('MissingModelRow', () => {
     const download = screen.getByTestId('missing-model-download')
     expect(download).not.toHaveAttribute('aria-describedby')
     expect(download).not.toHaveAccessibleDescription()
+    expect(mockFetchModelMetadata).not.toHaveBeenCalled()
 
     await user.click(download)
 
+    expect(mockFetchModelMetadata).toHaveBeenCalledWith(
+      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
+    )
     expect(mockDownloadModel).toHaveBeenCalledWith(
       {
         name: 'model.safetensors',

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -449,6 +449,9 @@ describe('MissingModelRow', () => {
 
     renderRow(model, vi.fn(), false)
     const store = useMissingModelStore()
+    expect(mockFetchModelMetadata).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByTestId('missing-model-download'))
 
     await waitFor(() => {
       expect(store.gatedRepoUrls[model.representative.url!]).toBe(

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -451,7 +451,7 @@ describe('MissingModelRow', () => {
     const store = useMissingModelStore()
     expect(mockFetchModelMetadata).not.toHaveBeenCalled()
 
-    await userEvent.click(screen.getByTestId('missing-model-download'))
+    await userEvent.click(screen.getByRole('button', { name: /download/i }))
 
     await waitFor(() => {
       expect(store.gatedRepoUrls[model.representative.url!]).toBe(

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -241,14 +241,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  onMounted,
-  useId,
-  useTemplateRef,
-  watch
-} from 'vue'
+import { computed, nextTick, useId, useTemplateRef, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -336,7 +329,6 @@ const modelLabelControl = useTemplateRef<HTMLButtonElement>('modelLabelControl')
 const {
   fileSizeFor,
   gatedRepoUrlFor,
-  prefetchModelMetadata,
   downloadMissingModel,
   openModelAccessPage
 } = useMissingModelDownload()
@@ -428,15 +420,6 @@ const { showUploadDialog } = useModelUpload(
   },
   () => missingModelUploadContext.value
 )
-
-onMounted(() => {
-  if (isCloud) return
-
-  const url = model.representative.url
-  if (url && downloadable.value) {
-    void prefetchModelMetadata(url)
-  }
-})
 
 function handleDownload() {
   const rep = model.representative

--- a/src/platform/missingModel/composables/useMissingModelDownload.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.ts
@@ -25,6 +25,7 @@ export function useMissingModelDownload() {
   }
 
   function downloadMissingModel(model: ModelWithUrl): void {
+    void prefetchModelMetadata(model.url)
     downloadModel(model, store.folderPaths)
   }
 

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -415,7 +415,7 @@ describe('missingModelPipeline', () => {
       })
     })
 
-    it('fetches file sizes only for candidates with complete download metadata', async () => {
+    it('does not fetch remote metadata while initializing downloadable candidates', async () => {
       const downloadableCandidate = {
         nodeType: 'CheckpointLoaderSimple',
         widgetName: 'ckpt_name',
@@ -437,90 +437,28 @@ describe('missingModelPipeline', () => {
         downloadableCandidate,
         urlOnlyCandidate
       ]
-      mockHandles.fetchModelMetadata.mockResolvedValue({
-        fileSize: 1024,
-        gatedRepoUrl: null
-      })
 
-      await runMissingModelPipeline({
+      const result = await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
         missingModelStore: useMissingModelStore()
       })
       await vi.dynamicImportSettled()
 
-      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledOnce()
-      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
-        'https://example.com/downloadable.safetensors'
-      )
-      expect(useMissingModelStore().setFileSize).toHaveBeenCalledWith(
-        'https://example.com/downloadable.safetensors',
-        1024
-      )
-    })
-
-    it('stores gated repo URLs for candidates with complete download metadata', async () => {
-      const downloadableCandidate = {
-        nodeType: 'CheckpointLoaderSimple',
-        widgetName: 'ckpt_name',
-        name: 'gated.safetensors',
-        url: 'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors',
-        directory: 'checkpoints',
-        isMissing: true,
-        isAssetSupported: true
-      } satisfies MissingModelCandidate
-      mockHandles.state.enrichedCandidates = [downloadableCandidate]
-      mockHandles.fetchModelMetadata.mockResolvedValue({
-        fileSize: null,
-        gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
+      expect(result).toEqual({
+        missingModels: [
+          {
+            name: 'downloadable.safetensors',
+            url: 'https://example.com/downloadable.safetensors',
+            directory: 'checkpoints',
+            hash: undefined,
+            hash_type: undefined
+          }
+        ],
+        confirmedCandidates: [downloadableCandidate, urlOnlyCandidate]
       })
-
-      await runMissingModelPipeline({
-        graph: createGraph(),
-        graphData: createWorkflowGraphData(),
-        missingModelStore: useMissingModelStore()
-      })
-      await vi.dynamicImportSettled()
-
-      expect(useMissingModelStore().setGatedRepoUrl).toHaveBeenCalledWith(
-        'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors',
-        'https://huggingface.co/bfl/FLUX.1'
-      )
+      expect(mockHandles.fetchModelMetadata).not.toHaveBeenCalled()
       expect(useMissingModelStore().setFileSize).not.toHaveBeenCalled()
-    })
-
-    it('does not store gated repo URLs after verification is aborted', async () => {
-      const controller = new AbortController()
-      const downloadableCandidate = {
-        nodeType: 'CheckpointLoaderSimple',
-        widgetName: 'ckpt_name',
-        name: 'gated.safetensors',
-        url: 'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors',
-        directory: 'checkpoints',
-        isMissing: true,
-        isAssetSupported: true
-      } satisfies MissingModelCandidate
-      mockHandles.state.enrichedCandidates = [downloadableCandidate]
-      vi.mocked(
-        useMissingModelStore().createVerificationAbortController
-      ).mockReturnValueOnce(controller)
-      mockHandles.fetchModelMetadata.mockResolvedValue({
-        fileSize: null,
-        gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
-      })
-      controller.abort()
-
-      await runMissingModelPipeline({
-        graph: createGraph(),
-        graphData: createWorkflowGraphData(),
-        missingModelStore: useMissingModelStore()
-      })
-      await vi.dynamicImportSettled()
-
-      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
-        'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors'
-      )
-      expect(useMissingModelStore().setGatedRepoUrl).not.toHaveBeenCalled()
     })
 
     it('clears surfaced and cached missing models when no candidates are confirmed missing', async () => {

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -32,8 +32,6 @@ interface MissingModelPipelineStore {
   missingModelCandidates: MissingModelCandidate[] | null
   createVerificationAbortController: () => AbortController
   setFolderPaths: (paths: Record<string, string[]>) => void
-  setFileSize: (url: string, size: number) => void
-  setGatedRepoUrl: (url: string, repoUrl: string) => void
 }
 
 interface RunMissingModelPipelineOptions {
@@ -201,19 +199,6 @@ export async function runMissingModelPipeline({
           })
           cacheModelCandidates(activeWf, confirmedCandidates)
         })
-
-      const missingModelMetadata =
-        import('@/platform/missingModel/missingModelMetadata')
-      void Promise.allSettled(
-        downloadableCandidates.map(async (c) => {
-          const { fetchAndStoreModelMetadata } = await missingModelMetadata
-          await fetchAndStoreModelMetadata(
-            c.url,
-            missingModelStore,
-            controller.signal
-          )
-        })
-      )
     }
   } else {
     clearMissingModels(activeWf, silent)


### PR DESCRIPTION
## Summary

Prevent opening a local workflow from requesting remote model metadata before the user initiates a download. This replaces the stale implementation in #14127 on a fresh branch from `main`.

## Changes

- **What**: Remove metadata requests from pipeline initialization and row mount. Route per-row and Download all metadata requests through the shared download action.

## Review Focus

`useMissingModelDownload` remains the single owner for metadata storage and URL-keyed request deduplication.

## Test Plan

- [x] Regression tests failed on `main`: pipeline initialization and row mount each issued a request.
- [x] Four focused Vitest files pass, 60 tests total.
- [x] Typecheck, lint, format, and knip pass.
- [x] Browser E2E is not needed; component tests exercise the real download click and Pinia update path.