### PR TITLE
ci: raise playwright-tests job timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -128,8 +128,8 @@ jobs:
           if-no-files-found: warn
 
   playwright-tests:
-    # Ideally, each shard runs test in 6 minutes, but allow up to 15 minutes
-    timeout-minutes: 15
+    # Ideally, each shard runs test in 6 minutes, but allow up to 30 minutes
+    timeout-minutes: 30
     needs: setup
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
- Raises the `playwright-tests` job timeout from 15 to 30 minutes.
- Two cloud jobs hit the 15-minute limit; a retry passed in 9m43s.
- Workflow-only change; no product behavior changes.

<details><summary>Full context for agent readers</summary>

The cloud Playwright matrix job is being cancelled on busy runners at the current 15-minute job timeout:

- [Run 34530402021](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34530402021): workflow completed with `cancelled`; `playwright-tests (cloud)` ran from `2026-09-10T21:10:55Z` to `2026-09-10T21:26:03Z` (15m08s) and was cancelled.
- [Run 34533933890](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34533933890): workflow completed with `cancelled`; `playwright-tests (cloud)` ran from `2026-09-10T21:48:50Z` to `2026-09-10T22:03:57Z` (15m07s) and was cancelled.
- [Retry run 34534098124](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34534098124): workflow completed with `success`; `playwright-tests (cloud)` ran from `2026-09-10T21:50:29Z` to `2026-09-10T22:00:12Z` (9m43s) and passed.

This keeps the existing test matrix unchanged and gives transiently slow cloud runs enough time to finish.

Validation: inspected the workflow diff and verified the three GitHub Actions run outcomes and cloud-job timestamps through the GitHub CLI.

</details>
