### PR TITLE
feat(website): add the test Cloud family for Workshop previews (FE-2009)

### DIFF
--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -3,9 +3,9 @@ name: 'CI: Vercel Website Preview'
 
 on:
   pull_request:
-    # `labeled`/`unlabeled` so adding or removing the `workshop` label rebuilds
-    # the preview, which is otherwise only refreshed by a push. Same reason
-    # cloud-dispatch-build.yaml listens for it.
+    # `labeled`/`unlabeled` so adding or removing the `workshop` or
+    # `workshop-test` label rebuilds the preview, which is otherwise only
+    # refreshed by a push. Same reason cloud-dispatch-build.yaml listens for it.
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches-ignore:
       - 'core/**'
@@ -62,21 +62,32 @@ jobs:
           WEBSITE_ASHBY_API_KEY: ${{ secrets.WEBSITE_ASHBY_API_KEY }}
           WEBSITE_ASHBY_JOB_BOARD_NAME: ${{ secrets.WEBSITE_ASHBY_JOB_BOARD_NAME }}
           WEBSITE_CLOUD_API_KEY: ${{ secrets.WEBSITE_CLOUD_API_KEY }}
-          WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') }}
+          WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') || contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
+          WORKSHOP_TEST_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
         # A preview has to answer "what goes out if we release right now?", so
         # by default it matches production and leaves the unreleased Workshop
-        # feature out. Label a PR `workshop` to build it in and get a review URL.
+        # feature out. Label a PR `workshop` to build it in and get a review URL
+        # signed in against staging Cloud, or `workshop-test` for test Cloud.
         #
         # Set only when labelled, rather than always set with an empty value.
-        # An unlabelled PR must leave the variable undefined so that whatever
+        # An unlabelled PR must leave the variables undefined so that whatever
         # `vercel pull` fetched for the preview environment still governs --
-        # otherwise, on the day Workshop launches, setting it in Vercel would
-        # take effect in production while every preview kept overriding it back
-        # off, and preview would stop matching production again.
-        # See apps/website/src/config/workshop-release.ts.
+        # otherwise, on the day Workshop launches, setting them in Vercel would
+        # take effect in production while every preview kept overriding them
+        # back, and preview would stop matching production again.
+        #
+        # A labelled preview always names a lower Cloud family: ingest's
+        # staging/test CORS allowlists admit the website's preview origins and
+        # production's does not (cloud FE-2009), and the build fails if a
+        # preview names prod. See apps/website/src/config/workshop-release.ts.
         run: |
           if [ "$WORKSHOP_LABELLED" = "true" ]; then
             export WORKSHOP_IN_BUILD=1
+            if [ "$WORKSHOP_TEST_LABELLED" = "true" ]; then
+              export PUBLIC_WORKSHOP_CLOUD_ENV=test
+            else
+              export PUBLIC_WORKSHOP_CLOUD_ENV=staging
+            fi
           fi
           VERCEL_ENV=preview vercel build
 
@@ -126,17 +137,21 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
           ALIAS_OK: ${{ steps.alias-set.outcome == 'success' }}
-          WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') }}
+          WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') || contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
+          WORKSHOP_TEST_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
         run: |
           if [[ "$ALIAS_OK" == "true" ]]; then
             STABLE_URL="https://$ALIAS_HOST"
           else
             STABLE_URL="$DEPLOY_URL"
           fi
-          # Say which of the two builds this is. Without it, a reviewer who
-          # finds Workshop missing cannot tell the gate from a bug.
-          if [[ "$WORKSHOP_LABELLED" == "true" ]]; then
-            BUILD_NOTE="Includes the unreleased **Workshop** feature (\`workshop\` label)."
+          # Say which build this is and which Cloud it talks to. Without it, a
+          # reviewer who finds Workshop missing cannot tell the gate from a bug,
+          # and one who cannot sign in cannot tell staging from test.
+          if [[ "$WORKSHOP_TEST_LABELLED" == "true" ]]; then
+            BUILD_NOTE="Includes the unreleased **Workshop** feature (\`workshop-test\` label), signed in against **test** Cloud."
+          elif [[ "$WORKSHOP_LABELLED" == "true" ]]; then
+            BUILD_NOTE="Includes the unreleased **Workshop** feature (\`workshop\` label), signed in against **staging** Cloud."
           else
             BUILD_NOTE="Matches production — what ships if we release right now."
           fi

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -182,10 +182,11 @@ reached without a code change:
 | `0`     | Workshop out          | reproducing a release build locally            |
 | _unset_ | environment default   | everything else                                |
 
-**To review Workshop on a deployed URL,** add the `workshop` label to the PR.
+**To review Workshop on a deployed URL,** add the `workshop` label to the PR
+(signs in against staging Cloud) or `workshop-test` (test Cloud).
 `ci-vercel-website-preview.yaml` listens for `labeled`/`unlabeled`, so the
-preview rebuilds without needing a push, and the preview comment says which of
-the two builds you are looking at.
+preview rebuilds without needing a push, and the preview comment says which
+build you are looking at and which Cloud it talks to.
 
 **To reproduce the next release locally:**
 
@@ -194,11 +195,38 @@ WORKSHOP_IN_BUILD=0 pnpm --filter @comfyorg/website build
 test ! -d apps/website/dist/workshop && echo "no Workshop in this build"
 ```
 
-**To launch,** set `WORKSHOP_IN_BUILD=1` in the Vercel _production_ environment
-— and in the _preview_ environment at the same time, so the two go on matching.
-No code change, and reversible by removing it. An unlabelled PR deliberately
-leaves the variable undefined rather than setting it empty, so that the Vercel
-preview value is what governs once it exists.
+**To launch,** set `WORKSHOP_IN_BUILD=1` and `PUBLIC_WORKSHOP_CLOUD_ENV=prod` in
+the Vercel _production_ environment — and `WORKSHOP_IN_BUILD=1` with
+`PUBLIC_WORKSHOP_CLOUD_ENV=staging` in the _preview_ environment at the same
+time, so the two go on matching in content while each keeps to the Cloud it is
+allowed to reach. No code change, and reversible by removing them. An
+unlabelled PR deliberately leaves both variables undefined rather than setting
+them empty, so that the Vercel preview values are what govern once they exist.
+Production Cloud must also allow `https://comfy.org` in ingest's CORS
+allowlist (cloud FE-2009) before launch; until it does, sign-in on comfy.org
+fails at the browser's preflight rather than quietly using staging.
+
+### Which Cloud the Workshop talks to
+
+`PUBLIC_WORKSHOP_CLOUD_ENV` picks the backend family. Router, Cloud and the
+Firebase project move together, because a token minted in one family is only
+valid there:
+
+| Value     | Router                 | Cloud                    | Firebase project  | Who uses it                                   |
+| --------- | ---------------------- | ------------------------ | ----------------- | --------------------------------------------- |
+| `prod`    | `api.comfy.org`        | `cloud.comfy.org`        | `dreamboothy`     | production, at launch                         |
+| `staging` | `stagingapi.comfy.org` | `stagingcloud.comfy.org` | `dreamboothy-dev` | previews (`workshop` label); local by default |
+| `test`    | `testapi.comfy.org`    | `testcloud.comfy.org`    | `dreamboothy-dev` | previews (`workshop-test` label)              |
+
+The backends decide who may call them: ingest's CORS allowlist admits
+`comfy.org` only in production and the website's Vercel preview origins only
+in staging and test (cloud FE-2009). So a production build must say `prod`, a
+preview must say `staging` or `test`, and `workshop-release-gate` fails the
+build otherwise — a wrong family is a build error, not a preflight error in a
+visitor's browser. Builds without Workshop in them are not checked, so nothing
+changes for production until launch. Local builds may leave it unset
+(staging) or pick a family for a specific check. `test` has no Turnstile
+sitekey, so the widget stays off there and the server's shadow policy applies.
 
 The switch is `src/config/workshop-release.ts`; the removal is the
 `workshop-release-gate` Astro integration, which deletes the emitted directory

--- a/apps/website/src/config/workshop-cloud-env.test.ts
+++ b/apps/website/src/config/workshop-cloud-env.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isWorkshopCloudEnv,
+  resolveWorkshopCloudEnv
+} from './workshop-cloud-env'
+
+describe('resolveWorkshopCloudEnv', () => {
+  it.for([
+    { name: 'unset means staging', value: undefined, expected: 'staging' },
+    { name: 'empty means staging', value: '', expected: 'staging' },
+    { name: 'prod is prod', value: 'prod', expected: 'prod' },
+    { name: 'staging is staging', value: 'staging', expected: 'staging' },
+    { name: 'test is test', value: 'test', expected: 'test' },
+    // The build-time check rejects a misspelling before a build; at runtime
+    // the safe answer is the family that cannot reach production.
+    {
+      name: 'anything else stays on staging',
+      value: 'production',
+      expected: 'staging'
+    }
+  ])('$name', ({ value, expected }) => {
+    expect(resolveWorkshopCloudEnv(value)).toBe(expected)
+  })
+})
+
+describe('isWorkshopCloudEnv', () => {
+  it('accepts exactly the three families', () => {
+    expect(isWorkshopCloudEnv('prod')).toBe(true)
+    expect(isWorkshopCloudEnv('staging')).toBe(true)
+    expect(isWorkshopCloudEnv('test')).toBe(true)
+    expect(isWorkshopCloudEnv('Prod')).toBe(false)
+    expect(isWorkshopCloudEnv('')).toBe(false)
+    expect(isWorkshopCloudEnv(undefined)).toBe(false)
+  })
+})

--- a/apps/website/src/config/workshop-cloud-env.test.ts
+++ b/apps/website/src/config/workshop-cloud-env.test.ts
@@ -25,12 +25,14 @@ describe('resolveWorkshopCloudEnv', () => {
 })
 
 describe('isWorkshopCloudEnv', () => {
-  it('accepts exactly the three families', () => {
-    expect(isWorkshopCloudEnv('prod')).toBe(true)
-    expect(isWorkshopCloudEnv('staging')).toBe(true)
-    expect(isWorkshopCloudEnv('test')).toBe(true)
-    expect(isWorkshopCloudEnv('Prod')).toBe(false)
-    expect(isWorkshopCloudEnv('')).toBe(false)
-    expect(isWorkshopCloudEnv(undefined)).toBe(false)
+  it.for([
+    { name: 'prod is valid', value: 'prod', expected: true },
+    { name: 'staging is valid', value: 'staging', expected: true },
+    { name: 'test is valid', value: 'test', expected: true },
+    { name: 'family names are case-sensitive', value: 'Prod', expected: false },
+    { name: 'empty is invalid', value: '', expected: false },
+    { name: 'unset is invalid', value: undefined, expected: false }
+  ])('$name', ({ value, expected }) => {
+    expect(isWorkshopCloudEnv(value)).toBe(expected)
   })
 })

--- a/apps/website/src/config/workshop-cloud-env.ts
+++ b/apps/website/src/config/workshop-cloud-env.ts
@@ -1,0 +1,29 @@
+/**
+ * The backend families the Workshop can be built against, shared by the
+ * client-side switch (`workshop-env.ts`) and the build-time check
+ * (`workshop-release.ts`) so both agree on the spelling.
+ *
+ * Each family is a Router origin, a Cloud origin and a Firebase project that
+ * only trust each other; a token minted in one is meaningless in another.
+ */
+export const WORKSHOP_CLOUD_ENVS = ['prod', 'staging', 'test'] as const
+
+export type WorkshopCloudEnv = (typeof WORKSHOP_CLOUD_ENVS)[number]
+
+export function isWorkshopCloudEnv(
+  value: string | undefined
+): value is WorkshopCloudEnv {
+  return (WORKSHOP_CLOUD_ENVS as readonly string[]).includes(value ?? '')
+}
+
+/**
+ * Unset means staging, so local development needs no configuration and
+ * lands on a family that cannot touch production. Deployed builds never rely
+ * on this default: `assertWorkshopCloudEnvForBuild` makes them name a family
+ * and rejects anything misspelt before the build starts.
+ */
+export function resolveWorkshopCloudEnv(
+  value: string | undefined
+): WorkshopCloudEnv {
+  return isWorkshopCloudEnv(value) ? value : 'staging'
+}

--- a/apps/website/src/config/workshop-env.test.ts
+++ b/apps/website/src/config/workshop-env.test.ts
@@ -4,32 +4,45 @@ afterEach(() => {
   vi.resetModules()
 })
 
+async function loadWorkshopEnv(value: string | undefined) {
+  vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', value)
+  return import('./workshop-env')
+}
+
 describe('Workshop backend environment', () => {
   it('defaults to staging when no environment is configured', async () => {
-    vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', '')
+    const env = await loadWorkshopEnv('')
 
-    const {
-      WORKSHOP_CLOUD_BASE_URL,
-      WORKSHOP_FIREBASE_OPTIONS,
-      WORKSHOP_ROUTER_BASE_URL
-    } = await import('./workshop-env')
-
-    expect(WORKSHOP_ROUTER_BASE_URL).toBe('https://stagingapi.comfy.org')
-    expect(WORKSHOP_CLOUD_BASE_URL).toBe('https://stagingcloud.comfy.org')
-    expect(WORKSHOP_FIREBASE_OPTIONS.projectId).toBe('dreamboothy-dev')
+    expect(env.WORKSHOP_ROUTER_BASE_URL).toBe('https://stagingapi.comfy.org')
+    expect(env.WORKSHOP_CLOUD_BASE_URL).toBe('https://stagingcloud.comfy.org')
+    expect(env.WORKSHOP_FIREBASE_OPTIONS.projectId).toBe('dreamboothy-dev')
+    expect(env.WORKSHOP_TURNSTILE_SITE_KEY).not.toBe('')
   })
 
   it('uses production only when explicitly requested', async () => {
-    vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', 'prod')
+    const env = await loadWorkshopEnv('prod')
 
-    const {
-      WORKSHOP_CLOUD_BASE_URL,
-      WORKSHOP_FIREBASE_OPTIONS,
-      WORKSHOP_ROUTER_BASE_URL
-    } = await import('./workshop-env')
+    expect(env.WORKSHOP_ROUTER_BASE_URL).toBe('https://api.comfy.org')
+    expect(env.WORKSHOP_CLOUD_BASE_URL).toBe('https://cloud.comfy.org')
+    expect(env.WORKSHOP_FIREBASE_OPTIONS.projectId).toBe('dreamboothy')
+    expect(env.WORKSHOP_TURNSTILE_SITE_KEY).not.toBe('')
+  })
 
-    expect(WORKSHOP_ROUTER_BASE_URL).toBe('https://api.comfy.org')
-    expect(WORKSHOP_CLOUD_BASE_URL).toBe('https://cloud.comfy.org')
-    expect(WORKSHOP_FIREBASE_OPTIONS.projectId).toBe('dreamboothy')
+  it('uses the test family when requested', async () => {
+    const env = await loadWorkshopEnv('test')
+
+    expect(env.WORKSHOP_ROUTER_BASE_URL).toBe('https://testapi.comfy.org')
+    expect(env.WORKSHOP_CLOUD_BASE_URL).toBe('https://testcloud.comfy.org')
+    // Test validates tokens from the same dev Firebase project as staging.
+    expect(env.WORKSHOP_FIREBASE_OPTIONS.projectId).toBe('dreamboothy-dev')
+    // testcloud has no Turnstile sitekey, so the widget stays off there.
+    expect(env.WORKSHOP_TURNSTILE_SITE_KEY).toBe('')
+  })
+
+  it('never lands on production for a value it does not recognise', async () => {
+    const env = await loadWorkshopEnv('production')
+
+    expect(env.WORKSHOP_CLOUD_BASE_URL).toBe('https://stagingcloud.comfy.org')
+    expect(env.WORKSHOP_FIREBASE_OPTIONS.projectId).toBe('dreamboothy-dev')
   })
 })

--- a/apps/website/src/config/workshop-env.ts
+++ b/apps/website/src/config/workshop-env.ts
@@ -1,27 +1,43 @@
 /**
  * Which backend family the Workshop talks to. One switch selects the Router
- * origin and the Firebase project together, because a token minted against
- * one family is only valid inside it. Staging is the safe default because
- * prod cannot serve comfy.org yet: the origin is missing from
- * the ingest CORS allowlist (FE-2009) and Firebase authorized domains
- * (FE-2010). Staging already allows the website's preview URLs.
+ * origin, the Cloud origin and the Firebase project together, because a token
+ * minted against one family is only valid inside it.
+ *
+ * `PUBLIC_WORKSHOP_CLOUD_ENV` names the family: `prod`, `staging` or `test`.
+ * Unset means staging, so local development needs no configuration. A build
+ * that ships must name it explicitly — see `assertWorkshopCloudEnvForBuild`
+ * in `workshop-release.ts` — because the backends' CORS allowlists pair each
+ * origin with exactly one family: comfy.org may only reach production Cloud,
+ * and a Vercel preview may only reach staging or test (cloud FE-2009).
  */
 import type { FirebaseOptions } from 'firebase/app'
 
-const PROD = import.meta.env.PUBLIC_WORKSHOP_CLOUD_ENV === 'prod'
+import type { WorkshopCloudEnv } from './workshop-cloud-env'
+import { resolveWorkshopCloudEnv } from './workshop-cloud-env'
 
-export const WORKSHOP_ROUTER_BASE_URL = PROD
-  ? 'https://api.comfy.org'
-  : 'https://stagingapi.comfy.org'
+const WORKSHOP_CLOUD_ENV: WorkshopCloudEnv = resolveWorkshopCloudEnv(
+  import.meta.env.PUBLIC_WORKSHOP_CLOUD_ENV
+)
 
-export const WORKSHOP_CLOUD_BASE_URL = PROD
-  ? 'https://cloud.comfy.org'
-  : 'https://stagingcloud.comfy.org'
+const ROUTER_BASE_URLS: Record<WorkshopCloudEnv, string> = {
+  prod: 'https://api.comfy.org',
+  staging: 'https://stagingapi.comfy.org',
+  test: 'https://testapi.comfy.org'
+}
+
+const CLOUD_BASE_URLS: Record<WorkshopCloudEnv, string> = {
+  prod: 'https://cloud.comfy.org',
+  staging: 'https://stagingcloud.comfy.org',
+  test: 'https://testcloud.comfy.org'
+}
+
+export const WORKSHOP_ROUTER_BASE_URL = ROUTER_BASE_URLS[WORKSHOP_CLOUD_ENV]
+export const WORKSHOP_CLOUD_BASE_URL = CLOUD_BASE_URLS[WORKSHOP_CLOUD_ENV]
 
 // Public web-app configs, same values the platform app ships in
-// src/config/firebase.ts. Staging backends validate tokens from the dev
+// src/config/firebase.ts. Staging and test both validate tokens from the dev
 // project; prod validates the prod project.
-const STAGING_FIREBASE: FirebaseOptions = {
+const DEV_FIREBASE: FirebaseOptions = {
   apiKey: 'AIzaSyDa_YMeyzV0SkVe92vBZ1tVikWBmOU5KVE',
   authDomain: 'dreamboothy-dev.firebaseapp.com',
   databaseURL: 'https://dreamboothy-dev-default-rtdb.firebaseio.com',
@@ -43,18 +59,23 @@ const PROD_FIREBASE: FirebaseOptions = {
   measurementId: 'G-3ZBD3MBTG4'
 }
 
-export const WORKSHOP_FIREBASE_OPTIONS: FirebaseOptions = PROD
-  ? PROD_FIREBASE
-  : STAGING_FIREBASE
+export const WORKSHOP_FIREBASE_OPTIONS: FirebaseOptions =
+  WORKSHOP_CLOUD_ENV === 'prod' ? PROD_FIREBASE : DEV_FIREBASE
 
 /**
  * Public per-environment Turnstile sitekeys, the same constants the platform
  * app bakes in. Whether the widget renders is still governed by Cloudflare's
  * hostname allowlist; where it cannot, sign-up proceeds without a token and
- * the server's own policy decides.
+ * the server's own policy decides. Test has no sitekey (testcloud reports
+ * none), so the widget stays off there and the server's shadow policy applies.
  */
 // TODO(auth parity, E7): the cloud app overrides this live from remote config;
 // give the website a live source (PostHog flag payload) so a rotation needs no deploy.
-export const WORKSHOP_TURNSTILE_SITE_KEY = PROD
-  ? '0x4AAAAAADnYZPVOpFCL_zeo'
-  : '0x4AAAAAADnYY4_Q0qxHZ5a7'
+const TURNSTILE_SITE_KEYS: Record<WorkshopCloudEnv, string> = {
+  prod: '0x4AAAAAADnYZPVOpFCL_zeo',
+  staging: '0x4AAAAAADnYY4_Q0qxHZ5a7',
+  test: ''
+}
+
+export const WORKSHOP_TURNSTILE_SITE_KEY =
+  TURNSTILE_SITE_KEYS[WORKSHOP_CLOUD_ENV]

--- a/apps/website/src/config/workshop-release.test.ts
+++ b/apps/website/src/config/workshop-release.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { isWorkshopInBuild, isWorkshopRoute } from './workshop-release'
+import {
+  assertWorkshopCloudEnvForBuild,
+  isWorkshopInBuild,
+  isWorkshopRoute
+} from './workshop-release'
 
 describe('isWorkshopInBuild', () => {
   it.for([
@@ -56,5 +60,92 @@ describe('isWorkshopRoute', () => {
     expect(isWorkshopRoute('/pricing')).toBe(false)
     // A sibling route that merely starts with the same letters must survive.
     expect(isWorkshopRoute('/workshops-are-elsewhere')).toBe(false)
+  })
+})
+
+describe('assertWorkshopCloudEnvForBuild', () => {
+  it.for([
+    { name: 'a local build needs no family' },
+    { name: 'a local build may name one', family: 'test' },
+    {
+      name: 'a production build without Workshop ignores the family',
+      vercelEnv: 'production'
+    },
+    {
+      name: 'a preview without Workshop ignores the family',
+      vercelEnv: 'preview',
+      family: 'prod'
+    },
+    {
+      name: 'a production build with Workshop targets prod',
+      vercelEnv: 'production',
+      inBuild: '1',
+      family: 'prod'
+    },
+    {
+      name: 'a preview with Workshop may target staging',
+      vercelEnv: 'preview',
+      inBuild: '1',
+      family: 'staging'
+    },
+    {
+      name: 'a preview with Workshop may target test',
+      vercelEnv: 'preview',
+      inBuild: '1',
+      family: 'test'
+    }
+  ])('$name', ({ vercelEnv, inBuild, family }) => {
+    vi.stubEnv('VERCEL_ENV', vercelEnv)
+    vi.stubEnv('WORKSHOP_IN_BUILD', inBuild)
+    vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', family)
+
+    expect(() => assertWorkshopCloudEnvForBuild()).not.toThrow()
+  })
+
+  it.for([
+    {
+      name: 'a misspelt family fails every build',
+      family: 'production',
+      message: /not one of prod, staging, test/
+    },
+    {
+      name: 'a production build with Workshop must name its family',
+      vercelEnv: 'production',
+      inBuild: '1',
+      message: /PUBLIC_WORKSHOP_CLOUD_ENV is unset/
+    },
+    {
+      name: 'comfy.org may not reach staging',
+      vercelEnv: 'production',
+      inBuild: '1',
+      family: 'staging',
+      message: /may only reach prod Cloud/
+    },
+    {
+      name: 'comfy.org may not reach test',
+      vercelEnv: 'production',
+      inBuild: '1',
+      family: 'test',
+      message: /may only reach prod Cloud/
+    },
+    {
+      name: 'a preview with Workshop must name its family',
+      vercelEnv: 'preview',
+      inBuild: '1',
+      message: /PUBLIC_WORKSHOP_CLOUD_ENV is unset/
+    },
+    {
+      name: 'a preview may not reach prod',
+      vercelEnv: 'preview',
+      inBuild: '1',
+      family: 'prod',
+      message: /may only reach staging or test Cloud/
+    }
+  ])('$name', ({ vercelEnv, inBuild, family, message }) => {
+    vi.stubEnv('VERCEL_ENV', vercelEnv)
+    vi.stubEnv('WORKSHOP_IN_BUILD', inBuild)
+    vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', family)
+
+    expect(() => assertWorkshopCloudEnvForBuild()).toThrow(message)
   })
 })

--- a/apps/website/src/config/workshop-release.test.ts
+++ b/apps/website/src/config/workshop-release.test.ts
@@ -135,6 +135,13 @@ describe('assertWorkshopCloudEnvForBuild', () => {
       message: /PUBLIC_WORKSHOP_CLOUD_ENV is unset/
     },
     {
+      name: 'a preview with Workshop treats an empty family as unset',
+      vercelEnv: 'preview',
+      inBuild: '1',
+      family: '',
+      message: /PUBLIC_WORKSHOP_CLOUD_ENV is unset/
+    },
+    {
       name: 'a preview may not reach prod',
       vercelEnv: 'preview',
       inBuild: '1',

--- a/apps/website/src/config/workshop-release.ts
+++ b/apps/website/src/config/workshop-release.ts
@@ -31,6 +31,9 @@
  * - `0` — keep it out. Reproduces a release build locally.
  */
 
+import type { WorkshopCloudEnv } from './workshop-cloud-env'
+import { WORKSHOP_CLOUD_ENVS, isWorkshopCloudEnv } from './workshop-cloud-env'
+
 /** Environments whose builds are deployed somewhere people can reach. */
 const DEPLOYED = new Set(['production', 'preview'])
 
@@ -45,4 +48,62 @@ export function isWorkshopInBuild(): boolean {
 /** Every route Workshop owns. Kept here so the gate has one definition. */
 export function isWorkshopRoute(pattern: string): boolean {
   return pattern === '/workshop' || pattern.startsWith('/workshop/')
+}
+
+/**
+ * Which backend families a deployed build may point Workshop at.
+ *
+ * The backends' CORS allowlists pair each origin with one family — comfy.org
+ * with production Cloud, a Vercel preview with staging or test (cloud
+ * FE-2009) — so this is not a preference, it is what will work.
+ */
+function allowedFamiliesFor(
+  vercelEnv: string
+): readonly WorkshopCloudEnv[] | undefined {
+  switch (vercelEnv) {
+    case 'production':
+      return ['prod']
+    case 'preview':
+      return ['staging', 'test']
+    default:
+      return undefined
+  }
+}
+
+/**
+ * A build that ships with Workshop in it must name its backend family, and
+ * name one its origin is allowed to reach. Anything else fails here, at build
+ * time, rather than as a preflight error in a visitor's browser.
+ *
+ * Local builds keep the staging default (see `workshop-env.ts`), and a build
+ * without Workshop in it has nothing to point anywhere and is left alone — so
+ * production builds are untouched until the day Workshop launches, when
+ * `PUBLIC_WORKSHOP_CLOUD_ENV=prod` goes in alongside `WORKSHOP_IN_BUILD=1`.
+ * A misspelt value fails every build, deployed or not.
+ */
+export function assertWorkshopCloudEnvForBuild(): void {
+  const raw = process.env.PUBLIC_WORKSHOP_CLOUD_ENV
+  const family = raw === undefined || raw === '' ? undefined : raw
+  if (family !== undefined && !isWorkshopCloudEnv(family)) {
+    throw new Error(
+      `PUBLIC_WORKSHOP_CLOUD_ENV=${JSON.stringify(family)} is not one of ${WORKSHOP_CLOUD_ENVS.join(', ')}.`
+    )
+  }
+  if (!isWorkshopInBuild()) return
+
+  const vercelEnv = process.env.VERCEL_ENV ?? ''
+  const allowed = allowedFamiliesFor(vercelEnv)
+  if (!allowed) return
+
+  const choices = allowed.join(' or ')
+  if (family === undefined) {
+    throw new Error(
+      `Workshop is in this ${vercelEnv} build but PUBLIC_WORKSHOP_CLOUD_ENV is unset. Set it to ${choices} in the Vercel ${vercelEnv} environment.`
+    )
+  }
+  if (!allowed.includes(family)) {
+    throw new Error(
+      `PUBLIC_WORKSHOP_CLOUD_ENV=${family} is not allowed for a ${vercelEnv} build: this origin may only reach ${choices} Cloud (ingest CORS_ORIGIN, cloud FE-2009).`
+    )
+  }
 }

--- a/apps/website/src/env.d.ts
+++ b/apps/website/src/env.d.ts
@@ -8,7 +8,10 @@ interface ViteTypeOptions {
 }
 
 interface ImportMetaEnv {
-  /** 'staging' points every Workshop backend at the staging family. */
+  /**
+   * Which Cloud family Workshop talks to: 'prod', 'staging' or 'test'. Unset
+   * means staging. See config/workshop-env.ts and workshop-release.ts.
+   */
   readonly PUBLIC_WORKSHOP_CLOUD_ENV?: string
   /** '1' forces the Workshop auth flag on — PostHog only runs in PROD builds. */
   readonly PUBLIC_WORKSHOP_AUTH_FLAG?: string

--- a/apps/website/src/env.d.ts
+++ b/apps/website/src/env.d.ts
@@ -10,7 +10,8 @@ interface ViteTypeOptions {
 interface ImportMetaEnv {
   /**
    * Which Cloud family Workshop talks to: 'prod', 'staging' or 'test'. Unset
-   * means staging. See config/workshop-env.ts and workshop-release.ts.
+   * means staging for local builds. Deployed builds that include Workshop must
+   * set an allowed family. See config/workshop-env.ts and workshop-release.ts.
    */
   readonly PUBLIC_WORKSHOP_CLOUD_ENV?: string
   /** '1' forces the Workshop auth flag on — PostHog only runs in PROD builds. */

--- a/apps/website/src/integrations/workshop-release-gate.test.ts
+++ b/apps/website/src/integrations/workshop-release-gate.test.ts
@@ -44,6 +44,19 @@ async function buildDone() {
 }
 
 describe('Workshop release output', () => {
+  it('rejects an invalid Cloud family before building', () => {
+    vi.stubEnv('VERCEL_ENV', 'preview')
+    vi.stubEnv('WORKSHOP_IN_BUILD', '1')
+    vi.stubEnv('PUBLIC_WORKSHOP_CLOUD_ENV', 'prod')
+
+    const hook = workshopReleaseGate().hooks['astro:build:start']
+    if (!hook) throw new Error('Missing build start hook')
+
+    expect(() => hook({ logger, setPrerenderer: vi.fn() })).toThrow(
+      /may only reach staging or test Cloud/
+    )
+  })
+
   it('removes only Workshop output when disabled, including repeated builds', async () => {
     vi.stubEnv('WORKSHOP_IN_BUILD', '0')
     await buildDone()

--- a/apps/website/src/integrations/workshop-release-gate.ts
+++ b/apps/website/src/integrations/workshop-release-gate.ts
@@ -7,7 +7,11 @@ import { rm } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 
-import { isWorkshopInBuild, isWorkshopRoute } from '../config/workshop-release'
+import {
+  assertWorkshopCloudEnvForBuild,
+  isWorkshopInBuild,
+  isWorkshopRoute
+} from '../config/workshop-release'
 
 /**
  * Keeps Workshop out of a release build.
@@ -26,11 +30,19 @@ import { isWorkshopInBuild, isWorkshopRoute } from '../config/workshop-release'
  * we release right now?", so it excludes Workshop for the same reason. Local
  * development keeps it, and so does any build asked for it explicitly. See
  * `config/workshop-release.ts` for the switch.
+ *
+ * A build that does ship with Workshop in it must also say which Cloud family
+ * it talks to, and one its origin is allowed to reach; that is checked before
+ * anything is generated, so a wrong family is a build error rather than a
+ * preflight error in a visitor's browser.
  */
 export function workshopReleaseGate(): AstroIntegration {
   return {
     name: 'workshop-release-gate',
     hooks: {
+      'astro:build:start': () => {
+        assertWorkshopCloudEnvForBuild()
+      },
       'astro:build:done': async ({ dir, pages, logger }) => {
         if (isWorkshopInBuild()) return
 


### PR DESCRIPTION
## Summary

Lets a Workshop preview sign in against **test** Cloud (`workshop-test` label) as well as staging, and makes any build that ships with Workshop in it name the Cloud family its origin is allowed to reach — so nothing here has to be backed out to launch on production, and a wrong family fails the build instead of a visitor's preflight.

## Changes

- **What**:
  - `PUBLIC_WORKSHOP_CLOUD_ENV` is now `prod | staging | test`. `test` → `testapi.comfy.org` / `testcloud.comfy.org`, the `dreamboothy-dev` Firebase project (shared with staging), and no Turnstile sitekey (testcloud reports none, so the widget stays off and the server's shadow policy applies). Unset still means staging; `prod` is unchanged.
  - New `workshop-cloud-env.ts` holds the family names once, for the client switch (`workshop-env.ts`) and the build-time check (`workshop-release.ts`).
  - `assertWorkshopCloudEnvForBuild()` runs at `astro:build:start` in `workshop-release-gate`: if Workshop is in a deployed build, production must say `prod` and preview must say `staging` or `test`; a misspelt value fails any build. Builds without Workshop (every production build today) are not checked.
  - `ci-vercel-website-preview.yaml`: `workshop` ⇒ `PUBLIC_WORKSHOP_CLOUD_ENV=staging`, `workshop-test` ⇒ `test` (both put Workshop in the build); the preview comment names the Cloud. Unlabelled PRs still leave both variables to the Vercel preview environment.
  - README: launch now sets `PUBLIC_WORKSHOP_CLOUD_ENV=prod` in production and `staging` in preview alongside `WORKSHOP_IN_BUILD=1`; new "Which Cloud the Workshop talks to" section.
- **Breaking**: none for today's builds. On launch day production needs `PUBLIC_WORKSHOP_CLOUD_ENV=prod` next to `WORKSHOP_IN_BUILD=1` — which Cloud's CORS policy requires anyway: comfy.org is only allowed to reach production Cloud (Comfy-Org/cloud#8916 keeps it out of staging/test on purpose).

## Review Focus

- The allowed-family rule is copied from the backend, not invented here: ingest's `CORS_ORIGIN` admits `comfy.org` only in prod and the website's Vercel preview origins only in stg/test (Comfy-Org/cloud#8916, FE-2009). If that policy ever changes, `allowedFamiliesFor` in `workshop-release.ts` is the one place to follow it.
- Vercel exposes `VERCEL_ENV` and the pulled env vars to `astro build`; the existing release gate already relies on that, and the new check reads the same `process.env`.

## Verification

- `vitest`: `workshop-cloud-env`, `workshop-env`, `workshop-release` — 31 tests, including every allow/deny cell of the build check. Full `apps/website` unit suite:  Test Files 214 passed (214); Tests 1555 passed (1555);
- `astro check` + `vue-tsc`: 0 errors. `eslint`, `oxlint --type-aware`, repo-wide `oxfmt --check`, `knip`: clean (lint-staged re-ran them on commit).
- Live gate checks: `VERCEL_ENV=preview WORKSHOP_IN_BUILD=1` with no family fails in ~2 s with "…PUBLIC_WORKSHOP_CLOUD_ENV is unset. Set it to staging or test…"; `VERCEL_ENV=production WORKSHOP_IN_BUILD=1 PUBLIC_WORKSHOP_CLOUD_ENV=staging` fails with "…may only reach prod Cloud…".
- Full preview build with `PUBLIC_WORKSHOP_CLOUD_ENV=test`: 1000 pages including 269 Workshop pages; the selected family is inlined into `dist/_website/identity.*.js`.
- Actually signing in against test from a preview additionally needs Comfy-Org/cloud#8916 (ingest CORS for preview origins) and Comfy-Org/cloud#8917 (Router preflight headers) deployed to test.
