### PR TITLE
[backport core/1.53] fix: resolve assigned input slot positions

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -796,6 +796,32 @@ describe('LGraphNode', () => {
       ])
       delete (node.constructor as NodeConstructorWithSlotOffset).slot_start_y
     })
+    test('should resolve an assigned input through its stable installed view', () => {
+      node.flags.collapsed = false
+      const firstInput = { ...inputSlot }
+      const secondInput: INodeInputSlot = {
+        name: 'test_in_2',
+        type: 'number',
+        link: null,
+        boundingRect: [0, 0, 0, 0]
+      }
+      node.inputs = [firstInput, secondInput]
+
+      const installedFirst = node.inputs[0]
+      expect(installedFirst).not.toBe(firstInput)
+      expect(node.getInputSlotPos(firstInput)).toEqual(
+        node.getInputSlotPos(installedFirst)
+      )
+
+      node.inputs.reverse()
+      expect(node.getInputSlotPos(firstInput)).toEqual(
+        node.getInputSlotPos(installedFirst)
+      )
+      expect(node.getInputSlotPos(firstInput)).toEqual([
+        100 + LiteGraph.NODE_SLOT_HEIGHT * 0.5,
+        200 + 1.7 * LiteGraph.NODE_SLOT_HEIGHT
+      ])
+    })
     test('should not overwrite onMouseDown prototype', () => {
       expect(Object.prototype.hasOwnProperty.call(node, 'onMouseDown')).toEqual(
         false

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -61,7 +61,10 @@ import {
   outputHasLinks,
   outputLinks
 } from './node/slotLinks'
-import { createInputSlotView } from './node/slotDescriptorView'
+import {
+  createInputSlotView,
+  resolveInputSlotView
+} from './node/slotDescriptorView'
 import { initializeWidgetsView } from './node/widgetsView'
 import {
   extensionConfigureView,
@@ -3663,7 +3666,10 @@ export class LGraphNode
    * @returns Position of the centre of the input slot in graph co-ordinates.
    */
   getInputSlotPos(input: INodeInputSlot): Point {
-    return calculateInputSlotPosFromSlot(this._getSlotPositionContext(), input)
+    return calculateInputSlotPosFromSlot(
+      this._getSlotPositionContext(),
+      resolveInputSlotView(this.inputs, input)
+    )
   }
 
   /**

--- a/src/lib/litegraph/src/node/slotDescriptorView.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.ts
@@ -3,19 +3,36 @@ import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
 import { toClass } from '@/lib/litegraph/src/utils/type'
 
+const assignedInputViews = new WeakMap<
+  INodeInputSlot[],
+  WeakMap<INodeInputSlot, INodeInputSlot>
+>()
+
 export function createInputSlotView(
   node: LGraphNode,
   inputs: INodeInputSlot[]
 ): INodeInputSlot[] {
-  return new Proxy(inputs, {
+  const assignedViews = new WeakMap<INodeInputSlot, INodeInputSlot>()
+  const view = new Proxy(inputs, {
     set(target, property, value: unknown, receiver) {
       const input =
         isArrayIndex(property) && isInputSlot(value)
           ? toClass(NodeInputSlot, value, node)
           : value
+      if (isInputSlot(value) && isInputSlot(input) && value !== input)
+        assignedViews.set(value, input)
       return Reflect.set(target, property, input, receiver)
     }
   })
+  assignedInputViews.set(view, assignedViews)
+  return view
+}
+
+export function resolveInputSlotView(
+  inputs: INodeInputSlot[],
+  input: INodeInputSlot
+): INodeInputSlot {
+  return assignedInputViews.get(inputs)?.get(input) ?? input
 }
 
 function isArrayIndex(property: string | symbol): property is string {


### PR DESCRIPTION
Backport of https://github.com/Comfy-Org/ComfyUI_frontend/pull/16510 (assigned input slot position resolution) to the 1.53 release branch.

Why now: the 1.53 backport of https://github.com/Comfy-Org/ComfyUI_frontend/pull/17319 depends on the `assignedInputViews` plumbing introduced here. Merge this PR before that backport.

Cherry-pick of merge commit `cc4df4532eaf0c6c038fe0622c5c96a364a92989` (conflict-free).

<details><summary>Full context for agent readers</summary>

- Source PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16510 (risk:xhigh, merged to main, never previously backported).
- Dependent: the 1.53 backport of https://github.com/Comfy-Org/ComfyUI_frontend/pull/17319 (unpack-subgraph link preflight fix) fails to apply cleanly without this change.
- Merge order: this PR first, then the https://github.com/Comfy-Org/ComfyUI_frontend/pull/17319 backport stacked on top.
- Part of the ECS migration release-readiness backport chain for 1.53.

<!-- authored-by:agent supreme-operator w3-w40 -->
</details>
