### PR TITLE
Merge main into be-11470-recording-tooling-ts (unblock 16782)

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -128,8 +128,8 @@ jobs:
           if-no-files-found: warn
 
   playwright-tests:
-    # Ideally, each shard runs test in 6 minutes, but allow up to 15 minutes
-    timeout-minutes: 15
+    # Ideally, each shard runs test in 6 minutes, but allow up to 30 minutes
+    timeout-minutes: 30
     needs: setup
     runs-on: ubuntu-latest
     container:

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -677,7 +677,7 @@ fix so the bug stays fixed:
 
 1. **Record the conversation.** Reproduce the bug's turn with
    `scripts/agentConversationRecord.ts` against the non-standalone local
-   stack (Postgres + doc host). In that mode the agent writes the per-op
+   stack (Postgres + Redis + doc host). In that mode the agent writes the per-op
    audit rows (`agent_tool_calls` parent and child rows) to Postgres,
    which is what a replay asserts; the doc host is a separate required
    service and writes none of them. That one command records the turn and

--- a/browser_tests/tests/defaultKeybindings.spec.ts
+++ b/browser_tests/tests/defaultKeybindings.spec.ts
@@ -315,6 +315,24 @@ test.describe('Default Keybindings', { tag: '@keyboard' }, () => {
         .toBeLessThan(initialCount)
     })
 
+    test('Select-all still reaches the canvas after the settings dialog closes', async ({
+      comfyPage
+    }) => {
+      const nodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+      expect(nodeCount).toBeGreaterThan(1)
+
+      await comfyPage.settingDialog.open()
+      await comfyPage.settingDialog.close()
+
+      await comfyPage.keyboard.press('Control+a')
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => window.app!.canvas.selectedItems.size)
+        )
+        .toBe(nodeCount)
+    })
+
     test("'r' refreshes node definitions", async ({ comfyPage }) => {
       const request = await pressKeyAndExpectRequest(
         comfyPage,

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -30,6 +30,30 @@ test.describe('Group node migration', { tag: '@node' }, () => {
     expect(state.hasGroupNodesExtra).toBe(false)
   })
 
+  test('Preserves group node widget values through subgraph conversion', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('groupnodes/group_node_v1.3.3')
+
+    const interiorValues = await comfyPage.page.evaluate(() =>
+      [...window.app!.graph.subgraphs.values()].flatMap((subgraph) =>
+        subgraph.nodes.flatMap(
+          (node) => node.widgets?.map((widget) => widget.value) ?? []
+        )
+      )
+    )
+
+    expect(interiorValues).toHaveLength(14)
+    expect(interiorValues).toEqual(
+      expect.arrayContaining([
+        156680208700286,
+        'euler',
+        'v1-5-pruned-emaonly.ckpt',
+        expect.stringContaining('purple galaxy bottle')
+      ])
+    )
+  })
+
   test(
     'Loads a legacy ("/") separator group node without error and converts it',
     { tag: ['@vue-nodes'] },

--- a/browser_tests/tests/legacyDoNotReplicate/legacyEcosystemDrawSerialize.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyEcosystemDrawSerialize.spec.ts
@@ -1,0 +1,211 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Legacy ecosystem widget draw and serialization mutations',
+  { tag: ['@vue-nodes', '@widget'] },
+  () => {
+    test('a no-op custom draw hides only its widget and preserves its value', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+      const steps = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+      const cfg = comfyPage.vueNodes.getWidgetByName('KSampler', 'cfg')
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.value = 37
+        widget.hidden = true
+        widget.draw = () => {}
+        widget.computeSize = () => [0, -4]
+      })
+      await comfyPage.nextFrame()
+
+      await expect(steps).toBeHidden()
+      await expect(cfg).toBeVisible()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(37)
+    })
+
+    test('a connected custom draw is suppressed until its input disconnects', async ({
+      comfyPage
+    }) => {
+      await comfyPage.nodeOps.clearGraph()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.LiteGraph!.createNode('Note')!
+        node.title = 'Connected custom draw'
+        const widget = node.addWidget('number', 'steps', 20, () => {})
+        node.addInput('steps', 'INT', { widget: { name: widget.name } })
+        window.app!.graph.add(node)
+
+        const legacy = Object.assign(widget, { drawCalls: 0 })
+        widget.draw = function (ctx, _owner, width, y, height) {
+          legacy.drawCalls++
+          ctx.fillRect(0, y, width, height)
+        }
+        const source = window.LiteGraph!.createNode('Note')!
+        source.addOutput('steps', 'INT')
+        window.app!.graph.add(source)
+        const link = source.connect(0, node, 0)
+        if (!link) throw new Error('Failed to connect custom draw widget input')
+        window.app!.graph.setDirtyCanvas(true, true)
+      })
+      await comfyPage.nextFrame()
+
+      const node = comfyPage.vueNodes.getNodeByTitle('Connected custom draw')
+      await expect(node).toBeVisible()
+      const steps = comfyPage.vueNodes.getWidgetByName(
+        'Connected custom draw',
+        'steps'
+      )
+      await expect(steps).toBeVisible()
+      await expect(node.locator('.lg-node-widget canvas')).toHaveCount(0)
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.title === 'Connected custom draw'
+            )
+            const widget = node?.widgets?.find(
+              (candidate) => candidate.name === 'steps'
+            )
+            return widget &&
+              'drawCalls' in widget &&
+              typeof widget.drawCalls === 'number'
+              ? widget.drawCalls
+              : 0
+          })
+        )
+        .toBe(0)
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.title === 'Connected custom draw'
+        )
+        if (!node) throw new Error('Connected custom draw node not found')
+
+        node.disconnectInput(0)
+      })
+      await comfyPage.nextFrame()
+
+      await expect(steps).toHaveCount(0)
+      await expect(node.locator('.lg-node-widget canvas')).toHaveCount(1)
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.title === 'Connected custom draw'
+            )
+            const widget = node?.widgets?.find(
+              (candidate) => candidate.name === 'steps'
+            )
+            return widget &&
+              'drawCalls' in widget &&
+              typeof widget.drawCalls === 'number'
+              ? widget.drawCalls
+              : 0
+          })
+        )
+        .toBeGreaterThan(0)
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.title === 'Connected custom draw'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(20)
+    })
+
+    test('serialize false removes a widget from both positional and named values', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+
+      const { before, after } = await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!node || !widget) throw new Error('KSampler steps widget not found')
+
+        widget.value = 37
+        const before = node.serialize()
+        widget.serialize = false
+        const after = node.serialize()
+        return { before, after }
+      })
+
+      expect(before.widgets_values_named?.steps).toBe(37)
+      expect(after.widgets_values_named).toEqual(
+        Object.fromEntries(
+          Object.entries(before.widgets_values_named ?? {}).filter(
+            ([name]) => name !== 'steps'
+          )
+        )
+      )
+      expect(before.widgets_values).toContain(37)
+      expect(after.widgets_values).toEqual(
+        before.widgets_values?.filter((value) => value !== 37)
+      )
+    })
+
+    test('wholesale options replacement keeps a toggle functional and preserves hidden state', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('widgets/boolean_widget')
+      const node = comfyPage.vueNodes.getNodeByTitle('Node With Boolean Input')
+      const enabledButton = node.getByRole('button', { name: 'Enabled' })
+
+      await comfyPage.page.evaluate(() => {
+        const widget = window.app!.graph.nodes[0]?.widgets?.[0]
+        if (!widget) throw new Error('Boolean widget not found')
+        widget.options = { on: 'Enabled', off: 'Disabled' }
+      })
+      await comfyPage.nextFrame()
+
+      await expect(enabledButton).toBeVisible()
+      await enabledButton.click()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(
+            () => window.app!.graph.nodes[0]?.widgets?.[0]?.value
+          )
+        )
+        .toBe(true)
+
+      await comfyPage.page.evaluate(() => {
+        const widget = window.app!.graph.nodes[0]?.widgets?.[0]
+        if (!widget) throw new Error('Boolean widget not found')
+        widget.options.hidden = true
+        widget.options = { on: 'Enabled', off: 'Disabled' }
+      })
+      await comfyPage.nextFrame()
+
+      await expect(node).toBeVisible()
+      await expect(enabledButton).toHaveCount(0)
+    })
+  }
+)

--- a/browser_tests/tests/legacyDoNotReplicate/legacyEcosystemHiddenRestore.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyEcosystemHiddenRestore.spec.ts
@@ -1,0 +1,209 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Legacy ecosystem widget visibility patterns',
+  { tag: ['@vue-nodes', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    })
+
+    test('restores visibility from a captured origHidden value', async ({
+      comfyPage
+    }) => {
+      const steps = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        const legacyWidget = Object.assign(widget, {
+          origHidden: widget.hidden ?? false
+        })
+        legacyWidget.hidden = true
+      })
+      await comfyPage.nextFrame()
+      await expect(steps).toBeHidden()
+
+      const hidden = await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        const origHidden = Reflect.get(widget, 'origHidden')
+        if (typeof origHidden !== 'boolean') {
+          throw new Error('KSampler steps origHidden value not found')
+        }
+        widget.hidden = origHidden
+        return widget.hidden
+      })
+      await comfyPage.nextFrame()
+
+      expect(hidden).toBe(false)
+      await expect(steps).toBeVisible()
+    })
+
+    test('keeps widget.hidden false while its associated input is connected', async ({
+      comfyPage
+    }) => {
+      const steps = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      const connectedHidden = await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!node || !widget) throw new Error('KSampler steps widget not found')
+        if (node.isSubgraphNode())
+          throw new Error('KSampler is a subgraph node')
+
+        const producer = window.LiteGraph!.createNode('Note')!
+        producer.addOutput('INT', 'INT')
+        window.app!.graph.add(producer)
+
+        const input = node.addInput('steps', 'INT', {
+          widget: { name: widget.name }
+        })
+        const inputIndex = node.inputs.indexOf(input)
+        const capturedValue = widget.hidden ?? false
+        const link = producer.connect(0, node, inputIndex)
+        if (!link) throw new Error('Failed to connect steps widget input')
+
+        return {
+          capturedValue,
+          hidden: widget.hidden
+        }
+      })
+      await comfyPage.nextFrame()
+
+      expect(connectedHidden).toEqual({
+        capturedValue: false,
+        hidden: false
+      })
+      await expect(steps).toBeVisible()
+
+      const restoredHidden = await comfyPage.page.evaluate((capturedValue) => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!node || !widget) throw new Error('KSampler steps widget not found')
+
+        node.disconnectInput('steps')
+        widget.hidden = capturedValue
+        return widget.hidden
+      }, connectedHidden.capturedValue)
+      await comfyPage.nextFrame()
+
+      expect(restoredHidden).toBe(false)
+      await expect(steps).toBeVisible()
+    })
+
+    test('toggles multiple widgets without dropping their serialized values', async ({
+      comfyPage
+    }) => {
+      const steps = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+      const cfg = comfyPage.vueNodes.getWidgetByName('KSampler', 'cfg')
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        if (!node) throw new Error('KSampler node not found')
+
+        for (const name of ['steps', 'cfg']) {
+          const widget = node.widgets?.find(
+            (candidate) => candidate.name === name
+          )
+          if (!widget) throw new Error(`KSampler ${name} widget not found`)
+          const show = false
+          widget.hidden = !show
+        }
+      })
+      await comfyPage.nextFrame()
+
+      await expect(steps).toBeHidden()
+      await expect(cfg).toBeHidden()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            const values = node?.serialize().widgets_values_named
+            return { steps: values?.steps, cfg: values?.cfg }
+          })
+        )
+        .toEqual({ steps: 20, cfg: 8 })
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        if (!node) throw new Error('KSampler node not found')
+
+        for (const name of ['steps', 'cfg']) {
+          const widget = node.widgets?.find(
+            (candidate) => candidate.name === name
+          )
+          if (!widget) throw new Error(`KSampler ${name} widget not found`)
+          const show = true
+          widget.hidden = !show
+        }
+      })
+      await comfyPage.nextFrame()
+
+      await expect(steps).toBeVisible()
+      await expect(cfg).toBeVisible()
+    })
+
+    test('reacts to options.hidden being set and cleared', async ({
+      comfyPage
+    }) => {
+      const steps = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+        widget.options.hidden = true
+      })
+      await comfyPage.nextFrame()
+      await expect(steps).toBeHidden()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+        widget.options.hidden = false
+      })
+      await comfyPage.nextFrame()
+
+      await expect(steps).toBeVisible()
+    })
+  }
+)

--- a/browser_tests/tests/legacyDoNotReplicate/legacyEcosystemTypeToggle.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyEcosystemTypeToggle.spec.ts
@@ -1,0 +1,235 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Legacy ecosystem widget type toggles',
+  { tag: ['@vue-nodes', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    })
+
+    test('restoring an efficiency-nodes type toggle restores its Vue control', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+      await expect(widget).toBeVisible()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.value = 37
+        widget.type = 'tschide'
+        widget.computeSize = () => [0, -4]
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeHidden()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(37)
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.type = 'number'
+        widget.computeSize = undefined
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeVisible()
+      await expect(widget.getByRole('spinbutton')).toHaveValue('37')
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(37)
+    })
+
+    test('keeps a pre-hidden widget hidden after restoring its type', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.hidden = true
+        widget.type = 'tschide'
+        widget.computeSize = () => [0, -4]
+        widget.type = 'number'
+        widget.computeSize = undefined
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeHidden()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            const widget = node?.widgets?.find(
+              (candidate) => candidate.name === 'steps'
+            )
+            return { hidden: widget?.hidden, type: widget?.type }
+          })
+        )
+        .toEqual({ hidden: true, type: 'number' })
+    })
+
+    test('hides an mxToolkit-style hidden combo without dropping node data', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName(
+        'KSampler',
+        'sampler_name'
+      )
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'sampler_name'
+        )
+        if (!widget) throw new Error('KSampler sampler_name widget not found')
+
+        widget.hidden = true
+        widget.type = 'hidden'
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeHidden()
+      await expect(comfyPage.vueNodes.getNodeByTitle('KSampler')).toBeVisible()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.sampler_name
+          })
+        )
+        .toBe('euler')
+    })
+
+    test('renders an unknown sentinel as a visible legacy fallback', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+      const node = comfyPage.vueNodes.getNodeByTitle('KSampler')
+      await expect(widget).toBeVisible()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.value = 39
+        widget.type = 'ggcustomtag'
+        widget.computeSize = () => [0, -4]
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toHaveCount(0)
+      await expect(node.locator('.lg-node-widget canvas')).toBeVisible()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(39)
+    })
+
+    test('restores an m3rr-style converted widget after hiding it', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.value = 40
+        widget.hidden = true
+        widget.type = 'converted-widget'
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeHidden()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(40)
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.type = 'number'
+        widget.hidden = false
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeVisible()
+      await expect(widget.getByRole('spinbutton')).toHaveValue('40')
+    })
+  }
+)

--- a/src/composables/graph/useSubgraphOperations.test.ts
+++ b/src/composables/graph/useSubgraphOperations.test.ts
@@ -1,9 +1,16 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { LGraph, LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode, SubgraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
 import { useSubgraphOperations } from './useSubgraphOperations'
+
+const captureCanvasState = vi.fn()
 
 vi.mock<unknown>(
   import('@/composables/canvas/useSelectedLiteGraphItems'),
@@ -25,7 +32,58 @@ function createRegularNode(): LGraphNode {
 
 describe('useSubgraphOperations', () => {
   beforeEach(() => {
+    useCanvasStore().selectedItems = []
+    useWorkflowStore().activeWorkflow = fromPartial<LoadedComfyWorkflow>({
+      changeTracker: { captureCanvasState }
+    })
     vi.mocked(useSubgraphStore().publishSubgraph).mockResolvedValue(undefined)
+  })
+
+  it('preserves previews and history when every unpack is refused', () => {
+    const subgraphNode = createSubgraphNode()
+    const unpackSubgraph = vi.fn(() => false)
+    const revokeSubgraphPreviews = vi
+      .spyOn(useNodeOutputStore(), 'revokeSubgraphPreviews')
+      .mockImplementation(() => {})
+    vi.mocked(useCanvasStore().getCanvas).mockReturnValue(
+      fromPartial<LGraphCanvas>({
+        graph: fromPartial<LGraph>({ unpackSubgraph }),
+        selectedItems: new Set([subgraphNode])
+      })
+    )
+
+    useSubgraphOperations().unpackSubgraph()
+
+    expect(unpackSubgraph).toHaveBeenCalledWith(subgraphNode, {
+      skipMissingNodes: true
+    })
+    expect(revokeSubgraphPreviews).not.toHaveBeenCalled()
+    expect(captureCanvasState).not.toHaveBeenCalled()
+  })
+
+  it('updates previews and history only for successful unpacks', () => {
+    const refusedNode = createSubgraphNode()
+    const unpackedNode = createSubgraphNode()
+    const unpackSubgraph = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+    const graph = fromPartial<LGraph>({ unpackSubgraph })
+    const revokeSubgraphPreviews = vi
+      .spyOn(useNodeOutputStore(), 'revokeSubgraphPreviews')
+      .mockImplementation(() => {})
+    vi.mocked(useCanvasStore().getCanvas).mockReturnValue(
+      fromPartial<LGraphCanvas>({
+        graph,
+        selectedItems: new Set([refusedNode, unpackedNode])
+      })
+    )
+
+    useSubgraphOperations().unpackSubgraph()
+
+    expect(revokeSubgraphPreviews).toHaveBeenCalledOnce()
+    expect(revokeSubgraphPreviews).toHaveBeenCalledWith(unpackedNode, graph)
+    expect(captureCanvasState).toHaveBeenCalledOnce()
   })
 
   it('addSubgraphToLibrary calls publishSubgraph when single SubgraphNode selected', async () => {

--- a/src/composables/graph/useSubgraphOperations.ts
+++ b/src/composables/graph/useSubgraphOperations.ts
@@ -38,11 +38,15 @@ export function useSubgraphOperations() {
     const graph = canvas.subgraph ?? canvas.graph
     if (!graph) return
 
+    let changed = false
     for (const subgraphNode of subgraphNodes) {
-      nodeOutputStore.revokeSubgraphPreviews(subgraphNode)
-      graph.unpackSubgraph(subgraphNode, { skipMissingNodes })
+      if (!graph.unpackSubgraph(subgraphNode, { skipMissingNodes })) continue
+      nodeOutputStore.revokeSubgraphPreviews(subgraphNode, graph)
+      changed = true
     }
-    workflowStore.activeWorkflow?.changeTracker.captureCanvasState()
+    if (changed) {
+      workflowStore.activeWorkflow?.changeTracker.captureCanvasState()
+    }
   }
 
   const unpackSubgraph = () => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -138,6 +138,7 @@ import { SubgraphInputNode } from './subgraph/SubgraphInputNode'
 import { SubgraphOutput } from './subgraph/SubgraphOutput'
 import { SubgraphOutputNode } from './subgraph/SubgraphOutputNode'
 import {
+  findUnresolvableSubgraphLink,
   findReleasableSubgraphs,
   findUsedSubgraphIds,
   getBoundaryLinks,
@@ -2430,9 +2431,28 @@ export class LGraph
   unpackSubgraph(
     subgraphNode: SubgraphNode,
     options?: { skipMissingNodes?: boolean }
-  ) {
+  ): boolean {
     if (!(subgraphNode instanceof SubgraphNode))
       throw new Error('Can only unpack Subgraph Nodes')
+
+    const malformedLink = findUnresolvableSubgraphLink(subgraphNode)
+    if (malformedLink) {
+      reportError(
+        new Error('Cannot unpack subgraph: unresolvable inner link'),
+        {
+          errorType: 'error_unpacking_subgraph_link',
+          context: {
+            subgraphNodeId: subgraphNode.id,
+            linkId: malformedLink.id,
+            originId: malformedLink.origin_id,
+            originSlot: malformedLink.origin_slot,
+            targetId: malformedLink.target_id,
+            targetSlot: malformedLink.target_slot
+          }
+        }
+      )
+      return false
+    }
 
     // Record state before unpacking for proper undo support
     this.beforeChange()
@@ -2443,6 +2463,7 @@ export class LGraph
       // Mark state change complete for proper undo support
       this.afterChange()
     }
+    return true
   }
 
   private _unpackSubgraphImpl(

--- a/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
@@ -10,7 +10,11 @@ import {
 
 import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
 import { LGraphGroup } from '@/lib/litegraph/src/litegraph'
-import type { LGraph, Positionable } from '@/lib/litegraph/src/litegraph'
+import type {
+  LGraph,
+  Positionable,
+  SubgraphNode
+} from '@/lib/litegraph/src/litegraph'
 import {
   createTestNode,
   createTestWidgetNode
@@ -19,6 +23,7 @@ import { useLinkStore } from '@/stores/linkStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
+import { toNodeId } from '@/types/nodeId'
 import { toRerouteId } from '@/types/rerouteId'
 
 import {
@@ -32,6 +37,20 @@ import {
 beforeEach(() => {
   resetSubgraphFixtureState()
 })
+
+function expectUnpackRejected(graph: LGraph, subgraphNode: SubgraphNode): void {
+  const before = JSON.stringify(graph.serialize())
+  const nodeCount = graph.nodes.length
+  const beforeChange = vi.spyOn(graph, 'beforeChange')
+  const afterChange = vi.spyOn(graph, 'afterChange')
+
+  expect(graph.unpackSubgraph(subgraphNode)).toBe(false)
+  expect(graph.getNodeById(subgraphNode.id)).toBeDefined()
+  expect(graph.nodes.length).toBe(nodeCount)
+  expect(JSON.stringify(graph.serialize())).toBe(before)
+  expect(beforeChange).not.toHaveBeenCalled()
+  expect(afterChange).not.toHaveBeenCalled()
+}
 
 describe('SubgraphConversion', () => {
   describe('Convert to Subgraph store integrity', () => {
@@ -237,6 +256,102 @@ describe('SubgraphConversion', () => {
 
       expect(graph.reroutes.size).toBe(2)
       expect(graph.groups.length).toBe(1)
+    })
+    it('Should leave the graph untouched when a subgraph link is malformed', () => {
+      const subgraph = createTestSubgraph()
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph!
+      graph.add(subgraphNode)
+
+      const innerNode1 = createTestNode(subgraph, [], ['number'])
+      const innerNode2 = createTestNode(subgraph, ['number'], [])
+      const innerLink = innerNode1.connect(0, innerNode2, 0)
+      assert(innerLink)
+
+      innerLink.target_id = toNodeId(9999)
+      expectUnpackRejected(graph, subgraphNode)
+    })
+    it('Should leave the graph untouched when a subgraph link has an invalid origin slot', () => {
+      const subgraph = createTestSubgraph()
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph!
+      graph.add(subgraphNode)
+
+      const innerNode1 = createTestNode(subgraph, [], ['number'])
+      const innerNode2 = createTestNode(subgraph, ['number'], [])
+      const innerLink = innerNode1.connect(0, innerNode2, 0)
+      assert(innerLink)
+
+      innerLink.origin_slot = 9999
+      expectUnpackRejected(graph, subgraphNode)
+    })
+    it('Should leave the graph untouched when a subgraph link has an invalid target slot', () => {
+      const subgraph = createTestSubgraph()
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph!
+      graph.add(subgraphNode)
+
+      const innerNode1 = createTestNode(subgraph, [], ['number'])
+      const innerNode2 = createTestNode(subgraph, ['number'], [])
+      const innerLink = innerNode1.connect(0, innerNode2, 0)
+      assert(innerLink)
+
+      innerLink.target_slot = 9999
+      expectUnpackRejected(graph, subgraphNode)
+    })
+    it.for([9999, 0.5])(
+      'Should leave the graph untouched when a subgraph input link has invalid boundary slot %s',
+      (invalidSlot) => {
+        const subgraph = createTestSubgraph({
+          inputs: [{ name: 'value', type: 'number' }]
+        })
+        const subgraphNode = createTestSubgraphNode(subgraph)
+        const graph = subgraphNode.graph!
+        graph.add(subgraphNode)
+
+        const innerNode = createTestNode(subgraph, ['number'])
+        const innerLink = subgraph.inputNode.slots[0].connect(
+          innerNode.inputs[0],
+          innerNode
+        )
+        assert(innerLink)
+        innerLink.origin_slot = invalidSlot
+        expectUnpackRejected(graph, subgraphNode)
+      }
+    )
+    it.for([9999, 0.5])(
+      'Should leave the graph untouched when a subgraph output link has invalid boundary slot %s',
+      (invalidSlot) => {
+        const subgraph = createTestSubgraph({
+          outputs: [{ name: 'value', type: 'number' }]
+        })
+        const subgraphNode = createTestSubgraphNode(subgraph)
+        const graph = subgraphNode.graph!
+        graph.add(subgraphNode)
+
+        const innerNode = createTestNode(subgraph, [], ['number'])
+        const innerLink = subgraph.outputNode.slots[0].connect(
+          innerNode.outputs[0],
+          innerNode
+        )
+        assert(innerLink)
+        innerLink.target_slot = invalidSlot
+        expectUnpackRejected(graph, subgraphNode)
+      }
+    )
+    it('Should report success when unpacking an intact subgraph', () => {
+      const subgraph = createTestSubgraph()
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph!
+      graph.add(subgraphNode)
+
+      const innerNode1 = createTestNode(subgraph, [], ['number'])
+      const innerNode2 = createTestNode(subgraph, ['number'], [])
+      assert(innerNode1.connect(0, innerNode2, 0))
+
+      expect(graph.unpackSubgraph(subgraphNode)).toBe(true)
+      expect(graph.getNodeById(subgraphNode.id)).toBeNull()
+      expect(graph.nodes.length).toBe(2)
     })
     it('Should map reroutes onto split outputs', () => {
       const subgraph = createTestSubgraph({

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -24,6 +24,7 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import { LiteGraph, createUuidv4 } from '@/lib/litegraph/src/litegraph'
 import { nextUniqueName } from '@/lib/litegraph/src/strings'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import type {
   ISerialisedNode,
   SerialisableLLink,
@@ -241,6 +242,32 @@ export function multiClone(nodes: Iterable<LGraphNode>): ISerialisedNode[] {
   }
 
   return clonedNodes
+}
+
+export function findUnresolvableSubgraphLink(
+  subgraphNode: SubgraphNode
+): LLink | undefined {
+  const { subgraph } = subgraphNode
+
+  for (const link of subgraph.links.values()) {
+    const originOk =
+      link.origin_id === UNASSIGNED_NODE_ID ||
+      (link.origin_id === SUBGRAPH_INPUT_ID
+        ? Number.isInteger(link.origin_slot) &&
+          link.origin_slot >= 0 &&
+          link.origin_slot < subgraph.inputs.length
+        : subgraph.getNodeById(link.origin_id)?.outputs[link.origin_slot] !==
+          undefined)
+    const targetOk =
+      link.target_id === UNASSIGNED_NODE_ID ||
+      (link.target_id === SUBGRAPH_OUTPUT_ID
+        ? Number.isInteger(link.target_slot) &&
+          link.target_slot >= 0 &&
+          link.target_slot < subgraph.outputs.length
+        : subgraph.getNodeById(link.target_id)?.inputs[link.target_slot] !==
+          undefined)
+    if (!originOk || !targetOk) return link
+  }
 }
 
 /**

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -55,6 +55,14 @@ vi.mock<unknown>(import('@/platform/workspace/api/workspaceApi'), () => ({
   WorkspaceApiError: mockWorkspaceApiError
 }))
 
+const mockCapabilitiesRefresh = vi.hoisted(() => vi.fn(async () => undefined))
+vi.mock<unknown>(
+  import('@/platform/workspace/composables/useBillingCapabilities'),
+  () => ({
+    useBillingCapabilities: () => ({ refresh: mockCapabilitiesRefresh })
+  })
+)
+
 vi.mock<unknown>(
   import('@/platform/cloud/subscription/composables/useBillingPlans'),
   () => ({
@@ -892,6 +900,162 @@ describe('useWorkspaceBilling', () => {
 
       await expect(billing.manageSubscription()).rejects.toThrow('portal down')
       expect(billing.error.value).toBe('portal down')
+    })
+
+    it('re-reads billing state once when the tab regains visibility after opening the portal', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockWorkspaceApi.getBillingBalance.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledTimes(1)
+      expect(mockCapabilitiesRefresh).toHaveBeenCalledTimes(1)
+
+      // One-shot: switching tabs later must not keep refetching.
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-reads billing state when focus returns without a visibility change', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockWorkspaceApi.getBillingBalance.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      window.dispatchEvent(new Event('focus'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledTimes(1)
+      expect(mockCapabilitiesRefresh).toHaveBeenCalledTimes(1)
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores hidden transitions and refreshes on the visible return', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+      const visibilitySpy = vi.spyOn(document, 'visibilityState', 'get')
+      visibilitySpy.mockReturnValue('hidden')
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+
+      visibilitySpy.mockReturnValue('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('replaces pending return listeners on repeated portal opens', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockWorkspaceApi.getBillingBalance.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      window.dispatchEvent(new Event('focus'))
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledTimes(1)
+      expect(mockCapabilitiesRefresh).toHaveBeenCalledTimes(1)
+    })
+
+    it('removes pending return listeners when its scope is disposed', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => ({}) as Window)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+      scope?.stop()
+      scope = undefined
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+      expect(mockCapabilitiesRefresh).not.toHaveBeenCalled()
+    })
+
+    it('does not watch for a return when the portal window is blocked', async () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => null)
+      )
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: 'https://billing.example/portal'
+      })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+      expect(mockCapabilitiesRefresh).not.toHaveBeenCalled()
+    })
+
+    it('does not watch for a return when no portal was opened', async () => {
+      vi.stubGlobal('open', vi.fn())
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({ url: '' })
+
+      const billing = setupBilling()
+      await billing.manageSubscription()
+
+      mockWorkspaceApi.getBillingStatus.mockClear()
+      mockCapabilitiesRefresh.mockClear()
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
+      expect(mockCapabilitiesRefresh).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -1,4 +1,11 @@
-import { computed, ref, shallowRef, watch } from 'vue'
+import {
+  computed,
+  getCurrentScope,
+  onScopeDispose,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
 
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
@@ -19,6 +26,7 @@ import {
   WorkspaceApiError,
   workspaceApi
 } from '@/platform/workspace/api/workspaceApi'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
@@ -366,6 +374,44 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     }
   }
 
+  // A cancellation or card change made in the portal tab or window never
+  // pushes back to this one — status has no return refetch and capability
+  // reads are paced — so the next return to the app re-reads everything the
+  // portal could have changed.
+  let stopPortalReturnRefresh: (() => void) | null = null
+  function refreshOnPortalReturn() {
+    stopPortalReturnRefresh?.()
+
+    const stopListening = () => {
+      document.removeEventListener('visibilitychange', onReturn)
+      window.removeEventListener('focus', onReturn)
+      stopPortalReturnRefresh = null
+    }
+    const onReturn = (event: Event) => {
+      if (
+        event.type === 'visibilitychange' &&
+        document.visibilityState !== 'visible'
+      ) {
+        return
+      }
+      stopListening()
+      void Promise.allSettled([
+        fetchStatus(),
+        fetchBalance(),
+        useBillingCapabilities().refresh()
+      ])
+    }
+    stopPortalReturnRefresh = stopListening
+    document.addEventListener('visibilitychange', onReturn)
+    window.addEventListener('focus', onReturn)
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPortalReturnRefresh?.()
+    })
+  }
+
   async function manageSubscription(): Promise<void> {
     isLoading.value = true
     error.value = null
@@ -373,7 +419,8 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       const returnUrl = window.location.href
       const response = await workspaceApi.getPaymentPortalUrl(returnUrl)
       if (response.url) {
-        window.open(response.url, '_blank')
+        const portalWindow = window.open(response.url, '_blank')
+        if (portalWindow) refreshOnPortalReturn()
       }
     } catch (err) {
       error.value =

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -3,7 +3,11 @@ import { mapKeys } from 'es-toolkit'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-import type { LGraphNode, SubgraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  LGraph,
+  LGraphNode,
+  SubgraphNode
+} from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type {
@@ -404,10 +408,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     app.nodePreviewImages = clone(nodePreviewImages.value)
   }
 
-  function revokeSubgraphPreviews(subgraphNode: SubgraphNode) {
-    const { graph } = subgraphNode
-    if (!graph) return
-
+  function revokeSubgraphPreviews(subgraphNode: SubgraphNode, graph: LGraph) {
     revokePreviewsByLocatorId(
       createNodeLocatorId(graph.isRootGraph ? null : graph.id, subgraphNode.id)
     )


### PR DESCRIPTION
<!-- authored-by:agent lane-test-harness-stack -->
Merges `origin/main` into the head branch of https://github.com/Comfy-Org/ComfyUI_frontend/pull/16782 so that PR becomes mergeable after https://github.com/Comfy-Org/ComfyUI_frontend/pull/16764 landed. No functional change beyond conflict resolution.

<details><summary>Full context for agent readers</summary>

Why: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16782 was stacked on https://github.com/Comfy-Org/ComfyUI_frontend/pull/16764. After 16764 merged and 16782 was retargeted to `main`, three files conflicted as add/add because both branches introduced them independently:

- `browser_tests/README.md`
- `browser_tests/fixtures/data/agent/agentConversation.ts`
- `browser_tests/fixtures/data/agent/agentConversation.test.ts`

Resolution: kept the 16782 versions (`--ours`) because they are the superset that 16764's copy was derived from; the label-drift fix in this branch is preserved. Same helper-PR pattern as https://github.com/Comfy-Org/ComfyUI_frontend/pull/17391 (merged), used because pushing directly to a `nathaniel/*` branch is out of scope for this lane.

Verification on the merge commit:

- `pnpm vitest run browser_tests/fixtures/data/agent` passes (2 files, 76 tests)
- `pnpm typecheck` passes

After this merges into `nathaniel/be-11470-recording-tooling-ts`, 16782 should show MERGEABLE and can be approved and enqueued.

</details>
