### PR TITLE
test(keybindings): keep canvas focus after the settings dialog closes

### DIFF
--- a/browser_tests/tests/defaultKeybindings.spec.ts
+++ b/browser_tests/tests/defaultKeybindings.spec.ts
@@ -315,6 +315,24 @@ test.describe('Default Keybindings', { tag: '@keyboard' }, () => {
         .toBeLessThan(initialCount)
     })
 
+    test('Select-all still reaches the canvas after the settings dialog closes', async ({
+      comfyPage
+    }) => {
+      const nodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+      expect(nodeCount).toBeGreaterThan(1)
+
+      await comfyPage.settingDialog.open()
+      await comfyPage.settingDialog.close()
+
+      await comfyPage.keyboard.press('Control+a')
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => window.app!.canvas.selectedItems.size)
+        )
+        .toBe(nodeCount)
+    })
+
     test("'r' refreshes node definitions", async ({ comfyPage }) => {
       const request = await pressKeyAndExpectRequest(
         comfyPage,


### PR DESCRIPTION
## Summary

Adds the missing assertion that keyboard shortcuts return to the canvas once a dialog closes — the fix from https://github.com/Comfy-Org/ComfyUI_frontend/pull/16401 (stale canvas focus after navigation) has no test behind it.

## Changes

- **What**: one test in `defaultKeybindings.spec.ts` → `Graph Operations`.

## Review Focus

`defaultKeybindings.spec.ts` covers the opposite direction — `'Ctrl+s' does not fall through to the browser while a dialog is open` — but nothing covers focus coming *back*. So today a regression that left focus stranded on a closed dialog would pass the suite.

Two deliberate choices worth checking:

- **`canvas.selectedItems.size` via `page.evaluate`.** Legacy canvas rendering has no per-node DOM, so there is no locator-based observable for selection state. `fitToView.ts` and `boundsUtils.ts` already read `selectedItems` the same way.
- **Asserting `nodeCount > 1` first.** Without it, a graph that failed to load would make the selection count match trivially at 0 and the test would pass green while asserting nothing.

Found by auditing the 1.53 → 1.54 QA test plan against the suite. Second in a series; the first is https://github.com/Comfy-Org/ComfyUI_frontend/pull/17320.
