### PR TITLE
fix(website): preserve disabled Workshop builds

### DIFF
--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -39,6 +39,8 @@ jobs:
       contents: read
     env:
       ALIAS_HOST: comfy-website-preview-pr-${{ github.event.pull_request.number }}.vercel.app
+      WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') || contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
+      WORKSHOP_TEST_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -62,8 +64,6 @@ jobs:
           WEBSITE_ASHBY_API_KEY: ${{ secrets.WEBSITE_ASHBY_API_KEY }}
           WEBSITE_ASHBY_JOB_BOARD_NAME: ${{ secrets.WEBSITE_ASHBY_JOB_BOARD_NAME }}
           WEBSITE_CLOUD_API_KEY: ${{ secrets.WEBSITE_CLOUD_API_KEY }}
-          WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') || contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
-          WORKSHOP_TEST_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
         # A preview has to answer "what goes out if we release right now?", so
         # by default it matches production and leaves the unreleased Workshop
         # feature out. Label a PR `workshop` to build it in and get a review URL
@@ -137,8 +137,6 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
           ALIAS_OK: ${{ steps.alias-set.outcome == 'success' }}
-          WORKSHOP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop') || contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
-          WORKSHOP_TEST_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'workshop-test') }}
         run: |
           if [[ "$ALIAS_OK" == "true" ]]; then
             STABLE_URL="https://$ALIAS_HOST"

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -226,7 +226,7 @@ build otherwise — a wrong family is a build error, not a preflight error in a
 visitor's browser. Builds without Workshop in them are not checked, so nothing
 changes for production until launch. Local builds may leave it unset
 (staging) or pick a family for a specific check. `test` has no Turnstile
-sitekey, so the widget stays off there and the server's shadow policy applies.
+sitekey in this mapping, so the client widget stays off there.
 
 The switch is `src/config/workshop-release.ts`; the removal is the
 `workshop-release-gate` Astro integration, which deletes the emitted directory

--- a/apps/website/src/config/workshop-cloud-env.test.ts
+++ b/apps/website/src/config/workshop-cloud-env.test.ts
@@ -12,8 +12,8 @@ describe('resolveWorkshopCloudEnv', () => {
     { name: 'prod is prod', value: 'prod', expected: 'prod' },
     { name: 'staging is staging', value: 'staging', expected: 'staging' },
     { name: 'test is test', value: 'test', expected: 'test' },
-    // The build-time check rejects a misspelling before a build; at runtime
-    // the safe answer is the family that cannot reach production.
+    // Workshop builds reject a misspelling before building; at runtime the
+    // safe answer is the family that cannot reach production.
     {
       name: 'anything else stays on staging',
       value: 'production',

--- a/apps/website/src/config/workshop-cloud-env.ts
+++ b/apps/website/src/config/workshop-cloud-env.ts
@@ -13,14 +13,14 @@ export type WorkshopCloudEnv = (typeof WORKSHOP_CLOUD_ENVS)[number]
 export function isWorkshopCloudEnv(
   value: string | undefined
 ): value is WorkshopCloudEnv {
-  return (WORKSHOP_CLOUD_ENVS as readonly string[]).includes(value ?? '')
+  return WORKSHOP_CLOUD_ENVS.some((env) => env === value)
 }
 
 /**
  * Unset means staging, so local development needs no configuration and
- * lands on a family that cannot touch production. Deployed builds never rely
- * on this default: `assertWorkshopCloudEnvForBuild` makes them name a family
- * and rejects anything misspelt before the build starts.
+ * lands on a family that cannot touch production. Deployed builds that include
+ * Workshop never rely on this default: `assertWorkshopCloudEnvForBuild` makes
+ * them name a family and rejects anything misspelt before the build starts.
  */
 export function resolveWorkshopCloudEnv(
   value: string | undefined

--- a/apps/website/src/config/workshop-env.ts
+++ b/apps/website/src/config/workshop-env.ts
@@ -66,8 +66,8 @@ export const WORKSHOP_FIREBASE_OPTIONS: FirebaseOptions =
  * Public per-environment Turnstile sitekeys, the same constants the platform
  * app bakes in. Whether the widget renders is still governed by Cloudflare's
  * hostname allowlist; where it cannot, sign-up proceeds without a token and
- * the server's own policy decides. Test has no sitekey (testcloud reports
- * none), so the widget stays off there and the server's shadow policy applies.
+ * the server's own policy decides. Test has no sitekey in this mapping, so the
+ * widget stays off there.
  */
 // TODO(auth parity, E7): the cloud app overrides this live from remote config;
 // give the website a live source (PostHog flag payload) so a rotation needs no deploy.

--- a/apps/website/src/config/workshop-release.test.ts
+++ b/apps/website/src/config/workshop-release.test.ts
@@ -68,8 +68,10 @@ describe('assertWorkshopCloudEnvForBuild', () => {
     { name: 'a local build needs no family' },
     { name: 'a local build may name one', family: 'test' },
     {
-      name: 'a production build without Workshop ignores the family',
-      vercelEnv: 'production'
+      name: 'a disabled production build ignores an invalid family',
+      vercelEnv: 'production',
+      inBuild: '0',
+      family: 'production'
     },
     {
       name: 'a preview without Workshop ignores the family',
@@ -104,7 +106,9 @@ describe('assertWorkshopCloudEnvForBuild', () => {
 
   it.for([
     {
-      name: 'a misspelt family fails every build',
+      name: 'a Workshop build rejects a misspelt family',
+      vercelEnv: 'preview',
+      inBuild: '1',
       family: 'production',
       message: /not one of prod, staging, test/
     },

--- a/apps/website/src/config/workshop-release.ts
+++ b/apps/website/src/config/workshop-release.ts
@@ -79,9 +79,10 @@ function allowedFamiliesFor(
  * without Workshop in it has nothing to point anywhere and is left alone — so
  * production builds are untouched until the day Workshop launches, when
  * `PUBLIC_WORKSHOP_CLOUD_ENV=prod` goes in alongside `WORKSHOP_IN_BUILD=1`.
- * A misspelt value fails every build, deployed or not.
  */
 export function assertWorkshopCloudEnvForBuild(): void {
+  if (!isWorkshopInBuild()) return
+
   const raw = process.env.PUBLIC_WORKSHOP_CLOUD_ENV
   const family = raw === undefined || raw === '' ? undefined : raw
   if (family !== undefined && !isWorkshopCloudEnv(family)) {
@@ -89,8 +90,6 @@ export function assertWorkshopCloudEnvForBuild(): void {
       `PUBLIC_WORKSHOP_CLOUD_ENV=${JSON.stringify(family)} is not one of ${WORKSHOP_CLOUD_ENVS.join(', ')}.`
     )
   }
-  if (!isWorkshopInBuild()) return
-
   const vercelEnv = process.env.VERCEL_ENV ?? ''
   const allowed = allowedFamiliesFor(vercelEnv)
   if (!allowed) return


### PR DESCRIPTION
## Summary

Follow-up to #17401 for review findings that landed as it was being merged:

- skip Cloud-family validation when Workshop is excluded, preserving current production builds even if a stale family value exists
- compute Workshop label classification once at the preview job level and reuse it for the build and published note
- retain the authoritative family tuple type without an assertion
- narrow Turnstile documentation to the client behavior proven by this repository
- keep Cloud-family guard cases consistently parameterized

## Verification

- Focused Workshop configuration and release-gate suites: 4 files, 40 tests passed
- Website Astro and Vue typecheck: 0 errors
- Targeted ESLint, type-aware oxlint, oxfmt, and git diff checks passed
- The exact disabled-production reproduction now clears the Workshop build-start guard; local generation then reaches the separate production data-freshness check that requires the CI-only WEBSITE_CLOUD_API_KEY
