### PR TITLE
test(copy-paste): assert repeated pastes keep node identities distinct

### DIFF
--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -179,11 +179,10 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
         .toBe(initialCount * (i + 2))
     }
 
-    const nodeIds = await comfyPage.page.evaluate(() =>
-      window.app!.graph.nodes.map((node) => String(node.id))
+    const uniqueNodeInstanceCount = await comfyPage.page.evaluate(
+      () => new Set(window.app!.graph.nodes).size
     )
-    expect(nodeIds).toHaveLength(initialCount * (pasteCount + 1))
-    expect(new Set(nodeIds).size).toBe(nodeIds.length)
+    expect(uniqueNodeInstanceCount).toBe(initialCount * (pasteCount + 1))
   })
 
   test('Can undo paste multiple nodes as single action', async ({

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -158,9 +158,7 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
     await expect(comfyPage.canvas).toHaveScreenshot('drag-copy-copied-node.png')
   })
 
-  test('Repeated pastes keep every node a distinct instance', async ({
-    comfyPage
-  }) => {
+  test('Repeated pastes never reuse node instances', async ({ comfyPage }) => {
     await expect
       .poll(() => comfyPage.nodeOps.getGraphNodesCount())
       .toBeGreaterThan(1)

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -158,7 +158,9 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
     await expect(comfyPage.canvas).toHaveScreenshot('drag-copy-copied-node.png')
   })
 
-  test('Repeated pastes never reuse node instances', async ({ comfyPage }) => {
+  test('Repeated pastes never reuse node instances or IDs', async ({
+    comfyPage
+  }) => {
     await expect
       .poll(() => comfyPage.nodeOps.getGraphNodesCount())
       .toBeGreaterThan(1)
@@ -177,10 +179,18 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
         .toBe(initialCount * (i + 2))
     }
 
-    const uniqueNodeInstanceCount = await comfyPage.page.evaluate(
-      () => new Set(window.app!.graph.nodes).size
-    )
-    expect(uniqueNodeInstanceCount).toBe(initialCount * (pasteCount + 1))
+    const uniqueCounts = await comfyPage.page.evaluate(() => {
+      const nodes = window.app!.graph.nodes
+      return {
+        instances: new Set(nodes).size,
+        ids: new Set(nodes.map((node) => node.id)).size
+      }
+    })
+    const expectedNodeCount = initialCount * (pasteCount + 1)
+    expect(uniqueCounts).toEqual({
+      instances: expectedNodeCount,
+      ids: expectedNodeCount
+    })
   })
 
   test('Can undo paste multiple nodes as single action', async ({

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -158,6 +158,34 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
     await expect(comfyPage.canvas).toHaveScreenshot('drag-copy-copied-node.png')
   })
 
+  test('Repeated pastes keep every node a distinct instance', async ({
+    comfyPage
+  }) => {
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+      .toBeGreaterThan(1)
+    const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+
+    await comfyPage.canvas.click()
+    await comfyPage.keyboard.selectAll()
+    await comfyPage.page.mouse.move(10, 10)
+    await comfyPage.clipboard.copy()
+
+    const pasteCount = 5
+    for (let i = 0; i < pasteCount; i++) {
+      await comfyPage.clipboard.paste()
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+        .toBe(initialCount * (i + 2))
+    }
+
+    const nodeIds = await comfyPage.page.evaluate(() =>
+      window.app!.graph.nodes.map((node) => String(node.id))
+    )
+    expect(nodeIds).toHaveLength(initialCount * (pasteCount + 1))
+    expect(new Set(nodeIds).size).toBe(nodeIds.length)
+  })
+
   test('Can undo paste multiple nodes as single action', async ({
     comfyPage
   }) => {


### PR DESCRIPTION
## Summary

Exercises the duplicate node-instance invariants added by https://github.com/Comfy-Org/ComfyUI_frontend/pull/14256. `copyPaste.spec.ts` only ever pastes once, so nothing in the suite drives the code path those invariants guard.

## Changes

- **What**: one test in `copyPaste.spec.ts` → `Copy Paste`.

## Review Focus

**Why identity and not just a count.** A count-only assertion still passes if the same instance is added twice under one id — which is precisely the failure `LGraph.add/remove` now guards against. So the test checks both `new Set(graph.nodes).size` and the unique node-ID count against the expected node count after the pastes.

**Why the count is checked inside the loop.** Asserting only the final total tells you it broke, not where. Checking after each paste means a failure names the iteration.

`page.evaluate` for node identity and IDs: legacy canvas rendering exposes no per-node DOM, so there is no locator-based route to graph state. `fitToView.ts` and `boundsUtils.ts` reach it the same way.

Third in a series from auditing the 1.53 → 1.54 QA plan against the suite:
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/17320
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/17384