### PR TITLE
style(models): variant label as a pill badge — launch backup if distinct thumbnails slip

### DIFF
--- a/apps/website/MODELS_LOCAL_PREVIEW.md
+++ b/apps/website/MODELS_LOCAL_PREVIEW.md
@@ -288,27 +288,20 @@ Seedance 2.5, Seedream 5.0 Pro, FLUX 3 Video, Veo 3.1 and Qwen Image 3.0.
 All 114 visible models now have a nonempty display name distinct from their raw
 Router slug; card/detail names agree. Rob's explicit overrides still win.
 
-### Shared-thumbnail ribbons
+### Shared-thumbnail variant labels
 
 `src/data/workshop-thumbnail-labels.json` holds short editorial labels keyed by
 canonical Router ID, separate from Rob's generated content. The shared card
-renders a diagonal upper-right ribbon only when two distinct models use the same
+renders the label as a rounded pill only when two distinct models use the same
 thumbnail URL and media kind. Labels are resolved against the full catalogue,
 so filtering does not remove them; unique artwork and missing images stay plain.
 The current data covers 56 models sharing 21 assets, including video thumbnails.
 Labels are at most 12 characters and distinct within each shared-art group.
-Ribbon text steps down from 16px (up to six characters), to 12px (seven to nine),
-to 9px (ten to twelve), expressed in rem so browser text scaling still applies.
-The ribbon uses a heavy sans-serif face (800 weight), rather than inheriting
-PP Formula. The stripe is 40px thick, up from the initial 24px; its centre stays
-in the same corner position. Its dimensions stay fixed across label lengths,
-and labels are never truncated.
+The pill is warm-white text on the dropdown surface with a hairline border,
+in the site's own type. It sits top-right on hub cards and bottom-left on
+grid cards, near the model name, and slides away while the card is hovered
+or focused so it never blocks the artwork being compared.
 Full names, links, image/video sources and Router requests remain unchanged.
-Verified with 27 focused card/catalogue/Hub/homepage tests, website Vue typecheck,
-scoped type-aware lint and the enabled build. Browser checks cover six model
-groups at 1440px plus 390px/320px layouts: labels remain on filtered cards,
-text stays inside each thumbnail, video frames decode and no paid requests run.
-Probe and screenshots: `temp/scripts/thumbnail-ribbon.JNFijc/` at repository root.
 
 Catalogue search follow-up, observed during this check: `krea turbo` returns no
 results while `Krea 2 Medium Turbo` matches. `filterWorkshopModels` still uses a

--- a/apps/website/src/components/workshop/WorkshopModelCard.test.ts
+++ b/apps/website/src/components/workshop/WorkshopModelCard.test.ts
@@ -185,7 +185,7 @@ describe('WorkshopModelCard', () => {
   )
 
   it.for([false, true])(
-    'keeps incomplete status alongside the ribbon (hub: %s)',
+    'keeps incomplete status alongside the variant label (hub: %s)',
     (providerBadge) => {
       render(WorkshopModelCard, {
         props: {

--- a/apps/website/src/components/workshop/WorkshopModelCard.vue
+++ b/apps/website/src/components/workshop/WorkshopModelCard.vue
@@ -117,12 +117,10 @@ const pillClass =
         v-if="thumbnailLabel"
         :class="
           cn(
-            'bg-brand text-page pointer-events-none absolute top-4 -right-11 z-10 flex h-10 w-40 rotate-45 items-center justify-center font-sans font-extrabold whitespace-nowrap shadow-sm select-none',
-            thumbnailLabel.length > 9
-              ? 'text-[0.5625rem]'
-              : thumbnailLabel.length > 6
-                ? 'text-xs'
-                : 'text-base'
+            'bg-site-dropdown pointer-events-none absolute z-10 rounded-xl border border-white/10 px-3 py-2 text-sm leading-none font-bold whitespace-nowrap text-primary-warm-white shadow-sm transition-all duration-500 select-none group-hover:opacity-0 group-focus-visible:opacity-0',
+            providerBadge
+              ? 'top-3 right-3 group-hover:translate-x-1 group-hover:-translate-y-1'
+              : 'bottom-3 left-3 group-hover:-translate-x-1 group-hover:translate-y-1'
           )
         "
         aria-hidden="true"


### PR DESCRIPTION
**Backup for launch** — if distinct per-variant thumbnails land in time, close this unmerged. It exists so we aren't choosing between the ribbon and nothing on launch day.

Ben's diagonal ribbon solves a real problem: variant families share a thumbnail and the name difference is easy to miss. This keeps the mechanism (`thumbnailLabel`, same data, same tests) and changes the clothing — and, since the first draft of this description, the clothing changed again in review with Alex:

| | ribbon | pill (as shipped) |
| -- | -- | -- |
| artwork covered | 160px diagonal + overflow | ~70×28px corner, and it slides away while the card is hovered or focused |
| colours | yellow on ink | warm-white on the dropdown surface with a hairline border — subtler, since the label is a tiebreaker, not a CTA |
| position | upper-right sash | top-right on hub cards; bottom-left on grid cards, next to the model name it disambiguates |
| label sizing | 3 font steps by length | one size, hugs content |

The hide-on-hover is deliberate: the label's job is done once you're comparing the artwork. `MODELS_LOCAL_PREVIEW.md` now describes the pill rather than the retired ribbon.

Stacked on #17381 (base: `comfydesigner/models-catalogue-sizing`) to keep the chain linear — no content dependency on it.
