### PR TITLE
test: ban partial module mocks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -143,7 +143,7 @@
         "**/{__test__,__tests__,__fixtures__}/**/*.{ts,tsx}"
       ],
       "rules": {
-        "comfy/no-import-actual": "warn",
+        "comfy/no-import-actual": "error",
         "comfy/use-global-pinia": "error"
       }
     },

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -143,6 +143,7 @@
         "**/{__test__,__tests__,__fixtures__}/**/*.{ts,tsx}"
       ],
       "rules": {
+        "comfy/no-import-actual": "warn",
         "comfy/use-global-pinia": "error"
       }
     },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -74,6 +74,7 @@
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/user-event": "catalog:",
     "@testing-library/vue": "catalog:",
+    "@total-typescript/shoehorn": "catalog:",
     "@types/leaflet": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
     "astro": "catalog:",

--- a/apps/website/scripts/router-gemini-video.test.ts
+++ b/apps/website/scripts/router-gemini-video.test.ts
@@ -1,17 +1,13 @@
 import { expect, it, vi } from 'vitest'
 
 import { prepareModelRouterRender } from '../src/config/router-render'
-import { loadWorkshopExampleFile } from '../src/config/workshop-example-file'
+import { loadWorkshopExampleFile } from '../src/config/workshop-example-file-loader'
 import { getRouterWorkshopModelDetail } from '../src/config/workshop-router-content'
 import { prepareWorkshopRequestCallback } from '../src/config/workshop-request-callbacks'
 
-vi.mock(
-  import('../src/config/workshop-example-file'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    loadWorkshopExampleFile: vi.fn()
-  })
-)
+vi.mock(import('../src/config/workshop-example-file-loader'), () => ({
+  loadWorkshopExampleFile: vi.fn()
+}))
 
 it.for([{}, { image_url: 'https://example.com/still.png' }])(
   'rejects an edit without source video even when an image is present',

--- a/apps/website/scripts/router-render.test.ts
+++ b/apps/website/scripts/router-render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { loadWorkshopExampleFile } from '../src/config/workshop-example-file'
+import { loadWorkshopExampleFile } from '../src/config/workshop-example-file-loader'
 import { runWorkshopRouter } from '../src/config/workshop-router'
 import { WorkshopRouterError } from '../src/config/workshop-router-errors'
 import {
@@ -9,18 +9,13 @@ import {
   router_render
 } from './router-render'
 
-vi.mock(import('../src/config/workshop-router'), async (importOriginal) => ({
-  ...(await importOriginal()),
+vi.mock(import('../src/config/workshop-router'), () => ({
   runWorkshopRouter: vi.fn()
 }))
 
-vi.mock(
-  import('../src/config/workshop-example-file'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    loadWorkshopExampleFile: vi.fn()
-  })
-)
+vi.mock(import('../src/config/workshop-example-file-loader'), () => ({
+  loadWorkshopExampleFile: vi.fn()
+}))
 
 describe('router_render', () => {
   it.for([

--- a/apps/website/src/components/auth/AuthEmailForm.test.ts
+++ b/apps/website/src/components/auth/AuthEmailForm.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
-import { render, screen, waitFor } from '@testing-library/vue'
+import type { RenderOptions } from '@testing-library/vue'
+import { render as testingRender, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { defineComponent, h, onMounted } from 'vue'
 
 import AuthEmailForm from './AuthEmailForm.vue'
 
@@ -10,28 +11,32 @@ const widgetBehavior = vi.hoisted(() => ({
   mode: 'silent' as 'silent' | 'unavailable' | 'token',
   reset: vi.fn()
 }))
-vi.mock<unknown>(import('@comfyorg/account/vue'), async (importOriginal) => {
-  const { h, onMounted } = await import('vue')
-  return {
-    ...(await (importOriginal as () => Promise<object>)()),
-    TurnstileWidget: defineComponent({
-      name: 'TurnstileWidgetStub',
-      emits: ['update:token', 'update:unavailable'],
-      setup(_, { emit, expose }) {
-        expose({ reset: widgetBehavior.reset })
-        onMounted(() => {
-          if (widgetBehavior.mode === 'unavailable') {
-            emit('update:unavailable', true)
-          }
-          if (widgetBehavior.mode === 'token') {
-            emit('update:token', 'cf-token')
-          }
-        })
-        return () => h('div', { 'data-testid': 'turnstile-stub' })
+const turnstileWidgetStub = defineComponent({
+  name: 'TurnstileWidgetStub',
+  emits: ['update:token', 'update:unavailable'],
+  setup(_, { emit, expose }) {
+    expose({ reset: widgetBehavior.reset })
+    onMounted(() => {
+      if (widgetBehavior.mode === 'unavailable') {
+        emit('update:unavailable', true)
+      }
+      if (widgetBehavior.mode === 'token') {
+        emit('update:token', 'cf-token')
       }
     })
+    return () => h('div', { 'data-testid': 'turnstile-stub' })
   }
 })
+
+function render<C>(component: C, options?: RenderOptions<C>) {
+  return testingRender(component, {
+    ...options,
+    global: {
+      ...options?.global,
+      stubs: { TurnstileWidget: turnstileWidgetStub }
+    }
+  })
+}
 
 vi.mock<unknown>(import('../../scripts/posthog'), async () => {
   const { ref } = await import('vue')

--- a/apps/website/src/components/auth/AuthEmailForm.test.ts
+++ b/apps/website/src/components/auth/AuthEmailForm.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
-import type { RenderOptions } from '@testing-library/vue'
-import { render as testingRender, screen, waitFor } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, onMounted } from 'vue'
+
+import type {
+  TurnstileApi,
+  TurnstileRenderOptions
+} from '@comfyorg/account/turnstileScript'
 
 import AuthEmailForm from './AuthEmailForm.vue'
 
@@ -11,32 +14,18 @@ const widgetBehavior = vi.hoisted(() => ({
   mode: 'silent' as 'silent' | 'unavailable' | 'token',
   reset: vi.fn()
 }))
-const turnstileWidgetStub = defineComponent({
-  name: 'TurnstileWidgetStub',
-  emits: ['update:token', 'update:unavailable'],
-  setup(_, { emit, expose }) {
-    expose({ reset: widgetBehavior.reset })
-    onMounted(() => {
-      if (widgetBehavior.mode === 'unavailable') {
-        emit('update:unavailable', true)
-      }
-      if (widgetBehavior.mode === 'token') {
-        emit('update:token', 'cf-token')
-      }
-    })
-    return () => h('div', { 'data-testid': 'turnstile-stub' })
-  }
-})
+const turnstileApi = vi.hoisted(
+  () =>
+    ({
+      render: vi.fn(),
+      reset: widgetBehavior.reset,
+      remove: vi.fn()
+    }) satisfies TurnstileApi
+)
 
-function render<C>(component: C, options?: RenderOptions<C>) {
-  return testingRender(component, {
-    ...options,
-    global: {
-      ...options?.global,
-      stubs: { TurnstileWidget: turnstileWidgetStub }
-    }
-  })
-}
+vi.mock(import('@comfyorg/account/turnstileScript'), () => ({
+  loadTurnstile: () => Promise.resolve(turnstileApi)
+}))
 
 vi.mock<unknown>(import('../../scripts/posthog'), async () => {
   const { ref } = await import('vue')
@@ -49,6 +38,17 @@ const submitButton = (name: RegExp) =>
 beforeEach(() => {
   widgetBehavior.mode = 'silent'
   widgetBehavior.reset.mockReset()
+  turnstileApi.render.mockImplementation(
+    (_container: string | HTMLElement, options: TurnstileRenderOptions) => {
+      if (widgetBehavior.mode === 'unavailable') {
+        options['error-callback']?.()
+      }
+      if (widgetBehavior.mode === 'token') {
+        options.callback?.('cf-token')
+      }
+      return 'widget-id'
+    }
+  )
 })
 
 describe('AuthEmailForm sign-in', () => {

--- a/apps/website/src/components/auth/AuthSignIn.test.ts
+++ b/apps/website/src/components/auth/AuthSignIn.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment happy-dom
-import { render, screen, waitFor } from '@testing-library/vue'
+import type { RenderOptions } from '@testing-library/vue'
+import { render as testingRender, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, onMounted } from 'vue'
 
 import { AUTH_ERROR_MESSAGES } from '@comfyorg/account/firebaseAuthError'
 
@@ -47,20 +49,24 @@ vi.mock<unknown>(import('../../scripts/posthog'), async () => {
   }
 })
 
-vi.mock<unknown>(import('@comfyorg/account/vue'), async (importOriginal) => {
-  const { defineComponent, h, onMounted } = await import('vue')
-  return {
-    ...(await (importOriginal as () => Promise<object>)()),
-    TurnstileWidget: defineComponent({
-      emits: ['update:token', 'update:unavailable'],
-      setup(_, { emit, expose }) {
-        expose({ reset: handles.turnstileReset })
-        onMounted(() => emit('update:token', 'cf-token'))
-        return () => h('div', { 'data-testid': 'turnstile' })
-      }
-    })
+const turnstileWidgetStub = defineComponent({
+  emits: ['update:token', 'update:unavailable'],
+  setup(_, { emit, expose }) {
+    expose({ reset: handles.turnstileReset })
+    onMounted(() => emit('update:token', 'cf-token'))
+    return () => h('div', { 'data-testid': 'turnstile' })
   }
 })
+
+function render<C>(component: C, options?: RenderOptions<C>) {
+  return testingRender(component, {
+    ...options,
+    global: {
+      ...options?.global,
+      stubs: { TurnstileWidget: turnstileWidgetStub }
+    }
+  })
+}
 
 vi.mock<unknown>(import('@comfyorg/account/webviewDetection'), () => ({
   isEmbeddedWebView: () => handles.embedded

--- a/apps/website/src/components/auth/AuthSignIn.test.ts
+++ b/apps/website/src/components/auth/AuthSignIn.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment happy-dom
-import type { RenderOptions } from '@testing-library/vue'
-import { render as testingRender, screen, waitFor } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, onMounted } from 'vue'
 
 import { AUTH_ERROR_MESSAGES } from '@comfyorg/account/firebaseAuthError'
+import type {
+  TurnstileApi,
+  TurnstileRenderOptions
+} from '@comfyorg/account/turnstileScript'
 
 import { removeAllToasts, useAuthToasts } from '../../config/auth-toast-state'
 import AuthSignIn from './AuthSignIn.vue'
@@ -49,24 +51,18 @@ vi.mock<unknown>(import('../../scripts/posthog'), async () => {
   }
 })
 
-const turnstileWidgetStub = defineComponent({
-  emits: ['update:token', 'update:unavailable'],
-  setup(_, { emit, expose }) {
-    expose({ reset: handles.turnstileReset })
-    onMounted(() => emit('update:token', 'cf-token'))
-    return () => h('div', { 'data-testid': 'turnstile' })
-  }
-})
+const turnstileApi = vi.hoisted(
+  () =>
+    ({
+      render: vi.fn(),
+      reset: handles.turnstileReset,
+      remove: vi.fn()
+    }) satisfies TurnstileApi
+)
 
-function render<C>(component: C, options?: RenderOptions<C>) {
-  return testingRender(component, {
-    ...options,
-    global: {
-      ...options?.global,
-      stubs: { TurnstileWidget: turnstileWidgetStub }
-    }
-  })
-}
+vi.mock(import('@comfyorg/account/turnstileScript'), () => ({
+  loadTurnstile: () => Promise.resolve(turnstileApi)
+}))
 
 vi.mock<unknown>(import('@comfyorg/account/webviewDetection'), () => ({
   isEmbeddedWebView: () => handles.embedded
@@ -148,6 +144,12 @@ beforeEach(() => {
   handles.emailSignUp.mockReset()
   handles.provision.mockReset().mockResolvedValue(undefined)
   handles.turnstileReset.mockReset()
+  turnstileApi.render.mockImplementation(
+    (_container: string | HTMLElement, options: TurnstileRenderOptions) => {
+      options.callback?.('cf-token')
+      return 'widget-id'
+    }
+  )
   handles.isProvisioningError.mockReset().mockReturnValue(false)
   handles.isNewUser.mockReset().mockReturnValue(false)
   handles.captureAuthCompleted.mockClear()

--- a/apps/website/src/components/hero/camera/CameraWidget.test.ts
+++ b/apps/website/src/components/hero/camera/CameraWidget.test.ts
@@ -11,8 +11,8 @@ import type { CameraState } from './types'
 // raycasting and drag math are the code under test. The fake renderer updates
 // world matrices the way WebGLRenderer.render does, so raycasts see current
 // object positions.
-vi.mock(import('three'), async (importOriginal) => {
-  const three = await importOriginal<typeof ThreeModule>()
+vi.mock<unknown>(import('three'), async () => {
+  const three = await import('three/src/Three.js')
   type WebGLRendererContract = Pick<
     ThreeModule.WebGLRenderer,
     'domElement' | 'outputColorSpace' | 'setSize' | 'setPixelRatio' | 'dispose'
@@ -28,11 +28,7 @@ vi.mock(import('three'), async (importOriginal) => {
       camera.updateMatrixWorld(true)
     }
   }
-  return {
-    ...three,
-    WebGLRenderer:
-      FakeWebGLRenderer as unknown as typeof ThreeModule.WebGLRenderer
-  }
+  return { ...three, WebGLRenderer: FakeWebGLRenderer }
 })
 
 const SIZE = 300

--- a/apps/website/src/components/hero/camera/CameraWidget.test.ts
+++ b/apps/website/src/components/hero/camera/CameraWidget.test.ts
@@ -2,13 +2,18 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PerspectiveCamera, Vector3 } from 'three'
-import type { Camera, Scene, WebGLRenderer } from 'three'
+import type { Camera, Scene, WebGLRenderer as WebGLRendererType } from 'three'
+import { WebGLRenderer } from 'three/src/renderers/WebGLRenderer.js'
 
 import { CameraWidget } from './CameraWidget'
 import type { CameraState } from './types'
 
+vi.mock(import('three/src/renderers/WebGLRenderer.js'), () => ({
+  WebGLRenderer: vi.fn()
+}))
+
 function fakeRenderer() {
-  return fromPartial<WebGLRenderer>({
+  return fromPartial<WebGLRendererType>({
     domElement: document.createElement('canvas'),
     setSize: vi.fn(),
     setPixelRatio: vi.fn(),
@@ -66,14 +71,11 @@ function createWidget(
 ) {
   const container = createContainer()
   const states: CameraState[] = []
-  const widget = new CameraWidget(
-    {
-      container,
-      onStateChange: (state) => states.push(state),
-      ...options
-    },
-    fakeRenderer()
-  )
+  const widget = new CameraWidget({
+    container,
+    onStateChange: (state) => states.push(state),
+    ...options
+  })
   const canvas = container.querySelector('canvas')!
   vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
     left: 0,
@@ -119,6 +121,7 @@ describe('CameraWidget', () => {
   beforeEach(() => {
     FakeImage.instances = []
     FakeResizeObserver.instances = []
+    vi.mocked(WebGLRenderer).mockImplementation(fakeRenderer)
     vi.stubGlobal('Image', FakeImage)
     vi.stubGlobal('ResizeObserver', FakeResizeObserver)
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(

--- a/apps/website/src/components/hero/camera/CameraWidget.test.ts
+++ b/apps/website/src/components/hero/camera/CameraWidget.test.ts
@@ -1,35 +1,24 @@
 // @vitest-environment happy-dom
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PerspectiveCamera, Vector3 } from 'three'
-import type * as ThreeModule from 'three'
-import type { Camera, Scene } from 'three'
+import type { Camera, Scene, WebGLRenderer } from 'three'
 
 import { CameraWidget } from './CameraWidget'
 import type { CameraState } from './types'
 
-// Everything except the GPU-bound renderer runs for real: scene graph,
-// raycasting and drag math are the code under test. The fake renderer updates
-// world matrices the way WebGLRenderer.render does, so raycasts see current
-// object positions.
-vi.mock<unknown>(import('three'), async () => {
-  const three = await import('three/src/Three.js')
-  type WebGLRendererContract = Pick<
-    ThreeModule.WebGLRenderer,
-    'domElement' | 'outputColorSpace' | 'setSize' | 'setPixelRatio' | 'dispose'
-  >
-  class FakeWebGLRenderer implements WebGLRendererContract {
-    domElement = document.createElement('canvas')
-    outputColorSpace: ThreeModule.ColorSpace = ''
-    setSize() {}
-    setPixelRatio() {}
-    dispose() {}
+function fakeRenderer() {
+  return fromPartial<WebGLRenderer>({
+    domElement: document.createElement('canvas'),
+    setSize: vi.fn(),
+    setPixelRatio: vi.fn(),
+    dispose: vi.fn(),
     render(scene: Scene, camera: Camera) {
       scene.updateMatrixWorld(true)
       camera.updateMatrixWorld(true)
     }
-  }
-  return { ...three, WebGLRenderer: FakeWebGLRenderer }
-})
+  })
+}
 
 const SIZE = 300
 
@@ -77,11 +66,14 @@ function createWidget(
 ) {
   const container = createContainer()
   const states: CameraState[] = []
-  const widget = new CameraWidget({
-    container,
-    onStateChange: (state) => states.push(state),
-    ...options
-  })
+  const widget = new CameraWidget(
+    {
+      container,
+      onStateChange: (state) => states.push(state),
+      ...options
+    },
+    fakeRenderer()
+  )
   const canvas = container.querySelector('canvas')!
   vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
     left: 0,
@@ -130,7 +122,7 @@ describe('CameraWidget', () => {
     vi.stubGlobal('Image', FakeImage)
     vi.stubGlobal('ResizeObserver', FakeResizeObserver)
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
-      fake2dContext as unknown as CanvasRenderingContext2D
+      fromPartial<CanvasRenderingContext2D>(fake2dContext)
     )
   })
 

--- a/apps/website/src/components/hero/camera/CameraWidget.ts
+++ b/apps/website/src/components/hero/camera/CameraWidget.ts
@@ -118,7 +118,7 @@ export class CameraWidget {
   private paused = false
   private disposed = false
 
-  constructor(options: CameraWidgetOptions) {
+  constructor(options: CameraWidgetOptions, renderer?: WebGLRenderer) {
     this.container = options.container
     this.onStateChange = options.onStateChange
     this.pal = { ...DEFAULT_PALETTE, ...options.palette }
@@ -133,13 +133,13 @@ export class CameraWidget {
     this.liveElevation = this.state.elevation
     this.liveDistance = this.state.distance
 
-    this.initThreeJS()
+    this.initThreeJS(renderer)
     this.bindEvents()
     if (this.state.imageUrl) this.updateImage(this.state.imageUrl)
     this.animate()
   }
 
-  private initThreeJS(): void {
+  private initThreeJS(renderer?: WebGLRenderer): void {
     const width = this.container.clientWidth || 300
     const height = this.container.clientHeight || 300
 
@@ -154,7 +154,8 @@ export class CameraWidget {
     this.previewCamera = new PerspectiveCamera(50, width / height, 0.1, 100)
     this.activeCamera = this.camera
 
-    this.renderer = new WebGLRenderer({ antialias: true, alpha: true })
+    this.renderer =
+      renderer ?? new WebGLRenderer({ antialias: true, alpha: true })
     this.renderer.setSize(width, height, false)
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     this.renderer.outputColorSpace = SRGBColorSpace

--- a/apps/website/src/components/hero/camera/CameraWidget.ts
+++ b/apps/website/src/components/hero/camera/CameraWidget.ts
@@ -31,10 +31,10 @@ import {
   TorusGeometry,
   TubeGeometry,
   Vector2,
-  Vector3,
-  WebGLRenderer
+  Vector3
 } from 'three'
 import type { Camera, Material } from 'three'
+import { WebGLRenderer } from 'three/src/renderers/WebGLRenderer.js'
 
 import type { CameraPalette, CameraState, CameraWidgetOptions } from './types'
 
@@ -118,7 +118,7 @@ export class CameraWidget {
   private paused = false
   private disposed = false
 
-  constructor(options: CameraWidgetOptions, renderer?: WebGLRenderer) {
+  constructor(options: CameraWidgetOptions) {
     this.container = options.container
     this.onStateChange = options.onStateChange
     this.pal = { ...DEFAULT_PALETTE, ...options.palette }
@@ -133,13 +133,13 @@ export class CameraWidget {
     this.liveElevation = this.state.elevation
     this.liveDistance = this.state.distance
 
-    this.initThreeJS(renderer)
+    this.initThreeJS()
     this.bindEvents()
     if (this.state.imageUrl) this.updateImage(this.state.imageUrl)
     this.animate()
   }
 
-  private initThreeJS(renderer?: WebGLRenderer): void {
+  private initThreeJS(): void {
     const width = this.container.clientWidth || 300
     const height = this.container.clientHeight || 300
 
@@ -154,8 +154,7 @@ export class CameraWidget {
     this.previewCamera = new PerspectiveCamera(50, width / height, 0.1, 100)
     this.activeCamera = this.camera
 
-    this.renderer =
-      renderer ?? new WebGLRenderer({ antialias: true, alpha: true })
+    this.renderer = new WebGLRenderer({ antialias: true, alpha: true })
     this.renderer.setSize(width, height, false)
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     this.renderer.outputColorSpace = SRGBColorSpace

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -49,19 +49,16 @@ vi.mock(import('../../config/workshop-session-state'), () => ({
   })
 }))
 
-vi.mock(import('../../scripts/posthog'), async (importOriginal) => ({
-  ...(await importOriginal()),
+vi.mock(import('../../scripts/posthog'), () => ({
   useWorkshopAuthFlag: () => computed(() => auth.enabled.value),
   useWorkshopAuthFlagSettled: () => computed(() => auth.flagSettled.value)
 }))
 
-vi.mock(import('../../config/workshop-router'), async (importOriginal) => ({
-  ...(await importOriginal()),
+vi.mock(import('../../config/workshop-router'), () => ({
   runWorkshopRouter: vi.fn()
 }))
 
-vi.mock(import('../../config/workshop-credits'), async (importOriginal) => ({
-  ...(await importOriginal()),
+vi.mock(import('../../config/workshop-credits'), () => ({
   refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined),
   useWorkshopCredits: () => ({
     balance: computed(() => credits.balance.value),

--- a/apps/website/src/components/workshop/PlaygroundOutput.test.ts
+++ b/apps/website/src/components/workshop/PlaygroundOutput.test.ts
@@ -10,8 +10,7 @@ import { WORKSHOP_CLOUD_BASE_URL } from '../../config/workshop-env'
 import PlaygroundOutput from './PlaygroundOutput.vue'
 import { downloadOutput } from '../../config/workshop-output-download'
 
-vi.mock(import('../../config/workshop-output-download'), async (original) => ({
-  ...(await original()),
+vi.mock(import('../../config/workshop-output-download'), () => ({
   downloadOutput: vi.fn(async () => true)
 }))
 

--- a/apps/website/src/config/workshop-creator-request.ts
+++ b/apps/website/src/config/workshop-creator-request.ts
@@ -7,7 +7,7 @@ import { workshopFileBase64 } from './workshop-file-encoding'
 import { WorkshopRouterError } from './workshop-router-errors'
 import { renderWorkshopRequestTemplate } from './workshop-request-template'
 import { prepareWorkshopRequestCallback } from './workshop-request-callbacks'
-import { loadWorkshopExampleFile } from './workshop-example-file'
+import { loadWorkshopExampleFile } from './workshop-example-file-loader'
 import { MAX_REQUEST_BYTES } from './workshop-limits'
 
 export interface EncodedWorkshopFile {

--- a/apps/website/src/config/workshop-example-file-loader.ts
+++ b/apps/website/src/config/workshop-example-file-loader.ts
@@ -1,0 +1,64 @@
+import type { FileValue } from './workshop-playground'
+
+import {
+  WORKSHOP_EXAMPLE_MIME_TYPES,
+  workshopExampleFile
+} from './workshop-example-file'
+
+const files = new WeakMap<FileValue, File>()
+const MAX_BYTES = 7 * 1024 * 1024
+
+export async function loadWorkshopExampleFile(
+  value: FileValue,
+  signal: AbortSignal
+): Promise<File> {
+  signal.throwIfAborted()
+  const cached = files.get(value)
+  if (cached) return cached
+  if (!value.sourceUrl || !workshopExampleFile(value.sourceUrl))
+    throw new Error('Invalid example media URL')
+  const requestSignal = AbortSignal.any([signal, AbortSignal.timeout(30_000)])
+  const response = await fetch(value.sourceUrl, {
+    signal: requestSignal,
+    credentials: 'omit',
+    redirect: 'error'
+  })
+  if (
+    !response.ok ||
+    Number(response.headers.get('Content-Length')) > MAX_BYTES
+  ) {
+    await response.body?.cancel()
+    throw new Error('Example media unavailable or too large')
+  }
+  const type =
+    response.headers.get('Content-Type')?.split(';')[0].trim().toLowerCase() ??
+    ''
+  if (![...WORKSHOP_EXAMPLE_MIME_TYPES.values()].includes(type)) {
+    await response.body?.cancel()
+    throw new Error('Invalid example media type')
+  }
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error('Empty example media')
+  const chunks: Uint8Array<ArrayBuffer>[] = []
+  let bytes = 0
+  try {
+    for (;;) {
+      requestSignal.throwIfAborted()
+      const { done, value: chunk } = await reader.read()
+      if (done) break
+      bytes += chunk.byteLength
+      if (bytes > MAX_BYTES) throw new Error('Example media too large')
+      chunks.push(new Uint8Array(chunk))
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => {})
+    throw error
+  } finally {
+    reader.releaseLock()
+  }
+  signal.throwIfAborted()
+  if (!bytes) throw new Error('Empty example media')
+  const file = new File(chunks, value.name, { type })
+  files.set(value, file)
+  return file
+}

--- a/apps/website/src/config/workshop-example-file.test.ts
+++ b/apps/website/src/config/workshop-example-file.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-  loadWorkshopExampleFile,
-  workshopExampleFile
-} from './workshop-example-file'
+import { workshopExampleFile } from './workshop-example-file'
+import { loadWorkshopExampleFile } from './workshop-example-file-loader'
 import { getRouterWorkshopModelDetail } from './workshop-router-content'
 import { defaultValues, schemaForModel } from './workshop-playground'
 import { prepareWorkshopRouterInput } from './workshop-request'

--- a/apps/website/src/config/workshop-example-file.ts
+++ b/apps/website/src/config/workshop-example-file.ts
@@ -1,7 +1,7 @@
 import type { FileValue } from './workshop-playground'
 import { isHttpImageSource } from './workshop-image-source'
 
-const MIME_TYPES = new Map([
+export const WORKSHOP_EXAMPLE_MIME_TYPES = new Map([
   ['png', 'image/png'],
   ['jpg', 'image/jpeg'],
   ['jpeg', 'image/jpeg'],
@@ -13,8 +13,6 @@ const MIME_TYPES = new Map([
   ['wav', 'audio/wav'],
   ['m4a', 'audio/mp4']
 ])
-const files = new WeakMap<FileValue, File>()
-const MAX_BYTES = 7 * 1024 * 1024
 
 export function workshopExampleFile(
   source: string,
@@ -23,7 +21,9 @@ export function workshopExampleFile(
   if (!isHttpImageSource(source)) return
   const name = new URL(source).pathname.split('/').at(-1) || 'example'
   const type =
-    MIME_TYPES.get(name.split('.').at(-1)?.toLowerCase() ?? '') ?? fallbackType
+    WORKSHOP_EXAMPLE_MIME_TYPES.get(
+      name.split('.').at(-1)?.toLowerCase() ?? ''
+    ) ?? fallbackType
   return { name, type, size: 0, previewUrl: source, sourceUrl: source }
 }
 
@@ -41,59 +41,4 @@ export function workshopExampleFiles(
   }
   if (!result.length || (!multiple && result.length > 1)) return
   return multiple ? result : result[0]
-}
-
-export async function loadWorkshopExampleFile(
-  value: FileValue,
-  signal: AbortSignal
-): Promise<File> {
-  signal.throwIfAborted()
-  const cached = files.get(value)
-  if (cached) return cached
-  if (!value.sourceUrl || !workshopExampleFile(value.sourceUrl))
-    throw new Error('Invalid example media URL')
-  const requestSignal = AbortSignal.any([signal, AbortSignal.timeout(30_000)])
-  const response = await fetch(value.sourceUrl, {
-    signal: requestSignal,
-    credentials: 'omit',
-    redirect: 'error'
-  })
-  if (
-    !response.ok ||
-    Number(response.headers.get('Content-Length')) > MAX_BYTES
-  ) {
-    await response.body?.cancel()
-    throw new Error('Example media unavailable or too large')
-  }
-  const type =
-    response.headers.get('Content-Type')?.split(';')[0].trim().toLowerCase() ??
-    ''
-  if (![...MIME_TYPES.values()].includes(type)) {
-    await response.body?.cancel()
-    throw new Error('Invalid example media type')
-  }
-  const reader = response.body?.getReader()
-  if (!reader) throw new Error('Empty example media')
-  const chunks: Uint8Array<ArrayBuffer>[] = []
-  let bytes = 0
-  try {
-    for (;;) {
-      requestSignal.throwIfAborted()
-      const { done, value: chunk } = await reader.read()
-      if (done) break
-      bytes += chunk.byteLength
-      if (bytes > MAX_BYTES) throw new Error('Example media too large')
-      chunks.push(new Uint8Array(chunk))
-    }
-  } catch (error) {
-    await reader.cancel().catch(() => {})
-    throw error
-  } finally {
-    reader.releaseLock()
-  }
-  signal.throwIfAborted()
-  if (!bytes) throw new Error('Empty example media')
-  const file = new File(chunks, value.name, { type })
-  files.set(value, file)
-  return file
 }

--- a/apps/website/src/config/workshop-request.ts
+++ b/apps/website/src/config/workshop-request.ts
@@ -20,7 +20,7 @@ import { workshopFileBase64 } from './workshop-file-encoding'
 import { prepareWorkshopCreatorRequest } from './workshop-creator-request'
 import type { WorkshopUrlEncoder } from './workshop-url-input'
 import { resolveWorkshopUrlInputs } from './workshop-url-input'
-import { loadWorkshopExampleFile } from './workshop-example-file'
+import { loadWorkshopExampleFile } from './workshop-example-file-loader'
 import { MAX_REQUEST_BYTES } from './workshop-limits'
 
 const ACCEPT: Record<WorkshopMediaBinding['accept'], readonly string[]> = {

--- a/apps/website/src/config/workshop-url-input.ts
+++ b/apps/website/src/config/workshop-url-input.ts
@@ -2,10 +2,8 @@ import type { FieldSchema, FileValue, FormValues } from './workshop-playground'
 import { urlUploadField, validateForm } from './workshop-playground'
 import { WorkshopRouterError } from './workshop-router-errors'
 import { isHttpImageSource } from './workshop-image-source'
-import {
-  loadWorkshopExampleFile,
-  workshopExampleFile
-} from './workshop-example-file'
+import { workshopExampleFile } from './workshop-example-file'
+import { loadWorkshopExampleFile } from './workshop-example-file-loader'
 
 const downloadedSources = new Map<string, FileValue>()
 const formSources = new WeakMap<FormValues, ReadonlyMap<string, FileValue>>()

--- a/apps/website/src/routes/models/model-page.test.ts
+++ b/apps/website/src/routes/models/model-page.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { WorkshopModelDetail } from '../../config/models-catalogue'
+import type {
+  WorkshopFilter,
+  WorkshopModelDetail
+} from '../../config/models-catalogue'
 import { prepareModelPage } from './model-page'
 
 const mocks = vi.hoisted(() => ({
@@ -18,9 +21,13 @@ vi.mock(import('../../config/workshop-related'), () => ({
 vi.mock(import('../../config/workshop-node-pricing'), () => ({
   estimateWorkshopNodePrice: mocks.price
 }))
-vi.mock(import('../../config/models-catalogue'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  getWorkshopModel: mocks.successor
+vi.mock(import('../../config/models-catalogue'), () => ({
+  catalogSearch: ({ capabilities = [] }: Partial<WorkshopFilter>) =>
+    new URLSearchParams(
+      capabilities.map((capability) => ['capability', capability])
+    ).toString(),
+  getWorkshopModel: mocks.successor,
+  workshopModels: []
 }))
 
 const model: WorkshopModelDetail = {

--- a/apps/website/src/templates/events/EventsDirectoryRow.test.ts
+++ b/apps/website/src/templates/events/EventsDirectoryRow.test.ts
@@ -1,10 +1,8 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
-
-import type * as vueuseModule from '@vueuse/core'
 
 import type { ComfyEvent } from '../../data/events'
 
@@ -16,18 +14,17 @@ const localized = (en: string) => ({ en, 'zh-CN': en })
 // Captures the resize callback so a test can feed it a fake overflow entry;
 // happy-dom performs no layout, so the clamp can never trip on its own.
 const { resizeCallbacks } = vi.hoisted(() => ({
-  resizeCallbacks: [] as Array<(entries: Array<{ target: Element }>) => void>
+  resizeCallbacks: [] as ResizeObserverCallback[]
 }))
-vi.mock(import('@vueuse/core'), async (importOriginal) => {
-  const actual = await importOriginal<typeof vueuseModule>()
-  return {
-    ...actual,
-    useResizeObserver: vi.fn((_el: unknown, cb: unknown) => {
-      resizeCallbacks.push(cb as (typeof resizeCallbacks)[number])
-      return { stop: () => {} }
-    }) as unknown as typeof actual.useResizeObserver
+class MockResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback, record = true) {
+    if (record) resizeCallbacks.push(callback)
   }
-})
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
 
 const makeEvent = (overrides: Partial<ComfyEvent> = {}): ComfyEvent => ({
   id: 'meetup-1',
@@ -46,6 +43,11 @@ const AFTER = new Date('2027-01-01T00:00:00Z')
 const BEFORE = new Date('2026-01-01T00:00:00Z')
 
 describe('EventsDirectoryRow', () => {
+  beforeEach(() => {
+    resizeCallbacks.length = 0
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  })
+
   it('marks past rows with a Past pill and leaves upcoming rows without one', () => {
     const { unmount } = render(EventsDirectoryRow, {
       props: { row: rowOf(makeEvent(), AFTER) }
@@ -97,7 +99,16 @@ describe('EventsDirectoryRow', () => {
     const desc = screen.getByText('A description that could run long.')
     Object.defineProperty(desc, 'scrollHeight', { value: 64 })
     Object.defineProperty(desc, 'clientHeight', { value: 32 })
-    for (const cb of resizeCallbacks) cb([{ target: desc }])
+    const entry: ResizeObserverEntry = {
+      target: desc,
+      borderBoxSize: [],
+      contentBoxSize: [],
+      contentRect: desc.getBoundingClientRect(),
+      devicePixelContentBoxSize: []
+    }
+    for (const cb of resizeCallbacks) {
+      cb([entry], new MockResizeObserver(cb, false))
+    }
     await nextTick()
 
     await userEvent.click(screen.getByRole('button', { name: 'Read more' }))

--- a/apps/website/src/templates/events/EventsDirectorySection.test.ts
+++ b/apps/website/src/templates/events/EventsDirectorySection.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import type { ComfyEvent } from '../../data/events'
-import type * as eventsModule from '../../data/events'
+import type { Locale } from '../../i18n/translations'
 
 import EventsDirectorySection from './EventsDirectorySection.vue'
 
@@ -48,9 +48,35 @@ const { NOW, fixtureEvents } = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('../../data/events'), async (importOriginal) => {
-  const actual = await importOriginal<typeof eventsModule>()
-  return { ...actual, directoryEvents: fixtureEvents, eventsDerivedAt: NOW }
+vi.mock(import('../../data/events'), () => {
+  const eventPath = (event: { id: string }) => `/events/${event.id}`
+  const eventVideoId = (event: ComfyEvent) =>
+    event.recordingVideoId ?? event.liveVideoId
+  return {
+    directoryEvents: fixtureEvents,
+    eventsDerivedAt: NOW,
+    eventPath,
+    eventStatus: (event: ComfyEvent, now: Date): 'past' | 'upcoming' => {
+      const end = event.endDateTime
+        ? new Date(event.endDateTime)
+        : new Date(new Date(event.startDateTime).getTime() + 60 * 60 * 1000)
+      return now >= end ? 'past' : 'upcoming'
+    },
+    eventVideoId,
+    toCalendarEvent: (event: ComfyEvent, locale: Locale) => ({
+      title: event.title[locale] || event.title.en,
+      description: event.description[locale] || event.description.en,
+      location: event.location?.[locale] || event.location?.en || '',
+      start: new Date(event.startDateTime),
+      end: event.endDateTime
+        ? new Date(event.endDateTime)
+        : new Date(new Date(event.startDateTime).getTime() + 60 * 60 * 1000)
+    }),
+    youtubeWatchHref: (videoId: string) => {
+      const href = `https://www.youtube.com/watch?v=${videoId}`
+      return { en: href, 'zh-CN': href }
+    }
+  }
 })
 
 // The real map pulls in Leaflet at mount, so it is replaced with one button

--- a/apps/website/src/templates/events/EventsDirectorySection.test.ts
+++ b/apps/website/src/templates/events/EventsDirectorySection.test.ts
@@ -1,17 +1,16 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { render, screen, within } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 
 import type { ComfyEvent } from '../../data/events'
-import type { Locale } from '../../i18n/translations'
 
 import EventsDirectorySection from './EventsDirectorySection.vue'
 
 // Three fixtures against a fixed clock: an upcoming hackathon and a past
 // meetup with coordinates, plus a virtual workshop without any.
-const { NOW, fixtureEvents } = vi.hoisted(() => {
+const { NOW, fixtureEvents } = (() => {
   const localized = (en: string) => ({ en, 'zh-CN': en })
   const paris: ComfyEvent = {
     id: 'paris',
@@ -46,38 +45,7 @@ const { NOW, fixtureEvents } = vi.hoisted(() => {
     NOW: new Date('2026-06-01T00:00:00Z'),
     fixtureEvents: [paris, online, tokyo]
   }
-})
-
-vi.mock(import('../../data/events'), () => {
-  const eventPath = (event: { id: string }) => `/events/${event.id}`
-  const eventVideoId = (event: ComfyEvent) =>
-    event.recordingVideoId ?? event.liveVideoId
-  return {
-    directoryEvents: fixtureEvents,
-    eventsDerivedAt: NOW,
-    eventPath,
-    eventStatus: (event: ComfyEvent, now: Date): 'past' | 'upcoming' => {
-      const end = event.endDateTime
-        ? new Date(event.endDateTime)
-        : new Date(new Date(event.startDateTime).getTime() + 60 * 60 * 1000)
-      return now >= end ? 'past' : 'upcoming'
-    },
-    eventVideoId,
-    toCalendarEvent: (event: ComfyEvent, locale: Locale) => ({
-      title: event.title[locale] || event.title.en,
-      description: event.description[locale] || event.description.en,
-      location: event.location?.[locale] || event.location?.en || '',
-      start: new Date(event.startDateTime),
-      end: event.endDateTime
-        ? new Date(event.endDateTime)
-        : new Date(new Date(event.startDateTime).getTime() + 60 * 60 * 1000)
-    }),
-    youtubeWatchHref: (videoId: string) => {
-      const href = `https://www.youtube.com/watch?v=${videoId}`
-      return { en: href, 'zh-CN': href }
-    }
-  }
-})
+})()
 
 // The real map pulls in Leaflet at mount, so it is replaced with one button
 // per marker that replays the block's `select` event.
@@ -101,7 +69,7 @@ const stubs = {
 
 function renderSection() {
   return render(EventsDirectorySection, {
-    props: { locale: 'en' },
+    props: { locale: 'en', events: fixtureEvents, derivedAt: NOW },
     global: { stubs }
   })
 }

--- a/apps/website/src/templates/events/EventsDirectorySection.vue
+++ b/apps/website/src/templates/events/EventsDirectorySection.vue
@@ -5,6 +5,7 @@ import { computed, reactive, ref, watch } from 'vue'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import type { MapPinMarker } from '../../components/blocks/MapPins01.vue'
+import type { ComfyEvent } from '../../data/events'
 import type { Locale } from '../../i18n/translations'
 import type { EventsDirectoryView } from '../../utils/eventsDirectory'
 
@@ -23,7 +24,15 @@ import {
 } from '../../utils/eventsDirectory'
 import EventsDirectoryList from './EventsDirectoryList.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const {
+  locale = 'en',
+  events = directoryEvents,
+  derivedAt = eventsDerivedAt
+} = defineProps<{
+  locale?: Locale
+  events?: readonly ComfyEvent[]
+  derivedAt?: Date
+}>()
 
 // Search, type and organizer feed whichever view is active, so the whole
 // section is one reactive model: three filter fields plus the view. Everything
@@ -33,7 +42,7 @@ const view = ref<EventsDirectoryView>('map')
 const sort = ref<'latest' | 'oldest'>('latest')
 
 const visibleEvents = computed(() =>
-  filterDirectoryEvents(directoryEvents, filters, locale)
+  filterDirectoryEvents(events, filters, locale)
 )
 
 // `directoryEvents` is latest-first, so Oldest is a plain reversal of the
@@ -50,7 +59,7 @@ const sortedEvents = computed(() =>
 // clock that ordered `directoryEvents`, so a row's position and its CTA can
 // never straddle the upcoming/past boundary.
 const rows = computed(() =>
-  directoryRows(sortedEvents.value, locale, eventsDerivedAt)
+  directoryRows(sortedEvents.value, locale, derivedAt)
 )
 
 // Pins are the filtered events that have coordinates; virtual events stay in

--- a/apps/website/src/templates/events/PastEventsSection.test.ts
+++ b/apps/website/src/templates/events/PastEventsSection.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import type { ComfyEvent } from '../../data/events'
-import type * as eventsModule from '../../data/events'
 
 import PastEventsSection from './PastEventsSection.vue'
 
@@ -79,9 +78,13 @@ const { fixturePastEvents } = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('../../data/events'), async (importOriginal) => {
-  const actual = await importOriginal<typeof eventsModule>()
-  return { ...actual, pastEvents: fixturePastEvents }
+vi.mock(import('../../data/events'), () => {
+  return {
+    eventPath: (event: { id: string }) => `/events/${event.id}`,
+    eventVideoId: (event: ComfyEvent) =>
+      event.recordingVideoId ?? event.liveVideoId,
+    pastEvents: fixturePastEvents
+  }
 })
 
 describe('PastEventsSection', () => {

--- a/apps/website/src/templates/events/PastEventsSection.test.ts
+++ b/apps/website/src/templates/events/PastEventsSection.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 
 import type { ComfyEvent } from '../../data/events'
@@ -13,7 +13,7 @@ import PastEventsSection from './PastEventsSection.vue'
 // art, an unrecorded workshop with no art whose only destination is its
 // external page, an untranslated conference, and a destinationless meetup with
 // neither a recording nor a link.
-const { fixturePastEvents } = vi.hoisted(() => {
+const { fixturePastEvents } = (() => {
   const localized = (en: string) => ({ en, 'zh-CN': en })
   const recorded: ComfyEvent = {
     id: 'recorded-livestream',
@@ -76,20 +76,11 @@ const { fixturePastEvents } = vi.hoisted(() => {
   return {
     fixturePastEvents: [recorded, clip, artless, untranslated, destinationless]
   }
-})
-
-vi.mock(import('../../data/events'), () => {
-  return {
-    eventPath: (event: { id: string }) => `/events/${event.id}`,
-    eventVideoId: (event: ComfyEvent) =>
-      event.recordingVideoId ?? event.liveVideoId,
-    pastEvents: fixturePastEvents
-  }
-})
+})()
 
 describe('PastEventsSection', () => {
   it('renders a card for every past event, artless ones included', () => {
-    render(PastEventsSection)
+    render(PastEventsSection, { props: { events: fixturePastEvents } })
 
     expect(screen.getByText('Recorded Livestream')).toBeTruthy()
     expect(screen.getByText('Clip Meetup')).toBeTruthy()
@@ -97,7 +88,7 @@ describe('PastEventsSection', () => {
   })
 
   it('sends a recorded event to its own page under a WATCH NOW label', () => {
-    render(PastEventsSection)
+    render(PastEventsSection, { props: { events: fixturePastEvents } })
 
     const link = screen.getByRole('link', {
       name: 'Recorded Livestream — WATCH NOW'
@@ -107,7 +98,7 @@ describe('PastEventsSection', () => {
   })
 
   it('links an unrecorded event out under LEARN MORE in a new tab', () => {
-    render(PastEventsSection)
+    render(PastEventsSection, { props: { events: fixturePastEvents } })
 
     const link = screen.getByRole('link', {
       name: 'Artless Workshop — LEARN MORE'
@@ -117,7 +108,9 @@ describe('PastEventsSection', () => {
   })
 
   it('falls back to English title, art alt, and link for untranslated events', () => {
-    render(PastEventsSection, { props: { locale: 'zh-CN' } })
+    render(PastEventsSection, {
+      props: { locale: 'zh-CN', events: fixturePastEvents }
+    })
 
     const link = screen.getByRole('link', {
       name: 'English-Only Conference — 了解更多'
@@ -127,7 +120,7 @@ describe('PastEventsSection', () => {
   })
 
   it('offers a filter tab only for categories that have a card', () => {
-    render(PastEventsSection)
+    render(PastEventsSection, { props: { events: fixturePastEvents } })
 
     expect(screen.getByRole('button', { name: /^ALL \d+$/ })).toBeTruthy()
     expect(
@@ -141,7 +134,7 @@ describe('PastEventsSection', () => {
   })
 
   it('narrows the cards to a tab category and restores them via ALL', async () => {
-    render(PastEventsSection)
+    render(PastEventsSection, { props: { events: fixturePastEvents } })
 
     await userEvent.click(
       screen.getByRole('button', { name: /^WORKSHOP \d+$/ })
@@ -163,7 +156,7 @@ describe('PastEventsSection', () => {
   })
 
   it('holds the overflowing card behind LOAD MORE and gives it no CTA', async () => {
-    render(PastEventsSection)
+    render(PastEventsSection, { props: { events: fixturePastEvents } })
 
     // PAST_EVENTS_PAGE_SIZE is 4, so the fifth fixture waits behind the button.
     expect(screen.queryByText('Destinationless Meetup')).toBeNull()
@@ -180,7 +173,9 @@ describe('PastEventsSection', () => {
   })
 
   it('passes each card its own art, poster included for clips', () => {
-    const { container } = render(PastEventsSection)
+    const { container } = render(PastEventsSection, {
+      props: { events: fixturePastEvents }
+    })
 
     expect(
       screen.getByRole('img', { name: 'Livestream art' }).getAttribute('src')

--- a/apps/website/src/templates/events/PastEventsSection.vue
+++ b/apps/website/src/templates/events/PastEventsSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+import type { ComfyEvent } from '../../data/events'
 import type { Locale } from '../../i18n/translations'
 
 import CardArticleGallery01 from '../../components/blocks/CardArticleGallery01.vue'
@@ -13,7 +14,10 @@ import {
   pastCtaLabel
 } from '../../utils/eventsDirectory'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale = 'en', events = pastEvents } = defineProps<{
+  locale?: Locale
+  events?: readonly ComfyEvent[]
+}>()
 
 const CATEGORY_ORDER = [
   'livestream',
@@ -36,7 +40,7 @@ function cardDate(iso: string): string {
 }
 
 const items = computed<CardArticleGalleryItem[]>(() =>
-  pastEvents.map((event) => {
+  events.map((event) => {
     // Carousel art is sized and hosted for the hero slider only, so no
     // featured.media fallback here. An event without dedicated card art still
     // gets a card; CardArticle01 fills the media slot with a brand gradient.

--- a/apps/website/src/utils/cloudNodes.test.ts
+++ b/apps/website/src/utils/cloudNodes.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sanitizeUserContent } from '@comfyorg/object-info-parser'
 
 import type { NodesSnapshot } from '../data/cloudNodes'
 
@@ -12,25 +13,13 @@ import type { RegistryPackWithNodes } from './cloudNodes.registry'
 const fetchRegistryPacksWithNodesMock = vi.hoisted(() =>
   vi.fn(async () => new Map<string, RegistryPackWithNodes | null>())
 )
-const sanitizeCallSpy = vi.hoisted(() => vi.fn())
 
 vi.mock(import('./cloudNodes.registry'), () => ({
   DEFAULT_REGISTRY_BASE_URL: 'https://api.comfy.org' as const,
   fetchRegistryPacksWithNodes: fetchRegistryPacksWithNodesMock
 }))
 
-vi.mock(import('@comfyorg/object-info-parser'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    sanitizeUserContent: (
-      defs: Parameters<typeof actual.sanitizeUserContent>[0]
-    ) => {
-      sanitizeCallSpy(defs)
-      return actual.sanitizeUserContent(defs)
-    }
-  }
-})
+vi.mock(import('@comfyorg/object-info-parser'), { spy: true })
 
 import {
   fetchCloudNodesForBuild,
@@ -196,7 +185,7 @@ describe('fetchCloudNodesForBuild', () => {
       fetchImpl: fetchImpl
     })
 
-    expect(sanitizeCallSpy).toHaveBeenCalledTimes(1)
+    expect(sanitizeUserContent).toHaveBeenCalledTimes(1)
   })
 
   it('returns stale with missing env when snapshot is present', async () => {

--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -65,29 +65,31 @@ without running registration services. Create one capture per test file and
 keep the mock factory in that file:
 
 ```typescript
-const extensions = await vi.hoisted(async () => {
-  const { createExtensionCapture } =
-    await import('@/utils/__tests__/extensionTestUtils')
-  return createExtensionCapture()
+const extensions = vi.hoisted<{
+  registered: ComfyExtension[]
+  registerExtension: (extension: ComfyExtension) => void
+}>(() => {
+  const registered: ComfyExtension[] = []
+  return {
+    registered,
+    registerExtension: vi.fn((extension) => registered.push(extension))
+  }
 })
 
-vi.mock(import('@/scripts/app'), async (importOriginal) => {
-  const original = await importOriginal()
-  original.app.registerExtension = extensions.registerExtension
-  return original
-})
+vi.mock(import('@/scripts/app'), () => ({
+  app: { registerExtension: extensions.registerExtension }
+}))
 
 await import('@/extensions/core/customWidgets')
-const extension = extensions.getExtension('Comfy.CustomWidgets')
+const extension = extensions.registered.find(
+  ({ name }) => name === 'Comfy.CustomWidgets'
+)
 ```
 
-For an existing partial app or extension-service mock, replace only its
-`registerExtension` member. The capture retains registrations across Vitest's
-mock resets; named lookup throws if the module did not register that extension.
-Use the authoritative `ComfyExtension` hook signatures rather than casting the
-captured object to a custom hook interface. Reset scenario state per test, not
-the module cache. Each capture owns its registrations; there is no shared
-registry or Pinia setup in the helper.
+Mock only `registerExtension` and the other app members exercised by the module
+under test. Keep one registration array per test file and use the authoritative
+`ComfyExtension` hook signatures. Reset scenario state per test, not the module
+cache.
 
 ## Don't Mock `vue-i18n` — Use a Real Plugin
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1044,6 +1044,9 @@ importers:
       '@testing-library/vue':
         specifier: 'catalog:'
         version: 8.1.0(@vue/compiler-dom@3.5.42)(@vue/compiler-sfc@3.5.41)(@vue/server-renderer@3.5.42)(vue@3.5.42(typescript@6.0.3))
+      '@total-typescript/shoehorn':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@types/leaflet':
         specifier: 'catalog:'
         version: 1.9.22

--- a/src/components/common/VirtualGrid.test.ts
+++ b/src/components/common/VirtualGrid.test.ts
@@ -1,4 +1,6 @@
 import { render, screen } from '@testing-library/vue'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { useElementSize, useScroll } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Ref } from 'vue'
 import { nextTick, ref } from 'vue'
@@ -11,19 +13,21 @@ let mockedWidth: Ref<number>
 let mockedHeight: Ref<number>
 let mockedScrollY: Ref<number>
 
-vi.mock<unknown>(import('@vueuse/core'), async () => {
-  const actual = await vi.importActual<Record<string, unknown>>('@vueuse/core')
-  return {
-    ...actual,
-    useElementSize: () => ({ width: mockedWidth, height: mockedHeight }),
-    useScroll: () => ({ y: mockedScrollY })
-  }
-})
+vi.mock(import('@vueuse/core'), { spy: true })
 
 beforeEach(() => {
   mockedWidth = ref(400)
   mockedHeight = ref(200)
   mockedScrollY = ref(0)
+  vi.mocked(useElementSize).mockImplementation(() =>
+    fromPartial({
+      width: mockedWidth,
+      height: mockedHeight
+    })
+  )
+  vi.mocked(useScroll).mockImplementation(() =>
+    fromPartial({ y: mockedScrollY })
+  )
 })
 
 function createItems(count: number): TestItem[] {

--- a/src/components/graph/NodeTooltip.test.ts
+++ b/src/components/graph/NodeTooltip.test.ts
@@ -5,6 +5,10 @@ import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n, mergeCustomNodesI18n } from '@/i18n'
+import {
+  isOverNodeInput,
+  isOverNodeOutput
+} from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { Settings } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
@@ -13,12 +17,7 @@ import { useNodeDefStore } from '@/stores/nodeDefStore'
 import NodeTooltip from './NodeTooltip.vue'
 
 const enMessages = cloneDeep(i18n.global.getLocaleMessage('en'))
-type HitTest = (
-  node: MockNode,
-  x: number,
-  y: number,
-  offset: [number, number]
-) => number
+type HitTest = typeof isOverNodeInput
 
 interface MockWidget {
   name: string
@@ -59,14 +58,7 @@ const mockCanvas = vi.hoisted(
   })
 )
 
-vi.mock<unknown>(
-  import('@/lib/litegraph/src/canvas/measureSlots'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    isOverNodeInput: mockIsOverNodeInput,
-    isOverNodeOutput: mockIsOverNodeOutput
-  })
-)
+vi.mock(import('@/lib/litegraph/src/litegraph'), { spy: true })
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -153,6 +145,8 @@ async function renderAndHoverCanvas() {
 
 describe('NodeTooltip', () => {
   beforeEach(() => {
+    vi.mocked(isOverNodeInput).mockImplementation(mockIsOverNodeInput)
+    vi.mocked(isOverNodeOutput).mockImplementation(mockIsOverNodeOutput)
     vi.spyOn(useSettingStore(), 'get').mockImplementation(
       <K extends keyof Settings>(key: K): Settings[K] => {
         switch (key) {

--- a/src/components/graph/SelectionRectangle.test.ts
+++ b/src/components/graph/SelectionRectangle.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import { fromPartial } from '@total-typescript/shoehorn'
-import type * as VueUse from '@vueuse/core'
+import { useRafFn } from '@vueuse/core'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -8,14 +8,10 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import SelectionRectangle from './SelectionRectangle.vue'
 
-const rafCallbacks: Array<() => void> = []
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
-  useRafFn: (cb: () => void) => {
-    rafCallbacks.push(cb)
-    return { pause: vi.fn(), resume: vi.fn() }
-  }
-}))
+type RafCallback = Parameters<typeof useRafFn>[0]
+
+const rafCallbacks: RafCallback[] = []
+vi.mock(import('@vueuse/core'), { spy: true })
 
 function createPanelEl() {
   const panel = document.createElement('div')
@@ -43,10 +39,19 @@ function dragRectangle(eDown: [number, number], eMove: [number, number]) {
       eMove: { safeOffsetX: eMove[0], safeOffsetY: eMove[1] }
     }
   })
-  rafCallbacks[rafCallbacks.length - 1]()
+  rafCallbacks[rafCallbacks.length - 1](
+    fromPartial({ delta: 0, timestamp: performance.now() })
+  )
 }
 
 describe('SelectionRectangle', () => {
+  beforeEach(() => {
+    vi.mocked(useRafFn).mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return fromPartial({ pause: vi.fn(), resume: vi.fn() })
+    })
+  })
+
   afterEach(() => {
     rafCallbacks.length = 0
     useCanvasStore().canvas = null

--- a/src/components/load3d/Load3DMenuBar.test.ts
+++ b/src/components/load3d/Load3DMenuBar.test.ts
@@ -1,5 +1,12 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { fromPartial } from '@total-typescript/shoehorn'
+import {
+  createSharedComposable,
+  useDocumentVisibility,
+  useElementSize,
+  useStorage
+} from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Ref } from 'vue'
 import { ref } from 'vue'
@@ -17,16 +24,23 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 let mockedTopBarWidth: Ref<number>
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  createSharedComposable: (composable: () => unknown) => composable,
-  useDocumentVisibility: () => ref('visible'),
-  useElementSize: () => ({ width: mockedTopBarWidth, height: ref(40) }),
-  useStorage: (_key: string, defaultValue: unknown) => ref(defaultValue)
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
 beforeEach(() => {
   mockedTopBarWidth = ref(0)
+  vi.mocked(createSharedComposable).mockImplementation(
+    (composable) => composable
+  )
+  vi.mocked(useDocumentVisibility).mockImplementation(() => ref('visible'))
+  vi.mocked(useElementSize).mockImplementation(() =>
+    fromPartial({
+      width: mockedTopBarWidth,
+      height: ref(40)
+    })
+  )
+  vi.mocked(useStorage).mockImplementation((_key, defaultValue) =>
+    ref(defaultValue)
+  )
 })
 
 const i18n = createI18n({

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
-import type * as RekaUi from 'reka-ui'
 
 import './testUtils/mockTanstackVirtualizer'
 
@@ -33,13 +32,16 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('reka-ui'), async (importOriginal) => {
-  const actual = await importOriginal<typeof RekaUi>()
+vi.mock<unknown>(import('reka-ui'), async () => {
   const { computed, defineComponent, h, inject, provide } = await import('vue')
   const popoverOpenKey = Symbol('popoverOpen')
 
   return {
-    ...actual,
+    useForwardPropsEmits: (props: object) => props,
+    Primitive: defineComponent({
+      name: 'Primitive',
+      template: '<button><slot /></button>'
+    }),
     PopoverContent: defineComponent({
       name: 'PopoverContent',
       props: {

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -18,22 +18,20 @@ import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNod
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import type { useComfyRegistryService } from '@/services/comfyRegistryService'
 import type { MissingNodeType } from '@/types/comfy'
 import { toNodeId } from '@/types/nodeId'
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
 
 import TabErrors from './TabErrors.vue'
-vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    useComfyRegistryService: () => ({
-      ...actual.useComfyRegistryService(),
+vi.mock(import('@/services/comfyRegistryService'), () => ({
+  useComfyRegistryService: () =>
+    fromAny<ReturnType<typeof useComfyRegistryService>, unknown>({
       inferPackFromNodeName: vi.fn(async () => null),
-      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+      listAllPacks: vi.fn(async () => ({ nodes: [] })),
+      getPackById: vi.fn()
     })
-  }
-})
+}))
 
 const { mockFocusNode, mockRefreshMissingModels } = vi.hoisted(() => ({
   mockFocusNode: vi.fn(),

--- a/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
+++ b/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
@@ -3,20 +3,18 @@ import { describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import type { useComfyRegistryService } from '@/services/comfyRegistryService'
 import type { MissingNodeType } from '@/types/comfy'
 
 import { useErrorGroups } from './useErrorGroups'
-vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    useComfyRegistryService: () => ({
-      ...actual.useComfyRegistryService(),
+vi.mock(import('@/services/comfyRegistryService'), () => ({
+  useComfyRegistryService: () =>
+    fromAny<ReturnType<typeof useComfyRegistryService>, unknown>({
       inferPackFromNodeName: vi.fn(async () => null),
-      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+      listAllPacks: vi.fn(async () => ({ nodes: [] })),
+      getPackById: vi.fn()
     })
-  }
-})
+}))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -9,29 +9,30 @@ import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import type { useComfyRegistryService } from '@/services/comfyRegistryService'
 import type { MissingNodeType } from '@/types/comfy'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
-import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
 import {
+  forEachNode,
   getExecutionIdByNode,
-  getNodeByExecutionId
+  getNodeByExecutionId,
+  getRootParentNode,
+  mapAllNodes
 } from '@/utils/graphTraversalUtil'
 import { isLGraphNode } from '@/utils/litegraphUtil'
 
 import { useErrorGroups } from './useErrorGroups'
 
-vi.mock(import('@/services/comfyRegistryService'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    useComfyRegistryService: () => ({
-      ...actual.useComfyRegistryService(),
+vi.mock(import('@/services/comfyRegistryService'), () => ({
+  useComfyRegistryService: () =>
+    fromAny<ReturnType<typeof useComfyRegistryService>, unknown>({
       inferPackFromNodeName: vi.fn(async () => null),
-      listAllPacks: vi.fn(async () => ({ nodes: [] }))
+      listAllPacks: vi.fn(async () => ({ nodes: [] })),
+      getPackById: vi.fn()
     })
-  }
-})
+}))
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -46,13 +47,7 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   }
 }))
 
-vi.mock(import('@/utils/graphTraversalUtil'), () => ({
-  getNodeByExecutionId: vi.fn(),
-  getExecutionIdByNode: vi.fn(),
-  getRootParentNode: vi.fn(() => null),
-  forEachNode: vi.fn(),
-  mapAllNodes: vi.fn(() => [])
-}))
+vi.mock(import('@/utils/graphTraversalUtil'), { spy: true })
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
 const unknownValidationMessage = vi.hoisted(
@@ -226,6 +221,10 @@ describe('useErrorGroups', () => {
   beforeEach(() => {
     mockIsCloud.value = false
     vi.mocked(isLGraphNode).mockReturnValue(false)
+    vi.mocked(forEachNode).mockImplementation(() => {})
+    vi.mocked(mapAllNodes).mockReturnValue([])
+    vi.mocked(getRootParentNode).mockReturnValue(null)
+    vi.mocked(getNodeByExecutionId).mockReturnValue(null)
   })
 
   describe('missingPackGroups', () => {
@@ -548,12 +547,12 @@ describe('useErrorGroups', () => {
       const { rootGraph, host } = createBoundaryLinkedSubgraph({
         interiorType: 'InteriorClass'
       })
-      const { getNodeByExecutionId: actualGetNodeByExecutionId } =
-        await vi.importActual<typeof GraphTraversalUtil>(
-          '@/utils/graphTraversalUtil'
-        )
       vi.mocked(getNodeByExecutionId).mockImplementation((_, nodeId) => {
-        return actualGetNodeByExecutionId(rootGraph, nodeId)
+        const [hostId, interiorId] = nodeId.split(':').map(Number)
+        const subgraphNode = rootGraph.getNodeById(toNodeId(hostId))
+        return interiorId && subgraphNode instanceof SubgraphNode
+          ? (subgraphNode.subgraph.getNodeById(toNodeId(interiorId)) ?? null)
+          : subgraphNode
       })
       store.recordNodeErrors({
         '12:5': nodeError(

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
@@ -1,6 +1,7 @@
 import { getActivePinia } from 'pinia'
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen } from '@testing-library/vue'
+import { useLocalStorage } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -17,15 +18,7 @@ vi.mock<unknown>(import('@/services/nodeSearchService'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), async () => {
-  const actual = await vi.importActual('@vueuse/core')
-  return {
-    ...actual,
-    useLocalStorage: vi.fn((_key: string, defaultValue: unknown) =>
-      ref(defaultValue)
-    )
-  }
-})
+vi.mock(import('@vueuse/core'), { spy: true })
 
 vi.mock<unknown>(import('@/composables/node/useNodeDragToCanvas'), () => ({
   useNodeDragToCanvas: () => ({
@@ -94,6 +87,9 @@ const i18n = createI18n({
 
 describe('NodeLibrarySidebarTabV2', () => {
   beforeEach(() => {
+    vi.mocked(useLocalStorage).mockImplementation((_key, defaultValue) =>
+      ref(defaultValue)
+    )
     hoisted.mockSearchNode.mockReturnValue([])
   })
 

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -2,7 +2,12 @@ import { useAuthStore } from '@/stores/authStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { FirebaseError } from 'firebase/app'
-import { AuthErrorCodes } from 'firebase/auth'
+import {
+  AuthErrorCodes,
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import type { UserCredential } from 'firebase/auth'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,12 +16,7 @@ import { useAuthActions } from '@/composables/auth/useAuthActions'
 import enLocale from '@/locales/en/main.json'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'), { spy: true })
 
 type ModifiedWorkflow = Pick<ComfyWorkflow, 'path' | 'isModified'>
 
@@ -137,6 +137,9 @@ function makeWorkflow(path: string): ModifiedWorkflow {
 }
 
 beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
   mockAuthStore = useAuthStore()
   mockToastStore = useToastStore()
   mockWorkflowStore = useWorkflowStore()

--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -1,4 +1,5 @@
 import { markRaw } from 'vue'
+import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
@@ -22,20 +23,6 @@ const mockApp = vi.hoisted(() => ({
 // canvasStore transitively imports the app singleton; stub it so the real
 // ComfyApp module never loads during these unit tests.
 vi.mock<unknown>(import('@/scripts/app'), () => ({ app: mockApp }))
-
-// Mock the litegraph module
-vi.mock<unknown>(
-  import('@/lib/litegraph/src/litegraph'),
-  async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, unknown>
-    return {
-      ...actual,
-      Reroute: class Reroute {
-        constructor() {}
-      }
-    }
-  }
-)
 
 // Real LGraphNode instances so the production isLGraphNode (instanceof) guard runs
 // unmodified — the node accessors filter selectedItems with the real predicate.
@@ -82,20 +69,18 @@ class MockNode implements Positionable {
   }
 }
 
-class MockReroute extends Reroute implements Positionable {
-  // @ts-expect-error - Override for testing
-  override pos: [number, number]
-  size: [number, number]
-
-  constructor(
-    pos: [number, number] = [0, 0],
-    size: [number, number] = [20, 20]
-  ) {
-    // @ts-expect-error - Mock constructor
-    super()
-    this.pos = pos
-    this.size = size
-  }
+function makeReroute(
+  pos: [number, number] = [0, 0],
+  size: [number, number] = [20, 20]
+): Reroute & Positionable {
+  const reroute = fromAny<Reroute & Positionable, unknown>(
+    Object.create(Reroute.prototype)
+  )
+  Object.defineProperties(reroute, {
+    pos: { value: pos, writable: true },
+    size: { value: size, writable: true }
+  })
+  return reroute
 }
 
 describe('useSelectedLiteGraphItems', () => {
@@ -125,7 +110,7 @@ describe('useSelectedLiteGraphItems', () => {
   describe('isIgnoredItem', () => {
     it('should return true for Reroute instances', () => {
       const { isIgnoredItem } = useSelectedLiteGraphItems()
-      const reroute = new MockReroute()
+      const reroute = makeReroute()
       expect(isIgnoredItem(reroute)).toBe(true)
     })
 
@@ -141,7 +126,7 @@ describe('useSelectedLiteGraphItems', () => {
       const { filterSelectableItems } = useSelectedLiteGraphItems()
       const node1 = new MockNode([0, 0])
       const node2 = new MockNode([100, 100])
-      const reroute = new MockReroute([50, 50])
+      const reroute = makeReroute([50, 50])
 
       const items = new Set<Positionable>([node1, node2, reroute])
       const filtered = filterSelectableItems(items)
@@ -154,8 +139,8 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('should return empty set when all items are ignored', () => {
       const { filterSelectableItems } = useSelectedLiteGraphItems()
-      const reroute1 = new MockReroute([0, 0])
-      const reroute2 = new MockReroute([50, 50])
+      const reroute1 = makeReroute([0, 0])
+      const reroute2 = makeReroute([50, 50])
 
       const items = new Set<Positionable>([reroute1, reroute2])
       const filtered = filterSelectableItems(items)
@@ -177,7 +162,7 @@ describe('useSelectedLiteGraphItems', () => {
       const { getSelectableItems } = useSelectedLiteGraphItems()
       const node1 = new MockNode()
       const node2 = new MockNode()
-      const reroute = new MockReroute()
+      const reroute = makeReroute()
 
       mockCanvas.selectedItems.add(node1)
       mockCanvas.selectedItems.add(node2)
@@ -202,7 +187,7 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('hasSelectableItems should be false when only ignored items are selected', () => {
       const { hasSelectableItems } = useSelectedLiteGraphItems()
-      const reroute = new MockReroute()
+      const reroute = makeReroute()
 
       mockCanvas.selectedItems.add(reroute)
       expect(hasSelectableItems()).toBe(false)
@@ -225,8 +210,8 @@ describe('useSelectedLiteGraphItems', () => {
     it('hasMultipleSelectableItems should not count ignored items', () => {
       const { hasMultipleSelectableItems } = useSelectedLiteGraphItems()
       const node = new MockNode()
-      const reroute1 = new MockReroute()
-      const reroute2 = new MockReroute()
+      const reroute1 = makeReroute()
+      const reroute2 = makeReroute()
 
       mockCanvas.selectedItems.add(node)
       mockCanvas.selectedItems.add(reroute1)
@@ -242,7 +227,7 @@ describe('useSelectedLiteGraphItems', () => {
       const { getSelectedNodes } = useSelectedLiteGraphItems()
       const node1 = makeNode(LGraphEventMode.ALWAYS, 1)
       const node2 = makeNode(LGraphEventMode.NEVER, 2)
-      const reroute = new MockReroute()
+      const reroute = makeReroute()
 
       // The non-node (reroute) must be filtered out by isLGraphNode.
       mockCanvas.selectedItems = new Set([node1, reroute, node2])

--- a/src/composables/graph/useArrangeSession.test.ts
+++ b/src/composables/graph/useArrangeSession.test.ts
@@ -1,22 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
 
+import { useArrangeNodes } from '@/composables/graph/useArrangeNodes'
 import { useArrangeSession } from '@/composables/graph/useArrangeSession'
 
 const mockArrangeNodes = vi.fn()
 
-vi.mock<unknown>(
-  import('@/composables/graph/useArrangeNodes'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    useArrangeNodes: () => ({ arrangeNodes: mockArrangeNodes })
-  })
-)
+vi.mock(import('@/composables/graph/useArrangeNodes'), { spy: true })
 
 describe('useArrangeSession', () => {
   let frameCallbacks: Array<FrameRequestCallback>
   let nextHandle: number
 
   beforeEach(() => {
+    vi.mocked(useArrangeNodes).mockImplementation(() => ({
+      arrangeNodes: mockArrangeNodes,
+      canArrange: computed(() => true)
+    }))
     frameCallbacks = []
     nextHandle = 1
     vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -1,5 +1,6 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
+import { useElementSize } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -13,14 +14,7 @@ import type { NodeId } from '@/types/nodeId'
 
 import { usePainter } from './usePainter'
 
-vi.mock(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  useElementSize: vi.fn(() => ({
-    width: ref(512),
-    height: ref(512),
-    stop: vi.fn()
-  }))
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
 vi.mock<unknown>(import('@/composables/maskeditor/StrokeProcessor'), () => ({
   StrokeProcessor: vi.fn(() => ({
@@ -131,6 +125,11 @@ function mountPainter(
 
 describe('usePainter', () => {
   beforeEach(() => {
+    vi.mocked(useElementSize).mockImplementation(() => ({
+      width: ref(512),
+      height: ref(512),
+      stop: vi.fn()
+    }))
     makePaintNode()
     mockIsInputConnected.mockReturnValue(false)
     mockGetInputNode.mockReturnValue(null)

--- a/src/composables/useImageCrop.test.ts
+++ b/src/composables/useImageCrop.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { fromPartial } from '@total-typescript/shoehorn'
+import { useResizeObserver } from '@vueuse/core'
 import { createApp, defineComponent, nextTick, ref, computed } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -12,7 +13,7 @@ import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
-import type { resolveNode } from '@/utils/litegraphUtil'
+import { resolveNode } from '@/utils/litegraphUtil'
 import {
   createMockLGraphNode,
   createMockSubgraphNode
@@ -22,21 +23,17 @@ import { imageCropLoadingAfterUrlChange, useImageCrop } from './useImageCrop'
 
 const resizeObserverCallbacks: Array<() => void> = []
 
-vi.mock(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  useResizeObserver: (_target: unknown, cb: ResizeObserverCallback) => {
-    resizeObserverCallbacks.push(() => cb([], fromPartial<ResizeObserver>({})))
-    return { stop: vi.fn(), isSupported: computed(() => true) }
-  }
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
 const mockResolveNode = vi.hoisted(() => vi.fn<typeof resolveNode>())
-vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  resolveNode: mockResolveNode
-}))
+vi.mock(import('@/utils/litegraphUtil'), { spy: true })
 
 beforeEach(() => {
+  vi.mocked(useResizeObserver).mockImplementation((_target, cb) => {
+    resizeObserverCallbacks.push(() => cb([], fromPartial<ResizeObserver>({})))
+    return { stop: vi.fn(), isSupported: computed(() => true) }
+  })
+  vi.mocked(resolveNode).mockImplementation(mockResolveNode)
   useCanvasStore().canvas = fromPartial<LGraphCanvas>({
     graph: { rootGraph: { id: 'test-graph' } }
   })

--- a/src/composables/usePaste.test.ts
+++ b/src/composables/usePaste.test.ts
@@ -97,10 +97,7 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   }
 }))
 
-vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  createNode: vi.fn()
-}))
+vi.mock(import('@/utils/litegraphUtil'), { spy: true })
 
 vi.mock(
   import('@/workbench/eventHelpers'),
@@ -112,6 +109,7 @@ vi.mock(
 
 describe('pasteImageNode', () => {
   beforeEach(() => {
+    vi.mocked(createNode).mockImplementation(vi.fn())
     vi.mocked(mockCanvas.graph!.add).mockImplementation(
       (node: LGraphNode | LGraphGroup | null) => node as LGraphNode
     )

--- a/src/composables/useStablePrimeVueSplitterSizer.test.ts
+++ b/src/composables/useStablePrimeVueSplitterSizer.test.ts
@@ -1,16 +1,16 @@
 import type { SplitterResizeEndEvent } from 'primevue/splitter'
+import { useStorage } from '@vueuse/core'
 
 import { nextTick, ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useStablePrimeVueSplitterSizer } from './useStablePrimeVueSplitterSizer'
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...(actual as object),
-    useStorage: <T>(_key: string, defaultValue: T) => ref(defaultValue)
-  }
+vi.mock(import('@vueuse/core'), { spy: true })
+beforeEach(() => {
+  vi.mocked(useStorage).mockImplementation((_key, defaultValue) =>
+    ref(defaultValue)
+  )
 })
 
 function createPanel(width: number) {

--- a/src/composables/useWaveAudioPlayer.test.ts
+++ b/src/composables/useWaveAudioPlayer.test.ts
@@ -1,23 +1,24 @@
 import { fromAny } from '@total-typescript/shoehorn'
+import { useMediaControls } from '@vueuse/core'
 import { ref } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useWaveAudioPlayer } from './useWaveAudioPlayer'
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return {
-    ...actual,
-    useMediaControls: () => ({
+vi.mock(import('@vueuse/core'), { spy: true })
+
+const mockFetchApi = vi.fn()
+const originalAudioContext = globalThis.AudioContext
+
+beforeEach(() => {
+  vi.mocked(useMediaControls).mockImplementation(() =>
+    fromAny({
       playing: ref(false),
       currentTime: ref(0),
       duration: ref(0)
     })
-  }
+  )
 })
-
-const mockFetchApi = vi.fn()
-const originalAudioContext = globalThis.AudioContext
 
 afterEach(() => {
   globalThis.AudioContext = originalAudioContext

--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -14,6 +14,8 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/agentPanelStore'
 import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 let agentStore: Mocked<ReturnType<typeof useAgentPanelStore>>
 let canvasStore: Mocked<ReturnType<typeof useCanvasStore>>
@@ -57,16 +59,8 @@ vi.mock('@/workbench/extensions/agent/crdt/mintPortWiring', () => ({
   notifyMintPortsBeforeGraphLoad: mocks.notifyBeforeGraphLoad
 }))
 
-vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  isLGraphNode: (node: unknown): node is LGraphNode =>
-    typeof node === 'object' && node !== null && 'id' in node
-}))
-
-vi.mock(import('@/utils/graphTraversalUtil'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  getNodeByLocatorId: mocks.getNodeByLocatorId
-}))
+vi.mock(import('@/utils/litegraphUtil'), { spy: true })
+vi.mock(import('@/utils/graphTraversalUtil'), { spy: true })
 
 vi.mock(
   '@/workbench/extensions/agent/services/agent/workflowTabActivityTracker',
@@ -113,6 +107,11 @@ describe('AgentPanel extension flag gate', () => {
     Object.assign(consentStore, { accepted: true })
     Object.assign(consentStore, { identity: 'account-a/workspace-a' })
     vi.mocked(consentStore.load).mockResolvedValue(false)
+    vi.mocked(isLGraphNode).mockImplementation(
+      (node: unknown): node is LGraphNode =>
+        typeof node === 'object' && node !== null && 'id' in node
+    )
+    vi.mocked(getNodeByLocatorId).mockImplementation(mocks.getNodeByLocatorId)
     agentStore = vi.mocked(useAgentPanelStore())
     agentStore.consentAccepted = false
     canvasStore = vi.mocked(useCanvasStore())

--- a/src/extensions/core/customWidgets.clone.test.ts
+++ b/src/extensions/core/customWidgets.clone.test.ts
@@ -9,11 +9,7 @@ const extensions = await vi.hoisted(async () => {
     await import('@/utils/__tests__/extensionTestUtils')
   return createExtensionCapture()
 })
-vi.mock(import('@/scripts/app'), async (importOriginal) => {
-  const original = await importOriginal()
-  original.app.registerExtension = extensions.registerExtension
-  return original
-})
+app.registerExtension = extensions.registerExtension
 await import('./customWidgets')
 const extension = extensions.getExtension('Comfy.CustomWidgets')
 const TEST_CUSTOM_COMBO_TYPE = 'test/CustomComboCopyPaste'

--- a/src/extensions/core/customWidgets.subgraphPromotion.test.ts
+++ b/src/extensions/core/customWidgets.subgraphPromotion.test.ts
@@ -17,11 +17,7 @@ const extensions = await vi.hoisted(async () => {
     await import('@/utils/__tests__/extensionTestUtils')
   return createExtensionCapture()
 })
-vi.mock(import('@/scripts/app'), async (importOriginal) => {
-  const original = await importOriginal()
-  original.app.registerExtension = extensions.registerExtension
-  return original
-})
+app.registerExtension = extensions.registerExtension
 await import('./customWidgets')
 const extension = extensions.getExtension('Comfy.CustomWidgets')
 // Regression coverage for https://github.com/Comfy-Org/ComfyUI/issues/15060

--- a/src/extensions/core/load3d/HDRIManager.test.ts
+++ b/src/extensions/core/load3d/HDRIManager.test.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createRendererViewState } from '@/renderer/three/sharedWebGLRenderer'
@@ -17,14 +18,16 @@ vi.mock('./Load3dUtils', () => ({
   }
 }))
 
-vi.mock('three', async (importOriginal) => {
-  const actual = await importOriginal<typeof THREE>()
-  class MockPMREMGenerator {
-    compileEquirectangularShader = vi.fn()
-    fromEquirectangular = mockFromEquirectangular
-    dispose = mockDisposePMREM
-  }
-  return { ...actual, PMREMGenerator: MockPMREMGenerator }
+vi.mock('three', { spy: true })
+
+beforeEach(() => {
+  vi.spyOn(THREE, 'PMREMGenerator').mockImplementation(function () {
+    return fromPartial<THREE.PMREMGenerator>({
+      compileEquirectangularShader: vi.fn(),
+      fromEquirectangular: mockFromEquirectangular,
+      dispose: mockDisposePMREM
+    })
+  })
 })
 
 vi.mock('three/examples/jsm/loaders/EXRLoader', () => {
@@ -79,7 +82,7 @@ describe('HDRIManager', () => {
 
     manager = new HDRIManager(
       scene,
-      {} as THREE.WebGLRenderer,
+      fromAny<THREE.WebGLRenderer, unknown>({}),
       createRendererViewState(),
       eventManager
     )

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -14,6 +14,7 @@ import type {
   ModelAdapterCapabilities,
   ModelLoadContext
 } from './ModelAdapter'
+import { fetchModelData } from './ModelAdapter'
 
 function makeEventManagerStub() {
   return {
@@ -101,11 +102,7 @@ vi.mock('./SplatModelAdapter', () => ({
   }
 }))
 
-vi.mock('./ModelAdapter', async () => {
-  const actual =
-    await vi.importActual<typeof import('./ModelAdapter')>('./ModelAdapter')
-  return { ...actual, fetchModelData: fetchModelDataMock }
-})
+vi.mock('./ModelAdapter', { spy: true })
 
 vi.mock('@/scripts/metadata/ply', () => ({
   isGaussianSplatPLY: isGaussianSplatPLYMock
@@ -139,6 +136,7 @@ function makeLoaderManager() {
 
 describe('LoaderManager', () => {
   beforeEach(() => {
+    vi.mocked(fetchModelData).mockImplementation(fetchModelDataMock)
     meshLoad.mockResolvedValue(null)
     splatLoad.mockResolvedValue(null)
     pointCloudLoad.mockResolvedValue(null)

--- a/src/extensions/core/load3d/RecordingManager.test.ts
+++ b/src/extensions/core/load3d/RecordingManager.test.ts
@@ -12,15 +12,13 @@ vi.mock('@/base/common/downloadUtil', () => ({
   downloadBlob: downloadBlobMock
 }))
 
-vi.mock('three', async (importOriginal) => {
-  const actual = await importOriginal<typeof THREE>()
-  // Avoid TextureLoader -> ImageLoader -> new Image() in happy-dom.
-  class StubTextureLoader {
-    load() {
-      return new actual.Texture()
-    }
+vi.mock('three', { spy: true })
+
+beforeEach(() => {
+  function MockTextureLoader() {
+    return { load: () => new THREE.Texture() }
   }
-  return { ...actual, TextureLoader: StubTextureLoader }
+  vi.spyOn(THREE, 'TextureLoader').mockImplementation(MockTextureLoader)
 })
 
 type DataAvailableHandler = (event: { data: Blob }) => void

--- a/src/extensions/core/load3d/SceneManager.test.ts
+++ b/src/extensions/core/load3d/SceneManager.test.ts
@@ -21,12 +21,13 @@ vi.mock('./Load3dUtils', () => ({
   }
 }))
 
-vi.mock('three', async (importOriginal) => {
-  const actual = await importOriginal<typeof THREE>()
-  class StubTextureLoader {
-    load = mockTextureLoad
+vi.mock('three', { spy: true })
+
+beforeEach(() => {
+  function MockTextureLoader() {
+    return { load: mockTextureLoad }
   }
-  return { ...actual, TextureLoader: StubTextureLoader }
+  vi.spyOn(THREE, 'TextureLoader').mockImplementation(MockTextureLoader)
 })
 
 vi.mock('three/examples/jsm/controls/OrbitControls', () => {

--- a/src/extensions/core/load3d/createLoad3d.test.ts
+++ b/src/extensions/core/load3d/createLoad3d.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as THREE from 'three'
 
 import { DEFAULT_MODEL_CAPABILITIES } from './ModelAdapter'
 import type { ModelAdapter, ModelAdapterCapabilities } from './ModelAdapter'
@@ -8,28 +9,27 @@ const { rendererCtor } = vi.hoisted(() => ({
   rendererCtor: vi.fn()
 }))
 
-vi.mock('three', async () => {
-  const actual = await vi.importActual<typeof import('three')>('three')
-  return {
-    ...actual,
-    WebGLRenderer: class {
-      domElement = document.createElement('canvas')
-      autoClear = false
-      outputColorSpace = ''
-      constructor(opts: unknown) {
-        rendererCtor(opts)
-      }
-      setSize() {}
-      setPixelRatio() {}
-      setClearColor() {}
+vi.mock('three', { spy: true })
+
+beforeEach(() => {
+  function MockWebGLRenderer(opts: unknown) {
+    rendererCtor(opts)
+    return {
+      domElement: document.createElement('canvas'),
+      autoClear: false,
+      outputColorSpace: '',
+      setSize() {},
+      setPixelRatio() {},
+      setClearColor() {},
       getSize(target: { set(x: number, y: number): unknown }) {
         target.set(300, 300)
         return target
-      }
-      forceContextLoss() {}
+      },
+      forceContextLoss() {},
       dispose() {}
     }
   }
+  vi.spyOn(THREE, 'WebGLRenderer').mockImplementation(MockWebGLRenderer)
 })
 
 vi.mock('./SceneManager', () => ({

--- a/src/extensions/core/load3d/exportMenuHelper.test.ts
+++ b/src/extensions/core/load3d/exportMenuHelper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 
 import type Load3d from './Load3d'
 import { createExportMenuItems } from './exportMenuHelper'
@@ -14,19 +15,16 @@ vi.mock('@/i18n', () => ({
     vars ? `${key}:${JSON.stringify(vars)}` : key
 }))
 
-vi.mock(import('@/lib/litegraph/src/litegraph'), async (importOriginal) => {
-  const actual = await importOriginal()
-  class MockContextMenu {
-    constructor(...args: unknown[]) {
-      contextMenuMock(...args)
-    }
+vi.mock(import('@/lib/litegraph/src/litegraph'), { spy: true })
+
+class MockContextMenu {
+  constructor(...args: unknown[]) {
+    contextMenuMock(...args)
   }
-  // Replace ContextMenu in-place on the real LiteGraph singleton so consumers
-  // that import other members keep getting the real implementations.
-  ;(actual.LiteGraph as unknown as { ContextMenu: unknown }).ContextMenu =
-    MockContextMenu
-  return actual
-})
+}
+
+;(LiteGraph as unknown as { ContextMenu: unknown }).ContextMenu =
+  MockContextMenu
 
 function makeLoad3d(
   exportImpl: (format: string) => Promise<void> = vi

--- a/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
@@ -8,16 +8,11 @@ import {
   ToInputRenderLink
 } from '@/lib/litegraph/src/litegraph'
 import { getSlotLayoutAtPoint } from '@/renderer/core/canvas/litegraph/slotCalculations'
-import type * as SlotCalculations from '@/renderer/core/canvas/litegraph/slotCalculations'
 
 vi.mock(import('@/renderer/core/layout/store/layoutStore'))
 vi.mock(
   import('@/renderer/core/canvas/litegraph/slotCalculations'), // eslint-disable-line import-x/no-restricted-paths
-
-  async (importOriginal) => ({
-    ...(await importOriginal<typeof SlotCalculations>()),
-    getSlotLayoutAtPoint: vi.fn()
-  })
+  { spy: true }
 )
 
 describe('LGraphCanvas slot hit detection', () => {

--- a/src/lib/litegraph/src/LGraphGroup.test.ts
+++ b/src/lib/litegraph/src/LGraphGroup.test.ts
@@ -17,10 +17,7 @@ import { createUuidv4 } from '@/utils/uuid'
 
 import { test } from './__fixtures__/testExtensions'
 
-vi.mock(import('@/utils/colorUtil'), async (importOriginal) => {
-  const actual = await importOriginal<typeof colorUtil>()
-  return { ...actual, readableTextColor: vi.fn(actual.readableTextColor) }
-})
+vi.mock(import('@/utils/colorUtil'), { spy: true })
 
 function createMockContext() {
   return {

--- a/src/lib/litegraph/src/widgets/ComboWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/ComboWidget.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type * as LGraphCanvasModule from '@/lib/litegraph/src/LGraphCanvas'
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { IComboWidget } from '@/lib/litegraph/src/types/widgets'
 import { ComboWidget } from '@/lib/litegraph/src/widgets/ComboWidget'
 
-const { LGraphCanvas } = await vi.importActual<typeof LGraphCanvasModule>(
-  '@/lib/litegraph/src/LGraphCanvas'
-)
 type LGraphCanvasType = InstanceType<typeof LGraphCanvas>
 
 interface MockWidgetConfig extends Omit<IComboWidget, 'options'> {

--- a/src/platform/assets/components/AssetCard.test.ts
+++ b/src/platform/assets/components/AssetCard.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUseModule from '@vueuse/core'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -19,11 +18,6 @@ vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
 
 vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
   showConfirmDialog: vi.fn()
-}))
-
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUseModule>()),
-  useImage: () => ({ isLoading: false, error: null })
 }))
 
 const HASH = 'blake3:abc123def456'

--- a/src/platform/assets/composables/useAssetBrowserDialog.test.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.test.ts
@@ -1,4 +1,3 @@
-import type * as I18nModule from '@/i18n'
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { describe, expect, it, vi } from 'vitest'
@@ -9,8 +8,7 @@ import type AssetBrowserModal from '@/platform/assets/components/AssetBrowserMod
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
-vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   t: (key: string, params?: Record<string, string>) => {
     if (params) {
       return `${key}:${JSON.stringify(params)}`

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useAssetExportStore } from '@/stores/assetExportStore'
@@ -30,8 +29,7 @@ vi.mock(import('@/base/common/downloadUtil'), () => ({
   downloadFile: mockDownloadFile
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -1,5 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
-import type * as I18nModule from '@/i18n'
 import type { ComfyApp } from '@/scripts/app'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { useAssetsStore } from '@/stores/assetsStore'
@@ -18,8 +16,7 @@ import { api } from '@/scripts/api'
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: true }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockDistributionState.isCloud
   }
@@ -46,8 +43,8 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
+  t: (key: string) => key,
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -1,25 +1,21 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
-import type * as MissingMediaScanModule from '@/platform/missingMedia/missingMediaScan'
 import {
   createPromotedMediaRuntime,
   seedMediaNodeDefs
 } from '@/platform/missingMedia/__fixtures__/promotedMedia'
+import { scanNodeMediaCandidates } from '@/platform/missingMedia/missingMediaScan'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 
 import { markDeletedAssetsAsMissingMedia } from './markDeletedAssetsAsMissingMedia'
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: true
 }))
 
-const mockScanNodeMediaCandidates = vi.hoisted(() => vi.fn())
-vi.mock(import('@/platform/missingMedia/missingMediaScan'), () => ({
-  scanNodeMediaCandidates: mockScanNodeMediaCandidates
-}))
+vi.mock(import('@/platform/missingMedia/missingMediaScan'), { spy: true })
+const mockScanNodeMediaCandidates = vi.mocked(scanNodeMediaCandidates)
 
 function makeGraph(nodes: unknown[]): LGraph {
   return { nodes } as unknown as LGraph
@@ -46,14 +42,16 @@ describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
         nodeType: 'LoadImage',
         widgetName: 'image',
         mediaType: 'image',
-        name: 'sub/foo.png [output]'
+        name: 'sub/foo.png [output]',
+        isMissing: undefined
       },
       {
         nodeId: '1',
         nodeType: 'LoadImage',
         widgetName: 'mask',
         mediaType: 'image',
-        name: 'unrelated.png'
+        name: 'unrelated.png',
+        isMissing: undefined
       }
     ])
 
@@ -142,7 +140,8 @@ describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
         nodeType: 'LoadImage',
         widgetName: 'image',
         mediaType: 'image',
-        name: 'nested.png [output]'
+        name: 'nested.png [output]',
+        isMissing: undefined
       }
     ])
 
@@ -173,10 +172,7 @@ describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
       sourceValue: 'stale-interior.png',
       sourceOptions: []
     })
-    const { scanNodeMediaCandidates } = await vi.importActual<
-      typeof MissingMediaScanModule
-    >('@/platform/missingMedia/missingMediaScan')
-    mockScanNodeMediaCandidates.mockImplementation(scanNodeMediaCandidates)
+    mockScanNodeMediaCandidates.mockRestore()
 
     markDeletedAssetsAsMissingMedia(rootGraph, new Set([deletedValue]))
 

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import type { ComfyApp } from '@/scripts/app'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { useAuthStore } from '@/stores/authStore'
@@ -12,8 +11,7 @@ const mockGetAuthHeader = vi.fn<
 >(async () => null)
 const originalFetch = globalThis.fetch
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: true
 }))
 
@@ -291,9 +289,4 @@ vi.mock(import('@/scripts/app'), async () => {
   const { fromPartial } = await import('@total-typescript/shoehorn')
   return { app: fromPartial<ComfyApp>({}) }
 })
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { AxiosAdapter } from 'axios'
 import axios, { AxiosError } from 'axios'
@@ -33,8 +32,7 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
 
 // The axios interceptor gates on shouldRemintCloudRequest(), which is a no-op
 // off-cloud; the unit env is not a cloud build, so force it on.
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: true
 }))
 

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -18,9 +17,11 @@ const electron = {
 
 const errorReporter = vi.hoisted(() => vi.fn())
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
-  isDesktop: true
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
+  DISTRIBUTION: 'desktop',
+  isCloud: false,
+  isDesktop: true,
+  isNightly: false
 }))
 
 vi.mock(import('@/platform/telemetry/reportError'), () => ({

--- a/src/platform/cloud/oauth/OAuthConsentView.test.ts
+++ b/src/platform/cloud/oauth/OAuthConsentView.test.ts
@@ -4,16 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import OAuthConsentView from '@/platform/cloud/oauth/OAuthConsentView.vue'
-import { OAuthApiError } from '@/platform/cloud/oauth/oauthApi'
-import type * as oauthApi from '@/platform/cloud/oauth/oauthApi'
+import {
+  OAuthApiError,
+  submitOAuthConsentDecision
+} from '@/platform/cloud/oauth/oauthApi'
 import type { OAuthConsentChallenge } from '@/platform/cloud/oauth/oauthApi'
 
-const submitOAuthConsentDecision = vi.hoisted(() => vi.fn())
-
-vi.mock(import('@/platform/cloud/oauth/oauthApi'), async (importOriginal) => ({
-  ...(await importOriginal<typeof oauthApi>()),
-  submitOAuthConsentDecision
-}))
+vi.mock(import('@/platform/cloud/oauth/oauthApi'), { spy: true })
+const mockSubmitOAuthConsentDecision = vi.mocked(submitOAuthConsentDecision)
 
 const i18n = createI18n({
   legacy: false,
@@ -98,7 +96,7 @@ const renderConsent = (overrides: Partial<OAuthConsentChallenge> = {}) =>
 
 describe('OAuthConsentView', () => {
   beforeEach(() => {
-    submitOAuthConsentDecision.mockReset().mockResolvedValue(undefined)
+    mockSubmitOAuthConsentDecision.mockReset().mockResolvedValue(undefined)
   })
 
   it('shows the generic app icon regardless of client_display_name', () => {
@@ -145,7 +143,7 @@ describe('OAuthConsentView', () => {
     // sole workspace_id.
     await user.click(screen.getByRole('button', { name: 'Continue' }))
 
-    expect(submitOAuthConsentDecision).toHaveBeenCalledWith({
+    expect(mockSubmitOAuthConsentDecision).toHaveBeenCalledWith({
       oauthRequestId: '550e8400-e29b-41d4-a716-446655440000',
       csrfToken: 'csrf-token',
       decision: 'allow',
@@ -166,7 +164,7 @@ describe('OAuthConsentView', () => {
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
-    expect(submitOAuthConsentDecision).toHaveBeenCalledWith(
+    expect(mockSubmitOAuthConsentDecision).toHaveBeenCalledWith(
       expect.objectContaining({
         decision: 'deny',
         workspaceId: 'personal-workspace'
@@ -187,11 +185,11 @@ describe('OAuthConsentView', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(screen.getByRole('alert')).toBeVisible()
-    expect(submitOAuthConsentDecision).not.toHaveBeenCalled()
+    expect(mockSubmitOAuthConsentDecision).not.toHaveBeenCalled()
   })
 
   it('maps OAuthApiError(400) to the expired-request message', async () => {
-    submitOAuthConsentDecision.mockRejectedValue(
+    mockSubmitOAuthConsentDecision.mockRejectedValue(
       new OAuthApiError('expired', 400)
     )
     const user = userEvent.setup()
@@ -209,7 +207,7 @@ describe('OAuthConsentView', () => {
   })
 
   it('maps OAuthApiError(401) to the session-expired message', async () => {
-    submitOAuthConsentDecision.mockRejectedValue(
+    mockSubmitOAuthConsentDecision.mockRejectedValue(
       new OAuthApiError('session expired', 401)
     )
     const user = userEvent.setup()
@@ -225,7 +223,7 @@ describe('OAuthConsentView', () => {
   })
 
   it('maps OAuthApiError(403) to the scope-broadening re-prompt message', async () => {
-    submitOAuthConsentDecision.mockRejectedValue(
+    mockSubmitOAuthConsentDecision.mockRejectedValue(
       new OAuthApiError('scope broadening', 403)
     )
     const user = userEvent.setup()
@@ -243,7 +241,7 @@ describe('OAuthConsentView', () => {
   })
 
   it('maps OAuthApiError(404) to the feature-unavailable message', async () => {
-    submitOAuthConsentDecision.mockRejectedValue(
+    mockSubmitOAuthConsentDecision.mockRejectedValue(
       new OAuthApiError('disabled', 404)
     )
     const user = userEvent.setup()

--- a/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
+++ b/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
@@ -186,10 +186,4 @@ describe('CloudSignInForm in-flight state', () => {
     expect(emitted().submit).toBeUndefined()
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -1,4 +1,3 @@
-import type * as I18nModule from '@/i18n'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useAuthStore } from '@/stores/authStore'
@@ -26,15 +25,7 @@ const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockUserGetIdToken = vi.hoisted(() => vi.fn())
 const mockStoreGetIdToken = vi.hoisted(() => vi.fn())
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
-
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 
@@ -677,3 +668,4 @@ describe('installDesktopLoginRedemption', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 })
+vi.mock(import('firebase/auth'))

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useAuthStore } from '@/stores/authStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
@@ -129,8 +128,7 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: true
 }))
 
@@ -562,10 +560,4 @@ describe('PricingTable', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -134,8 +133,7 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   }))
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
@@ -1027,10 +1025,4 @@ describe('useSubscription', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
@@ -84,8 +83,7 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   })
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
@@ -909,10 +907,4 @@ describe('useSubscriptionDialog', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/cloud/subscription/launchCancellationFlow.test.ts
+++ b/src/platform/cloud/subscription/launchCancellationFlow.test.ts
@@ -1,4 +1,3 @@
-import type * as I18nModule from '@/i18n'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -32,8 +31,7 @@ vi.mock<unknown>(import('@/composables/billing/useBillingContext'), () => ({
   })
 }))
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useAuthStore } from '@/stores/authStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -69,8 +68,7 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: vi.fn(() => mockTelemetry)
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
@@ -335,10 +333,4 @@ describe('performSubscriptionCheckout', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useAuthStore } from '@/stores/authStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,8 +13,7 @@ const {
   mockTrackBillingEvent: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockIsCloud.value
   }
@@ -164,10 +162,4 @@ describe('performTeamSubscriptionCheckout', () => {
     expect(assignedHref).toBeUndefined()
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/keybindings/presetService.test.ts
+++ b/src/platform/keybindings/presetService.test.ts
@@ -1,4 +1,3 @@
-import type * as I18nModule from '@/i18n'
 import type { ComfyApp } from '@/scripts/app'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -74,8 +73,7 @@ vi.mock<unknown>(import('@/platform/keybindings/keybindingService'), () => ({
   })
 }))
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   t: (key: string) => key
 }))
 

--- a/src/platform/missingMedia/missingMediaAssetResolver.test.ts
+++ b/src/platform/missingMedia/missingMediaAssetResolver.test.ts
@@ -2,8 +2,6 @@ import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import type * as AssetServiceModule from '@/platform/assets/services/assetService'
-import type * as FetchJobsModule from '@/platform/remote/comfyui/jobs/fetchJobs'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import {
   getAssetDetectionNames,
@@ -23,31 +21,16 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({ flags: { assetsEnabled: true } })
 }))
 
-vi.mock(import('@/platform/assets/services/assetService'), async () => {
-  const actual = await vi.importActual<typeof AssetServiceModule>(
-    '@/platform/assets/services/assetService'
-  )
-
-  return {
-    ...actual,
-    assetService: {
-      ...actual.assetService,
-      getAllAssetsByTag: mockGetAllAssetsByTag,
-      getAssetsPageByTag: mockGetAssetsPageByTag
-    }
+vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
+  assetService: {
+    getAllAssetsByTag: mockGetAllAssetsByTag,
+    getAssetsPageByTag: mockGetAssetsPageByTag
   }
-})
+}))
 
-vi.mock(import('@/platform/remote/comfyui/jobs/fetchJobs'), async () => {
-  const actual = await vi.importActual<typeof FetchJobsModule>(
-    '@/platform/remote/comfyui/jobs/fetchJobs'
-  )
-
-  return {
-    ...actual,
-    fetchHistoryPage: mockFetchHistoryPage
-  }
-})
+vi.mock<unknown>(import('@/platform/remote/comfyui/jobs/fetchJobs'), () => ({
+  fetchHistoryPage: mockFetchHistoryPage
+}))
 
 function makeAsset(name: string, assetHash?: string): AssetItem {
   return fromPartial({

--- a/src/platform/missingMedia/missingMediaPipeline.test.ts
+++ b/src/platform/missingMedia/missingMediaPipeline.test.ts
@@ -115,10 +115,4 @@ describe('runMissingMediaPipeline', () => {
     expect(activeWorkflow.pendingWarnings).toBeNull()
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -5,15 +5,12 @@ import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import type { IComboWidget } from '@/lib/litegraph/src/types/widgets'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import type * as AssetServiceModule from '@/platform/assets/services/assetService'
 import {
   createMediaNodeDef,
   seedMediaNodeDefs
 } from '@/platform/missingMedia/__fixtures__/promotedMedia'
-import type * as FetchJobsModule from '@/platform/remote/comfyui/jobs/fetchJobs'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
-import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
 import type { MissingMediaAssetResolver } from './missingMediaAssetResolver'
 import {
   isMissingMediaCandidateScopeActive,
@@ -38,8 +35,7 @@ const { mockFetchHistoryPage } = vi.hoisted(() => ({
   mockFetchHistoryPage: vi.fn()
 }))
 
-vi.mock<unknown>(import('@/utils/graphTraversalUtil'), async (importActual) => {
-  const actual = await importActual<typeof GraphTraversalUtil>()
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => {
   type TestNode = LGraphNode & { _testExecutionId?: string }
   type TestGraph = { _testNodes: TestNode[] }
   const isTestGraph = (graph: LGraph | TestGraph): graph is TestGraph =>
@@ -53,21 +49,23 @@ vi.mock<unknown>(import('@/utils/graphTraversalUtil'), async (importActual) => {
     node?.mode === LGraphEventMode.BYPASS
 
   return {
-    ...actual,
     collectAllNodes: (graph: LGraph | TestGraph) =>
-      isTestGraph(graph) ? graph._testNodes : actual.collectAllNodes(graph),
+      isTestGraph(graph) ? graph._testNodes : graph.nodes,
     getExecutionIdByNode: (graph: LGraph | TestGraph, node: TestNode) =>
+      isTestGraph(graph) ? executionIdForNode(node) : String(node.id),
+    getNodeByExecutionId: (graph: LGraph | TestGraph, executionId: string) =>
       isTestGraph(graph)
-        ? executionIdForNode(node)
-        : actual.getExecutionIdByNode(graph, node),
+        ? findNodeByExecutionId(graph, executionId)
+        : graph.nodes.find(
+            (node) => String(node.id) === executionId.split(':').at(-1)
+          ),
     isExecutionPathActive: (graph: LGraph | TestGraph, executionId: string) => {
-      if (!isTestGraph(graph)) {
-        return actual.isExecutionPathActive(graph, executionId)
-      }
       const path = executionId.split(':')
       return path.every((_, index) => {
         const prefix = path.slice(0, index + 1).join(':')
-        const node = findNodeByExecutionId(graph, prefix)
+        const node = isTestGraph(graph)
+          ? findNodeByExecutionId(graph, prefix)
+          : graph.nodes.find((node) => String(node.id) === prefix)
         return !!node && !isInactive(node)
       })
     }
@@ -78,31 +76,16 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({ flags: { assetsEnabled: true } })
 }))
 
-vi.mock(import('@/platform/assets/services/assetService'), async () => {
-  const actual = await vi.importActual<typeof AssetServiceModule>(
-    '@/platform/assets/services/assetService'
-  )
-
-  return {
-    ...actual,
-    assetService: {
-      ...actual.assetService,
-      getAllAssetsByTag: mockGetAllAssetsByTag,
-      getAssetsPageByTag: mockGetAssetsPageByTag
-    }
+vi.mock<unknown>(import('@/platform/assets/services/assetService'), () => ({
+  assetService: {
+    getAllAssetsByTag: mockGetAllAssetsByTag,
+    getAssetsPageByTag: mockGetAssetsPageByTag
   }
-})
+}))
 
-vi.mock(import('@/platform/remote/comfyui/jobs/fetchJobs'), async () => {
-  const actual = await vi.importActual<typeof FetchJobsModule>(
-    '@/platform/remote/comfyui/jobs/fetchJobs'
-  )
-
-  return {
-    ...actual,
-    fetchHistoryPage: mockFetchHistoryPage
-  }
-})
+vi.mock<unknown>(import('@/platform/remote/comfyui/jobs/fetchJobs'), () => ({
+  fetchHistoryPage: mockFetchHistoryPage
+}))
 
 function makeCandidate(
   nodeId: string,

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -11,20 +11,12 @@ import type {
   MissingModelGroup,
   MissingModelViewModel
 } from '@/platform/missingModel/types'
-import type * as MissingModelDownload from '@/platform/missingModel/missingModelDownload'
+import { downloadModel } from '@/platform/missingModel/missingModelDownload'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 
-const mockDownloadModel = vi.hoisted(() => vi.fn())
+const mockDownloadModel = vi.mocked(downloadModel)
 
-vi.mock(import('@/platform/missingModel/missingModelDownload'), async () => {
-  const actual = await vi.importActual<typeof MissingModelDownload>(
-    '@/platform/missingModel/missingModelDownload'
-  )
-  return {
-    ...actual,
-    downloadModel: mockDownloadModel
-  }
-})
+vi.mock(import('@/platform/missingModel/missingModelDownload'), { spy: true })
 
 vi.mock<unknown>(import('./MissingModelRow.vue'), () => ({
   default: {
@@ -52,10 +44,13 @@ vi.mock<unknown>(import('./MissingModelRow.vue'), () => ({
 }))
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
-vi.mock(import('@/platform/distribution/types'), () => ({
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
+  DISTRIBUTION: 'cloud',
   get isCloud() {
     return mockIsCloud.value
-  }
+  },
+  isDesktop: false,
+  isNightly: false
 }))
 
 import MissingModelCard from './MissingModelCard.vue'
@@ -163,6 +158,7 @@ describe('MissingModelCard', () => {
   beforeEach(() => {
     i18n.global.setLocaleMessage('en', enMessages)
     mockIsCloud.value = true
+    mockDownloadModel.mockResolvedValue(undefined)
   })
 
   describe('Rendering & Props', () => {

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -10,18 +10,21 @@ import type {
   UploadModelDialogContext,
   UploadModelSuccess
 } from '@/platform/assets/composables/useUploadModelWizard'
+import {
+  downloadModel,
+  fetchModelMetadata,
+  openGatedRepoPage
+} from '@/platform/missingModel/missingModelDownload'
 import type { MissingModelViewModel } from '@/platform/missingModel/types'
-import type * as MissingModelDownload from '@/platform/missingModel/missingModelDownload'
-import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockIsDesktop = vi.hoisted(() => ({ value: false }))
 const mockShowUploadDialog = vi.hoisted(() => vi.fn())
 const mockCopyToClipboard = vi.hoisted(() => vi.fn())
-const mockDownloadModel = vi.hoisted(() => vi.fn())
-const mockFetchModelMetadata = vi.hoisted(() => vi.fn())
-const mockOpenGatedRepoPage = vi.hoisted(() => vi.fn())
+const mockDownloadModel = vi.mocked(downloadModel)
+const mockFetchModelMetadata = vi.mocked(fetchModelMetadata)
+const mockOpenGatedRepoPage = vi.mocked(openGatedRepoPage)
 const mockRootGraph = vi.hoisted<{
   value: Record<string, never> | null
 }>(() => ({ value: null }))
@@ -60,16 +63,10 @@ vi.mock<unknown>(import('@/scripts/api'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@/utils/graphTraversalUtil'), async () => {
-  const actual = await vi.importActual<typeof GraphTraversalUtil>(
-    '@/utils/graphTraversalUtil'
-  )
-  return {
-    ...actual,
-    getActiveGraphNodeIds: vi.fn(() => new Set()),
-    getNodeByExecutionId: mockGetNodeByExecutionId
-  }
-})
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
+  getActiveGraphNodeIds: vi.fn(() => new Set()),
+  getNodeByExecutionId: mockGetNodeByExecutionId
+}))
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -109,17 +106,7 @@ vi.mock(import('@/composables/useCopyToClipboard'), () => ({
   })
 }))
 
-vi.mock(import('@/platform/missingModel/missingModelDownload'), async () => {
-  const actual = await vi.importActual<typeof MissingModelDownload>(
-    '@/platform/missingModel/missingModelDownload'
-  )
-  return {
-    ...actual,
-    downloadModel: mockDownloadModel,
-    fetchModelMetadata: mockFetchModelMetadata,
-    openGatedRepoPage: mockOpenGatedRepoPage
-  }
-})
+vi.mock(import('@/platform/missingModel/missingModelDownload'), { spy: true })
 
 import MissingModelRow from './MissingModelRow.vue'
 
@@ -194,6 +181,7 @@ describe('MissingModelRow', () => {
     mockApiListeners.clear()
     mockUploadContext.resolver = undefined
     mockUploadCallbacks.onUploadSuccess = undefined
+    mockDownloadModel.mockResolvedValue(undefined)
     mockFetchModelMetadata.mockResolvedValue({
       fileSize: null,
       gatedRepoUrl: null

--- a/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
@@ -28,8 +27,7 @@ const mockDownloadList = vi.fn(
   >[] => []
 )
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,11 +18,13 @@ const { fetchMock, mockIsDesktop, mockStartDownload } = vi.hoisted(() => ({
   mockStartDownload: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
+  DISTRIBUTION: 'localhost',
+  isCloud: false,
   get isDesktop() {
     return mockIsDesktop.value
-  }
+  },
+  isNightly: false
 }))
 
 beforeEach(() => {

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -1,5 +1,4 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import type * as DistributionModule from '@/platform/distribution/types'
 import type { ComfyApp } from '@/scripts/app'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useMissingModelStore } from './missingModelStore'
@@ -72,8 +71,7 @@ const { mockHandles } = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 
@@ -691,10 +689,4 @@ vi.mock(import('@/scripts/app'), async () => {
   const { fromPartial } = await import('@total-typescript/shoehorn')
   return { app: fromPartial<ComfyApp>({}) }
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'))

--- a/src/platform/missingModel/missingModelScan.test.ts
+++ b/src/platform/missingModel/missingModelScan.test.ts
@@ -1,4 +1,3 @@
-import type * as I18nModule from '@/i18n'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
@@ -1741,8 +1740,8 @@ const { mockUpdateModelsForNodeType, mockGetAssets } = vi.hoisted(() => ({
   mockGetAssets: vi.fn().mockReturnValue([])
 }))
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
+  t: (key: string) => key,
   st: (_key: string, fallback: string) => fallback
 }))
 

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -1,5 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
-import type * as I18nModule from '@/i18n'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -15,14 +13,12 @@ const mockNodeLocatorIdToNodeExecutionId = vi.hoisted(() =>
   vi.fn((nodeLocatorId: string) => nodeLocatorId)
 )
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   t: vi.fn((key: string) => `translated:${key}`),
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -1,5 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
-import type * as I18nModule from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,13 +14,11 @@ vi.mock(import('@/platform/nodeReplacement/cnrIdUtil'), () => ({
   getCnrIdFromNode: vi.fn(() => undefined)
 }))
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 

--- a/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
+++ b/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
@@ -1,17 +1,13 @@
-import type * as DistributionModule from '@/platform/distribution/types'
-import type * as I18nModule from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false
 }))
 

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -1,5 +1,4 @@
 import { fromPartial, fromAny } from '@total-typescript/shoehorn'
-import type * as I18nModule from '@/i18n'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -24,16 +23,9 @@ import { widgetId } from '@/types/widgetId'
 import type { UUID } from '@/utils/uuid'
 import type { NodeReplacement } from './types'
 
-vi.mock(import('@/lib/litegraph/src/litegraph'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    LiteGraph: Object.assign({}, actual.LiteGraph, {
-      createNode: vi.fn(),
-      registered_node_types: {}
-    })
-  }
-})
+vi.mock(import('@/lib/litegraph/src/litegraph'), { spy: true })
+LiteGraph.createNode = vi.fn()
+LiteGraph.registered_node_types = {}
 
 vi.mock(import('@/core/graph/nodeShell/nodeShellState'), () => ({
   canTransferReplacementOwnership: vi.fn(() => true),
@@ -57,8 +49,7 @@ vi.mock(import('@/utils/graphTraversalUtil'), () => ({
 
 const { mockToastAdd } = vi.hoisted(() => ({ mockToastAdd: vi.fn() }))
 
-vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   st: (_key: string, fallback: string) => fallback,
   t: (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key

--- a/src/platform/settings/composables/useSettingSearch.test.ts
+++ b/src/platform/settings/composables/useSettingSearch.test.ts
@@ -1,4 +1,3 @@
-import type * as I18nModule from '@/i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -9,8 +8,7 @@ import type { SettingTreeNode } from '@/platform/settings/settingStore'
 import type { SettingParams } from '@/platform/settings/types'
 
 // Mock dependencies
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_: string, fallback: string) => fallback)
 }))
 

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 
@@ -58,8 +57,7 @@ vi.mock<unknown>(import('@/composables/useVueFeatureFlags'), () => ({
   useVueFeatureFlags: () => ({ shouldRenderVueNodes: ref(false) })
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return env.state.isCloud
   },

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -1,5 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
-import type * as I18nModule from '@/i18n'
 import { useDialogStore } from '@/stores/dialogStore'
 /**
  * Settings dialog migration regression net: `useSettingsDialog().show()` must
@@ -12,15 +10,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const showDialog = vi.hoisted(() => vi.fn())
 const isCloudRef = vi.hoisted(() => ({ value: false }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return isCloudRef.value
   }
 }))
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock(import('@/i18n'), () => ({
   t: (k: string) => k
 }))
 

--- a/src/platform/telemetry/hostUserIdSync.test.ts
+++ b/src/platform/telemetry/hostUserIdSync.test.ts
@@ -1,14 +1,20 @@
 import { fromPartial } from '@total-typescript/shoehorn'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { useAuthStore } from '@/stores/authStore'
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn()
-}))
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 import { syncHostUserIdWithFirebaseAuth } from './hostUserIdSync'
 

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
@@ -1,5 +1,10 @@
 import { createHash } from 'node:crypto'
 import { fromPartial } from '@total-typescript/shoehorn'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import type { User } from 'firebase/auth'
 import { getActivePinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -15,12 +20,13 @@ vi.mock(import('@/platform/telemetry/utils/checkoutAttribution'), () => ({
   captureCheckoutAttributionFromSearch: mockCaptureCheckoutAttributionFromSearch
 }))
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  onAuthStateChanged: vi.fn(),
-  onIdTokenChanged: vi.fn(),
-  setPersistence: vi.fn()
-}))
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 import { ImpactTelemetryProvider } from './ImpactTelemetryProvider'
 

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as VueModule from 'vue'
 import type { Ref } from 'vue'
 import { nextTick, ref } from 'vue'
 
@@ -75,7 +74,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
 }))
 
 vi.mock<unknown>(import('@/platform/remoteConfig/remoteConfig'), async () => {
-  const { ref } = await vi.importActual<typeof VueModule>('vue')
   hoisted.refs.remoteConfig = ref<RemoteConfig>({})
   return { remoteConfig: hoisted.refs.remoteConfig }
 })
@@ -89,7 +87,6 @@ vi.mock(import('@/platform/telemetry/utils/getExecutionContext'), () => ({
 vi.mock<unknown>(
   import('@/composables/billing/useBillingContext'),
   async () => {
-    const { ref } = await vi.importActual<typeof VueModule>('vue')
     hoisted.refs.tier = ref<string | null>(null)
     return { useBillingContext: () => ({ tier: hoisted.refs.tier }) }
   }

--- a/src/platform/updates/common/releaseStore.test.ts
+++ b/src/platform/updates/common/releaseStore.test.ts
@@ -1,7 +1,5 @@
-import type * as DistributionModule from '@/platform/distribution/types'
-import type * as VueUseModule from '@vueuse/core'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { until } from '@vueuse/core'
+import { createSharedComposable, until, useStorage } from '@vueuse/core'
 import { compare } from 'semver'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -22,8 +20,7 @@ vi.mock(import('semver'), () => ({
 
 const mockData = vi.hoisted(() => ({ isDesktop: true, isCloud: false }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isDesktop() {
     return mockData.isDesktop
   },
@@ -45,12 +42,9 @@ vi.mock(import('@/platform/updates/common/releaseService'), () => {
   }
 })
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUseModule>()),
-  until: vi.fn(() => Promise.resolve()),
-  useStorage: vi.fn(() => ({ value: {} })),
-  createSharedComposable: vi.fn((fn) => fn)
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(useStorage).mockReturnValue(ref({}))
+vi.mocked(createSharedComposable).mockImplementation((fn) => fn)
 
 beforeEach(() => {
   const get = vi.fn((key: string) => {

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -1,6 +1,5 @@
-import type * as VueUseModule from '@vueuse/core'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { until } from '@vueuse/core'
+import { until, useStorage } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
@@ -17,11 +16,8 @@ const { mockDismissalStorage } = await vi.hoisted(async () => {
   const { ref } = await import('vue')
   return { mockDismissalStorage: ref({} as Record<string, number>) }
 })
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUseModule>()),
-  useStorage: vi.fn(() => mockDismissalStorage),
-  until: vi.fn(() => Promise.resolve())
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(useStorage).mockReturnValue(mockDismissalStorage)
 
 describe('useVersionCompatibilityStore', () => {
   let store: ReturnType<typeof useVersionCompatibilityStore>
@@ -29,6 +25,7 @@ describe('useVersionCompatibilityStore', () => {
   let mockSettingStore: ReturnType<typeof useSettingStore>
 
   beforeEach(() => {
+    vi.mocked(useStorage).mockReturnValue(mockDismissalStorage)
     // Clear the mock dismissal storage
     mockDismissalStorage.value = {}
 

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -1,4 +1,3 @@
-import type * as DistributionModule from '@/platform/distribution/types'
 import { useReleaseStore } from '../common/releaseStore'
 beforeEach(() => {
   Object.assign(useReleaseStore(), {
@@ -46,8 +45,7 @@ const { toastErrorHandlerMock } = vi.hoisted(() => ({
   toastErrorHandlerMock: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal<typeof DistributionModule>()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   isCloud: false,
   isNightly: false,
   get isDesktop() {

--- a/src/platform/updates/components/WhatsNewPopup.test.ts
+++ b/src/platform/updates/components/WhatsNewPopup.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import type * as I18nModule from '@/i18n'
 import type { ComfyApp } from '@/scripts/app'
 import { useReleaseStore } from '../common/releaseStore'
 beforeEach(() => {
@@ -45,8 +44,7 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-vi.mock<unknown>(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal<typeof I18nModule>()),
+vi.mock<unknown>(import('@/i18n'), () => ({
   i18n: {
     global: {
       locale: {

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -2,6 +2,11 @@ import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore' // eslint-disable-line import-x/no-restricted-paths
 import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -31,6 +36,14 @@ import type { AppMode } from '@/utils/appMode'
 import { isValidUuid } from '@/utils/formatUtil'
 import { zeroUuid } from '@/utils/uuid'
 import { t } from '@/i18n'
+
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 function createModeTestWorkflow(
   options: {
@@ -2832,10 +2845,3 @@ vi.mock(import('@vueuse/router'), async () => {
   const { ref } = await import('vue')
   return { useRouteHash: () => ref('') }
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -1,4 +1,9 @@
 import { useAuthStore } from '@/stores/authStore'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -34,15 +39,17 @@ vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) => key)
 }))
 
-vi.mock(import('@/scripts/api'), async (importOriginal) => ({
-  api: Object.assign((await importOriginal()).api, {
-    apiURL: vi.fn((path: string) => `/api${path}`)
-  })
-}))
-
 vi.mock(import('./workspaceApiUrl'), () => ({
   workspaceApiUrl: (path: string) => `/api${path}`
 }))
+
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 import { workspaceApi } from './workspaceApi'
 
@@ -787,10 +794,3 @@ describe('workspaceApi', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -13,6 +13,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import {
+  remoteConfigErrorStatus,
+  remoteConfigState
+} from '@/platform/remoteConfig/remoteConfig'
 
 import WorkspaceAuthGate from './WorkspaceAuthGate.vue'
 
@@ -43,25 +47,6 @@ const mockRefreshRemoteConfig = vi.fn()
 vi.mock(import('@/platform/remoteConfig/refreshRemoteConfig'), () => ({
   refreshRemoteConfig: (options: unknown) => mockRefreshRemoteConfig(options)
 }))
-
-const mockRemoteConfigState = vi.hoisted(() => ({
-  value: 'authenticated' as
-    | 'uninitialized'
-    | 'anonymous'
-    | 'authenticated'
-    | 'error'
-}))
-const mockRemoteConfigErrorStatus = vi.hoisted(() => ({
-  value: null as number | null
-}))
-vi.mock<unknown>(
-  import('@/platform/remoteConfig/remoteConfig'),
-  async (importOriginal) => ({
-    ...(await (importOriginal as () => Promise<object>)()),
-    remoteConfigState: mockRemoteConfigState,
-    remoteConfigErrorStatus: mockRemoteConfigErrorStatus
-  })
-)
 
 const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
@@ -114,8 +99,8 @@ describe('WorkspaceAuthGate', () => {
     Object.assign(useAuthStore(), { currentUser: null })
     Object.assign(useApiKeyAuthStore(), { isAuthenticated: false })
     mockUnifiedCloudAuthEnabled.value = false
-    mockRemoteConfigState.value = 'authenticated'
-    mockRemoteConfigErrorStatus.value = null
+    remoteConfigState.value = 'authenticated'
+    remoteConfigErrorStatus.value = null
     Object.assign(useTeamWorkspaceStore(), { initState: 'uninitialized' })
     Object.assign(useTeamWorkspaceStore(), {
       activeWorkspaceId: 'workspace-123'
@@ -463,7 +448,7 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error when authenticated config is unavailable', async () => {
-      mockRemoteConfigState.value = 'error'
+      remoteConfigState.value = 'error'
 
       mountComponent()
       await flushPromises()
@@ -476,8 +461,8 @@ describe('WorkspaceAuthGate', () => {
 
     it('requires sign out when authenticated config rejects the credential', async () => {
       const user = userEvent.setup()
-      mockRemoteConfigState.value = 'error'
-      mockRemoteConfigErrorStatus.value = 401
+      remoteConfigState.value = 'error'
+      remoteConfigErrorStatus.value = 401
 
       mountComponent()
       await flushPromises()

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -4,12 +4,25 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import WorkspaceAuthGate from './WorkspaceAuthGate.vue'
+
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
@@ -617,10 +630,3 @@ describe('WorkspaceAuthGate', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -27,14 +27,10 @@ vi.mock(import('@/components/dialog/confirm/confirmDialog'), () => ({
   showConfirmDialog: mockShowConfirmDialog
 }))
 
-vi.mock(
-  import('@/platform/workspace/api/partnerNodePolicyApi'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    getPartnerNodePolicy: vi.fn(() => new Promise<never>(() => {})),
-    getPartnerProviders: vi.fn(() => new Promise<never>(() => {}))
-  })
-)
+vi.mock(import('@/platform/workspace/api/partnerNodePolicyApi'), () => ({
+  getPartnerNodePolicy: vi.fn(() => new Promise<never>(() => {})),
+  getPartnerProviders: vi.fn(() => new Promise<never>(() => {}))
+}))
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useWorkspaceUI'),

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -3,6 +3,11 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import axios, { AxiosError, AxiosHeaders } from 'axios'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
@@ -10,6 +15,14 @@ import type { EffectScope } from 'vue'
 import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
 
 import { useBillingCapabilities } from './useBillingCapabilities'
+
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 const mockGetBillingCapabilities = vi.hoisted(() => vi.fn())
 const mockReportError = vi.hoisted(() => vi.fn())
@@ -975,10 +988,3 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canTopUp.value).toBe(false)
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -5,6 +5,11 @@ import { billingOperation } from './billingOperationTestUtils'
 import type { BillingOperation } from './billingOperationTestUtils'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useAuthStore } from '@/stores/authStore'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { createI18n } from 'vue-i18n'
 
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
@@ -20,6 +25,14 @@ import {
   findPlanSlug,
   useSubscriptionCheckout
 } from './useSubscriptionCheckout'
+
+vi.mock(import('firebase/auth'), { spy: true })
+
+beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+})
 
 function makeStandardYearly(): Plan {
   return {
@@ -4259,10 +4272,3 @@ describe('useSubscriptionCheckout', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -620,9 +620,4 @@ describe('useWorkspaceUI', () => {
   })
 })
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))
+vi.mock(import('firebase/auth'), { spy: true })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -2,17 +2,27 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type * as PartnerNodePolicyApi from '@/platform/workspace/api/partnerNodePolicyApi'
 import type {
   PartnerNodePolicy,
   PartnerProvider
 } from '@/platform/workspace/api/partnerNodePolicyApi'
-import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
 const mockUpdatePartnerNodePolicy = vi.hoisted(() => vi.fn())
+const PartnerNodePolicyApiError = vi.hoisted(
+  () =>
+    class PartnerNodePolicyApiError extends Error {
+      constructor(
+        public readonly status: number,
+        message: string
+      ) {
+        super(message)
+        this.name = 'PartnerNodePolicyApiError'
+      }
+    }
+)
 const mockFlags = vi.hoisted(() => ({
   partnerNodeGovernanceEnabled: true
 }))
@@ -21,16 +31,12 @@ vi.mock<unknown>(import('@/composables/useFeatureFlags'), () => ({
   useFeatureFlags: () => ({ flags: mockFlags })
 }))
 
-vi.mock(
-  import('@/platform/workspace/api/partnerNodePolicyApi'),
-  async (importOriginal) =>
-    ({
-      ...(await importOriginal<typeof PartnerNodePolicyApi>()),
-      getPartnerNodePolicy: mockGetPartnerNodePolicy,
-      getPartnerProviders: mockGetPartnerProviders,
-      updatePartnerNodePolicy: mockUpdatePartnerNodePolicy
-    }) satisfies typeof PartnerNodePolicyApi
-)
+vi.mock(import('@/platform/workspace/api/partnerNodePolicyApi'), () => ({
+  getPartnerNodePolicy: mockGetPartnerNodePolicy,
+  getPartnerProviders: mockGetPartnerProviders,
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy: mockUpdatePartnerNodePolicy
+}))
 
 const providers: PartnerProvider[] = [
   {

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -2,6 +2,11 @@ import { useAuthStore } from '@/stores/authStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { User } from 'firebase/auth'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { storeToRefs } from 'pinia'
 import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,6 +21,8 @@ import {
   StorageKeys
 } from '@/platform/workflow/persistence/base/storageKeys'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
+
+vi.mock(import('firebase/auth'), { spy: true })
 
 const mockTrackUnifiedAuthRefresh = vi.fn()
 
@@ -138,6 +145,10 @@ function expectedExpiresAtMs(expiresAt: string): string {
 }
 
 beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockImplementation(vi.fn())
+  vi.mocked(onIdTokenChanged).mockImplementation(vi.fn())
+
   vi.mocked(useToastStore().add).mockImplementation(() => {})
 })
 

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -3544,10 +3544,3 @@ describe('useWorkspaceAuthStore', () => {
     })
   })
 })
-
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from '@vueuse/core'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -36,8 +35,9 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   breakpointsTailwind: {},
   createSharedComposable: sharedComposable.create,
   useBreakpoints: () => ({

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -46,6 +46,9 @@ vi.mock(import('@/platform/distribution/types'), () => ({
 }))
 
 vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(VueUse.createSharedComposable).mockImplementation(
+  sharedComposable.create
+)
 
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useSubscription'),
@@ -74,9 +77,7 @@ vi.mock<unknown>(import('../tour/useFirstRunTourController'), () => ({
   useFirstRunTourController: () => ({ beginTour: mocks.beginTour })
 }))
 
-import { useFirstRunEntryIndividual } from './firstRunEntry'
-
-const useFirstRunEntry = sharedComposable.create(useFirstRunEntryIndividual)
+const { useFirstRunEntry } = await import('./firstRunEntry')
 
 type FirstRunEntry = ReturnType<typeof useFirstRunEntry>
 

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -1,15 +1,25 @@
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
+import { fromAny } from '@total-typescript/shoehorn'
+import * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
 
 import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
 import type { SharedWorkflowUrlLoadStatus } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
 
-const mocks = vi.hoisted(() => ({
+const mocks = vi.hoisted<{
+  isCloud: boolean
+  isDesktopWidth: boolean
+  subscriptionEnabled: boolean
+  isNewUser: boolean | null
+  tourFlag: boolean
+  beginTour: ReturnType<typeof vi.fn>
+}>(() => ({
   isCloud: true,
   isDesktopWidth: true,
   subscriptionEnabled: true,
-  isNewUser: true as boolean | null,
+  isNewUser: true,
   tourFlag: true,
 
   beginTour: vi.fn()
@@ -35,19 +45,7 @@ vi.mock(import('@/platform/distribution/types'), () => ({
   }
 }))
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  breakpointsTailwind: {},
-  createSharedComposable: sharedComposable.create,
-  useBreakpoints: () => ({
-    greaterOrEqual: () => ({
-      get value() {
-        return mocks.isDesktopWidth
-      }
-    })
-  })
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useSubscription'),
@@ -76,11 +74,18 @@ vi.mock<unknown>(import('../tour/useFirstRunTourController'), () => ({
   useFirstRunTourController: () => ({ beginTour: mocks.beginTour })
 }))
 
-import { useFirstRunEntry } from './firstRunEntry'
+import { useFirstRunEntryIndividual } from './firstRunEntry'
+
+const useFirstRunEntry = sharedComposable.create(useFirstRunEntryIndividual)
 
 type FirstRunEntry = ReturnType<typeof useFirstRunEntry>
 
 beforeEach(() => {
+  vi.mocked(VueUse.useBreakpoints).mockReturnValue(
+    fromAny<ReturnType<typeof VueUse.useBreakpoints>, unknown>({
+      greaterOrEqual: () => computed(() => mocks.isDesktopWidth)
+    })
+  )
   vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
 })
 

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
@@ -21,11 +21,7 @@ import { useFirstRunTourController } from '../tour/useFirstRunTourController'
  * Getting Started screen for first-run tour candidates, the template browser
  * for everyone else.
  */
-export const useFirstRunEntry = createSharedComposable(
-  useFirstRunEntryIndividual
-)
-
-export function useFirstRunEntryIndividual() {
+export const useFirstRunEntry = createSharedComposable(() => {
   const settingStore = useSettingStore()
   const gettingStartedVisible = ref(false)
   const isDesktopWidth =
@@ -123,4 +119,4 @@ export function useFirstRunEntryIndividual() {
     handleUrlWorkflow,
     dismissGettingStarted
   }
-}
+})

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
@@ -21,7 +21,11 @@ import { useFirstRunTourController } from '../tour/useFirstRunTourController'
  * Getting Started screen for first-run tour candidates, the template browser
  * for everyone else.
  */
-export const useFirstRunEntry = createSharedComposable(() => {
+export const useFirstRunEntry = createSharedComposable(
+  useFirstRunEntryIndividual
+)
+
+export function useFirstRunEntryIndividual() {
   const settingStore = useSettingStore()
   const gettingStartedVisible = ref(false)
   const isDesktopWidth =
@@ -119,4 +123,4 @@ export const useFirstRunEntry = createSharedComposable(() => {
     handleUrlWorkflow,
     dismissGettingStarted
   }
-})
+}

--- a/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
@@ -33,13 +33,13 @@ function graph(id: string) {
   })
 }
 
-vi.mock<unknown>(
-  import('@/lib/litegraph/src/litegraph'),
-  async (importOriginal) => ({
-    ...(await importOriginal<typeof Litegraph>()),
-    LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
-  })
+const litegraph = await vi.hoisted(
+  () => import('@/lib/litegraph/src/litegraph')
 )
+vi.mock<unknown>(import('@/lib/litegraph/src/litegraph'), () => ({
+  ...litegraph,
+  LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
+}))
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
   async () => {
@@ -64,11 +64,11 @@ vi.mock<unknown>(
     }
   }
 )
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), async () => {
   const { computed, onScopeDispose } = await import('vue')
   return {
-    ...actual,
+    ...vueUse,
     useElementBounding: () => {
       onScopeDispose(state.releaseBounds)
       return {

--- a/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
@@ -2,14 +2,22 @@ import type * as Litegraph from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import * as VueUse from '@vueuse/core'
+import {
+  computed,
+  effectScope,
+  nextTick,
+  onScopeDispose,
+  reactive,
+  shallowRef
+} from 'vue'
 
 import { toNodeId } from '@/types/nodeId'
 import { createUuidv4 } from '@/utils/uuid'
 
 import { canvasNodeTarget } from './canvasCoachTarget'
 
-const { TITLE_HEIGHT } = vi.hoisted(() => ({ TITLE_HEIGHT: 30 }))
+const TITLE_HEIGHT = 30
 
 const state = vi.hoisted(() => ({
   camera: null as Record<string, number> | null,
@@ -33,57 +41,48 @@ function graph(id: string) {
   })
 }
 
-const litegraph = await vi.hoisted(
-  () => import('@/lib/litegraph/src/litegraph')
-)
-vi.mock<unknown>(import('@/lib/litegraph/src/litegraph'), () => ({
-  ...litegraph,
-  LiteGraph: { NODE_TITLE_HEIGHT: TITLE_HEIGHT }
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
+
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
-  async () => {
-    const { reactive } = await import('vue')
-    state.camera = reactive({ x: 0, y: 0, z: 1 })
+  () => {
+    state.camera = { x: 0, y: 0, z: 1 }
     return { useTransformState: () => ({ camera: state.camera }) }
   }
 )
 
-vi.mock<unknown>(
-  import('@/renderer/core/layout/store/layoutStore'),
-  async () => {
-    const { shallowRef } = await import('vue')
-    state.layout = shallowRef<unknown>(null)
-    return {
-      layoutStore: {
-        getNodeLayoutRef: (graphId: unknown, nodeId: unknown) => {
-          state.layoutReads(graphId, nodeId)
-          return state.layout
-        }
-      }
-    }
-  }
-)
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), async () => {
-  const { computed, onScopeDispose } = await import('vue')
+vi.mock<unknown>(import('@/renderer/core/layout/store/layoutStore'), () => {
+  state.layout = { value: null }
   return {
-    ...vueUse,
-    useElementBounding: () => {
-      onScopeDispose(state.releaseBounds)
-      return {
-        left: computed(() => state.canvasOffset.left),
-        top: computed(() => state.canvasOffset.top)
+    layoutStore: {
+      getNodeLayoutRef: (graphId: unknown, nodeId: unknown) => {
+        state.layoutReads(graphId, nodeId)
+        return state.layout
       }
     }
   }
 })
-
 function placeNode(bounds = { x: 100, y: 200, width: 80, height: 40 }) {
   state.layout!.value = { bounds }
 }
 
 beforeEach(() => {
+  state.camera = reactive({ x: 0, y: 0, z: 1 })
+  state.layout = shallowRef<unknown>(null)
+  vi.mocked(VueUse.useElementBounding).mockImplementation(() => {
+    onScopeDispose(state.releaseBounds)
+    return {
+      bottom: computed(() => 0),
+      height: computed(() => 0),
+      left: computed(() => state.canvasOffset.left),
+      right: computed(() => 0),
+      top: computed(() => state.canvasOffset.top),
+      width: computed(() => 0),
+      x: computed(() => 0),
+      y: computed(() => 0),
+      update: vi.fn()
+    }
+  })
   useCanvasStore().canvas = fromPartial({
     graph: graph('root'),
     canvas: document.createElement('canvas')

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -13,7 +13,6 @@ import { toNodeId } from '@/types/nodeId'
 
 import { TOUR_ROLE_PINS } from '../roles/tourRolePins'
 import type { RolePin } from '../roles/tourRolePins'
-import type * as CanvasCoachTarget from './canvasCoachTarget'
 import {
   firstRunTourSteps,
   releaseFirstRunTargets
@@ -29,21 +28,22 @@ const runState = ref<RunState>('idle')
 const framings: { glide?: boolean }[] = []
 
 const disposals = vi.hoisted(() => ({ spy: vi.fn() }))
-vi.mock(import('./canvasCoachTarget'), async (importOriginal) => {
-  const actual = await importOriginal<typeof CanvasCoachTarget>()
-  return {
-    canvasNodeTarget: (...args: Parameters<typeof actual.canvasNodeTarget>) => {
-      const target = actual.canvasNodeTarget(...args)
-      return {
-        ...target,
-        dispose: () => {
-          disposals.spy()
-          target.dispose?.()
-        }
+const canvasCoachTarget = await vi.hoisted(() => import('./canvasCoachTarget'))
+vi.mock(import('./canvasCoachTarget'), () => ({
+  ...canvasCoachTarget,
+  canvasNodeTarget: (
+    nodeId: Parameters<typeof canvasCoachTarget.canvasNodeTarget>[0]
+  ) => {
+    const target = canvasCoachTarget.canvasNodeTarget(nodeId)
+    return {
+      ...target,
+      dispose: () => {
+        disposals.spy()
+        target.dispose?.()
       }
     }
   }
-})
+}))
 
 vi.mock(import('./cameraFraming'), () => ({
   frameNode: (_id: unknown, _signal: AbortSignal, options = {}) => {

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -28,21 +28,13 @@ const runState = ref<RunState>('idle')
 const framings: { glide?: boolean }[] = []
 
 const disposals = vi.hoisted(() => ({ spy: vi.fn() }))
-const canvasCoachTarget = await vi.hoisted(() => import('./canvasCoachTarget'))
+
 vi.mock(import('./canvasCoachTarget'), () => ({
-  ...canvasCoachTarget,
-  canvasNodeTarget: (
-    nodeId: Parameters<typeof canvasCoachTarget.canvasNodeTarget>[0]
-  ) => {
-    const target = canvasCoachTarget.canvasNodeTarget(nodeId)
-    return {
-      ...target,
-      dispose: () => {
-        disposals.spy()
-        target.dispose?.()
-      }
-    }
-  }
+  canvasNodeTarget: () => ({
+    getRect: () => new DOMRect(0, 0, 1, 1),
+    onMove: () => () => {},
+    dispose: disposals.spy
+  })
 }))
 
 vi.mock(import('./cameraFraming'), () => ({

--- a/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from '@vueuse/core'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -78,8 +77,9 @@ const {
   }
 })
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   useDocumentVisibility: () => ({ value: 'visible' }),
   useIntervalFn: (callback: () => void) => {
     counters.pollRegistrations++

--- a/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
@@ -3,6 +3,7 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useLinkStore } from '@/stores/linkStore'
 import { fromPartial } from '@total-typescript/shoehorn'
+import * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, shallowRef } from 'vue'
 import { toNodeId } from '@/types/nodeId'
@@ -77,33 +78,36 @@ const {
   }
 })
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useDocumentVisibility: () => ({ value: 'visible' }),
-  useIntervalFn: (callback: () => void) => {
-    counters.pollRegistrations++
-    // The callback is driven explicitly so WS fanout and 100 ms poll cadence
-    // remain separate deterministic axes in this baseline.
-    pollControl.current = () => {
-      counters.pollCallbacks++
-      callback()
+vi.mock(import('@vueuse/core'), { spy: true })
+function setupVueUseMocks() {
+  vi.mocked(VueUse.useDocumentVisibility).mockReturnValue(shallowRef('visible'))
+  vi.mocked(VueUse.useIntervalFn, { partial: true }).mockImplementation(
+    (callback) => {
+      counters.pollRegistrations++
+      pollControl.current = () => {
+        counters.pollCallbacks++
+        callback()
+      }
+      return {
+        isActive: shallowRef(false),
+        pause: () => void counters.pollPauses++,
+        resume: () => void counters.pollResumes++
+      }
     }
-    return {
-      pause: () => counters.pollPauses++,
-      resume: () => counters.pollResumes++
-    }
-  },
-  useRafFn: () => ({
+  )
+  vi.mocked(VueUse.useRafFn, { partial: true }).mockReturnValue({
+    isActive: shallowRef(false),
     pause: vi.fn(),
     resume: vi.fn()
-  }),
-  useThrottleFn: (callback: () => void) => () => {
-    counters.throttleRequests++
-    counters.throttleCallbacks++
-    callback()
-  }
-}))
+  })
+  vi.mocked(VueUse.useThrottleFn, { partial: true }).mockImplementation(
+    (callback) => () => {
+      counters.throttleRequests++
+      counters.throttleCallbacks++
+      return callback()
+    }
+  )
+}
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {
@@ -362,6 +366,7 @@ async function runCell(
 }
 
 beforeEach(() => {
+  setupVueUseMocks()
   Object.assign(useExecutionStore(), {
     nodeLocationProgressStates: useExecutionStore().nodeProgressStates
   })

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from '@vueuse/core'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { Mock } from 'vitest'
@@ -95,10 +94,11 @@ const mockIntervalResume = vi.fn()
 const rafCallbacks: Record<string, () => void> = {}
 let rafCallbackId = 0
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), async () => {
   const { ref } = await import('vue')
   return {
-    ...(await importOriginal<typeof VueUse>()),
+    ...vueUse,
     useDocumentVisibility: vi.fn(() => ref('visible')),
     useRafFn: vi.fn((callback, options) => {
       const id = rafCallbackId++

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -1,8 +1,9 @@
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { Mock } from 'vitest'
+import * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, shallowRef } from 'vue'
+import { nextTick, ref, shallowRef } from 'vue'
 
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -94,46 +95,35 @@ const mockIntervalResume = vi.fn()
 const rafCallbacks: Record<string, () => void> = {}
 let rafCallbackId = 0
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), async () => {
-  const { ref } = await import('vue')
-  return {
-    ...vueUse,
-    useDocumentVisibility: vi.fn(() => ref('visible')),
-    useRafFn: vi.fn((callback, options) => {
+vi.mock(import('@vueuse/core'), { spy: true })
+function setupVueUseMocks() {
+  vi.mocked(VueUse.useDocumentVisibility).mockReturnValue(ref('visible'))
+  vi.mocked(VueUse.useRafFn, { partial: true }).mockImplementation(
+    (callback, options) => {
       const id = rafCallbackId++
-      rafCallbacks[id] = callback
-
-      if (options?.immediate !== false) {
-        void Promise.resolve().then(() => callback())
-      }
-
-      const resumeFn = vi.fn(() => {
-        mockResume()
-        // Execute the RAF callback immediately when resumed
-        const callback = Object.hasOwn(rafCallbacks, id)
-          ? rafCallbacks[id]
-          : undefined
-        callback?.()
-      })
-
+      const run = () => callback({ timestamp: 0, delta: 0 })
+      rafCallbacks[id] = run
+      if (options?.immediate !== false) void Promise.resolve().then(run)
       return {
+        isActive: ref(false),
         pause: mockPause,
-        resume: resumeFn
+        resume: vi.fn(() => {
+          mockResume()
+          rafCallbacks[id]?.()
+        })
       }
-    }),
-    useIntervalFn: vi.fn((callback, _interval, options) => {
+    }
+  )
+  vi.mocked(VueUse.useIntervalFn, { partial: true }).mockImplementation(
+    (callback, _interval, options) => {
       const id = rafCallbackId++
       const state = { active: options?.immediate !== false }
       rafCallbacks[id] = () => {
         if (state.active) callback()
       }
-
-      if (state.active) {
-        void Promise.resolve().then(() => callback())
-      }
-
+      if (state.active) void Promise.resolve().then(callback)
       return {
+        isActive: ref(state.active),
         pause: vi.fn(() => {
           state.active = false
           mockIntervalPause()
@@ -144,14 +134,12 @@ vi.mock<unknown>(import('@vueuse/core'), async () => {
           callback()
         })
       }
-    }),
-    useThrottleFn: vi.fn((callback) => {
-      return (...args: unknown[]) => {
-        return callback(...args)
-      }
-    })
-  }
-})
+    }
+  )
+  vi.mocked(VueUse.useThrottleFn, { partial: true }).mockImplementation(
+    (callback) => callback
+  )
+}
 
 let moduleMockCanvas: MockCanvas = null!
 let moduleMockGraph: MockGraph = null!
@@ -261,6 +249,7 @@ describe('useMinimap', () => {
   }
 
   beforeEach(() => {
+    setupVueUseMocks()
     registerMockLink(1, 'node2')
 
     mockContext2D = createMockCanvas2DContext()

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -21,11 +21,7 @@ import {
   createMockLinks
 } from '@/utils/__tests__/litegraphTestUtils'
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useThrottleFn: vi.fn((fn) => fn)
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({
   api: {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from '@vueuse/core'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useThrottleFn } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -22,8 +21,9 @@ import {
   createMockLinks
 } from '@/utils/__tests__/litegraphTestUtils'
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   useThrottleFn: vi.fn((fn) => fn)
 }))
 

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
@@ -12,11 +12,7 @@ import {
 import { useMinimapViewport } from '@/renderer/extensions/minimap/composables/useMinimapViewport'
 import type { MinimapCanvas } from '@/renderer/extensions/minimap/types'
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useRafFn: vi.fn()
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
 vi.mock(import('@/renderer/core/spatial/boundsCalculator'), () => ({
   calculateNodeBounds: vi.fn(),

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
@@ -12,8 +12,9 @@ import {
 import { useMinimapViewport } from '@/renderer/extensions/minimap/composables/useMinimapViewport'
 import type { MinimapCanvas } from '@/renderer/extensions/minimap/types'
 
-vi.mock(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock(import('@vueuse/core'), () => ({
+  ...vueUse,
   useRafFn: vi.fn()
 }))
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
@@ -31,13 +31,7 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: mockApp
 }))
 
-const graphTraversalUtil = await vi.hoisted(
-  () => import('@/utils/graphTraversalUtil')
-)
-vi.mock(import('@/utils/graphTraversalUtil'), () => ({
-  ...graphTraversalUtil,
-  getNodeByLocatorId: vi.fn()
-}))
+vi.mock(import('@/utils/graphTraversalUtil'), { spy: true })
 
 vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: () => ({

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
@@ -31,13 +31,13 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: mockApp
 }))
 
-vi.mock(import('@/utils/graphTraversalUtil'), async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>
-  return {
-    ...actual,
-    getNodeByLocatorId: vi.fn()
-  }
-})
+const graphTraversalUtil = await vi.hoisted(
+  () => import('@/utils/graphTraversalUtil')
+)
+vi.mock(import('@/utils/graphTraversalUtil'), () => ({
+  ...graphTraversalUtil,
+  getNodeByLocatorId: vi.fn()
+}))
 
 vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
   useErrorHandling: () => ({

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -17,6 +17,7 @@ import {
   LGraphEventMode,
   TitleMode
 } from '@/lib/litegraph/src/types/globalEnums'
+import type { LGraphNode as LiteGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { NodeState } from '@/types/nodeState'
 import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
 import { useVueElementTracking } from '@/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking'
@@ -24,23 +25,19 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 
 const mockData = vi.hoisted(() => ({
   mockExecuting: false,
   mockLgraphNode: null as Record<string, unknown> | null
 }))
 
-const graphTraversalUtil = await vi.hoisted(
-  () => import('@/utils/graphTraversalUtil')
+vi.mock(import('@/utils/graphTraversalUtil'), { spy: true })
+vi.mocked(getNodeByLocatorId).mockImplementation(() =>
+  fromAny<LiteGraphNode, unknown>(
+    mockData.mockLgraphNode ?? { isSubgraphNode: () => false }
+  )
 )
-vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => {
-  return {
-    ...graphTraversalUtil,
-    getNodeByLocatorId: vi.fn(
-      () => mockData.mockLgraphNode ?? { isSubgraphNode: () => false }
-    )
-  }
-})
 
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),
@@ -198,6 +195,11 @@ const mockRerouteNodeData: NodeState = {
 
 describe('LGraphNode', () => {
   beforeEach(() => {
+    vi.mocked(getNodeByLocatorId).mockImplementation(() =>
+      fromAny<LiteGraphNode, unknown>(
+        mockData.mockLgraphNode ?? { isSubgraphNode: () => false }
+      )
+    )
     mockData.mockExecuting = false
     mockData.mockLgraphNode = null
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -30,18 +30,17 @@ const mockData = vi.hoisted(() => ({
   mockLgraphNode: null as Record<string, unknown> | null
 }))
 
-vi.mock<unknown>(
-  import('@/utils/graphTraversalUtil'),
-  async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, unknown>
-    return {
-      ...actual,
-      getNodeByLocatorId: vi.fn(
-        () => mockData.mockLgraphNode ?? { isSubgraphNode: () => false }
-      )
-    }
-  }
+const graphTraversalUtil = await vi.hoisted(
+  () => import('@/utils/graphTraversalUtil')
 )
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => {
+  return {
+    ...graphTraversalUtil,
+    getNodeByLocatorId: vi.fn(
+      () => mockData.mockLgraphNode ?? { isSubgraphNode: () => false }
+    )
+  }
+})
 
 vi.mock<unknown>(
   import('@/renderer/core/layout/transform/useTransformState'),

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -1,5 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { tryOnScopeDispose, useEventListener } from '@vueuse/core'
 
 import { toNodeId } from '@/types/nodeId'
 
@@ -200,15 +201,14 @@ vi.mock(import('@/renderer/core/canvas/links/linkDropOrchestrator'), () => ({
   resolveNodeSurfaceSlotCandidate: () => null
 }))
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useEventListener: (event: string, handler: (...args: unknown[]) => void) => {
+vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(useEventListener).mockImplementation((event, handler) => {
+  if (typeof event === 'string' && typeof handler === 'function') {
     capturedHandlers[event] = handler
-    return vi.fn()
-  },
-  tryOnScopeDispose: () => {}
-}))
+  }
+  return vi.fn()
+})
+vi.mocked(tryOnScopeDispose).mockImplementation(() => true)
 
 vi.mock<unknown>(import('@/lib/litegraph/src/LLink'), () => ({
   LLink: { getReroutes: () => [] },
@@ -256,6 +256,13 @@ function startDrag() {
 
 describe('useSlotLinkInteraction auto-pan', () => {
   beforeEach(() => {
+    vi.mocked(useEventListener).mockImplementation((event, handler) => {
+      if (typeof event === 'string' && typeof handler === 'function') {
+        capturedHandlers[event] = handler
+      }
+      return vi.fn()
+    })
+    vi.mocked(tryOnScopeDispose).mockImplementation(() => true)
     capturedOnPan.current = null
     capturedAutoPan.current = null
     for (const k of Object.keys(capturedHandlers)) {

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from '@vueuse/core'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -201,8 +200,9 @@ vi.mock(import('@/renderer/core/canvas/links/linkDropOrchestrator'), () => ({
   resolveNodeSurfaceSlotCandidate: () => null
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   useEventListener: (event: string, handler: (...args: unknown[]) => void) => {
     capturedHandlers[event] = handler
     return vi.fn()

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -2,7 +2,6 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
-import type { ComfyApp } from '@/scripts/app'
 
 import { render, screen } from '@testing-library/vue'
 
@@ -51,7 +50,6 @@ const testState = vi.hoisted(() => {
   const contentSizes = new Map<string, { width: number; height: number }>()
 
   return {
-    visibility: null as { value: 'visible' | 'hidden' } | null,
     nodeLayouts: new Map<NodeId, NodeLayout>(),
     contentSizes,
     reportContentSize: vi.fn(
@@ -68,24 +66,9 @@ const testState = vi.hoisted(() => {
   }
 })
 
-vi.mock(import('@/scripts/app'), async () => {
-  const { fromPartial } = await import('@total-typescript/shoehorn')
-  return { app: fromPartial<ComfyApp>({ canvas: {}, nodePreviewImages: {} }) }
-})
-
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock(import('@vueuse/core'), async () => {
-  const { ref } = await import('vue')
-  return {
-    ...vueUse,
-    useDocumentVisibility: () => {
-      const visibility = ref<'visible' | 'hidden'>('visible')
-      testState.visibility = visibility
-      return visibility
-    },
-    createSharedComposable: <T>(fn: T) => fn
-  }
-})
+vi.mock<unknown>(import('@/scripts/app'), () => ({
+  app: { canvas: {}, nodePreviewImages: {} }
+}))
 
 vi.mock<unknown>(
   import('@/composables/element/useCanvasPositionConversion'),
@@ -199,7 +182,6 @@ describe('useVueNodeResizeTracking', () => {
   beforeEach(() => {
     useCanvasStore().linearMode = false
     Object.assign(useCanvasStore(), { rootGraphId: ROOT_GRAPH_ID })
-    if (testState.visibility) testState.visibility.value = 'visible'
     testState.nodeLayouts.clear()
     testState.contentSizes.clear()
   })
@@ -334,13 +316,12 @@ describe('useVueNodeResizeTracking', () => {
     const { entry } = createResizeEntry({ nodeId })
     document.body.append(entry.target)
     seedNodeLayout({ nodeId, left: 100, top: 200, width: 240, height: 180 })
-    if (!testState.visibility) throw new Error('visibility ref not initialized')
-
     resizeObserverState.callback?.([entry], createObserverMock())
     expect(testState.reportContentSize).toHaveBeenCalledTimes(1)
     vi.clearAllMocks()
 
-    testState.visibility.value = 'hidden'
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
     await nextTick()
     resizeObserverState.callback?.([entry], createObserverMock())
 
@@ -349,7 +330,8 @@ describe('useVueNodeResizeTracking', () => {
     expect(testState.syncSlotOffsets).not.toHaveBeenCalled()
 
     vi.clearAllMocks()
-    testState.visibility.value = 'visible'
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
     await nextTick()
 
     expect(resizeObserverState.observe).toHaveBeenCalledWith(entry.target)

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -7,6 +7,7 @@ import { render, screen } from '@testing-library/vue'
 
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { NodeLayout } from '@/renderer/core/layout/types'
+import type { ComfyApp } from '@/scripts/app'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
@@ -66,9 +67,10 @@ const testState = vi.hoisted(() => {
   }
 })
 
-vi.mock<unknown>(import('@/scripts/app'), () => ({
-  app: { canvas: {}, nodePreviewImages: {} }
-}))
+vi.mock(import('@/scripts/app'), async () => {
+  const { fromPartial } = await import('@total-typescript/shoehorn')
+  return { app: fromPartial<ComfyApp>({ canvas: {}, nodePreviewImages: {} }) }
+})
 
 vi.mock<unknown>(
   import('@/composables/element/useCanvasPositionConversion'),

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from '@vueuse/core'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -74,10 +73,11 @@ vi.mock(import('@/scripts/app'), async () => {
   return { app: fromPartial<ComfyApp>({ canvas: {}, nodePreviewImages: {} }) }
 })
 
-vi.mock(import('@vueuse/core'), async (importOriginal) => {
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock(import('@vueuse/core'), async () => {
   const { ref } = await import('vue')
   return {
-    ...(await importOriginal<typeof VueUse>()),
+    ...vueUse,
     useDocumentVisibility: () => {
       const visibility = ref<'visible' | 'hidden'>('visible')
       testState.visibility = visibility

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -1,6 +1,5 @@
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
-import type * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -96,8 +95,9 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   createSharedComposable: (fn: () => unknown) => fn,
   whenever: vi.fn()
 }))

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -1,6 +1,6 @@
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { whenever } from '@vueuse/core'
+import * as VueUse from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -90,8 +90,12 @@ vi.mock<unknown>(
 )
 
 vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(VueUse.createSharedComposable).mockImplementation(
+  (composable) => composable
+)
 
-import { useNodeDragIndividual as useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
+const { useNodeDrag } =
+  await import('@/renderer/extensions/vueNodes/layout/useNodeDrag')
 
 const node1 = toNodeId('1')
 
@@ -103,7 +107,7 @@ function pointerEvent(clientX: number, clientY: number): PointerEvent {
 }
 
 beforeEach(() => {
-  vi.mocked(whenever).mockImplementation(() =>
+  vi.mocked(VueUse.whenever).mockImplementation(() =>
     Object.assign(vi.fn(), {
       pause: vi.fn(),
       resume: vi.fn(),

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -1,8 +1,10 @@
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { fromPartial } from '@total-typescript/shoehorn'
+import { whenever } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import type { NodeLayout } from '@/renderer/core/layout/types'
 import { toNodeId } from '@/types/nodeId'
@@ -41,15 +43,7 @@ const testState = vi.hoisted(() => {
 })
 
 vi.mock<unknown>(import('@/renderer/core/canvas/useAutoPan'), () => ({
-  AutoPanController: class {
-    updatePointer = vi.fn()
-    start = vi.fn()
-    stop = vi.fn()
-    constructor(opts: { onPan: (dx: number, dy: number) => void }) {
-      testState.capturedOnPan.current = opts.onPan
-      testState.capturedAutoPanInstance.current = this
-    }
-  }
+  AutoPanController: vi.fn()
 }))
 
 vi.mock<unknown>(
@@ -95,14 +89,9 @@ vi.mock<unknown>(
   })
 )
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  createSharedComposable: (fn: () => unknown) => fn,
-  whenever: vi.fn()
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
 
-import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
+import { useNodeDragIndividual as useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
 
 const node1 = toNodeId('1')
 
@@ -114,6 +103,23 @@ function pointerEvent(clientX: number, clientY: number): PointerEvent {
 }
 
 beforeEach(() => {
+  vi.mocked(whenever).mockImplementation(() =>
+    Object.assign(vi.fn(), {
+      pause: vi.fn(),
+      resume: vi.fn(),
+      stop: vi.fn()
+    })
+  )
+  vi.mocked(AutoPanController).mockImplementation(function (opts) {
+    const controller = {
+      updatePointer: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn()
+    }
+    testState.capturedOnPan.current = opts.onPan
+    testState.capturedAutoPanInstance.current = controller
+    return fromPartial<AutoPanController>(controller)
+  })
   Object.assign(useCanvasStore(), { selectedNodeIds: new Set() })
   useCanvasStore().selectedItems = []
   testState.nodeLayouts.clear()

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -15,9 +15,7 @@ import { useShiftKeySync } from '@/renderer/extensions/vueNodes/composables/useS
 import { useTransformState } from '@/renderer/core/layout/transform/useTransformState'
 import { isLGraphNode } from '@/utils/litegraphUtil'
 
-export const useNodeDrag = createSharedComposable(useNodeDragIndividual)
-
-export function useNodeDragIndividual() {
+export const useNodeDrag = createSharedComposable(() => {
   const mutations = useLayoutMutations(LayoutSource.Vue)
   const { selectedNodeIds, selectedItems } = storeToRefs(useCanvasStore())
 
@@ -323,4 +321,4 @@ export function useNodeDragIndividual() {
     handleDrag,
     endDrag
   }
-}
+})

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -17,7 +17,7 @@ import { isLGraphNode } from '@/utils/litegraphUtil'
 
 export const useNodeDrag = createSharedComposable(useNodeDragIndividual)
 
-function useNodeDragIndividual() {
+export function useNodeDragIndividual() {
   const mutations = useLayoutMutations(LayoutSource.Vue)
   const { selectedNodeIds, selectedItems } = storeToRefs(useCanvasStore())
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -31,26 +32,18 @@ vi.mock(import('@/scripts/widgets'), () => ({
   addValueControlWidgets: vi.fn()
 }))
 
-vi.mock(import('@/platform/distribution/types'), async (importOriginal) => ({
-  ...(await importOriginal()),
+vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
     return mockDistributionState.isCloud
   }
 }))
 
-vi.mock(import('@/composables/useFeatureFlags'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    useFeatureFlags: () => {
-      const featureFlags = actual.useFeatureFlags()
-      return {
-        ...featureFlags,
-        flags: { ...featureFlags.flags, assetsEnabled: false }
-      }
-    }
-  }
-})
+vi.mock(import('@/composables/useFeatureFlags'), () => ({
+  useFeatureFlags: () =>
+    fromPartial({
+      flags: { assetsEnabled: false }
+    })
+}))
 
 vi.mock(import('@/i18n'), () => ({
   t: vi.fn((key: string) =>

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -23,16 +23,15 @@ const mockCloudAuth = vi.hoisted(() => ({
   authHeader: null as { Authorization: `Bearer ${string}` } | null
 }))
 
-vi.mock(import('axios'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    default: Object.assign(actual.default, { get: vi.fn() })
-  }
-})
+const axiosModule = await vi.hoisted(() => import('axios'))
+vi.mock(import('axios'), () => ({
+  ...axiosModule,
+  default: Object.assign(axiosModule.default, { get: vi.fn() })
+}))
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const firebaseAuth = await vi.hoisted(() => import('firebase/auth'))
+vi.mock(import('firebase/auth'), () => ({
+  ...firebaseAuth,
   setPersistence: vi.fn().mockResolvedValue(undefined),
   onAuthStateChanged: vi.fn(() => vi.fn()),
   onIdTokenChanged: vi.fn(() => vi.fn())

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -1,5 +1,10 @@
 import { useAuthStore } from '@/stores/authStore'
 import axios from 'axios'
+import {
+  onAuthStateChanged,
+  onIdTokenChanged,
+  setPersistence
+} from 'firebase/auth'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
@@ -23,19 +28,11 @@ const mockCloudAuth = vi.hoisted(() => ({
   authHeader: null as { Authorization: `Bearer ${string}` } | null
 }))
 
-const axiosModule = await vi.hoisted(() => import('axios'))
-vi.mock(import('axios'), () => ({
-  ...axiosModule,
-  default: Object.assign(axiosModule.default, { get: vi.fn() })
-}))
-
-const firebaseAuth = await vi.hoisted(() => import('firebase/auth'))
-vi.mock(import('firebase/auth'), () => ({
-  ...firebaseAuth,
-  setPersistence: vi.fn().mockResolvedValue(undefined),
-  onAuthStateChanged: vi.fn(() => vi.fn()),
-  onIdTokenChanged: vi.fn(() => vi.fn())
-}))
+vi.mock(import('axios'), { spy: true })
+vi.mock(import('firebase/auth'), { spy: true })
+vi.mocked(setPersistence).mockResolvedValue(undefined)
+vi.mocked(onAuthStateChanged).mockReturnValue(vi.fn())
+vi.mocked(onIdTokenChanged).mockReturnValue(vi.fn())
 
 vi.mock(import('@/platform/distribution/types'), () => ({
   get isCloud() {
@@ -95,6 +92,9 @@ async function getResolvedValue(hook: ReturnType<typeof useRemoteWidget>) {
 }
 
 beforeEach(() => {
+  vi.mocked(setPersistence).mockResolvedValue(undefined)
+  vi.mocked(onAuthStateChanged).mockReturnValue(vi.fn())
+  vi.mocked(onIdTokenChanged).mockReturnValue(vi.fn())
   vi.mocked(useAuthStore().getAuthHeader).mockImplementation(
     async () => mockCloudAuth.authHeader
   )

--- a/src/renderer/three/RendererView.test.ts
+++ b/src/renderer/three/RendererView.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RendererView } from './RendererView'
 
-vi.mock<unknown>(import('three'), async (importOriginal) => {
-  const actual = await importOriginal<typeof THREE>()
+const THREE_SOURCE = await vi.hoisted(() => import('three/src/Three.js'))
+vi.mock<unknown>(import('three'), () => {
   class WebGLRenderer {
     domElement = document.createElement('canvas')
     autoClear = true
@@ -24,7 +24,7 @@ vi.mock<unknown>(import('three'), async (importOriginal) => {
     forceContextLoss = vi.fn()
     dispose = vi.fn()
   }
-  return { ...actual, WebGLRenderer }
+  return { ...THREE_SOURCE, WebGLRenderer }
 })
 
 const drawImage = vi.fn()

--- a/src/renderer/three/RendererView.test.ts
+++ b/src/renderer/three/RendererView.test.ts
@@ -1,39 +1,44 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import * as THREE from 'three'
+import { WebGLRenderer } from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RendererView } from './RendererView'
 
-const THREE_SOURCE = await vi.hoisted(() => import('three/src/Three.js'))
-vi.mock<unknown>(import('three'), () => {
-  class WebGLRenderer {
-    domElement = document.createElement('canvas')
-    autoClear = true
-    outputColorSpace = ''
-    toneMapping = 0
-    toneMappingExposure = 1
+vi.mock(import('three'), { spy: true })
+
+function fakeRenderer() {
+  const domElement = document.createElement('canvas')
+  return fromPartial<WebGLRenderer>({
+    domElement,
+    autoClear: true,
+    outputColorSpace: THREE.SRGBColorSpace,
+    toneMapping: THREE.NoToneMapping,
+    toneMappingExposure: 1,
     setSize(width: number, height: number) {
-      this.domElement.width = width
-      this.domElement.height = height
-    }
-    getSize(target: { set(x: number, y: number): unknown }) {
-      target.set(this.domElement.width, this.domElement.height)
-      return target
-    }
-    setPixelRatio() {}
-    setClearColor = vi.fn()
-    forceContextLoss = vi.fn()
-    dispose = vi.fn()
-  }
-  return { ...THREE_SOURCE, WebGLRenderer }
-})
+      domElement.width = width
+      domElement.height = height
+    },
+    getSize(target: THREE.Vector2) {
+      return target.set(domElement.width, domElement.height)
+    },
+    setPixelRatio: vi.fn(),
+    setClearColor: vi.fn(),
+    forceContextLoss: vi.fn(),
+    dispose: vi.fn()
+  })
+}
 
 const drawImage = vi.fn()
 
 beforeEach(() => {
-  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-    drawImage,
-    globalCompositeOperation: 'source-over'
-  } as unknown as ReturnType<HTMLCanvasElement['getContext']>)
+  vi.mocked(WebGLRenderer).mockImplementation(fakeRenderer)
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    fromPartial<CanvasRenderingContext2D & GPUCanvasContext>({
+      drawImage,
+      globalCompositeOperation: 'source-over'
+    })
+  )
 })
 
 describe('RendererView', () => {

--- a/src/renderer/three/sharedWebGLRenderer.test.ts
+++ b/src/renderer/three/sharedWebGLRenderer.test.ts
@@ -1,5 +1,7 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import * as THREE from 'three'
-import { describe, expect, it, vi } from 'vitest'
+import { WebGLRenderer } from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   acquireSharedRenderer,
@@ -8,44 +10,42 @@ import {
   ensureRendererSize
 } from './sharedWebGLRenderer'
 
-const { rendererCtor, forceContextLoss, dispose } = vi.hoisted(() => ({
-  rendererCtor: vi.fn(),
-  forceContextLoss: vi.fn(),
-  dispose: vi.fn()
-}))
+vi.mock(import('three'), { spy: true })
 
-const THREE_SOURCE = await vi.hoisted(() => import('three/src/Three.js'))
-vi.mock<unknown>(import('three'), () => {
-  class WebGLRenderer {
-    domElement = document.createElement('canvas')
-    autoClear = true
-    outputColorSpace = ''
-    toneMapping = 0
-    toneMappingExposure = 1
-    width = 0
-    height = 0
-    constructor(opts: unknown) {
-      rendererCtor(opts)
-    }
-    setSize(width: number, height: number) {
-      this.width = width
-      this.height = height
-    }
+const forceContextLoss = vi.fn()
+const dispose = vi.fn()
+
+function fakeRenderer() {
+  const domElement = document.createElement('canvas')
+  let width = 0
+  let height = 0
+  return fromPartial<WebGLRenderer>({
+    domElement,
+    autoClear: true,
+    outputColorSpace: THREE.SRGBColorSpace,
+    toneMapping: THREE.NoToneMapping,
+    toneMappingExposure: 1,
+    setSize(nextWidth: number, nextHeight: number) {
+      width = nextWidth
+      height = nextHeight
+    },
     getSize(target: THREE.Vector2) {
-      target.set(this.width, this.height)
-      return target
-    }
-    setPixelRatio() {}
-    setClearColor = vi.fn()
-    forceContextLoss = forceContextLoss
-    dispose = dispose
-  }
-  return { ...THREE_SOURCE, WebGLRenderer }
+      return target.set(width, height)
+    },
+    setPixelRatio: vi.fn(),
+    setClearColor: vi.fn(),
+    forceContextLoss,
+    dispose
+  })
+}
+
+beforeEach(() => {
+  vi.mocked(WebGLRenderer).mockImplementation(fakeRenderer)
 })
 
 describe('acquireSharedRenderer', () => {
   it('returns the same renderer for concurrent views and disposes after the last release', () => {
-    rendererCtor.mockClear()
+    vi.mocked(THREE.WebGLRenderer).mockClear()
     forceContextLoss.mockClear()
     dispose.mockClear()
 
@@ -53,7 +53,7 @@ describe('acquireSharedRenderer', () => {
     const second = acquireSharedRenderer()
 
     expect(second.renderer).toBe(first.renderer)
-    expect(rendererCtor).toHaveBeenCalledTimes(1)
+    expect(THREE.WebGLRenderer).toHaveBeenCalledTimes(1)
 
     first.release()
     expect(dispose).not.toHaveBeenCalled()
@@ -70,14 +70,14 @@ describe('acquireSharedRenderer', () => {
   })
 
   it('creates a fresh renderer after the previous one was torn down', () => {
-    rendererCtor.mockClear()
+    vi.mocked(THREE.WebGLRenderer).mockClear()
 
     const first = acquireSharedRenderer()
     first.release()
 
     const second = acquireSharedRenderer()
 
-    expect(rendererCtor).toHaveBeenCalledTimes(2)
+    expect(THREE.WebGLRenderer).toHaveBeenCalledTimes(2)
     expect(second.renderer).not.toBe(first.renderer)
     second.release()
   })
@@ -104,14 +104,16 @@ describe('ensureRendererSize', () => {
     renderer.setSize(300, 300)
 
     ensureRendererSize(renderer, 500, 200)
-    expect(renderer.getSize(new THREE.Vector2())).toEqual(
-      new THREE.Vector2(500, 300)
-    )
+    expect(renderer.getSize(new THREE.Vector2())).toMatchObject({
+      x: 500,
+      y: 300
+    })
 
     ensureRendererSize(renderer, 400, 250)
-    expect(renderer.getSize(new THREE.Vector2())).toEqual(
-      new THREE.Vector2(500, 300)
-    )
+    expect(renderer.getSize(new THREE.Vector2())).toMatchObject({
+      x: 500,
+      y: 300
+    })
 
     handle.release()
   })

--- a/src/renderer/three/sharedWebGLRenderer.test.ts
+++ b/src/renderer/three/sharedWebGLRenderer.test.ts
@@ -14,8 +14,8 @@ const { rendererCtor, forceContextLoss, dispose } = vi.hoisted(() => ({
   dispose: vi.fn()
 }))
 
-vi.mock<unknown>(import('three'), async (importOriginal) => {
-  const actual = await importOriginal<typeof THREE>()
+const THREE_SOURCE = await vi.hoisted(() => import('three/src/Three.js'))
+vi.mock<unknown>(import('three'), () => {
   class WebGLRenderer {
     domElement = document.createElement('canvas')
     autoClear = true
@@ -40,7 +40,7 @@ vi.mock<unknown>(import('three'), async (importOriginal) => {
     forceContextLoss = forceContextLoss
     dispose = dispose
   }
-  return { ...actual, WebGLRenderer }
+  return { ...THREE_SOURCE, WebGLRenderer }
 })
 
 describe('acquireSharedRenderer', () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -112,21 +112,15 @@ vi.mock('@/scripts/metadata/parser', () => ({
   getWorkflowDataFromFile: vi.fn()
 }))
 
-vi.mock('@/utils/eventUtils', async (importOriginal) => {
-  const eventUtils = await importOriginal<typeof import('@/utils/eventUtils')>()
-  return {
-    ...eventUtils,
-    extractFilesFromDragEvent: vi.fn()
-  }
-})
+vi.mock(import('@/utils/eventUtils'), { spy: true })
 
 vi.mock('./pnginfo', () => ({
   importA1111: mockImportA1111
 }))
 
-vi.mock('@/platform/workflow/core/services/workflowService', () => ({
-  useWorkflowService: vi.fn(() => mockWorkflowService)
-}))
+vi.mock(import('@/platform/workflow/core/services/workflowService'), {
+  spy: true
+})
 
 vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
   default: {
@@ -177,12 +171,12 @@ function createTestFile(name: string, type: string): File {
  * Point the workflowService mock at the real implementation for tests that
  * exercise the load lifecycle itself rather than app.ts's calls into it.
  */
-const actualWorkflowService = await vi.importActual<
-  typeof import('@/platform/workflow/core/services/workflowService')
->('@/platform/workflow/core/services/workflowService')
-
 async function useRealWorkflowService(): Promise<WorkflowService> {
-  const real = actualWorkflowService.useWorkflowService()
+  vi.mocked(useWorkflowService).mockRestore()
+  const real = useWorkflowService()
+  vi.mocked(useWorkflowService).mockReturnValue(
+    fromPartial<WorkflowService>(mockWorkflowService)
+  )
   mockWorkflowService.beforeLoadNewGraph.mockImplementation(
     real.beforeLoadNewGraph
   )
@@ -220,6 +214,9 @@ describe('ComfyApp', () => {
   let mockCanvas: LGraphCanvas
 
   beforeEach(() => {
+    vi.mocked(useWorkflowService).mockReturnValue(
+      fromPartial<WorkflowService>(mockWorkflowService)
+    )
     app = new ComfyApp()
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -32,6 +32,7 @@ import {
   createMockChangeTracker,
   createNodeState
 } from '@/utils/__tests__/litegraphTestUtils'
+import { resolveNode } from '@/utils/litegraphUtil'
 import type { WidgetId } from '@/types/widgetId'
 
 const mockEmptyWorkflowDialog = vi.hoisted(() => {
@@ -55,19 +56,15 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
   }
 }))
 
-const mockResolveNode = vi.hoisted(() =>
-  vi.fn<(id: SerializedNodeId) => LGraphNode | undefined>(() => undefined)
-)
-vi.mock(import('@/utils/litegraphUtil'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  resolveNode: mockResolveNode
-}))
+vi.mock(import('@/utils/litegraphUtil'), { spy: true })
 
 vi.mock(import('@/components/builder/useEmptyWorkflowDialog'), () => ({
   useEmptyWorkflowDialog: () => mockEmptyWorkflowDialog
 }))
 
 import { useAppModeStore } from './appModeStore'
+
+const mockResolveNode = vi.mocked(resolveNode)
 
 function createBuilderWorkflow(
   activeMode: string = 'builder:inputs'

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -21,7 +21,6 @@ import {
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { useDialogService } from '@/services/dialogService'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
-import type * as ApiModule from '@/scripts/api'
 import { api } from '@/scripts/api'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 
@@ -109,10 +108,10 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
 // Keep the real API singleton (other modules rely on its full surface) but
 // override resetSocket so we can assert socket lifecycle calls without opening
 // a real WebSocket.
-vi.mock(import('@/scripts/api'), async (importOriginal) => {
-  const actual = await importOriginal<typeof ApiModule>()
-  Object.assign(actual.api, { resetSocket: mockResetSocket })
-  return actual
+const apiModule = await vi.hoisted(() => import('@/scripts/api'))
+vi.mock(import('@/scripts/api'), () => {
+  Object.assign(apiModule.api, { resetSocket: mockResetSocket })
+  return apiModule
 })
 
 // Mock useDialogService

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -38,10 +38,6 @@ const { mockFeatureFlags } = vi.hoisted(() => ({
   }
 }))
 
-const { mockResetSocket } = vi.hoisted(() => ({
-  mockResetSocket: vi.fn()
-}))
-
 const mockReportError = vi.hoisted(() => vi.fn())
 
 vi.mock<unknown>(import('@/platform/telemetry/reportError'), () => ({
@@ -105,14 +101,7 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   })
 }))
 
-// Keep the real API singleton (other modules rely on its full surface) but
-// override resetSocket so we can assert socket lifecycle calls without opening
-// a real WebSocket.
-const apiModule = await vi.hoisted(() => import('@/scripts/api'))
-vi.mock(import('@/scripts/api'), () => {
-  Object.assign(apiModule.api, { resetSocket: mockResetSocket })
-  return apiModule
-})
+let mockResetSocket: Mock
 
 // Mock useDialogService
 vi.mock(import('@/services/dialogService'))
@@ -143,6 +132,7 @@ describe('useAuthStore', () => {
   } as Partial<User> as MockUser
 
   beforeEach(() => {
+    mockResetSocket = vi.spyOn(api, 'resetSocket').mockResolvedValue(undefined)
     vi.stubGlobal('fetch', mockFetch)
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -13,19 +13,20 @@ import { api } from '@/scripts/api'
 import { useBootstrapStore } from './bootstrapStore'
 
 vi.mock(import('firebase/auth'))
-vi.mock(import('@/scripts/api'), async (importOriginal) => {
-  const actual = await importOriginal()
-  Object.assign(actual.api, {
+const apiModule = await vi.hoisted(() => import('@/scripts/api'))
+vi.mock(import('@/scripts/api'), () => {
+  const api = Object.assign(apiModule.api, {
     init: vi.fn().mockResolvedValue(undefined),
     getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
     getUserConfig: vi.fn().mockResolvedValue({})
   })
-  return actual
+  return { ...apiModule, api }
 })
 
-vi.mock(import('@/i18n'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const i18nModule = await vi.hoisted(() => import('@/i18n'))
+vi.mock(import('@/i18n'), () => ({
+  ...i18nModule,
   mergeCustomNodesI18n: vi.fn()
 }))
 

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -6,6 +6,7 @@ import { AxiosError } from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { mergeCustomNodesI18n } from '@/i18n'
+import * as i18nModule from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { bootstrapTracer } from '@/platform/telemetry/perf/bootstrapTracer'
 import { api } from '@/scripts/api'
@@ -13,22 +14,6 @@ import { api } from '@/scripts/api'
 import { useBootstrapStore } from './bootstrapStore'
 
 vi.mock(import('firebase/auth'))
-const apiModule = await vi.hoisted(() => import('@/scripts/api'))
-vi.mock(import('@/scripts/api'), () => {
-  const api = Object.assign(apiModule.api, {
-    init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
-    getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({})
-  })
-  return { ...apiModule, api }
-})
-
-const i18nModule = await vi.hoisted(() => import('@/i18n'))
-vi.mock(import('@/i18n'), () => ({
-  ...i18nModule,
-  mergeCustomNodesI18n: vi.fn()
-}))
 
 const mockDistributionTypes = vi.hoisted(() => ({
   isCloud: false
@@ -52,6 +37,8 @@ function requestFailure(status: number) {
 
 describe('bootstrapStore', () => {
   beforeEach(() => {
+    vi.spyOn(api, 'getCustomNodesI18n').mockResolvedValue({})
+    vi.spyOn(i18nModule, 'mergeCustomNodesI18n').mockImplementation(() => {})
     useSettingStore().isReady = false
     useAuthStore().isInitialized = false
     Object.assign(useAuthStore(), { isAuthenticated: false })

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -5,7 +5,7 @@ import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
-import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
 
 const mockApp = vi.hoisted(() => ({
   isGraphReady: true,
@@ -15,16 +15,8 @@ const mockApp = vi.hoisted(() => ({
 }))
 vi.mock<unknown>(import('@/scripts/app'), () => ({ app: mockApp }))
 
-const mockGetNodeByExecutionId = vi.hoisted(() => vi.fn())
-vi.mock(import('@/utils/graphTraversalUtil'), async () => {
-  const actual = await vi.importActual<typeof GraphTraversalUtil>(
-    '@/utils/graphTraversalUtil'
-  )
-  return {
-    ...actual,
-    getNodeByExecutionId: mockGetNodeByExecutionId
-  }
-})
+vi.mock(import('@/utils/graphTraversalUtil'), { spy: true })
+const mockGetNodeByExecutionId = vi.mocked(getNodeByExecutionId)
 
 vi.mock(import('@/i18n'), () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -4,7 +4,6 @@ import { nextTick, reactive, ref } from 'vue'
 import { assetService } from '@/platform/assets/services/assetService'
 import type * as DistributionTypes from '@/platform/distribution/types'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
-import type * as RemoteConfigModule from '@/platform/remoteConfig/remoteConfig'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import { api } from '@/scripts/api'
 import {
@@ -29,15 +28,11 @@ const remoteConfigHolder = await vi.hoisted(async () => {
   return { current: ref<RemoteConfig>({}) }
 })
 
-vi.mock<unknown>(
-  import('@/platform/remoteConfig/remoteConfig'),
-  async (importOriginal) => ({
-    ...(await importOriginal<typeof RemoteConfigModule>()),
-    get remoteConfig() {
-      return remoteConfigHolder.current
-    }
-  })
-)
+vi.mock<unknown>(import('@/platform/remoteConfig/remoteConfig'), () => ({
+  get remoteConfig() {
+    return remoteConfigHolder.current
+  }
+}))
 
 const featureState = vi.hoisted(() => ({
   serverFeatures: {} as Record<string, unknown>

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -49,13 +49,27 @@ const distribution = vi.hoisted(
 )
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiMock }))
-const firebaseAuth = await vi.hoisted(() => import('firebase/auth'))
-vi.mock(import('firebase/auth'), () => ({
-  ...firebaseAuth,
-  setPersistence: vi.fn(async () => {}),
-  onAuthStateChanged: vi.fn(() => () => {}),
-  onIdTokenChanged: vi.fn(() => () => {})
-}))
+vi.mock<unknown>(import('firebase/auth'), () => {
+  class AuthProvider {
+    addScope() {}
+    setCustomParameters() {}
+  }
+
+  return {
+    AuthErrorCodes: {
+      POPUP_CLOSED_BY_USER: 'auth/popup-closed-by-user',
+      EXPIRED_POPUP_REQUEST: 'auth/cancelled-popup-request',
+      POPUP_BLOCKED: 'auth/popup-blocked',
+      CREDENTIAL_TOO_OLD_LOGIN_AGAIN: 'auth/requires-recent-login'
+    },
+    GoogleAuthProvider: AuthProvider,
+    GithubAuthProvider: AuthProvider,
+    browserLocalPersistence: {},
+    setPersistence: vi.fn(async () => {}),
+    onAuthStateChanged: vi.fn(() => () => {}),
+    onIdTokenChanged: vi.fn(() => () => {})
+  }
+})
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({
   app: {
@@ -80,12 +94,6 @@ vi.mock(import('@/composables/useReconnectingNotification'), () => {
   }
 })
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useIntervalFn: vi.fn(() => ({ pause: vi.fn() }))
-}))
-
 vi.mock(import('@/base/common/async'), () => ({ runWhenGlobalIdle: vi.fn() }))
 vi.mock(import('@/composables/useBrowserTabTitle'), () => ({
   useBrowserTabTitle: vi.fn()
@@ -104,11 +112,6 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
 }))
 vi.mock(import('@/composables/useProgressFavicon'), () => ({
   useProgressFavicon: vi.fn()
-}))
-const i18nModule = await vi.hoisted(() => import('@/i18n'))
-vi.mock(import('@/i18n'), () => ({
-  ...i18nModule,
-  loadLocale: vi.fn().mockResolvedValue(undefined)
 }))
 vi.mock(import('@/platform/distribution/types'), () => distribution)
 

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -2,11 +2,9 @@ import { render, screen } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
-import type * as VueUseCore from '@vueuse/core'
 import { useReconnectQueueRefresh } from '@/composables/useReconnectQueueRefresh'
 import { useReconnectingNotification } from '@/composables/useReconnectingNotification'
 import type * as DistributionTypes from '@/platform/distribution/types'
-import type * as I18nModule from '@/i18n'
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
@@ -51,8 +49,9 @@ const distribution = vi.hoisted(
 )
 
 vi.mock<unknown>(import('@/scripts/api'), () => ({ api: apiMock }))
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const firebaseAuth = await vi.hoisted(() => import('firebase/auth'))
+vi.mock(import('firebase/auth'), () => ({
+  ...firebaseAuth,
   setPersistence: vi.fn(async () => {}),
   onAuthStateChanged: vi.fn(() => () => {}),
   onIdTokenChanged: vi.fn(() => () => {})
@@ -81,10 +80,11 @@ vi.mock(import('@/composables/useReconnectingNotification'), () => {
   }
 })
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
-  const actual = await importOriginal<typeof VueUseCore>()
-  return { ...actual, useIntervalFn: vi.fn(() => ({ pause: vi.fn() })) }
-})
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
+  useIntervalFn: vi.fn(() => ({ pause: vi.fn() }))
+}))
 
 vi.mock(import('@/base/common/async'), () => ({ runWhenGlobalIdle: vi.fn() }))
 vi.mock(import('@/composables/useBrowserTabTitle'), () => ({
@@ -105,10 +105,11 @@ vi.mock<unknown>(import('@/composables/useErrorHandling'), () => ({
 vi.mock(import('@/composables/useProgressFavicon'), () => ({
   useProgressFavicon: vi.fn()
 }))
-vi.mock(import('@/i18n'), async (importOriginal) => {
-  const actual = await importOriginal<typeof I18nModule>()
-  return { ...actual, loadLocale: vi.fn().mockResolvedValue(undefined) }
-})
+const i18nModule = await vi.hoisted(() => import('@/i18n'))
+vi.mock(import('@/i18n'), () => ({
+  ...i18nModule,
+  loadLocale: vi.fn().mockResolvedValue(undefined)
+}))
 vi.mock(import('@/platform/distribution/types'), () => distribution)
 
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({

--- a/src/views/LinearView.test.ts
+++ b/src/views/LinearView.test.ts
@@ -11,8 +11,9 @@ import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import LinearView from './LinearView.vue'
 
-vi.mock(import('firebase/auth'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const firebaseAuth = await vi.hoisted(() => import('firebase/auth'))
+vi.mock(import('firebase/auth'), () => ({
+  ...firebaseAuth,
   setPersistence: vi.fn(async () => {}),
   onAuthStateChanged: vi.fn(() => () => {}),
   onIdTokenChanged: vi.fn(() => () => {})

--- a/src/views/LinearView.test.ts
+++ b/src/views/LinearView.test.ts
@@ -11,13 +11,27 @@ import { createMockLoadedWorkflow } from '@/utils/__tests__/litegraphTestUtils'
 
 import LinearView from './LinearView.vue'
 
-const firebaseAuth = await vi.hoisted(() => import('firebase/auth'))
-vi.mock(import('firebase/auth'), () => ({
-  ...firebaseAuth,
-  setPersistence: vi.fn(async () => {}),
-  onAuthStateChanged: vi.fn(() => () => {}),
-  onIdTokenChanged: vi.fn(() => () => {})
-}))
+vi.mock<unknown>(import('firebase/auth'), () => {
+  class AuthProvider {
+    addScope() {}
+    setCustomParameters() {}
+  }
+
+  return {
+    AuthErrorCodes: {
+      POPUP_CLOSED_BY_USER: 'auth/popup-closed-by-user',
+      EXPIRED_POPUP_REQUEST: 'auth/cancelled-popup-request',
+      POPUP_BLOCKED: 'auth/popup-blocked',
+      CREDENTIAL_TOO_OLD_LOGIN_AGAIN: 'auth/requires-recent-login'
+    },
+    GoogleAuthProvider: AuthProvider,
+    GithubAuthProvider: AuthProvider,
+    browserLocalPersistence: {},
+    setPersistence: vi.fn(async () => {}),
+    onAuthStateChanged: vi.fn(() => () => {}),
+    onIdTokenChanged: vi.fn(() => () => {})
+  }
+})
 
 interface ViewState {
   sidebarLocation: 'left' | 'right'

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -10,7 +10,8 @@ import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mocked } from 'vitest'
-import { defineComponent, h, nextTick } from 'vue'
+import { computed, defineComponent, h, nextTick, ref } from 'vue'
+import { useClipboard } from '@vueuse/core'
 
 // jsdom does not implement ResizeObserver (happy-dom does); stub it before the
 // Vue node preview chain constructs its module-level observer at import time.
@@ -38,6 +39,9 @@ import { toNodeId } from '@/types/nodeId'
 
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { app } from '@/scripts/app'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
@@ -136,15 +140,13 @@ const appMock = vi.hoisted(() => {
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({ app: appMock }))
 
-const workflowSchema = await vi.hoisted(
-  () => import('@/platform/workflow/validation/schemas/workflowSchema')
-)
-vi.mock<unknown>(
-  import('@/platform/workflow/validation/schemas/workflowSchema'),
-  () => ({
-    ...workflowSchema,
-    validateComfyWorkflow: vi.fn(async (content: unknown) => content)
-  })
+vi.mock(import('@/platform/workflow/validation/schemas/workflowSchema'), {
+  spy: true
+})
+vi.mocked(validateComfyWorkflow).mockImplementation(async (content) =>
+  fromPartial<ComfyWorkflowJSON>(
+    typeof content === 'object' && content !== null ? content : {}
+  )
 )
 
 let workflowStore: ReturnType<typeof useWorkflowStore>
@@ -213,19 +215,15 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
 
 const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), async () => {
-  const { ref } = await import('vue')
-  return {
-    ...vueUse,
-    useClipboard: () => ({
-      copy: clipboard.copy,
-      copied: ref(false),
-      isSupported: ref(true),
-      text: ref('')
-    })
-  }
-})
+vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(useClipboard).mockReturnValue(
+  fromPartial({
+    copy: clipboard.copy,
+    copied: computed(() => false),
+    isSupported: ref(true),
+    text: ref('')
+  })
+)
 
 const telemetry = vi.hoisted(() => ({
   trackAgentMessageFeedback: vi.fn(),
@@ -265,42 +263,31 @@ const paywallBilling = vi.hoisted(() => ({
   tier: 'STANDARD' as SubscriptionTier | null
 }))
 
-vi.mock<unknown>(
-  import('@/platform/workspace/composables/useWorkspaceUI'),
-  async () => {
-    const { computed } = await import('vue')
-    return {
-      useWorkspaceUI: () => ({
-        workspaceRole: computed(() => paywallWorkspace.role)
-      })
-    }
-  }
+vi.mock(import('@/platform/workspace/composables/useWorkspaceUI'), {
+  spy: true
+})
+vi.mocked(useWorkspaceUI).mockReturnValue(
+  fromPartial({
+    workspaceRole: computed(() => paywallWorkspace.role)
+  })
 )
-
-vi.mock<unknown>(
-  import('@/composables/billing/useBillingContext'),
-  async () => {
-    const { computed } = await import('vue')
-    return {
-      useBillingContext: () => ({ tier: computed(() => paywallBilling.tier) })
-    }
-  }
+vi.mock(import('@/composables/billing/useBillingContext'), { spy: true })
+vi.mocked(useBillingContext).mockReturnValue(
+  fromPartial({
+    tier: computed(() => paywallBilling.tier)
+  })
 )
-
-vi.mock<unknown>(
-  import('@/platform/workspace/composables/useBillingCapabilities'),
-  async () => {
-    const { computed } = await import('vue')
-    return {
-      useBillingCapabilities: () => ({
-        canTopUp: computed(() => paywallCapabilities.canTopUp),
-        canSubscribeSelfServe: computed(
-          () => paywallCapabilities.canSubscribeSelfServe
-        ),
-        isReady: computed(() => paywallCapabilities.isReady)
-      })
-    }
-  }
+vi.mock(import('@/platform/workspace/composables/useBillingCapabilities'), {
+  spy: true
+})
+vi.mocked(useBillingCapabilities).mockReturnValue(
+  fromPartial({
+    canTopUp: computed(() => paywallCapabilities.canTopUp),
+    canSubscribeSelfServe: computed(
+      () => paywallCapabilities.canSubscribeSelfServe
+    ),
+    isReady: computed(() => paywallCapabilities.isReady)
+  })
 )
 
 import type { AgentMessages, TurnId } from './schemas/agentApiSchema'
@@ -317,6 +304,38 @@ import AgentPanelRoot from './AgentPanelRoot.vue'
 
 beforeEach(() => {
   Object.assign(useAgentConsentStore(), { accepted: true })
+  vi.mocked(validateComfyWorkflow).mockImplementation(async (content) =>
+    fromPartial<ComfyWorkflowJSON>(
+      typeof content === 'object' && content !== null ? content : {}
+    )
+  )
+  vi.mocked(useClipboard).mockReturnValue(
+    fromPartial({
+      copy: clipboard.copy,
+      copied: computed(() => false),
+      isSupported: ref(true),
+      text: ref('')
+    })
+  )
+  vi.mocked(useWorkspaceUI).mockReturnValue(
+    fromPartial({
+      workspaceRole: computed(() => paywallWorkspace.role)
+    })
+  )
+  vi.mocked(useBillingContext).mockReturnValue(
+    fromPartial({
+      tier: computed(() => paywallBilling.tier)
+    })
+  )
+  vi.mocked(useBillingCapabilities).mockReturnValue(
+    fromPartial({
+      canTopUp: computed(() => paywallCapabilities.canTopUp),
+      canSubscribeSelfServe: computed(
+        () => paywallCapabilities.canSubscribeSelfServe
+      ),
+      isReady: computed(() => paywallCapabilities.isReady)
+    })
+  )
   workflowStore = useWorkflowStore()
   canvasStore = useCanvasStore()
   executionErrors = vi.mocked(useExecutionErrorStore())

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -143,11 +143,6 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({ app: appMock }))
 vi.mock(import('@/platform/workflow/validation/schemas/workflowSchema'), {
   spy: true
 })
-vi.mocked(validateComfyWorkflow).mockImplementation(async (content) =>
-  fromPartial<ComfyWorkflowJSON>(
-    typeof content === 'object' && content !== null ? content : {}
-  )
-)
 
 let workflowStore: ReturnType<typeof useWorkflowStore>
 let canvasStore: ReturnType<typeof useCanvasStore>
@@ -216,14 +211,6 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
 const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
 
 vi.mock(import('@vueuse/core'), { spy: true })
-vi.mocked(useClipboard).mockReturnValue(
-  fromPartial({
-    copy: clipboard.copy,
-    copied: computed(() => false),
-    isSupported: ref(true),
-    text: ref('')
-  })
-)
 
 const telemetry = vi.hoisted(() => ({
   trackAgentMessageFeedback: vi.fn(),
@@ -266,29 +253,10 @@ const paywallBilling = vi.hoisted(() => ({
 vi.mock(import('@/platform/workspace/composables/useWorkspaceUI'), {
   spy: true
 })
-vi.mocked(useWorkspaceUI).mockReturnValue(
-  fromPartial({
-    workspaceRole: computed(() => paywallWorkspace.role)
-  })
-)
 vi.mock(import('@/composables/billing/useBillingContext'), { spy: true })
-vi.mocked(useBillingContext).mockReturnValue(
-  fromPartial({
-    tier: computed(() => paywallBilling.tier)
-  })
-)
 vi.mock(import('@/platform/workspace/composables/useBillingCapabilities'), {
   spy: true
 })
-vi.mocked(useBillingCapabilities).mockReturnValue(
-  fromPartial({
-    canTopUp: computed(() => paywallCapabilities.canTopUp),
-    canSubscribeSelfServe: computed(
-      () => paywallCapabilities.canSubscribeSelfServe
-    ),
-    isReady: computed(() => paywallCapabilities.isReady)
-  })
-)
 
 import type { AgentMessages, TurnId } from './schemas/agentApiSchema'
 import { zAgentWsEvent } from './schemas/agentApiSchema'

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -136,10 +136,13 @@ const appMock = vi.hoisted(() => {
 
 vi.mock<unknown>(import('@/scripts/app'), () => ({ app: appMock }))
 
+const workflowSchema = await vi.hoisted(
+  () => import('@/platform/workflow/validation/schemas/workflowSchema')
+)
 vi.mock<unknown>(
   import('@/platform/workflow/validation/schemas/workflowSchema'),
-  async (importOriginal) => ({
-    ...(await importOriginal<object>()),
+  () => ({
+    ...workflowSchema,
     validateComfyWorkflow: vi.fn(async (content: unknown) => content)
   })
 )
@@ -195,8 +198,7 @@ vi.mock<unknown>(
   })
 )
 
-vi.mock<unknown>(import('@/utils/litegraphUtil'), async (importOriginal) => ({
-  ...(await importOriginal<object>()),
+vi.mock<unknown>(import('@/utils/litegraphUtil'), () => ({
   isLGraphNode: (item: unknown) =>
     (item as { isNodeFake?: boolean } | null)?.isNodeFake === true
 }))
@@ -211,10 +213,11 @@ vi.mock<unknown>(import('@/composables/auth/useCurrentUser'), () => ({
 
 const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), async () => {
   const { ref } = await import('vue')
   return {
-    ...(await importOriginal<object>()),
+    ...vueUse,
     useClipboard: () => ({
       copy: clipboard.copy,
       copied: ref(false),
@@ -238,13 +241,9 @@ vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => telemetry
 }))
 
-vi.mock<unknown>(
-  import('@/platform/distribution/types'),
-  async (importOriginal) => ({
-    ...(await importOriginal<object>()),
-    isCloud: true
-  })
-)
+vi.mock<unknown>(import('@/platform/distribution/types'), () => ({
+  isCloud: true
+}))
 
 const openAccountPrecondition = vi.hoisted(() => vi.fn())
 vi.mock(

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
+import { fromPartial } from '@total-typescript/shoehorn'
 import { getActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { defineComponent, nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useIntersectionObserver } from '@vueuse/core'
 
 // jsdom lacks ResizeObserver, which the asset-preview import chain references.
 vi.hoisted(() => {
@@ -17,17 +19,16 @@ vi.hoisted(() => {
 const intersectionCallbacks = vi.hoisted(
   () => [] as ((entries: { isIntersecting: boolean }[]) => void)[]
 )
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useIntersectionObserver: (
-    _target: unknown,
-    callback: (entries: { isIntersecting: boolean }[]) => void
-  ) => {
-    intersectionCallbacks.push(callback)
-    return { stop: () => {} }
-  }
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(useIntersectionObserver).mockImplementation((_target, callback) => {
+  intersectionCallbacks.push((entries) =>
+    callback(
+      entries.map((entry) => fromPartial(entry)),
+      fromPartial({})
+    )
+  )
+  return fromPartial({ stop: vi.fn() })
+})
 
 import { i18n } from '@/i18n'
 import type { TurnId } from '../../schemas/agentApiSchema'
@@ -84,6 +85,17 @@ function mountHarness() {
 
 describe('ConversationView', () => {
   beforeEach(() => {
+    vi.mocked(useIntersectionObserver).mockImplementation(
+      (_target, callback) => {
+        intersectionCallbacks.push((entries) =>
+          callback(
+            entries.map((entry) => fromPartial(entry)),
+            fromPartial({})
+          )
+        )
+        return fromPartial({ stop: vi.fn() })
+      }
+    )
     Element.prototype.scrollIntoView = vi.fn()
     intersectionCallbacks.length = 0
   })

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -14,13 +14,12 @@ vi.hoisted(() => {
   }
 })
 
-import type * as VueUse from '@vueuse/core'
-
 const intersectionCallbacks = vi.hoisted(
   () => [] as ((entries: { isIntersecting: boolean }[]) => void)[]
 )
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal<typeof VueUse>()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   useIntersectionObserver: (
     _target: unknown,
     callback: (entries: { isIntersecting: boolean }[]) => void

--- a/src/workbench/extensions/agent/composables/agent/useAgentConsent.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentConsent.test.ts
@@ -44,14 +44,11 @@ const fetchApi = vi.hoisted(() => vi.fn())
 vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { fetchApi } }))
 
 const fetchWithUnifiedRemint = vi.hoisted(() => vi.fn())
-vi.mock(
-  import('@/platform/auth/unified/remintRetry'),
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    fetchWithUnifiedRemint,
-    shouldRemintCloudRequest: () => Promise.resolve(false)
-  })
-)
+vi.mock(import('@/platform/auth/unified/remintRetry'), () => ({
+  attachUnifiedRemintInterceptor: vi.fn(),
+  fetchWithUnifiedRemint,
+  shouldRemintCloudRequest: () => Promise.resolve(false)
+}))
 
 const showSignInDialog = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 vi.mock<unknown>(import('@/services/dialogService'), () => ({

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -6,8 +6,9 @@ const { writeText } = vi.hoisted(() => ({
   writeText: vi.fn<(value: string) => Promise<void>>(() => Promise.resolve())
 }))
 
-vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const vueUse = await vi.hoisted(() => import('@vueuse/core'))
+vi.mock<unknown>(import('@vueuse/core'), () => ({
+  ...vueUse,
   useClipboard: () => ({ copy: writeText })
 }))
 

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.clipboard.test.ts
@@ -1,16 +1,17 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useClipboard } from '@vueuse/core'
 
 const { writeText } = vi.hoisted(() => ({
-  writeText: vi.fn<(value: string) => Promise<void>>(() => Promise.resolve())
+  writeText: vi.fn<ReturnType<typeof useClipboard>['copy']>(() =>
+    Promise.resolve()
+  )
 }))
 
-const vueUse = await vi.hoisted(() => import('@vueuse/core'))
-vi.mock<unknown>(import('@vueuse/core'), () => ({
-  ...vueUse,
-  useClipboard: () => ({ copy: writeText })
-}))
+vi.mock(import('@vueuse/core'), { spy: true })
+vi.mocked(useClipboard).mockReturnValue(fromPartial({ copy: writeText }))
 
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 import CrdtDevPanel from './CrdtDevPanel.vue'
@@ -60,6 +61,7 @@ function renderPanel(overrides: Partial<AgentCrdtStatus> = {}) {
 
 describe('CrdtDevPanel clipboard controls', () => {
   beforeEach(() => {
+    vi.mocked(useClipboard).mockReturnValue(fromPartial({ copy: writeText }))
     setCrdtDebugEnabled(true)
     clearDevEvents()
     localStorage.clear()

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
+import { debounce } from 'es-toolkit/compat'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -11,11 +12,10 @@ import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores
 
 import PackEnableToggle from './PackEnableToggle.vue'
 
-const esToolkit = await vi.hoisted(() => import('es-toolkit/compat'))
-vi.mock(import('es-toolkit/compat'), () => ({
-  ...esToolkit,
-  debounce: <T extends (...args: unknown[]) => unknown>(fn: T) => fn
-}))
+vi.mock(import('es-toolkit/compat'), { spy: true })
+vi.mocked(debounce).mockImplementation((fn) =>
+  Object.assign(fn, { cancel: vi.fn(), flush: vi.fn() })
+)
 
 const {
   acknowledgmentState,
@@ -83,6 +83,9 @@ describe('PackEnableToggle', () => {
   const user = userEvent.setup()
 
   beforeEach(() => {
+    vi.mocked(debounce).mockImplementation((fn) =>
+      Object.assign(fn, { cancel: vi.fn(), flush: vi.fn() })
+    )
     mockGetConflictsForPackageByID = vi.fn()
     Object.assign(useConflictDetectionStore(), {
       getConflictsForPackageByID: mockGetConflictsForPackageByID

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -11,8 +11,9 @@ import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores
 
 import PackEnableToggle from './PackEnableToggle.vue'
 
-vi.mock(import('es-toolkit/compat'), async (importOriginal) => ({
-  ...(await importOriginal()),
+const esToolkit = await vi.hoisted(() => import('es-toolkit/compat'))
+vi.mock(import('es-toolkit/compat'), () => ({
+  ...esToolkit,
   debounce: <T extends (...args: unknown[]) => unknown>(fn: T) => fn
 }))
 

--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -10,7 +10,7 @@ import { useConflictDetection } from '@/workbench/extensions/manager/composables
 import { useComfyManagerService } from '@/workbench/extensions/manager/services/comfyManagerService'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores/conflictDetectionStore'
-import type * as ConflictUtils from '@/workbench/extensions/manager/utils/conflictUtils'
+import { consolidateConflictsByPackage } from '@/workbench/extensions/manager/utils/conflictUtils'
 import {
   checkAcceleratorCompatibility,
   checkOSCompatibility
@@ -49,18 +49,11 @@ vi.mock(
   })
 )
 
-vi.mock(
-  import('@/workbench/extensions/manager/utils/conflictUtils'),
-
-  async () => {
-    const actual = await vi.importActual<typeof ConflictUtils>(
-      '@/workbench/extensions/manager/utils/conflictUtils'
-    )
-    return {
-      ...actual,
-      consolidateConflictsByPackage: vi.fn((results) => results)
-    }
-  }
+vi.mock(import('@/workbench/extensions/manager/utils/conflictUtils'), {
+  spy: true
+})
+vi.mocked(consolidateConflictsByPackage).mockImplementation(
+  (results) => results
 )
 
 vi.mock(

--- a/tools/oxlint-plugins/comfy.ts
+++ b/tools/oxlint-plugins/comfy.ts
@@ -7,6 +7,7 @@ import type {
 import type { noDuplicateIngestType as NoDuplicateIngestType } from './comfyIngestTypes'
 import type { useGlobalPinia as UseGlobalPinia } from './globalPinia'
 import type {
+  noImportActual as NoImportActual,
   noModuleScopeVitestMocks as NoModuleScopeVitestMocks,
   noPersistentLiteGraphRegistration as NoPersistentLiteGraphRegistration,
   noRedundantLiteGraphCleanup as NoRedundantLiteGraphCleanup,
@@ -28,11 +29,13 @@ const { useGlobalPinia } = requireFrom('./globalPinia.ts') as {
   useGlobalPinia: typeof UseGlobalPinia
 }
 const {
+  noImportActual,
   noModuleScopeVitestMocks,
   noPersistentLiteGraphRegistration,
   noRedundantLiteGraphCleanup,
   noRedundantVitestCleanup
 } = requireFrom('./vitestCleanup.ts') as {
+  noImportActual: typeof NoImportActual
   noModuleScopeVitestMocks: typeof NoModuleScopeVitestMocks
   noPersistentLiteGraphRegistration: typeof NoPersistentLiteGraphRegistration
   noRedundantLiteGraphCleanup: typeof NoRedundantLiteGraphCleanup
@@ -48,6 +51,7 @@ export default {
     'no-comfy-page-setup-call': noComfyPageSetupCall,
     'prefer-initial-settings': preferInitialSettings,
     'no-duplicate-ingest-type': noDuplicateIngestType,
+    'no-import-actual': noImportActual,
     'no-module-scope-vitest-mocks': noModuleScopeVitestMocks,
     'no-persistent-litegraph-registration': noPersistentLiteGraphRegistration,
     'no-render-in-watch-effect': noRenderInWatchEffect,

--- a/tools/oxlint-plugins/noImportActual.test.ts
+++ b/tools/oxlint-plugins/noImportActual.test.ts
@@ -1,0 +1,43 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { RuleTester } from 'oxlint/plugins-dev'
+import { describe, it } from 'vitest'
+
+import { noImportActual } from './vitestCleanup'
+
+type Rule = Parameters<RuleTester['run']>[1]
+
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } }
+})
+
+ruleTester.run('no-import-actual', fromAny<Rule, unknown>(noImportActual), {
+  valid: [
+    `import { vi } from 'vitest'
+vi.mock(import('./dependency'), () => ({ dependency: vi.fn() }))
+vi.spyOn(dependency, 'method')`,
+    `const vi = { importActual: () => undefined }
+vi.importActual()`
+  ],
+  invalid: [
+    {
+      code: `import { vi } from 'vitest'
+vi.mock(import('./dependency'), async (importOriginal) => importOriginal())`,
+      errors: [{ message: /Avoid importOriginal/ }]
+    },
+    {
+      code: `import { vi as vitest } from 'vitest'
+vitest.importActual('./dependency')`,
+      errors: [{ message: /vi\.importActual/ }]
+    },
+    {
+      code: `import * as Vitest from 'vitest'
+Vitest.vi.mock('./dependency', function (importOriginal) {
+  return importOriginal()
+})`,
+      errors: [{ message: /Avoid importOriginal/ }]
+    }
+  ]
+})

--- a/tools/oxlint-plugins/noImportActual.test.ts
+++ b/tools/oxlint-plugins/noImportActual.test.ts
@@ -18,6 +18,14 @@ ruleTester.run('no-import-actual', fromAny<Rule, unknown>(noImportActual), {
     `import { vi } from 'vitest'
 vi.mock(import('./dependency'), () => ({ dependency: vi.fn() }))
 vi.spyOn(dependency, 'method')`,
+    `async function loadDependency() {
+  return import('./dependency')
+}`,
+    `import { vi } from 'vitest'
+vi.mock('./dependency', async () => {
+  const { ref } = await import('vue')
+  return { dependency: ref(false) }
+})`,
     `const vi = { importActual: () => undefined }
 vi.importActual()`
   ],
@@ -38,6 +46,14 @@ Vitest.vi.mock('./dependency', function (importOriginal) {
   return importOriginal()
 })`,
       errors: [{ message: /Avoid importOriginal/ }]
+    },
+    {
+      code: `import { vi } from 'vitest'
+vi.mock('./dependency', async () => {
+  const original = await import('./dependency')
+  return { ...original, dependency: vi.fn() }
+})`,
+      errors: [{ message: /Do not dynamically import/ }]
     }
   ]
 })

--- a/tools/oxlint-plugins/noImportActual.test.ts
+++ b/tools/oxlint-plugins/noImportActual.test.ts
@@ -68,6 +68,15 @@ vi.mock('./dependency', factory)`,
     },
     {
       code: `import { vi } from 'vitest'
+async function factory() {
+  const original = await import('./dependency')
+  return { ...original, dependency: vi.fn() }
+}
+vi.mock('./dependency', factory)`,
+      errors: [{ message: /Do not dynamically import/ }]
+    },
+    {
+      code: `import { vi } from 'vitest'
 vi.mock(\`./dependency\`, async () => {
   const original = await import(\`./dependency\`)
   return { ...original, dependency: vi.fn() }

--- a/tools/oxlint-plugins/noImportActual.test.ts
+++ b/tools/oxlint-plugins/noImportActual.test.ts
@@ -54,6 +54,25 @@ vi.mock('./dependency', async () => {
   return { ...original, dependency: vi.fn() }
 })`,
       errors: [{ message: /Do not dynamically import/ }]
+    },
+    {
+      code: `import { vi } from 'vitest'
+vi.doMock('./dependency', async (importOriginal) => importOriginal())`,
+      errors: [{ message: /Avoid importOriginal/ }]
+    },
+    {
+      code: `import { vi } from 'vitest'
+const factory = async (importOriginal: () => Promise<object>) => importOriginal()
+vi.mock('./dependency', factory)`,
+      errors: [{ message: /Avoid importOriginal/ }]
+    },
+    {
+      code: `import { vi } from 'vitest'
+vi.mock(\`./dependency\`, async () => {
+  const original = await import(\`./dependency\`)
+  return { ...original, dependency: vi.fn() }
+})`,
+      errors: [{ message: /Do not dynamically import/ }]
     }
   ]
 })

--- a/tools/oxlint-plugins/vitestCleanup.config.json
+++ b/tools/oxlint-plugins/vitestCleanup.config.json
@@ -24,6 +24,7 @@
         "**/tools/**/*.test.{ts,tsx}"
       ],
       "rules": {
+        "comfy/no-import-actual": "warn",
         "comfy/no-module-scope-vitest-mocks": "error",
         "comfy/no-persistent-litegraph-registration": "error",
         "comfy/no-redundant-litegraph-cleanup": "error",

--- a/tools/oxlint-plugins/vitestCleanup.config.json
+++ b/tools/oxlint-plugins/vitestCleanup.config.json
@@ -24,7 +24,7 @@
         "**/tools/**/*.test.{ts,tsx}"
       ],
       "rules": {
-        "comfy/no-import-actual": "warn",
+        "comfy/no-import-actual": "error",
         "comfy/no-module-scope-vitest-mocks": "error",
         "comfy/no-persistent-litegraph-registration": "error",
         "comfy/no-redundant-litegraph-cleanup": "error",

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -224,7 +224,12 @@ function mockFactory(
       (node.type === 'VariableDeclarator' && isFunctionExpression(node.init))
   )?.node
   if (isFunctionExpression(definition)) return definition
-  if (definition?.type === 'VariableDeclarator') return definition.init
+  if (
+    definition?.type === 'VariableDeclarator' &&
+    isFunctionExpression(definition.init)
+  ) {
+    return definition.init
+  }
 }
 
 function isVitestImport(

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -102,10 +102,6 @@ interface FunctionExpression extends Node {
   readonly params: readonly Node[]
 }
 
-function isCallExpression(node: Node | undefined): node is CallExpression {
-  return node?.type === 'CallExpression'
-}
-
 function isImportExpression(node: Node | undefined): node is ImportExpression {
   return node?.type === 'ImportExpression'
 }
@@ -475,10 +471,29 @@ export const noModuleScopeVitestMocks = {
 
 export const noImportActual = {
   create(context: RuleContext) {
+    const mockedModulesByFactory = new Map<FunctionExpression, Set<string>>()
+    const importsInFactories: {
+      node: ImportExpression
+      factory: FunctionExpression
+      importedModule: string
+    }[] = []
+
     return {
       CallExpression(node: CallExpression) {
         const methodName = vitestMethodName(context, node)
         const factory = mockFactory(context, node.arguments[1])
+        if (
+          methodName !== undefined &&
+          PARTIAL_MOCK_METHODS.has(methodName) &&
+          factory !== undefined
+        ) {
+          const mockedModule = staticModuleName(node.arguments[0])
+          if (mockedModule !== undefined) {
+            const modules = mockedModulesByFactory.get(factory) ?? new Set()
+            modules.add(mockedModule)
+            mockedModulesByFactory.set(factory, modules)
+          }
+        }
         const usesImportOriginal =
           methodName !== undefined &&
           PARTIAL_MOCK_METHODS.has(methodName) &&
@@ -495,25 +510,22 @@ export const noImportActual = {
       },
       ImportExpression(node: ImportExpression) {
         const importedModule = staticModuleName(node.source)
+        if (importedModule === undefined) return
         const ancestors = context.sourceCode.getAncestors(node)
-        const usesDynamicImportInMock = ancestors.some((ancestor, index) => {
-          if (!isFunctionExpression(ancestor)) return false
-          const call = ancestors[index - 1]
-          return (
-            isCallExpression(call) &&
-            call.arguments[1] === ancestor &&
-            PARTIAL_MOCK_METHODS.has(vitestMethodName(context, call) ?? '') &&
-            staticModuleName(call.arguments[0]) === importedModule
-          )
-        })
-
-        if (!usesDynamicImportInMock) return
-
-        context.report({
-          node,
-          message:
-            'Do not dynamically import the original module in a vi.mock() factory. Delete the mock, use vi.mock(..., { spy: true }), or provide a focused full mock.'
-        })
+        const factory = ancestors.findLast(isFunctionExpression)
+        if (factory === undefined) return
+        importsInFactories.push({ node, factory, importedModule })
+      },
+      'Program:exit'() {
+        for (const { node, factory, importedModule } of importsInFactories) {
+          if (!mockedModulesByFactory.get(factory)?.has(importedModule))
+            continue
+          context.report({
+            node,
+            message:
+              'Do not dynamically import the original module in a vi.mock() factory. Delete the mock, use vi.mock(..., { spy: true }), or provide a focused full mock.'
+          })
+        }
       }
     }
   }

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -79,6 +79,20 @@ interface CallExpression extends Node {
   readonly arguments: readonly Expression[]
 }
 
+interface FunctionExpression extends Node {
+  readonly type: 'ArrowFunctionExpression' | 'FunctionExpression'
+  readonly params: readonly Node[]
+}
+
+function isFunctionExpression(
+  node: Node | undefined
+): node is FunctionExpression {
+  return (
+    node?.type === 'ArrowFunctionExpression' ||
+    node?.type === 'FunctionExpression'
+  )
+}
+
 interface ScopeVariableDefinition {
   readonly type: string
   readonly node: Node & { readonly imported?: Identifier }
@@ -388,6 +402,29 @@ export const noModuleScopeVitestMocks = {
         context.report({
           node,
           message: `Install vi.${methodName}() in beforeEach or a test because automatic Vitest cleanup removes earlier mock installations before assertions run.`
+        })
+      }
+    }
+  }
+}
+
+export const noImportActual = {
+  create(context: RuleContext) {
+    return {
+      CallExpression(node: CallExpression) {
+        const methodName = vitestMethodName(context, node)
+        const factory = node.arguments[1]
+        const usesImportOriginal =
+          methodName === 'mock' &&
+          isFunctionExpression(factory) &&
+          factory.params.length > 0
+
+        if (methodName !== 'importActual' && !usesImportOriginal) return
+
+        context.report({
+          node,
+          message:
+            'Avoid importOriginal() and vi.importActual(). Import the module normally and use vi.spyOn(), vi.mock(..., { spy: true }), or a focused full mock.'
         })
       }
     }

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -218,15 +218,13 @@ function mockFactory(
   if (!identifier) return
 
   const variable = resolvedVariable(context, identifier)
-  for (const definition of variable?.defs ?? []) {
-    if (isFunctionExpression(definition.node)) return definition.node
-    if (
-      definition.node.type === 'VariableDeclarator' &&
-      isFunctionExpression(definition.node.init)
-    ) {
-      return definition.node.init
-    }
-  }
+  const definition = variable?.defs.find(
+    ({ node }) =>
+      isFunctionExpression(node) ||
+      (node.type === 'VariableDeclarator' && isFunctionExpression(node.init))
+  )?.node
+  if (isFunctionExpression(definition)) return definition
+  if (definition?.type === 'VariableDeclarator') return definition.init
 }
 
 function isVitestImport(
@@ -481,12 +479,11 @@ export const noImportActual = {
     return {
       CallExpression(node: CallExpression) {
         const methodName = vitestMethodName(context, node)
-        const factory = mockFactory(context, node.arguments[1])
-        if (
-          methodName !== undefined &&
-          PARTIAL_MOCK_METHODS.has(methodName) &&
-          factory !== undefined
-        ) {
+        const factory =
+          methodName !== undefined && PARTIAL_MOCK_METHODS.has(methodName)
+            ? mockFactory(context, node.arguments[1])
+            : undefined
+        if (factory !== undefined) {
           const mockedModule = staticModuleName(node.arguments[0])
           if (mockedModule !== undefined) {
             const modules = mockedModulesByFactory.get(factory) ?? new Set()
@@ -495,10 +492,7 @@ export const noImportActual = {
           }
         }
         const usesImportOriginal =
-          methodName !== undefined &&
-          PARTIAL_MOCK_METHODS.has(methodName) &&
-          factory !== undefined &&
-          factory.params.length > 0
+          factory !== undefined && factory.params.length > 0
 
         if (methodName !== 'importActual' && !usesImportOriginal) return
 

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -49,6 +49,11 @@ interface StringLiteral extends Node {
   readonly value: string
 }
 
+interface ImportExpression extends Node {
+  readonly type: 'ImportExpression'
+  readonly source: Expression
+}
+
 interface PropertyDefinition extends Node {
   readonly type: 'PropertyDefinition'
   readonly static: boolean
@@ -82,6 +87,20 @@ interface CallExpression extends Node {
 interface FunctionExpression extends Node {
   readonly type: 'ArrowFunctionExpression' | 'FunctionExpression'
   readonly params: readonly Node[]
+}
+
+function isCallExpression(node: Node | undefined): node is CallExpression {
+  return node?.type === 'CallExpression'
+}
+
+function isImportExpression(node: Node | undefined): node is ImportExpression {
+  return node?.type === 'ImportExpression'
+}
+
+function staticModuleName(node: Node | undefined): string | undefined {
+  if (!node) return
+  if (isImportExpression(node)) return staticModuleName(node.source)
+  if ('value' in node && typeof node.value === 'string') return node.value
 }
 
 function isFunctionExpression(
@@ -425,6 +444,28 @@ export const noImportActual = {
           node,
           message:
             'Avoid importOriginal() and vi.importActual(). Import the module normally and use vi.spyOn(), vi.mock(..., { spy: true }), or a focused full mock.'
+        })
+      },
+      ImportExpression(node: ImportExpression) {
+        const importedModule = staticModuleName(node.source)
+        const ancestors = context.sourceCode.getAncestors(node)
+        const usesDynamicImportInMock = ancestors.some((ancestor, index) => {
+          if (!isFunctionExpression(ancestor)) return false
+          const call = ancestors[index - 1]
+          return (
+            isCallExpression(call) &&
+            call.arguments[1] === ancestor &&
+            vitestMethodName(context, call) === 'mock' &&
+            staticModuleName(call.arguments[0]) === importedModule
+          )
+        })
+
+        if (!usesDynamicImportInMock) return
+
+        context.report({
+          node,
+          message:
+            'Do not dynamically import the original module in a vi.mock() factory. Delete the mock, use vi.mock(..., { spy: true }), or provide a focused full mock.'
         })
       }
     }

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -15,6 +15,7 @@ const REDUNDANT_LITEGRAPH_CLEANUP_METHODS = new Set([
 ])
 
 const MODULE_SCOPE_MOCK_METHODS = new Set(['spyOn', 'stubGlobal'])
+const PARTIAL_MOCK_METHODS = new Set(['doMock', 'mock'])
 const AFTER_EACH_IMPORTS = new Set(['afterEach'])
 const BEFORE_TEST_IMPORTS = new Set(['beforeAll', 'describe', 'suite'])
 const SUITE_CALLBACK_MODIFIERS = new Set([
@@ -49,6 +50,14 @@ interface StringLiteral extends Node {
   readonly value: string
 }
 
+interface TemplateLiteral extends Node {
+  readonly type: 'TemplateLiteral'
+  readonly expressions: readonly Expression[]
+  readonly quasis: readonly {
+    readonly value: { readonly cooked?: string; readonly raw: string }
+  }[]
+}
+
 interface ImportExpression extends Node {
   readonly type: 'ImportExpression'
   readonly source: Expression
@@ -75,6 +84,7 @@ type Expression =
   | Node
   | Identifier
   | StringLiteral
+  | TemplateLiteral
   | MemberExpression
   | ChainExpression
 
@@ -85,7 +95,10 @@ interface CallExpression extends Node {
 }
 
 interface FunctionExpression extends Node {
-  readonly type: 'ArrowFunctionExpression' | 'FunctionExpression'
+  readonly type:
+    | 'ArrowFunctionExpression'
+    | 'FunctionDeclaration'
+    | 'FunctionExpression'
   readonly params: readonly Node[]
 }
 
@@ -97,10 +110,19 @@ function isImportExpression(node: Node | undefined): node is ImportExpression {
   return node?.type === 'ImportExpression'
 }
 
+function isTemplateLiteral(node: Node): node is TemplateLiteral {
+  return node.type === 'TemplateLiteral'
+}
+
 function staticModuleName(node: Node | undefined): string | undefined {
   if (!node) return
   if (isImportExpression(node)) return staticModuleName(node.source)
   if ('value' in node && typeof node.value === 'string') return node.value
+  if (isTemplateLiteral(node)) {
+    if (node.expressions.length === 0) {
+      return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw
+    }
+  }
 }
 
 function isFunctionExpression(
@@ -108,13 +130,17 @@ function isFunctionExpression(
 ): node is FunctionExpression {
   return (
     node?.type === 'ArrowFunctionExpression' ||
+    node?.type === 'FunctionDeclaration' ||
     node?.type === 'FunctionExpression'
   )
 }
 
 interface ScopeVariableDefinition {
   readonly type: string
-  readonly node: Node & { readonly imported?: Identifier }
+  readonly node: Node & {
+    readonly imported?: Identifier
+    readonly init?: Expression
+  }
   readonly parent: Node & { readonly source?: StringLiteral }
 }
 
@@ -184,6 +210,26 @@ function resolvedVariable(
     )
     if (reference) return reference.resolved
     scope = scope.upper
+  }
+}
+
+function mockFactory(
+  context: RuleContext,
+  expression: Expression | undefined
+): FunctionExpression | undefined {
+  if (isFunctionExpression(expression)) return expression
+  const identifier = expression && asIdentifier(expression)
+  if (!identifier) return
+
+  const variable = resolvedVariable(context, identifier)
+  for (const definition of variable?.defs ?? []) {
+    if (isFunctionExpression(definition.node)) return definition.node
+    if (
+      definition.node.type === 'VariableDeclarator' &&
+      isFunctionExpression(definition.node.init)
+    ) {
+      return definition.node.init
+    }
   }
 }
 
@@ -432,10 +478,11 @@ export const noImportActual = {
     return {
       CallExpression(node: CallExpression) {
         const methodName = vitestMethodName(context, node)
-        const factory = node.arguments[1]
+        const factory = mockFactory(context, node.arguments[1])
         const usesImportOriginal =
-          methodName === 'mock' &&
-          isFunctionExpression(factory) &&
+          methodName !== undefined &&
+          PARTIAL_MOCK_METHODS.has(methodName) &&
+          factory !== undefined &&
           factory.params.length > 0
 
         if (methodName !== 'importActual' && !usesImportOriginal) return
@@ -455,7 +502,7 @@ export const noImportActual = {
           return (
             isCallExpression(call) &&
             call.arguments[1] === ancestor &&
-            vitestMethodName(context, call) === 'mock' &&
+            PARTIAL_MOCK_METHODS.has(vitestMethodName(context, call) ?? '') &&
             staticModuleName(call.arguments[0]) === importedModule
           )
         })

--- a/tools/test-recorder/src/pr/openPr.test.ts
+++ b/tools/test-recorder/src/pr/openPr.test.ts
@@ -1,4 +1,3 @@
-import type * as fs from 'node:fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { openPr } from './openPr'
@@ -9,8 +8,8 @@ vi.mock('./gh', () => ({
   switchBranch: vi.fn()
 }))
 vi.mock('./clipboard', () => ({ copyToClipboard: vi.fn() }))
-vi.mock('node:fs', async (importOriginal) => ({
-  ...(await importOriginal<typeof fs>()),
+vi.mock('node:fs', () => ({
+  default: { readFileSync: vi.fn(() => 'contents') },
   readFileSync: vi.fn(() => 'contents')
 }))
 vi.mock('@clack/prompts', () => ({


### PR DESCRIPTION
## Summary

Removes all `importOriginal` and `vi.importActual` usage and prevents new partial module mocks with Oxlint.

## Changes

- **What**: Replaces all 149 partial-module loading sites across 114 test files with focused mocks, spies, component stubs, or direct imports; adds `comfy/no-import-actual` as an error.

## Review Focus

Check the broad test-only mock migration, especially Three.js source imports and Firebase spy setup after Vitest's automatic mock reset.