### PR TITLE
test(group-node): assert widget values survive subgraph conversion

### DIFF
--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -43,21 +43,15 @@ test.describe('Group node migration', { tag: '@node' }, () => {
       )
     )
 
-    expect(
-      interiorValues.length,
-      'converted subgraph should expose interior widgets'
-    ).toBeGreaterThan(0)
-
-    expect(interiorValues).toContain(156680208700286)
-    expect(interiorValues).toContain('euler')
-    expect(interiorValues).toContain('v1-5-pruned-emaonly.ckpt')
-    expect(
-      interiorValues.some(
-        (value) =>
-          typeof value === 'string' && value.includes('purple galaxy bottle')
-      ),
-      'the positive prompt text should survive conversion'
-    ).toBe(true)
+    expect(interiorValues).toHaveLength(14)
+    expect(interiorValues).toEqual(
+      expect.arrayContaining([
+        156680208700286,
+        'euler',
+        'v1-5-pruned-emaonly.ckpt',
+        expect.stringContaining('purple galaxy bottle')
+      ])
+    )
   })
 
   test(

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -30,6 +30,36 @@ test.describe('Group node migration', { tag: '@node' }, () => {
     expect(state.hasGroupNodesExtra).toBe(false)
   })
 
+  test('Preserves group node widget values through subgraph conversion', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('groupnodes/group_node_v1.3.3')
+
+    const interiorValues = await comfyPage.page.evaluate(() =>
+      [...window.app!.graph.subgraphs.values()].flatMap((subgraph) =>
+        subgraph.nodes.flatMap(
+          (node) => node.widgets?.map((widget) => widget.value) ?? []
+        )
+      )
+    )
+
+    expect(
+      interiorValues.length,
+      'converted subgraph should expose interior widgets'
+    ).toBeGreaterThan(0)
+
+    expect(interiorValues).toContain(156680208700286)
+    expect(interiorValues).toContain('euler')
+    expect(interiorValues).toContain('v1-5-pruned-emaonly.ckpt')
+    expect(
+      interiorValues.some(
+        (value) =>
+          typeof value === 'string' && value.includes('purple galaxy bottle')
+      ),
+      'the positive prompt text should survive conversion'
+    ).toBe(true)
+  })
+
   test(
     'Loads a legacy ("/") separator group node without error and converts it',
     { tag: ['@vue-nodes'] },


### PR DESCRIPTION
## Summary

Asserts that group-node widget values survive the auto-conversion to subgraphs — the legacy-workflow half of https://github.com/Comfy-Org/ComfyUI_frontend/pull/17099 and https://github.com/Comfy-Org/ComfyUI_frontend/pull/15759, which currently has no coverage.

## Changes

- **What**: one test in `groupNode.spec.ts` → `Group node migration`.

## Review Focus

`groupNode.spec.ts` already loads `groupnodes/group_node_v1.3.3`, but asserts only three things: group-node instance count, subgraph count, and the `extra.groupNodes` flag. **A conversion that dropped or shifted every widget value would pass all three.** That is the hole.

The asset carries 14 widget values. The test asserts four distinctive ones survive on the converted subgraph's interior nodes — the seed `156680208700286`, `'euler'`, the checkpoint filename, and the positive prompt text. They are picked to be *shift-sensitive*: if a value lands on the wrong widget its type or content changes, not merely its index, so an off-by-one migration fails rather than silently passing.

`interiorValues.length > 0` is asserted first so an empty read cannot make the `toContain` checks vacuous.

Fourth in a series from auditing the 1.53 → 1.54 QA plan against the suite:
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/17320
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/17384
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/17390
