### PR TITLE
fix: refresh slot labels after rename with ECS node state (1.53 backport)

### DIFF
--- a/src/core/graph/nodeShell/slotLabelReactivity.regression.test.ts
+++ b/src/core/graph/nodeShell/slotLabelReactivity.regression.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { computed, isReactive } from 'vue'
+
+import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+describe('slot label reactivity (regression #16642)', () => {
+  test('plain-object output written by index is upgraded and reactive', () => {
+    const node = new LGraphNode('Plain')
+    node.addOutput('out', 'STRING')
+
+    const outLabel = computed(() => node.outputs[0].label)
+    expect(outLabel.value).toBeUndefined()
+
+    const output: INodeOutputSlot = {
+      name: 'out',
+      type: 'STRING',
+      links: [],
+      boundingRect: new Float64Array(4)
+    }
+    node.outputs[0] = output
+    expect(outLabel.value).toBeUndefined()
+
+    node.outputs[0].label = 'c'
+
+    expect(outLabel.value).toBe('c')
+    expect(isReactive(node.outputs[0])).toBe(true)
+  })
+})

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -63,6 +63,7 @@ import {
 } from './node/slotLinks'
 import {
   createInputSlotView,
+  createOutputSlotView,
   resolveInputSlotView
 } from './node/slotDescriptorView'
 import { initializeWidgetsView } from './node/widgetsView'
@@ -1038,6 +1039,7 @@ export class LGraphNode
       type,
       this.title_mode
     )
+    this._state.outputs = createOutputSlotView(this, this._state.outputs)
     this._inputs = this._state.inputs
     this._outputs = this._state.outputs
     for (const property of [

--- a/src/lib/litegraph/src/node/slotDescriptorView.test.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.test.ts
@@ -60,6 +60,22 @@ describe('slot identity', () => {
     expect(node._state.inputs[0]).toBe(node.inputs[0])
   })
 
+  it('upgrades extension-assigned outputs when they are written', () => {
+    const node = new LGraphNode('Node')
+    const output = {
+      name: 'output',
+      type: 'INT',
+      links: [],
+      boundingRect: new Float64Array(4)
+    }
+
+    node.outputs = [output]
+
+    expect(node._state.outputs).toBe(node.outputs)
+    expect(node.outputs[0]).toBeInstanceOf(NodeOutputSlot)
+    expect(node._state.outputs[0]).toBe(node.outputs[0])
+  })
+
   it('preserves native indexOf behavior for arbitrary values', () => {
     const node = new LGraphNode('Node')
     node.addInput('slot', 'INT')

--- a/src/lib/litegraph/src/node/slotDescriptorView.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.ts
@@ -1,6 +1,10 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
+import type {
+  INodeInputSlot,
+  INodeOutputSlot
+} from '@/lib/litegraph/src/interfaces'
 import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
+import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
 import { toClass } from '@/lib/litegraph/src/utils/type'
 
 const assignedInputViews = new WeakMap<
@@ -28,6 +32,21 @@ export function createInputSlotView(
   return view
 }
 
+export function createOutputSlotView(
+  node: LGraphNode,
+  outputs: INodeOutputSlot[]
+): INodeOutputSlot[] {
+  return new Proxy(outputs, {
+    set(target, property, value: unknown, receiver) {
+      const output =
+        isArrayIndex(property) && isOutputSlot(value)
+          ? toClass(NodeOutputSlot, value, node)
+          : value
+      return Reflect.set(target, property, output, receiver)
+    }
+  })
+}
+
 export function resolveInputSlotView(
   inputs: INodeInputSlot[],
   input: INodeInputSlot
@@ -47,6 +66,15 @@ function isArrayIndex(property: string | symbol): property is string {
 }
 
 function isInputSlot(value: unknown): value is INodeInputSlot {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'name' in value &&
+    'type' in value
+  )
+}
+
+function isOutputSlot(value: unknown): value is INodeOutputSlot {
   return (
     value !== null &&
     typeof value === 'object' &&


### PR DESCRIPTION
Backport of the slot-label refresh fix to the 1.53 release line.

- Slot labels now refresh after an input or output rename when the node runs on ECS node state.
- Clean cherry-pick of the original fix; regression test included and passing.
- Merge after the slot-position backport this branch is stacked on (link below).

<details><summary>Full context for agent readers</summary>

Original fix on main: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17319

This backport is stacked on the 1.53 backport of the assigned-input-slot-position fix, because the regression test and the label refresh path depend on it:

- core/1.53 dependency: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17385
- cloud/1.53 dependency: https://github.com/Comfy-Org/ComfyUI_frontend/pull/17386

Merge order: land the dependency backport first, then this PR. Once the dependency merges, this PR's diff reduces to the single cherry-picked commit.

Verification: cherry-pick applied cleanly (no conflicts); `src/core/graph/nodeShell/slotLabelReactivity.regression.test.ts` passes locally on this branch; knip pre-push check passed.

Tracking issue for the ECS migration follow-ups: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973

<!-- authored-by:agent supreme-operator w3-w40 -->
</details>
