### PR TITLE
style(models): Eric's sizing pass — smaller hero, five across, a row that shows it scrolls

### DIFF
--- a/apps/website/src/components/workshop/CardRow.vue
+++ b/apps/website/src/components/workshop/CardRow.vue
@@ -49,7 +49,7 @@ const arrowClass = (spent: boolean) =>
 </script>
 
 <template>
-  <div>
+  <div class="@container">
     <div class="mb-5 flex items-baseline justify-between gap-4">
       <slot name="heading" />
       <div class="flex items-center gap-3">

--- a/apps/website/src/components/workshop/FeaturedBanner.vue
+++ b/apps/website/src/components/workshop/FeaturedBanner.vue
@@ -18,12 +18,32 @@ const { models, locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
+// "Recraft V4.1 Pro Text-to-Image" repeats the task chip shown directly
+// above it. When a name ends with its own task label, the banner drops the
+// suffix - the full name still stands on the card and the model page.
+function bannerName(model: WorkshopModel, task: string): string {
+  const words = task
+    .trim()
+    .split(/\s+/)
+    .map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  // Whitespace required before the label: a hyphen is not enough, or the
+  // match starts mid-word ("Context-to-Image" \u2192 "Con") and product names
+  // like "P-Image" lose their last token.
+  const suffix = new RegExp(`\\s+${words.join('[\\s\\-\u2013\u2014]*')}$`, 'i')
+  const stripped = model.name.replace(suffix, '').trim()
+  return stripped.length >= 3 ? stripped : model.name
+}
+
 const slides = computed(() =>
-  models.map((model) => ({
-    model,
-    task: taskLabelFor(model, locale),
-    capabilities: model.capabilities.slice(0, CAPABILITY_LIMIT)
-  }))
+  models.map((model) => {
+    const task = taskLabelFor(model, locale)
+    return {
+      model,
+      task,
+      name: bannerName(model, task),
+      capabilities: model.capabilities.slice(0, CAPABILITY_LIMIT)
+    }
+  })
 )
 
 const activeIndex = ref(0)
@@ -85,7 +105,7 @@ const fill = computed(() =>
   >
     <a
       :href="active.model.href"
-      class="group short:h-76 sm:short:h-80 block h-112"
+      class="group short:h-57 sm:short:h-60 block h-100"
       data-testid="featured-slide"
     >
       <video
@@ -115,7 +135,7 @@ const fill = computed(() =>
       />
 
       <div
-        class="sm:short:pb-16 lg:short:p-8 lg:short:pb-16 relative flex h-full flex-col justify-end gap-4 p-8 pb-20 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pb-20"
+        class="short:gap-3 short:pt-5 short:pb-11 relative flex h-full flex-col justify-end gap-4 p-8 pt-6 pb-16 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pt-8 lg:pb-18"
       >
         <div class="flex flex-wrap items-center gap-2">
           <Badge variant="subtle" size="md" class="text-primary-comfy-canvas">
@@ -132,13 +152,21 @@ const fill = computed(() =>
           </Badge>
         </div>
 
-        <h2 class="text-4xl font-bold text-primary-warm-white">
-          {{ active.model.name }}
+        <h2
+          class="mt-2 text-2xl font-bold text-balance text-primary-warm-white lg:text-[2rem]"
+        >
+          {{ active.name }}
         </h2>
 
+        <!-- max-h, not line-clamp: current Chrome blockifies a line-clamped
+             box to flow-root and renders it at zero height, so the summary
+             never showed while still spending a gap slot. A two-line crop
+             does the same job without the broken machinery. 3em = two lines
+             at leading-normal; the exact-fit lh unit is missing from older
+             Safari/Firefox, where the crop would silently vanish. -->
         <p
           v-if="active.model.summary"
-          class="text-content-secondary line-clamp-2 max-w-prose"
+          class="text-content-secondary short:hidden max-h-[3em] max-w-prose shrink-0 overflow-hidden"
         >
           {{ active.model.summary }}
         </p>

--- a/apps/website/src/components/workshop/FeaturedBanner.vue
+++ b/apps/website/src/components/workshop/FeaturedBanner.vue
@@ -6,6 +6,7 @@ import type { WorkshopModel } from '../../config/models-catalogue'
 import { prefersReducedMotion } from '../../composables/useReducedMotion'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
+import { bannerName } from '../../lib/workshop/banner-name'
 import { taskLabelFor } from '../../lib/workshop/task-label'
 import Badge from '../ui/badge/Badge.vue'
 import Button from '@/components/ui/button/Button.vue'
@@ -18,29 +19,13 @@ const { models, locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
-// "Recraft V4.1 Pro Text-to-Image" repeats the task chip shown directly
-// above it. When a name ends with its own task label, the banner drops the
-// suffix - the full name still stands on the card and the model page.
-function bannerName(model: WorkshopModel, task: string): string {
-  const words = task
-    .trim()
-    .split(/\s+/)
-    .map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-  // Whitespace required before the label: a hyphen is not enough, or the
-  // match starts mid-word ("Context-to-Image" \u2192 "Con") and product names
-  // like "P-Image" lose their last token.
-  const suffix = new RegExp(`\\s+${words.join('[\\s\\-\u2013\u2014]*')}$`, 'i')
-  const stripped = model.name.replace(suffix, '').trim()
-  return stripped.length >= 3 ? stripped : model.name
-}
-
 const slides = computed(() =>
   models.map((model) => {
     const task = taskLabelFor(model, locale)
     return {
       model,
       task,
-      name: bannerName(model, task),
+      name: bannerName(model.name, task),
       capabilities: model.capabilities.slice(0, CAPABILITY_LIMIT)
     }
   })
@@ -135,7 +120,7 @@ const fill = computed(() =>
       />
 
       <div
-        class="short:gap-3 short:pt-5 short:pb-11 relative flex h-full flex-col justify-end gap-4 p-8 pt-6 pb-16 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pt-8 lg:pb-18"
+        class="short:gap-3 short:pt-5 short:pb-14 relative flex h-full flex-col justify-end gap-4 p-8 pt-6 pb-16 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pt-8 lg:pb-18"
       >
         <div class="flex flex-wrap items-center gap-2">
           <Badge variant="subtle" size="md" class="text-primary-comfy-canvas">
@@ -158,15 +143,9 @@ const fill = computed(() =>
           {{ active.name }}
         </h2>
 
-        <!-- max-h, not line-clamp: current Chrome blockifies a line-clamped
-             box to flow-root and renders it at zero height, so the summary
-             never showed while still spending a gap slot. A two-line crop
-             does the same job without the broken machinery. 3em = two lines
-             at leading-normal; the exact-fit lh unit is missing from older
-             Safari/Firefox, where the crop would silently vanish. -->
         <p
           v-if="active.model.summary"
-          class="text-content-secondary short:hidden max-h-[3em] max-w-prose shrink-0 overflow-hidden"
+          class="text-content-secondary short:hidden line-clamp-2 max-w-prose shrink-0"
         >
           {{ active.model.summary }}
         </p>

--- a/apps/website/src/components/workshop/ModelsCatalogue.vue
+++ b/apps/website/src/components/workshop/ModelsCatalogue.vue
@@ -22,13 +22,13 @@ const browseAll = ref(false)
     <template #aside>
       <button
         type="button"
-        class="group hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 -mx-1 inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-1 text-base font-medium text-primary-warm-white transition-colors outline-none focus-visible:ring-3"
+        class="group hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 -mx-1 inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-1 text-xl font-medium text-primary-warm-white transition-colors outline-none focus-visible:ring-3"
         data-testid="browse-all"
         @click="browseAll = true"
       >
         {{ t('workshop.sections.browseAll', locale) }}
         <ChevronRight
-          class="size-4 transition-transform group-hover:translate-x-0.5"
+          class="size-5 transition-transform group-hover:translate-x-0.5"
           aria-hidden="true"
         />
       </button>

--- a/apps/website/src/components/workshop/WorkshopFilterMenu.vue
+++ b/apps/website/src/components/workshop/WorkshopFilterMenu.vue
@@ -154,7 +154,7 @@ const sheetLabels = computed(() => ({
       </span>
       <span
         v-if="selectedCount"
-        class="bg-primary-comfy-yellow inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold text-primary-comfy-ink tabular-nums max-sm:absolute max-sm:-top-1 max-sm:-right-1"
+        class="bg-primary-comfy-yellow inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold text-primary-comfy-ink max-sm:absolute max-sm:-top-1 max-sm:-right-1"
         data-testid="workshop-filter-count"
       >
         {{ selectedCount }}

--- a/apps/website/src/components/workshop/WorkshopHero.vue
+++ b/apps/website/src/components/workshop/WorkshopHero.vue
@@ -37,7 +37,7 @@ const slots = useSlots()
     >
       <SplitReveal :text="t('workshop.hero.eyebrow', locale)" />
     </p>
-    <h1 class="text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
+    <h1 class="text-3xl font-light text-primary-comfy-canvas lg:text-5xl">
       <SplitReveal :text="t(headingKey, locale)" :delay="90" />
     </h1>
     <div

--- a/apps/website/src/components/workshop/WorkshopHero.vue
+++ b/apps/website/src/components/workshop/WorkshopHero.vue
@@ -24,7 +24,7 @@ const slots = useSlots()
   <header
     :class="
       cn(
-        'lg:short:-mt-12 lg:short:pt-12 relative isolate -mx-6 -mt-16 overflow-hidden px-6 pt-16 max-sm:-mt-10 max-sm:pt-10 lg:-mx-8 lg:-mt-24 lg:px-8 lg:pt-24',
+        'relative isolate -mx-6 -mt-8 overflow-hidden px-6 pt-8 max-sm:-mt-5 max-sm:pt-5 lg:-mx-8 lg:-mt-12 lg:px-8 lg:pt-12',
         slots.default
           ? 'mb-8 max-sm:mb-5'
           : 'sm:short:pb-0 mb-6 pb-2 max-sm:mb-4 max-sm:pb-0'

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.test.ts
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { nextTick } from 'vue'
 
 import type { WorkshopModel } from '../../config/models-catalogue'
 import WorkshopModelsGrid from './WorkshopModelsGrid.vue'
@@ -107,6 +109,24 @@ describe('WorkshopModelsGrid', () => {
     await user.click(screen.getByRole('button', { name: /Back to/ }))
     await user.click(screen.getByRole('button', { name: 'Text to video 1' }))
     expect(cardNames()).toEqual([expect.stringContaining('Kling AI')])
+  })
+
+  it('returns the viewport to the top when a section or browse-all opens', async () => {
+    const scrollTo = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => undefined)
+    const user = userEvent.setup()
+    render(WorkshopModelsGrid, { props: { models } })
+
+    await user.click(screen.getByRole('button', { name: 'Edit images 1' }))
+    await nextTick()
+    await vi.waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ top: 0 }))
+
+    scrollTo.mockClear()
+    await user.click(screen.getByRole('button', { name: /Back to/ }))
+    await user.click(screen.getByTestId('browse-all-end'))
+    await vi.waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ top: 0 }))
+    scrollTo.mockRestore()
   })
 
   it('filters by capability from the filter menu', async () => {

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.vue
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.vue
@@ -241,7 +241,7 @@ const menuItemClass =
       </button>
 
       <div
-        class="bg-page sticky top-20 z-30 mb-8 flex flex-wrap items-center justify-end gap-3 py-4 max-sm:mb-4 max-sm:py-2 lg:top-26"
+        class="bg-page sticky top-20 z-30 -mx-6 mb-8 flex flex-wrap items-center justify-end gap-3 px-6 py-4 max-sm:mb-4 max-sm:py-2 lg:top-26 lg:-mx-8 lg:px-8"
       >
         <h1
           v-if="inSection"
@@ -357,7 +357,7 @@ const menuItemClass =
             {{ t('workshop.models.heading', locale) }}
           </h2>
           <ul
-            class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5"
+            class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
             aria-labelledby="workshop-models-heading"
             data-testid="workshop-models-grid"
           >

--- a/apps/website/src/components/workshop/WorkshopSections.vue
+++ b/apps/website/src/components/workshop/WorkshopSections.vue
@@ -108,7 +108,7 @@ const unplaced = computed(() =>
         <li
           v-for="family in section.shown"
           :key="family.key"
-          class="w-58 shrink-0 snap-start"
+          class="w-60 shrink-0 snap-start sm:w-[calc((100cqw-2*1.25rem)/2.5)] md:w-[calc((100cqw-3*1.25rem)/3.5)] lg:w-[calc((100cqw-4*1.25rem)/4.5)] xl:w-[calc((100cqw-5*1.25rem)/5.5)]"
         >
           <WorkshopModelCard :model="family.latest" :locale />
         </li>
@@ -144,7 +144,7 @@ const unplaced = computed(() =>
         <li
           v-for="family in otherFormats.slice(0, ROW_LIMIT)"
           :key="family.key"
-          class="w-58 shrink-0 snap-start"
+          class="w-60 shrink-0 snap-start sm:w-[calc((100cqw-2*1.25rem)/2.5)] md:w-[calc((100cqw-3*1.25rem)/3.5)] lg:w-[calc((100cqw-4*1.25rem)/4.5)] xl:w-[calc((100cqw-5*1.25rem)/5.5)]"
         >
           <WorkshopModelCard :model="family.latest" :locale />
         </li>

--- a/apps/website/src/components/workshop/WorkshopSections.vue
+++ b/apps/website/src/components/workshop/WorkshopSections.vue
@@ -43,6 +43,9 @@ const GROUPED = OTHER_FORMAT_USE_CASES
 const titleClass =
   'group hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 inline-flex cursor-pointer items-baseline gap-2 rounded-lg text-xl font-medium text-primary-warm-white transition-colors outline-none focus-visible:ring-3'
 
+const cardClass =
+  'w-60 shrink-0 snap-start sm:w-[calc((100cqw-2*1.25rem)/2.5)] md:w-[calc((100cqw-3*1.25rem)/3.5)] lg:w-[calc((100cqw-4*1.25rem)/4.5)] xl:w-[calc((100cqw-5*1.25rem)/5.5)]'
+
 const sections = computed(() =>
   USE_CASES.filter((useCase) => !GROUPED.includes(useCase))
     .map((useCase) => {
@@ -108,7 +111,7 @@ const unplaced = computed(() =>
         <li
           v-for="family in section.shown"
           :key="family.key"
-          class="w-60 shrink-0 snap-start sm:w-[calc((100cqw-2*1.25rem)/2.5)] md:w-[calc((100cqw-3*1.25rem)/3.5)] lg:w-[calc((100cqw-4*1.25rem)/4.5)] xl:w-[calc((100cqw-5*1.25rem)/5.5)]"
+          :class="cardClass"
         >
           <WorkshopModelCard :model="family.latest" :locale />
         </li>
@@ -144,7 +147,7 @@ const unplaced = computed(() =>
         <li
           v-for="family in otherFormats.slice(0, ROW_LIMIT)"
           :key="family.key"
-          class="w-60 shrink-0 snap-start sm:w-[calc((100cqw-2*1.25rem)/2.5)] md:w-[calc((100cqw-3*1.25rem)/3.5)] lg:w-[calc((100cqw-4*1.25rem)/4.5)] xl:w-[calc((100cqw-5*1.25rem)/5.5)]"
+          :class="cardClass"
         >
           <WorkshopModelCard :model="family.latest" :locale />
         </li>

--- a/apps/website/src/lib/workshop/banner-name.test.ts
+++ b/apps/website/src/lib/workshop/banner-name.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { bannerName } from './banner-name'
+
+describe('bannerName', () => {
+  it('drops a trailing task label however it is separated', () => {
+    expect(bannerName('Recraft V4.1 Pro Text-to-Image', 'Text to Image')).toBe(
+      'Recraft V4.1 Pro'
+    )
+    expect(bannerName('Seedance Text to Video', 'Text to Video')).toBe(
+      'Seedance'
+    )
+  })
+
+  it('requires the label to start at a word boundary', () => {
+    expect(bannerName('Context-to-Image', 'Text to Image')).toBe(
+      'Context-to-Image'
+    )
+  })
+
+  it('leaves one-word modality labels alone', () => {
+    expect(bannerName('Stable Audio', 'Audio')).toBe('Stable Audio')
+    expect(bannerName('Tripo 3D', '3D')).toBe('Tripo 3D')
+    expect(bannerName('Ideogram & Pruna P-Image', 'Image')).toBe(
+      'Ideogram & Pruna P-Image'
+    )
+  })
+
+  it('keeps the full name when stripping leaves almost nothing', () => {
+    expect(bannerName('AI Text to Image', 'Text to Image')).toBe(
+      'AI Text to Image'
+    )
+  })
+
+  it('ignores a localized label that does not match the name', () => {
+    expect(bannerName('Flux Text-to-Image', '文生图')).toBe(
+      'Flux Text-to-Image'
+    )
+  })
+})

--- a/apps/website/src/lib/workshop/banner-name.test.ts
+++ b/apps/website/src/lib/workshop/banner-name.test.ts
@@ -10,6 +10,12 @@ describe('bannerName', () => {
     expect(bannerName('Seedance Text to Video', 'Text to Video')).toBe(
       'Seedance'
     )
+    expect(bannerName('Seedance Text–to–Video', 'Text to Video')).toBe(
+      'Seedance'
+    )
+    expect(bannerName('Seedance Text—to—Video', 'Text to Video')).toBe(
+      'Seedance'
+    )
   })
 
   it('requires the label to start at a word boundary', () => {

--- a/apps/website/src/lib/workshop/banner-name.ts
+++ b/apps/website/src/lib/workshop/banner-name.ts
@@ -1,0 +1,16 @@
+// "Recraft V4.1 Pro Text-to-Image" repeats the task chip shown directly
+// above the banner heading. When a name ends with its own task label, the
+// banner drops the suffix - the full name still stands on the card and the
+// model page. One-word labels (the modality fallback: Audio, Video, 3D) are
+// left alone: they are real product words in names like "Stable Audio".
+// Whitespace is required before the label: a hyphen is not enough, or the
+// match starts mid-word ("Context-to-Image") and product names like
+// "P-Image" lose their last token.
+export function bannerName(name: string, task: string): string {
+  const words = task.trim().split(/\s+/).filter(Boolean)
+  if (words.length < 2) return name
+  const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const suffix = new RegExp(`\\s+${escaped.join('[\\s\\-–—]*')}$`, 'i')
+  const stripped = name.replace(suffix, '').trim()
+  return stripped.length >= 3 ? stripped : name
+}

--- a/apps/website/src/routes/models/[slug].astro
+++ b/apps/website/src/routes/models/[slug].astro
@@ -37,7 +37,7 @@ const restTagCount = restTags.length
   ogImage={model.thumbnailUrl}
   noindex
 >
-  <div class="mx-auto max-w-10xl px-6 py-10 lg:px-8 lg:py-14">
+  <div class="mx-auto max-w-10xl px-6 pt-5 pb-10 lg:px-8 lg:pt-7 lg:pb-14">
     <nav aria-label="Breadcrumb" class="mb-8 text-xs text-primary-warm-gray sm:px-8 lg:px-10">
       <ol class="flex flex-wrap items-center gap-2">
         <li>

--- a/apps/website/src/routes/models/index.astro
+++ b/apps/website/src/routes/models/index.astro
@@ -11,7 +11,7 @@ import { t } from '../../i18n/translations'
   description={t('workshop.meta.description')}
   noindex
 >
-  <div class="mx-auto max-w-10xl px-6 py-16 max-sm:py-10 lg:px-8 lg:py-24 lg:short:pt-14">
+  <div class="mx-auto max-w-10xl px-6 pt-8 pb-16 max-sm:pt-5 max-sm:pb-10 lg:px-8 lg:pt-12 lg:pb-24">
     <ModelsCatalogue models={workshopModels} client:load />
   </div>
 </BaseLayout>


### PR DESCRIPTION
Eric's sizing feedback on the models catalogue, stacked on [#17379](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17379).

## What changed (numbers as shipped)

| | |
| -- | -- |
| **Hero** | `h-100` (400px) on tall screens; the `short:` laptop variant (any viewport ≤1100px tall — nearly every laptop and 1080p desktop) goes to `h-57`/`sm:h-60` (228/240px, down from 304/320). That is the ~75% Eric asked for where most visitors are; check the preview at a laptop-height window. |
| **Banner heading** | 32px (`text-2xl lg:text-[2rem]`), and `bannerName` drops a task-label suffix that repeats the chip above it ("Recraft V4.1 Pro Text-to-Image" → "Recraft V4.1 Pro"). It now lives in `lib/workshop/banner-name.ts` as a tested pure function; one-word modality labels are left alone so "Stable Audio" keeps its name. |
| **Banner summary** | `line-clamp-2` with `shrink-0` — the zero-height render was the flex column shrinking its only shrinkable child, not a clamp bug; the ellipsis is back (verified in Chromium). |
| **Drilled-in grid** | `lg:3 / xl:4 / 2xl:5` columns. Note for design: the base was `lg:4 / xl:5`, so 1024–1535px gets one column fewer (bigger cards) than before — confirm with Eric or we revert to the base ladder. |
| **Row cards** | Container-query ladder (2.5/3.5/4.5/5.5 per row) so the next card always peeks by half; a fixed width made the peek arithmetic (4px at some widths). |
| **Page chrome** | Halved top padding on `/models` routes, hero pull-up margins kept in sync, browse-all link at `text-xl`, filter-count badge sized for its digits, sticky filter bar bleeds to the gutters so content doesn't show through the seam. |
| **Phones** | The banner's short-screen bottom padding clears the pagination bar (it overlapped the CTA by 4px). |

Base: `comfydesigner/models-catalogue-polish` — merge that one first.
