### PR TITLE
feat(models): carry over eight of Mar's catalogue fixes that apply cleanly

### DIFF
--- a/apps/website/e2e/fixtures/blockExternalMedia.ts
+++ b/apps/website/e2e/fixtures/blockExternalMedia.ts
@@ -83,7 +83,10 @@ export const test = base.extend({
         return route.abort('blockedbyclient')
       if (EMBED_HOSTS.has(url.hostname))
         return route.fulfill({ contentType: 'text/html', body: '' })
-      if (url.hostname === 'js-na2.hsforms.net')
+      if (
+        url.hostname === 'js-na2.hsforms.net' ||
+        url.hostname === 'apis.google.com'
+      )
         return route.fulfill({ contentType: 'text/javascript', body: '' })
       if (url.hostname === 'fonts.googleapis.com')
         return route.fulfill({

--- a/apps/website/e2e/workshop.spec.ts
+++ b/apps/website/e2e/workshop.spec.ts
@@ -67,6 +67,7 @@ test.describe('Models catalog', () => {
       .getByRole('heading', { level: 2 })
       .innerText()
     const promisedCount = Number(rowHeading.match(/(\d+)\s*$/)?.[1])
+    const rowLabel = rowHeading.replace(/\s*\d+\s*$/, '').trim()
     expect(promisedCount).toBeGreaterThan(0)
     await videos.getByTestId('section-generate-videos-open').click()
     const cards = page
@@ -76,13 +77,34 @@ test.describe('Models catalog', () => {
     await expect(cards).toHaveCount(promisedCount)
     await expect(page.getByTestId('workshop-hero')).toHaveCount(0)
     await expect(page.getByRole('heading', { level: 1 })).toContainText(
-      'Generate videos'
+      rowLabel
     )
     await page
       .getByRole('button', { name: 'Back to all categories', exact: true })
       .click()
     await expect(sections).toBeVisible()
     await expect(page.getByTestId('workshop-hero')).toBeVisible()
+  })
+
+  test('the rows listing opens the whole catalogue', async ({ page }) => {
+    await page.goto('/models/')
+    await page.getByTestId('browse-all').click()
+
+    await expect(page.getByTestId('workshop-sections')).toHaveCount(0)
+    const heading = page.getByRole('heading', { level: 1 })
+    await expect(heading).toContainText('All models')
+    const promisedCount = Number(
+      (await heading.innerText()).match(/(\d+)\s*$/)?.[1]
+    )
+    expect(promisedCount).toBeGreaterThan(0)
+    await expect(
+      page
+        .getByTestId('workshop-models-grid')
+        .getByTestId('workshop-model-card')
+    ).toHaveCount(promisedCount)
+
+    await page.getByTestId('section-back').click()
+    await expect(page.getByTestId('workshop-sections')).toBeVisible()
   })
 
   test('cards open canonical model pages with related models', async ({
@@ -286,5 +308,44 @@ test.describe('Model playground', () => {
     await expect(
       page.getByRole('textbox', { name: 'Prompt', exact: true })
     ).not.toHaveValue('')
+  })
+})
+
+test.describe('Filter sheet @mobile', () => {
+  test('the handle pulls the sheet up and lets it go', async ({ page }) => {
+    await page.goto('/models/')
+    await page.getByTestId('workshop-filter').click()
+
+    const sheet = page.getByTestId('workshop-filter-menu')
+    await expect(sheet).toBeVisible()
+    const resting = await sheet.boundingBox()
+    if (!resting) throw new Error('Filter sheet has no visible bounds')
+
+    const handle = page.getByTestId('workshop-filter-grabber')
+    const grip = await handle.boundingBox()
+    if (!grip) throw new Error('Filter handle has no visible bounds')
+    const from = { x: grip.x + grip.width / 2, y: grip.y + grip.height / 2 }
+
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x, from.y - 260, { steps: 8 })
+    await page.mouse.up()
+
+    await expect
+      .poll(async () => (await sheet.boundingBox())?.height ?? 0)
+      .toBeGreaterThan(resting.height)
+
+    const grown = await handle.boundingBox()
+    if (!grown) throw new Error('Expanded filter handle has no visible bounds')
+    await page.mouse.move(grown.x + grown.width / 2, grown.y + grown.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(
+      grown.x + grown.width / 2,
+      grown.y + grown.height / 2 + 500,
+      { steps: 8 }
+    )
+    await page.mouse.up()
+
+    await expect(sheet).toHaveCount(0)
   })
 })

--- a/apps/website/src/components/hub/BrowseToolbar.test.ts
+++ b/apps/website/src/components/hub/BrowseToolbar.test.ts
@@ -18,7 +18,8 @@ const labels = {
   selected: '{n} selected',
   typeAll: 'All types',
   showResults: 'Show results',
-  showModels: 'Show models'
+  showModels: 'Show models',
+  resize: 'Resize filters'
 }
 
 describe('BrowseToolbar', () => {

--- a/apps/website/src/components/hub/BrowseToolbar.vue
+++ b/apps/website/src/components/hub/BrowseToolbar.vue
@@ -75,6 +75,7 @@ export interface ToolbarLabels {
   readonly typeAll: string
   readonly showResults: string
   readonly showModels: string
+  readonly resize: string
 }
 
 const {
@@ -270,7 +271,8 @@ const sheetLabels = computed(() => ({
   applied: labels.selected,
   clearAll: labels.clearAll,
   show: showLabel.value,
-  close: labels.filter
+  close: labels.filter,
+  resize: labels.resize
 }))
 
 function phoneToggle(key: string, value: string) {
@@ -427,7 +429,7 @@ function phoneToggle(key: string, value: string) {
       <div
         v-if="filterOpen"
         ref="panel"
-        class="bg-site-dropdown z-40 flex scrollbar-thin flex-col gap-7 overflow-y-auto border border-white/10 shadow-2xl max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:max-h-[85vh] max-sm:gap-4 max-sm:rounded-t-3xl max-sm:p-5 sm:absolute sm:top-full sm:right-0 sm:mt-3 sm:max-h-[75vh] sm:w-full sm:max-w-4xl sm:rounded-3xl sm:p-8"
+        class="bg-site-dropdown z-40 flex scrollbar-thin flex-col gap-7 overflow-y-auto border border-white/10 shadow-2xl max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:gap-4 max-sm:rounded-t-3xl max-sm:p-5 sm:absolute sm:top-full sm:right-0 sm:mt-3 sm:max-h-[75vh] sm:w-full sm:max-w-4xl sm:rounded-3xl sm:p-8"
         data-testid="hub-filter-menu"
       >
         <FacetSheet

--- a/apps/website/src/components/hub/HubBrowse.vue
+++ b/apps/website/src/components/hub/HubBrowse.vue
@@ -163,7 +163,8 @@ const toolbarLabels: ToolbarLabels = {
   less: t('workshop.hub.facets.less', locale),
   selected: t('workshop.hub.facets.selected', locale),
   showResults: t('workshop.hub.facets.show', locale),
-  showModels: t('workshop.search.show', locale)
+  showModels: t('workshop.search.show', locale),
+  resize: t('workshop.filter.resize', locale)
 }
 // Workflows are dated and models are priced, so a tab offers what the things
 // it lists can actually be ordered by.

--- a/apps/website/src/components/workshop/CardRow.vue
+++ b/apps/website/src/components/workshop/CardRow.vue
@@ -41,7 +41,7 @@ useMutationObserver(row, measure, { childList: true, subtree: true })
 
 const arrowClass = (spent: boolean) =>
   cn(
-    'focus-visible:ring-primary-comfy-yellow/50 grid size-9 place-items-center rounded-full border border-transparency-white-t20 text-primary-warm-white transition-colors outline-none focus-visible:ring-3',
+    'focus-visible:ring-primary-comfy-yellow/50 grid size-9 place-items-center rounded-xl border border-transparency-white-t20 text-primary-warm-white transition-colors outline-none focus-visible:ring-3',
     spent
       ? 'cursor-default opacity-30'
       : 'hover:border-primary-comfy-yellow hover:text-primary-comfy-yellow cursor-pointer'
@@ -50,7 +50,7 @@ const arrowClass = (spent: boolean) =>
 
 <template>
   <div>
-    <div class="mb-5 flex items-center justify-between gap-4">
+    <div class="mb-5 flex items-baseline justify-between gap-4">
       <slot name="heading" />
       <div class="flex items-center gap-3">
         <slot name="actions" />

--- a/apps/website/src/components/workshop/FacetSheet.test.ts
+++ b/apps/website/src/components/workshop/FacetSheet.test.ts
@@ -35,6 +35,21 @@ const groups = [
 ]
 
 describe('FacetSheet', () => {
+  it('toggles the sheet height from the keyboard', async () => {
+    const user = userEvent.setup()
+    render(FacetSheet, { props: { groups, labels, resultCount: 2 } })
+
+    const grabber = screen.getByRole('button', { name: 'Resize filters' })
+    expect(grabber.getAttribute('aria-expanded')).toBe('false')
+
+    grabber.focus()
+    await user.keyboard('{Enter}')
+    expect(grabber.getAttribute('aria-expanded')).toBe('true')
+
+    await user.keyboard(' ')
+    expect(grabber.getAttribute('aria-expanded')).toBe('false')
+  })
+
   it('filters options and shows the empty result', async () => {
     const user = userEvent.setup()
     render(FacetSheet, { props: { groups, labels, resultCount: 2 } })

--- a/apps/website/src/components/workshop/FacetSheet.test.ts
+++ b/apps/website/src/components/workshop/FacetSheet.test.ts
@@ -12,7 +12,8 @@ const labels = {
   applied: '{n} applied',
   clearAll: 'Clear all',
   show: 'Show {n}',
-  close: 'Close'
+  close: 'Close',
+  resize: 'Resize filters'
 }
 
 const groups = [

--- a/apps/website/src/components/workshop/FacetSheet.vue
+++ b/apps/website/src/components/workshop/FacetSheet.vue
@@ -110,6 +110,10 @@ function drag(event: PointerEvent) {
   dragged.value = Math.min(Math.max(from.height + travelled, 0), viewport.value)
 }
 
+function toggleRest() {
+  rest.value = rest.value === 'expanded' ? 'collapsed' : 'expanded'
+}
+
 function endDrag() {
   const from = grab.value
   grab.value = null
@@ -119,8 +123,7 @@ function endDrag() {
   // A tap counts only on the handle itself; on the title it would fire while
   // the thumb is reaching for the close button beside it.
   if (!from.moved) {
-    if (from.fromHandle)
-      rest.value = rest.value === 'expanded' ? 'collapsed' : 'expanded'
+    if (from.fromHandle) toggleRest()
     return
   }
   const settled = restAt(reached / viewport.value)
@@ -162,6 +165,8 @@ function visibleOptions(group: FacetSheetGroup) {
         :aria-expanded="rest === 'expanded'"
         class="mx-auto flex h-6 w-16 cursor-grab items-center justify-center"
         data-testid="workshop-filter-grabber"
+        @keydown.enter.prevent="toggleRest"
+        @keydown.space.prevent="toggleRest"
       >
         <span class="h-1 w-10 rounded-full bg-white/20" aria-hidden="true" />
       </button>
@@ -180,7 +185,7 @@ function visibleOptions(group: FacetSheetGroup) {
       </div>
     </div>
 
-    <TabsRoot v-model="activeKey" class="flex min-h-0 flex-col">
+    <TabsRoot v-model="activeKey" class="flex min-h-0 flex-col max-sm:flex-1">
       <TabsList
         class="flex scrollbar-hide items-center gap-1 overflow-x-auto border-b border-white/10 p-2 max-sm:px-4 max-sm:pb-3"
       >
@@ -206,7 +211,7 @@ function visibleOptions(group: FacetSheetGroup) {
         v-for="group in groups"
         :key="group.key"
         :value="group.key"
-        class="flex min-h-0 flex-col outline-none"
+        class="flex min-h-0 flex-col outline-none max-sm:flex-1"
       >
         <div class="border-b border-white/10 p-2 max-sm:px-4 max-sm:py-3">
           <input

--- a/apps/website/src/components/workshop/FacetSheet.vue
+++ b/apps/website/src/components/workshop/FacetSheet.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { Check, X } from '@lucide/vue'
+import { useMediaQuery, useWindowSize } from '@vueuse/core'
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import { computed, ref, watch } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
+
+import type { SheetRest } from '../../composables/useBottomSheet'
+import { heightAt, restAt } from '../../composables/useBottomSheet'
+import { prefersReducedMotion } from '../../composables/useReducedMotion'
 
 interface FacetSheetOption {
   readonly value: string
@@ -28,6 +33,7 @@ interface FacetSheetLabels {
   /** Carries {n}. */
   readonly show: string
   readonly close: string
+  readonly resize: string
 }
 
 // One facet picker for the whole prototype. Both catalogues narrow the same
@@ -62,6 +68,66 @@ const selectedCount = computed(() =>
   groups.reduce((total, group) => total + group.selected.length, 0)
 )
 
+// The handle is the only way to make the sheet taller, so it drags rather than
+// decorates: a pull settles at the nearest rest, and a pull past the bottom
+// puts the sheet away.
+const onPhone = useMediaQuery('(max-width: 639px)')
+const { height: viewport } = useWindowSize()
+const rest = ref<Exclude<SheetRest, 'closed'>>('collapsed')
+const dragged = ref<number | null>(null)
+const grab = ref<{
+  y: number
+  height: number
+  moved: boolean
+  fromHandle: boolean
+} | null>(null)
+
+const sheetHeight = computed(() =>
+  onPhone.value
+    ? (dragged.value ?? heightAt(rest.value, viewport.value))
+    : undefined
+)
+
+function startDrag(event: PointerEvent) {
+  const target = event.target instanceof Element ? event.target : undefined
+  if (target?.closest('[data-testid="workshop-filter-close"]')) return
+  if (event.currentTarget instanceof HTMLElement)
+    event.currentTarget.setPointerCapture(event.pointerId)
+  grab.value = {
+    y: event.clientY,
+    height: sheetHeight.value ?? 0,
+    moved: false,
+    fromHandle:
+      target?.closest('[data-testid="workshop-filter-grabber"]') != null
+  }
+}
+
+function drag(event: PointerEvent) {
+  const from = grab.value
+  if (!from) return
+  const travelled = from.y - event.clientY
+  if (Math.abs(travelled) > 4) from.moved = true
+  dragged.value = Math.min(Math.max(from.height + travelled, 0), viewport.value)
+}
+
+function endDrag() {
+  const from = grab.value
+  grab.value = null
+  if (!from) return
+  const reached = dragged.value ?? 0
+  dragged.value = null
+  // A tap counts only on the handle itself; on the title it would fire while
+  // the thumb is reaching for the close button beside it.
+  if (!from.moved) {
+    if (from.fromHandle)
+      rest.value = rest.value === 'expanded' ? 'collapsed' : 'expanded'
+    return
+  }
+  const settled = restAt(reached / viewport.value)
+  if (settled === 'closed') emit('close')
+  else rest.value = settled
+}
+
 function visibleOptions(group: FacetSheetGroup) {
   const needle = (search.value[group.key] ?? '').trim().toLowerCase()
   return needle
@@ -73,28 +139,50 @@ function visibleOptions(group: FacetSheetGroup) {
 </script>
 
 <template>
-  <div class="flex min-h-0 flex-col">
-    <span
-      class="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-white/20 sm:hidden"
-      aria-hidden="true"
-    />
-
-    <div class="flex items-center justify-between p-3 pb-1 sm:hidden">
-      <h2 class="text-content text-base font-bold">{{ labels.title }}</h2>
+  <div
+    :class="
+      cn(
+        'flex min-h-0 flex-col',
+        !grab && !prefersReducedMotion() && 'max-sm:transition-[height]'
+      )
+    "
+    :style="{ height: sheetHeight ? `${sheetHeight}px` : undefined }"
+  >
+    <div
+      class="shrink-0 touch-none sm:hidden"
+      data-testid="workshop-filter-grip"
+      @pointerdown="startDrag"
+      @pointermove="drag"
+      @pointerup="endDrag"
+      @pointercancel="endDrag"
+    >
       <button
         type="button"
-        :aria-label="labels.close"
-        class="text-content-secondary hover:text-content grid size-9 cursor-pointer place-items-center rounded-xl bg-white/8"
-        data-testid="workshop-filter-close"
-        @click="emit('close')"
+        :aria-label="labels.resize"
+        :aria-expanded="rest === 'expanded'"
+        class="mx-auto flex h-6 w-16 cursor-grab items-center justify-center"
+        data-testid="workshop-filter-grabber"
       >
-        <X class="size-4" aria-hidden="true" />
+        <span class="h-1 w-10 rounded-full bg-white/20" aria-hidden="true" />
       </button>
+
+      <div class="flex items-center justify-between px-4 pt-1 pb-5">
+        <h2 class="text-content text-base font-bold">{{ labels.title }}</h2>
+        <button
+          type="button"
+          :aria-label="labels.close"
+          class="text-content-secondary hover:text-content grid size-9 cursor-pointer place-items-center rounded-xl bg-white/8"
+          data-testid="workshop-filter-close"
+          @click="emit('close')"
+        >
+          <X class="size-4" aria-hidden="true" />
+        </button>
+      </div>
     </div>
 
     <TabsRoot v-model="activeKey" class="flex min-h-0 flex-col">
       <TabsList
-        class="flex scrollbar-hide items-center gap-1 overflow-x-auto border-b border-white/10 p-2"
+        class="flex scrollbar-hide items-center gap-1 overflow-x-auto border-b border-white/10 p-2 max-sm:px-4 max-sm:pb-3"
       >
         <TabsTrigger
           v-for="group in groups"
@@ -120,7 +208,7 @@ function visibleOptions(group: FacetSheetGroup) {
         :value="group.key"
         class="flex min-h-0 flex-col outline-none"
       >
-        <div class="border-b border-white/10 p-2">
+        <div class="border-b border-white/10 p-2 max-sm:px-4 max-sm:py-3">
           <input
             v-model="search[group.key]"
             type="search"
@@ -131,10 +219,11 @@ function visibleOptions(group: FacetSheetGroup) {
           />
         </div>
 
-        <!-- One height whatever the facet holds, so switching tab does not
-          resize the sheet under the thumb. -->
+        <!-- On a phone the list takes whatever the sheet's own height leaves,
+          so switching tab does not resize it under the thumb. On a pointer the
+          popover hugs its list instead of standing half empty. -->
         <ul
-          class="h-72 scrollbar-thin overflow-y-auto py-1"
+          class="scrollbar-thin overflow-y-auto py-1 max-sm:min-h-0 max-sm:flex-1 sm:max-h-72 sm:min-h-32"
           :aria-label="group.label"
         >
           <li v-for="option in visibleOptions(group)" :key="option.value">

--- a/apps/website/src/components/workshop/FeaturedBanner.vue
+++ b/apps/website/src/components/workshop/FeaturedBanner.vue
@@ -85,7 +85,7 @@ const fill = computed(() =>
   >
     <a
       :href="active.model.href"
-      class="short:h-76 group block h-84"
+      class="group short:h-76 sm:short:h-80 block h-112"
       data-testid="featured-slide"
     >
       <video
@@ -115,7 +115,7 @@ const fill = computed(() =>
       />
 
       <div
-        class="sm:short:gap-3 relative flex h-full flex-col justify-end gap-4 p-6 pb-16 sm:max-w-2xl sm:justify-center lg:p-8 lg:pb-16"
+        class="sm:short:pb-16 lg:short:p-8 lg:short:pb-16 relative flex h-full flex-col justify-end gap-4 p-8 pb-20 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pb-20"
       >
         <div class="flex flex-wrap items-center gap-2">
           <Badge variant="subtle" size="md" class="text-primary-comfy-canvas">

--- a/apps/website/src/components/workshop/ModelsCatalogue.vue
+++ b/apps/website/src/components/workshop/ModelsCatalogue.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { ChevronRight } from '@lucide/vue'
 import { ref } from 'vue'
 
 import type { WorkshopModel } from '../../config/models-catalogue'
 import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
 import WorkshopHero from './WorkshopHero.vue'
 import WorkshopModelsGrid from './WorkshopModelsGrid.vue'
 
@@ -11,16 +13,31 @@ const { models, locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
-// Inside a category the category is the heading, so the page's own hero would
-// be a second title above it.
 const inSection = ref(false)
+const browseAll = ref(false)
 </script>
 
 <template>
-  <WorkshopHero
-    v-if="!inSection"
-    subtitle-key="workshop.hero.subtitle"
+  <WorkshopHero v-if="!inSection" subtitle-key="workshop.hero.subtitle" :locale>
+    <template #aside>
+      <button
+        type="button"
+        class="group hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 -mx-1 inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-1 text-base font-medium text-primary-warm-white transition-colors outline-none focus-visible:ring-3"
+        data-testid="browse-all"
+        @click="browseAll = true"
+      >
+        {{ t('workshop.sections.browseAll', locale) }}
+        <ChevronRight
+          class="size-4 transition-transform group-hover:translate-x-0.5"
+          aria-hidden="true"
+        />
+      </button>
+    </template>
+  </WorkshopHero>
+  <WorkshopModelsGrid
+    v-model:browse-all="browseAll"
+    :models
     :locale
+    @section="inSection = $event"
   />
-  <WorkshopModelsGrid :models :locale @section="inSection = $event" />
 </template>

--- a/apps/website/src/components/workshop/WorkshopFilterMenu.vue
+++ b/apps/website/src/components/workshop/WorkshopFilterMenu.vue
@@ -125,7 +125,8 @@ const sheetLabels = computed(() => ({
   applied: t('workshop.filter.applied', locale),
   clearAll: t('workshop.filter.clearAll', locale),
   show: t('workshop.search.show', locale),
-  close: t('workshop.search.close', locale)
+  close: t('workshop.search.close', locale),
+  resize: t('workshop.filter.resize', locale)
 }))
 </script>
 
@@ -189,7 +190,7 @@ const sheetLabels = computed(() => ({
           :aria-label="t('workshop.filter.label', locale)"
           :aria-modal="isPhone || undefined"
           data-testid="workshop-filter-menu"
-          class="bg-site-dropdown z-50 flex flex-col overflow-y-auto border border-white/10 shadow-2xl shadow-black/50 outline-none max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:max-h-[85vh] max-sm:rounded-t-3xl sm:absolute sm:top-full sm:right-0 sm:mt-2 sm:max-h-[75vh] sm:w-96 sm:max-w-[calc(100vw-2rem)] sm:rounded-2xl"
+          class="bg-site-dropdown z-50 flex flex-col overflow-y-auto border border-white/10 shadow-2xl shadow-black/50 outline-none max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:rounded-t-3xl sm:absolute sm:top-full sm:right-0 sm:mt-2 sm:max-h-[75vh] sm:w-96 sm:max-w-[calc(100vw-2rem)] sm:rounded-2xl"
           @keydown.escape.stop.prevent="open = false"
         >
           <FacetSheet

--- a/apps/website/src/components/workshop/WorkshopHero.vue
+++ b/apps/website/src/components/workshop/WorkshopHero.vue
@@ -24,8 +24,10 @@ const slots = useSlots()
   <header
     :class="
       cn(
-        'lg:short:-mt-10 lg:short:pt-10 relative isolate -mx-6 -mt-16 overflow-hidden px-6 pt-16 max-sm:-mt-10 max-sm:pt-10 lg:-mx-8 lg:-mt-24 lg:px-8 lg:pt-24',
-        slots.default ? 'mb-8 max-sm:mb-5' : 'mb-6 pb-2 max-sm:mb-4 max-sm:pb-0'
+        'lg:short:-mt-12 lg:short:pt-12 relative isolate -mx-6 -mt-16 overflow-hidden px-6 pt-16 max-sm:-mt-10 max-sm:pt-10 lg:-mx-8 lg:-mt-24 lg:px-8 lg:pt-24',
+        slots.default
+          ? 'mb-8 max-sm:mb-5'
+          : 'sm:short:pb-0 mb-6 pb-2 max-sm:mb-4 max-sm:pb-0'
       )
     "
     data-testid="workshop-hero"
@@ -38,9 +40,18 @@ const slots = useSlots()
     <h1 class="text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
       <SplitReveal :text="t(headingKey, locale)" :delay="90" />
     </h1>
-    <p v-if="subtitleKey" class="mt-4 text-lg text-primary-comfy-canvas/70">
-      <SplitReveal :text="t(subtitleKey, locale)" :delay="260" :stagger="50" />
-    </p>
+    <div
+      class="sm:short:mt-3 mt-4 flex flex-wrap items-center justify-between gap-x-6 gap-y-4"
+    >
+      <p v-if="subtitleKey" class="text-lg text-primary-comfy-canvas/70">
+        <SplitReveal
+          :text="t(subtitleKey, locale)"
+          :delay="260"
+          :stagger="50"
+        />
+      </p>
+      <slot name="aside" />
+    </div>
 
     <slot />
   </header>

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.test.ts
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.test.ts
@@ -105,7 +105,7 @@ describe('WorkshopModelsGrid', () => {
     expect(cardNames()).toEqual([expect.stringContaining('Flux')])
 
     await user.click(screen.getByRole('button', { name: /Back to/ }))
-    await user.click(screen.getByRole('button', { name: 'Generate videos 1' }))
+    await user.click(screen.getByRole('button', { name: 'Text to video 1' }))
     expect(cardNames()).toEqual([expect.stringContaining('Kling AI')])
   })
 
@@ -162,5 +162,24 @@ describe('WorkshopModelsGrid', () => {
 
     await user.click(screen.getByRole('button', { name: 'Clear filters' }))
     expect(cardNames()).toHaveLength(3)
+  })
+
+  describe('browsing rows', () => {
+    it('leaves the rows for the whole catalogue and back', async () => {
+      const user = userEvent.setup()
+      render(WorkshopModelsGrid, { props: { models } })
+      expect(screen.getByTestId('workshop-sections')).toBeTruthy()
+
+      await user.click(screen.getByTestId('browse-all-end'))
+
+      expect(screen.queryByTestId('workshop-sections')).toBeNull()
+      expect(cardNames()).toHaveLength(models.length)
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toContain(
+        'All models'
+      )
+
+      await user.click(screen.getByTestId('section-back'))
+      expect(screen.getByTestId('workshop-sections')).toBeTruthy()
+    })
   })
 })

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.vue
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { ArrowUpDown, ChevronDown, ChevronLeft } from '@lucide/vue'
+import {
+  ArrowUpDown,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight
+} from '@lucide/vue'
 import {
   DropdownMenuContent,
   DropdownMenuPortal,
@@ -83,10 +88,6 @@ const sortLabelKey: Record<SortOrder, TranslationKey> = {
   priceDesc: 'workshop.sort.priceDesc'
 }
 
-function selectRail(value: UseCase | 'all' | 'other') {
-  useCase.value = value
-}
-
 // A facet answers "what else is in here", so it counts what the category
 // holds rather than what the whole catalogue holds.
 const withinSection = computed(() =>
@@ -152,15 +153,15 @@ const isFiltered = computed(
 
 // Willie's browseable listing: rows per use case until the visitor narrows
 // down, then the flat grid takes over.
-const browsing = computed(() => !isFiltered.value)
-// The browsing rows are the use cases, each with its name and its count, so a
-// row of chips saying the same six words would be the same list twice. V1.1
-// leaves a category the way it entered one, through its own header.
-const inSection = computed(() => useCase.value !== 'all')
+const browseAll = defineModel<boolean>('browseAll', { default: false })
+const browsing = computed(() => !isFiltered.value && !browseAll.value)
+const inSection = computed(() => useCase.value !== 'all' || browseAll.value)
 const sectionTitleKey = computed<TranslationKey>(() =>
-  useCase.value === 'other'
-    ? 'workshop.sections.otherFormats'
-    : useCaseLabelKey[useCase.value]
+  useCase.value === 'all'
+    ? 'workshop.sections.allModels'
+    : useCase.value === 'other'
+      ? 'workshop.sections.otherFormats'
+      : useCaseLabelKey[useCase.value]
 )
 
 // A category names the screen it opens, so the page heading above it would say
@@ -193,7 +194,12 @@ function openSection(value: UseCase | 'other') {
   useCase.value = value
 }
 
-function clearFilters() {
+function leaveSection() {
+  browseAll.value = false
+  useCase.value = 'all'
+}
+
+function resetFilters() {
   query.value = ''
   useCase.value = 'all'
   modalities.value = []
@@ -201,6 +207,12 @@ function clearFilters() {
   providers.value = []
 }
 
+function clearFilters() {
+  browseAll.value = false
+  resetFilters()
+}
+
+watch(browseAll, (on) => on && resetFilters())
 const menuItemClass =
   'flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm text-primary-comfy-canvas outline-none select-none data-[highlighted]:bg-transparency-white-t4'
 </script>
@@ -211,7 +223,7 @@ const menuItemClass =
       v-if="browsing && featured.length"
       :models="featured"
       :locale
-      class="mb-10"
+      class="short:mb-6 mb-10"
     />
 
     <div class="min-w-0">
@@ -220,7 +232,7 @@ const menuItemClass =
         type="button"
         class="hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 -ml-1 inline-flex cursor-pointer items-center gap-1 rounded-lg px-1 text-sm font-medium text-primary-warm-gray opacity-60 transition hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-3"
         data-testid="section-back"
-        @click="selectRail('all')"
+        @click="leaveSection"
       >
         <ChevronLeft class="size-4" aria-hidden="true" />
         {{ t('workshop.sections.back', locale) }}
@@ -314,14 +326,28 @@ const menuItemClass =
         </div>
       </div>
 
-      <WorkshopSections
-        v-if="browsing"
-        :models
-        :label-key="useCaseLabelKey"
-        :sort
-        :locale
-        @open="openSection"
-      />
+      <template v-if="browsing">
+        <WorkshopSections
+          :models
+          :label-key="useCaseLabelKey"
+          :sort
+          :locale
+          @open="openSection"
+        />
+
+        <button
+          type="button"
+          class="group hover:border-primary-comfy-yellow hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 mx-auto mt-12 flex w-fit cursor-pointer items-center justify-center gap-2 rounded-2xl border border-transparency-white-t8 px-8 py-4 text-sm font-medium text-primary-comfy-canvas transition-colors outline-none focus-visible:ring-3 max-sm:w-full"
+          data-testid="browse-all-end"
+          @click="browseAll = true"
+        >
+          {{ t('workshop.sections.browseAll', locale) }}
+          <ChevronRight
+            class="size-4 transition-transform group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </button>
+      </template>
 
       <template v-else>
         <div v-if="visible.length">

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.vue
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.vue
@@ -65,10 +65,6 @@ onMounted(() => {
   modalities.value = [...(initial.modalities ?? [])]
 })
 
-// A row title clicked far down the page opens a much shorter screen, which
-// would otherwise leave the viewport parked on the footer.
-watch(useCase, () => void nextTick(() => window.scrollTo({ top: 0 })))
-
 const useCaseLabelKey: Record<UseCase | 'all' | 'other', TranslationKey> = {
   all: 'workshop.useCase.all',
   other: 'workshop.sections.otherFormats',
@@ -154,6 +150,12 @@ const isFiltered = computed(
 // Willie's browseable listing: rows per use case until the visitor narrows
 // down, then the flat grid takes over.
 const browseAll = defineModel<boolean>('browseAll', { default: false })
+// A row title clicked far down the page opens a much shorter screen, which
+// would otherwise leave the viewport parked on the footer.
+watch(
+  [useCase, browseAll],
+  () => void nextTick(() => window.scrollTo({ top: 0 }))
+)
 const browsing = computed(() => !isFiltered.value && !browseAll.value)
 const inSection = computed(() => useCase.value !== 'all' || browseAll.value)
 const sectionTitleKey = computed<TranslationKey>(() =>

--- a/apps/website/src/components/workshop/WorkshopSearchField.test.ts
+++ b/apps/website/src/components/workshop/WorkshopSearchField.test.ts
@@ -8,6 +8,31 @@ import { defineComponent, h } from 'vue'
 import WorkshopSearchField from './WorkshopSearchField.vue'
 
 describe('WorkshopSearchField', () => {
+  it('reopens the suggestion panel when typing resumes after it closed', async () => {
+    const user = userEvent.setup()
+    render(
+      defineComponent({
+        setup: () => () =>
+          h(WorkshopSearchField, {
+            models: [],
+            modelValue: '',
+            providers: [],
+            capabilities: []
+          })
+      })
+    )
+
+    const field = screen.getByRole('combobox')
+    await user.click(field)
+    expect(field.getAttribute('aria-expanded')).toBe('true')
+
+    await user.keyboard('{Escape}')
+    expect(field.getAttribute('aria-expanded')).toBe('false')
+
+    await user.keyboard('flux')
+    expect(field.getAttribute('aria-expanded')).toBe('true')
+  })
+
   it('contains keyboard focus in mobile search and restores it when Escape is pressed from a button', async () => {
     const user = userEvent.setup()
     render(

--- a/apps/website/src/components/workshop/WorkshopSearchField.vue
+++ b/apps/website/src/components/workshop/WorkshopSearchField.vue
@@ -141,6 +141,7 @@ const clearButtonClass =
         :aria-controls="`${inputId}-panel`"
         :aria-expanded="open"
         @focus="open = true"
+        @input="open = true"
         @keydown.escape="open = false"
       />
       <button

--- a/apps/website/src/components/workshop/WorkshopSearchField.vue
+++ b/apps/website/src/components/workshop/WorkshopSearchField.vue
@@ -7,6 +7,7 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 import type { WorkshopModel } from '../../config/models-catalogue'
 import { filterWorkshopModels } from '../../config/models-catalogue'
+import { useVisualViewport } from '../../composables/useVisualViewport'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import WorkshopSearchPanel from './WorkshopSearchPanel.vue'
@@ -36,6 +37,15 @@ const open = ref(false)
 const sheetOpen = ref(false)
 const sheetInput = useTemplateRef<HTMLInputElement>('sheetInput')
 const sheetTrigger = useTemplateRef<HTMLButtonElement>('sheetTrigger')
+const { height: screen, offsetTop: screenTop } = useVisualViewport()
+const sheetStyle = computed(() =>
+  screen.value === null
+    ? { bottom: '0' }
+    : {
+        height: `${screen.value}px`,
+        transform: `translateY(${screenTop.value}px)`
+      }
+)
 
 // Focus moving to the clear button or into the panel itself is still inside
 // the search, so only a move out of the wrapper closes it.
@@ -47,6 +57,13 @@ function closeOnLeave(event: FocusEvent) {
     (!(moved instanceof Node) || !wrapper.contains(moved))
   )
     open.value = false
+}
+
+// Naming a model is the end of the search, so the panel closes on it. The
+// provider and capability chips do not: they are picked several at a time.
+function pickModel(model: WorkshopModel) {
+  query.value = model.name
+  open.value = false
 }
 
 // The sheet applies as you tap, so its button is a way out that says what is
@@ -145,7 +162,7 @@ const clearButtonClass =
         :providers
         :capabilities
         :locale
-        @pick="(model) => (query = model.name)"
+        @pick="pickModel"
         @toggle-provider="(value) => (providers = toggled(providers, value))"
         @toggle-capability="
           (value) => (capabilities = toggled(capabilities, value))
@@ -156,7 +173,8 @@ const clearButtonClass =
     <DialogRoot v-model:open="sheetOpen">
       <DialogPortal>
         <DialogContent
-          class="bg-page fixed inset-0 z-50 flex flex-col sm:hidden"
+          class="bg-page fixed inset-x-0 top-0 z-50 flex flex-col sm:hidden"
+          :style="sheetStyle"
           :aria-describedby="undefined"
           data-testid="workshop-search-sheet"
           @open-auto-focus.prevent="sheetInput?.focus()"

--- a/apps/website/src/components/workshop/WorkshopSearchPanel.vue
+++ b/apps/website/src/components/workshop/WorkshopSearchPanel.vue
@@ -108,7 +108,7 @@ const chipClass = (selected: boolean) =>
       cn(
         'bg-page flex flex-col gap-5 p-4',
         variant === 'sheet'
-          ? 'flex-1 overflow-y-auto'
+          ? 'min-h-0 flex-1 overflow-y-auto overscroll-contain'
           : 'absolute inset-x-0 top-full z-30 mt-2 rounded-2xl border border-transparency-white-t20 shadow-lg'
       )
     "

--- a/apps/website/src/components/workshop/WorkshopSections.vue
+++ b/apps/website/src/components/workshop/WorkshopSections.vue
@@ -98,7 +98,7 @@ const unplaced = computed(() =>
                 {{ section.total }}
               </span>
               <ChevronRight
-                class="size-5 transition-transform group-hover:translate-x-0.5"
+                class="size-5 self-center transition-transform group-hover:translate-x-0.5"
                 aria-hidden="true"
               />
             </button>
@@ -134,7 +134,7 @@ const unplaced = computed(() =>
                 {{ otherFormats.length }}
               </span>
               <ChevronRight
-                class="size-5 transition-transform group-hover:translate-x-0.5"
+                class="size-5 self-center transition-transform group-hover:translate-x-0.5"
                 aria-hidden="true"
               />
             </button>

--- a/apps/website/src/composables/useBottomSheet.test.ts
+++ b/apps/website/src/composables/useBottomSheet.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { heightAt, restAt } from './useBottomSheet'
+
+describe('restAt', () => {
+  it('puts the sheet away only once it is dragged well below its resting height', () => {
+    expect(restAt(0.1)).toBe('closed')
+    expect(restAt(0.33)).toBe('closed')
+    expect(restAt(0.35)).toBe('collapsed')
+  })
+
+  it('settles at whichever height the drag ended nearer to', () => {
+    expect(restAt(0.6)).toBe('collapsed')
+    expect(restAt(0.9)).toBe('expanded')
+    expect(restAt(1)).toBe('expanded')
+  })
+})
+
+describe('heightAt', () => {
+  it('gives a taller sheet when expanded, in whole pixels of the screen', () => {
+    const collapsed = heightAt('collapsed', 851)
+    const expanded = heightAt('expanded', 851)
+
+    expect(expanded).toBeGreaterThan(collapsed)
+    expect(expanded).toBeLessThan(851)
+    expect(Number.isInteger(collapsed)).toBe(true)
+  })
+
+  it('reads back as the rest it was asked for', () => {
+    for (const rest of ['collapsed', 'expanded'] as const)
+      expect(restAt(heightAt(rest, 851) / 851)).toBe(rest)
+  })
+})

--- a/apps/website/src/composables/useBottomSheet.ts
+++ b/apps/website/src/composables/useBottomSheet.ts
@@ -1,0 +1,20 @@
+// Where a sheet dragged by its handle comes to rest, as a share of the screen:
+// the height it opens at, the height a pull upwards gives it, and the point
+// below which letting go means putting it away rather than making it smaller.
+const COLLAPSED = 0.62
+const EXPANDED = 0.92
+const DISMISS = 0.34
+
+export type SheetRest = 'closed' | 'collapsed' | 'expanded'
+
+export function restAt(fraction: number): SheetRest {
+  if (fraction < DISMISS) return 'closed'
+  return fraction < (COLLAPSED + EXPANDED) / 2 ? 'collapsed' : 'expanded'
+}
+
+export function heightAt(
+  rest: Exclude<SheetRest, 'closed'>,
+  viewport: number
+): number {
+  return Math.round((rest === 'expanded' ? EXPANDED : COLLAPSED) * viewport)
+}

--- a/apps/website/src/composables/useVisualViewport.test.ts
+++ b/apps/website/src/composables/useVisualViewport.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+
+import { useVisualViewport } from './useVisualViewport'
+
+const own = Object.getOwnPropertyDescriptor(window, 'visualViewport')
+
+function withViewport(viewport: unknown) {
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: viewport
+  })
+}
+
+afterEach(() => {
+  if (own) Object.defineProperty(window, 'visualViewport', own)
+  else withViewport(undefined)
+})
+
+describe('useVisualViewport', () => {
+  it('reads nothing where the browser offers no visual viewport', () => {
+    withViewport(undefined)
+    const scope = effectScope()
+    const seen = scope.run(() => useVisualViewport())!
+    expect(seen.height.value).toBeNull()
+    scope.stop()
+  })
+
+  it('follows the screen as the keyboard takes it and gives it back', async () => {
+    const viewport = Object.assign(new EventTarget(), {
+      height: 851,
+      offsetTop: 0
+    })
+    withViewport(viewport)
+
+    const scope = effectScope()
+    const seen = scope.run(() => useVisualViewport())!
+    expect(seen.height.value).toBe(851)
+
+    viewport.height = 471
+    viewport.offsetTop = 12
+    viewport.dispatchEvent(new Event('resize'))
+    await nextTick()
+    expect(seen.height.value).toBe(471)
+    expect(seen.offsetTop.value).toBe(12)
+
+    viewport.height = 851
+    viewport.dispatchEvent(new Event('scroll'))
+    await nextTick()
+    expect(seen.height.value).toBe(851)
+
+    scope.stop()
+    viewport.height = 100
+    viewport.dispatchEvent(new Event('resize'))
+    await nextTick()
+    expect(seen.height.value).toBe(851)
+  })
+})

--- a/apps/website/src/composables/useVisualViewport.ts
+++ b/apps/website/src/composables/useVisualViewport.ts
@@ -1,0 +1,23 @@
+import { useEventListener } from '@vueuse/core'
+import { ref } from 'vue'
+
+// A phone keyboard does not shrink the window, it covers it, and a fixed
+// element keeps the size of what it covers. What is actually on screen is the
+// visual viewport, so a sheet meant to fill the screen follows that instead.
+export function useVisualViewport() {
+  const height = ref<number | null>(null)
+  const offsetTop = ref(0)
+
+  const viewport =
+    typeof window === 'undefined' ? undefined : window.visualViewport
+  const read = () => {
+    if (!viewport) return
+    height.value = viewport.height
+    offsetTop.value = viewport.offsetTop
+  }
+
+  read()
+  useEventListener(viewport, ['resize', 'scroll'], read)
+
+  return { height, offsetTop }
+}

--- a/apps/website/src/config/models-catalogue.ts
+++ b/apps/website/src/config/models-catalogue.ts
@@ -271,8 +271,8 @@ export function splitTask(
 export const USE_CASES = [
   'generate-images',
   'edit-images',
-  'animate-images',
   'generate-videos',
+  'animate-images',
   'edit-videos',
   'text',
   '3d',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9145,6 +9145,14 @@ Enterprise`
     en: 'Back to all categories',
     'zh-CN': '返回所有类别'
   },
+  'workshop.sections.browseAll': {
+    en: 'Browse all models',
+    'zh-CN': '浏览所有模型'
+  },
+  'workshop.sections.allModels': {
+    en: 'All models',
+    'zh-CN': '所有模型'
+  },
   'workshop.sections.scrollBack': {
     en: 'Scroll back',
     'zh-CN': '向前滚动'
@@ -9168,12 +9176,12 @@ Enterprise`
   },
   'workshop.useCase.editImages': { en: 'Edit images', 'zh-CN': '编辑图像' },
   'workshop.useCase.generateVideos': {
-    en: 'Generate videos',
-    'zh-CN': '生成视频'
+    en: 'Text to video',
+    'zh-CN': '文本生成视频'
   },
   'workshop.useCase.animateImages': {
-    en: 'Animate images',
-    'zh-CN': '让图像动起来'
+    en: 'Image to video',
+    'zh-CN': '图像生成视频'
   },
   'workshop.useCase.editVideos': { en: 'Edit videos', 'zh-CN': '编辑视频' },
   'workshop.useCase.3d': { en: '3D', 'zh-CN': '3D' },
@@ -9183,6 +9191,10 @@ Enterprise`
   'workshop.search.clear': { en: 'Clear search', 'zh-CN': '清除搜索' },
   'workshop.search.done': { en: 'Done', 'zh-CN': '完成' },
   'workshop.search.close': { en: 'Close search', 'zh-CN': '关闭搜索' },
+  'workshop.filter.resize': {
+    en: 'Drag to resize the filters',
+    'zh-CN': '拖动调整筛选器高度'
+  },
   'workshop.search.show': {
     en: 'Show {n} models',
     'zh-CN': '显示 {n} 个模型'

--- a/apps/website/src/routes/models/[slug].astro
+++ b/apps/website/src/routes/models/[slug].astro
@@ -25,6 +25,10 @@ const { model, related, relatedHeading, relatedHeadingShort, successor, priceEst
 const routes = getRoutes()
 const pillClass =
   'inline-flex h-7 items-center rounded-full border border-transparency-white-t20 px-3 text-xs leading-none text-primary-comfy-canvas transition-colors hover:border-primary-comfy-yellow hover:text-primary-comfy-yellow'
+const TAGS_SHOWN = 3
+const shownTags = tags.slice(0, TAGS_SHOWN)
+const restTags = tags.slice(TAGS_SHOWN)
+const restTagCount = restTags.length
 ---
 
 <BaseLayout
@@ -82,21 +86,6 @@ const pillClass =
         </div>
 
         <div class="flex flex-col gap-4 lg:items-end">
-          <ul
-            class="flex scrollbar-hide items-center gap-2 max-sm:overflow-x-auto sm:flex-wrap lg:justify-end"
-            data-testid="model-tags"
-          >
-            {tags.map((tag) => (
-              <li>
-                <a
-                  href={`${routes.workshop}${tag.search}`}
-                  class="inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t20 hover:text-primary-comfy-yellow"
-                >
-                  {tag.label}
-                </a>
-              </li>
-            ))}
-          </ul>
           <p
             class="flex items-baseline gap-2 text-sm text-primary-comfy-canvas/60"
             data-testid="model-price"
@@ -109,6 +98,34 @@ const pillClass =
             <p class="text-xs text-primary-warm-gray">
               {t('workshop.model.nodePriceDefaults')}
             </p>
+          )}
+          {shownTags.length > 0 && (
+            <ul
+              class="flex scrollbar-hide items-center gap-2 max-sm:overflow-x-auto sm:flex-wrap lg:justify-end"
+              data-testid="model-tags"
+            >
+              {shownTags.map((tag) => (
+                <li>
+                  <a
+                    href={`${routes.workshop}${tag.search}`}
+                    class="inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t20 hover:text-primary-comfy-yellow"
+                  >
+                    {tag.label}
+                  </a>
+                </li>
+              ))}
+              {restTagCount > 0 && (
+                <li>
+                  <span
+                    class="inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap text-primary-comfy-canvas/70"
+                    title={restTags.map((tag) => tag.label).join(', ')}
+                    data-testid="model-tags-rest"
+                  >
+                    +{restTagCount}
+                  </span>
+                </li>
+              )}
+            </ul>
           )}
         </div>
       </div>


### PR DESCRIPTION
Mar's catalogue polish from [#16556](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16556), now carried as one squashed commit with her authorship (Ben rebuilt the branch onto `ben/models-review-release-boundary`; per-commit provenance lives in #16556), plus a review-fix commit.

## What's in it

| | |
| -- | -- |
| **The catalogue opens whole** | A **See all models** escape from use-case browsing — `browseAll` state and a `leaveSection` back to the top. Live for every `/models` visitor on this base; the old version switch is retired. |
| **The price leads the model header** | Cost first in the model header; naming a model in search ends the search. |
| **The search sheet ends where the keyboard starts** | `useVisualViewport` sizes the mobile sheet to the visual viewport. Phone widths only. |
| **The filter popover hugs its list** | Stops it standing half empty with few facets. |
| **Alignment fixes** | Chevron on the row title text; row arrows take the shared radius; title and link on one baseline. |

## Review fixes (from Ben's review)

- The e2e network fixture serves `apis.google.com` an empty script — Firebase Auth loads gapi on mobile UAs and failed the isolation teardown on every `@mobile` run.
- Browse-all scrolls back to the top like a use-case change does.
- The filter sheet's tabs stretch to the sheet height on phones, so the footer stops riding up under a short list.
- The drag handle toggles on Enter/Space, not only on pointer drags.
- Typing in the search field reopens the suggestion panel after a pick.

Still open from review: the "Text to video" row label also holds reference-input, avatar and audio-to-video pages — label wording is with design.

Verification: typecheck 0 errors; workshop component/config vitest suites green. Mobile keyboard behaviour still needs a real device.
