### PR TITLE
feat(workshop): credits gate on the real balance, destination unwired

### DIFF
--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -180,6 +180,7 @@ async function signOutFromMenu() {
         </p>
         <a
           :href="WORKSHOP_CREDITS_URL"
+          data-testid="account-add-credits"
           target="_blank"
           rel="noopener noreferrer"
           role="menuitem"

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -3,7 +3,7 @@ import { onClickOutside } from '@vueuse/core'
 import { computed, ref, useTemplateRef } from 'vue'
 
 import { useWorkshopCredits } from '../../config/workshop-credits'
-import { WORKSHOP_CREDITS_URL } from '../../config/workshop-env'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import { runBeforeSignInLeave } from '../../config/workshop-return'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import type { Locale } from '../../i18n/translations'
@@ -179,7 +179,7 @@ async function signOutFromMenu() {
           {{ t('auth.header.balanceError', locale) }}
         </p>
         <a
-          :href="WORKSHOP_CREDITS_URL"
+          :href="platformTopUpHref(session.workspace.id)"
           data-testid="account-add-credits"
           target="_blank"
           rel="noopener noreferrer"

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -96,7 +96,6 @@ const model: WorkshopModelDetail = {
   provider: 'Demo',
   modality: 'image',
   task: 'text-to-image',
-  creditsPerRun: 8,
   nodeDisplayName: 'Demo Text to Image',
   fields: [prompt],
   defaults: {},
@@ -467,18 +466,19 @@ describe('ModelDetail', () => {
       'A red teapot'
     )
 
-    const buy = screen.getByRole('link', { name: 'Buy credits' })
+    const buy = screen.getByRole('link', { name: 'Add credits' })
     expect(buy.getAttribute('href')).toBe(
       `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
     )
     expect(buy.getAttribute('target')).toBe('_blank')
+    expect(screen.getByTestId('gate-note').textContent).toContain('Personal')
     expect(screen.queryByRole('button', { name: 'Run' })).toBeNull()
     expect(runWorkshopRouter).not.toHaveBeenCalled()
 
     credits.balance.value = { status: 'ok', credits: 100 }
     await nextTick()
     expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
     expect(screen.getByRole('textbox', { name: /Prompt/ })).toHaveProperty(
       'value',
       'A red teapot'
@@ -584,7 +584,7 @@ describe('ModelDetail', () => {
     expect(
       screen.getByTestId('playground-output').getAttribute('data-state')
     ).toBe('cancelled')
-    expect(screen.getByRole('link', { name: 'Buy credits' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Add credits' })).toBeTruthy()
     pending.resolve(routerResult)
     await vi.waitFor(() => expect(refreshWorkshopCredits).toHaveBeenCalled())
   })
@@ -1166,36 +1166,4 @@ describe('ModelDetail', () => {
       expect(runWorkshopRouter).not.toHaveBeenCalled()
     }
   )
-  it('blocks a run the balance cannot cover, with a button that promises nothing', async () => {
-    credits.balance.value = { status: 'ok', credits: 2 }
-    auth.session.value = credential
-    mountDetail({ model: runnable })
-    await nextTick()
-
-    const gate = screen.getByTestId('run-button')
-    expect(gate.getAttribute('data-gate')).toBe('noCredits')
-    expect(gate.getAttribute('href')).toContain(
-      'platform.comfy.org/billing?workspace='
-    )
-    expect(gate.getAttribute('target')).toBe('_blank')
-    expect(screen.getByTestId('gate-note').textContent).toContain(
-      'platform.comfy.org'
-    )
-    credits.balance.value = { status: 'ok', credits: 1_000 }
-    await nextTick()
-    expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
-      'ready'
-    )
-  })
-
-  it('fails open while the balance read has not settled', async () => {
-    credits.balance.value = { status: 'unknown' }
-    auth.session.value = credential
-    mountDetail({ model: runnable })
-    await nextTick()
-    expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
-      'ready'
-    )
-    credits.balance.value = { status: 'ok', credits: 1_000 }
-  })
 })

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -156,6 +156,7 @@ function mountDetail(options?: {
   clone?: { href: string }
   details?: () => ReturnType<typeof h>
   model?: WorkshopModelDetail
+  priceEstimate?: string
 }) {
   return render(
     defineComponent({
@@ -163,7 +164,11 @@ function mountDetail(options?: {
         return () =>
           h(
             ModelDetail,
-            { model: options?.model ?? model, clone: options?.clone },
+            {
+              model: options?.model ?? model,
+              clone: options?.clone,
+              priceEstimate: options?.priceEstimate
+            },
             options?.details ? { details: options.details } : undefined
           )
       }
@@ -497,6 +502,20 @@ describe('ModelDetail', () => {
     }
   )
 
+  it('shows the estimated cost on the Run button when the page has one', async () => {
+    auth.session.value = credential
+    credits.balance.value = { status: 'ok', credits: 100 }
+    mountDetail({ model: runnable, priceEstimate: '14.8 credits/Run' })
+    await nextTick()
+
+    expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
+      'ready'
+    )
+    expect(screen.getByTestId('run-price').textContent).toContain(
+      '14.8 credits/Run'
+    )
+  })
+
   it('offers a personal-workspace switch instead of billing to a member with no credits', async () => {
     auth.session.value = {
       ...credential,
@@ -517,7 +536,10 @@ describe('ModelDetail', () => {
       screen.getByRole('textbox', { name: /Prompt/ }),
       'Keep me'
     )
-    expect(screen.getByText(/Studio has no credits left/)).toBeTruthy()
+    expect(screen.getByTestId('gate-note').textContent).toContain(
+      'Not enough credits'
+    )
+    expect(screen.getByText(/Studio has used all its credits/)).toBeTruthy()
     expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
     await visitor.click(
       screen.getByRole('button', { name: 'Switch to personal workspace' })

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -1166,4 +1166,36 @@ describe('ModelDetail', () => {
       expect(runWorkshopRouter).not.toHaveBeenCalled()
     }
   )
+  it('blocks a run the balance cannot cover, with a button that promises nothing', async () => {
+    credits.balance.value = { status: 'ok', credits: 2 }
+    auth.session.value = credential
+    mountDetail({ model: runnable })
+    await nextTick()
+
+    const gate = screen.getByTestId('run-button')
+    expect(gate.getAttribute('data-gate')).toBe('noCredits')
+    expect(gate.getAttribute('href')).toContain(
+      'platform.comfy.org/billing?workspace='
+    )
+    expect(gate.getAttribute('target')).toBe('_blank')
+    expect(screen.getByTestId('gate-note').textContent).toContain(
+      'platform.comfy.org'
+    )
+    credits.balance.value = { status: 'ok', credits: 1_000 }
+    await nextTick()
+    expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
+      'ready'
+    )
+  })
+
+  it('fails open while the balance read has not settled', async () => {
+    credits.balance.value = { status: 'unknown' }
+    auth.session.value = credential
+    mountDetail({ model: runnable })
+    await nextTick()
+    expect(screen.getByTestId('run-button').getAttribute('data-gate')).toBe(
+      'ready'
+    )
+    credits.balance.value = { status: 'ok', credits: 1_000 }
+  })
 })

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -596,26 +596,20 @@ function useInCode() {
           <Button
             v-else-if="gate === 'ready'"
             size="lg"
-            :class="
-              cn(
-                'w-full px-5',
-                !isRunning && priceEstimate && 'justify-between'
-              )
-            "
+            class="w-full px-5"
             data-testid="run-button"
             data-gate="ready"
             @click="isRunning ? cancelRun() : run()"
           >
-            <span v-if="!isRunning" class="flex items-center gap-2.5">
+            <template v-if="!isRunning" #prepend>
               <Play class="size-5 fill-current" aria-hidden="true" />
-              {{ t('workshop.run.run', locale) }}
-            </span>
-            <template v-else>
-              {{ t('workshop.run.cancel', locale) }}
             </template>
+            {{
+              t(isRunning ? 'workshop.run.cancel' : 'workshop.run.run', locale)
+            }}
             <template v-if="!isRunning && priceEstimate" #append>
               <span
-                class="flex items-center gap-1.5 rounded-full bg-primary-comfy-ink/10 px-2.5 py-1 text-xs font-bold normal-case tabular-nums"
+                class="ml-auto flex items-center gap-1.5 rounded-full bg-primary-comfy-ink/10 px-2.5 py-1 text-xs font-bold normal-case tabular-nums"
                 data-testid="run-price"
               >
                 <Coins class="size-3.5" aria-hidden="true" />

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -30,13 +30,13 @@ import {
   refreshWorkshopCredits,
   useWorkshopCredits
 } from '../../config/workshop-credits'
-import { WORKSHOP_CREDITS_URL } from '../../config/workshop-env'
 import { runWorkshopRouter } from '../../config/workshop-router'
 import { prepareWorkshopRouterInput } from '../../config/workshop-request'
 import { createWorkshopUrlUploader } from '../../config/workshop-url-upload'
 import { WorkshopRouterError } from '../../config/workshop-router-errors'
 import { releaseRouterOutputs } from '../../config/workshop-response'
 import { retainRunHistory } from '../../config/workshop-run-history'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import { modelDocsHref } from '../../lib/workshop/model-docs'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import { workshopIdempotencyKey } from '../../config/workshop-snippets'
@@ -169,6 +169,15 @@ const authFlagSettled = useWorkshopAuthFlagSettled()
 const mounted = useMounted()
 const signInHref = useSignInHref(locale)
 const docsHref = modelDocsHref(model)
+// The gate blocks only on a balance it has actually read: unknown or errored
+// reads fail open to the run, whose server-side refusal is the real guard.
+const shortOfCredits = computed(
+  () =>
+    balance.value.status === 'ok' &&
+    model.creditsPerRun !== undefined &&
+    balance.value.credits < model.creditsPerRun
+)
+
 const gate = computed(() => {
   if (
     model.incompleteReason ||
@@ -185,7 +194,7 @@ const gate = computed(() => {
   if (
     runState.value.status !== 'running' &&
     balance.value.status === 'ok' &&
-    balance.value.credits <= 0
+    (balance.value.credits <= 0 || shortOfCredits.value)
   )
     return session.value.role === 'member' ? 'memberNoCredits' : 'noCredits'
   return 'ready'
@@ -527,19 +536,40 @@ function useInCode() {
           >
             {{ t('workshop.run.signIn', locale) }}
           </Button>
-          <Button
-            v-else-if="gate === 'noCredits'"
-            as="a"
-            :href="WORKSHOP_CREDITS_URL"
-            target="_blank"
-            rel="noopener noreferrer"
-            size="lg"
-            class="w-full px-5"
-            data-testid="run-button"
-            data-gate="noCredits"
-          >
-            {{ t('nav.buyCredits', locale) }}
-          </Button>
+          <!-- The MVP rail (DES-1015): buying happens on platform, in a new
+               tab, so this page and its inputs stay alive and the return is a
+               balance re-read. Naming the workspace is what makes topping up
+               the wrong wallet visible before it happens. -->
+          <template v-else-if="gate === 'noCredits'">
+            <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
+              <p class="text-sm font-bold text-primary-warm-white">
+                {{ t('workshop.error.creditsTitle', locale) }}
+              </p>
+              <p class="text-xs text-primary-warm-gray">
+                {{
+                  t('workshop.error.noCreditsPlatform', locale).replace(
+                    '{workspace}',
+                    () => session?.workspace.name ?? ''
+                  )
+                }}
+              </p>
+            </div>
+            <Button
+              as="a"
+              :href="platformTopUpHref(session?.workspace.id)"
+              target="_blank"
+              rel="noopener"
+              size="lg"
+              class="w-full px-5"
+              data-testid="run-button"
+              data-gate="noCredits"
+            >
+              {{ t('workshop.run.buyCredits', locale) }}
+              <template #append>
+                <ExternalLink class="size-5" aria-hidden="true" />
+              </template>
+            </Button>
+          </template>
           <Button
             v-else-if="gate === 'memberNoCredits'"
             size="lg"

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Download, ExternalLink } from '@lucide/vue'
+import { Coins, Download, ExternalLink, Play } from '@lucide/vue'
 import { useMounted, useTimestamp } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, useSlots, watch } from 'vue'
 
@@ -36,7 +36,10 @@ import { createWorkshopUrlUploader } from '../../config/workshop-url-upload'
 import { WorkshopRouterError } from '../../config/workshop-router-errors'
 import { releaseRouterOutputs } from '../../config/workshop-response'
 import { retainRunHistory } from '../../config/workshop-run-history'
-import { platformTopUpHref } from '../../lib/workshop/buy-credits'
+import {
+  TOP_UP_ON_PLATFORM,
+  platformTopUpHref
+} from '../../lib/workshop/buy-credits'
 import { modelDocsHref } from '../../lib/workshop/model-docs'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import { workshopIdempotencyKey } from '../../config/workshop-snippets'
@@ -55,10 +58,12 @@ import ModelSupport from './ModelSupport.vue'
 const {
   model,
   locale = 'en',
+  priceEstimate,
   clone
 } = defineProps<{
   model: WorkshopModelDetail
   locale?: Locale
+  priceEstimate?: string
   clone?: { href: string }
   /** Names the form's groups as numbered steps and keeps the result in view
    * while they are filled in. The workflow pages ask for it; a model page has
@@ -538,10 +543,12 @@ function useInCode() {
               </p>
               <p class="text-xs text-primary-warm-gray">
                 {{
-                  t('workshop.error.noCreditsPlatform', locale).replace(
-                    '{workspace}',
-                    () => session?.workspace.name ?? ''
-                  )
+                  t(
+                    TOP_UP_ON_PLATFORM
+                      ? 'workshop.error.noCreditsPlatform'
+                      : 'workshop.error.noCreditsCloud',
+                    locale
+                  ).replace('{workspace}', () => session?.workspace.name ?? '')
                 }}
               </p>
             </div>
@@ -561,25 +568,60 @@ function useInCode() {
               </template>
             </Button>
           </template>
-          <Button
-            v-else-if="gate === 'memberNoCredits'"
-            size="lg"
-            class="w-full px-5"
-            @click="switchToPersonal"
-          >
-            {{ t('workshop.run.switchPersonal', locale) }}
-          </Button>
+          <template v-else-if="gate === 'memberNoCredits'">
+            <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
+              <p class="text-sm font-bold text-primary-warm-white">
+                {{ t('workshop.error.creditsTitle', locale) }}
+              </p>
+              <p class="text-xs text-primary-warm-gray">
+                {{
+                  t('workshop.error.memberNoCredits', locale).replace(
+                    '{workspace}',
+                    () => session?.workspace.name ?? ''
+                  )
+                }}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="lg"
+              class="w-full px-5"
+              data-testid="run-button"
+              data-gate="memberNoCredits"
+              @click="switchToPersonal"
+            >
+              {{ t('workshop.run.switchPersonal', locale) }}
+            </Button>
+          </template>
           <Button
             v-else-if="gate === 'ready'"
             size="lg"
-            class="w-full px-5"
+            :class="
+              cn(
+                'w-full px-5',
+                !isRunning && priceEstimate && 'justify-between'
+              )
+            "
             data-testid="run-button"
             data-gate="ready"
             @click="isRunning ? cancelRun() : run()"
           >
-            {{
-              t(isRunning ? 'workshop.run.cancel' : 'workshop.run.run', locale)
-            }}
+            <span v-if="!isRunning" class="flex items-center gap-2.5">
+              <Play class="size-5 fill-current" aria-hidden="true" />
+              {{ t('workshop.run.run', locale) }}
+            </span>
+            <template v-else>
+              {{ t('workshop.run.cancel', locale) }}
+            </template>
+            <template v-if="!isRunning && priceEstimate" #append>
+              <span
+                class="flex items-center gap-1.5 rounded-full bg-primary-comfy-ink/10 px-2.5 py-1 text-xs font-bold normal-case tabular-nums"
+                data-testid="run-price"
+              >
+                <Coins class="size-3.5" aria-hidden="true" />
+                {{ priceEstimate }}
+              </span>
+            </template>
           </Button>
           <Button
             v-else
@@ -600,18 +642,6 @@ function useInCode() {
               )
             }}
           </Button>
-          <p
-            v-if="gate === 'memberNoCredits'"
-            role="status"
-            class="text-center text-sm text-primary-warm-gray"
-          >
-            {{
-              t('workshop.error.memberNoCredits', locale).replace(
-                '{workspace}',
-                () => session?.workspace.name ?? ''
-              )
-            }}
-          </p>
         </div>
       </div>
 

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -169,15 +169,6 @@ const authFlagSettled = useWorkshopAuthFlagSettled()
 const mounted = useMounted()
 const signInHref = useSignInHref(locale)
 const docsHref = modelDocsHref(model)
-// The gate blocks only on a balance it has actually read: unknown or errored
-// reads fail open to the run, whose server-side refusal is the real guard.
-const shortOfCredits = computed(
-  () =>
-    balance.value.status === 'ok' &&
-    model.creditsPerRun !== undefined &&
-    balance.value.credits < model.creditsPerRun
-)
-
 const gate = computed(() => {
   if (
     model.incompleteReason ||
@@ -194,7 +185,7 @@ const gate = computed(() => {
   if (
     runState.value.status !== 'running' &&
     balance.value.status === 'ok' &&
-    (balance.value.credits <= 0 || shortOfCredits.value)
+    balance.value.credits <= 0
   )
     return session.value.role === 'member' ? 'memberNoCredits' : 'noCredits'
   return 'ready'
@@ -610,17 +601,15 @@ function useInCode() {
             }}
           </Button>
           <p
-            v-if="gate === 'noCredits' || gate === 'memberNoCredits'"
+            v-if="gate === 'memberNoCredits'"
             role="status"
             class="text-center text-sm text-primary-warm-gray"
           >
             {{
-              gate === 'memberNoCredits'
-                ? t('workshop.error.memberNoCredits', locale).replace(
-                    '{workspace}',
-                    session?.workspace.name ?? ''
-                  )
-                : t('workshop.error.noCredits', locale)
+              t('workshop.error.memberNoCredits', locale).replace(
+                '{workspace}',
+                () => session?.workspace.name ?? ''
+              )
             }}
           </p>
         </div>
@@ -640,6 +629,7 @@ function useInCode() {
           :member-workspace="
             session?.role === 'member' ? session.workspace.name : undefined
           "
+          :workspace-id="session?.workspace.id"
           @switch-personal="switchToPersonal"
           @retry="gate === 'ready' ? run() : reset()"
           @use-in-code="useInCode"

--- a/apps/website/src/components/workshop/PlaygroundOutput.vue
+++ b/apps/website/src/components/workshop/PlaygroundOutput.vue
@@ -23,7 +23,7 @@ import type {
   RunState
 } from '../../config/workshop-run'
 import { formatElapsed, isExpired } from '../../config/workshop-run'
-import { WORKSHOP_CREDITS_URL } from '../../config/workshop-env'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
@@ -34,6 +34,7 @@ const {
   earlier = [],
   attachments = [],
   memberWorkspace,
+  workspaceId,
   locale = 'en'
 } = defineProps<{
   state: RunState
@@ -42,6 +43,7 @@ const {
   earlier?: readonly RunRecord[]
   attachments?: readonly RunOutput[]
   memberWorkspace?: string
+  workspaceId?: string
   locale?: Locale
 }>()
 
@@ -262,7 +264,7 @@ const earlierClass = (active: boolean) =>
       <Button
         v-else-if="state.reason === 'noCredits'"
         as="a"
-        :href="WORKSHOP_CREDITS_URL"
+        :href="platformTopUpHref(workspaceId)"
         target="_blank"
         rel="noopener noreferrer"
         variant="outline"

--- a/apps/website/src/config/workshop-env.ts
+++ b/apps/website/src/config/workshop-env.ts
@@ -15,7 +15,7 @@ import type { FirebaseOptions } from 'firebase/app'
 import type { WorkshopCloudEnv } from './workshop-cloud-env'
 import { resolveWorkshopCloudEnv } from './workshop-cloud-env'
 
-const WORKSHOP_CLOUD_ENV: WorkshopCloudEnv = resolveWorkshopCloudEnv(
+export const WORKSHOP_CLOUD_ENV: WorkshopCloudEnv = resolveWorkshopCloudEnv(
   import.meta.env.PUBLIC_WORKSHOP_CLOUD_ENV
 )
 

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9916,8 +9916,8 @@ Enterprise`
     'zh-CN': '积分不足'
   },
   'workshop.error.noCreditsPlatform': {
-    en: 'Add credits to {workspace} on platform.comfy.org',
-    'zh-CN': '在 platform.comfy.org 上为 {workspace} 添加积分'
+    en: 'Add credits to {workspace} to keep running models.',
+    'zh-CN': '为 {workspace} 添加积分以继续运行模型。'
   },
   'workshop.hub.tryNow': { en: 'Try now', 'zh-CN': '立即试用' },
   'workshop.hub.tag.partnerNodes': {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9911,6 +9911,14 @@ Enterprise`
   'workshop.hub.models': { en: 'Model', 'zh-CN': '模型' },
   'workshop.hub.categories': { en: 'CATEGORIES', 'zh-CN': '分类' },
   'workshop.hub.docs': { en: 'Read docs', 'zh-CN': '阅读文档' },
+  'workshop.error.creditsTitle': {
+    en: 'Not enough credits',
+    'zh-CN': '积分不足'
+  },
+  'workshop.error.noCreditsPlatform': {
+    en: 'Add credits to {workspace} on platform.comfy.org',
+    'zh-CN': '在 platform.comfy.org 上为 {workspace} 添加积分'
+  },
   'workshop.hub.tryNow': { en: 'Try now', 'zh-CN': '立即试用' },
   'workshop.hub.tag.partnerNodes': {
     en: 'Partner Nodes',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9678,9 +9678,9 @@ Enterprise`
       '你有 {credits} 积分，本次运行需要 {n}。购买积分后继续，你的输入会保留。'
   },
   'workshop.error.memberNoCredits': {
-    en: '{workspace} has no credits left. Only the workspace owner can buy more; you can run this on your personal workspace instead.',
+    en: '{workspace} has used all its credits. Ask the workspace owner to add more, or run this on your personal workspace.',
     'zh-CN':
-      '{workspace} 的积分已用完。只有工作区所有者可以购买；你可以改用个人工作区运行。'
+      '{workspace} 的积分已用完。请工作区所有者添加积分，或在个人工作区运行。'
   },
   'workshop.run.memberNoCredits': {
     en: 'Ask the owner for credits',
@@ -9915,9 +9915,13 @@ Enterprise`
     en: 'Not enough credits',
     'zh-CN': '积分不足'
   },
-  'workshop.error.noCreditsPlatform': {
+  'workshop.error.noCreditsCloud': {
     en: 'Add credits to {workspace} to keep running models.',
     'zh-CN': '为 {workspace} 添加积分以继续运行模型。'
+  },
+  'workshop.error.noCreditsPlatform': {
+    en: 'Add credits to {workspace} on platform.comfy.org',
+    'zh-CN': '在 platform.comfy.org 上为 {workspace} 添加积分'
   },
   'workshop.hub.tryNow': { en: 'Try now', 'zh-CN': '立即试用' },
   'workshop.hub.tag.partnerNodes': {

--- a/apps/website/src/lib/workshop/buy-credits.test.ts
+++ b/apps/website/src/lib/workshop/buy-credits.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { platformTopUpHref } from './buy-credits'
+
+describe('platformTopUpHref', () => {
+  it('carries the server-resolved workspace id', () => {
+    expect(platformTopUpHref('ws_123')).toBe(
+      'https://platform.comfy.org/billing?workspace=ws_123'
+    )
+  })
+
+  it('still lands on billing without one', () => {
+    expect(platformTopUpHref()).toBe('https://platform.comfy.org/billing')
+  })
+})

--- a/apps/website/src/lib/workshop/buy-credits.test.ts
+++ b/apps/website/src/lib/workshop/buy-credits.test.ts
@@ -1,15 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+import { WORKSHOP_CREDITS_URL } from '../../config/workshop-env'
 import { platformTopUpHref } from './buy-credits'
 
 describe('platformTopUpHref', () => {
-  it('carries the server-resolved workspace id', () => {
-    expect(platformTopUpHref('ws_123')).toBe(
-      'https://platform.comfy.org/billing?workspace=ws_123'
-    )
+  it('keeps a lower environment on its own cloud credits page', () => {
+    expect(platformTopUpHref('ws_123')).toBe(WORKSHOP_CREDITS_URL)
+    expect(platformTopUpHref()).toBe(WORKSHOP_CREDITS_URL)
   })
 
-  it('still lands on billing without one', () => {
-    expect(platformTopUpHref()).toBe('https://platform.comfy.org/billing')
+  it('deep-links production platform billing with the workspace id', async () => {
+    vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', 'prod')
+    vi.resetModules()
+    const { platformTopUpHref: prodHref } = await import('./buy-credits')
+    expect(prodHref('ws_123')).toBe(
+      'https://platform.comfy.org/billing?workspace=ws_123'
+    )
+    expect(prodHref()).toBe('https://platform.comfy.org/billing')
   })
 })

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -1,0 +1,20 @@
+/**
+ * The MVP rail (DES-1015): buying happens on platform.comfy.org, in a new
+ * tab so the model page and its inputs stay alive. The workspace travels as
+ * the server-resolved id — comfy.org and platform keep separate switchers,
+ * and without it a buyer can top up the wallet that is not the empty one.
+ * The parameter name is the shape agreed for platform's deep-link work, not
+ * yet its confirmed contract.
+ *
+ * Always the production origin, even though staging/test previews mint
+ * workspace ids platform cannot resolve: no lower-environment platform
+ * origin is modeled in this app yet. Resolve alongside the deep-link
+ * contract before the Workshop ships against prod Cloud.
+ */
+const PLATFORM_ORIGIN = 'https://platform.comfy.org'
+
+export function platformTopUpHref(workspaceId?: string): string {
+  const url = new URL('/billing', PLATFORM_ORIGIN)
+  if (workspaceId) url.searchParams.set('workspace', workspaceId)
+  return url.toString()
+}

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -1,3 +1,8 @@
+import {
+  WORKSHOP_CLOUD_ENV,
+  WORKSHOP_CREDITS_URL
+} from '../../config/workshop-env'
+
 /**
  * The MVP rail (DES-1015): buying happens on platform.comfy.org, in a new
  * tab so the model page and its inputs stay alive. The workspace travels as
@@ -6,14 +11,14 @@
  * The parameter name is the shape agreed for platform's deep-link work, not
  * yet its confirmed contract.
  *
- * Always the production origin, even though staging/test previews mint
- * workspace ids platform cannot resolve: no lower-environment platform
- * origin is modeled in this app yet. Resolve alongside the deep-link
- * contract before the Workshop ships against prod Cloud.
+ * Platform billing exists only against production Cloud. The lower families
+ * keep the visitor on their own cloud's credits page, so a preview can never
+ * hand a staging workspace id to production billing.
  */
 const PLATFORM_ORIGIN = 'https://platform.comfy.org'
 
 export function platformTopUpHref(workspaceId?: string): string {
+  if (WORKSHOP_CLOUD_ENV !== 'prod') return WORKSHOP_CREDITS_URL
   const url = new URL('/billing', PLATFORM_ORIGIN)
   if (workspaceId) url.searchParams.set('workspace', workspaceId)
   return url.toString()

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -17,6 +17,8 @@ import {
  */
 const PLATFORM_ORIGIN = 'https://platform.comfy.org'
 
+export const TOP_UP_ON_PLATFORM = WORKSHOP_CLOUD_ENV === 'prod'
+
 export function platformTopUpHref(workspaceId?: string): string {
   if (WORKSHOP_CLOUD_ENV !== 'prod') return WORKSHOP_CREDITS_URL
   const url = new URL('/billing', PLATFORM_ORIGIN)

--- a/apps/website/src/routes/models/[slug].astro
+++ b/apps/website/src/routes/models/[slug].astro
@@ -139,7 +139,7 @@ const restTagCount = restTags.length
     </header>
 
     <div class="sm:px-8 lg:px-10">
-    <ModelDetail model={model} client:load />
+    <ModelDetail model={model} priceEstimate={priceEstimate} client:load />
 
     <section
       class="mt-24 border-t border-transparency-white-t8 pt-12"


### PR DESCRIPTION
The credits gate from DES-1015, wired to the branch's real balance reader — and, since review, to an **environment-honest top-up destination**.

## Where the button leads

One helper (`platformTopUpHref` in `lib/workshop/buy-credits.ts`) answers for every surface:

- **Production**: platform billing, deep-linked with the server-resolved workspace id (`platform.comfy.org/billing?workspace=…`) — comfy.org and platform keep separate workspace switchers, and the id is what stops a buyer topping up the wrong wallet. The parameter name matches the shape agreed for platform's deep-link work; the contract itself is still with Willie.
- **Staging / test** (every preview): that environment's own cloud credits page. A preview can never hand a staging workspace id to production billing.

The gate, the run-failure link in `PlaygroundOutput`, and the header's Add credits row all route through it — one destination per environment, not three.

## The gate

At a settled zero balance, Run swaps for the gate: "Not enough credits", "Add credits to {workspace} to keep running models.", and the Add credits link (new tab; the return is a balance re-read on refocus). Unknown/errored reads **fail open** to Run — the server refusal is the real guard. Members get the base's switch-to-personal variant instead of a top-up they may not be allowed to make.

Dropped in review: a `creditsPerRun` partial-balance branch. The content pipeline enforces that editorial prices are never published as exact Router charges (`creditsPerRun` is `undefined` for every Router model), so the branch could only ever fire in its own test fixture. Blocking below an exact per-run price needs a Router-supplied price and is follow-up work.

Tests: zero-balance gate with the env-aware link and release on refresh; fail-open on unsettled reads; helper behaviour per environment. Base: `comfydesigner/models-banner-docs`.
