### PR TITLE
prototype(billing): the dialog subscribe flow as a standalone checkout page

### DIFF
--- a/src/platform/cloud/subscription/views/CheckoutPageView.stories.ts
+++ b/src/platform/cloud/subscription/views/CheckoutPageView.stories.ts
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
-import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
+import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+import SubscriptionAddPaymentPreviewWorkspace from '@/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue'
 
 /**
- * Standalone checkout page (prototype): the dialog subscribe flow lifted onto
- * a full page so every product can link one checkout URL instead of
- * duplicating the flow. Same content component as the dialog — logic and
- * outcome states are identical by construction; only the shell differs.
+ * Standalone checkout page (prototype): our own checkout in the spirit of
+ * Stripe Checkout — the confirm-your-payment step owning the whole viewport,
+ * no dialog chrome. The plan arrives pre-chosen via the URL; plan selection
+ * is a separate page. In Storybook the payment column shows the selector's
+ * no-key state; on a cloud dev server the real payment element mounts there.
  */
 const meta: Meta = {
   title: 'Views/CheckoutPage',
@@ -17,28 +19,79 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-function pageStory(initialPlanMode: 'personal' | 'team'): Story {
+const NEXT_YEAR = '2027-06-28T00:00:00Z'
+
+function preview(
+  tier: 'CREATOR' | 'PRO',
+  duration: 'MONTHLY' | 'ANNUAL',
+  priceCents: number
+): PreviewSubscribeResponse {
+  return {
+    allowed: true,
+    transition_type: 'new_subscription',
+    effective_at: '2026-06-19T00:00:00Z',
+    is_immediate: true,
+    cost_today_cents: priceCents,
+    cost_next_period_cents: priceCents,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    quote_id: 'quote_page',
+    quote_version: 1,
+    amount_due_cents: priceCents,
+    currency: 'usd',
+    renewal_amount_cents: priceCents,
+    renewal_at: NEXT_YEAR,
+    payment_method_configuration_id: 'pmc_story',
+    new_plan: {
+      slug: `${tier.toLowerCase()}-${duration.toLowerCase()}`,
+      tier,
+      duration,
+      price_cents: priceCents,
+      credits_cents: 0,
+      seat_summary: {
+        seat_count: 1,
+        total_cost_cents: priceCents,
+        total_credits_cents: 0
+      },
+      period_end: NEXT_YEAR
+    }
+  }
+}
+
+function pageStory(
+  tierKey: 'creator' | 'pro',
+  billingCycle: 'monthly' | 'yearly',
+  previewData: PreviewSubscribeResponse
+): Story {
   return {
     render: () => ({
-      components: { SubscriptionRequiredDialogContentUnified },
+      components: { SubscriptionAddPaymentPreviewWorkspace },
       setup() {
-        return { initialPlanMode, noop: () => {} }
+        return { tierKey, billingCycle, previewData }
       },
       template: `
-        <div class="flex min-h-screen w-screen items-center justify-center bg-base-background p-4 xl:p-10">
-          <div class="relative flex max-h-[920px] min-h-0 w-full max-w-6xl flex-1 overflow-hidden rounded-2xl border border-interface-stroke bg-secondary-background shadow-xl">
-            <SubscriptionRequiredDialogContentUnified
-              :on-close="noop"
-              :embedded-checkout-enabled="true"
-              :initial-plan-mode="initialPlanMode"
-            />
-          </div>
+        <div class="flex h-screen w-screen flex-col bg-secondary-background">
+          <SubscriptionAddPaymentPreviewWorkspace
+            :tier-key="tierKey"
+            :billing-cycle="billingCycle"
+            :preview-data="previewData"
+            :use-payment-element="true"
+            :quote-is-current="true"
+          />
         </div>
       `
     })
   }
 }
 
-export const PersonalPlans: Story = pageStory('personal')
+export const CreatorYearly: Story = pageStory(
+  'creator',
+  'yearly',
+  preview('CREATOR', 'ANNUAL', 33_600)
+)
 
-export const TeamPlans: Story = pageStory('team')
+export const ProMonthly: Story = pageStory(
+  'pro',
+  'monthly',
+  preview('PRO', 'MONTHLY', 10_000)
+)

--- a/src/platform/cloud/subscription/views/CheckoutPageView.stories.ts
+++ b/src/platform/cloud/subscription/views/CheckoutPageView.stories.ts
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
+
+/**
+ * Standalone checkout page (prototype): the dialog subscribe flow lifted onto
+ * a full page so every product can link one checkout URL instead of
+ * duplicating the flow. Same content component as the dialog — logic and
+ * outcome states are identical by construction; only the shell differs.
+ */
+const meta: Meta = {
+  title: 'Views/CheckoutPage',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function pageStory(initialPlanMode: 'personal' | 'team'): Story {
+  return {
+    render: () => ({
+      components: { SubscriptionRequiredDialogContentUnified },
+      setup() {
+        return { initialPlanMode, noop: () => {} }
+      },
+      template: `
+        <div class="flex min-h-screen w-screen items-center justify-center bg-base-background p-4 xl:p-10">
+          <div class="relative flex max-h-[920px] min-h-0 w-full max-w-6xl flex-1 overflow-hidden rounded-2xl border border-interface-stroke bg-secondary-background shadow-xl">
+            <SubscriptionRequiredDialogContentUnified
+              :on-close="noop"
+              :embedded-checkout-enabled="true"
+              :initial-plan-mode="initialPlanMode"
+            />
+          </div>
+        </div>
+      `
+    })
+  }
+}
+
+export const PersonalPlans: Story = pageStory('personal')
+
+export const TeamPlans: Story = pageStory('team')

--- a/src/platform/cloud/subscription/views/CheckoutPageView.vue
+++ b/src/platform/cloud/subscription/views/CheckoutPageView.vue
@@ -1,33 +1,35 @@
 <template>
-  <div
-    class="flex min-h-screen w-screen items-center justify-center bg-base-background p-4 xl:p-10"
-  >
-    <div
-      class="relative flex max-h-[920px] min-h-0 w-full max-w-6xl flex-1 overflow-hidden rounded-2xl border border-interface-stroke bg-secondary-background shadow-xl"
-    >
-      <SubscriptionRequiredDialogContentUnified
-        :on-close="handleClose"
-        :embedded-checkout-enabled="flags.embeddedCheckoutEnabled"
-        :initial-plan-mode="initialPlanMode"
-      />
-    </div>
+  <div class="flex min-h-screen w-screen flex-col bg-secondary-background">
+    <SubscriptionRequiredDialogContentUnified
+      :on-close="handleClose"
+      :embedded-checkout-enabled="flags.embeddedCheckoutEnabled"
+      :initial-checkout="initialCheckout"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
+import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 const { flags } = useFeatureFlags()
 const route = useRoute()
 const router = useRouter()
 
-const initialPlanMode = computed(() =>
-  route.query.plans === 'team' ? ('team' as const) : ('personal' as const)
-)
+// The plan arrives chosen (products deep-link it); this page is only the
+// checkout. Plan selection gets its own full-page treatment separately.
+const TIERS = ['standard', 'creator', 'pro'] as const
+const tier = TIERS.find((t) => t === route.query.tier) ?? 'creator'
+const billingCycle = route.query.cycle === 'yearly' ? 'yearly' : 'monthly'
+
+const initialCheckout: SubscriptionCheckoutSelection = {
+  planMode: 'personal',
+  tierKey: tier,
+  billingCycle
+}
 
 // Cross-product entry: /checkout?return=<url>. Only first-party origins may
 // pull the customer back out; anything else lands on the workspace.

--- a/src/platform/cloud/subscription/views/CheckoutPageView.vue
+++ b/src/platform/cloud/subscription/views/CheckoutPageView.vue
@@ -1,0 +1,58 @@
+<template>
+  <div
+    class="flex min-h-screen w-screen items-center justify-center bg-base-background p-4 xl:p-10"
+  >
+    <div
+      class="relative flex max-h-[920px] min-h-0 w-full max-w-6xl flex-1 overflow-hidden rounded-2xl border border-interface-stroke bg-secondary-background shadow-xl"
+    >
+      <SubscriptionRequiredDialogContentUnified
+        :on-close="handleClose"
+        :embedded-checkout-enabled="flags.embeddedCheckoutEnabled"
+        :initial-plan-mode="initialPlanMode"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
+
+const { flags } = useFeatureFlags()
+const route = useRoute()
+const router = useRouter()
+
+const initialPlanMode = computed(() =>
+  route.query.plans === 'team' ? ('team' as const) : ('personal' as const)
+)
+
+// Cross-product entry: /checkout?return=<url>. Only first-party origins may
+// pull the customer back out; anything else lands on the workspace.
+function safeReturnUrl(): URL | null {
+  const raw = route.query.return
+  if (typeof raw !== 'string') return null
+  try {
+    const url = new URL(raw)
+    const host = url.hostname
+    const firstParty =
+      host === 'comfy.org' ||
+      host.endsWith('.comfy.org') ||
+      host === 'localhost'
+    return firstParty && ['https:', 'http:'].includes(url.protocol) ? url : null
+  } catch {
+    return null
+  }
+}
+
+function handleClose() {
+  const returnUrl = safeReturnUrl()
+  if (returnUrl) {
+    window.location.assign(returnUrl.href)
+    return
+  }
+  void router.push('/')
+}
+</script>

--- a/src/platform/cloud/subscription/views/CheckoutPageView.vue
+++ b/src/platform/cloud/subscription/views/CheckoutPageView.vue
@@ -1,30 +1,43 @@
 <template>
-  <div class="flex min-h-screen w-screen flex-col bg-secondary-background">
-    <SubscriptionRequiredDialogContentUnified
-      :on-close="handleClose"
-      :embedded-checkout-enabled="flags.embeddedCheckoutEnabled"
-      :initial-checkout="initialCheckout"
-    />
-  </div>
+  <WorkspaceAuthGate>
+    <div class="flex min-h-screen w-screen flex-col bg-secondary-background">
+      <SubscriptionRequiredDialogContentUnified
+        v-if="capabilitiesReady"
+        :on-close="handleClose"
+        :embedded-checkout-enabled="flags.embeddedCheckoutEnabled"
+        :initial-checkout="initialCheckout"
+      />
+    </div>
+  </WorkspaceAuthGate>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import WorkspaceAuthGate from '@/platform/workspace/auth/WorkspaceAuthGate.vue'
 import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 const { flags } = useFeatureFlags()
 const route = useRoute()
 const router = useRouter()
 
-// The splash loader is normally removed by the graph view's boot or the
-// workspace auth gate; this route mounts outside both.
-onMounted(() => {
-  document.getElementById('splash-loader')?.remove()
-})
+// The dialog assumes a warm app: capabilities resolve long before anyone
+// opens it. On a cold page load they are still in flight when this view
+// mounts, and initialCheckout's capability guard would bail to the pricing
+// table — so the checkout waits for the read, behind the splash.
+const { isReady: capabilitiesReady } = useBillingCapabilities()
+
+watch(
+  capabilitiesReady,
+  (ready) => {
+    if (ready) document.getElementById('splash-loader')?.remove()
+  },
+  { immediate: true }
+)
 
 // The plan arrives chosen (products deep-link it); this page is only the
 // checkout. Plan selection gets its own full-page treatment separately.

--- a/src/platform/cloud/subscription/views/CheckoutPageView.vue
+++ b/src/platform/cloud/subscription/views/CheckoutPageView.vue
@@ -9,6 +9,7 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
@@ -18,6 +19,12 @@ import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composa
 const { flags } = useFeatureFlags()
 const route = useRoute()
 const router = useRouter()
+
+// The splash loader is normally removed by the graph view's boot or the
+// workspace auth gate; this route mounts outside both.
+onMounted(() => {
+  document.getElementById('splash-loader')?.remove()
+})
 
 // The plan arrives chosen (products deep-link it); this page is only the
 // checkout. Plan selection gets its own full-page treatment separately.

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,7 +5,7 @@ import {
   createWebHashHistory,
   createWebHistory
 } from 'vue-router'
-import type { RouteLocationNormalized } from 'vue-router'
+import type { NavigationGuardNext, RouteLocationNormalized } from 'vue-router'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
@@ -59,6 +59,26 @@ const router = createRouter({
       createWebHistory(basePath),
   routes: [
     ...(isCloud ? cloudOnboardingRoutes : []),
+    ...(isCloud
+      ? [
+          {
+            path: '/checkout',
+            name: 'CheckoutPage',
+            component: () =>
+              import('@/platform/cloud/subscription/views/CheckoutPageView.vue'),
+            beforeEnter: async (
+              _to: RouteLocationNormalized,
+              _from: RouteLocationNormalized,
+              next: NavigationGuardNext
+            ) => {
+              const userStore = useUserStore()
+              await userStore.initialize()
+              if (userStore.needsLogin) next('/user-select')
+              else next()
+            }
+          }
+        ]
+      : []),
     {
       path: '/',
       component: LayoutDefault,


### PR DESCRIPTION
Prototype for the standalone checkout discussion (Pablo/Luke): our own checkout in the spirit of Stripe Checkout — the confirm-your-payment step owning the entire viewport, no dialog chrome, so every product can link one checkout URL instead of duplicating the flow.

- `/checkout` (cloud builds only) jumps straight into the confirm step via the dialog's existing `initialCheckout` fast-path — the pricing table never renders on this page. The plan arrives pre-chosen: `?tier=standard|creator|pro&cycle=monthly|yearly` (defaults creator/monthly). Plan selection gets its own full-page treatment separately.
- The step is the same `SubscriptionRequiredDialogContentUnified` content the dialog mounts, stretched full-bleed — every state (preview, pay, 3DS verify, success, declined) is identical by construction; no logic copied.
- Cross-product entry: `?return=<url>` sends the customer back on close, allowlisted to comfy.org origins. The global auth guard already handles login-and-return.
- Storybook (`Views/CheckoutPage`) renders the full-viewport split (Creator yearly, Pro monthly) as the visual reference; on a cloud dev server the real payment element mounts in the right column.

Not for merge as-is — reference for scoping the real thing. Open questions: final URL (`cloud.comfy.org/checkout` with `comfy.org/checkout` aliasing is the low-effort answer since the flow's stores live here); what the header back-arrow and X become on a page (both plausibly "back to the product" via the return URL); deep-link params for team plans. Converges with the universal payment-link endpoint direction (that endpoint could mint links to this page for subscribe flows).
