### PR TITLE
feat(models): a Docs link on the featured banner, per provider

### DIFF
--- a/apps/website/src/components/workshop/FeaturedBanner.test.ts
+++ b/apps/website/src/components/workshop/FeaturedBanner.test.ts
@@ -59,7 +59,7 @@ describe('FeaturedBanner', () => {
     render(FeaturedBanner, { props: { models: [base, kling] } })
     expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Flux')
     expect(screen.getByText('Text to Image')).toBeTruthy()
-    expect(screen.getByTestId('featured-slide').getAttribute('href')).toBe(
+    expect(screen.getByTestId('featured-slide-link').getAttribute('href')).toBe(
       '/models/flux/'
     )
   })
@@ -72,8 +72,21 @@ describe('FeaturedBanner', () => {
 
     expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Kling')
     expect(screen.getByText(kling.summary ?? '')).toBeTruthy()
-    expect(screen.getByTestId('featured-slide').getAttribute('href')).toBe(
+    expect(screen.getByTestId('featured-slide-link').getAttribute('href')).toBe(
       '/models/kling/'
+    )
+  })
+
+  it('keeps a name whose task label only matches mid-word', () => {
+    const midWord: WorkshopModel = {
+      ...base,
+      name: 'Context-to-Image',
+      slug: 'context',
+      href: '/models/context/'
+    }
+    render(FeaturedBanner, { props: { models: [midWord] } })
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
+      'Context-to-Image'
     )
   })
 

--- a/apps/website/src/components/workshop/FeaturedBanner.test.ts
+++ b/apps/website/src/components/workshop/FeaturedBanner.test.ts
@@ -77,17 +77,26 @@ describe('FeaturedBanner', () => {
     )
   })
 
-  it('keeps a name whose task label only matches mid-word', () => {
-    const midWord: WorkshopModel = {
-      ...base,
-      name: 'Context-to-Image',
-      slug: 'context',
-      href: '/models/context/'
+  it('shows the docs button only when the provider has a docs section', async () => {
+    const user = userEvent.setup()
+    const undocumented: WorkshopModel = {
+      ...kling,
+      slug: 'magnific',
+      name: 'Magnific',
+      href: '/models/magnific/',
+      provider: 'Magnific',
+      routerId: 'magnific/upscale'
     }
-    render(FeaturedBanner, { props: { models: [midWord] } })
-    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
-      'Context-to-Image'
+    render(FeaturedBanner, { props: { models: [base, undocumented] } })
+
+    const docs = screen.getByTestId('featured-docs-link')
+    expect(docs.getAttribute('href')).toBe(
+      'https://docs.comfy.org/development/comfy-router/models#black-forest-labs'
     )
+    expect(docs.getAttribute('target')).toBe('_blank')
+
+    await user.click(screen.getByRole('button', { name: 'Magnific' }))
+    expect(screen.queryByTestId('featured-docs-link')).toBeNull()
   })
 
   it('drops the pagination when there is nothing to page through', () => {

--- a/apps/website/src/components/workshop/FeaturedBanner.vue
+++ b/apps/website/src/components/workshop/FeaturedBanner.vue
@@ -27,6 +27,7 @@ const slides = computed(() =>
       model,
       task,
       name: bannerName(model.name, task),
+      docsHref: modelDocsHref(model),
       capabilities: model.capabilities.slice(0, CAPABILITY_LIMIT)
     }
   })
@@ -95,7 +96,8 @@ const fill = computed(() =>
     >
       <a
         :href="active.model.href"
-        :aria-label="active.name"
+        tabindex="-1"
+        aria-hidden="true"
         class="absolute inset-0"
         data-testid="featured-slide-link"
       ></a>
@@ -161,12 +163,12 @@ const fill = computed(() =>
             {{ t('workshop.hub.tryNow', locale) }}
           </Button>
           <Button
-            v-if="modelDocsHref(active.model)"
+            v-if="active.docsHref"
             as="a"
             variant="outline"
-            :href="modelDocsHref(active.model)"
+            :href="active.docsHref"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             class="w-fit"
             data-testid="featured-docs-link"
           >

--- a/apps/website/src/components/workshop/FeaturedBanner.vue
+++ b/apps/website/src/components/workshop/FeaturedBanner.vue
@@ -7,6 +7,7 @@ import { prefersReducedMotion } from '../../composables/useReducedMotion'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import { bannerName } from '../../lib/workshop/banner-name'
+import { modelDocsHref } from '../../lib/workshop/model-docs'
 import { taskLabelFor } from '../../lib/workshop/task-label'
 import Badge from '../ui/badge/Badge.vue'
 import Button from '@/components/ui/button/Button.vue'
@@ -88,16 +89,21 @@ const fill = computed(() =>
     class="rounded-4.5xl relative isolate overflow-hidden border border-transparency-white-t8"
     data-testid="section-featured"
   >
-    <a
-      :href="active.model.href"
-      class="group short:h-57 sm:short:h-60 block h-100"
+    <div
+      class="group short:h-57 sm:short:h-60 relative block h-100"
       data-testid="featured-slide"
     >
+      <a
+        :href="active.model.href"
+        :aria-label="active.name"
+        class="absolute inset-0"
+        data-testid="featured-slide-link"
+      ></a>
       <video
         v-if="active.model.thumbnail?.kind === 'video'"
         :key="active.model.slug"
         :src="active.model.thumbnail.url"
-        class="absolute inset-0 size-full object-cover"
+        class="pointer-events-none absolute inset-0 size-full object-cover"
         aria-hidden="true"
         muted
         loop
@@ -111,16 +117,16 @@ const fill = computed(() =>
         :key="active.model.slug"
         :src="active.model.thumbnailUrl"
         alt=""
-        class="absolute inset-0 size-full object-cover"
+        class="pointer-events-none absolute inset-0 size-full object-cover"
         decoding="async"
       />
       <div
-        class="from-page via-page/85 to-page/20 sm:via-page/80 absolute inset-0 bg-linear-to-t sm:bg-linear-to-r sm:to-transparent"
+        class="from-page via-page/85 to-page/20 sm:via-page/80 pointer-events-none absolute inset-0 bg-linear-to-t sm:bg-linear-to-r sm:to-transparent"
         aria-hidden="true"
       />
 
       <div
-        class="short:gap-3 short:pt-5 short:pb-14 relative flex h-full flex-col justify-end gap-4 p-8 pt-6 pb-16 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pt-8 lg:pb-18"
+        class="short:gap-3 short:pt-5 short:pb-14 pointer-events-none relative flex h-full flex-col justify-end gap-4 p-8 pt-6 pb-16 max-sm:gap-3 max-sm:p-6 max-sm:pb-14 sm:max-w-2xl sm:justify-center lg:p-12 lg:pt-8 lg:pb-18"
       >
         <div class="flex flex-wrap items-center gap-2">
           <Badge variant="subtle" size="md" class="text-primary-comfy-canvas">
@@ -150,11 +156,25 @@ const fill = computed(() =>
           {{ active.model.summary }}
         </p>
 
-        <Button as="span" class="w-fit">
-          {{ t('workshop.hub.tryNow', locale) }}
-        </Button>
+        <div class="pointer-events-auto flex w-fit items-center gap-3">
+          <Button as="a" :href="active.model.href" class="w-fit">
+            {{ t('workshop.hub.tryNow', locale) }}
+          </Button>
+          <Button
+            v-if="modelDocsHref(active.model)"
+            as="a"
+            variant="outline"
+            :href="modelDocsHref(active.model)"
+            target="_blank"
+            rel="noopener"
+            class="w-fit"
+            data-testid="featured-docs-link"
+          >
+            {{ t('workshop.hub.docs', locale) }}
+          </Button>
+        </div>
       </div>
-    </a>
+    </div>
 
     <div
       v-if="slides.length > 1"

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Download } from '@lucide/vue'
+import { Download, ExternalLink } from '@lucide/vue'
 import { useMounted, useTimestamp } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, useSlots, watch } from 'vue'
 
@@ -37,6 +37,7 @@ import { createWorkshopUrlUploader } from '../../config/workshop-url-upload'
 import { WorkshopRouterError } from '../../config/workshop-router-errors'
 import { releaseRouterOutputs } from '../../config/workshop-response'
 import { retainRunHistory } from '../../config/workshop-run-history'
+import { modelDocsHref } from '../../lib/workshop/model-docs'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import { workshopIdempotencyKey } from '../../config/workshop-snippets'
 import type { Locale, TranslationKey } from '../../i18n/translations'
@@ -404,34 +405,49 @@ function useInCode() {
 <template>
   <div class="flex flex-col gap-10" data-testid="model-detail">
     <div
-      role="tablist"
-      :aria-label="t('workshop.title', locale)"
-      class="flex scrollbar-hide gap-8 overflow-x-auto border-b border-transparency-white-t8 max-sm:gap-5"
-      data-testid="model-tabs"
-      @keydown="onTabKeydown"
+      class="flex items-center gap-8 border-b border-transparency-white-t8 max-sm:gap-5"
     >
-      <button
-        v-for="section in sections"
-        :id="`tab-${section}`"
-        :key="section"
-        type="button"
-        role="tab"
-        :aria-selected="section === activeSection"
-        :aria-controls="`panel-${section}`"
-        :tabindex="section === activeSection ? 0 : -1"
-        :data-testid="`tab-${section}`"
-        :class="
-          cn(
-            'cursor-pointer border-b-2 pb-3 text-sm font-bold tracking-wider uppercase transition-colors',
-            section === activeSection
-              ? 'border-primary-comfy-yellow text-primary-warm-white'
-              : 'border-transparent text-primary-warm-gray hover:text-primary-warm-white'
-          )
-        "
-        @click="activeSection = section"
+      <div
+        role="tablist"
+        :aria-label="t('workshop.title', locale)"
+        class="flex scrollbar-hide min-w-0 gap-8 overflow-x-auto max-sm:gap-5"
+        data-testid="model-tabs"
+        @keydown="onTabKeydown"
       >
-        {{ t(sectionLabel[section], locale) }}
-      </button>
+        <button
+          v-for="section in sections"
+          :id="`tab-${section}`"
+          :key="section"
+          type="button"
+          role="tab"
+          :aria-selected="section === activeSection"
+          :aria-controls="`panel-${section}`"
+          :tabindex="section === activeSection ? 0 : -1"
+          :data-testid="`tab-${section}`"
+          :class="
+            cn(
+              'cursor-pointer border-b-2 pb-3 text-sm font-bold tracking-wider uppercase transition-colors',
+              section === activeSection
+                ? 'border-primary-comfy-yellow text-primary-warm-white'
+                : 'border-transparent text-primary-warm-gray hover:text-primary-warm-white'
+            )
+          "
+          @click="activeSection = section"
+        >
+          {{ t(sectionLabel[section], locale) }}
+        </button>
+      </div>
+      <a
+        v-if="modelDocsHref(model)"
+        :href="modelDocsHref(model)"
+        target="_blank"
+        rel="noopener"
+        class="hover:text-primary-comfy-yellow ml-auto inline-flex shrink-0 items-center gap-1.5 pb-3 text-sm font-bold tracking-wider whitespace-nowrap text-primary-warm-white uppercase transition-colors"
+        data-testid="model-docs-link"
+      >
+        {{ t('workshop.hub.docs', locale) }}
+        <ExternalLink class="size-4" aria-hidden="true" />
+      </a>
     </div>
 
     <section

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -168,6 +168,7 @@ const authEnabled = useWorkshopAuthFlag()
 const authFlagSettled = useWorkshopAuthFlagSettled()
 const mounted = useMounted()
 const signInHref = useSignInHref(locale)
+const docsHref = modelDocsHref(model)
 const gate = computed(() => {
   if (
     model.incompleteReason ||
@@ -438,10 +439,10 @@ function useInCode() {
         </button>
       </div>
       <a
-        v-if="modelDocsHref(model)"
-        :href="modelDocsHref(model)"
+        v-if="docsHref"
+        :href="docsHref"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         class="hover:text-primary-comfy-yellow ml-auto inline-flex shrink-0 items-center gap-1.5 pb-3 text-sm font-bold tracking-wider whitespace-nowrap text-primary-warm-white uppercase transition-colors"
         data-testid="model-docs-link"
       >

--- a/apps/website/src/components/workshop/TagOverflow.test.ts
+++ b/apps/website/src/components/workshop/TagOverflow.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import TagOverflow from './TagOverflow.vue'
+
+const tags = [
+  { label: 'Upscale', href: '/models/?capability=Upscale' },
+  { label: 'Inpainting', href: '/models/?capability=Inpainting' }
+]
+
+describe('TagOverflow', () => {
+  it('opens on click and links every overflow tag', async () => {
+    const user = userEvent.setup()
+    render(TagOverflow, { props: { tags } })
+
+    const trigger = screen.getByTestId('model-tags-rest')
+    expect(trigger.textContent.trim()).toBe('+2')
+    expect(screen.queryByTestId('model-tags-rest-list')).toBeNull()
+
+    await user.click(trigger)
+
+    const links = screen.getAllByRole('link')
+    expect(links.map((link) => link.getAttribute('href'))).toEqual(
+      tags.map((tag) => tag.href)
+    )
+  })
+
+  it('closes again on Escape', async () => {
+    const user = userEvent.setup()
+    render(TagOverflow, { props: { tags } })
+
+    await user.click(screen.getByTestId('model-tags-rest'))
+    const list = screen.getByTestId('model-tags-rest-list')
+
+    await user.keyboard('{Escape}')
+    expect(list.getAttribute('data-state')).toBe('closed')
+  })
+})

--- a/apps/website/src/components/workshop/TagOverflow.vue
+++ b/apps/website/src/components/workshop/TagOverflow.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import {
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardRoot,
+  HoverCardTrigger
+} from 'reka-ui'
+
+// The hero's +N: the same hover card the catalogue's TagRow gives its
+// overflow, for tags that carry their own hrefs. A native title tooltip is
+// what this replaces.
+const { tags } = defineProps<{
+  tags: readonly { label: string; href: string }[]
+}>()
+
+// HoverCard ignores touch pointers by design, so a tap toggles it by hand -
+// otherwise the overflow tags are unreachable on phones.
+const open = ref(false)
+
+const pill =
+  'inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap text-primary-comfy-canvas'
+</script>
+
+<template>
+  <HoverCardRoot v-model:open="open" :open-delay="120">
+    <HoverCardTrigger
+      as="button"
+      type="button"
+      :aria-label="tags.map((tag) => tag.label).join(', ')"
+      :class="`${pill} cursor-default text-primary-comfy-canvas/70 tabular-nums`"
+      data-testid="model-tags-rest"
+      @click.prevent="open = !open"
+    >
+      +{{ tags.length }}
+    </HoverCardTrigger>
+    <HoverCardPortal>
+      <HoverCardContent
+        side="top"
+        align="end"
+        :side-offset="6"
+        class="bg-site-dropdown z-50 flex max-w-64 flex-col gap-1.5 rounded-2xl border border-white/10 p-2 shadow-2xl shadow-black/50"
+        data-testid="model-tags-rest-list"
+      >
+        <a
+          v-for="tag in tags"
+          :key="tag.href"
+          :href="tag.href"
+          :class="`${pill} hover:text-primary-comfy-yellow w-full justify-start transition-colors hover:bg-transparency-white-t20`"
+        >
+          {{ tag.label }}
+        </a>
+      </HoverCardContent>
+    </HoverCardPortal>
+  </HoverCardRoot>
+</template>

--- a/apps/website/src/components/workshop/TagOverflow.vue
+++ b/apps/website/src/components/workshop/TagOverflow.vue
@@ -1,57 +1,53 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-
+import { cn } from '@comfyorg/tailwind-utils'
 import {
-  HoverCardContent,
-  HoverCardPortal,
-  HoverCardRoot,
-  HoverCardTrigger
+  PopoverContent,
+  PopoverPortal,
+  PopoverRoot,
+  PopoverTrigger
 } from 'reka-ui'
 
-// The hero's +N: the same hover card the catalogue's TagRow gives its
-// overflow, for tags that carry their own hrefs. A native title tooltip is
-// what this replaces.
 const { tags } = defineProps<{
   tags: readonly { label: string; href: string }[]
 }>()
 
-// HoverCard ignores touch pointers by design, so a tap toggles it by hand -
-// otherwise the overflow tags are unreachable on phones.
-const open = ref(false)
-
 const pill =
-  'inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap text-primary-comfy-canvas'
+  'inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap'
 </script>
 
 <template>
-  <HoverCardRoot v-model:open="open" :open-delay="120">
-    <HoverCardTrigger
-      as="button"
-      type="button"
+  <PopoverRoot>
+    <PopoverTrigger
       :aria-label="tags.map((tag) => tag.label).join(', ')"
-      :class="`${pill} cursor-default text-primary-comfy-canvas/70 tabular-nums`"
+      :class="
+        cn(pill, 'cursor-pointer text-primary-comfy-canvas/70 tabular-nums')
+      "
       data-testid="model-tags-rest"
-      @click.prevent="open = !open"
     >
       +{{ tags.length }}
-    </HoverCardTrigger>
-    <HoverCardPortal>
-      <HoverCardContent
+    </PopoverTrigger>
+    <PopoverPortal>
+      <PopoverContent
         side="top"
         align="end"
         :side-offset="6"
-        class="bg-site-dropdown z-50 flex max-w-64 flex-col gap-1.5 rounded-2xl border border-white/10 p-2 shadow-2xl shadow-black/50"
+        class="bg-site-dropdown z-50 flex max-w-64 flex-col gap-1.5 rounded-2xl border border-white/10 p-2 shadow-2xl shadow-black/50 outline-none"
         data-testid="model-tags-rest-list"
       >
         <a
           v-for="tag in tags"
           :key="tag.href"
           :href="tag.href"
-          :class="`${pill} hover:text-primary-comfy-yellow w-full justify-start transition-colors hover:bg-transparency-white-t20`"
+          :class="
+            cn(
+              pill,
+              'hover:text-primary-comfy-yellow w-full justify-start text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t20'
+            )
+          "
         >
           {{ tag.label }}
         </a>
-      </HoverCardContent>
-    </HoverCardPortal>
-  </HoverCardRoot>
+      </PopoverContent>
+    </PopoverPortal>
+  </PopoverRoot>
 </template>

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -184,6 +184,8 @@ export const externalLinks = {
   docsUpdateComfyUI: 'https://docs.comfy.org/installation/update_comfyui',
   docsComfyRouter:
     'https://docs.comfy.org/development/comfy-router/quickstart#comfy-router-quickstart',
+  docsComfyRouterModels:
+    'https://docs.comfy.org/development/comfy-router/models',
   docsPlatform: 'https://docs.comfy.org/development/overview',
   docsPlatformExamples: 'https://docs.comfy.org/platform/examples',
   docsSdk: 'https://docs.comfy.org/development/api-development/sdks',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9910,6 +9910,7 @@ Enterprise`
   'workshop.hub.facets.noResults': { en: 'No matches', 'zh-CN': '无匹配' },
   'workshop.hub.models': { en: 'Model', 'zh-CN': '模型' },
   'workshop.hub.categories': { en: 'CATEGORIES', 'zh-CN': '分类' },
+  'workshop.hub.docs': { en: 'Read docs', 'zh-CN': '阅读文档' },
   'workshop.hub.tryNow': { en: 'Try now', 'zh-CN': '立即试用' },
   'workshop.hub.tag.partnerNodes': {
     en: 'Partner Nodes',

--- a/apps/website/src/lib/workshop/model-docs.test.ts
+++ b/apps/website/src/lib/workshop/model-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import routerIndex from '../../content/workshop-router-index.json'
 import { modelDocsHref } from './model-docs'
 
 const DOCS = 'https://docs.comfy.org/development/comfy-router/models'
@@ -27,6 +28,17 @@ describe('modelDocsHref', () => {
     expect(
       modelDocsHref({ provider: 'Luma', routerId: 'luma_2/dream-machine' })
     ).toBe(`${DOCS}#luma-2`)
+  })
+
+  it('maps every provider in the Router index or lists it as undocumented', () => {
+    const prefixes = new Set(
+      routerIndex.map((entry) => entry.id.split('/')[0] ?? '')
+    )
+    const undocumented: string[] = []
+    for (const prefix of prefixes) {
+      if (!modelDocsHref({ routerId: `${prefix}/x` }))
+        expect(undocumented).toContain(prefix)
+    }
   })
 
   it('offers no link for a provider the docs do not cover', () => {

--- a/apps/website/src/lib/workshop/model-docs.test.ts
+++ b/apps/website/src/lib/workshop/model-docs.test.ts
@@ -30,6 +30,13 @@ describe('modelDocsHref', () => {
     ).toBe(`${DOCS}#luma-2`)
   })
 
+  it('sends the special Router prefixes to their own sections', () => {
+    expect(modelDocsHref({ routerId: 'gemini-interactions/omni-1.1' })).toBe(
+      `${DOCS}#gemini-interactions`
+    )
+    expect(modelDocsHref({ routerId: 'vertexai/veo-3' })).toBe(`${DOCS}#google`)
+  })
+
   it('maps every provider in the Router index or lists it as undocumented', () => {
     const prefixes = new Set(
       routerIndex.map((entry) => entry.id.split('/')[0] ?? '')

--- a/apps/website/src/lib/workshop/model-docs.test.ts
+++ b/apps/website/src/lib/workshop/model-docs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { modelDocsHref } from './model-docs'
+
+const DOCS = 'https://docs.comfy.org/development/comfy-router/models'
+
+describe('modelDocsHref', () => {
+  it('links a model through its Router id or its display name', () => {
+    expect(
+      modelDocsHref({ provider: 'Black Forest Labs', routerId: 'bfl/flux' })
+    ).toBe(`${DOCS}#black-forest-labs`)
+    expect(modelDocsHref({ provider: 'Black Forest Labs' })).toBe(
+      `${DOCS}#black-forest-labs`
+    )
+    expect(modelDocsHref({ provider: 'xAI', routerId: 'xai/grok-image' })).toBe(
+      `${DOCS}#xai`
+    )
+    expect(
+      modelDocsHref({ provider: 'Lightricks', routerId: 'ltx/ltx-2' })
+    ).toBe(`${DOCS}#ltx`)
+  })
+
+  it('keeps Luma and Luma 2 distinct via the raw provider slug', () => {
+    expect(
+      modelDocsHref({ provider: 'Luma', routerId: 'luma/dream-machine' })
+    ).toBe(`${DOCS}#luma`)
+    expect(
+      modelDocsHref({ provider: 'Luma', routerId: 'luma_2/dream-machine' })
+    ).toBe(`${DOCS}#luma-2`)
+  })
+
+  it('offers no link for a provider the docs do not cover', () => {
+    expect(modelDocsHref({ provider: 'Magnific' })).toBeUndefined()
+    expect(
+      modelDocsHref({ provider: 'Sync Labs', routerId: 'synclabs/lipsync' })
+    ).toBeUndefined()
+    expect(modelDocsHref({ provider: 'constructor' })).toBeUndefined()
+    expect(modelDocsHref({})).toBeUndefined()
+  })
+})

--- a/apps/website/src/lib/workshop/model-docs.ts
+++ b/apps/website/src/lib/workshop/model-docs.ts
@@ -28,6 +28,7 @@ const ANCHORS: Readonly<Record<string, string>> = {
   fal: 'fal',
   freepik: 'freepik',
   gemini: 'google',
+  geminiinteractions: 'gemini-interactions',
   google: 'google',
   grok: 'xai',
   heygen: 'heygen',
@@ -49,6 +50,7 @@ const ANCHORS: Readonly<Record<string, string>> = {
   tencent: 'tencent',
   tencenthunyuan3d: 'tencent',
   veo: 'veo',
+  vertexai: 'google',
   wan: 'wan',
   wavespeed: 'wavespeed',
   xai: 'xai'

--- a/apps/website/src/lib/workshop/model-docs.ts
+++ b/apps/website/src/lib/workshop/model-docs.ts
@@ -1,0 +1,71 @@
+import type { WorkshopModel } from '../../config/models-catalogue'
+
+/**
+ * Where a model's docs live. The Router docs page carries one section per
+ * provider; the ids below are verified against the live page. Providers
+ * without a section get no link at all — a docs button that lands on the
+ * page top with the model nowhere in sight is worse than none.
+ *
+ * Keys are normalized (lowercased, non-alphanumerics stripped), because the
+ * lookup speaks two vocabularies: the Router id's raw provider slug ("bfl",
+ * "xai", "luma_2") and the display name shown on the model ("Black Forest
+ * Labs", "xAI"). The raw slug is tried first — it is the only place "Luma"
+ * and "Luma 2" stay distinct. A new model under a known provider needs
+ * nothing; a new provider needs one line here once its docs section exists.
+ */
+const DOCS_URL = 'https://docs.comfy.org/development/comfy-router/models'
+
+const ANCHORS: Readonly<Record<string, string>> = {
+  anthropic: 'anthropic',
+  beeble: 'beeble',
+  bfl: 'black-forest-labs',
+  blackforestlabs: 'black-forest-labs',
+  bria: 'bria',
+  bytedance: 'byteplus',
+  byteplus: 'byteplus',
+  byteplusmediakit: 'byteplus',
+  elevenlabs: 'elevenlabs',
+  fal: 'fal',
+  freepik: 'freepik',
+  gemini: 'google',
+  google: 'google',
+  grok: 'xai',
+  heygen: 'heygen',
+  ideogram: 'ideogram',
+  kling: 'kling',
+  krea: 'krea',
+  lightricks: 'ltx',
+  ltx: 'ltx',
+  ltxv: 'ltx',
+  luma: 'luma',
+  luma2: 'luma-2',
+  meshy: 'meshy',
+  minimax: 'minimax',
+  moonvalley: 'moonvalley',
+  openai: 'openai',
+  qwen: 'qwen',
+  recraft: 'recraft',
+  runway: 'runway',
+  tencent: 'tencent',
+  tencenthunyuan3d: 'tencent',
+  veo: 'veo',
+  wan: 'wan',
+  wavespeed: 'wavespeed',
+  xai: 'xai'
+}
+
+function anchorFor(provider: string): string | undefined {
+  const key = provider.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return Object.hasOwn(ANCHORS, key) ? ANCHORS[key] : undefined
+}
+
+export function modelDocsHref(model: {
+  readonly provider?: string
+  readonly routerId?: WorkshopModel['routerId']
+}): string | undefined {
+  const rawProvider = model.routerId?.split('/')[0]
+  const anchor =
+    (rawProvider ? anchorFor(rawProvider) : undefined) ??
+    (model.provider ? anchorFor(model.provider) : undefined)
+  return anchor ? `${DOCS_URL}#${anchor}` : undefined
+}

--- a/apps/website/src/lib/workshop/model-docs.ts
+++ b/apps/website/src/lib/workshop/model-docs.ts
@@ -1,4 +1,5 @@
 import type { WorkshopModel } from '../../config/models-catalogue'
+import { externalLinks } from '../../config/routes'
 
 /**
  * Where a model's docs live. The Router docs page carries one section per
@@ -13,7 +14,7 @@ import type { WorkshopModel } from '../../config/models-catalogue'
  * and "Luma 2" stay distinct. A new model under a known provider needs
  * nothing; a new provider needs one line here once its docs section exists.
  */
-const DOCS_URL = 'https://docs.comfy.org/development/comfy-router/models'
+const DOCS_URL = externalLinks.docsComfyRouterModels
 
 const ANCHORS: Readonly<Record<string, string>> = {
   anthropic: 'anthropic',

--- a/apps/website/src/routes/models/[slug].astro
+++ b/apps/website/src/routes/models/[slug].astro
@@ -10,6 +10,7 @@ import WorkshopModelCard from '../../components/workshop/WorkshopModelCard.vue'
 import { getRoutes } from '../../config/routes'
 import { catalogSearch } from '../../config/models-catalogue'
 import { routerWorkshopModelPaths } from '../../config/workshop-browse-content'
+import TagOverflow from '../../components/workshop/TagOverflow.vue'
 import { t } from '../../i18n/translations'
 import { prepareModelPage } from './model-page'
 
@@ -56,7 +57,7 @@ const restTagCount = restTags.length
       </ol>
     </nav>
     <header class="mb-12 sm:mx-8 lg:mx-10" data-testid="model-hero">
-      <div class="flex flex-col gap-6 pr-8 lg:flex-row lg:items-end lg:justify-between lg:pr-10">
+      <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
         <div class="flex max-w-2xl flex-col gap-4">
           <div class="flex flex-wrap items-center gap-3">
             <p
@@ -116,13 +117,13 @@ const restTagCount = restTags.length
               ))}
               {restTagCount > 0 && (
                 <li>
-                  <span
-                    class="inline-flex h-7 shrink-0 items-center rounded-full bg-transparency-white-t8 px-3 text-xs leading-none whitespace-nowrap text-primary-comfy-canvas/70"
-                    title={restTags.map((tag) => tag.label).join(', ')}
-                    data-testid="model-tags-rest"
-                  >
-                    +{restTagCount}
-                  </span>
+                  <TagOverflow
+                    client:visible
+                    tags={restTags.map((tag) => ({
+                      label: tag.label,
+                      href: `${routes.workshop}${tag.search}`
+                    }))}
+                  />
                 </li>
               )}
             </ul>


### PR DESCRIPTION
Robin's suggestion: each featured slide gets a **Docs** link beside Try now, pointing at the provider's section of the [Router models docs](https://docs.comfy.org/development/comfy-router/models). A provider without a docs section gets **no button** — landing on the page top with the model nowhere in sight is worse than none. The model page's tab row gets the same link, with the external marker; the banner button is deliberately marker-less.

`modelDocsHref` lives in `lib/workshop/model-docs.ts`: the lookup tries the Router id's raw provider prefix first (the only place Luma and Luma 2 stay distinct), then the display name. `gemini-interactions/*` and `vertexai/*` map explicitly, and a test walks the whole Router index so a new unmapped provider fails loudly. The URL lives in `externalLinks` with the other docs links; both links carry `noopener noreferrer`.

Structurally the slide un-nests: the banner was one `<a>` and a link can't contain a link. A stretched link keeps the full surface clickable (image and gradient pass pointers through), Try now is a real link, and the stretched link sits out of the tab order — its focus ring was clipped invisible, and Try now is the keyboard path.

Also here (should arguably have been its own PR — flagging rather than splitting at this point): the hero's `+N` tag overflow becomes a reka **Popover** with the overflow tags as links. Review moved it from a HoverCard: hover fought the click toggle, touch never opened it, and the portaled links could not be tabbed to. Tests cover open, links, and Escape.

Base: `comfydesigner/models-catalogue-sizing`.
