### PR TITLE
feat(workshop): the DES-1015 profile menu on the real session

### DIFF
--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -199,6 +199,61 @@ describe('HeaderAccount', () => {
   })
 })
 
+describe('HeaderAccount menu', () => {
+  function signIn() {
+    h.user!.value = { email: 'a@b.co', displayName: 'Ada' }
+    h.session!.value = { token: 'jwt', uid: 'user-1', workspace, role: 'owner' }
+    h.balance!.value = { status: 'ok', credits: 42 }
+  }
+
+  it('links Add credits to platform for this workspace and settings to Cloud', async () => {
+    signIn()
+    render(HeaderAccount)
+
+    await userEvent.click(screen.getByRole('button', { name: /account/i }))
+
+    const topUp = screen.getByTestId('account-add-credits')
+    expect(topUp.getAttribute('href')).toBe(
+      'https://platform.comfy.org/billing?workspace=ws'
+    )
+    expect(topUp.getAttribute('target')).toBe('_blank')
+    expect(
+      screen.getByTestId('account-workspace-settings').getAttribute('href')
+    ).toBe('https://cloud.comfy.org')
+  })
+
+  it('opens with focus on the first item, roves with arrows, and Escape returns to the trigger', async () => {
+    const user = userEvent.setup()
+    signIn()
+    render(HeaderAccount)
+
+    const trigger = screen.getByRole('button', { name: /account/i })
+    await user.click(trigger)
+    await waitFor(() =>
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.activeElement).toBe(
+        screen.getByTestId('account-add-credits')
+      )
+    )
+
+    await user.keyboard('{ArrowDown}')
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.activeElement).toBe(
+      screen.getByTestId('account-workspace-settings')
+    )
+    await user.keyboard('{ArrowUp}')
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.activeElement).toBe(
+      screen.getByTestId('account-add-credits')
+    )
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('menu')).toBeNull()
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.activeElement).toBe(trigger)
+  })
+})
+
 describe('HeaderAccount sign-in link', () => {
   it('runs the registered stashes before leaving for sign-in', async () => {
     const assign = vi.fn()

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
   sessionFailure: undefined as { value: unknown } | undefined,
   balance: undefined as { value: unknown } | undefined,
   ensureFresh: vi.fn(),
+  remint: vi.fn(),
   signOut: vi.fn()
 }))
 
@@ -38,6 +39,7 @@ vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
       session,
       sessionFailure,
       ensureFresh: h.ensureFresh,
+      remint: h.remint,
       signOut: h.signOut
     })
   }
@@ -47,12 +49,16 @@ vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
   const { ref } = await import('vue')
   const balance = ref<unknown>({ status: 'unknown' })
   h.balance = balance
-  return { useWorkshopCredits: () => ({ balance }) }
+  return {
+    useWorkshopCredits: () => ({ balance }),
+    refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined)
+  }
 })
 
 const workspace = { id: 'ws', name: 'Personal', type: 'personal' as const }
 
 beforeEach(() => {
+  h.remint.mockReset()
   h.flag!.value = true
   h.user!.value = null
   h.session!.value = undefined
@@ -211,9 +217,7 @@ describe('HeaderAccount menu', () => {
     await userEvent.click(screen.getByRole('button', { name: /account/i }))
 
     const topUp = screen.getByTestId('account-add-credits')
-    expect(topUp.getAttribute('href')).toBe(
-      'https://platform.comfy.org/billing?workspace=ws'
-    )
+    expect(topUp.getAttribute('href')).toBe(platformTopUpHref(workspace.id))
     expect(topUp.getAttribute('target')).toBe('_blank')
     expect(
       screen.getByTestId('account-workspace-settings').getAttribute('href')
@@ -230,25 +234,123 @@ describe('HeaderAccount menu', () => {
     await waitFor(() =>
       // eslint-disable-next-line testing-library/no-node-access
       expect(document.activeElement).toBe(
-        screen.getByTestId('account-add-credits')
+        screen.getByTestId('account-switch-workspace')
       )
     )
 
     await user.keyboard('{ArrowDown}')
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.activeElement).toBe(
-      screen.getByTestId('account-workspace-settings')
+      screen.getByTestId('account-add-credits')
     )
     await user.keyboard('{ArrowUp}')
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.activeElement).toBe(
-      screen.getByTestId('account-add-credits')
+      screen.getByTestId('account-switch-workspace')
     )
 
     await user.keyboard('{Escape}')
     expect(screen.queryByRole('menu')).toBeNull()
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.activeElement).toBe(trigger)
+  })
+})
+
+describe('HeaderAccount workspace switcher', () => {
+  function signIn() {
+    h.user!.value = { email: 'a@b.co', displayName: 'Ada' }
+    h.session!.value = { token: 'jwt', uid: 'user-1', workspace, role: 'owner' }
+    h.balance!.value = { status: 'ok', credits: 42 }
+  }
+
+  const listing = {
+    workspaces: [
+      {
+        id: 'ws',
+        name: 'Personal',
+        role: 'owner',
+        type: 'personal',
+        subscription_tier: 'PRO',
+        created_at: '2026-01-01T00:00:00Z',
+        joined_at: '2026-01-01T00:00:00Z'
+      },
+      {
+        id: 'team-1',
+        name: 'Comfy team',
+        role: 'member',
+        type: 'team',
+        created_at: '2026-02-01T00:00:00Z',
+        joined_at: '2026-02-01T00:00:00Z'
+      }
+    ]
+  }
+
+  it('lists the account workspaces with the current one checked', async () => {
+    signIn()
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify(listing), { status: 200 })
+        )
+    )
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+    })
+    render(HeaderAccount)
+
+    await userEvent.click(screen.getByRole('button', { name: /account/i }))
+    await userEvent.click(screen.getByTestId('account-switch-workspace'))
+    expect(await screen.findByTestId('account-workspace-team-1')).toBeTruthy()
+    const current = screen.getByTestId('account-workspace-ws')
+    expect(current.textContent).toContain('Personal')
+    expect(current.textContent).toContain('PRO')
+  })
+
+  it('switches by reminting for the picked workspace', async () => {
+    signIn()
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify(listing), { status: 200 })
+        )
+    )
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+    })
+    h.remint.mockResolvedValue({ status: 'ok' })
+    render(HeaderAccount)
+
+    await userEvent.click(screen.getByRole('button', { name: /account/i }))
+    await userEvent.click(screen.getByTestId('account-switch-workspace'))
+    await userEvent.click(await screen.findByTestId('account-workspace-team-1'))
+
+    await waitFor(() =>
+      expect(h.remint).toHaveBeenCalledWith(undefined, {
+        workspaceId: 'team-1'
+      })
+    )
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  })
+
+  it('shows the failure line when the list cannot load', async () => {
+    signIn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 500 }))
+    )
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+    })
+    render(HeaderAccount)
+
+    await userEvent.click(screen.getByRole('button', { name: /account/i }))
+    await userEvent.click(screen.getByTestId('account-switch-workspace'))
+
+    expect(await screen.findByText('Could not load workspaces.')).toBeTruthy()
   })
 })
 

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import { onBeforeSignInLeave } from '../../config/workshop-return'
-import { WORKSHOP_CLOUD_BASE_URL } from '../../config/workshop-env'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import HeaderAccount from './HeaderAccount.vue'
 
 const h = vi.hoisted(() => ({
@@ -137,10 +137,8 @@ describe('HeaderAccount', () => {
       await userEvent
         .setup()
         .click(screen.getByRole('button', { name: /account/i }))
-      const buy = screen.getByRole('menuitem', { name: 'Buy credits' })
-      expect(buy.getAttribute('href')).toBe(
-        `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
-      )
+      const buy = screen.getByRole('menuitem', { name: /add credits/i })
+      expect(buy.getAttribute('href')).toBe(platformTopUpHref(workspace.id))
       expect(buy.getAttribute('target')).toBe('_blank')
       expect(screen.getByRole('menuitem', { name: /sign out/i })).toBeTruthy()
     }

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -1,9 +1,8 @@
-// @vitest-environment happy-dom
-import { fireEvent, render, screen, waitFor } from '@testing-library/vue'
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
-import { onBeforeSignInLeave } from '../../config/workshop-return'
 import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import HeaderAccount from './HeaderAccount.vue'
 
@@ -143,10 +142,12 @@ describe('HeaderAccount', () => {
       await userEvent
         .setup()
         .click(screen.getByRole('button', { name: /account/i }))
-      const buy = screen.getByRole('menuitem', { name: /add credits/i })
+      const buy = await screen.findByRole('menuitem', {
+        name: /add credits/i
+      })
       expect(buy.getAttribute('href')).toBe(platformTopUpHref(workspace.id))
       expect(buy.getAttribute('target')).toBe('_blank')
-      expect(screen.getByRole('menuitem', { name: /sign out/i })).toBeTruthy()
+      expect(screen.getByRole('menuitem', { name: /log out/i })).toBeTruthy()
     }
   )
 
@@ -212,11 +213,12 @@ describe('HeaderAccount menu', () => {
 
   it('links Add credits to platform for this workspace and settings to Cloud', async () => {
     signIn()
+    const user = userEvent.setup()
     render(HeaderAccount)
 
-    await userEvent.click(screen.getByRole('button', { name: /account/i }))
+    await user.click(screen.getByTestId('header-account'))
 
-    const topUp = screen.getByTestId('account-add-credits')
+    const topUp = await screen.findByTestId('account-add-credits')
     expect(topUp.getAttribute('href')).toBe(platformTopUpHref(workspace.id))
     expect(topUp.getAttribute('target')).toBe('_blank')
     expect(
@@ -224,33 +226,34 @@ describe('HeaderAccount menu', () => {
     ).toBe('https://cloud.comfy.org')
   })
 
-  it('opens with focus on the first item, roves with arrows, and Escape returns to the trigger', async () => {
-    const user = userEvent.setup()
+  it('hides the top-up row from a member', async () => {
     signIn()
+    h.session!.value = {
+      token: 'jwt',
+      uid: 'user-1',
+      workspace,
+      role: 'member'
+    }
+    const user = userEvent.setup()
     render(HeaderAccount)
 
-    const trigger = screen.getByRole('button', { name: /account/i })
-    await user.click(trigger)
-    await waitFor(() =>
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(document.activeElement).toBe(
-        screen.getByTestId('account-switch-workspace')
-      )
-    )
+    await user.click(screen.getByTestId('header-account'))
 
-    await user.keyboard('{ArrowDown}')
-    // eslint-disable-next-line testing-library/no-node-access
-    expect(document.activeElement).toBe(
-      screen.getByTestId('account-add-credits')
-    )
-    await user.keyboard('{ArrowUp}')
-    // eslint-disable-next-line testing-library/no-node-access
-    expect(document.activeElement).toBe(
-      screen.getByTestId('account-switch-workspace')
-    )
+    await screen.findByTestId('account-workspace-settings')
+    expect(screen.queryByTestId('account-add-credits')).toBeNull()
+  })
+
+  it('closes on Escape and hands focus back to the trigger', async () => {
+    signIn()
+    const user = userEvent.setup()
+    render(HeaderAccount)
+
+    const trigger = screen.getByTestId('header-account')
+    await user.click(trigger)
+    await screen.findByRole('menu')
 
     await user.keyboard('{Escape}')
-    expect(screen.queryByRole('menu')).toBeNull()
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.activeElement).toBe(trigger)
   })
@@ -285,6 +288,13 @@ describe('HeaderAccount workspace switcher', () => {
     ]
   }
 
+  async function openSwitcher(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByTestId('header-account'))
+    await screen.findByTestId('account-workspace')
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{Enter}')
+  }
+
   it('lists the account workspaces with the current one checked', async () => {
     signIn()
     vi.stubGlobal(
@@ -298,10 +308,11 @@ describe('HeaderAccount workspace switcher', () => {
     onTestFinished(() => {
       vi.unstubAllGlobals()
     })
+    const user = userEvent.setup()
     render(HeaderAccount)
 
-    await userEvent.click(screen.getByRole('button', { name: /account/i }))
-    await userEvent.click(screen.getByTestId('account-switch-workspace'))
+    await openSwitcher(user)
+
     expect(await screen.findByTestId('account-workspace-team-1')).toBeTruthy()
     const current = screen.getByTestId('account-workspace-ws')
     expect(current.textContent).toContain('Personal')
@@ -322,11 +333,11 @@ describe('HeaderAccount workspace switcher', () => {
       vi.unstubAllGlobals()
     })
     h.remint.mockResolvedValue({ status: 'ok' })
+    const user = userEvent.setup()
     render(HeaderAccount)
 
-    await userEvent.click(screen.getByRole('button', { name: /account/i }))
-    await userEvent.click(screen.getByTestId('account-switch-workspace'))
-    await userEvent.click(await screen.findByTestId('account-workspace-team-1'))
+    await openSwitcher(user)
+    await user.click(await screen.findByTestId('account-workspace-team-1'))
 
     await waitFor(() =>
       expect(h.remint).toHaveBeenCalledWith(undefined, {
@@ -345,85 +356,11 @@ describe('HeaderAccount workspace switcher', () => {
     onTestFinished(() => {
       vi.unstubAllGlobals()
     })
+    const user = userEvent.setup()
     render(HeaderAccount)
 
-    await userEvent.click(screen.getByRole('button', { name: /account/i }))
-    await userEvent.click(screen.getByTestId('account-switch-workspace'))
+    await openSwitcher(user)
 
     expect(await screen.findByText('Could not load workspaces.')).toBeTruthy()
-  })
-})
-
-describe('HeaderAccount sign-in link', () => {
-  it('runs the registered stashes before leaving for sign-in', async () => {
-    const assign = vi.fn()
-    vi.spyOn(window.location, 'assign').mockImplementation(assign)
-    const stash = vi.fn()
-    const stop = onBeforeSignInLeave(stash)
-    onTestFinished(stop)
-    render(HeaderAccount)
-
-    await userEvent
-      .setup()
-      .click(screen.getByRole('link', { name: /sign in/i }))
-
-    expect(stash.mock.invocationCallOrder[0]).toBeLessThan(
-      assign.mock.invocationCallOrder[0]
-    )
-  })
-
-  it('sends the visitor to sign in with the current page as the return destination', async () => {
-    const assign = vi.fn()
-    vi.spyOn(window.location, 'assign').mockImplementation(assign)
-    window.history.replaceState({}, '', '/workshop/models/example/?tab=api')
-    render(HeaderAccount)
-
-    await userEvent
-      .setup()
-      .click(screen.getByRole('link', { name: /sign in/i }))
-
-    expect(assign).toHaveBeenCalledWith(
-      '/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F%3Ftab%3Dapi'
-    )
-  })
-
-  it('leaves a modified click to the browser with the return destination already on the link', async () => {
-    const assign = vi.fn()
-    vi.spyOn(window.location, 'assign').mockImplementation(assign)
-    window.history.replaceState({}, '', '/workshop/models/example/?tab=api')
-    render(HeaderAccount)
-
-    const link = screen.getByRole('link', { name: /sign in/i })
-    expect(
-      link.getAttribute('href'),
-      'the first render must match the server output'
-    ).toBe('/login/')
-
-    await fireEvent(link, new Event('pointerdown', { bubbles: true }))
-    link.dispatchEvent(
-      new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-        metaKey: true
-      })
-    )
-
-    expect(assign).not.toHaveBeenCalled()
-    expect(
-      link.getAttribute('href'),
-      'open-in-new-tab must land on the model page after sign-in, not the Workshop home'
-    ).toBe('/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F%3Ftab%3Dapi')
-  })
-
-  it('prepares the destination on focus, so a keyboard open-in-new-tab keeps it too', async () => {
-    window.history.replaceState({}, '', '/workshop/models/example/')
-    render(HeaderAccount)
-    const link = screen.getByRole('link', { name: /sign in/i })
-
-    await fireEvent.focus(link)
-
-    expect(link.getAttribute('href')).toBe(
-      '/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F'
-    )
   })
 })

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { Coins, ExternalLink, LogOut, Settings } from '@lucide/vue'
 import { onClickOutside } from '@vueuse/core'
 import { computed, ref, useTemplateRef } from 'vue'
 
 import { useWorkshopCredits } from '../../config/workshop-credits'
+import { externalLinks } from '../../config/routes'
 import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import { runBeforeSignInLeave } from '../../config/workshop-return'
 import { useWorkshopSession } from '../../config/workshop-session-state'
@@ -164,39 +166,95 @@ async function signOutFromMenu() {
       <div
         v-if="menuOpen"
         role="menu"
-        class="absolute right-0 z-50 mt-2 w-56 rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-2 shadow-lg"
+        class="absolute right-0 z-50 mt-2 w-72 rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-2 shadow-lg"
       >
-        <p class="px-3 py-2 text-xs break-all text-primary-comfy-canvas/55">
-          {{ user?.email ?? user?.displayName }}
-        </p>
-        <p class="px-3 pb-2 text-xs text-primary-comfy-canvas/55">
-          {{ session.workspace.name }}
-        </p>
+        <!-- The DES-1015 menu: workspace leads, actions follow, the person
+             signs off in the footer. Plan and role wait on session data. -->
+        <div class="flex items-center gap-3 px-3 py-2">
+          <img
+            v-if="user?.photoURL"
+            :src="user.photoURL"
+            alt=""
+            referrerpolicy="no-referrer"
+            class="size-9 rounded-xl"
+          />
+          <span
+            v-else
+            aria-hidden="true"
+            class="bg-primary-comfy-yellow grid size-9 shrink-0 place-items-center rounded-xl text-sm font-bold text-primary-comfy-ink"
+          >
+            {{ initial }}
+          </span>
+          <span class="min-w-0">
+            <span
+              class="block truncate text-sm font-bold text-primary-warm-white"
+              data-testid="account-workspace"
+            >
+              {{ session.workspace.name }}
+            </span>
+          </span>
+        </div>
         <p
           v-if="balance.status === 'error'"
           class="px-3 pb-2 text-xs text-red-400"
         >
           {{ t('auth.header.balanceError', locale) }}
         </p>
+        <div class="m-1 h-px bg-transparency-white-t8" aria-hidden="true" />
         <a
           :href="platformTopUpHref(session.workspace.id)"
-          data-testid="account-add-credits"
           target="_blank"
           rel="noopener noreferrer"
           role="menuitem"
-          class="block rounded-xl px-3 py-2 text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
+          data-testid="account-add-credits"
+          class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
           @click="menuOpen = false"
         >
-          {{ t('nav.buyCredits', locale) }}
+          <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
+          <span class="flex flex-1 items-center gap-3">
+            {{ t('workshop.run.buyCredits', locale) }}
+            <ExternalLink
+              class="size-5 text-primary-warm-gray"
+              aria-hidden="true"
+            />
+          </span>
+          <span
+            v-if="balance.status === 'ok'"
+            class="text-sm font-bold text-primary-warm-white tabular-nums"
+          >
+            {{ formatCredits(balance.credits) }}
+          </span>
         </a>
-        <button
-          type="button"
+        <a
+          :href="externalLinks.cloud"
+          target="_blank"
+          rel="noopener noreferrer"
           role="menuitem"
-          class="w-full rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
-          @click="signOutFromMenu"
+          data-testid="account-workspace-settings"
+          class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
+          @click="menuOpen = false"
         >
-          {{ t('auth.signIn.signOut', locale) }}
-        </button>
+          <Settings class="size-5 text-primary-warm-gray" aria-hidden="true" />
+          {{ t('nav.workspaceSettings', locale) }}
+        </a>
+        <div class="m-1 h-px bg-transparency-white-t8" aria-hidden="true" />
+        <div role="none" class="flex items-center gap-3 px-3 py-1">
+          <span
+            class="min-w-0 flex-1 truncate text-xs text-primary-comfy-canvas/55"
+          >
+            {{ user?.email ?? user?.displayName }}
+          </span>
+          <button
+            type="button"
+            role="menuitem"
+            :aria-label="t('auth.signIn.signOut', locale)"
+            data-testid="account-sign-out"
+            class="grid size-8 shrink-0 cursor-pointer place-items-center rounded-lg text-primary-warm-gray transition-colors hover:bg-primary-comfy-canvas/10 hover:text-primary-warm-white"
+            @click="signOutFromMenu"
+          >
+            <LogOut class="size-4" aria-hidden="true" />
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
-import { Coins, ExternalLink, LogOut, Settings } from '@lucide/vue'
+import {
+  ArrowLeftRight,
+  Check,
+  Coins,
+  ExternalLink,
+  LogOut,
+  Settings
+} from '@lucide/vue'
 import { onClickOutside } from '@vueuse/core'
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 
-import { useWorkshopCredits } from '../../config/workshop-credits'
+import {
+  refreshWorkshopCredits,
+  useWorkshopCredits
+} from '../../config/workshop-credits'
 import { externalLinks } from '../../config/routes'
 import { platformTopUpHref } from '../../lib/workshop/buy-credits'
+import type { WorkspaceWithRole } from '../../lib/workshop/workspaces'
+import { listWorkspaces } from '../../lib/workshop/workspaces'
 import { runBeforeSignInLeave } from '../../config/workshop-return'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import type { Locale } from '../../i18n/translations'
@@ -17,7 +29,7 @@ const { locale = 'en' } = defineProps<{
 }>()
 
 const enabled = useWorkshopAuthFlag()
-const { user, session, sessionFailure, ensureFresh, signOut } =
+const { user, session, sessionFailure, ensureFresh, remint, signOut } =
   useWorkshopSession()
 const { balance } = useWorkshopCredits()
 
@@ -55,6 +67,55 @@ onClickOutside(menuRoot, () => {
   menuOpen.value = false
 })
 
+// Mar's switcher from #16556, on real rails: the list is the account's own
+// workspaces, the switch is a remint for the picked one, and the balance
+// re-reads for the wallet that just came into scope.
+const workspacesOpen = ref(false)
+const workspaces = ref<'loading' | 'error' | readonly WorkspaceWithRole[]>(
+  'loading'
+)
+const switching = ref<string | undefined>(undefined)
+
+async function toggleWorkspaces() {
+  workspacesOpen.value = !workspacesOpen.value
+  if (!workspacesOpen.value || !session.value) return
+  workspaces.value = 'loading'
+  try {
+    workspaces.value = await listWorkspaces(session.value.token)
+  } catch {
+    workspaces.value = 'error'
+  }
+}
+
+async function switchWorkspace(workspaceId: string) {
+  if (switching.value) return
+  if (workspaceId === session.value?.workspace.id) {
+    workspacesOpen.value = false
+    return
+  }
+  switching.value = workspaceId
+  try {
+    const result = await remint(undefined, { workspaceId })
+    if (result?.status === 'ok') {
+      await refreshWorkshopCredits({ force: true })
+      menuOpen.value = false
+    } else {
+      workspaces.value = 'error'
+    }
+  } finally {
+    switching.value = undefined
+  }
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(' ')
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+}
+
 // The div is a menu in name, so it keeps the menu's keyboard promises:
 // focus enters on open, arrows rove the items, Escape hands focus back.
 const menuItems = () => [
@@ -62,6 +123,7 @@ const menuItems = () => [
 ]
 
 watch(menuOpen, (open) => {
+  if (!open) workspacesOpen.value = false
   if (open) void nextTick(() => menuItems()[0]?.focus())
 })
 
@@ -203,7 +265,7 @@ async function signOutFromMenu() {
         class="absolute right-0 z-50 mt-2 w-72 rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-2 shadow-lg"
       >
         <!-- The DES-1015 menu: workspace leads, actions follow, the person
-             signs off in the footer. Plan and role wait on session data. -->
+             signs off in the footer. Plan waits on session data. -->
         <div class="flex items-center gap-3 px-3 py-2">
           <img
             v-if="user?.photoURL"
@@ -219,14 +281,89 @@ async function signOutFromMenu() {
           >
             {{ initial }}
           </span>
-          <span class="min-w-0">
+          <span class="min-w-0 flex-1">
             <span
               class="block truncate text-sm font-bold text-primary-warm-white"
               data-testid="account-workspace"
             >
               {{ session.workspace.name }}
             </span>
+            <span
+              class="block text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+            >
+              {{ session.role }}
+            </span>
           </span>
+          <button
+            type="button"
+            role="menuitem"
+            :aria-label="t('nav.switchWorkspace', locale)"
+            :aria-expanded="workspacesOpen"
+            data-testid="account-switch-workspace"
+            class="grid size-8 shrink-0 cursor-pointer place-items-center rounded-lg text-primary-warm-gray transition-colors hover:bg-primary-comfy-canvas/10 hover:text-primary-warm-white"
+            @click="toggleWorkspaces"
+          >
+            <ArrowLeftRight class="size-4" aria-hidden="true" />
+          </button>
+        </div>
+        <div
+          v-if="workspacesOpen"
+          class="absolute top-0 right-full z-50 mr-2 w-72 rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-2 shadow-lg"
+          data-testid="account-workspaces"
+        >
+          <p
+            class="px-3 pt-1 pb-2 text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+          >
+            {{ t('nav.workspaces', locale) }}
+          </p>
+          <p
+            v-if="workspaces === 'loading'"
+            class="px-3 py-2 text-xs text-primary-comfy-canvas/55"
+          >
+            {{ t('nav.workspacesLoading', locale) }}
+          </p>
+          <p
+            v-else-if="workspaces === 'error'"
+            class="px-3 py-2 text-xs text-red-400"
+          >
+            {{ t('nav.workspacesError', locale) }}
+          </p>
+          <template v-else>
+            <button
+              v-for="workspace in workspaces"
+              :key="workspace.id"
+              type="button"
+              role="menuitem"
+              :disabled="switching !== undefined"
+              :data-testid="`account-workspace-${workspace.id}`"
+              class="flex w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10 disabled:opacity-60"
+              @click="switchWorkspace(workspace.id)"
+            >
+              <span
+                class="grid size-9 shrink-0 place-items-center rounded-xl bg-transparency-white-t8 text-sm font-bold text-primary-warm-white"
+                aria-hidden="true"
+              >
+                {{ initialsOf(workspace.name) }}
+              </span>
+              <span class="min-w-0 flex-1">
+                <span class="block truncate">{{ workspace.name }}</span>
+                <span
+                  class="block text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+                >
+                  {{
+                    (workspace.subscription_tier ?? workspace.role)
+                      .split('_')
+                      .join(' ')
+                  }}
+                </span>
+              </span>
+              <Check
+                v-if="workspace.id === session.workspace.id"
+                class="text-primary-comfy-yellow size-4 shrink-0"
+                aria-hidden="true"
+              />
+            </button>
+          </template>
         </div>
         <p
           v-if="balance.status === 'error'"

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -244,19 +244,26 @@ async function signOutFromMenu() {
           class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
           @click="menuOpen = false"
         >
-          <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
-          <span class="flex flex-1 items-center gap-3">
+          <Coins
+            class="size-5 shrink-0 text-primary-warm-gray"
+            aria-hidden="true"
+          />
+          <span class="flex flex-1 items-center gap-3 whitespace-nowrap">
             {{ t('workshop.run.buyCredits', locale) }}
             <ExternalLink
-              class="size-5 text-primary-warm-gray"
+              class="size-5 shrink-0 text-primary-warm-gray"
               aria-hidden="true"
             />
           </span>
           <span
             v-if="balance.status === 'ok'"
-            class="text-sm font-bold text-primary-warm-white tabular-nums"
+            class="flex shrink-0 items-center gap-1.5 text-sm font-bold text-primary-warm-white tabular-nums"
           >
-            {{ formatCredits(balance.credits) }}
+            <Coins class="size-4 shrink-0" aria-hidden="true" />
+            {{ balance.credits.toLocaleString(locale) }}
+            <span class="sr-only">
+              {{ t('auth.header.credits', locale) }}
+            </span>
           </span>
         </a>
         <a
@@ -268,7 +275,10 @@ async function signOutFromMenu() {
           class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
           @click="menuOpen = false"
         >
-          <Settings class="size-5 text-primary-warm-gray" aria-hidden="true" />
+          <Settings
+            class="size-5 shrink-0 text-primary-warm-gray"
+            aria-hidden="true"
+          />
           {{ t('nav.workspaceSettings', locale) }}
         </a>
         <div class="m-1 h-px bg-transparency-white-t8" aria-hidden="true" />

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -7,8 +7,20 @@ import {
   LogOut,
   Settings
 } from '@lucide/vue'
-import { onClickOutside } from '@vueuse/core'
-import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from 'reka-ui'
+import { computed, ref, watch } from 'vue'
+
+import { cn } from '@comfyorg/tailwind-utils'
 
 import {
   refreshWorkshopCredits,
@@ -61,11 +73,6 @@ function goToSignIn(event: MouseEvent): void {
 }
 
 const menuOpen = ref(false)
-const menuRoot = useTemplateRef('menuRoot')
-const accountButton = useTemplateRef('accountButton')
-onClickOutside(menuRoot, () => {
-  menuOpen.value = false
-})
 
 // Mar's switcher from #16556, on real rails: the list is the account's own
 // workspaces, the switch is a remint for the picked one, and the balance
@@ -76,21 +83,20 @@ const workspaces = ref<'loading' | 'error' | readonly WorkspaceWithRole[]>(
 )
 const switching = ref<string | undefined>(undefined)
 
-async function toggleWorkspaces() {
-  workspacesOpen.value = !workspacesOpen.value
-  if (!workspacesOpen.value || !session.value) return
+watch(workspacesOpen, async (open) => {
+  if (!open || !session.value) return
   workspaces.value = 'loading'
   try {
     workspaces.value = await listWorkspaces(session.value.token)
   } catch {
     workspaces.value = 'error'
   }
-}
+})
 
 async function switchWorkspace(workspaceId: string) {
   if (switching.value) return
   if (workspaceId === session.value?.workspace.id) {
-    workspacesOpen.value = false
+    menuOpen.value = false
     return
   }
   switching.value = workspaceId
@@ -116,59 +122,41 @@ function initialsOf(name: string): string {
     .toUpperCase()
 }
 
-// The div is a menu in name, so it keeps the menu's keyboard promises:
-// focus enters on open, arrows rove the items, Escape hands focus back.
-const menuItems = () => [
-  ...(menuRoot.value?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [])
-]
-
-watch(menuOpen, (open) => {
-  if (!open) workspacesOpen.value = false
-  if (open) void nextTick(() => menuItems()[0]?.focus())
-})
-
-function onMenuKeydown(event: KeyboardEvent) {
-  if (!menuOpen.value) return
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    menuOpen.value = false
-    accountButton.value?.focus()
-    return
-  }
-  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
-  event.preventDefault()
-  const items = menuItems()
-  const index = items.indexOf(document.activeElement as HTMLElement)
-  const step = event.key === 'ArrowDown' ? 1 : -1
-  const next =
-    index === -1
-      ? step === 1
-        ? items[0]
-        : items.at(-1)
-      : items[(index + step + items.length) % items.length]
-  next?.focus()
+const workspaceInitials = computed(() =>
+  initialsOf(session.value?.workspace.name ?? '')
+)
+const hasCredits = computed(
+  () => balance.value.status === 'ok' && balance.value.credits > 0
+)
+const formattedCredits = computed(() =>
+  balance.value.status === 'ok'
+    ? new Intl.NumberFormat(locale).format(balance.value.credits)
+    : undefined
+)
+function formatCredits(credits: number): string {
+  const key = credits === 1 ? 'auth.header.credit' : 'auth.header.credits'
+  return `${credits.toLocaleString(locale)} ${t(key, locale)}`
 }
 
-const initial = computed(() => {
-  const name = user.value?.displayName ?? user.value?.email ?? ''
-  return name.slice(0, 1).toUpperCase()
-})
-
-// The button carries the avatar and, when known, the balance; an aria-label
-// would replace all of that with one word, so it names the account AND folds
-// the balance in when there is one, matching what the chip shows.
+// The chip shows the bare number; the label keeps the unit for a reader
+// who cannot see which chip it is.
 const accountLabel = computed(() => {
-  const account = t('auth.header.account', locale)
+  const account = t('nav.accountMenu', locale)
   const current = balance.value
   return current.status === 'ok'
     ? `${account}, ${formatCredits(current.credits)}`
     : account
 })
 
-function formatCredits(credits: number): string {
-  const key = credits === 1 ? 'auth.header.credit' : 'auth.header.credits'
-  return `${credits.toLocaleString(locale)} ${t(key, locale)}`
-}
+const roleLabel = computed(() =>
+  t(
+    session.value?.role === 'member' ? 'nav.roleMember' : 'nav.roleOwner',
+    locale
+  )
+)
+// Buying is owner-only server-side, so a member gets no purchase route here.
+// See DES-1015.
+const canTopUp = computed(() => session.value?.role !== 'member')
 
 const sessionRetryPending = ref(false)
 async function retrySession(): Promise<void> {
@@ -185,6 +173,13 @@ async function signOutFromMenu() {
   menuOpen.value = false
   await signOut()
 }
+
+const itemClass =
+  'flex w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-3 text-sm text-primary-comfy-canvas outline-none hover:bg-transparency-white-t4 focus-visible:bg-transparency-white-t4'
+const avatarClass =
+  'grid size-12 shrink-0 place-items-center text-base font-bold text-primary-warm-white'
+const surfaceClass =
+  'border-primary-comfy-ink-light bg-site-dropdown z-50 rounded-2xl border p-2 shadow-lg data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0'
 </script>
 
 <template>
@@ -227,206 +222,211 @@ async function signOutFromMenu() {
       {{ t('auth.header.signingIn', locale) }}
     </span>
 
-    <div v-else ref="menuRoot" class="relative" @keydown="onMenuKeydown">
-      <button
-        ref="accountButton"
-        type="button"
-        class="hover:border-primary-comfy-yellow/60 flex h-10 items-center gap-2.5 rounded-2xl border border-primary-comfy-canvas/25 pr-3 pl-1.5 transition-colors"
+    <DropdownMenuRoot v-else v-model:open="menuOpen">
+      <DropdownMenuTrigger
+        data-testid="header-account"
         :aria-label="accountLabel"
-        :aria-expanded="menuOpen"
-        aria-haspopup="menu"
-        @click="menuOpen = !menuOpen"
+        class="bg-transparency-white-t4 focus-visible:ring-primary-comfy-yellow/50 flex h-10 cursor-pointer items-center gap-1.5 rounded-full border border-transparency-white-t20 p-1 outline-none focus-visible:ring-3"
       >
-        <img
-          v-if="user?.photoURL"
-          :src="user.photoURL"
-          alt=""
-          referrerpolicy="no-referrer"
-          class="size-7 rounded-full"
-        />
         <span
-          v-else
-          aria-hidden="true"
-          class="bg-primary-comfy-yellow flex size-7 items-center justify-center rounded-full text-xs font-bold text-primary-comfy-ink"
+          v-if="formattedCredits !== undefined"
+          data-testid="header-credits"
+          :class="
+            cn(
+              'flex h-8 items-center gap-1.5 rounded-full px-3 text-sm font-bold whitespace-nowrap tabular-nums',
+              hasCredits
+                ? 'bg-primary-comfy-yellow/10 text-primary-comfy-yellow'
+                : 'bg-primary-comfy-red/10 text-primary-comfy-red'
+            )
+          "
         >
-          {{ initial }}
+          <Coins class="size-4" aria-hidden="true" />
+          {{ formattedCredits }}
         </span>
-        <span
-          v-if="balance.status === 'ok'"
-          class="text-xs font-bold text-primary-comfy-canvas tabular-nums"
-        >
-          {{ formatCredits(balance.credits) }}
-        </span>
-      </button>
 
-      <div
-        v-if="menuOpen"
-        role="menu"
-        class="absolute right-0 z-50 mt-2 w-72 rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-2 shadow-lg"
-      >
-        <!-- The DES-1015 menu: workspace leads, actions follow, the person
-             signs off in the footer. Plan waits on session data. -->
-        <div class="flex items-center gap-3 px-3 py-2">
-          <img
-            v-if="user?.photoURL"
-            :src="user.photoURL"
-            alt=""
-            referrerpolicy="no-referrer"
-            class="size-9 rounded-xl"
-          />
-          <span
-            v-else
-            aria-hidden="true"
-            class="bg-primary-comfy-yellow grid size-9 shrink-0 place-items-center rounded-xl text-sm font-bold text-primary-comfy-ink"
-          >
-            {{ initial }}
-          </span>
-          <span class="min-w-0 flex-1">
-            <span
-              class="block truncate text-sm font-bold text-primary-warm-white"
-              data-testid="account-workspace"
-            >
-              {{ session.workspace.name }}
-            </span>
-            <span
-              class="block text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
-            >
-              {{ session.role }}
-            </span>
-          </span>
-          <button
-            type="button"
-            role="menuitem"
-            :aria-label="t('nav.switchWorkspace', locale)"
-            :aria-expanded="workspacesOpen"
-            data-testid="account-switch-workspace"
-            class="grid size-8 shrink-0 cursor-pointer place-items-center rounded-lg text-primary-warm-gray transition-colors hover:bg-primary-comfy-canvas/10 hover:text-primary-warm-white"
-            @click="toggleWorkspaces"
-          >
-            <ArrowLeftRight class="size-4" aria-hidden="true" />
-          </button>
-        </div>
-        <div
-          v-if="workspacesOpen"
-          class="absolute top-0 right-full z-50 mr-2 w-72 rounded-2xl border border-primary-comfy-canvas/15 bg-primary-comfy-ink p-2 shadow-lg"
-          data-testid="account-workspaces"
+        <span
+          class="grid size-8 shrink-0 place-items-center rounded-full bg-transparency-white-t8 text-xs font-bold text-primary-warm-white"
+          aria-hidden="true"
         >
-          <p
-            class="px-3 pt-1 pb-2 text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
-          >
-            {{ t('nav.workspaces', locale) }}
-          </p>
-          <p
-            v-if="workspaces === 'loading'"
-            class="px-3 py-2 text-xs text-primary-comfy-canvas/55"
-          >
-            {{ t('nav.workspacesLoading', locale) }}
-          </p>
-          <p
-            v-else-if="workspaces === 'error'"
-            class="px-3 py-2 text-xs text-red-400"
-          >
-            {{ t('nav.workspacesError', locale) }}
-          </p>
-          <template v-else>
-            <button
-              v-for="workspace in workspaces"
-              :key="workspace.id"
-              type="button"
-              role="menuitem"
-              :disabled="switching !== undefined"
-              :data-testid="`account-workspace-${workspace.id}`"
-              class="flex w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10 disabled:opacity-60"
-              @click="switchWorkspace(workspace.id)"
+          {{ workspaceInitials }}
+        </span>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuPortal>
+        <DropdownMenuContent
+          align="end"
+          :side-offset="10"
+          :class="cn(surfaceClass, 'w-96')"
+        >
+          <DropdownMenuSub v-model:open="workspacesOpen">
+            <DropdownMenuSubTrigger
+              data-testid="account-workspace"
+              class="hover:bg-transparency-white-t4 data-[state=open]:bg-transparency-white-t4 focus-visible:bg-transparency-white-t4 flex w-full cursor-pointer items-center gap-3 rounded-xl p-2 text-left outline-none"
             >
               <span
-                class="grid size-9 shrink-0 place-items-center rounded-xl bg-transparency-white-t8 text-sm font-bold text-primary-warm-white"
+                :class="cn(avatarClass, 'rounded-xl bg-transparency-white-t8')"
                 aria-hidden="true"
               >
-                {{ initialsOf(workspace.name) }}
+                {{ workspaceInitials }}
               </span>
               <span class="min-w-0 flex-1">
-                <span class="block truncate">{{ workspace.name }}</span>
                 <span
-                  class="block text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+                  class="block truncate text-base font-bold text-primary-warm-white"
                 >
-                  {{
-                    (workspace.subscription_tier ?? workspace.role)
-                      .split('_')
-                      .join(' ')
-                  }}
+                  {{ session.workspace.name }}
+                </span>
+                <span
+                  class="block truncate text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+                >
+                  {{ roleLabel }}
                 </span>
               </span>
-              <Check
-                v-if="workspace.id === session.workspace.id"
-                class="text-primary-comfy-yellow size-4 shrink-0"
+              <span
+                class="grid size-8 shrink-0 place-items-center rounded-lg text-primary-warm-gray"
+                aria-hidden="true"
+              >
+                <ArrowLeftRight class="size-4" />
+              </span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent
+                side="left"
+                align="start"
+                :side-offset="12"
+                :class="cn(surfaceClass, 'w-72')"
+                data-testid="account-workspaces"
+              >
+                <p
+                  class="px-3 pt-1 pb-2 text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+                >
+                  {{ t('nav.workspaces', locale) }}
+                </p>
+                <p
+                  v-if="workspaces === 'loading'"
+                  class="px-3 py-2 text-xs text-primary-comfy-canvas/55"
+                >
+                  {{ t('nav.workspacesLoading', locale) }}
+                </p>
+                <p
+                  v-else-if="workspaces === 'error'"
+                  class="px-3 py-2 text-xs text-red-400"
+                >
+                  {{ t('nav.workspacesError', locale) }}
+                </p>
+                <template v-else>
+                  <DropdownMenuItem
+                    v-for="workspace in workspaces"
+                    :key="workspace.id"
+                    :class="itemClass"
+                    :disabled="switching !== undefined"
+                    :data-testid="`account-workspace-${workspace.id}`"
+                    @select.prevent="switchWorkspace(workspace.id)"
+                  >
+                    <span
+                      class="grid size-9 shrink-0 place-items-center rounded-lg bg-transparency-white-t8 text-sm font-bold text-primary-warm-white"
+                      aria-hidden="true"
+                    >
+                      {{ initialsOf(workspace.name) }}
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span class="block truncate">{{ workspace.name }}</span>
+                      <span
+                        class="block text-[11px] font-bold tracking-wider text-primary-warm-gray uppercase"
+                      >
+                        {{
+                          (workspace.subscription_tier ?? workspace.role)
+                            .split('_')
+                            .join(' ')
+                        }}
+                      </span>
+                    </span>
+                    <Check
+                      v-if="workspace.id === session.workspace.id"
+                      class="text-primary-comfy-yellow size-4 shrink-0"
+                      aria-hidden="true"
+                    />
+                  </DropdownMenuItem>
+                </template>
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
+
+          <p
+            v-if="balance.status === 'error'"
+            class="px-3 pb-2 text-xs text-red-400"
+          >
+            {{ t('auth.header.balanceError', locale) }}
+          </p>
+
+          <DropdownMenuItem v-if="canTopUp" as-child>
+            <a
+              :href="platformTopUpHref(session.workspace.id)"
+              target="_blank"
+              rel="noopener noreferrer"
+              :class="itemClass"
+              data-testid="account-add-credits"
+            >
+              <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
+              <span class="flex flex-1 items-center gap-3">
+                {{ t('workshop.run.buyCredits', locale) }}
+                <ExternalLink
+                  class="size-5 text-primary-warm-gray"
+                  aria-hidden="true"
+                />
+              </span>
+            </a>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem as-child>
+            <a
+              :href="externalLinks.cloud"
+              target="_blank"
+              rel="noopener noreferrer"
+              :class="itemClass"
+              data-testid="account-workspace-settings"
+            >
+              <Settings
+                class="size-5 text-primary-warm-gray"
                 aria-hidden="true"
               />
-            </button>
-          </template>
-        </div>
-        <p
-          v-if="balance.status === 'error'"
-          class="px-3 pb-2 text-xs text-red-400"
-        >
-          {{ t('auth.header.balanceError', locale) }}
-        </p>
-        <div class="m-1 h-px bg-transparency-white-t8" aria-hidden="true" />
-        <a
-          :href="platformTopUpHref(session.workspace.id)"
-          target="_blank"
-          rel="noopener noreferrer"
-          role="menuitem"
-          data-testid="account-add-credits"
-          class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
-          @click="menuOpen = false"
-        >
-          <Coins
-            class="size-5 shrink-0 text-primary-warm-gray"
-            aria-hidden="true"
+              <span class="flex flex-1 items-center gap-3">
+                {{ t('nav.workspaceSettings', locale) }}
+                <ExternalLink
+                  class="size-5 text-primary-warm-gray"
+                  aria-hidden="true"
+                />
+              </span>
+            </a>
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator
+            class="-mx-2 mt-2 h-px bg-transparency-white-t8"
           />
-          <span class="flex flex-1 items-center gap-3 whitespace-nowrap">
-            {{ t('workshop.run.buyCredits', locale) }}
-            <ExternalLink
-              class="size-5 shrink-0 text-primary-warm-gray"
-              aria-hidden="true"
-            />
-          </span>
-        </a>
-        <a
-          :href="externalLinks.cloud"
-          target="_blank"
-          rel="noopener noreferrer"
-          role="menuitem"
-          data-testid="account-workspace-settings"
-          class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-primary-comfy-canvas transition-colors hover:bg-primary-comfy-canvas/10"
-          @click="menuOpen = false"
-        >
-          <Settings
-            class="size-5 shrink-0 text-primary-warm-gray"
-            aria-hidden="true"
-          />
-          {{ t('nav.workspaceSettings', locale) }}
-        </a>
-        <div class="m-1 h-px bg-transparency-white-t8" aria-hidden="true" />
-        <div role="none" class="flex items-center gap-3 px-3 py-1">
-          <span
-            class="min-w-0 flex-1 truncate text-xs text-primary-comfy-canvas/55"
-          >
-            {{ user?.email ?? user?.displayName }}
-          </span>
-          <button
-            type="button"
-            role="menuitem"
-            :aria-label="t('auth.signIn.signOut', locale)"
-            data-testid="account-sign-out"
-            class="grid size-8 shrink-0 cursor-pointer place-items-center rounded-lg text-primary-warm-gray transition-colors hover:bg-primary-comfy-canvas/10 hover:text-primary-warm-white"
-            @click="signOutFromMenu"
-          >
-            <LogOut class="size-4" aria-hidden="true" />
-          </button>
-        </div>
-      </div>
-    </div>
+
+          <div class="group/footer flex items-center gap-3 px-3 pt-3">
+            <span
+              class="min-w-0 flex-1 truncate text-sm text-primary-warm-gray"
+              data-testid="account-email"
+            >
+              {{ user?.email ?? user?.displayName }}
+            </span>
+            <DropdownMenuItem as-child>
+              <button
+                type="button"
+                :aria-label="t('nav.signOut', locale)"
+                class="flex h-8 shrink-0 cursor-pointer items-center gap-2 rounded-lg px-2 text-sm text-primary-warm-gray transition-colors outline-none group-hover/footer:bg-transparency-white-t8 group-hover/footer:text-primary-warm-white focus-visible:bg-transparency-white-t8 focus-visible:text-primary-warm-white"
+                data-testid="account-sign-out"
+                @click="signOutFromMenu"
+              >
+                <span class="hidden group-hover/footer:inline">
+                  {{ t('nav.signOut', locale) }}
+                </span>
+                <LogOut class="size-5" aria-hidden="true" />
+              </button>
+            </DropdownMenuItem>
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenuPortal>
+    </DropdownMenuRoot>
   </div>
 </template>

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Coins, ExternalLink, LogOut, Settings } from '@lucide/vue'
 import { onClickOutside } from '@vueuse/core'
-import { computed, ref, useTemplateRef } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 
 import { useWorkshopCredits } from '../../config/workshop-credits'
 import { externalLinks } from '../../config/routes'
@@ -50,9 +50,42 @@ function goToSignIn(event: MouseEvent): void {
 
 const menuOpen = ref(false)
 const menuRoot = useTemplateRef('menuRoot')
+const accountButton = useTemplateRef('accountButton')
 onClickOutside(menuRoot, () => {
   menuOpen.value = false
 })
+
+// The div is a menu in name, so it keeps the menu's keyboard promises:
+// focus enters on open, arrows rove the items, Escape hands focus back.
+const menuItems = () => [
+  ...(menuRoot.value?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [])
+]
+
+watch(menuOpen, (open) => {
+  if (open) void nextTick(() => menuItems()[0]?.focus())
+})
+
+function onMenuKeydown(event: KeyboardEvent) {
+  if (!menuOpen.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    menuOpen.value = false
+    accountButton.value?.focus()
+    return
+  }
+  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+  event.preventDefault()
+  const items = menuItems()
+  const index = items.indexOf(document.activeElement as HTMLElement)
+  const step = event.key === 'ArrowDown' ? 1 : -1
+  const next =
+    index === -1
+      ? step === 1
+        ? items[0]
+        : items.at(-1)
+      : items[(index + step + items.length) % items.length]
+  next?.focus()
+}
 
 const initial = computed(() => {
   const name = user.value?.displayName ?? user.value?.email ?? ''
@@ -132,8 +165,9 @@ async function signOutFromMenu() {
       {{ t('auth.header.signingIn', locale) }}
     </span>
 
-    <div v-else ref="menuRoot" class="relative">
+    <div v-else ref="menuRoot" class="relative" @keydown="onMenuKeydown">
       <button
+        ref="accountButton"
         type="button"
         class="hover:border-primary-comfy-yellow/60 flex h-10 items-center gap-2.5 rounded-2xl border border-primary-comfy-canvas/25 pr-3 pl-1.5 transition-colors"
         :aria-label="accountLabel"

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -255,16 +255,6 @@ async function signOutFromMenu() {
               aria-hidden="true"
             />
           </span>
-          <span
-            v-if="balance.status === 'ok'"
-            class="flex shrink-0 items-center gap-1.5 text-sm font-bold text-primary-warm-white tabular-nums"
-          >
-            <Coins class="size-4 shrink-0" aria-hidden="true" />
-            {{ balance.credits.toLocaleString(locale) }}
-            <span class="sr-only">
-              {{ t('auth.header.credits', locale) }}
-            </span>
-          </span>
         </a>
         <a
           :href="externalLinks.cloud"

--- a/apps/website/src/components/workshop/HeaderAccountSignIn.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccountSignIn.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
+
+import { onBeforeSignInLeave } from '../../config/workshop-return'
+import HeaderAccount from './HeaderAccount.vue'
+
+const h = vi.hoisted(() => ({
+  flag: undefined as { value: boolean } | undefined,
+  user: undefined as { value: unknown } | undefined,
+  session: undefined as { value: unknown } | undefined,
+  sessionFailure: undefined as { value: unknown } | undefined,
+  balance: undefined as { value: unknown } | undefined,
+  ensureFresh: vi.fn(),
+  remint: vi.fn(),
+  signOut: vi.fn()
+}))
+
+vi.mock<unknown>(import('../../scripts/posthog'), async () => {
+  const { ref } = await import('vue')
+  const flag = ref(true)
+  h.flag = flag
+  return { useWorkshopAuthFlag: () => flag }
+})
+
+vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
+  const { ref } = await import('vue')
+  const user = ref<unknown>(null)
+  const session = ref<unknown>(undefined)
+  const sessionFailure = ref<unknown>(undefined)
+  h.user = user
+  h.session = session
+  h.sessionFailure = sessionFailure
+  return {
+    useWorkshopSession: () => ({
+      user,
+      session,
+      sessionFailure,
+      ensureFresh: h.ensureFresh,
+      remint: h.remint,
+      signOut: h.signOut
+    })
+  }
+})
+
+vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
+  const { ref } = await import('vue')
+  const balance = ref<unknown>({ status: 'unknown' })
+  h.balance = balance
+  return {
+    useWorkshopCredits: () => ({ balance }),
+    refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined)
+  }
+})
+
+beforeEach(() => {
+  h.remint.mockReset()
+  h.flag!.value = true
+  h.user!.value = null
+  h.session!.value = undefined
+  h.sessionFailure!.value = undefined
+  h.balance!.value = { status: 'unknown' }
+  h.ensureFresh.mockReset().mockResolvedValue({ status: 'error' })
+  h.signOut.mockReset().mockResolvedValue(undefined)
+})
+
+describe('HeaderAccount sign-in link', () => {
+  it('runs the registered stashes before leaving for sign-in', async () => {
+    const assign = vi.fn()
+    vi.spyOn(window.location, 'assign').mockImplementation(assign)
+    const stash = vi.fn()
+    const stop = onBeforeSignInLeave(stash)
+    onTestFinished(stop)
+    render(HeaderAccount)
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('link', { name: /sign in/i }))
+
+    expect(stash.mock.invocationCallOrder[0]).toBeLessThan(
+      assign.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('sends the visitor to sign in with the current page as the return destination', async () => {
+    const assign = vi.fn()
+    vi.spyOn(window.location, 'assign').mockImplementation(assign)
+    window.history.replaceState({}, '', '/workshop/models/example/?tab=api')
+    render(HeaderAccount)
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('link', { name: /sign in/i }))
+
+    expect(assign).toHaveBeenCalledWith(
+      '/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F%3Ftab%3Dapi'
+    )
+  })
+
+  it('leaves a modified click to the browser with the return destination already on the link', async () => {
+    const assign = vi.fn()
+    vi.spyOn(window.location, 'assign').mockImplementation(assign)
+    window.history.replaceState({}, '', '/workshop/models/example/?tab=api')
+    render(HeaderAccount)
+
+    const link = screen.getByRole('link', { name: /sign in/i })
+    expect(
+      link.getAttribute('href'),
+      'the first render must match the server output'
+    ).toBe('/login/')
+
+    await fireEvent(link, new Event('pointerdown', { bubbles: true }))
+    link.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true
+      })
+    )
+
+    expect(assign).not.toHaveBeenCalled()
+    expect(
+      link.getAttribute('href'),
+      'open-in-new-tab must land on the model page after sign-in, not the Workshop home'
+    ).toBe('/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F%3Ftab%3Dapi')
+  })
+
+  it('prepares the destination on focus, so a keyboard open-in-new-tab keeps it too', async () => {
+    window.history.replaceState({}, '', '/workshop/models/example/')
+    render(HeaderAccount)
+    const link = screen.getByRole('link', { name: /sign in/i })
+
+    await fireEvent.focus(link)
+
+    expect(link.getAttribute('href')).toBe(
+      '/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F'
+    )
+  })
+})

--- a/apps/website/src/config/workshop-balance.test.ts
+++ b/apps/website/src/config/workshop-balance.test.ts
@@ -186,7 +186,8 @@ describe('createBalanceReader', () => {
     await refreshing
 
     expect(session.remint).toHaveBeenCalledWith(
-      expect.objectContaining({ uid: 'uid-1' })
+      expect.objectContaining({ uid: 'uid-1' }),
+      expect.objectContaining({ workspaceId: expect.any(String) })
     )
   })
 

--- a/apps/website/src/config/workshop-balance.ts
+++ b/apps/website/src/config/workshop-balance.ts
@@ -95,9 +95,13 @@ export function createBalanceReader(
     let token = snapshot.session.token
     let result = await fetchBalance(token)
     // One re-mint on a stale token, spent for the identity whose read
-    // failed, never whoever is signed in by the time the 401 lands.
+    // failed, never whoever is signed in by the time the 401 lands. The
+    // mint names the read's own workspace: a target-less mint resolves the
+    // personal workspace and would silently switch a team session.
     if (result.status === 'error' && result.unauthorized) {
-      const reminted = await session.remint(owner)
+      const reminted = await session.remint(owner, {
+        workspaceId: snapshot.session.workspace.id
+      })
       if (reminted?.status === 'ok') {
         token = reminted.session.token
         result = await fetchBalance(token)

--- a/apps/website/src/config/workshop-session-state.test.ts
+++ b/apps/website/src/config/workshop-session-state.test.ts
@@ -89,6 +89,8 @@ async function importFresh() {
 }
 
 beforeEach(() => {
+  window.localStorage.removeItem('workshop:workspace')
+  h.remint.mockReset()
   h.initialFlag = true
   h.listeners.clear()
   h.snapshot = { phase: 'signed-out', user: null, session: undefined }
@@ -144,6 +146,50 @@ describe('useWorkshopSession', () => {
       popupUser,
       expect.objectContaining({ workspaceId: undefined })
     )
+  })
+
+  it('restores the remembered workspace after a reload lands on personal', async () => {
+    window.localStorage.setItem(
+      'workshop:workspace',
+      JSON.stringify({ uid: 'user-1', workspaceId: 'team-9' })
+    )
+    h.remint.mockResolvedValue({ status: 'ok' })
+    await importFresh()
+
+    h.publish({
+      phase: 'authenticated',
+      user: { uid: 'user-1' },
+      session: okSession,
+      settled: true
+    })
+
+    await vi.waitFor(() =>
+      expect(h.remint).toHaveBeenCalledWith(undefined, {
+        workspaceId: 'team-9'
+      })
+    )
+  })
+
+  it('remembers the workspace each authenticated snapshot names', async () => {
+    window.localStorage.removeItem('workshop:workspace')
+    await importFresh()
+
+    h.publish({
+      phase: 'authenticated',
+      user: { uid: 'user-1' },
+      session: {
+        ...okSession,
+        workspace: { id: 'team-3', name: 'Studio', type: 'team' }
+      },
+      settled: true
+    })
+
+    await vi.waitFor(() =>
+      expect(window.localStorage.getItem('workshop:workspace')).toBe(
+        JSON.stringify({ uid: 'user-1', workspaceId: 'team-3' })
+      )
+    )
+    expect(h.remint).not.toHaveBeenCalled()
   })
 
   it('clears the session on sign-out', async () => {

--- a/apps/website/src/config/workshop-session-state.test.ts
+++ b/apps/website/src/config/workshop-session-state.test.ts
@@ -140,7 +140,10 @@ describe('useWorkshopSession', () => {
 
     await s.ensureFresh(popupUser)
 
-    expect(h.ensureFresh).toHaveBeenCalledWith(popupUser)
+    expect(h.ensureFresh).toHaveBeenCalledWith(
+      popupUser,
+      expect.objectContaining({ workspaceId: undefined })
+    )
   })
 
   it('clears the session on sign-out', async () => {

--- a/apps/website/src/config/workshop-session-state.test.ts
+++ b/apps/website/src/config/workshop-session-state.test.ts
@@ -170,6 +170,42 @@ describe('useWorkshopSession', () => {
     )
   })
 
+  it('holds the boot snapshot back while the restore is in flight', async () => {
+    window.localStorage.setItem(
+      'workshop:workspace',
+      JSON.stringify({ uid: 'user-1', workspaceId: 'team-9' })
+    )
+    let releaseRemint!: (value: unknown) => void
+    h.remint.mockImplementation(
+      () => new Promise((resolve) => (releaseRemint = resolve))
+    )
+    const s = await importFresh()
+
+    h.publish({
+      phase: 'authenticated',
+      user: { uid: 'user-1' },
+      session: okSession,
+      settled: true
+    })
+
+    await vi.waitFor(() => expect(h.remint).toHaveBeenCalledOnce())
+    expect(s.session.value, 'the personal boot must not flash').toBeUndefined()
+
+    const restored = {
+      ...okSession,
+      workspace: { id: 'team-9', name: 'Studio', type: 'team' as const }
+    }
+    h.publish({
+      phase: 'authenticated',
+      user: { uid: 'user-1' },
+      session: restored,
+      settled: true
+    })
+    releaseRemint({ status: 'ok', session: restored })
+
+    await vi.waitFor(() => expect(s.session.value?.workspace.id).toBe('team-9'))
+  })
+
   it('remembers the workspace each authenticated snapshot names', async () => {
     window.localStorage.removeItem('workshop:workspace')
     await importFresh()

--- a/apps/website/src/config/workshop-session-state.ts
+++ b/apps/website/src/config/workshop-session-state.ts
@@ -14,6 +14,8 @@
  * before use — freshness is valid-on-read, guaranteed by the client, not by
  * these warm-ups.
  */
+import { z } from 'zod'
+
 import type { User } from 'firebase/auth'
 import { computed, effectScope, shallowRef, watch } from 'vue'
 import type { EffectScope } from 'vue'
@@ -76,12 +78,73 @@ const ensureFreshHere: typeof workshopSessionClient.ensureFresh = (
     ...options
   })
 
+/**
+ * The exchange resolves a target-less boot mint to the personal workspace
+ * by design, so the chosen workspace must be the site's memory: written on
+ * every authenticated snapshot, restored with one targeted re-mint on the
+ * first snapshot after a reload, and dropped if that restore is refused.
+ */
+const REMEMBERED_WORKSPACE_KEY = 'workshop:workspace'
+
+const zRememberedWorkspace = z.object({
+  uid: z.string(),
+  workspaceId: z.string()
+})
+
+function rememberedWorkspace(uid: string): string | undefined {
+  try {
+    const raw = window.localStorage.getItem(REMEMBERED_WORKSPACE_KEY)
+    if (!raw) return undefined
+    const parsed = zRememberedWorkspace.safeParse(JSON.parse(raw))
+    return parsed.success && parsed.data.uid === uid
+      ? parsed.data.workspaceId
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function rememberWorkspace(uid: string, workspaceId: string | undefined): void {
+  try {
+    if (workspaceId)
+      window.localStorage.setItem(
+        REMEMBERED_WORKSPACE_KEY,
+        JSON.stringify({ uid, workspaceId })
+      )
+    else window.localStorage.removeItem(REMEMBERED_WORKSPACE_KEY)
+  } catch {
+    /* storage may be unavailable; the workspace just does not persist */
+  }
+}
+
+let restoredForUid: string | undefined
+
+function keepWorkspaceRemembered(): void {
+  const current = snapshot.value
+  if (current.phase !== 'authenticated') return
+  const { uid, workspace } = current.session
+  if (restoredForUid !== uid) {
+    restoredForUid = uid
+    const remembered = rememberedWorkspace(uid)
+    if (remembered && remembered !== workspace.id) {
+      void workshopSessionClient
+        .remint(undefined, { workspaceId: remembered })
+        .then((result) => {
+          if (result?.status !== 'ok') rememberWorkspace(uid, undefined)
+        })
+      return
+    }
+  }
+  rememberWorkspace(uid, workspace.id)
+}
+
 async function begin(expectedGeneration: number): Promise<void> {
   const firebase = await import('./workshop-firebase')
   if (generation !== expectedGeneration) return
 
   stopSnapshot = workshopSessionClient.subscribe((next) => {
     snapshot.value = next
+    keepWorkspaceRemembered()
   })
   detachIdentity = workshopSessionClient.attachIdentity(
     firebase.workshopIdentity

--- a/apps/website/src/config/workshop-session-state.ts
+++ b/apps/website/src/config/workshop-session-state.ts
@@ -122,20 +122,36 @@ let restoredForUid: string | undefined
 function keepWorkspaceRemembered(): void {
   const current = snapshot.value
   if (current.phase !== 'authenticated') return
-  const { uid, workspace } = current.session
-  if (restoredForUid !== uid) {
-    restoredForUid = uid
-    const remembered = rememberedWorkspace(uid)
-    if (remembered && remembered !== workspace.id) {
-      void workshopSessionClient
-        .remint(undefined, { workspaceId: remembered })
-        .then((result) => {
-          if (result?.status !== 'ok') rememberWorkspace(uid, undefined)
-        })
-      return
-    }
+  rememberWorkspace(current.session.uid, current.session.workspace.id)
+}
+
+/**
+ * The restore is one extra mint, and publishing the boot's personal
+ * credential first would flash the wrong workspace for its duration. Hold
+ * that first snapshot back - the page stays on its signing-in state - and
+ * publish either the restored workspace or, if the restore is refused, the
+ * held personal one so sign-in still completes.
+ */
+function holdsForRestore(next: SessionSnapshot<User>): boolean {
+  if (next.phase !== 'authenticated') {
+    if (next.phase === 'signed-out') restoredForUid = undefined
+    return false
   }
-  rememberWorkspace(uid, workspace.id)
+  const { uid, workspace } = next.session
+  if (restoredForUid === uid) return false
+  restoredForUid = uid
+  const remembered = rememberedWorkspace(uid)
+  if (!remembered || remembered === workspace.id) return false
+  void workshopSessionClient
+    .remint(undefined, { workspaceId: remembered })
+    .then((result) => {
+      if (result?.status !== 'ok') {
+        rememberWorkspace(uid, undefined)
+        snapshot.value = next
+        keepWorkspaceRemembered()
+      }
+    })
+  return true
 }
 
 async function begin(expectedGeneration: number): Promise<void> {
@@ -143,6 +159,7 @@ async function begin(expectedGeneration: number): Promise<void> {
   if (generation !== expectedGeneration) return
 
   stopSnapshot = workshopSessionClient.subscribe((next) => {
+    if (holdsForRestore(next)) return
     snapshot.value = next
     keepWorkspaceRemembered()
   })

--- a/apps/website/src/config/workshop-session-state.ts
+++ b/apps/website/src/config/workshop-session-state.ts
@@ -57,6 +57,25 @@ function stopListeners(): void {
   stopFocusListener = undefined
 }
 
+// A refresh that means "keep my session fresh" must keep the workspace the
+// session is in: a target-less mint resolves the personal workspace, which
+// reads as the account silently switching itself.
+function currentWorkspaceId(): string | undefined {
+  const current = snapshot.value
+  return current.phase === 'authenticated'
+    ? current.session.workspace.id
+    : undefined
+}
+
+const ensureFreshHere: typeof workshopSessionClient.ensureFresh = (
+  user,
+  options
+) =>
+  workshopSessionClient.ensureFresh(user, {
+    workspaceId: currentWorkspaceId(),
+    ...options
+  })
+
 async function begin(expectedGeneration: number): Promise<void> {
   const firebase = await import('./workshop-firebase')
   if (generation !== expectedGeneration) return
@@ -71,7 +90,7 @@ async function begin(expectedGeneration: number): Promise<void> {
   // billing stay a separate consumer.
   stopTelemetry = subscribeAuthRefreshTelemetry()
 
-  const onFocus = () => void workshopSessionClient.ensureFresh()
+  const onFocus = () => void ensureFreshHere()
   window.addEventListener('focus', onFocus)
   stopFocusListener = () => window.removeEventListener('focus', onFocus)
 }
@@ -133,7 +152,7 @@ export function useWorkshopSession() {
     ),
     settled: computed(() => snapshot.value.phase !== 'pending'),
     signedIn: computed(() => snapshot.value.phase === 'authenticated'),
-    ensureFresh: workshopSessionClient.ensureFresh,
+    ensureFresh: ensureFreshHere,
     remint: workshopSessionClient.remint,
     signOut
   }

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9091,12 +9091,23 @@ Enterprise`
   'nav.buyCredits': { en: 'Buy credits', 'zh-CN': '购买积分' },
   'nav.creditsLabel': { en: 'Credits', 'zh-CN': '积分' },
   'nav.workspaces': { en: 'Workspaces', 'zh-CN': '工作区' },
+  'nav.workspacesError': {
+    en: 'Could not load workspaces.',
+    'zh-CN': '无法加载工作区。'
+  },
+  'nav.workspacesLoading': {
+    en: 'Loading workspaces…',
+    'zh-CN': '正在加载工作区…'
+  },
+  'nav.switchWorkspace': {
+    en: 'Switch workspace',
+    'zh-CN': '切换工作区'
+  },
   'nav.planAndCredits': { en: 'Plan & credits', 'zh-CN': '套餐与积分' },
   'nav.workspaceSettings': {
     en: 'Workspace settings',
     'zh-CN': '工作区设置'
   },
-  'nav.switchWorkspace': { en: 'Switch workspace', 'zh-CN': '切换工作区' },
   'nav.planFree': { en: 'Free', 'zh-CN': '免费' },
   'nav.roleOwner': { en: 'Owner', 'zh-CN': '所有者' },
   'nav.roleMember': { en: 'Member', 'zh-CN': '成员' },

--- a/apps/website/src/lib/workshop/workspaces.ts
+++ b/apps/website/src/lib/workshop/workspaces.ts
@@ -1,0 +1,29 @@
+import type { z } from 'zod'
+
+import { zListWorkspacesResponse } from '@comfyorg/ingest-types/zod'
+
+import { WORKSHOP_CLOUD_BASE_URL } from '../../config/workshop-env'
+
+export type WorkspaceWithRole = z.infer<
+  typeof zListWorkspacesResponse
+>['workspaces'][number]
+
+/**
+ * The workspaces the signed-in account belongs to, from the session's own
+ * Cloud. Switching itself is the session client's remint with a target
+ * workspace id; this list is what makes the targets visible.
+ */
+export async function listWorkspaces(
+  token: string
+): Promise<readonly WorkspaceWithRole[]> {
+  const response = await fetch(
+    new URL('/api/workspaces', WORKSHOP_CLOUD_BASE_URL),
+    { headers: { Authorization: 'Bearer ' + token } }
+  )
+  if (!response.ok)
+    throw new Error('Workspace list failed with status ' + response.status)
+  const body: unknown = await response.json().catch(() => undefined)
+  const parsed = zListWorkspacesResponse.safeParse(body)
+  if (!parsed.success) throw new Error('Workspace list response malformed')
+  return parsed.data.workspaces
+}


### PR DESCRIPTION
The profile menu from the DES-1015 board ([Figma 4113-2](https://www.figma.com/design/cULtZN6S9CT5BUaR15qzJ7/Comfy.org-Billing?node-id=4113-2)), rebuilt on the real session now that unified auth (#17283) is merged.

**In:** workspace header with avatar/initials · **Add credits** row with the live balance beside it (button still unwired — destination pending, see #17400) · **Workspace settings** out to Cloud · footer bar with truncating email and a quiet sign-out.

**Deliberately out, waiting on data:** the `PRO · OWNER` plan/role line (session carries neither yet) and the workspace switcher (one workspace per session today). Both slot back in without moving anything.

Not visually verified signed-in from this environment — auth is real here, so the menu needs a signed-in session on the Vercel preview to see. 15 menu tests (incl. SSR) pass; typecheck 0 errors.

Base: `comfydesigner/workshop-add-credits-ui` (extends its menu work).
