### PR TITLE
feat(camera-angle): 3D camera angle picker widget for the CameraAngle node

### DIFF
--- a/src/components/cameraAngle/CameraAngle.test.ts
+++ b/src/components/cameraAngle/CameraAngle.test.ts
@@ -1,0 +1,247 @@
+import { render, screen, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      cameraAngle: {
+        cameraView: 'Camera',
+        objectView: 'Object',
+        cameraViewTooltip: 'Move the camera',
+        objectViewTooltip: 'Turn the subject',
+        horizontalLabel: 'Horizontal angle',
+        verticalLabel: 'Vertical angle',
+        zoomLabel: 'Shot size',
+        preview: 'Preview',
+        showPreview: 'Show shot preview',
+        hidePreview: 'Hide shot preview',
+        horizontal: { front: 'Front', back: 'Back' },
+        vertical: { eyeLevel: 'Eye level', highAngle: 'High angle' },
+        zoom: { medium: 'Medium shot', closeUp: 'Close-up' },
+        faces: {
+          back: 'BACK',
+          left: 'LEFT',
+          right: 'RIGHT',
+          top: 'TOP',
+          bottom: 'BOTTOM'
+        }
+      }
+    }
+  }
+})
+
+type ApiMocks = Record<string, ReturnType<typeof vi.fn>>
+
+const holder = vi.hoisted(() => ({
+  toolbarWidth: null as { value: number } | null,
+  state: null as { value: Record<string, number> } | null,
+  viewMode: null as { value: string } | null,
+  prompt: null as { value: string } | null,
+  previewVisible: null as { value: boolean } | null,
+  api: null as ApiMocks | null
+}))
+
+vi.mock<unknown>(import('@vueuse/core'), async (importOriginal) => {
+  const { ref } = await import('vue')
+  const width = ref(600)
+  holder.toolbarWidth = width
+  return {
+    ...(await importOriginal()),
+    useElementSize: () => ({ width, height: ref(400) })
+  }
+})
+
+vi.mock<unknown>(import('@/composables/useCameraAngle'), async () => {
+  const { ref } = await import('vue')
+  const state = ref({ horizontal: 0, vertical: 0, zoom: 5 })
+  const viewMode = ref('camera')
+  const prompt = ref('front view eye-level shot medium shot')
+  const previewVisible = ref(false)
+  const api = {
+    initialize: vi.fn(),
+    cleanup: vi.fn(),
+    handleMouseEnter: vi.fn(),
+    handleMouseLeave: vi.fn(),
+    setViewMode: vi.fn(),
+    setPreviewVisible: vi.fn(),
+    setField: vi.fn()
+  }
+  holder.state = state
+  holder.viewMode = viewMode
+  holder.prompt = prompt
+  holder.previewVisible = previewVisible
+  holder.api = api
+  return {
+    useCameraAngle: () => ({ ...api, state, viewMode, prompt, previewVisible })
+  }
+})
+
+const { getNodeByLocatorIdMock } = vi.hoisted(() => ({
+  getNodeByLocatorIdMock: vi.fn(() => ({ id: 7 }))
+}))
+
+vi.mock<unknown>(import('@/scripts/app'), () => ({
+  app: { rootGraphOrUndefined: {} }
+}))
+vi.mock<unknown>(import('@/utils/graphTraversalUtil'), () => ({
+  getNodeByLocatorId: getNodeByLocatorIdMock
+}))
+
+import { LGraph } from '@/lib/litegraph/src/LGraph'
+import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+
+import CameraAngle from './CameraAngle.vue'
+
+const SelectStub = defineComponent({
+  name: 'Select',
+  props: { modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue'],
+  template: `
+    <div data-testid="preset-select" :data-value="modelValue">
+      <button data-testid="pick-back" @click="$emit('update:modelValue', 'back')">back</button>
+      <button data-testid="pick-close-up" @click="$emit('update:modelValue', 'closeUp')">close-up</button>
+      <slot />
+    </div>
+  `
+})
+const Passthrough = defineComponent({
+  name: 'SelectPassthrough',
+  template: '<slot />'
+})
+
+function makeWidget(): SimplifiedWidget {
+  return {
+    name: 'view',
+    type: 'cameraAngle',
+    value: 'camera',
+    options: {},
+    nodeLocatorId: createNodeLocatorId(null, toNodeId(7))
+  }
+}
+
+function renderComponent() {
+  return render(CameraAngle, {
+    props: { widget: makeWidget() },
+    global: {
+      plugins: [i18n],
+      directives: { tooltip: {} },
+      stubs: {
+        Select: SelectStub,
+        SelectContent: Passthrough,
+        SelectTrigger: Passthrough,
+        SelectValue: Passthrough,
+        SelectItem: Passthrough
+      }
+    }
+  })
+}
+
+function api(): ApiMocks {
+  return holder.api!
+}
+
+describe('CameraAngle', () => {
+  beforeEach(() => {
+    useCanvasStore().currentGraph = new LGraph()
+    holder.state!.value = { horizontal: 0, vertical: 0, zoom: 5 }
+    holder.viewMode!.value = 'camera'
+    holder.previewVisible!.value = false
+    holder.toolbarWidth!.value = 600
+    Object.values(api()).forEach((fn) => fn.mockClear())
+  })
+
+  it('initializes the viewport on mount and cleans up on unmount', () => {
+    const { unmount } = renderComponent()
+    expect(getNodeByLocatorIdMock).toHaveBeenCalledWith(
+      expect.anything(),
+      createNodeLocatorId(null, toNodeId(7))
+    )
+    expect(api().initialize).toHaveBeenCalledOnce()
+
+    unmount()
+    expect(api().cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('switches to object view from the toolbar', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    expect(screen.getByRole('button', { name: 'Camera' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    await user.click(screen.getByRole('button', { name: 'Object' }))
+
+    expect(api().setViewMode).toHaveBeenCalledWith('object')
+  })
+
+  it('toggles the shot preview from the toolbar and disables it in object view', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    const button = screen.getByRole('button', { name: 'Show shot preview' })
+    expect(button).toHaveAttribute('aria-pressed', 'false')
+    await user.click(button)
+    expect(api().setPreviewVisible).toHaveBeenCalledWith(true)
+
+    holder.viewMode!.value = 'object'
+    await nextTick()
+    expect(
+      screen.getByRole('button', { name: 'Show shot preview' })
+    ).toBeDisabled()
+  })
+
+  it('collapses the toolbar to icons when it gets narrow', async () => {
+    renderComponent()
+    expect(screen.getByRole('button', { name: 'Object' })).toHaveTextContent(
+      'Object'
+    )
+
+    holder.toolbarWidth!.value = 300
+    await nextTick()
+
+    const button = screen.getByRole('button', { name: 'Object' })
+    expect(button).not.toHaveTextContent('Object')
+    expect(
+      screen.getByRole('button', { name: 'Show shot preview' })
+    ).not.toHaveTextContent('Preview')
+  })
+
+  it('shows the prompt that will be output', () => {
+    renderComponent()
+    expect(screen.getByTestId('camera-angle-prompt')).toHaveTextContent(
+      'front view eye-level shot medium shot'
+    )
+  })
+
+  it('reflects the current buckets in the preset selects', () => {
+    holder.state!.value = { horizontal: 180, vertical: 50, zoom: 9 }
+    renderComponent()
+
+    const values = screen
+      .getAllByTestId('preset-select')
+      .map((el) => el.dataset.value)
+    expect(values).toEqual(['back', 'highAngle', 'closeUp'])
+  })
+
+  it('applies a preset value when a bucket is chosen', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    const [horizontal, , zoom] = screen.getAllByTestId('preset-select')
+    await user.click(within(horizontal).getByTestId('pick-back'))
+    await user.click(within(zoom).getByTestId('pick-close-up'))
+
+    expect(api().setField).toHaveBeenCalledWith('horizontal', 180)
+    expect(api().setField).toHaveBeenCalledWith('zoom', 8)
+  })
+})

--- a/src/components/cameraAngle/CameraAngle.vue
+++ b/src/components/cameraAngle/CameraAngle.vue
@@ -1,0 +1,241 @@
+<template>
+  <ViewportWidgetShell
+    ref="shell"
+    bottom-class="h-12"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <template #top>
+      <button
+        v-for="option in viewModeOptions"
+        :key="option.value"
+        v-tooltip.bottom="tip(option.tooltip)"
+        type="button"
+        :class="actionClass(viewMode === option.value)"
+        :aria-pressed="viewMode === option.value"
+        :aria-label="option.label"
+        @click="setViewMode(option.value)"
+      >
+        <i :class="cn('size-4', option.icon)" />
+        <span v-if="!compact">{{ option.label }}</span>
+      </button>
+      <div class="mx-1 h-5 w-px shrink-0 bg-interface-menu-stroke" />
+      <button
+        v-tooltip.bottom="tip(previewLabel)"
+        type="button"
+        :disabled="viewMode === 'object'"
+        :class="
+          cn(
+            actionClass(viewMode === 'camera' && previewVisible),
+            viewMode === 'object' && 'cursor-not-allowed opacity-40'
+          )
+        "
+        :aria-pressed="viewMode === 'camera' && previewVisible"
+        :aria-label="previewLabel"
+        @click="setPreviewVisible(!previewVisible)"
+      >
+        <i class="icon-[lucide--picture-in-picture-2] size-4" />
+        <span v-if="!compact">{{ $t('cameraAngle.preview') }}</span>
+      </button>
+      <span
+        class="ml-auto min-w-0 truncate text-xs text-muted-foreground"
+        :title="prompt"
+        data-testid="camera-angle-prompt"
+      >
+        {{ prompt }}
+      </span>
+    </template>
+    <template #bottom>
+      <Select
+        v-for="group in presetGroups"
+        :key="group.field"
+        :model-value="group.current"
+        @update:model-value="(key) => selectPreset(group.field, key)"
+      >
+        <SelectTrigger
+          size="md"
+          class="min-w-0 flex-1"
+          :aria-label="group.label"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            v-for="term in group.terms"
+            :key="term.key"
+            :value="term.key"
+          >
+            {{ $t(`cameraAngle.${group.field}.${term.key}`) }}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </template>
+  </ViewportWidgetShell>
+</template>
+
+<script setup lang="ts">
+import { useElementSize } from '@vueuse/core'
+import {
+  computed,
+  onMounted,
+  onUnmounted,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import type { Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import ViewportWidgetShell from '@/components/load3d/ViewportWidgetShell.vue'
+import { actionClass, tip } from '@/components/load3d/menubar/menuBarStyles'
+import Select from '@/components/ui/select/Select.vue'
+import SelectContent from '@/components/ui/select/SelectContent.vue'
+import SelectItem from '@/components/ui/select/SelectItem.vue'
+import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
+import SelectValue from '@/components/ui/select/SelectValue.vue'
+import { useCameraAngle } from '@/composables/useCameraAngle'
+import {
+  DISTANCE_TERMS,
+  HORIZONTAL_TERMS,
+  VERTICAL_TERMS,
+  distanceTerm,
+  horizontalTerm,
+  verticalTerm
+} from '@/extensions/core/cameraAngle/cameraAngleMath'
+import type { CameraAngleTerm } from '@/extensions/core/cameraAngle/cameraAngleMath'
+import type {
+  CameraAngleField,
+  CameraAngleViewMode
+} from '@/extensions/core/cameraAngle/types'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { app } from '@/scripts/app'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { widget } = defineProps<{
+  widget: SimplifiedWidget
+}>()
+
+const node = ref<LGraphNode | null>(null)
+
+const { t } = useI18n()
+const shell = useTemplateRef<InstanceType<typeof ViewportWidgetShell>>('shell')
+const { width: toolbarWidth } = useElementSize(
+  computed(() => shell.value?.toolbar ?? null)
+)
+const compactWidthThreshold = 420
+const compact = computed(
+  () => toolbarWidth.value > 0 && toolbarWidth.value < compactWidthThreshold
+)
+
+const {
+  initialize,
+  cleanup,
+  handleMouseEnter,
+  handleMouseLeave,
+  setViewMode,
+  setPreviewVisible,
+  setField,
+  state,
+  viewMode,
+  previewVisible,
+  prompt
+} = useCameraAngle(node as Ref<LGraphNode | null>, {
+  faceLabels: () => ({
+    back: t('cameraAngle.faces.back'),
+    left: t('cameraAngle.faces.left'),
+    right: t('cameraAngle.faces.right'),
+    top: t('cameraAngle.faces.top'),
+    bottom: t('cameraAngle.faces.bottom')
+  })
+})
+
+const previewLabel = computed(() =>
+  previewVisible.value
+    ? t('cameraAngle.hidePreview')
+    : t('cameraAngle.showPreview')
+)
+
+const viewModeOptions = computed<
+  {
+    value: CameraAngleViewMode
+    label: string
+    tooltip: string
+    icon: string
+  }[]
+>(() => [
+  {
+    value: 'camera',
+    label: t('cameraAngle.cameraView'),
+    tooltip: t('cameraAngle.cameraViewTooltip'),
+    icon: 'icon-[lucide--video]'
+  },
+  {
+    value: 'object',
+    label: t('cameraAngle.objectView'),
+    tooltip: t('cameraAngle.objectViewTooltip'),
+    icon: 'icon-[lucide--box]'
+  }
+])
+
+interface PresetGroup {
+  field: CameraAngleField
+  label: string
+  terms: readonly CameraAngleTerm[]
+  current: string
+}
+
+const presetGroups = computed<PresetGroup[]>(() => [
+  {
+    field: 'horizontal',
+    label: t('cameraAngle.horizontalLabel'),
+    terms: HORIZONTAL_TERMS,
+    current: horizontalTerm(state.value.horizontal).key
+  },
+  {
+    field: 'vertical',
+    label: t('cameraAngle.verticalLabel'),
+    terms: VERTICAL_TERMS,
+    current: verticalTerm(state.value.vertical).key
+  },
+  {
+    field: 'zoom',
+    label: t('cameraAngle.zoomLabel'),
+    terms: DISTANCE_TERMS,
+    current: distanceTerm(state.value.zoom).key
+  }
+])
+
+function selectPreset(field: CameraAngleField, key: unknown) {
+  const group = presetGroups.value.find((g) => g.field === field)
+  const term = group?.terms.find((candidate) => candidate.key === key)
+  if (term) setField(field, term.preset)
+}
+
+const canvasStore = useCanvasStore()
+
+function resolveOwnerNode(): LGraphNode | null {
+  const locatorId = widget.nodeLocatorId
+  const graph = app.rootGraphOrUndefined
+  return locatorId && graph ? getNodeByLocatorId(graph, locatorId) : null
+}
+
+onMounted(() => {
+  watch(
+    () => canvasStore.rootGraphId,
+    () => {
+      const container = shell.value?.container
+      if (node.value || !container) return
+      node.value = resolveOwnerNode()
+      if (node.value) initialize(container)
+    },
+    { immediate: true }
+  )
+})
+
+onUnmounted(() => {
+  cleanup()
+})
+</script>

--- a/src/components/cameraInfo/CameraInfo.vue
+++ b/src/components/cameraInfo/CameraInfo.vue
@@ -1,104 +1,90 @@
 <template>
-  <div
-    class="relative size-full min-h-[300px]"
-    @pointerdown.stop
-    @mousedown.stop
+  <ViewportWidgetShell
+    ref="shell"
+    bottom-class="justify-end"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
   >
-    <div
-      ref="container"
-      class="relative size-full"
-      data-capture-wheel="true"
-      tabindex="-1"
-      @pointerdown.stop="focusContainer"
-      @contextmenu.stop.prevent
-      @mouseenter="handleMouseEnter"
-      @mouseleave="handleMouseLeave"
-    />
-    <div class="pointer-events-none absolute inset-x-0 top-0">
-      <div
-        ref="toolbar"
-        class="pointer-events-auto flex h-10 items-center gap-1 bg-interface-menu-surface px-2"
-        @wheel.stop
+    <template #top>
+      <button
+        v-tooltip.bottom="tip(gizmosLabel)"
+        type="button"
+        :disabled="lookingThrough"
+        :class="
+          cn(
+            actionClass(!lookingThrough && gizmosOn),
+            lookingThrough && 'cursor-not-allowed opacity-40'
+          )
+        "
+        :aria-pressed="!lookingThrough && gizmosOn"
+        :aria-label="compact ? gizmosLabel : undefined"
+        @click="toggleGizmos"
       >
-        <button
-          v-tooltip.bottom="tip(gizmosLabel)"
-          type="button"
-          :disabled="lookingThrough"
+        <i
           :class="
             cn(
-              actionClass(!lookingThrough && gizmosOn),
-              lookingThrough && 'cursor-not-allowed opacity-40'
+              'size-4',
+              gizmosOn ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off]'
             )
           "
-          :aria-pressed="!lookingThrough && gizmosOn"
-          :aria-label="compact ? gizmosLabel : undefined"
-          @click="toggleGizmos"
-        >
-          <i
-            :class="
-              cn(
-                'size-4',
-                gizmosOn ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off]'
-              )
-            "
-          />
-          <span v-if="!compact">{{ gizmosLabel }}</span>
-        </button>
-        <div class="mx-1 h-5 w-px shrink-0 bg-interface-menu-stroke" />
-        <button
-          v-for="option in transformGizmoOptions"
-          :key="option.value"
-          v-tooltip.bottom="tip($t(option.labelKey))"
-          type="button"
-          :disabled="lookingThrough || !option.enabled"
-          :aria-pressed="
-            !lookingThrough && effectiveTransformGizmoMode === option.value
-          "
-          :aria-label="compact ? $t(option.labelKey) : undefined"
-          :class="
-            cn(
-              actionClass(
-                !lookingThrough && effectiveTransformGizmoMode === option.value
-              ),
-              (lookingThrough || !option.enabled) &&
-                'cursor-not-allowed opacity-40'
-            )
-          "
-          @click="selectTransformGizmo(option.value)"
-        >
-          <i :class="cn('size-4', option.icon)" />
-          <span v-if="!compact">{{ $t(option.labelKey) }}</span>
-        </button>
-      </div>
-    </div>
-    <div class="pointer-events-none absolute inset-x-0 bottom-0">
-      <div
-        class="pointer-events-auto flex h-10 items-center justify-end gap-1 bg-interface-menu-surface px-2"
-        @wheel.stop
+        />
+        <span v-if="!compact">{{ gizmosLabel }}</span>
+      </button>
+      <div class="mx-1 h-5 w-px shrink-0 bg-interface-menu-stroke" />
+      <button
+        v-for="option in transformGizmoOptions"
+        :key="option.value"
+        v-tooltip.bottom="tip($t(option.labelKey))"
+        type="button"
+        :disabled="lookingThrough || !option.enabled"
+        :aria-pressed="
+          !lookingThrough && effectiveTransformGizmoMode === option.value
+        "
+        :aria-label="compact ? $t(option.labelKey) : undefined"
+        :class="
+          cn(
+            actionClass(
+              !lookingThrough && effectiveTransformGizmoMode === option.value
+            ),
+            (lookingThrough || !option.enabled) &&
+              'cursor-not-allowed opacity-40'
+          )
+        "
+        @click="selectTransformGizmo(option.value)"
       >
-        <button
-          v-tooltip.top="tip(lookThroughLabel)"
-          type="button"
-          :class="
-            cn(iconBtnClass, lookingThrough && 'bg-button-active-surface')
-          "
-          :aria-pressed="lookingThrough"
-          :aria-label="lookThroughLabel"
-          @click="toggleLookThrough"
-        >
-          <i class="icon-[lucide--video] size-4" />
-        </button>
-      </div>
-    </div>
-  </div>
+        <i :class="cn('size-4', option.icon)" />
+        <span v-if="!compact">{{ $t(option.labelKey) }}</span>
+      </button>
+    </template>
+    <template #bottom>
+      <button
+        v-tooltip.top="tip(lookThroughLabel)"
+        type="button"
+        :class="cn(iconBtnClass, lookingThrough && 'bg-button-active-surface')"
+        :aria-pressed="lookingThrough"
+        :aria-label="lookThroughLabel"
+        @click="toggleLookThrough"
+      >
+        <i class="icon-[lucide--video] size-4" />
+      </button>
+    </template>
+  </ViewportWidgetShell>
 </template>
 
 <script setup lang="ts">
 import { useElementSize } from '@vueuse/core'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  computed,
+  onMounted,
+  onUnmounted,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
 import type { Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import ViewportWidgetShell from '@/components/load3d/ViewportWidgetShell.vue'
 import {
   actionClass,
   iconBtnClass,
@@ -135,9 +121,10 @@ if (isComponentWidget(widget)) {
 
 const { t } = useI18n()
 
-const container = ref<HTMLElement | null>(null)
-const toolbar = ref<HTMLElement | null>(null)
-const { width: toolbarWidth } = useElementSize(toolbar)
+const shell = useTemplateRef<InstanceType<typeof ViewportWidgetShell>>('shell')
+const { width: toolbarWidth } = useElementSize(
+  computed(() => shell.value?.toolbar ?? null)
+)
 const compactWidthThreshold = 480
 const compact = computed(
   () => toolbarWidth.value > 0 && toolbarWidth.value < compactWidthThreshold
@@ -199,10 +186,6 @@ const effectiveTransformGizmoMode = computed<TransformGizmoMode>(() =>
     : 'none'
 )
 
-function focusContainer() {
-  container.value?.focus()
-}
-
 function toggleGizmos() {
   gizmosOn.value = !gizmosOn.value
 }
@@ -220,7 +203,8 @@ watch(effectiveTransformGizmoMode, (m) => setTransformGizmoMode(m))
 watch(lookingThrough, (on) => setLookThrough(on))
 
 onMounted(() => {
-  if (container.value) initialize(container.value)
+  const container = shell.value?.container
+  if (container) initialize(container)
 })
 
 onUnmounted(() => {

--- a/src/components/load3d/ViewportWidgetShell.test.ts
+++ b/src/components/load3d/ViewportWidgetShell.test.ts
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import ViewportWidgetShell from './ViewportWidgetShell.vue'
+
+type ShellInstance = InstanceType<typeof ViewportWidgetShell>
+
+function renderShell(withBottom: boolean) {
+  const shellRef = ref<ShellInstance | null>(null)
+  const events: string[] = []
+  const Harness = defineComponent({
+    components: { ViewportWidgetShell },
+    setup: () => ({ shellRef, events, withBottom }),
+    template: `
+      <ViewportWidgetShell
+        ref="shellRef"
+        bottom-class="h-12"
+        @mouseenter="events.push('enter')"
+        @mouseleave="events.push('leave')"
+      >
+        <template #top><button type="button">Top action</button></template>
+        <template v-if="withBottom" #bottom><span>Bottom content</span></template>
+      </ViewportWidgetShell>
+    `
+  })
+  render(Harness)
+  return { shellRef, events }
+}
+
+describe('ViewportWidgetShell', () => {
+  it('exposes the viewport container and toolbar and relays hover events', async () => {
+    const { shellRef, events } = renderShell(true)
+    const user = userEvent.setup()
+
+    const container = shellRef.value!.container!
+    const toolbar = shellRef.value!.toolbar!
+    expect(container.dataset.captureWheel).toBe('true')
+    expect(toolbar).toContainElement(
+      screen.getByRole('button', { name: 'Top action' })
+    )
+
+    await user.hover(container)
+    await user.unhover(container)
+    expect(events).toEqual(['enter', 'leave'])
+  })
+
+  it('renders the bottom bar only when the slot is provided', () => {
+    renderShell(false)
+    expect(screen.queryByText('Bottom content')).toBeNull()
+
+    renderShell(true)
+    expect(screen.getByText('Bottom content')).toBeInTheDocument()
+  })
+})

--- a/src/components/load3d/ViewportWidgetShell.vue
+++ b/src/components/load3d/ViewportWidgetShell.vue
@@ -1,0 +1,65 @@
+<template>
+  <div
+    class="relative size-full min-h-[300px]"
+    @pointerdown.stop
+    @mousedown.stop
+  >
+    <div
+      ref="container"
+      class="relative size-full"
+      data-capture-wheel="true"
+      tabindex="-1"
+      @pointerdown.stop="focusContainer"
+      @contextmenu.stop.prevent
+      @mouseenter="emit('mouseenter')"
+      @mouseleave="emit('mouseleave')"
+    />
+    <div class="pointer-events-none absolute inset-x-0 top-0">
+      <div
+        ref="toolbar"
+        class="pointer-events-auto flex h-10 items-center gap-1 bg-interface-menu-surface px-2"
+        @wheel.stop
+      >
+        <slot name="top" />
+      </div>
+    </div>
+    <div
+      v-if="$slots.bottom"
+      class="pointer-events-none absolute inset-x-0 bottom-0"
+    >
+      <div
+        :class="
+          cn(
+            'pointer-events-auto flex h-10 items-center gap-1 bg-interface-menu-surface px-2',
+            bottomClass
+          )
+        "
+        @wheel.stop
+      >
+        <slot name="bottom" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { bottomClass } = defineProps<{ bottomClass?: string }>()
+
+const emit = defineEmits<{
+  mouseenter: []
+  mouseleave: []
+}>()
+
+const container = ref<HTMLElement | null>(null)
+const toolbar = ref<HTMLElement | null>(null)
+
+function focusContainer() {
+  container.value?.focus()
+}
+
+defineExpose({ container, toolbar })
+</script>

--- a/src/composables/useCameraAngle.test.ts
+++ b/src/composables/useCameraAngle.test.ts
@@ -1,0 +1,299 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+
+interface ViewportInstance {
+  ctorArgs: unknown[]
+  applyState: ReturnType<typeof vi.fn>
+  setViewMode: ReturnType<typeof vi.fn>
+  setPreviewVisible: ReturnType<typeof vi.fn>
+  setImage: ReturnType<typeof vi.fn>
+  remove: ReturnType<typeof vi.fn>
+  viewport: {
+    updateStatusMouseOnScene: ReturnType<typeof vi.fn>
+    updateStatusMouseOnNode: ReturnType<typeof vi.fn>
+    refreshViewport: ReturnType<typeof vi.fn>
+  }
+}
+
+const { ViewportMock, instances } = vi.hoisted(() => {
+  const instances: ViewportInstance[] = []
+  const ViewportMock = vi.fn(function (...ctorArgs: unknown[]) {
+    const instance: ViewportInstance = {
+      ctorArgs,
+      applyState: vi.fn(),
+      setViewMode: vi.fn(),
+      setPreviewVisible: vi.fn(),
+      setImage: vi.fn(() => Promise.resolve()),
+      remove: vi.fn(),
+      viewport: {
+        updateStatusMouseOnScene: vi.fn(),
+        updateStatusMouseOnNode: vi.fn(),
+        refreshViewport: vi.fn()
+      }
+    }
+    instances.push(instance)
+    return instance
+  })
+  return { ViewportMock, instances }
+})
+
+vi.mock<unknown>(
+  import('@/extensions/core/cameraAngle/CameraAngleViewport'),
+  () => ({
+    CameraAngleViewport: ViewportMock
+  })
+)
+
+import { useCameraAngle } from './useCameraAngle'
+
+interface FakeWidget {
+  name: string
+  value: unknown
+  callback?: (value: unknown, ...rest: unknown[]) => void
+}
+
+interface FakeNode {
+  widgets: FakeWidget[]
+  imageSource: FakeNode | null
+  findInputSlot(name: string): number
+  getInputNode(slot: number): FakeNode | null
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+  onConnectionsChange?: () => void
+}
+
+function makeNode(values: Record<string, unknown>): FakeNode {
+  return {
+    widgets: Object.entries(values).map(([name, value]) => ({ name, value })),
+    imageSource: null,
+    findInputSlot(name) {
+      return name === 'image' ? 0 : -1
+    },
+    getInputNode() {
+      return this.imageSource
+    }
+  }
+}
+
+function widget(node: FakeNode, name: string): FakeWidget {
+  const found = node.widgets.find((w) => w.name === name)
+  if (!found) throw new Error(`missing widget ${name}`)
+  return found
+}
+
+function nodeRef(node: FakeNode) {
+  return ref(node) as unknown as Ref<LGraphNode | null>
+}
+
+function ctorState(instance: ViewportInstance) {
+  return instance.ctorArgs[1] as {
+    horizontal: number
+    vertical: number
+    zoom: number
+  }
+}
+
+function ctorOptions(instance: ViewportInstance) {
+  return instance.ctorArgs[2] as {
+    onStateChange: (state: {
+      horizontal: number
+      vertical: number
+      zoom: number
+    }) => void
+  }
+}
+
+const DEFAULT_WIDGETS = {
+  horizontal_angle: 30,
+  vertical_angle: 10,
+  zoom: 2,
+  view: 'object'
+}
+
+beforeEach(() => {
+  instances.length = 0
+  ViewportMock.mockClear()
+})
+
+describe('useCameraAngle', () => {
+  it('constructs the viewport from widget values and restores the stored view mode', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const container = document.createElement('div')
+    const camera = useCameraAngle(nodeRef(node))
+
+    camera.initialize(container)
+
+    expect(ViewportMock).toHaveBeenCalledOnce()
+    expect(instances[0].ctorArgs[0]).toBe(container)
+    expect(ctorState(instances[0])).toEqual({
+      horizontal: 30,
+      vertical: 10,
+      zoom: 2
+    })
+    expect(instances[0].setViewMode).toHaveBeenCalledWith('object')
+    expect(instances[0].setPreviewVisible).toHaveBeenCalledWith(false)
+    expect(camera.viewMode.value).toBe('object')
+    expect(camera.prompt.value).toBe(
+      'front-right quarter view eye-level shot medium shot'
+    )
+  })
+
+  it('does nothing when the node is null', () => {
+    const camera = useCameraAngle(ref(null))
+    camera.initialize(document.createElement('div'))
+
+    expect(ViewportMock).not.toHaveBeenCalled()
+  })
+
+  it('alerts and does not throw when the viewport fails to construct', () => {
+    ViewportMock.mockImplementationOnce(() => {
+      throw new Error('webgl unavailable')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const camera = useCameraAngle(nodeRef(makeNode(DEFAULT_WIDGETS)))
+
+    expect(() => camera.initialize(document.createElement('div'))).not.toThrow()
+    expect(useToastStore().addAlert).toHaveBeenCalledOnce()
+
+    consoleError.mockRestore()
+  })
+
+  it('writes viewport interaction results back into the widgets', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    ctorOptions(instances[0]).onStateChange({
+      horizontal: 180,
+      vertical: 50,
+      zoom: 9
+    })
+
+    expect(widget(node, 'horizontal_angle').value).toBe(180)
+    expect(widget(node, 'vertical_angle').value).toBe(50)
+    expect(widget(node, 'zoom').value).toBe(9)
+    expect(camera.prompt.value).toBe('back view high-angle shot close-up')
+  })
+
+  it('re-applies state to the viewport when a widget changes, keeping the original callback', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const original = vi.fn()
+    widget(node, 'zoom').callback = original
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    const zoom = widget(node, 'zoom')
+    zoom.value = 8
+    zoom.callback!(8)
+
+    expect(original).toHaveBeenCalledWith(8)
+    expect(instances[0].applyState).toHaveBeenLastCalledWith({
+      horizontal: 30,
+      vertical: 10,
+      zoom: 8
+    })
+    expect(camera.state.value.zoom).toBe(8)
+  })
+
+  it('applies a preset field with clamping and mirrors it to the widgets', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    camera.setField('vertical', 99)
+
+    expect(widget(node, 'vertical_angle').value).toBe(60)
+    expect(instances[0].applyState).toHaveBeenLastCalledWith({
+      horizontal: 30,
+      vertical: 60,
+      zoom: 2
+    })
+  })
+
+  it('toggles the shot preview inset', () => {
+    const camera = useCameraAngle(nodeRef(makeNode(DEFAULT_WIDGETS)))
+    camera.initialize(document.createElement('div'))
+
+    camera.setPreviewVisible(true)
+
+    expect(camera.previewVisible.value).toBe(true)
+    expect(instances[0].setPreviewVisible).toHaveBeenLastCalledWith(true)
+  })
+
+  it('persists the view mode into the view widget and forwards it', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    camera.setViewMode('camera')
+
+    expect(widget(node, 'view').value).toBe('camera')
+    expect(instances[0].setViewMode).toHaveBeenLastCalledWith('camera')
+  })
+
+  it('shows the upstream image and clears it when the link is removed', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const source = makeNode({})
+    node.imageSource = source
+    const getNodeImageUrls = vi
+      .spyOn(useNodeOutputStore(), 'getNodeImageUrls')
+      .mockReturnValue(['http://example/upstream.png'])
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    expect(getNodeImageUrls).toHaveBeenCalledWith(source)
+    expect(instances[0].setImage).toHaveBeenCalledWith(
+      'http://example/upstream.png'
+    )
+
+    node.imageSource = null
+    node.onConnectionsChange?.()
+
+    expect(instances[0].setImage).toHaveBeenLastCalledWith(null)
+  })
+
+  it('routes node hover into the viewport status flags', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    camera.handleMouseEnter()
+    camera.handleMouseLeave()
+    node.onMouseEnter?.()
+
+    expect(instances[0].viewport.updateStatusMouseOnScene).toHaveBeenCalledWith(
+      true
+    )
+    expect(instances[0].viewport.updateStatusMouseOnScene).toHaveBeenCalledWith(
+      false
+    )
+    expect(instances[0].viewport.updateStatusMouseOnNode).toHaveBeenCalledWith(
+      true
+    )
+  })
+
+  it('removes the viewport and restores callbacks on cleanup', () => {
+    const node = makeNode(DEFAULT_WIDGETS)
+    const original = vi.fn()
+    const originalEnter = vi.fn()
+    const originalConnections = vi.fn()
+    widget(node, 'zoom').callback = original
+    node.onMouseEnter = originalEnter
+    node.onConnectionsChange = originalConnections
+    const camera = useCameraAngle(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+    expect(node.onMouseEnter).not.toBe(originalEnter)
+
+    camera.cleanup()
+
+    expect(instances[0].remove).toHaveBeenCalledOnce()
+    expect(widget(node, 'zoom').callback).toBe(original)
+    expect(node.onMouseEnter).toBe(originalEnter)
+    expect(node.onConnectionsChange).toBe(originalConnections)
+  })
+})

--- a/src/composables/useCameraAngle.ts
+++ b/src/composables/useCameraAngle.ts
@@ -1,0 +1,164 @@
+import { computed, ref, toRaw, toRef, watch } from 'vue'
+import type { MaybeRef } from 'vue'
+
+import { useViewportNodeWiring } from '@/composables/useViewportNodeWiring'
+import { CameraAngleViewport } from '@/extensions/core/cameraAngle/CameraAngleViewport'
+import {
+  clampState,
+  describeCameraAngle,
+  roundState
+} from '@/extensions/core/cameraAngle/cameraAngleMath'
+import {
+  CAMERA_ANGLE_WIDGET_NAMES,
+  DEFAULT_CAMERA_ANGLE_STATE
+} from '@/extensions/core/cameraAngle/types'
+import type {
+  CameraAngleField,
+  CameraAngleState,
+  CameraAngleViewMode,
+  SubjectFaceLabels
+} from '@/extensions/core/cameraAngle/types'
+import {
+  readStateFromWidgets,
+  readViewMode,
+  writeStateToWidgets,
+  writeViewMode
+} from '@/extensions/core/cameraAngle/widgetBridge'
+import type { NodeWithWidgets } from '@/extensions/core/cameraAngle/widgetBridge'
+import { t } from '@/i18n'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+
+const IMAGE_INPUT_NAME = 'image'
+const WIDGET_NAMES = Object.values(CAMERA_ANGLE_WIDGET_NAMES)
+
+export interface UseCameraAngleOptions {
+  faceLabels?: () => SubjectFaceLabels
+}
+
+export function useCameraAngle(
+  nodeRef: MaybeRef<LGraphNode | null>,
+  options: UseCameraAngleOptions = {}
+) {
+  const node = toRef(nodeRef)
+  const nodeOutputStore = useNodeOutputStore()
+  const wiring = useViewportNodeWiring()
+  let viewport: CameraAngleViewport | null = null
+  let lastImageUrl: string | null = null
+
+  const state = ref<CameraAngleState>(DEFAULT_CAMERA_ANGLE_STATE)
+  const viewMode = ref<CameraAngleViewMode>('camera')
+  const previewVisible = ref(false)
+  const prompt = computed(() => describeCameraAngle(state.value))
+
+  const rawNode = () => toRaw(node.value)
+
+  const initialize = (container: HTMLElement): void => {
+    const raw = rawNode()
+    if (!raw) return
+    if (viewport) cleanup()
+
+    try {
+      const target = raw as NodeWithWidgets
+      state.value = readStateFromWidgets(target)
+      viewMode.value = readViewMode(target)
+      viewport = new CameraAngleViewport(container, state.value, {
+        faceLabels: options.faceLabels?.(),
+        onStateChange: (next) => {
+          state.value = roundState(next)
+          writeStateToWidgets(target, next)
+        }
+      })
+      viewport.setViewMode(viewMode.value)
+      viewport.setPreviewVisible(previewVisible.value)
+      wiring.wireWidgets(target, WIDGET_NAMES, () => {
+        if (!viewport) return
+        state.value = readStateFromWidgets(target)
+        viewport.applyState(state.value)
+      })
+      wiring.wireNode(raw as LGraphNode, {
+        viewport: () => viewport?.viewport,
+        onConnectionsChange: syncSubjectImage
+      })
+      syncSubjectImage()
+    } catch (error) {
+      console.error('Failed to initialize CameraAngleViewport:', error)
+      cleanup()
+      useToastStore().addAlert(
+        t('toastMessages.failedToInitializeCameraAngleViewer')
+      )
+    }
+  }
+
+  const cleanup = (): void => {
+    wiring.unwire()
+    viewport?.remove()
+    viewport = null
+    lastImageUrl = null
+  }
+
+  const handleMouseEnter = (): void => {
+    viewport?.viewport.updateStatusMouseOnScene(true)
+    viewport?.viewport.refreshViewport()
+  }
+
+  const handleMouseLeave = (): void => {
+    viewport?.viewport.updateStatusMouseOnScene(false)
+  }
+
+  const setViewMode = (mode: CameraAngleViewMode): void => {
+    viewMode.value = mode
+    const raw = rawNode()
+    if (raw) writeViewMode(raw as NodeWithWidgets, mode)
+    viewport?.setViewMode(mode)
+  }
+
+  const setPreviewVisible = (visible: boolean): void => {
+    previewVisible.value = visible
+    viewport?.setPreviewVisible(visible)
+  }
+
+  const setField = (field: CameraAngleField, value: number): void => {
+    const next = clampState({ ...state.value, [field]: value })
+    state.value = next
+    const raw = rawNode()
+    if (raw) writeStateToWidgets(raw as NodeWithWidgets, next)
+    viewport?.applyState(next)
+  }
+
+  function subjectImageUrl(target: LGraphNode): string | null {
+    const slot = target.findInputSlot(IMAGE_INPUT_NAME)
+    const inputNode = slot >= 0 ? target.getInputNode(slot) : null
+    if (!inputNode) return null
+    return nodeOutputStore.getNodeImageUrls(inputNode)?.[0] ?? null
+  }
+
+  function syncSubjectImage(): void {
+    const raw = rawNode()
+    if (!raw || !viewport) return
+    const url = subjectImageUrl(raw as LGraphNode)
+    if (url === lastImageUrl) return
+    lastImageUrl = url
+    void viewport.setImage(url)
+  }
+
+  watch(() => nodeOutputStore.nodeOutputs, syncSubjectImage, { deep: true })
+  watch(() => nodeOutputStore.nodePreviewImages, syncSubjectImage, {
+    deep: true
+  })
+
+  return {
+    initialize,
+    cleanup,
+    handleMouseEnter,
+    handleMouseLeave,
+    setViewMode,
+    setPreviewVisible,
+    setField,
+    state,
+    viewMode,
+    previewVisible,
+    prompt
+  }
+}

--- a/src/composables/useCameraInfo.ts
+++ b/src/composables/useCameraInfo.ts
@@ -1,7 +1,7 @@
 import { computed, ref, toRaw, toRef } from 'vue'
 import type { MaybeRef } from 'vue'
 
-import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { useViewportNodeWiring } from '@/composables/useViewportNodeWiring'
 import { CameraInfoViewport } from '@/extensions/core/cameraInfo/CameraInfoViewport'
 import type { TransformGizmoMode } from '@/extensions/core/cameraInfo/CameraInfoViewport'
 import { DEFAULT_CAMERA_INFO_STATE } from '@/extensions/core/cameraInfo/types'
@@ -14,13 +14,6 @@ import type { NodeWithWidgets } from '@/extensions/core/cameraInfo/widgetBridge'
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-
-type WidgetCallback = (value: unknown, ...rest: unknown[]) => void
-interface MutableWidget {
-  name: string
-  value: unknown
-  callback?: WidgetCallback
-}
 
 const WIDGET_NAMES = [
   'mode',
@@ -45,17 +38,11 @@ const WIDGET_NAMES = [
 
 export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
   const node = toRef(nodeRef)
+  const wiring = useViewportNodeWiring()
   let viewport: CameraInfoViewport | null = null
-  let wiredNode: LGraphNode | null = null
-  let originalOnMouseEnter: LGraphNode['onMouseEnter']
-  let originalOnMouseLeave: LGraphNode['onMouseLeave']
 
   const cameraState = ref<CameraInfoState>(DEFAULT_CAMERA_INFO_STATE)
   const mode = computed(() => cameraState.value.mode)
-
-  const wrappedWidgets: { widget: MutableWidget; original?: WidgetCallback }[] =
-    []
-  const wrappedSet = new WeakSet<MutableWidget>()
 
   const initialize = (container: HTMLElement): void => {
     const raw = toRaw(node.value)
@@ -71,7 +58,7 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
         }
       })
       wireWidgetsToOverlay(raw as NodeWithWidgets)
-      wireNodeMouseStatus(raw as LGraphNode)
+      wiring.wireNode(raw as LGraphNode, { viewport: () => viewport?.viewport })
     } catch (error) {
       console.error('Failed to initialize CameraInfoViewport:', error)
       cleanup()
@@ -82,8 +69,7 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
   }
 
   const cleanup = (): void => {
-    unwireWidgets()
-    unwireNodeMouseStatus()
+    wiring.unwire()
     viewport?.remove()
     viewport = null
   }
@@ -109,54 +95,14 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
     viewport?.setLookThrough(on)
   }
 
-  function wireNodeMouseStatus(target: LGraphNode): void {
-    wiredNode = target
-    originalOnMouseEnter = target.onMouseEnter
-    originalOnMouseLeave = target.onMouseLeave
-    target.onMouseEnter = useChainCallback(target.onMouseEnter, () => {
-      viewport?.viewport.updateStatusMouseOnNode(true)
-      viewport?.viewport.refreshViewport()
-    })
-    target.onMouseLeave = useChainCallback(target.onMouseLeave, () => {
-      viewport?.viewport.updateStatusMouseOnNode(false)
-    })
-  }
-
-  function unwireNodeMouseStatus(): void {
-    if (!wiredNode) return
-    wiredNode.onMouseEnter = originalOnMouseEnter
-    wiredNode.onMouseLeave = originalOnMouseLeave
-    wiredNode = null
-  }
-
   function wireWidgetsToOverlay(target: NodeWithWidgets): void {
-    if (!target.widgets) return
-    for (const name of WIDGET_NAMES) {
-      const widget = target.widgets.find(
-        (w): w is MutableWidget => w.name === name
-      )
-      if (!widget || wrappedSet.has(widget)) continue
-      wrappedSet.add(widget)
-      const original = widget.callback
-      const isModeWidget = widget.name === 'mode'
-      wrappedWidgets.push({ widget, original })
-      widget.callback = (value, ...rest) => {
-        original?.call(widget, value, ...rest)
-        if (isModeWidget) wireWidgetsToOverlay(target)
-        if (!viewport) return
-        const state = readStateFromWidgets(target)
-        cameraState.value = state
-        viewport.applyState(state)
-      }
-    }
-  }
-
-  function unwireWidgets(): void {
-    for (const { widget, original } of wrappedWidgets) {
-      widget.callback = original
-      wrappedSet.delete(widget)
-    }
-    wrappedWidgets.length = 0
+    wiring.wireWidgets(target, WIDGET_NAMES, (widget) => {
+      if (widget.name === 'mode') wireWidgetsToOverlay(target)
+      if (!viewport) return
+      const state = readStateFromWidgets(target)
+      cameraState.value = state
+      viewport.applyState(state)
+    })
   }
 
   return {

--- a/src/composables/useViewportNodeWiring.test.ts
+++ b/src/composables/useViewportNodeWiring.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+import { useViewportNodeWiring } from './useViewportNodeWiring'
+import type { WirableWidget } from './useViewportNodeWiring'
+
+interface FakeNode {
+  widgets: WirableWidget[]
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+  onConnectionsChange?: () => void
+}
+
+function makeNode(names: string[]): FakeNode {
+  return { widgets: names.map((name) => ({ name, value: 0 })) }
+}
+
+function asGraphNode(node: FakeNode): LGraphNode {
+  return node as unknown as LGraphNode
+}
+
+describe('useViewportNodeWiring', () => {
+  it('wraps named widget callbacks, keeps the original and reports the widget', () => {
+    const node = makeNode(['a', 'b', 'c'])
+    const original = vi.fn()
+    node.widgets[0].callback = original
+    const onChange = vi.fn()
+    const wiring = useViewportNodeWiring()
+
+    wiring.wireWidgets(node, ['a', 'b', 'missing'], onChange)
+    node.widgets[0].callback(5, 'extra')
+    node.widgets[2].callback?.(1)
+
+    expect(original).toHaveBeenCalledWith(5, 'extra')
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(node.widgets[0])
+    expect(node.widgets[1].callback).toBeDefined()
+  })
+
+  it('does not double-wrap a widget that is wired twice', () => {
+    const node = makeNode(['a'])
+    const onChange = vi.fn()
+    const wiring = useViewportNodeWiring()
+
+    wiring.wireWidgets(node, ['a'], onChange)
+    wiring.wireWidgets(node, ['a'], onChange)
+    node.widgets[0].callback!(1)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes node hover into the viewport status and chains existing handlers', () => {
+    const node = makeNode([])
+    const existingEnter = vi.fn()
+    node.onMouseEnter = existingEnter
+    const viewport = {
+      updateStatusMouseOnNode: vi.fn(),
+      refreshViewport: vi.fn()
+    }
+    const onConnectionsChange = vi.fn()
+    const wiring = useViewportNodeWiring()
+
+    wiring.wireNode(asGraphNode(node), {
+      viewport: () => viewport,
+      onConnectionsChange
+    })
+    node.onMouseEnter()
+    node.onMouseLeave?.()
+    node.onConnectionsChange?.()
+
+    expect(existingEnter).toHaveBeenCalledOnce()
+    expect(viewport.updateStatusMouseOnNode).toHaveBeenNthCalledWith(1, true)
+    expect(viewport.refreshViewport).toHaveBeenCalledOnce()
+    expect(viewport.updateStatusMouseOnNode).toHaveBeenNthCalledWith(2, false)
+    expect(onConnectionsChange).toHaveBeenCalledOnce()
+  })
+
+  it('restores widget callbacks and node handlers on unwire', () => {
+    const node = makeNode(['a'])
+    const original = vi.fn()
+    node.widgets[0].callback = original
+    const originalEnter = vi.fn()
+    node.onMouseEnter = originalEnter
+    const wiring = useViewportNodeWiring()
+    wiring.wireWidgets(node, ['a'], vi.fn())
+    wiring.wireNode(asGraphNode(node), { viewport: () => null })
+    expect(node.onMouseEnter).not.toBe(originalEnter)
+
+    wiring.unwire()
+
+    expect(node.widgets[0].callback).toBe(original)
+    expect(node.onMouseEnter).toBe(originalEnter)
+    expect(node.onConnectionsChange).toBeUndefined()
+  })
+})

--- a/src/composables/useViewportNodeWiring.ts
+++ b/src/composables/useViewportNodeWiring.ts
@@ -10,7 +10,7 @@ export interface WirableWidget {
   callback?: WidgetCallback
 }
 
-export interface NodeWithWirableWidgets {
+interface NodeWithWirableWidgets {
   widgets?: WirableWidget[]
 }
 
@@ -19,7 +19,7 @@ type ViewportStatus = Pick<
   'updateStatusMouseOnNode' | 'refreshViewport'
 >
 
-export interface NodeWiringHooks {
+interface NodeWiringHooks {
   viewport: () => ViewportStatus | null | undefined
   onConnectionsChange?: () => void
 }

--- a/src/composables/useViewportNodeWiring.ts
+++ b/src/composables/useViewportNodeWiring.ts
@@ -1,0 +1,94 @@
+import { useChainCallback } from '@/composables/functional/useChainCallback'
+import type { Viewport3d } from '@/extensions/core/load3d/Viewport3d'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+type WidgetCallback = (value: unknown, ...rest: unknown[]) => void
+
+export interface WirableWidget {
+  name: string
+  value: unknown
+  callback?: WidgetCallback
+}
+
+export interface NodeWithWirableWidgets {
+  widgets?: WirableWidget[]
+}
+
+type ViewportStatus = Pick<
+  Viewport3d,
+  'updateStatusMouseOnNode' | 'refreshViewport'
+>
+
+export interface NodeWiringHooks {
+  viewport: () => ViewportStatus | null | undefined
+  onConnectionsChange?: () => void
+}
+
+export function useViewportNodeWiring() {
+  const wrappedWidgets: { widget: WirableWidget; original?: WidgetCallback }[] =
+    []
+  const wrappedSet = new WeakSet<WirableWidget>()
+  let wiredNode: LGraphNode | null = null
+  let originalOnMouseEnter: LGraphNode['onMouseEnter']
+  let originalOnMouseLeave: LGraphNode['onMouseLeave']
+  let originalOnConnectionsChange: LGraphNode['onConnectionsChange']
+
+  function wireWidgets(
+    node: NodeWithWirableWidgets,
+    names: readonly string[],
+    onChange: (widget: WirableWidget) => void
+  ): void {
+    for (const name of names) {
+      const widget = node.widgets?.find((w) => w.name === name)
+      if (!widget || wrappedSet.has(widget)) continue
+      wrappedSet.add(widget)
+      const original = widget.callback
+      wrappedWidgets.push({ widget, original })
+      widget.callback = (value, ...rest) => {
+        original?.call(widget, value, ...rest)
+        onChange(widget)
+      }
+    }
+  }
+
+  function wireNode(node: LGraphNode, hooks: NodeWiringHooks): void {
+    unwireNode()
+    wiredNode = node
+    originalOnMouseEnter = node.onMouseEnter
+    originalOnMouseLeave = node.onMouseLeave
+    originalOnConnectionsChange = node.onConnectionsChange
+    node.onMouseEnter = useChainCallback(node.onMouseEnter, () => {
+      const viewport = hooks.viewport()
+      viewport?.updateStatusMouseOnNode(true)
+      viewport?.refreshViewport()
+    })
+    node.onMouseLeave = useChainCallback(node.onMouseLeave, () => {
+      hooks.viewport()?.updateStatusMouseOnNode(false)
+    })
+    if (hooks.onConnectionsChange) {
+      node.onConnectionsChange = useChainCallback(
+        node.onConnectionsChange,
+        hooks.onConnectionsChange
+      )
+    }
+  }
+
+  function unwireNode(): void {
+    if (!wiredNode) return
+    wiredNode.onMouseEnter = originalOnMouseEnter
+    wiredNode.onMouseLeave = originalOnMouseLeave
+    wiredNode.onConnectionsChange = originalOnConnectionsChange
+    wiredNode = null
+  }
+
+  function unwire(): void {
+    for (const { widget, original } of wrappedWidgets) {
+      widget.callback = original
+      wrappedSet.delete(widget)
+    }
+    wrappedWidgets.length = 0
+    unwireNode()
+  }
+
+  return { wireWidgets, wireNode, unwire }
+}

--- a/src/extensions/core/cameraAngle.test.ts
+++ b/src/extensions/core/cameraAngle.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComfyExtension } from '@/types/comfy'
+
+interface WidgetCtorArgs {
+  name: string
+  type?: string
+  options: {
+    serialize?: boolean
+    getValue?: () => unknown
+    setValue?: (value: unknown) => void
+  }
+}
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    extension: null as ComfyExtension | null,
+    addWidget: vi.fn(),
+    lastCtorArgs: null as WidgetCtorArgs | null
+  }
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension: (ext: ComfyExtension) => {
+      state.extension = ext
+    }
+  })
+}))
+
+vi.mock('@/scripts/domWidget', () => ({
+  ComponentWidgetImpl: class {
+    name: string
+    type = 'custom'
+    options: WidgetCtorArgs['options']
+    constructor(args: WidgetCtorArgs) {
+      state.lastCtorArgs = args
+      this.name = args.name
+      this.options = args.options
+    }
+    get value() {
+      return this.options.getValue?.()
+    }
+    set value(next: unknown) {
+      this.options.setValue?.(next)
+    }
+  },
+  addWidget: state.addWidget
+}))
+
+await import('./cameraAngle')
+
+function makeNode(comfyClass: string) {
+  return {
+    constructor: { comfyClass },
+    size: [100, 100] as [number, number],
+    setSize: vi.fn()
+  }
+}
+
+async function createViewWidget() {
+  const widgets = await state.extension!.getCustomWidgets!({} as never)
+  const build = widgets.CAMERA_ANGLE_VIEW
+  if (!build) throw new Error('CAMERA_ANGLE_VIEW widget not registered')
+  const result = build(
+    makeNode('CameraAngle') as never,
+    'view',
+    [] as never,
+    {} as never
+  )
+  if (!result) throw new Error('widget was not created')
+  const widget = 'name' in result ? result : result.widget
+  if (!widget) throw new Error('widget was not created')
+  return widget
+}
+
+describe('Comfy.CameraAngle extension', () => {
+  it('registers a non-prompt view widget that remembers a valid view mode', async () => {
+    const widget = await createViewWidget()
+
+    expect(state.addWidget).toHaveBeenCalledWith(expect.anything(), widget)
+    expect(state.lastCtorArgs?.options.serialize).toBe(false)
+    expect(widget.value).toBe('camera')
+
+    widget.value = 'object'
+    expect(widget.value).toBe('object')
+
+    widget.value = 'not-a-mode'
+    expect(widget.value).toBe('object')
+  })
+
+  it('enlarges CameraAngle nodes only', () => {
+    const node = makeNode('CameraAngle')
+    const other = makeNode('SomethingElse')
+
+    state.extension!.nodeCreated!(node as never, {} as never)
+    state.extension!.nodeCreated!(other as never, {} as never)
+
+    expect(node.setSize).toHaveBeenCalledWith([360, 480])
+    expect(other.setSize).not.toHaveBeenCalled()
+  })
+})

--- a/src/extensions/core/cameraAngle.ts
+++ b/src/extensions/core/cameraAngle.ts
@@ -1,0 +1,54 @@
+import { defineAsyncComponent } from 'vue'
+
+import { CAMERA_ANGLE_VIEW_WIDGET_NAME } from '@/extensions/core/cameraAngle/types'
+import type { CameraAngleViewMode } from '@/extensions/core/cameraAngle/types'
+import { isViewMode } from '@/extensions/core/cameraAngle/widgetBridge'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import { useExtensionService } from '@/services/extensionService'
+
+const CameraAngle = defineAsyncComponent(
+  () => import('@/components/cameraAngle/CameraAngle.vue')
+)
+
+const NODE_CLASS = 'CameraAngle'
+const MIN_WIDTH = 360
+const MIN_HEIGHT = 480
+
+useExtensionService().registerExtension({
+  name: 'Comfy.CameraAngle',
+
+  getCustomWidgets() {
+    return {
+      CAMERA_ANGLE_VIEW(node) {
+        let viewMode: CameraAngleViewMode = 'camera'
+        const widget = new ComponentWidgetImpl<string | object>({
+          node,
+          name: CAMERA_ANGLE_VIEW_WIDGET_NAME,
+          component: CameraAngle,
+          inputSpec: {
+            name: CAMERA_ANGLE_VIEW_WIDGET_NAME,
+            type: 'CAMERA_ANGLE_VIEW',
+            isPreview: false
+          },
+          options: {
+            serialize: false,
+            getValue: () => viewMode,
+            setValue: (value) => {
+              if (isViewMode(value)) viewMode = value
+            }
+          }
+        })
+        widget.type = 'cameraAngle'
+        addWidget(node, widget)
+        return { widget }
+      }
+    }
+  },
+
+  nodeCreated(node: LGraphNode) {
+    if (node.constructor.comfyClass !== NODE_CLASS) return
+    const [width, height] = node.size
+    node.setSize([Math.max(width, MIN_WIDTH), Math.max(height, MIN_HEIGHT)])
+  }
+})

--- a/src/extensions/core/cameraAngle/CameraAngleViewport.test.ts
+++ b/src/extensions/core/cameraAngle/CameraAngleViewport.test.ts
@@ -378,7 +378,8 @@ describe('CameraAngleViewport', () => {
     expect(deferred.subject.hasImage()).toBe(false)
   })
 
-  it('tears down the viewport on remove', () => {
+  it('tears down the viewport once even when removed twice', () => {
+    viewport.remove()
     viewport.remove()
 
     expect(stub.remove).toHaveBeenCalledOnce()

--- a/src/extensions/core/cameraAngle/CameraAngleViewport.test.ts
+++ b/src/extensions/core/cameraAngle/CameraAngleViewport.test.ts
@@ -1,0 +1,362 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createViewport3dMock } = vi.hoisted(() => ({
+  createViewport3dMock: vi.fn()
+}))
+
+vi.mock('@/extensions/core/load3d/createViewport3d', () => ({
+  createViewport3d: createViewport3dMock
+}))
+
+import { CameraAngleViewport } from './CameraAngleViewport'
+import {
+  MAX_DISPLAY_DISTANCE,
+  ORBIT_SPHERE_RADIUS,
+  SUBJECT_CENTER,
+  YAW_RING_LATITUDE
+} from './types'
+import type { CameraAngleState } from './types'
+
+const CANVAS_WIDTH = 800
+const CANVAS_HEIGHT = 600
+
+function makeViewportStub() {
+  const canvas = document.createElement('canvas')
+  canvas.width = CANVAS_WIDTH
+  canvas.height = CANVAS_HEIGHT
+  Object.defineProperty(canvas, 'clientWidth', {
+    value: CANVAS_WIDTH,
+    configurable: true
+  })
+  Object.defineProperty(canvas, 'clientHeight', {
+    value: CANVAS_HEIGHT,
+    configurable: true
+  })
+  canvas.getBoundingClientRect = () =>
+    new DOMRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
+  canvas.setPointerCapture = vi.fn()
+  canvas.releasePointerCapture = vi.fn()
+  canvas.hasPointerCapture = vi.fn(() => false)
+
+  const activeCamera = new THREE.PerspectiveCamera(
+    35,
+    CANVAS_WIDTH / CANVAS_HEIGHT
+  )
+  activeCamera.position.set(0, SUBJECT_CENTER.y + 2, 6)
+  activeCamera.lookAt(0, SUBJECT_CENTER.y, 0)
+  activeCamera.updateMatrixWorld(true)
+
+  let preRender: (() => void) | null = null
+  let postRender: (() => void) | null = null
+  const controls = { enabled: true }
+  return {
+    sceneManager: {
+      scene: new THREE.Scene(),
+      toggleGrid: vi.fn(),
+      getCurrentBackgroundInfo: () => ({ type: 'color', value: '#123456' })
+    },
+    cameraManager: { activeCamera },
+    controlsManager: { controls },
+    viewHelperManager: { visibleViewHelper: vi.fn() },
+    renderer: {
+      setViewport: vi.fn(),
+      setScissor: vi.fn(),
+      setScissorTest: vi.fn(),
+      setClearColor: vi.fn(),
+      clear: vi.fn(),
+      render: vi.fn()
+    },
+    domElement: canvas,
+    setOverlay: vi.fn(),
+    setCameraState: vi.fn(),
+    addPreRenderCallback: vi.fn((cb: () => void) => {
+      preRender = cb
+      return vi.fn()
+    }),
+    addPostRenderCallback: vi.fn((cb: () => void) => {
+      postRender = cb
+      return vi.fn()
+    }),
+    setExternalActiveCamera: vi.fn((camera: THREE.Camera | null) => {
+      controls.enabled = camera === null
+    }),
+    forceRender: vi.fn(),
+    remove: vi.fn(),
+    runPreRender: () => preRender?.(),
+    runPostRender: () => postRender?.()
+  }
+}
+
+function dispatchPointer(
+  target: HTMLElement,
+  type: string,
+  clientX: number,
+  clientY: number
+): void {
+  const event = new MouseEvent(type, { clientX, clientY, button: 0 })
+  Object.defineProperty(event, 'pointerId', { value: 1 })
+  target.dispatchEvent(event)
+}
+
+function dispatchWheel(target: HTMLElement, deltaY: number): void {
+  const event = new WheelEvent('wheel')
+  Object.defineProperty(event, 'deltaY', { value: deltaY })
+  target.dispatchEvent(event)
+}
+
+function screenPositionOf(
+  world: THREE.Vector3Like,
+  camera: THREE.Camera
+): { x: number; y: number } {
+  const ndc = new THREE.Vector3(world.x, world.y, world.z).project(camera)
+  return {
+    x: ((ndc.x + 1) / 2) * CANVAS_WIDTH,
+    y: ((1 - ndc.y) / 2) * CANVAS_HEIGHT
+  }
+}
+
+const frames: FrameRequestCallback[] = []
+
+function runFrame(): void {
+  const queued = frames.splice(0)
+  for (const cb of queued) cb(0)
+}
+
+describe('CameraAngleViewport', () => {
+  let stub: ReturnType<typeof makeViewportStub>
+  let onStateChange: ReturnType<typeof vi.fn<(state: CameraAngleState) => void>>
+  let viewport: CameraAngleViewport
+
+  beforeEach(() => {
+    frames.length = 0
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {
+      frames.length = 0
+    })
+    stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    onStateChange = vi.fn<(state: CameraAngleState) => void>()
+    viewport = new CameraAngleViewport(
+      document.createElement('div'),
+      { horizontal: 0, vertical: 0, zoom: 5 },
+      { onStateChange }
+    )
+  })
+
+  afterEach(() => {
+    viewport.remove()
+  })
+
+  it('frames the subject with the overview camera and installs the subject overlay', () => {
+    const cameraState = stub.setCameraState.mock.calls[0][0] as {
+      position: THREE.Vector3
+      target: THREE.Vector3
+    }
+    expect(cameraState.target.y).toBe(SUBJECT_CENTER.y)
+    const distance = cameraState.position.distanceTo(cameraState.target)
+    expect(distance * Math.tan((35 / 2) * (Math.PI / 180))).toBeGreaterThan(
+      MAX_DISPLAY_DISTANCE
+    )
+    expect(stub.setOverlay).toHaveBeenCalledWith(viewport.subject)
+    expect(stub.sceneManager.toggleGrid).toHaveBeenCalledWith(false)
+    expect(stub.controlsManager.controls.enabled).toBe(false)
+    expect(viewport.orbitHandles.isVisible()).toBe(true)
+    expect(viewport.orbitSphere.isVisible()).toBe(true)
+    expect(viewport.cameraMarker.isVisible()).toBe(true)
+    expect(stub.viewHelperManager.visibleViewHelper).toHaveBeenCalledWith(false)
+  })
+
+  it('refits the overview camera only when the canvas aspect changes', () => {
+    const distanceOf = (call: unknown) => {
+      const { position, target } = call as {
+        position: THREE.Vector3
+        target: THREE.Vector3
+      }
+      return position.distanceTo(target)
+    }
+    const initial = distanceOf(stub.setCameraState.mock.calls[0][0])
+    stub.setCameraState.mockClear()
+
+    stub.runPreRender()
+    expect(stub.setCameraState).not.toHaveBeenCalled()
+
+    stub.domElement.width = 300
+    stub.runPreRender()
+    expect(stub.setCameraState).toHaveBeenCalledOnce()
+    expect(distanceOf(stub.setCameraState.mock.calls[0][0])).toBeGreaterThan(
+      initial
+    )
+  })
+
+  it('applies external state to the subject camera and handles', () => {
+    viewport.applyState({ horizontal: 90, vertical: 0, zoom: 0 })
+
+    expect(viewport.getState()).toEqual({
+      horizontal: 90,
+      vertical: 0,
+      zoom: 0
+    })
+    expect(viewport.subject.getSubjectCamera().position.x).toBeGreaterThan(0)
+    expect(stub.forceRender).toHaveBeenCalled()
+    expect(onStateChange).not.toHaveBeenCalled()
+  })
+
+  it('looks through the subject camera in object view and restores the overview after', () => {
+    viewport.setViewMode('object')
+
+    expect(stub.setExternalActiveCamera).toHaveBeenCalledWith(
+      viewport.subject.getSubjectCamera()
+    )
+    expect(viewport.orbitHandles.isVisible()).toBe(false)
+    expect(viewport.orbitSphere.isVisible()).toBe(false)
+    expect(viewport.cameraMarker.isVisible()).toBe(false)
+    expect(viewport.getViewMode()).toBe('object')
+
+    stub.viewHelperManager.visibleViewHelper.mockClear()
+    viewport.setViewMode('camera')
+
+    expect(stub.setExternalActiveCamera).toHaveBeenLastCalledWith(null)
+    expect(stub.controlsManager.controls.enabled).toBe(false)
+    expect(viewport.orbitHandles.isVisible()).toBe(true)
+    expect(stub.viewHelperManager.visibleViewHelper).toHaveBeenLastCalledWith(
+      false
+    )
+    expect(stub.forceRender.mock.invocationCallOrder.at(-1)).toBeGreaterThan(
+      stub.viewHelperManager.visibleViewHelper.mock.invocationCallOrder.at(-1)!
+    )
+  })
+
+  it('keeps the handles hidden when state changes while in object view', () => {
+    viewport.setViewMode('object')
+    viewport.applyState({ horizontal: 45, vertical: 10, zoom: 3 })
+
+    expect(viewport.orbitHandles.isVisible()).toBe(false)
+  })
+
+  it('fits the subject camera aspect only while in object view', () => {
+    const cam = viewport.subject.getSubjectCamera()
+    stub.runPreRender()
+    expect(cam.aspect).toBe(1)
+
+    viewport.setViewMode('object')
+    stub.runPreRender()
+    expect(cam.aspect).toBeCloseTo(CANVAS_WIDTH / CANVAS_HEIGHT)
+  })
+
+  it('renders the inset preview only when enabled and in camera view', () => {
+    stub.runPostRender()
+    expect(stub.renderer.render).not.toHaveBeenCalled()
+
+    viewport.setPreviewVisible(true)
+    expect(viewport.isPreviewVisible()).toBe(true)
+    stub.runPostRender()
+    expect(stub.renderer.render).toHaveBeenCalledOnce()
+    const [, y, width, height] = stub.renderer.setViewport.mock.lastCall as [
+      number,
+      number,
+      number,
+      number
+    ]
+    expect(width).toBe(height)
+    expect(y).toBeGreaterThanOrEqual(48)
+    expect(stub.renderer.setClearColor).toHaveBeenLastCalledWith('#123456')
+
+    viewport.setViewMode('object')
+    stub.renderer.render.mockClear()
+    stub.runPostRender()
+    expect(stub.renderer.render).not.toHaveBeenCalled()
+  })
+
+  it('turns the subject on drag and zooms on wheel in object view', () => {
+    viewport.setViewMode('object')
+
+    dispatchPointer(stub.domElement, 'pointerdown', 100, 100)
+    dispatchPointer(stub.domElement, 'pointermove', 140, 100)
+    runFrame()
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ horizontal: 340 })
+    )
+
+    dispatchWheel(stub.domElement, -100)
+    runFrame()
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ zoom: 6 })
+    )
+  })
+
+  it('ignores drags on empty space in camera view but still zooms on wheel', () => {
+    dispatchPointer(stub.domElement, 'pointerdown', 10, 10)
+    dispatchPointer(stub.domElement, 'pointermove', 50, 10)
+    runFrame()
+    expect(onStateChange).not.toHaveBeenCalled()
+    expect(stub.domElement.setPointerCapture).not.toHaveBeenCalled()
+
+    dispatchWheel(stub.domElement, 100)
+    runFrame()
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ zoom: 4 })
+    )
+  })
+
+  it('never re-enables the overview orbit controls', () => {
+    dispatchPointer(stub.domElement, 'pointerdown', 10, 10)
+    dispatchPointer(stub.domElement, 'pointerup', 10, 10)
+
+    expect(stub.controlsManager.controls.enabled).toBe(false)
+  })
+
+  it('drags the yaw handle to change the horizontal angle', () => {
+    const latitude = (YAW_RING_LATITUDE * Math.PI) / 180
+    const yawHandle = screenPositionOf(
+      {
+        x: 0,
+        y: SUBJECT_CENTER.y + ORBIT_SPHERE_RADIUS * Math.sin(latitude),
+        z: ORBIT_SPHERE_RADIUS * Math.cos(latitude)
+      },
+      stub.cameraManager.activeCamera
+    )
+
+    dispatchPointer(stub.domElement, 'pointerdown', yawHandle.x, yawHandle.y)
+
+    dispatchPointer(
+      stub.domElement,
+      'pointermove',
+      yawHandle.x + 120,
+      yawHandle.y
+    )
+    runFrame()
+    const next = onStateChange.mock.lastCall?.[0] as { horizontal: number }
+    expect(next.horizontal).toBeGreaterThan(0)
+    expect(next.horizontal).toBeLessThan(90)
+
+    dispatchPointer(
+      stub.domElement,
+      'pointerup',
+      yawHandle.x + 120,
+      yawHandle.y
+    )
+    expect(stub.domElement.style.cursor).toBe('grab')
+  })
+
+  it('forwards images to the subject card', async () => {
+    const setImage = vi
+      .spyOn(viewport.subject, 'setImage')
+      .mockResolvedValue(undefined)
+
+    await viewport.setImage('http://example/a.png')
+
+    expect(setImage).toHaveBeenCalledWith('http://example/a.png')
+    expect(stub.forceRender).toHaveBeenCalled()
+  })
+
+  it('tears down the viewport on remove', () => {
+    viewport.remove()
+
+    expect(stub.remove).toHaveBeenCalledOnce()
+    expect(stub.sceneManager.scene.children).toHaveLength(0)
+  })
+})

--- a/src/extensions/core/cameraAngle/CameraAngleViewport.test.ts
+++ b/src/extensions/core/cameraAngle/CameraAngleViewport.test.ts
@@ -49,6 +49,7 @@ function makeViewportStub() {
 
   let preRender: (() => void) | null = null
   let postRender: (() => void) | null = null
+  let overlay: { dispose(): void } | null = null
   const controls = { enabled: true }
   return {
     sceneManager: {
@@ -68,7 +69,9 @@ function makeViewportStub() {
       render: vi.fn()
     },
     domElement: canvas,
-    setOverlay: vi.fn(),
+    setOverlay: vi.fn((next: { dispose(): void }) => {
+      overlay = next
+    }),
     setCameraState: vi.fn(),
     addPreRenderCallback: vi.fn((cb: () => void) => {
       preRender = cb
@@ -82,7 +85,7 @@ function makeViewportStub() {
       controls.enabled = camera === null
     }),
     forceRender: vi.fn(),
-    remove: vi.fn(),
+    remove: vi.fn(() => overlay?.dispose()),
     runPreRender: () => preRender?.(),
     runPostRender: () => postRender?.()
   }
@@ -342,15 +345,37 @@ describe('CameraAngleViewport', () => {
     expect(stub.domElement.style.cursor).toBe('grab')
   })
 
-  it('forwards images to the subject card', async () => {
+  it('forwards images to the subject card and re-renders once applied', async () => {
     const setImage = vi
       .spyOn(viewport.subject, 'setImage')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue(true)
+    stub.forceRender.mockClear()
 
     await viewport.setImage('http://example/a.png')
 
     expect(setImage).toHaveBeenCalledWith('http://example/a.png')
-    expect(stub.forceRender).toHaveBeenCalled()
+    expect(stub.forceRender).toHaveBeenCalledOnce()
+  })
+
+  it('does not render an image that finishes loading after removal', async () => {
+    let resolveLoad: (texture: THREE.Texture) => void = () => {}
+    const pending = new Promise<THREE.Texture>((resolve) => {
+      resolveLoad = resolve
+    })
+    const deferred = new CameraAngleViewport(
+      document.createElement('div'),
+      undefined,
+      { loadTexture: () => pending }
+    )
+    const load = deferred.setImage('http://example/late.png')
+
+    deferred.remove()
+    stub.forceRender.mockClear()
+    resolveLoad(new THREE.Texture())
+    await load
+
+    expect(stub.forceRender).not.toHaveBeenCalled()
+    expect(deferred.subject.hasImage()).toBe(false)
   })
 
   it('tears down the viewport on remove', () => {

--- a/src/extensions/core/cameraAngle/CameraAngleViewport.ts
+++ b/src/extensions/core/cameraAngle/CameraAngleViewport.ts
@@ -64,6 +64,7 @@ export class CameraAngleViewport {
   private readonly input: PointerInteraction<OrbitHandleType>
   private overviewAspect: number | null = null
   private previewVisible = false
+  private removed = false
 
   constructor(
     container: HTMLElement,
@@ -165,11 +166,13 @@ export class CameraAngleViewport {
     return this.previewVisible
   }
 
-  setImage(url: string | null): Promise<void> {
-    return this.subject.setImage(url).then(() => this.viewport.forceRender())
+  async setImage(url: string | null): Promise<void> {
+    const applied = await this.subject.setImage(url)
+    if (applied && !this.removed) this.viewport.forceRender()
   }
 
   remove(): void {
+    this.removed = true
     this.input.detach()
     this.input.cancel()
     this.canvas.style.cursor = ''

--- a/src/extensions/core/cameraAngle/CameraAngleViewport.ts
+++ b/src/extensions/core/cameraAngle/CameraAngleViewport.ts
@@ -1,0 +1,298 @@
+import * as THREE from 'three'
+
+import { OrbitHandles } from '@/extensions/core/cameraInfo/handles/OrbitHandles'
+import type { OrbitHandleType } from '@/extensions/core/cameraInfo/handles/OrbitHandles'
+import { pickHandleAtPointer } from '@/extensions/core/cameraInfo/handles/handlePicking'
+import { PointerInteraction } from '@/extensions/core/cameraInfo/handles/pointerInteraction'
+import type { PointerPosition } from '@/extensions/core/cameraInfo/handles/pointerInteraction'
+import {
+  fitCameraAspect,
+  renderInsetPreview
+} from '@/extensions/core/cameraInfo/subjectCameraPreview'
+import type { Viewport3d } from '@/extensions/core/load3d/Viewport3d'
+import { createViewport3d } from '@/extensions/core/load3d/createViewport3d'
+import type { Load3DOptions } from '@/extensions/core/load3d/interfaces'
+
+import { SubjectBox } from './SubjectBox'
+import type { SubjectBoxOptions } from './SubjectBox'
+import {
+  clampState,
+  dollyByWheel,
+  overviewDistance,
+  rotateByDrag,
+  stateFromHandleDrag,
+  toHandleOrbitState
+} from './cameraAngleMath'
+import { CameraMarker, OrbitSphere } from './orbitGizmos'
+import {
+  CAMERA_ANGLE_LIMITS,
+  DEFAULT_CAMERA_ANGLE_STATE,
+  SUBJECT_CENTER,
+  YAW_RING_LATITUDE
+} from './types'
+import type { CameraAngleState, CameraAngleViewMode } from './types'
+
+const OVERVIEW_DIRECTION = new THREE.Vector3(2.4, 1.4, 4.2).normalize()
+const DEFAULT_OVERVIEW_FOV = 35
+const PREVIEW_SIZE_CSS = 150
+const PREVIEW_MAX_FRACTION = 0.35
+const PREVIEW_MARGIN_CSS = 8
+const PREVIEW_BOTTOM_BAR_CSS = 48
+const PREVIEW_BORDER_COLOR = 0x8a93a6
+const DEFAULT_PREVIEW_BACKGROUND = 0x282828
+
+export interface CameraAngleViewportOptions
+  extends Load3DOptions, SubjectBoxOptions {
+  onStateChange?: (state: CameraAngleState) => void
+}
+
+export class CameraAngleViewport {
+  readonly viewport: Viewport3d
+  readonly subject: SubjectBox
+  readonly orbitHandles: OrbitHandles
+  readonly orbitSphere: OrbitSphere
+  readonly cameraMarker: CameraMarker
+
+  private state: CameraAngleState
+  private viewMode: CameraAngleViewMode = 'camera'
+  private readonly onStateChange?: CameraAngleViewportOptions['onStateChange']
+  private readonly disposePreRender: () => void
+  private readonly disposePostRender: () => void
+  private readonly raycaster = new THREE.Raycaster()
+  private readonly pointerNdc = new THREE.Vector2()
+  private readonly dragPoint = new THREE.Vector3()
+  private readonly input: PointerInteraction<OrbitHandleType>
+  private overviewAspect: number | null = null
+  private previewVisible = false
+
+  constructor(
+    container: HTMLElement,
+    initialState: CameraAngleState = DEFAULT_CAMERA_ANGLE_STATE,
+    options?: CameraAngleViewportOptions
+  ) {
+    this.state = clampState(initialState)
+    this.onStateChange = options?.onStateChange
+    this.viewport = createViewport3d(container, options)
+    this.viewport.viewHelperManager.visibleViewHelper(false)
+    this.viewport.sceneManager.toggleGrid(false)
+    this.viewport.controlsManager.controls.enabled = false
+    this.fitOverviewCamera()
+
+    this.subject = new SubjectBox(this.state, {
+      loadTexture: options?.loadTexture,
+      faceLabels: options?.faceLabels
+    })
+    this.viewport.setOverlay(this.subject)
+
+    const scene = this.viewport.sceneManager.scene
+    this.orbitSphere = new OrbitSphere()
+    this.orbitSphere.attach(scene)
+    this.cameraMarker = new CameraMarker()
+    this.cameraMarker.attach(scene)
+    this.orbitHandles = new OrbitHandles({
+      pitchLimits: CAMERA_ANGLE_LIMITS.vertical,
+      yawRingLatitude: YAW_RING_LATITUDE
+    })
+    this.orbitHandles.attach(scene)
+    this.syncGizmos()
+
+    this.input = new PointerInteraction<OrbitHandleType>({
+      canvas: this.canvas,
+      pickHandle: (position) => this.pickHandle(position),
+      dragHandle: (type, position) => this.dragHandle(type, position),
+      hoverChanged: (type) => {
+        this.orbitHandles.setHovered(type)
+        this.viewport.forceRender()
+      },
+      handleDragChanged: () => {},
+      freeDragEnabled: () => this.viewMode === 'object',
+      freeDrag: (dx, dy) => this.commit(rotateByDrag(this.state, dx, dy)),
+      wheelEnabled: () => true,
+      wheel: (deltaY) => this.commit(dollyByWheel(this.state, deltaY)),
+      idleCursor: () =>
+        this.viewMode === 'object' || this.input.hoveredHandle ? 'grab' : ''
+    })
+    this.input.attach()
+
+    this.disposePreRender = this.viewport.addPreRenderCallback(() => {
+      this.fitOverviewCamera()
+      if (this.viewMode === 'object') this.fitSubjectAspect()
+    })
+    this.disposePostRender = this.viewport.addPostRenderCallback(() => {
+      if (this.viewMode === 'camera' && this.previewVisible)
+        this.renderSubjectPreview()
+    })
+  }
+
+  getState(): CameraAngleState {
+    return { ...this.state }
+  }
+
+  getViewMode(): CameraAngleViewMode {
+    return this.viewMode
+  }
+
+  applyState(next: CameraAngleState): void {
+    this.state = clampState(next)
+    this.subject.applyState(this.state)
+    this.syncGizmos()
+    this.viewport.forceRender()
+  }
+
+  setViewMode(mode: CameraAngleViewMode): void {
+    if (this.viewMode === mode) return
+    this.viewMode = mode
+    this.input.cancel()
+    const lookingThrough = mode === 'object'
+    this.syncGizmos()
+    if (lookingThrough) this.fitSubjectAspect()
+    this.viewport.setExternalActiveCamera(
+      lookingThrough ? this.subject.getSubjectCamera() : null
+    )
+    this.viewport.controlsManager.controls.enabled = false
+    if (!lookingThrough)
+      this.viewport.viewHelperManager.visibleViewHelper(false)
+    this.viewport.forceRender()
+  }
+
+  setPreviewVisible(visible: boolean): void {
+    if (this.previewVisible === visible) return
+    this.previewVisible = visible
+    this.viewport.forceRender()
+  }
+
+  isPreviewVisible(): boolean {
+    return this.previewVisible
+  }
+
+  setImage(url: string | null): Promise<void> {
+    return this.subject.setImage(url).then(() => this.viewport.forceRender())
+  }
+
+  remove(): void {
+    this.input.detach()
+    this.input.cancel()
+    this.canvas.style.cursor = ''
+    this.disposePreRender()
+    this.disposePostRender()
+    this.orbitHandles.dispose()
+    this.orbitSphere.dispose()
+    this.cameraMarker.dispose()
+    this.viewport.remove()
+  }
+
+  private get canvas(): HTMLCanvasElement {
+    return this.viewport.domElement
+  }
+
+  private syncGizmos(): void {
+    const visible = this.viewMode === 'camera'
+    this.orbitHandles.update(toHandleOrbitState(this.state))
+    this.orbitHandles.setVisible(visible)
+    this.cameraMarker.update(this.state)
+    this.cameraMarker.setVisible(visible)
+    this.orbitSphere.setVisible(visible)
+  }
+
+  private commit(next: CameraAngleState): void {
+    this.applyState(next)
+    this.onStateChange?.(this.getState())
+  }
+
+  private updatePointer({ clientX, clientY }: PointerPosition): void {
+    const rect = this.canvas.getBoundingClientRect()
+    this.pointerNdc.x = ((clientX - rect.left) / rect.width) * 2 - 1
+    this.pointerNdc.y = -((clientY - rect.top) / rect.height) * 2 + 1
+  }
+
+  private pickHandle(position: PointerPosition): OrbitHandleType | null {
+    if (this.viewMode !== 'camera') return null
+    this.updatePointer(position)
+    return pickHandleAtPointer<OrbitHandleType>(
+      this.raycaster,
+      this.pointerNdc,
+      this.viewport.cameraManager.activeCamera,
+      this.orbitHandles.pickableMeshes(),
+      this.canvas
+    )
+  }
+
+  private dragHandle(type: OrbitHandleType, position: PointerPosition): void {
+    this.updatePointer(position)
+    this.raycaster.setFromCamera(
+      this.pointerNdc,
+      this.viewport.cameraManager.activeCamera
+    )
+    const plane = this.orbitHandles.dragPlaneFor(
+      type,
+      toHandleOrbitState(this.state)
+    )
+    if (!this.raycaster.ray.intersectPlane(plane, this.dragPoint)) return
+    this.commit(stateFromHandleDrag(type, this.state, this.dragPoint))
+  }
+
+  private fitOverviewCamera(): void {
+    const aspect = this.canvas.width / this.canvas.height
+    if (!Number.isFinite(aspect) || aspect <= 0) return
+    if (aspect === this.overviewAspect) return
+    this.overviewAspect = aspect
+    const camera = this.viewport.cameraManager.activeCamera
+    const fov =
+      camera instanceof THREE.PerspectiveCamera
+        ? camera.fov
+        : DEFAULT_OVERVIEW_FOV
+    const target = new THREE.Vector3(
+      SUBJECT_CENTER.x,
+      SUBJECT_CENTER.y,
+      SUBJECT_CENTER.z
+    )
+    const position = OVERVIEW_DIRECTION.clone()
+      .multiplyScalar(overviewDistance(aspect, fov))
+      .add(target)
+    this.viewport.setCameraState({
+      position,
+      target,
+      zoom: 1,
+      cameraType: 'perspective'
+    })
+  }
+
+  private fitSubjectAspect(): void {
+    fitCameraAspect(
+      this.subject.getSubjectCamera(),
+      this.canvas.width / this.canvas.height
+    )
+  }
+
+  private renderSubjectPreview(): void {
+    const canvas = this.canvas
+    const pixelScale = canvas.clientHeight
+      ? canvas.height / canvas.clientHeight
+      : 1
+    const side = Math.floor(
+      Math.min(
+        PREVIEW_SIZE_CSS * pixelScale,
+        Math.min(canvas.width, canvas.height) * PREVIEW_MAX_FRACTION
+      )
+    )
+    const background = this.viewport.sceneManager.getCurrentBackgroundInfo()
+    renderInsetPreview({
+      renderer: this.viewport.renderer,
+      canvas,
+      scene: this.viewport.sceneManager.scene,
+      camera: this.subject.getSubjectCamera(),
+      hidden: [this.orbitHandles, this.orbitSphere, this.cameraMarker],
+      layout: {
+        width: side,
+        height: side,
+        marginRight: PREVIEW_MARGIN_CSS * pixelScale,
+        marginBottom: (PREVIEW_BOTTOM_BAR_CSS + PREVIEW_MARGIN_CSS) * pixelScale
+      },
+      borderColor: PREVIEW_BORDER_COLOR,
+      backgroundColor:
+        background.type === 'color'
+          ? background.value
+          : DEFAULT_PREVIEW_BACKGROUND
+    })
+  }
+}

--- a/src/extensions/core/cameraAngle/CameraAngleViewport.ts
+++ b/src/extensions/core/cameraAngle/CameraAngleViewport.ts
@@ -172,6 +172,7 @@ export class CameraAngleViewport {
   }
 
   remove(): void {
+    if (this.removed) return
     this.removed = true
     this.input.detach()
     this.input.cancel()

--- a/src/extensions/core/cameraAngle/SubjectBox.test.ts
+++ b/src/extensions/core/cameraAngle/SubjectBox.test.ts
@@ -1,0 +1,136 @@
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SubjectBox } from './SubjectBox'
+import { MAX_SUBJECT_DISTANCE, SUBJECT_CENTER, SUBJECT_HEIGHT } from './types'
+
+function fakeTexture(width: number, height: number): THREE.Texture {
+  const texture = new THREE.Texture()
+  texture.image = { width, height }
+  return texture
+}
+
+function subjectMesh(scene: THREE.Scene): THREE.Mesh {
+  return scene.getObjectByName('CameraAngleSubject')?.children[0] as THREE.Mesh
+}
+
+function boxSize(scene: THREE.Scene): THREE.Vector3 {
+  const geometry = subjectMesh(scene).geometry
+  geometry.computeBoundingBox()
+  return geometry.boundingBox!.getSize(new THREE.Vector3())
+}
+
+function frontTexture(scene: THREE.Scene): THREE.Texture | null {
+  const materials = subjectMesh(scene).material as THREE.MeshBasicMaterial[]
+  return materials[4].map
+}
+
+describe('SubjectBox', () => {
+  it('places the subject camera on the orbit and aims it at the subject centre', () => {
+    const box = new SubjectBox({ horizontal: 0, vertical: 0, zoom: 0 })
+    const camera = box.getSubjectCamera()
+
+    expect(camera.position.x).toBeCloseTo(SUBJECT_CENTER.x)
+    expect(camera.position.y).toBeCloseTo(SUBJECT_CENTER.y)
+    expect(camera.position.z).toBeCloseTo(MAX_SUBJECT_DISTANCE)
+
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(
+      camera.quaternion
+    )
+    expect(forward.z).toBeCloseTo(-1)
+  })
+
+  it('moves the camera when state is applied', () => {
+    const box = new SubjectBox()
+    box.applyState({ horizontal: 90, vertical: 0, zoom: 0 })
+
+    expect(box.getSubjectCamera().position.x).toBeCloseTo(MAX_SUBJECT_DISTANCE)
+    expect(box.getState()).toEqual({ horizontal: 90, vertical: 0, zoom: 0 })
+  })
+
+  it('stays a unit cube and centre-crops the image onto the front face', async () => {
+    const loadTexture = vi
+      .fn<(url: string) => Promise<THREE.Texture>>()
+      .mockResolvedValueOnce(fakeTexture(400, 100))
+      .mockResolvedValueOnce(fakeTexture(100, 400))
+    const box = new SubjectBox(undefined, { loadTexture })
+    const scene = new THREE.Scene()
+    box.attach(scene)
+
+    await box.setImage('http://example/wide.png')
+    expect(loadTexture).toHaveBeenCalledWith('http://example/wide.png')
+    expect(box.hasImage()).toBe(true)
+    expect(boxSize(scene).toArray()).toEqual([
+      SUBJECT_HEIGHT,
+      SUBJECT_HEIGHT,
+      SUBJECT_HEIGHT
+    ])
+    const wide = frontTexture(scene)!
+    expect(wide.repeat.toArray()).toEqual([0.25, 1])
+    expect(wide.offset.toArray()).toEqual([0.375, 0])
+
+    await box.setImage('http://example/tall.png')
+    const tall = frontTexture(scene)!
+    expect(tall.repeat.toArray()).toEqual([1, 0.25])
+    expect(tall.offset.toArray()).toEqual([0, 0.375])
+
+    await box.setImage(null)
+    expect(box.hasImage()).toBe(false)
+    expect(frontTexture(scene)).toBeNull()
+  })
+
+  it('keeps only the latest requested image when loads overlap', async () => {
+    let resolveFirst: (texture: THREE.Texture) => void = () => {}
+    const first = new Promise<THREE.Texture>((resolve) => {
+      resolveFirst = resolve
+    })
+    const loadTexture = vi
+      .fn<(url: string) => Promise<THREE.Texture>>()
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce(fakeTexture(100, 300))
+    const box = new SubjectBox(undefined, { loadTexture })
+
+    const firstLoad = box.setImage('first')
+    await box.setImage('second')
+    resolveFirst(fakeTexture(300, 100))
+    await firstLoad
+
+    expect(box.getAspect()).toBeCloseTo(1 / 3)
+  })
+
+  it('ignores a failed image load', async () => {
+    const box = new SubjectBox(undefined, {
+      loadTexture: () => Promise.reject(new Error('network'))
+    })
+    await expect(box.setImage('broken')).resolves.toBeUndefined()
+    expect(box.hasImage()).toBe(false)
+  })
+
+  it('detaches from the scene and releases every GPU resource on dispose', async () => {
+    const box = new SubjectBox(undefined, {
+      loadTexture: async () => fakeTexture(64, 64)
+    })
+    const scene = new THREE.Scene()
+    box.attach(scene)
+    await box.setImage('http://example/image.png')
+    const mesh = subjectMesh(scene)
+    const edges = scene.getObjectByName('CameraAngleSubject')!
+      .children[1] as THREE.LineSegments
+    const owned: THREE.EventDispatcher<{ dispose: object }>[] = [
+      mesh.geometry,
+      edges.geometry,
+      ...new Set(mesh.material as THREE.Material[]),
+      frontTexture(scene)!
+    ]
+    const disposed = owned.map((resource) => {
+      const listener = vi.fn()
+      resource.addEventListener('dispose', listener)
+      return listener
+    })
+
+    box.dispose()
+
+    expect(scene.children).toHaveLength(0)
+    for (const listener of disposed) expect(listener).toHaveBeenCalledOnce()
+  })
+})

--- a/src/extensions/core/cameraAngle/SubjectBox.test.ts
+++ b/src/extensions/core/cameraAngle/SubjectBox.test.ts
@@ -14,6 +14,12 @@ function subjectMesh(scene: THREE.Scene): THREE.Mesh {
   return scene.getObjectByName('CameraAngleSubject')?.children[0] as THREE.Mesh
 }
 
+function disposeListener(resource: THREE.Texture) {
+  const listener = vi.fn()
+  resource.addEventListener('dispose', listener)
+  return listener
+}
+
 function boxSize(scene: THREE.Scene): THREE.Vector3 {
   const geometry = subjectMesh(scene).geometry
   geometry.computeBoundingBox()
@@ -68,15 +74,19 @@ describe('SubjectBox', () => {
     const wide = frontTexture(scene)!
     expect(wide.repeat.toArray()).toEqual([0.25, 1])
     expect(wide.offset.toArray()).toEqual([0.375, 0])
+    const wideDisposed = disposeListener(wide)
 
-    await box.setImage('http://example/tall.png')
+    await expect(box.setImage('http://example/tall.png')).resolves.toBe(true)
     const tall = frontTexture(scene)!
     expect(tall.repeat.toArray()).toEqual([1, 0.25])
     expect(tall.offset.toArray()).toEqual([0, 0.375])
+    expect(wideDisposed).toHaveBeenCalledOnce()
+    const tallDisposed = disposeListener(tall)
 
-    await box.setImage(null)
+    await expect(box.setImage(null)).resolves.toBe(true)
     expect(box.hasImage()).toBe(false)
     expect(frontTexture(scene)).toBeNull()
+    expect(tallDisposed).toHaveBeenCalledOnce()
   })
 
   it('keeps only the latest requested image when loads overlap', async () => {
@@ -91,18 +101,21 @@ describe('SubjectBox', () => {
     const box = new SubjectBox(undefined, { loadTexture })
 
     const firstLoad = box.setImage('first')
-    await box.setImage('second')
-    resolveFirst(fakeTexture(300, 100))
-    await firstLoad
+    await expect(box.setImage('second')).resolves.toBe(true)
+    const stale = fakeTexture(300, 100)
+    const staleDisposed = disposeListener(stale)
+    resolveFirst(stale)
 
+    await expect(firstLoad).resolves.toBe(false)
     expect(box.getAspect()).toBeCloseTo(1 / 3)
+    expect(staleDisposed).toHaveBeenCalledOnce()
   })
 
   it('ignores a failed image load', async () => {
     const box = new SubjectBox(undefined, {
       loadTexture: () => Promise.reject(new Error('network'))
     })
-    await expect(box.setImage('broken')).resolves.toBeUndefined()
+    await expect(box.setImage('broken')).resolves.toBe(false)
     expect(box.hasImage()).toBe(false)
   })
 

--- a/src/extensions/core/cameraAngle/SubjectBox.ts
+++ b/src/extensions/core/cameraAngle/SubjectBox.ts
@@ -200,25 +200,26 @@ export class SubjectBox implements SceneOverlay {
     this.placeSubjectCamera()
   }
 
-  async setImage(url: string | null): Promise<void> {
+  async setImage(url: string | null): Promise<boolean> {
     const token = ++this.loadToken
     if (!url) {
       this.applyTexture(null)
-      return
+      return true
     }
     let texture: THREE.Texture
     try {
       texture = await this.loadTexture(url)
     } catch {
-      return
+      return false
     }
     if (token !== this.loadToken || this.disposed) {
       texture.dispose()
-      return
+      return false
     }
     texture.colorSpace = THREE.SRGBColorSpace
     centerCropToSquare(texture)
     this.applyTexture(texture)
+    return true
   }
 
   private applyTexture(texture: THREE.Texture | null): void {

--- a/src/extensions/core/cameraAngle/SubjectBox.ts
+++ b/src/extensions/core/cameraAngle/SubjectBox.ts
@@ -1,0 +1,245 @@
+import * as THREE from 'three'
+
+import { computeSubjectTransform } from '@/extensions/core/cameraInfo/cameraTransform'
+import type { SceneOverlay } from '@/extensions/core/load3d/interfaces'
+
+import { clampState, toOrbitCameraInfoState } from './cameraAngleMath'
+import {
+  CAMERA_ANGLE_FOV,
+  DEFAULT_CAMERA_ANGLE_STATE,
+  DEFAULT_SUBJECT_FACE_LABELS,
+  SUBJECT_CENTER,
+  SUBJECT_HEIGHT
+} from './types'
+import type { CameraAngleState, SubjectFaceLabels } from './types'
+
+const SUBJECT_CAMERA_NEAR = 0.1
+const SUBJECT_CAMERA_FAR = 100
+const FRONT_COLOR = 0xd8dbe2
+const FACE_COLOR = '#2a2d36'
+const FACE_GRID_COLOR = '#3d4150'
+const FACE_TEXT_COLOR = '#aeb4c2'
+const EDGE_COLOR = 0x1a1a1a
+const FACE_TEXTURE_SIZE = 256
+const FACE_GRID_CELL = 32
+const FACE_FONT = 'bold 40px sans-serif'
+
+export type TextureLoaderFn = (url: string) => Promise<THREE.Texture>
+
+export interface SubjectBoxOptions {
+  loadTexture?: TextureLoaderFn
+  faceLabels?: SubjectFaceLabels
+}
+
+const loadTextureWithThree: TextureLoaderFn = (url) =>
+  new THREE.TextureLoader().setCrossOrigin('anonymous').loadAsync(url)
+
+function makeFaceTexture(label: string): THREE.CanvasTexture | null {
+  const canvas = document.createElement('canvas')
+  canvas.width = FACE_TEXTURE_SIZE
+  canvas.height = FACE_TEXTURE_SIZE
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+  ctx.fillStyle = FACE_COLOR
+  ctx.fillRect(0, 0, FACE_TEXTURE_SIZE, FACE_TEXTURE_SIZE)
+  ctx.strokeStyle = FACE_GRID_COLOR
+  ctx.lineWidth = 1
+  for (let i = 0; i <= FACE_TEXTURE_SIZE; i += FACE_GRID_CELL) {
+    ctx.beginPath()
+    ctx.moveTo(i, 0)
+    ctx.lineTo(i, FACE_TEXTURE_SIZE)
+    ctx.moveTo(0, i)
+    ctx.lineTo(FACE_TEXTURE_SIZE, i)
+    ctx.stroke()
+  }
+  ctx.fillStyle = FACE_TEXT_COLOR
+  ctx.font = FACE_FONT
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(label, FACE_TEXTURE_SIZE / 2, FACE_TEXTURE_SIZE / 2)
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.colorSpace = THREE.SRGBColorSpace
+  return texture
+}
+
+function makeFaceMaterial(label: string): THREE.MeshBasicMaterial {
+  const texture = makeFaceTexture(label)
+  return new THREE.MeshBasicMaterial(
+    texture ? { map: texture } : { color: FACE_COLOR }
+  )
+}
+
+function centerCropToSquare(texture: THREE.Texture): void {
+  const aspect = textureAspect(texture)
+  const repeatX = aspect > 1 ? 1 / aspect : 1
+  const repeatY = aspect < 1 ? aspect : 1
+  texture.repeat.set(repeatX, repeatY)
+  texture.offset.set((1 - repeatX) / 2, (1 - repeatY) / 2)
+}
+
+function textureAspect(texture: THREE.Texture): number {
+  const image = texture.image as
+    | { width?: number; height?: number }
+    | null
+    | undefined
+  const width = image?.width ?? 0
+  const height = image?.height ?? 0
+  return width > 0 && height > 0 ? width / height : 1
+}
+
+export class SubjectBox implements SceneOverlay {
+  private scene: THREE.Scene | null = null
+  private state: CameraAngleState
+  private readonly loadTexture: TextureLoaderFn
+
+  private readonly group = new THREE.Group()
+  private readonly box: THREE.Mesh
+  private readonly edges: THREE.LineSegments
+  private readonly frontMaterial: THREE.MeshBasicMaterial
+  private readonly faceMaterials: THREE.MeshBasicMaterial[]
+  private imageTexture: THREE.Texture | null = null
+  private loadToken = 0
+  private aspect = 1
+
+  private readonly subjectCamera: THREE.PerspectiveCamera
+  private disposed = false
+
+  constructor(
+    initialState: CameraAngleState = DEFAULT_CAMERA_ANGLE_STATE,
+    options: SubjectBoxOptions = {}
+  ) {
+    this.state = clampState(initialState)
+    this.loadTexture = options.loadTexture ?? loadTextureWithThree
+    const labels = options.faceLabels ?? DEFAULT_SUBJECT_FACE_LABELS
+    this.group.name = 'CameraAngleSubject'
+    this.group.position.set(
+      SUBJECT_CENTER.x,
+      SUBJECT_CENTER.y,
+      SUBJECT_CENTER.z
+    )
+
+    this.frontMaterial = new THREE.MeshBasicMaterial({ color: FRONT_COLOR })
+    this.faceMaterials = [
+      makeFaceMaterial(labels.right),
+      makeFaceMaterial(labels.left),
+      makeFaceMaterial(labels.top),
+      makeFaceMaterial(labels.bottom),
+      this.frontMaterial,
+      makeFaceMaterial(labels.back)
+    ]
+
+    const geometry = this.buildGeometry()
+    this.box = new THREE.Mesh(geometry, this.faceMaterials)
+    this.edges = new THREE.LineSegments(
+      new THREE.EdgesGeometry(geometry),
+      new THREE.LineBasicMaterial({
+        color: EDGE_COLOR,
+        transparent: true,
+        opacity: 0.6
+      })
+    )
+    this.group.add(this.box)
+    this.group.add(this.edges)
+
+    this.subjectCamera = new THREE.PerspectiveCamera(
+      CAMERA_ANGLE_FOV,
+      1,
+      SUBJECT_CAMERA_NEAR,
+      SUBJECT_CAMERA_FAR
+    )
+    this.subjectCamera.name = 'CameraAngleSubjectCamera'
+    this.placeSubjectCamera()
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.group)
+    scene.add(this.subjectCamera)
+  }
+
+  detach(): void {
+    if (!this.scene) return
+    this.scene.remove(this.group)
+    this.scene.remove(this.subjectCamera)
+    this.scene = null
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.loadToken++
+    this.detach()
+    this.box.geometry.dispose()
+    this.edges.geometry.dispose()
+    ;(this.edges.material as THREE.Material).dispose()
+    this.applyTexture(null)
+    for (const material of new Set(this.faceMaterials)) {
+      material.map?.dispose()
+      material.dispose()
+    }
+  }
+
+  getSubjectCamera(): THREE.PerspectiveCamera {
+    return this.subjectCamera
+  }
+
+  getState(): CameraAngleState {
+    return { ...this.state }
+  }
+
+  getAspect(): number {
+    return this.aspect
+  }
+
+  hasImage(): boolean {
+    return this.imageTexture !== null
+  }
+
+  applyState(next: CameraAngleState): void {
+    this.state = clampState(next)
+    this.placeSubjectCamera()
+  }
+
+  async setImage(url: string | null): Promise<void> {
+    const token = ++this.loadToken
+    if (!url) {
+      this.applyTexture(null)
+      return
+    }
+    let texture: THREE.Texture
+    try {
+      texture = await this.loadTexture(url)
+    } catch {
+      return
+    }
+    if (token !== this.loadToken || this.disposed) {
+      texture.dispose()
+      return
+    }
+    texture.colorSpace = THREE.SRGBColorSpace
+    centerCropToSquare(texture)
+    this.applyTexture(texture)
+  }
+
+  private applyTexture(texture: THREE.Texture | null): void {
+    this.imageTexture?.dispose()
+    this.imageTexture = texture
+    this.aspect = texture ? textureAspect(texture) : 1
+    this.frontMaterial.map = texture
+    this.frontMaterial.color.set(texture ? 0xffffff : FRONT_COLOR)
+    this.frontMaterial.needsUpdate = true
+  }
+
+  private buildGeometry(): THREE.BoxGeometry {
+    return new THREE.BoxGeometry(SUBJECT_HEIGHT, SUBJECT_HEIGHT, SUBJECT_HEIGHT)
+  }
+
+  private placeSubjectCamera(): void {
+    const { position, quaternion } = computeSubjectTransform(
+      toOrbitCameraInfoState(this.state)
+    )
+    this.subjectCamera.position.copy(position)
+    this.subjectCamera.quaternion.copy(quaternion)
+    this.subjectCamera.updateMatrixWorld(true)
+  }
+}

--- a/src/extensions/core/cameraAngle/cameraAngleMath.test.ts
+++ b/src/extensions/core/cameraAngle/cameraAngleMath.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clampState,
+  describeCameraAngle,
+  displayDistanceToZoom,
+  distanceTerm,
+  distanceToZoom,
+  dollyByWheel,
+  horizontalTerm,
+  normalizeHorizontal,
+  overviewDistance,
+  rotateByDrag,
+  roundState,
+  stateFromHandleDrag,
+  toHandleOrbitState,
+  toOrbitCameraInfoState,
+  verticalTerm,
+  zoomToDisplayDistance,
+  zoomToDistance
+} from './cameraAngleMath'
+import {
+  CAMERA_ANGLE_FOV,
+  MAX_DISPLAY_DISTANCE,
+  MAX_SUBJECT_DISTANCE,
+  MIN_DISPLAY_DISTANCE,
+  MIN_SUBJECT_DISTANCE,
+  ORBIT_SPHERE_RADIUS,
+  SUBJECT_CENTER
+} from './types'
+import type { CameraAngleState } from './types'
+
+const FRONT: CameraAngleState = { horizontal: 0, vertical: 0, zoom: 5 }
+
+describe('term buckets', () => {
+  it.each([
+    [0, 'front'],
+    [22, 'front'],
+    [23, 'frontRight'],
+    [90, 'right'],
+    [180, 'back'],
+    [270, 'left'],
+    [338, 'front'],
+    [-45, 'frontLeft']
+  ])('maps %d° to the %s sector', (angle, key) => {
+    expect(horizontalTerm(angle).key).toBe(key)
+  })
+
+  it.each([
+    [-30, 'lowAngle'],
+    [-15, 'eyeLevel'],
+    [14, 'eyeLevel'],
+    [15, 'elevated'],
+    [45, 'highAngle']
+  ])('maps %d° elevation to %s', (angle, key) => {
+    expect(verticalTerm(angle).key).toBe(key)
+  })
+
+  it.each([
+    [0, 'wide'],
+    [1.9, 'wide'],
+    [2, 'medium'],
+    [6, 'closeUp'],
+    [10, 'closeUp']
+  ])('maps zoom %d to %s', (zoom, key) => {
+    expect(distanceTerm(zoom).key).toBe(key)
+  })
+
+  it('joins the three prompt phrases in order', () => {
+    expect(
+      describeCameraAngle({ horizontal: 135, vertical: 50, zoom: 1 })
+    ).toBe('back-right quarter view high-angle shot wide shot')
+  })
+})
+
+describe('state normalisation', () => {
+  it('wraps horizontal degrees into [0, 360)', () => {
+    expect(normalizeHorizontal(370)).toBe(10)
+    expect(normalizeHorizontal(-10)).toBe(350)
+    expect(normalizeHorizontal(360)).toBe(0)
+  })
+
+  it('clamps every field to its allowed range', () => {
+    expect(clampState({ horizontal: 400, vertical: -90, zoom: 99 })).toEqual({
+      horizontal: 360,
+      vertical: -30,
+      zoom: 10
+    })
+  })
+
+  it('rounds angles to whole degrees and zoom to a tenth for the widgets', () => {
+    expect(
+      roundState({ horizontal: 328.6, vertical: 35.4, zoom: 3.49999 })
+    ).toEqual({
+      horizontal: 329,
+      vertical: 35,
+      zoom: 3.5
+    })
+  })
+
+  it('maps zoom to distance and back', () => {
+    expect(zoomToDistance(0)).toBe(MAX_SUBJECT_DISTANCE)
+    expect(zoomToDistance(10)).toBe(MIN_SUBJECT_DISTANCE)
+    expect(distanceToZoom(zoomToDistance(3.5))).toBeCloseTo(3.5)
+  })
+
+  it('keeps the whole orbit sphere in view for the overview camera', () => {
+    const halfFov = Math.tan((35 / 2) * (Math.PI / 180))
+    const wide = overviewDistance(16 / 9, 35)
+    const tall = overviewDistance(0.5, 35)
+    expect(wide * halfFov).toBeGreaterThan(ORBIT_SPHERE_RADIUS)
+    expect(tall * halfFov * 0.5).toBeGreaterThan(ORBIT_SPHERE_RADIUS)
+    expect(tall).toBeGreaterThan(wide)
+  })
+
+  it('maps zoom onto the compressed gizmo distance and back', () => {
+    expect(zoomToDisplayDistance(0)).toBe(MAX_DISPLAY_DISTANCE)
+    expect(zoomToDisplayDistance(10)).toBe(MIN_DISPLAY_DISTANCE)
+    expect(displayDistanceToZoom(zoomToDisplayDistance(7))).toBeCloseTo(7)
+    expect(
+      toHandleOrbitState({ horizontal: 0, vertical: 0, zoom: 0 }).orbit.distance
+    ).toBe(MAX_DISPLAY_DISTANCE)
+  })
+
+  it('builds an orbit CameraInfoState around the subject centre', () => {
+    const state = toOrbitCameraInfoState({
+      horizontal: 30,
+      vertical: 10,
+      zoom: 0
+    })
+    expect(state.mode).toBe('orbit')
+    expect(state.target).toEqual(SUBJECT_CENTER)
+    expect(state.fov).toBe(CAMERA_ANGLE_FOV)
+    expect(state.orbit).toEqual({
+      yaw: 30,
+      pitch: 10,
+      distance: MAX_SUBJECT_DISTANCE
+    })
+  })
+})
+
+describe('object-view input', () => {
+  it('dragging right turns the subject to the right by lowering the azimuth', () => {
+    const next = rotateByDrag(FRONT, 40, 0)
+    expect(next.horizontal).toBe(340)
+    expect(next.vertical).toBe(0)
+  })
+
+  it('dragging down raises the camera and clamps at the elevation limit', () => {
+    expect(rotateByDrag(FRONT, 0, 40).vertical).toBe(20)
+    expect(rotateByDrag(FRONT, 0, 400).vertical).toBe(60)
+  })
+
+  it('scrolling up zooms in and clamps to the zoom range', () => {
+    expect(dollyByWheel(FRONT, -100).zoom).toBeCloseTo(6)
+    expect(dollyByWheel(FRONT, 2000).zoom).toBe(0)
+  })
+})
+
+describe('handle drag', () => {
+  it('reads the azimuth from a point on the yaw ring', () => {
+    const next = stateFromHandleDrag('yaw', FRONT, {
+      x: -1,
+      y: SUBJECT_CENTER.y,
+      z: 0
+    })
+    expect(next.horizontal).toBeCloseTo(270)
+  })
+
+  it('reads the elevation from a point on the pitch arc and clamps it', () => {
+    const above = stateFromHandleDrag('pitch', FRONT, {
+      x: 0,
+      y: SUBJECT_CENTER.y + 1,
+      z: 1
+    })
+    expect(above.vertical).toBeCloseTo(45)
+
+    const tooHigh = stateFromHandleDrag('pitch', FRONT, {
+      x: 0,
+      y: SUBJECT_CENTER.y + 10,
+      z: 0.1
+    })
+    expect(tooHigh.vertical).toBe(60)
+  })
+
+  it('reads the zoom from the distance handle along the view axis', () => {
+    const next = stateFromHandleDrag('distance', FRONT, {
+      x: 0,
+      y: SUBJECT_CENTER.y,
+      z: MIN_DISPLAY_DISTANCE
+    })
+    expect(next.zoom).toBeCloseTo(10)
+  })
+})

--- a/src/extensions/core/cameraAngle/cameraAngleMath.ts
+++ b/src/extensions/core/cameraAngle/cameraAngleMath.ts
@@ -1,0 +1,232 @@
+import { clamp } from 'es-toolkit'
+
+import type { Vector3Like } from 'three'
+
+import { DEFAULT_CAMERA_INFO_STATE } from '@/extensions/core/cameraInfo/types'
+import type { CameraInfoState } from '@/extensions/core/cameraInfo/types'
+import type { OrbitHandleType } from '@/extensions/core/cameraInfo/handles/OrbitHandles'
+import {
+  pointToDistance,
+  pointToPitchAngle,
+  pointToYawAngle
+} from '@/extensions/core/cameraInfo/handles/orbitDragMath'
+
+import {
+  CAMERA_ANGLE_FOV,
+  CAMERA_ANGLE_LIMITS,
+  MAX_DISPLAY_DISTANCE,
+  MAX_SUBJECT_DISTANCE,
+  MIN_DISPLAY_DISTANCE,
+  MIN_SUBJECT_DISTANCE,
+  ORBIT_SPHERE_RADIUS,
+  SUBJECT_CENTER
+} from './types'
+import type { CameraAngleState } from './types'
+
+const DRAG_DEGREES_PER_PIXEL = 0.5
+const WHEEL_ZOOM_PER_PIXEL = 0.01
+const ZOOM_DECIMALS = 1
+
+export interface CameraAngleTerm {
+  key: string
+  prompt: string
+  preset: number
+}
+
+export const HORIZONTAL_TERMS: readonly CameraAngleTerm[] = [
+  { key: 'front', prompt: 'front view', preset: 0 },
+  { key: 'frontRight', prompt: 'front-right quarter view', preset: 45 },
+  { key: 'right', prompt: 'right side view', preset: 90 },
+  { key: 'backRight', prompt: 'back-right quarter view', preset: 135 },
+  { key: 'back', prompt: 'back view', preset: 180 },
+  { key: 'backLeft', prompt: 'back-left quarter view', preset: 225 },
+  { key: 'left', prompt: 'left side view', preset: 270 },
+  { key: 'frontLeft', prompt: 'front-left quarter view', preset: 315 }
+]
+
+export const VERTICAL_TERMS: readonly CameraAngleTerm[] = [
+  { key: 'lowAngle', prompt: 'low-angle shot', preset: -20 },
+  { key: 'eyeLevel', prompt: 'eye-level shot', preset: 0 },
+  { key: 'elevated', prompt: 'elevated shot', preset: 30 },
+  { key: 'highAngle', prompt: 'high-angle shot', preset: 55 }
+]
+const VERTICAL_UPPER_BOUNDS = [-15, 15, 45]
+
+export const DISTANCE_TERMS: readonly CameraAngleTerm[] = [
+  { key: 'wide', prompt: 'wide shot', preset: 1 },
+  { key: 'medium', prompt: 'medium shot', preset: 5 },
+  { key: 'closeUp', prompt: 'close-up', preset: 8 }
+]
+const DISTANCE_UPPER_BOUNDS = [2, 6]
+
+export function normalizeHorizontal(degrees: number): number {
+  return ((degrees % 360) + 360) % 360
+}
+
+export function clampState(state: CameraAngleState): CameraAngleState {
+  return {
+    horizontal: clamp(
+      state.horizontal,
+      CAMERA_ANGLE_LIMITS.horizontal.min,
+      CAMERA_ANGLE_LIMITS.horizontal.max
+    ),
+    vertical: clamp(
+      state.vertical,
+      CAMERA_ANGLE_LIMITS.vertical.min,
+      CAMERA_ANGLE_LIMITS.vertical.max
+    ),
+    zoom: clamp(
+      state.zoom,
+      CAMERA_ANGLE_LIMITS.zoom.min,
+      CAMERA_ANGLE_LIMITS.zoom.max
+    )
+  }
+}
+
+export function roundState(state: CameraAngleState): CameraAngleState {
+  const zoomScale = 10 ** ZOOM_DECIMALS
+  return clampState({
+    horizontal: Math.round(state.horizontal),
+    vertical: Math.round(state.vertical),
+    zoom: Math.round(state.zoom * zoomScale) / zoomScale
+  })
+}
+
+function bucket(
+  value: number,
+  upperBounds: readonly number[],
+  terms: readonly CameraAngleTerm[]
+): CameraAngleTerm {
+  const index = upperBounds.findIndex((upper) => value < upper)
+  return terms[index === -1 ? terms.length - 1 : index]
+}
+
+export function horizontalTerm(degrees: number): CameraAngleTerm {
+  const sector =
+    Math.floor((normalizeHorizontal(degrees) + 22.5) / 45) %
+    HORIZONTAL_TERMS.length
+  return HORIZONTAL_TERMS[sector]
+}
+
+export function verticalTerm(degrees: number): CameraAngleTerm {
+  return bucket(degrees, VERTICAL_UPPER_BOUNDS, VERTICAL_TERMS)
+}
+
+export function distanceTerm(zoom: number): CameraAngleTerm {
+  return bucket(zoom, DISTANCE_UPPER_BOUNDS, DISTANCE_TERMS)
+}
+
+export function describeCameraAngle(state: CameraAngleState): string {
+  return [
+    horizontalTerm(state.horizontal).prompt,
+    verticalTerm(state.vertical).prompt,
+    distanceTerm(state.zoom).prompt
+  ].join(' ')
+}
+
+function zoomToRange(zoom: number, near: number, far: number): number {
+  return far - ((far - near) * zoom) / CAMERA_ANGLE_LIMITS.zoom.max
+}
+
+function rangeToZoom(distance: number, near: number, far: number): number {
+  return ((far - distance) * CAMERA_ANGLE_LIMITS.zoom.max) / (far - near)
+}
+
+export function zoomToDistance(zoom: number): number {
+  return zoomToRange(zoom, MIN_SUBJECT_DISTANCE, MAX_SUBJECT_DISTANCE)
+}
+
+export function distanceToZoom(distance: number): number {
+  return rangeToZoom(distance, MIN_SUBJECT_DISTANCE, MAX_SUBJECT_DISTANCE)
+}
+
+export function zoomToDisplayDistance(zoom: number): number {
+  return zoomToRange(zoom, MIN_DISPLAY_DISTANCE, MAX_DISPLAY_DISTANCE)
+}
+
+export function displayDistanceToZoom(distance: number): number {
+  return rangeToZoom(distance, MIN_DISPLAY_DISTANCE, MAX_DISPLAY_DISTANCE)
+}
+
+function orbitState(
+  state: CameraAngleState,
+  distance: number
+): CameraInfoState {
+  return {
+    ...DEFAULT_CAMERA_INFO_STATE,
+    mode: 'orbit',
+    target: { ...SUBJECT_CENTER },
+    fov: CAMERA_ANGLE_FOV,
+    orbit: { yaw: state.horizontal, pitch: state.vertical, distance }
+  }
+}
+
+export function toOrbitCameraInfoState(
+  state: CameraAngleState
+): CameraInfoState {
+  return orbitState(state, zoomToDistance(state.zoom))
+}
+
+export function toHandleOrbitState(state: CameraAngleState): CameraInfoState {
+  return orbitState(state, zoomToDisplayDistance(state.zoom))
+}
+
+const OVERVIEW_FIT_MARGIN = 1.2
+
+export function overviewDistance(aspect: number, fovDegrees: number): number {
+  const halfFov = (fovDegrees / 2) * (Math.PI / 180)
+  const shortSide = Math.min(1, aspect)
+  return (
+    (ORBIT_SPHERE_RADIUS * OVERVIEW_FIT_MARGIN) /
+    (Math.tan(halfFov) * shortSide)
+  )
+}
+
+export function rotateByDrag(
+  state: CameraAngleState,
+  dx: number,
+  dy: number
+): CameraAngleState {
+  return clampState({
+    ...state,
+    horizontal: normalizeHorizontal(
+      state.horizontal - dx * DRAG_DEGREES_PER_PIXEL
+    ),
+    vertical: state.vertical + dy * DRAG_DEGREES_PER_PIXEL
+  })
+}
+
+export function dollyByWheel(
+  state: CameraAngleState,
+  deltaY: number
+): CameraAngleState {
+  return clampState({
+    ...state,
+    zoom: state.zoom - deltaY * WHEEL_ZOOM_PER_PIXEL
+  })
+}
+
+export function stateFromHandleDrag(
+  type: OrbitHandleType,
+  state: CameraAngleState,
+  point: Vector3Like
+): CameraAngleState {
+  if (type === 'yaw') {
+    return clampState({
+      ...state,
+      horizontal: normalizeHorizontal(pointToYawAngle(point, SUBJECT_CENTER))
+    })
+  }
+  if (type === 'pitch') {
+    return clampState({
+      ...state,
+      vertical: pointToPitchAngle(point, SUBJECT_CENTER, state.horizontal)
+    })
+  }
+  return clampState({
+    ...state,
+    zoom: displayDistanceToZoom(
+      pointToDistance(point, SUBJECT_CENTER, state.horizontal, state.vertical)
+    )
+  })
+}

--- a/src/extensions/core/cameraAngle/orbitGizmos.test.ts
+++ b/src/extensions/core/cameraAngle/orbitGizmos.test.ts
@@ -1,0 +1,59 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { zoomToDisplayDistance } from './cameraAngleMath'
+import { CameraMarker, OrbitSphere } from './orbitGizmos'
+import { ORBIT_SPHERE_RADIUS, SUBJECT_CENTER } from './types'
+
+describe('OrbitSphere', () => {
+  it('is centred on the subject with the orbit radius and can be hidden', () => {
+    const scene = new THREE.Scene()
+    const sphere = new OrbitSphere()
+    sphere.attach(scene)
+
+    const mesh = scene.getObjectByName('CameraAngleOrbitSphere') as THREE.Mesh
+    expect(mesh.position.y).toBe(SUBJECT_CENTER.y)
+    mesh.geometry.computeBoundingSphere()
+    expect(mesh.geometry.boundingSphere!.radius).toBeCloseTo(
+      ORBIT_SPHERE_RADIUS
+    )
+
+    sphere.setVisible(false)
+    expect(sphere.isVisible()).toBe(false)
+
+    sphere.dispose()
+    expect(scene.children).toHaveLength(0)
+  })
+})
+
+describe('CameraMarker', () => {
+  it('sits on the compressed orbit and looks at the subject centre', () => {
+    const scene = new THREE.Scene()
+    const marker = new CameraMarker()
+    marker.attach(scene)
+    marker.update({ horizontal: 90, vertical: 0, zoom: 10 })
+
+    const group = scene.getObjectByName('CameraAngleCameraMarker')!
+    const distance = zoomToDisplayDistance(10)
+    expect(group.position.x).toBeCloseTo(SUBJECT_CENTER.x + distance)
+    expect(group.position.y).toBeCloseTo(SUBJECT_CENTER.y)
+    expect(group.position.z).toBeCloseTo(SUBJECT_CENTER.z)
+
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(
+      group.quaternion
+    )
+    expect(forward.x).toBeCloseTo(-1)
+  })
+
+  it('toggles visibility and detaches on dispose', () => {
+    const scene = new THREE.Scene()
+    const marker = new CameraMarker()
+    marker.attach(scene)
+
+    marker.setVisible(false)
+    expect(marker.isVisible()).toBe(false)
+
+    marker.dispose()
+    expect(scene.children).toHaveLength(0)
+  })
+})

--- a/src/extensions/core/cameraAngle/orbitGizmos.ts
+++ b/src/extensions/core/cameraAngle/orbitGizmos.ts
@@ -1,0 +1,121 @@
+import * as THREE from 'three'
+
+import { computeSubjectTransform } from '@/extensions/core/cameraInfo/cameraTransform'
+
+import { toHandleOrbitState } from './cameraAngleMath'
+import { ORBIT_SPHERE_RADIUS, SUBJECT_CENTER } from './types'
+import type { CameraAngleState } from './types'
+
+const SPHERE_COLOR = 0x8a93a6
+const SPHERE_OPACITY = 0.14
+const MARKER_COLOR = 0xffcc00
+const MARKER_BODY = { width: 0.22, height: 0.14, depth: 0.12 }
+const MARKER_LENS = { radius: 0.06, length: 0.08 }
+
+export class OrbitSphere {
+  private readonly mesh: THREE.Mesh
+  private scene: THREE.Scene | null = null
+
+  constructor() {
+    this.mesh = new THREE.Mesh(
+      new THREE.SphereGeometry(ORBIT_SPHERE_RADIUS, 12, 8),
+      new THREE.MeshBasicMaterial({
+        color: SPHERE_COLOR,
+        wireframe: true,
+        transparent: true,
+        opacity: SPHERE_OPACITY,
+        depthWrite: false
+      })
+    )
+    this.mesh.name = 'CameraAngleOrbitSphere'
+    this.mesh.position.set(SUBJECT_CENTER.x, SUBJECT_CENTER.y, SUBJECT_CENTER.z)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.mesh)
+  }
+
+  setVisible(visible: boolean): void {
+    this.mesh.visible = visible
+  }
+
+  isVisible(): boolean {
+    return this.mesh.visible
+  }
+
+  dispose(): void {
+    this.scene?.remove(this.mesh)
+    this.scene = null
+    this.mesh.geometry.dispose()
+    ;(this.mesh.material as THREE.Material).dispose()
+  }
+}
+
+export class CameraMarker {
+  private readonly group = new THREE.Group()
+  private readonly body: THREE.Mesh
+  private readonly lens: THREE.Mesh
+  private scene: THREE.Scene | null = null
+
+  constructor() {
+    this.group.name = 'CameraAngleCameraMarker'
+    const material = new THREE.MeshStandardMaterial({
+      color: MARKER_COLOR,
+      emissive: MARKER_COLOR,
+      emissiveIntensity: 0.45,
+      roughness: 0.4,
+      metalness: 0.2
+    })
+    this.body = new THREE.Mesh(
+      new THREE.BoxGeometry(
+        MARKER_BODY.width,
+        MARKER_BODY.height,
+        MARKER_BODY.depth
+      ),
+      material
+    )
+    this.lens = new THREE.Mesh(
+      new THREE.CylinderGeometry(
+        MARKER_LENS.radius,
+        MARKER_LENS.radius * 0.8,
+        MARKER_LENS.length,
+        16
+      ),
+      material
+    )
+    this.lens.rotation.x = Math.PI / 2
+    this.lens.position.z = -(MARKER_BODY.depth + MARKER_LENS.length) / 2
+    this.group.add(this.body)
+    this.group.add(this.lens)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.group)
+  }
+
+  update(state: CameraAngleState): void {
+    const { position, quaternion } = computeSubjectTransform(
+      toHandleOrbitState(state)
+    )
+    this.group.position.copy(position)
+    this.group.quaternion.copy(quaternion)
+  }
+
+  setVisible(visible: boolean): void {
+    this.group.visible = visible
+  }
+
+  isVisible(): boolean {
+    return this.group.visible
+  }
+
+  dispose(): void {
+    this.scene?.remove(this.group)
+    this.scene = null
+    this.body.geometry.dispose()
+    this.lens.geometry.dispose()
+    ;(this.body.material as THREE.Material).dispose()
+  }
+}

--- a/src/extensions/core/cameraAngle/types.ts
+++ b/src/extensions/core/cameraAngle/types.ts
@@ -1,0 +1,63 @@
+import type { Vector3Like } from 'three'
+
+export interface CameraAngleState {
+  horizontal: number
+  vertical: number
+  zoom: number
+}
+
+export type CameraAngleField = keyof CameraAngleState
+
+export type CameraAngleViewMode = 'camera' | 'object'
+
+export const CAMERA_ANGLE_VIEW_MODES: readonly CameraAngleViewMode[] = [
+  'camera',
+  'object'
+]
+
+export const CAMERA_ANGLE_WIDGET_NAMES: Record<CameraAngleField, string> = {
+  horizontal: 'horizontal_angle',
+  vertical: 'vertical_angle',
+  zoom: 'zoom'
+}
+
+export const CAMERA_ANGLE_VIEW_WIDGET_NAME = 'view'
+
+export const CAMERA_ANGLE_LIMITS = {
+  horizontal: { min: 0, max: 360 },
+  vertical: { min: -30, max: 60 },
+  zoom: { min: 0, max: 10 }
+} as const
+
+export const DEFAULT_CAMERA_ANGLE_STATE: CameraAngleState = {
+  horizontal: 0,
+  vertical: 0,
+  zoom: 5
+}
+
+export const SUBJECT_CENTER: Vector3Like = { x: 0, y: 0.5, z: 0 }
+export const SUBJECT_HEIGHT = 1
+export const CAMERA_ANGLE_FOV = 35
+export const MIN_SUBJECT_DISTANCE = 3.2
+export const MAX_SUBJECT_DISTANCE = 6
+
+export const ORBIT_SPHERE_RADIUS = 1.5
+export const MIN_DISPLAY_DISTANCE = 0.8
+export const MAX_DISPLAY_DISTANCE = 1.1
+export const YAW_RING_LATITUDE = -40
+
+export interface SubjectFaceLabels {
+  back: string
+  left: string
+  right: string
+  top: string
+  bottom: string
+}
+
+export const DEFAULT_SUBJECT_FACE_LABELS: SubjectFaceLabels = {
+  back: 'BACK',
+  left: 'LEFT',
+  right: 'RIGHT',
+  top: 'TOP',
+  bottom: 'BOTTOM'
+}

--- a/src/extensions/core/cameraAngle/widgetBridge.test.ts
+++ b/src/extensions/core/cameraAngle/widgetBridge.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_CAMERA_ANGLE_STATE } from './types'
+import {
+  isViewMode,
+  readStateFromWidgets,
+  readViewMode,
+  writeStateToWidgets,
+  writeViewMode
+} from './widgetBridge'
+import type { NodeWithWidgets, WidgetLike } from './widgetBridge'
+
+function nodeWithWidgets(
+  values: Record<string, unknown>
+): NodeWithWidgets & { widgets: WidgetLike[] } {
+  return {
+    widgets: Object.entries(values).map(([name, value]) => ({ name, value }))
+  }
+}
+
+describe('readStateFromWidgets', () => {
+  it('falls back to defaults when widgets are missing or malformed', () => {
+    expect(readStateFromWidgets({})).toEqual(DEFAULT_CAMERA_ANGLE_STATE)
+    expect(
+      readStateFromWidgets(
+        nodeWithWidgets({ horizontal_angle: 'abc', zoom: Number.NaN })
+      )
+    ).toEqual(DEFAULT_CAMERA_ANGLE_STATE)
+  })
+
+  it('reads and clamps the three angle widgets', () => {
+    const state = readStateFromWidgets(
+      nodeWithWidgets({ horizontal_angle: 90, vertical_angle: 99, zoom: 2.5 })
+    )
+    expect(state).toEqual({ horizontal: 90, vertical: 60, zoom: 2.5 })
+  })
+})
+
+describe('writeStateToWidgets', () => {
+  it('writes only widgets whose value changed', () => {
+    const node = nodeWithWidgets({
+      horizontal_angle: 0,
+      vertical_angle: 0,
+      zoom: 5
+    })
+    writeStateToWidgets(node, { horizontal: 45, vertical: 0, zoom: 5 })
+    expect(node.widgets.map((w) => w.value)).toEqual([45, 0, 5])
+  })
+
+  it('rounds fractional interaction values before writing', () => {
+    const node = nodeWithWidgets({
+      horizontal_angle: 0,
+      vertical_angle: 0,
+      zoom: 5
+    })
+    writeStateToWidgets(node, {
+      horizontal: 328.58,
+      vertical: 35.14,
+      zoom: 3.4999998
+    })
+    expect(node.widgets.map((w) => w.value)).toEqual([329, 35, 3.5])
+  })
+
+  it('ignores nodes without the widgets', () => {
+    expect(() =>
+      writeStateToWidgets({}, { horizontal: 1, vertical: 2, zoom: 3 })
+    ).not.toThrow()
+  })
+})
+
+describe('view mode widget', () => {
+  it('validates view mode strings', () => {
+    expect(isViewMode('camera')).toBe(true)
+    expect(isViewMode('object')).toBe(true)
+    expect(isViewMode('')).toBe(false)
+    expect(isViewMode(1)).toBe(false)
+  })
+
+  it('reads the stored mode and defaults to camera', () => {
+    expect(readViewMode(nodeWithWidgets({ view: 'object' }))).toBe('object')
+    expect(readViewMode(nodeWithWidgets({ view: '' }))).toBe('camera')
+    expect(readViewMode({})).toBe('camera')
+  })
+
+  it('writes the mode into the view widget', () => {
+    const node = nodeWithWidgets({ view: 'camera' })
+    writeViewMode(node, 'object')
+    expect(node.widgets[0].value).toBe('object')
+  })
+})

--- a/src/extensions/core/cameraAngle/widgetBridge.ts
+++ b/src/extensions/core/cameraAngle/widgetBridge.ts
@@ -1,0 +1,77 @@
+import { clampState, roundState } from './cameraAngleMath'
+import {
+  CAMERA_ANGLE_VIEW_MODES,
+  CAMERA_ANGLE_VIEW_WIDGET_NAME,
+  CAMERA_ANGLE_WIDGET_NAMES,
+  DEFAULT_CAMERA_ANGLE_STATE
+} from './types'
+import type {
+  CameraAngleField,
+  CameraAngleState,
+  CameraAngleViewMode
+} from './types'
+
+export interface WidgetLike {
+  name: string
+  value: unknown
+}
+
+export interface NodeWithWidgets {
+  widgets?: WidgetLike[]
+}
+
+const FIELDS = Object.keys(CAMERA_ANGLE_WIDGET_NAMES) as CameraAngleField[]
+
+function widgetByName(
+  node: NodeWithWidgets,
+  name: string
+): WidgetLike | undefined {
+  return node.widgets?.find((w) => w.name === name)
+}
+
+function numberOr(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+export function readStateFromWidgets(node: NodeWithWidgets): CameraAngleState {
+  const state = { ...DEFAULT_CAMERA_ANGLE_STATE }
+  for (const field of FIELDS) {
+    state[field] = numberOr(
+      widgetByName(node, CAMERA_ANGLE_WIDGET_NAMES[field])?.value,
+      DEFAULT_CAMERA_ANGLE_STATE[field]
+    )
+  }
+  return clampState(state)
+}
+
+export function writeStateToWidgets(
+  node: NodeWithWidgets,
+  state: CameraAngleState
+): void {
+  const rounded = roundState(state)
+  for (const field of FIELDS) {
+    const widget = widgetByName(node, CAMERA_ANGLE_WIDGET_NAMES[field])
+    if (!widget || widget.value === rounded[field]) continue
+    widget.value = rounded[field]
+  }
+}
+
+export function isViewMode(value: unknown): value is CameraAngleViewMode {
+  return (
+    typeof value === 'string' &&
+    (CAMERA_ANGLE_VIEW_MODES as readonly string[]).includes(value)
+  )
+}
+
+export function readViewMode(node: NodeWithWidgets): CameraAngleViewMode {
+  const value = widgetByName(node, CAMERA_ANGLE_VIEW_WIDGET_NAME)?.value
+  return isViewMode(value) ? value : 'camera'
+}
+
+export function writeViewMode(
+  node: NodeWithWidgets,
+  mode: CameraAngleViewMode
+): void {
+  const widget = widgetByName(node, CAMERA_ANGLE_VIEW_WIDGET_NAME)
+  if (widget && widget.value !== mode) widget.value = mode
+}

--- a/src/extensions/core/cameraInfo/CameraInfoOverlay.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoOverlay.ts
@@ -127,6 +127,10 @@ export class CameraInfoOverlay implements SceneOverlay {
     if (this.cameraHelper) this.cameraHelper.visible = visible
   }
 
+  isHelperVisible(): boolean {
+    return this.cameraHelper?.visible ?? false
+  }
+
   getState(): CameraInfoState {
     return cloneState(this.state)
   }

--- a/src/extensions/core/cameraInfo/CameraInfoViewport.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoViewport.ts
@@ -21,9 +21,12 @@ import {
   pointToPitchAngle,
   pointToYawAngle
 } from './handles/orbitDragMath'
+import { PointerInteraction } from './handles/pointerInteraction'
+import type { PointerPosition } from './handles/pointerInteraction'
 import { pointToRollAngle } from './handles/rollDragMath'
 import { dollySubjectByWheel, rotateSubjectByDrag } from './lookThroughDragMath'
 import type { LookThroughResult } from './lookThroughDragMath'
+import { fitCameraAspect, renderInsetPreview } from './subjectCameraPreview'
 import { DEFAULT_CAMERA_INFO_STATE } from './types'
 import type {
   CameraInfoFieldName,
@@ -31,10 +34,6 @@ import type {
   CameraInfoState
 } from './types'
 
-const PREVIEW_WIDTH = 200
-const PREVIEW_HEIGHT = 150
-const PREVIEW_PADDING = 8
-const PREVIEW_BORDER_COLOR = 0x2a2a2a
 const LOOK_THROUGH_SENSITIVITY = 0.005
 
 type DragHandleType = OrbitHandleType | 'roll'
@@ -55,13 +54,6 @@ export interface CameraInfoViewportOptions extends Load3DOptions {
   onHandleDrag?: (fieldName: CameraInfoFieldName, value: number) => void
 }
 
-interface DragState {
-  type: DragHandleType
-  pointerId: number
-}
-
-type PointerPosition = Pick<PointerEvent, 'clientX' | 'clientY'>
-
 export class CameraInfoViewport {
   readonly viewport: Viewport3d
   readonly overlay: CameraInfoOverlay
@@ -74,21 +66,9 @@ export class CameraInfoViewport {
   private readonly disposePostRender: () => void
   private readonly onHandleDrag?: CameraInfoViewportOptions['onHandleDrag']
   private readonly raycaster = new THREE.Raycaster()
-  private readonly pointer = new THREE.Vector2()
-
-  private dragState: DragState | null = null
-  private lookThroughDrag: {
-    pointerId: number
-    lastX: number
-    lastY: number
-  } | null = null
-  private pendingRotation: { dx: number; dy: number } | null = null
-  private pendingDolly: number | null = null
-  private pendingDragPointer: PointerPosition | null = null
-  private pendingHoverPointer: PointerPosition | null = null
-  private inputFrame: number | null = null
+  private readonly pointerNdc = new THREE.Vector2()
   private readonly dragPoint = new THREE.Vector3()
-  private hoveredHandle: DragHandleType | null = null
+  private readonly input: PointerInteraction<DragHandleType>
   private gizmosOn = true
   private lookingThrough = false
   private transformGizmoMode: TransformGizmoMode = 'none'
@@ -140,7 +120,33 @@ export class CameraInfoViewport {
     this.cameraHandle.attach(this.viewport.sceneManager.scene)
     this.syncCameraHandleSubject(initialState)
 
-    this.attachPointerHandlers()
+    this.input = new PointerInteraction<DragHandleType>({
+      canvas: this.canvas,
+      pickHandle: (position) => this.pickHandle(position),
+      dragHandle: (type, position) => this.dragHandle(type, position),
+      hoverChanged: (type) => {
+        this.orbitHandles.setHovered(type === 'roll' ? null : type)
+        this.rollHandle.setHovered(type === 'roll')
+        this.viewport.forceRender()
+      },
+      handleDragChanged: (dragging) => {
+        this.viewport.controlsManager.controls.enabled = !dragging
+      },
+      freeDragEnabled: () => this.lookingThrough,
+      freeDrag: (dx, dy) =>
+        this.applyResult(
+          rotateSubjectByDrag(
+            this.overlay.getState(),
+            -dx * LOOK_THROUGH_SENSITIVITY,
+            -dy * LOOK_THROUGH_SENSITIVITY
+          )
+        ),
+      wheelEnabled: () => this.lookingThrough,
+      wheel: (deltaY) =>
+        this.applyResult(dollySubjectByWheel(this.overlay.getState(), deltaY)),
+      idleCursor: () => (this.input.hoveredHandle ? 'grab' : '')
+    })
+    this.input.attach()
 
     this.disposePreRender = this.viewport.addPreRenderCallback(() => {
       if (this.lookingThrough) this.fitSubjectAspect()
@@ -180,9 +186,7 @@ export class CameraInfoViewport {
   setLookThrough(on: boolean): void {
     if (this.lookingThrough === on) return
     this.lookingThrough = on
-    this.lookThroughDrag = null
-    this.cancelInputFrame()
-    this.canvas.style.cursor = ''
+    this.input.cancel()
     this.refreshGizmoVisibility()
     if (on) this.fitSubjectAspect()
     this.viewport.setExternalActiveCamera(
@@ -192,8 +196,8 @@ export class CameraInfoViewport {
   }
 
   remove(): void {
-    this.detachPointerHandlers()
-    this.cancelInputFrame()
+    this.input.detach()
+    this.input.cancel()
     this.canvas.style.cursor = ''
     this.disposePreRender()
     this.disposePostRender()
@@ -277,43 +281,10 @@ export class CameraInfoViewport {
     return this.viewport.domElement
   }
 
-  private attachPointerHandlers(): void {
-    const canvas = this.canvas
-    canvas.addEventListener('pointerdown', this.onPointerDown)
-    canvas.addEventListener('pointermove', this.onPointerMove)
-    canvas.addEventListener('pointerup', this.onPointerUp)
-    canvas.addEventListener('pointercancel', this.onPointerUp)
-    canvas.addEventListener('pointerleave', this.onPointerLeave)
-    canvas.addEventListener('wheel', this.onWheel, { passive: false })
-  }
-
-  private detachPointerHandlers(): void {
-    const canvas = this.canvas
-    canvas.removeEventListener('pointerdown', this.onPointerDown)
-    canvas.removeEventListener('pointermove', this.onPointerMove)
-    canvas.removeEventListener('pointerup', this.onPointerUp)
-    canvas.removeEventListener('pointercancel', this.onPointerUp)
-    canvas.removeEventListener('pointerleave', this.onPointerLeave)
-    canvas.removeEventListener('wheel', this.onWheel)
-  }
-
-  private readonly onPointerLeave = (): void => {
-    if (this.dragState || this.lookThroughDrag) return
-    this.pendingHoverPointer = null
-    this.setHoveredHandle(null)
-  }
-
-  private readonly onWheel = (event: WheelEvent): void => {
-    if (!this.lookingThrough) return
-    event.preventDefault()
-    event.stopPropagation()
-    this.queueDolly(event.deltaY)
-  }
-
   private updatePointer({ clientX, clientY }: PointerPosition): void {
     const rect = this.canvas.getBoundingClientRect()
-    this.pointer.x = ((clientX - rect.left) / rect.width) * 2 - 1
-    this.pointer.y = -((clientY - rect.top) / rect.height) * 2 + 1
+    this.pointerNdc.x = ((clientX - rect.left) / rect.width) * 2 - 1
+    this.pointerNdc.y = -((clientY - rect.top) / rect.height) * 2 + 1
   }
 
   private pickableTargetsFor(mode: CameraInfoMode): THREE.Object3D[] {
@@ -334,169 +305,34 @@ export class CameraInfoViewport {
     this.updatePointer(position)
     return pickHandleAtPointer<DragHandleType>(
       this.raycaster,
-      this.pointer,
+      this.pointerNdc,
       this.viewport.cameraManager.activeCamera,
       targets,
       this.canvas
     )
   }
 
-  private setHoveredHandle(type: DragHandleType | null): void {
-    if (this.hoveredHandle === type) return
-    this.hoveredHandle = type
-    this.orbitHandles.setHovered(type === 'roll' ? null : type)
-    this.rollHandle.setHovered(type === 'roll')
-    this.canvas.style.cursor = type ? 'grab' : ''
-    this.viewport.forceRender()
-  }
-
-  private readonly onPointerDown = (event: PointerEvent): void => {
-    if (event.button !== 0) return
-
-    if (this.lookingThrough) {
-      this.lookThroughDrag = {
-        pointerId: event.pointerId,
-        lastX: event.clientX,
-        lastY: event.clientY
-      }
-      this.canvas.setPointerCapture(event.pointerId)
-      this.canvas.style.cursor = 'grabbing'
-      event.stopPropagation()
-      return
-    }
-
-    const type = this.pickHandle(event)
-    if (!type) return
-    this.pendingHoverPointer = null
-
-    this.setHoveredHandle(type)
-    this.dragState = { type, pointerId: event.pointerId }
-    this.canvas.setPointerCapture(event.pointerId)
-    this.canvas.style.cursor = 'grabbing'
-    this.viewport.controlsManager.controls.enabled = false
-    event.stopPropagation()
-  }
-
-  private readonly onPointerMove = (event: PointerEvent): void => {
-    if (this.lookThroughDrag) {
-      if (event.pointerId !== this.lookThroughDrag.pointerId) return
-      const dx = event.clientX - this.lookThroughDrag.lastX
-      const dy = event.clientY - this.lookThroughDrag.lastY
-      this.lookThroughDrag.lastX = event.clientX
-      this.lookThroughDrag.lastY = event.clientY
-      this.queueRotation(dx, dy)
-      return
-    }
-
-    if (!this.dragState) {
-      this.pendingHoverPointer = {
-        clientX: event.clientX,
-        clientY: event.clientY
-      }
-      this.scheduleInputFrame()
-      return
-    }
-    if (event.pointerId !== this.dragState.pointerId) return
-
-    this.pendingDragPointer = { clientX: event.clientX, clientY: event.clientY }
-    this.scheduleInputFrame()
-  }
-
-  private processDragMove(position: PointerPosition): void {
-    if (!this.dragState) return
+  private dragHandle(type: DragHandleType, position: PointerPosition): void {
     this.updatePointer(position)
     this.raycaster.setFromCamera(
-      this.pointer,
+      this.pointerNdc,
       this.viewport.cameraManager.activeCamera
     )
 
     const state = this.overlay.getState()
     const plane =
-      this.dragState.type === 'roll'
+      type === 'roll'
         ? this.rollHandle.dragPlane(state)
-        : this.orbitHandles.dragPlaneFor(this.dragState.type, state)
+        : this.orbitHandles.dragPlaneFor(type, state)
     if (!this.raycaster.ray.intersectPlane(plane, this.dragPoint)) return
 
     const { fieldName, value, nextState } = computeNextState(
-      this.dragState.type,
+      type,
       state,
       this.dragPoint
     )
     this.applyState(nextState)
     this.onHandleDrag?.(fieldName, value)
-  }
-
-  private readonly onPointerUp = (event: PointerEvent): void => {
-    if (this.lookThroughDrag) {
-      if (event.pointerId !== this.lookThroughDrag.pointerId) return
-      if (this.canvas.hasPointerCapture(event.pointerId)) {
-        this.canvas.releasePointerCapture(event.pointerId)
-      }
-      this.lookThroughDrag = null
-      this.flushInput()
-      this.cancelInputFrame()
-      this.canvas.style.cursor = ''
-      return
-    }
-
-    if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
-    this.flushInput()
-    this.cancelInputFrame()
-    if (this.canvas.hasPointerCapture(event.pointerId)) {
-      this.canvas.releasePointerCapture(event.pointerId)
-    }
-    this.dragState = null
-    this.viewport.controlsManager.controls.enabled = true
-    this.canvas.style.cursor = this.hoveredHandle ? 'grab' : ''
-  }
-
-  private queueRotation(dx: number, dy: number): void {
-    this.pendingRotation = {
-      dx: (this.pendingRotation?.dx ?? 0) + dx,
-      dy: (this.pendingRotation?.dy ?? 0) + dy
-    }
-    this.scheduleInputFrame()
-  }
-
-  private queueDolly(deltaY: number): void {
-    this.pendingDolly = (this.pendingDolly ?? 0) + deltaY
-    this.scheduleInputFrame()
-  }
-
-  private scheduleInputFrame(): void {
-    if (this.inputFrame !== null) return
-    this.inputFrame = requestAnimationFrame(() => {
-      this.inputFrame = null
-      this.flushInput()
-    })
-  }
-
-  private flushInput(): void {
-    const rotation = this.pendingRotation
-    const dolly = this.pendingDolly
-    const dragPointer = this.pendingDragPointer
-    const hoverPointer = this.pendingHoverPointer
-    this.pendingRotation = null
-    this.pendingDolly = null
-    this.pendingDragPointer = null
-    this.pendingHoverPointer = null
-    if (dragPointer) {
-      this.processDragMove(dragPointer)
-    } else if (hoverPointer && !this.dragState) {
-      this.setHoveredHandle(this.pickHandle(hoverPointer))
-    }
-    if (rotation) {
-      this.applyResult(
-        rotateSubjectByDrag(
-          this.overlay.getState(),
-          -rotation.dx * LOOK_THROUGH_SENSITIVITY,
-          -rotation.dy * LOOK_THROUGH_SENSITIVITY
-        )
-      )
-    }
-    if (dolly !== null) {
-      this.applyResult(dollySubjectByWheel(this.overlay.getState(), dolly))
-    }
   }
 
   private applyResult(result: LookThroughResult | null): void {
@@ -507,127 +343,31 @@ export class CameraInfoViewport {
     }
   }
 
-  private cancelInputFrame(): void {
-    if (this.inputFrame !== null) {
-      cancelAnimationFrame(this.inputFrame)
-      this.inputFrame = null
-    }
-    this.pendingRotation = null
-    this.pendingDolly = null
-    this.pendingDragPointer = null
-    this.pendingHoverPointer = null
-  }
-
   private fitSubjectAspect(): void {
     const canvas = this.viewport.domElement
-    const aspect = canvas.width / canvas.height
-    if (!Number.isFinite(aspect) || aspect <= 0) return
-    const cam = this.overlay.getSubjectCamera()
-    if (cam instanceof THREE.PerspectiveCamera) {
-      if (Math.abs(cam.aspect - aspect) < 1e-4) return
-      cam.aspect = aspect
-      cam.updateProjectionMatrix()
-      return
-    }
-    if (cam instanceof THREE.OrthographicCamera) {
-      const half = (cam.top - cam.bottom) / 2 || 1
-      const left = -half * aspect
-      const right = half * aspect
-      if (
-        Math.abs(cam.left - left) < 1e-4 &&
-        Math.abs(cam.right - right) < 1e-4
-      )
-        return
-      cam.left = left
-      cam.right = right
-      cam.updateProjectionMatrix()
-    }
+    fitCameraAspect(
+      this.overlay.getSubjectCamera(),
+      canvas.width / canvas.height
+    )
   }
 
   private renderSubjectCameraPreview(): void {
-    const renderer = this.viewport.renderer
-    const canvas = this.viewport.domElement
-    const canvasWidth = canvas.width
-    const canvasHeight = canvas.height
-    if (
-      canvasWidth < PREVIEW_WIDTH + PREVIEW_PADDING * 2 ||
-      canvasHeight < PREVIEW_HEIGHT + PREVIEW_PADDING * 2
-    ) {
-      return
-    }
-
-    const cam = this.overlay.getSubjectCamera()
-    const aspect = PREVIEW_WIDTH / PREVIEW_HEIGHT
-    let savedAspect: number | undefined
-    let savedOrtho:
-      | {
-          left: number
-          right: number
-          top: number
-          bottom: number
-        }
-      | undefined
-
-    if (cam instanceof THREE.PerspectiveCamera) {
-      savedAspect = cam.aspect
-      cam.aspect = aspect
-      cam.updateProjectionMatrix()
-    } else if (cam instanceof THREE.OrthographicCamera) {
-      savedOrtho = {
-        left: cam.left,
-        right: cam.right,
-        top: cam.top,
-        bottom: cam.bottom
-      }
-      const half = (cam.top - cam.bottom) / 2 || 1
-      cam.left = -half * aspect
-      cam.right = half * aspect
-      cam.top = half
-      cam.bottom = -half
-      cam.updateProjectionMatrix()
-    }
-
-    this.overlay.setHelperVisible(false)
-    const handlesWereVisible = this.orbitHandles.isVisible()
-    const rollWasVisible = this.rollHandle.isVisible()
-    const targetWasVisible = this.targetHandle.isVisible()
-    const cameraWasVisible = this.cameraHandle.isVisible()
-    this.orbitHandles.setVisible(false)
-    this.rollHandle.setVisible(false)
-    this.targetHandle.setVisible(false)
-    this.cameraHandle.setVisible(false)
-
-    const x = canvasWidth - PREVIEW_WIDTH - PREVIEW_PADDING
-    const y = PREVIEW_PADDING
-
-    renderer.setViewport(x - 1, y - 1, PREVIEW_WIDTH + 2, PREVIEW_HEIGHT + 2)
-    renderer.setScissor(x - 1, y - 1, PREVIEW_WIDTH + 2, PREVIEW_HEIGHT + 2)
-    renderer.setScissorTest(true)
-    renderer.setClearColor(PREVIEW_BORDER_COLOR)
-    renderer.clear()
-
-    renderer.setViewport(x, y, PREVIEW_WIDTH, PREVIEW_HEIGHT)
-    renderer.setScissor(x, y, PREVIEW_WIDTH, PREVIEW_HEIGHT)
-    renderer.setClearColor(0x0a0a0a)
-    renderer.clear()
-    renderer.render(this.viewport.sceneManager.scene, cam)
-
-    this.overlay.setHelperVisible(true)
-    if (handlesWereVisible) this.orbitHandles.setVisible(true)
-    if (rollWasVisible) this.rollHandle.setVisible(true)
-    if (targetWasVisible) this.targetHandle.setVisible(true)
-    if (cameraWasVisible) this.cameraHandle.setVisible(true)
-
-    if (savedAspect !== undefined && cam instanceof THREE.PerspectiveCamera) {
-      cam.aspect = savedAspect
-      cam.updateProjectionMatrix()
-    } else if (savedOrtho && cam instanceof THREE.OrthographicCamera) {
-      cam.left = savedOrtho.left
-      cam.right = savedOrtho.right
-      cam.top = savedOrtho.top
-      cam.bottom = savedOrtho.bottom
-      cam.updateProjectionMatrix()
-    }
+    renderInsetPreview({
+      renderer: this.viewport.renderer,
+      canvas: this.viewport.domElement,
+      scene: this.viewport.sceneManager.scene,
+      camera: this.overlay.getSubjectCamera(),
+      hidden: [
+        {
+          isVisible: () => this.overlay.isHelperVisible(),
+          setVisible: (visible) => this.overlay.setHelperVisible(visible)
+        },
+        this.orbitHandles,
+        this.rollHandle,
+        this.targetHandle,
+        this.cameraHandle
+      ]
+    })
   }
 }
 

--- a/src/extensions/core/cameraInfo/handles/OrbitHandles.test.ts
+++ b/src/extensions/core/cameraInfo/handles/OrbitHandles.test.ts
@@ -44,6 +44,31 @@ describe('OrbitHandles', () => {
     expect(yawHandle.position.z).toBeCloseTo(1.5)
   })
 
+  it('lowers the yaw ring to the requested latitude and drags on that plane', () => {
+    handles.dispose()
+    handles = new OrbitHandles({ yawRingLatitude: -40 })
+    handles.attach(scene)
+    const state = {
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'orbit' as const,
+      target: { x: 0, y: 0.5, z: 0 },
+      orbit: { yaw: 0, pitch: 0, distance: 1 }
+    }
+    handles.update(state)
+
+    const yawHandle = handles
+      .pickableMeshes()
+      .find((m) => m.userData.handleType === 'yaw')!
+    const world = new THREE.Vector3()
+    yawHandle.getWorldPosition(world)
+    const latitude = (-40 * Math.PI) / 180
+    expect(world.y).toBeCloseTo(0.5 + 1.5 * Math.sin(latitude))
+    expect(world.z).toBeCloseTo(1.5 * Math.cos(latitude))
+    expect(handles.dragPlaneFor('yaw', state).constant).toBeCloseTo(
+      -(0.5 + 1.5 * Math.sin(latitude))
+    )
+  })
+
   it('places the distance handle at the camera (distance along yaw direction)', () => {
     handles.update({
       ...DEFAULT_CAMERA_INFO_STATE,

--- a/src/extensions/core/cameraInfo/handles/OrbitHandles.ts
+++ b/src/extensions/core/cameraInfo/handles/OrbitHandles.ts
@@ -21,9 +21,19 @@ export type OrbitHandleType = 'yaw' | 'pitch' | 'distance'
 
 const DEG2RAD = Math.PI / 180
 
-function buildArcCurve(): THREE.CatmullRomCurve3 {
+interface PitchLimits {
+  min: number
+  max: number
+}
+
+export interface OrbitHandlesOptions {
+  pitchLimits?: PitchLimits
+  yawRingLatitude?: number
+}
+
+function buildArcCurve({ min, max }: PitchLimits): THREE.CatmullRomCurve3 {
   const points: THREE.Vector3[] = []
-  for (let deg = -ARC_PITCH_LIMIT; deg <= ARC_PITCH_LIMIT; deg += 5) {
+  for (let deg = min; deg <= max; deg += 5) {
     const r = deg * DEG2RAD
     points.push(
       new THREE.Vector3(0, RING_RADIUS * Math.sin(r), RING_RADIUS * Math.cos(r))
@@ -77,15 +87,24 @@ export class OrbitHandles {
   private readonly pitchHandleGlow: THREE.Mesh
   private readonly distanceHandleGlow: THREE.Mesh
 
+  private readonly yawRingRadius: number
+  private readonly yawRingHeight: number
+
   private scene: THREE.Scene | null = null
   private disposed = false
 
-  constructor() {
+  constructor({
+    pitchLimits = { min: -ARC_PITCH_LIMIT, max: ARC_PITCH_LIMIT },
+    yawRingLatitude = 0
+  }: OrbitHandlesOptions = {}) {
     this.root.name = 'CameraInfoOrbitHandles'
     this.root.add(this.yawGroup)
 
+    const latitude = yawRingLatitude * DEG2RAD
+    this.yawRingRadius = RING_RADIUS * Math.cos(latitude)
+    this.yawRingHeight = RING_RADIUS * Math.sin(latitude)
     this.yawRing = new THREE.Mesh(
-      new THREE.TorusGeometry(RING_RADIUS, TUBE_RADIUS, 16, 96),
+      new THREE.TorusGeometry(this.yawRingRadius, TUBE_RADIUS, 16, 96),
       new THREE.MeshBasicMaterial({
         color: YAW_COLOR,
         transparent: true,
@@ -93,11 +112,12 @@ export class OrbitHandles {
       })
     )
     this.yawRing.rotation.x = Math.PI / 2
+    this.yawRing.position.y = this.yawRingHeight
     this.root.add(this.yawRing)
 
     this.pitchArc = new THREE.Mesh(
       new THREE.TubeGeometry(
-        buildArcCurve(),
+        buildArcCurve(pitchLimits),
         ARC_SEGMENTS,
         TUBE_RADIUS,
         8,
@@ -203,9 +223,9 @@ export class OrbitHandles {
     this.yawGroup.rotation.y = yawRad
 
     this.yawHandle.position.set(
-      RING_RADIUS * Math.sin(yawRad),
-      0,
-      RING_RADIUS * Math.cos(yawRad)
+      this.yawRingRadius * Math.sin(yawRad),
+      this.yawRingHeight,
+      this.yawRingRadius * Math.cos(yawRad)
     )
 
     this.pitchHandle.position.set(0, RING_RADIUS * sinP, RING_RADIUS * cosP)
@@ -241,7 +261,10 @@ export class OrbitHandles {
 
   dragPlaneFor(type: OrbitHandleType, state: CameraInfoState): THREE.Plane {
     if (type === 'yaw') {
-      return new THREE.Plane(new THREE.Vector3(0, 1, 0), -state.target.y)
+      return new THREE.Plane(
+        new THREE.Vector3(0, 1, 0),
+        -(state.target.y + this.yawRingHeight)
+      )
     }
     const yawRad = state.orbit.yaw * DEG2RAD
     const normal = new THREE.Vector3(

--- a/src/extensions/core/cameraInfo/handles/pointerInteraction.test.ts
+++ b/src/extensions/core/cameraInfo/handles/pointerInteraction.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PointerInteraction } from './pointerInteraction'
+import type { PointerInteractionHost } from './pointerInteraction'
+
+type Handle = 'yaw' | 'pitch'
+
+const frames: FrameRequestCallback[] = []
+
+function runFrame(): void {
+  for (const cb of frames.splice(0)) cb(0)
+}
+
+function dispatchPointer(
+  target: HTMLElement,
+  type: string,
+  clientX: number,
+  clientY: number,
+  pointerId = 1
+): void {
+  const event = new MouseEvent(type, { clientX, clientY, button: 0 })
+  Object.defineProperty(event, 'pointerId', { value: pointerId })
+  target.dispatchEvent(event)
+}
+
+function dispatchWheel(target: HTMLElement, deltaY: number): WheelEvent {
+  const event = new WheelEvent('wheel', { cancelable: true })
+  Object.defineProperty(event, 'deltaY', { value: deltaY })
+  target.dispatchEvent(event)
+  return event
+}
+
+function makeHost(overrides: Partial<PointerInteractionHost<Handle>> = {}) {
+  const canvas = document.createElement('canvas')
+  canvas.setPointerCapture = vi.fn()
+  canvas.releasePointerCapture = vi.fn()
+  canvas.hasPointerCapture = vi.fn(() => true)
+  const host: PointerInteractionHost<Handle> = {
+    canvas,
+    pickHandle: vi.fn(() => null),
+    dragHandle: vi.fn(),
+    hoverChanged: vi.fn(),
+    handleDragChanged: vi.fn(),
+    freeDragEnabled: vi.fn(() => false),
+    freeDrag: vi.fn(),
+    wheelEnabled: vi.fn(() => false),
+    wheel: vi.fn(),
+    idleCursor: vi.fn(() => ''),
+    ...overrides
+  }
+  return host
+}
+
+beforeEach(() => {
+  frames.length = 0
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    frames.push(cb)
+    return frames.length
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {
+    frames.length = 0
+  })
+})
+
+describe('PointerInteraction', () => {
+  it('drags a picked handle, disabling the host while dragging', () => {
+    const host = makeHost({ pickHandle: vi.fn((): Handle | null => 'yaw') })
+    const interaction = new PointerInteraction(host)
+    interaction.attach()
+
+    dispatchPointer(host.canvas, 'pointerdown', 10, 10)
+    expect(host.handleDragChanged).toHaveBeenCalledWith(true)
+    expect(host.canvas.setPointerCapture).toHaveBeenCalledWith(1)
+    expect(host.canvas.style.cursor).toBe('grabbing')
+
+    dispatchPointer(host.canvas, 'pointermove', 30, 10)
+    runFrame()
+    expect(host.dragHandle).toHaveBeenCalledWith(
+      'yaw',
+      expect.objectContaining({ clientX: 30 })
+    )
+
+    dispatchPointer(host.canvas, 'pointerup', 30, 10)
+    expect(host.handleDragChanged).toHaveBeenLastCalledWith(false)
+    expect(host.canvas.releasePointerCapture).toHaveBeenCalledWith(1)
+  })
+
+  it('ignores moves from a different pointer during a drag', () => {
+    const host = makeHost({ pickHandle: vi.fn((): Handle | null => 'yaw') })
+    new PointerInteraction(host).attach()
+
+    dispatchPointer(host.canvas, 'pointerdown', 10, 10)
+    dispatchPointer(host.canvas, 'pointermove', 30, 10, 2)
+    runFrame()
+
+    expect(host.dragHandle).not.toHaveBeenCalled()
+  })
+
+  it('reports hover changes only when the picked handle changes', () => {
+    const pickHandle = vi
+      .fn<(p: { clientX: number }) => Handle | null>()
+      .mockReturnValueOnce('pitch')
+      .mockReturnValueOnce('pitch')
+      .mockReturnValueOnce(null)
+    const host = makeHost({
+      pickHandle,
+      idleCursor: vi.fn(() => 'grab')
+    })
+    const interaction = new PointerInteraction(host)
+    interaction.attach()
+
+    dispatchPointer(host.canvas, 'pointermove', 5, 5)
+    runFrame()
+    dispatchPointer(host.canvas, 'pointermove', 6, 6)
+    runFrame()
+    expect(host.hoverChanged).toHaveBeenCalledTimes(1)
+    expect(interaction.hoveredHandle).toBe('pitch')
+    expect(host.canvas.style.cursor).toBe('grab')
+
+    host.canvas.dispatchEvent(new MouseEvent('pointerleave'))
+    expect(host.hoverChanged).toHaveBeenLastCalledWith(null)
+  })
+
+  it('turns free drags into rotation deltas when the host allows them', () => {
+    const host = makeHost({ freeDragEnabled: vi.fn(() => true) })
+    new PointerInteraction(host).attach()
+
+    dispatchPointer(host.canvas, 'pointerdown', 100, 100)
+    dispatchPointer(host.canvas, 'pointermove', 110, 105)
+    dispatchPointer(host.canvas, 'pointermove', 130, 105)
+    runFrame()
+
+    expect(host.freeDrag).toHaveBeenCalledOnce()
+    expect(host.freeDrag).toHaveBeenCalledWith(30, 5)
+    expect(host.handleDragChanged).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on empty space when free drag is disabled', () => {
+    const host = makeHost()
+    new PointerInteraction(host).attach()
+
+    dispatchPointer(host.canvas, 'pointerdown', 100, 100)
+    dispatchPointer(host.canvas, 'pointermove', 130, 100)
+    runFrame()
+
+    expect(host.canvas.setPointerCapture).not.toHaveBeenCalled()
+    expect(host.freeDrag).not.toHaveBeenCalled()
+  })
+
+  it('accumulates wheel deltas per frame only when enabled', () => {
+    const host = makeHost({ wheelEnabled: vi.fn(() => true) })
+    new PointerInteraction(host).attach()
+
+    const first = dispatchWheel(host.canvas, 40)
+    dispatchWheel(host.canvas, 60)
+    runFrame()
+
+    expect(first.defaultPrevented).toBe(true)
+    expect(host.wheel).toHaveBeenCalledOnce()
+    expect(host.wheel).toHaveBeenCalledWith(100)
+
+    vi.mocked(host.wheelEnabled).mockReturnValue(false)
+    const ignored = dispatchWheel(host.canvas, 10)
+    runFrame()
+    expect(ignored.defaultPrevented).toBe(false)
+    expect(host.wheel).toHaveBeenCalledOnce()
+  })
+
+  it('cancel clears pending input, releases the handle drag and resets the cursor', () => {
+    const host = makeHost({ pickHandle: vi.fn((): Handle | null => 'yaw') })
+    const interaction = new PointerInteraction(host)
+    interaction.attach()
+    dispatchPointer(host.canvas, 'pointerdown', 10, 10)
+    dispatchPointer(host.canvas, 'pointermove', 30, 10)
+
+    interaction.cancel()
+    runFrame()
+
+    expect(host.dragHandle).not.toHaveBeenCalled()
+    expect(host.handleDragChanged).toHaveBeenLastCalledWith(false)
+    expect(host.hoverChanged).toHaveBeenLastCalledWith(null)
+    expect(host.canvas.style.cursor).toBe('')
+  })
+
+  it('stops listening after detach', () => {
+    const host = makeHost({ pickHandle: vi.fn((): Handle | null => 'yaw') })
+    const interaction = new PointerInteraction(host)
+    interaction.attach()
+    interaction.detach()
+
+    dispatchPointer(host.canvas, 'pointerdown', 10, 10)
+
+    expect(host.pickHandle).not.toHaveBeenCalled()
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/pointerInteraction.ts
+++ b/src/extensions/core/cameraInfo/handles/pointerInteraction.ts
@@ -1,0 +1,197 @@
+export type PointerPosition = Pick<PointerEvent, 'clientX' | 'clientY'>
+
+export interface PointerInteractionHost<T extends string> {
+  canvas: HTMLCanvasElement
+  pickHandle(position: PointerPosition): T | null
+  dragHandle(type: T, position: PointerPosition): void
+  hoverChanged(type: T | null): void
+  handleDragChanged(dragging: boolean): void
+  freeDragEnabled(): boolean
+  freeDrag(dx: number, dy: number): void
+  wheelEnabled(): boolean
+  wheel(deltaY: number): void
+  idleCursor(): string
+}
+
+interface HandleDrag<T> {
+  type: T
+  pointerId: number
+}
+
+interface FreeDrag {
+  pointerId: number
+  lastX: number
+  lastY: number
+}
+
+export class PointerInteraction<T extends string> {
+  private handleDrag: HandleDrag<T> | null = null
+  private freeDrag: FreeDrag | null = null
+  private hovered: T | null = null
+  private pendingRotation: { dx: number; dy: number } | null = null
+  private pendingDolly: number | null = null
+  private pendingDragPointer: PointerPosition | null = null
+  private pendingHoverPointer: PointerPosition | null = null
+  private inputFrame: number | null = null
+
+  constructor(private readonly host: PointerInteractionHost<T>) {}
+
+  get hoveredHandle(): T | null {
+    return this.hovered
+  }
+
+  attach(): void {
+    const canvas = this.host.canvas
+    canvas.addEventListener('pointerdown', this.onPointerDown)
+    canvas.addEventListener('pointermove', this.onPointerMove)
+    canvas.addEventListener('pointerup', this.onPointerUp)
+    canvas.addEventListener('pointercancel', this.onPointerUp)
+    canvas.addEventListener('pointerleave', this.onPointerLeave)
+    canvas.addEventListener('wheel', this.onWheel, { passive: false })
+  }
+
+  detach(): void {
+    const canvas = this.host.canvas
+    canvas.removeEventListener('pointerdown', this.onPointerDown)
+    canvas.removeEventListener('pointermove', this.onPointerMove)
+    canvas.removeEventListener('pointerup', this.onPointerUp)
+    canvas.removeEventListener('pointercancel', this.onPointerUp)
+    canvas.removeEventListener('pointerleave', this.onPointerLeave)
+    canvas.removeEventListener('wheel', this.onWheel)
+  }
+
+  cancel(): void {
+    this.cancelInputFrame()
+    const wasDraggingHandle = this.handleDrag !== null
+    this.handleDrag = null
+    this.freeDrag = null
+    if (wasDraggingHandle) this.host.handleDragChanged(false)
+    this.setHovered(null)
+    this.host.canvas.style.cursor = this.host.idleCursor()
+  }
+
+  private setHovered(type: T | null): void {
+    if (this.hovered === type) return
+    this.hovered = type
+    this.host.hoverChanged(type)
+    this.host.canvas.style.cursor = this.host.idleCursor()
+  }
+
+  private readonly onPointerDown = (event: PointerEvent): void => {
+    if (event.button !== 0) return
+
+    const type = this.host.pickHandle(event)
+    if (type) {
+      this.pendingHoverPointer = null
+      this.setHovered(type)
+      this.handleDrag = { type, pointerId: event.pointerId }
+      this.host.handleDragChanged(true)
+    } else if (this.host.freeDragEnabled()) {
+      this.freeDrag = {
+        pointerId: event.pointerId,
+        lastX: event.clientX,
+        lastY: event.clientY
+      }
+    } else {
+      return
+    }
+    this.host.canvas.setPointerCapture(event.pointerId)
+    this.host.canvas.style.cursor = 'grabbing'
+    event.stopPropagation()
+  }
+
+  private readonly onPointerMove = (event: PointerEvent): void => {
+    if (this.freeDrag) {
+      if (event.pointerId !== this.freeDrag.pointerId) return
+      const dx = event.clientX - this.freeDrag.lastX
+      const dy = event.clientY - this.freeDrag.lastY
+      this.freeDrag.lastX = event.clientX
+      this.freeDrag.lastY = event.clientY
+      this.pendingRotation = {
+        dx: (this.pendingRotation?.dx ?? 0) + dx,
+        dy: (this.pendingRotation?.dy ?? 0) + dy
+      }
+      this.scheduleInputFrame()
+      return
+    }
+
+    if (!this.handleDrag) {
+      this.pendingHoverPointer = {
+        clientX: event.clientX,
+        clientY: event.clientY
+      }
+      this.scheduleInputFrame()
+      return
+    }
+    if (event.pointerId !== this.handleDrag.pointerId) return
+    this.pendingDragPointer = { clientX: event.clientX, clientY: event.clientY }
+    this.scheduleInputFrame()
+  }
+
+  private readonly onPointerUp = (event: PointerEvent): void => {
+    const active = this.freeDrag ?? this.handleDrag
+    if (!active || event.pointerId !== active.pointerId) return
+    this.flushInput()
+    this.cancelInputFrame()
+    if (this.host.canvas.hasPointerCapture(event.pointerId)) {
+      this.host.canvas.releasePointerCapture(event.pointerId)
+    }
+    const wasDraggingHandle = this.handleDrag !== null
+    this.freeDrag = null
+    this.handleDrag = null
+    if (wasDraggingHandle) this.host.handleDragChanged(false)
+    this.host.canvas.style.cursor = this.host.idleCursor()
+  }
+
+  private readonly onPointerLeave = (): void => {
+    if (this.handleDrag || this.freeDrag) return
+    this.pendingHoverPointer = null
+    this.setHovered(null)
+  }
+
+  private readonly onWheel = (event: WheelEvent): void => {
+    if (!this.host.wheelEnabled()) return
+    event.preventDefault()
+    event.stopPropagation()
+    this.pendingDolly = (this.pendingDolly ?? 0) + event.deltaY
+    this.scheduleInputFrame()
+  }
+
+  private scheduleInputFrame(): void {
+    if (this.inputFrame !== null) return
+    this.inputFrame = requestAnimationFrame(() => {
+      this.inputFrame = null
+      this.flushInput()
+    })
+  }
+
+  private flushInput(): void {
+    const rotation = this.pendingRotation
+    const dolly = this.pendingDolly
+    const dragPointer = this.pendingDragPointer
+    const hoverPointer = this.pendingHoverPointer
+    this.pendingRotation = null
+    this.pendingDolly = null
+    this.pendingDragPointer = null
+    this.pendingHoverPointer = null
+
+    if (dragPointer && this.handleDrag) {
+      this.host.dragHandle(this.handleDrag.type, dragPointer)
+    } else if (hoverPointer && !this.handleDrag) {
+      this.setHovered(this.host.pickHandle(hoverPointer))
+    }
+    if (rotation) this.host.freeDrag(rotation.dx, rotation.dy)
+    if (dolly !== null) this.host.wheel(dolly)
+  }
+
+  private cancelInputFrame(): void {
+    if (this.inputFrame !== null) {
+      cancelAnimationFrame(this.inputFrame)
+      this.inputFrame = null
+    }
+    this.pendingRotation = null
+    this.pendingDolly = null
+    this.pendingDragPointer = null
+    this.pendingHoverPointer = null
+  }
+}

--- a/src/extensions/core/cameraInfo/subjectCameraPreview.test.ts
+++ b/src/extensions/core/cameraInfo/subjectCameraPreview.test.ts
@@ -1,0 +1,144 @@
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  PREVIEW_HEIGHT,
+  PREVIEW_WIDTH,
+  fitCameraAspect,
+  renderInsetPreview
+} from './subjectCameraPreview'
+
+function makeRenderer() {
+  return {
+    setViewport: vi.fn(),
+    setScissor: vi.fn(),
+    setScissorTest: vi.fn(),
+    setClearColor: vi.fn(),
+    clear: vi.fn(),
+    render: vi.fn()
+  }
+}
+
+describe('fitCameraAspect', () => {
+  it('updates a perspective camera aspect', () => {
+    const camera = new THREE.PerspectiveCamera(35, 1)
+    fitCameraAspect(camera, 2)
+    expect(camera.aspect).toBe(2)
+  })
+
+  it('widens an orthographic frustum to the aspect', () => {
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1)
+    fitCameraAspect(camera, 2)
+    expect(camera.left).toBe(-2)
+    expect(camera.right).toBe(2)
+  })
+
+  it('ignores a degenerate aspect', () => {
+    const camera = new THREE.PerspectiveCamera(35, 1)
+    fitCameraAspect(camera, 0)
+    fitCameraAspect(camera, Number.NaN)
+    expect(camera.aspect).toBe(1)
+  })
+})
+
+describe('renderInsetPreview', () => {
+  it('skips rendering when the canvas is too small for the inset', () => {
+    const renderer = makeRenderer()
+    renderInsetPreview({
+      renderer,
+      canvas: { width: PREVIEW_WIDTH, height: PREVIEW_HEIGHT },
+      scene: new THREE.Scene(),
+      camera: new THREE.PerspectiveCamera(),
+      hidden: []
+    })
+    expect(renderer.render).not.toHaveBeenCalled()
+  })
+
+  it('hides visible items during the render and restores only those', () => {
+    const renderer = makeRenderer()
+    const visibleItem = { visible: true }
+    const hiddenItem = { visible: false }
+    const wrap = (item: { visible: boolean }) => ({
+      isVisible: () => item.visible,
+      setVisible: (v: boolean) => {
+        item.visible = v
+      }
+    })
+    renderer.render.mockImplementation(() => {
+      expect(visibleItem.visible).toBe(false)
+      expect(hiddenItem.visible).toBe(false)
+    })
+
+    renderInsetPreview({
+      renderer,
+      canvas: { width: 800, height: 600 },
+      scene: new THREE.Scene(),
+      camera: new THREE.PerspectiveCamera(),
+      hidden: [wrap(visibleItem), wrap(hiddenItem)]
+    })
+
+    expect(renderer.render).toHaveBeenCalledOnce()
+    expect(visibleItem.visible).toBe(true)
+    expect(hiddenItem.visible).toBe(false)
+  })
+
+  it('renders with the inset aspect and restores the camera afterwards', () => {
+    const renderer = makeRenderer()
+    const camera = new THREE.PerspectiveCamera(35, 1.5)
+    renderer.render.mockImplementation(() => {
+      expect(camera.aspect).toBeCloseTo(PREVIEW_WIDTH / PREVIEW_HEIGHT)
+    })
+
+    renderInsetPreview({
+      renderer,
+      canvas: { width: 800, height: 600 },
+      scene: new THREE.Scene(),
+      camera,
+      hidden: []
+    })
+
+    expect(camera.aspect).toBe(1.5)
+  })
+
+  it('honours a custom layout and colours', () => {
+    const renderer = makeRenderer()
+    const camera = new THREE.PerspectiveCamera(35, 1)
+    renderer.render.mockImplementation(() => {
+      expect(camera.aspect).toBeCloseTo(1)
+    })
+
+    renderInsetPreview({
+      renderer,
+      canvas: { width: 800, height: 600 },
+      scene: new THREE.Scene(),
+      camera,
+      hidden: [],
+      layout: { width: 120, height: 120, marginRight: 10, marginBottom: 60 },
+      borderColor: 0x112233,
+      backgroundColor: '#445566'
+    })
+
+    expect(renderer.render).toHaveBeenCalledOnce()
+    expect(renderer.setViewport).toHaveBeenLastCalledWith(670, 60, 120, 120)
+    expect(renderer.setClearColor).toHaveBeenNthCalledWith(1, 0x112233)
+    expect(renderer.setClearColor).toHaveBeenNthCalledWith(2, '#445566')
+  })
+
+  it('restores an orthographic frustum after rendering', () => {
+    const renderer = makeRenderer()
+    const camera = new THREE.OrthographicCamera(-3, 3, 2, -2)
+
+    renderInsetPreview({
+      renderer,
+      canvas: { width: 800, height: 600 },
+      scene: new THREE.Scene(),
+      camera,
+      hidden: []
+    })
+
+    expect(renderer.render).toHaveBeenCalledOnce()
+    expect([camera.left, camera.right, camera.top, camera.bottom]).toEqual([
+      -3, 3, 2, -2
+    ])
+  })
+})

--- a/src/extensions/core/cameraInfo/subjectCameraPreview.ts
+++ b/src/extensions/core/cameraInfo/subjectCameraPreview.ts
@@ -1,0 +1,136 @@
+import * as THREE from 'three'
+
+export const PREVIEW_WIDTH = 200
+export const PREVIEW_HEIGHT = 150
+const PREVIEW_PADDING = 8
+const PREVIEW_BORDER_COLOR = 0x2a2a2a
+const PREVIEW_BACKGROUND_COLOR = 0x0a0a0a
+
+interface Hideable {
+  isVisible(): boolean
+  setVisible(visible: boolean): void
+}
+
+type PreviewRenderer = Pick<
+  THREE.WebGLRenderer,
+  'setViewport' | 'setScissor' | 'setScissorTest' | 'setClearColor' | 'clear'
+> & { render(scene: THREE.Object3D, camera: THREE.Camera): void }
+
+interface InsetPreviewLayout {
+  width: number
+  height: number
+  marginRight: number
+  marginBottom: number
+}
+
+export interface InsetPreviewTarget {
+  renderer: PreviewRenderer
+  canvas: { width: number; height: number }
+  scene: THREE.Scene
+  camera: THREE.Camera
+  hidden: readonly Hideable[]
+  layout?: Partial<InsetPreviewLayout>
+  borderColor?: THREE.ColorRepresentation
+  backgroundColor?: THREE.ColorRepresentation
+}
+
+export function fitCameraAspect(camera: THREE.Camera, aspect: number): void {
+  if (!Number.isFinite(aspect) || aspect <= 0) return
+  if (camera instanceof THREE.PerspectiveCamera) {
+    if (Math.abs(camera.aspect - aspect) < 1e-4) return
+    camera.aspect = aspect
+    camera.updateProjectionMatrix()
+    return
+  }
+  if (camera instanceof THREE.OrthographicCamera) {
+    const half = (camera.top - camera.bottom) / 2 || 1
+    const left = -half * aspect
+    const right = half * aspect
+    if (
+      Math.abs(camera.left - left) < 1e-4 &&
+      Math.abs(camera.right - right) < 1e-4
+    )
+      return
+    camera.left = left
+    camera.right = right
+    camera.updateProjectionMatrix()
+  }
+}
+
+function withPreviewAspect(
+  camera: THREE.Camera,
+  aspect: number,
+  render: () => void
+): void {
+  if (camera instanceof THREE.PerspectiveCamera) {
+    const saved = camera.aspect
+    camera.aspect = aspect
+    camera.updateProjectionMatrix()
+    render()
+    camera.aspect = saved
+    camera.updateProjectionMatrix()
+    return
+  }
+  if (camera instanceof THREE.OrthographicCamera) {
+    const { left, right, top, bottom } = camera
+    const half = (top - bottom) / 2 || 1
+    camera.left = -half * aspect
+    camera.right = half * aspect
+    camera.top = half
+    camera.bottom = -half
+    camera.updateProjectionMatrix()
+    render()
+    Object.assign(camera, { left, right, top, bottom })
+    camera.updateProjectionMatrix()
+    return
+  }
+  render()
+}
+
+export function renderInsetPreview({
+  renderer,
+  canvas,
+  scene,
+  camera,
+  hidden,
+  layout,
+  borderColor = PREVIEW_BORDER_COLOR,
+  backgroundColor = PREVIEW_BACKGROUND_COLOR
+}: InsetPreviewTarget): void {
+  const width = layout?.width ?? PREVIEW_WIDTH
+  const height = layout?.height ?? PREVIEW_HEIGHT
+  const marginRight = layout?.marginRight ?? PREVIEW_PADDING
+  const marginBottom = layout?.marginBottom ?? PREVIEW_PADDING
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    canvas.width < width + marginRight * 2 ||
+    canvas.height < height + marginBottom + PREVIEW_PADDING
+  ) {
+    return
+  }
+
+  const restore = hidden
+    .filter((item) => item.isVisible())
+    .map((item) => () => item.setVisible(true))
+  for (const item of hidden) item.setVisible(false)
+
+  const x = canvas.width - width - marginRight
+  const y = marginBottom
+
+  withPreviewAspect(camera, width / height, () => {
+    renderer.setViewport(x - 1, y - 1, width + 2, height + 2)
+    renderer.setScissor(x - 1, y - 1, width + 2, height + 2)
+    renderer.setScissorTest(true)
+    renderer.setClearColor(borderColor)
+    renderer.clear()
+
+    renderer.setViewport(x, y, width, height)
+    renderer.setScissor(x, y, width, height)
+    renderer.setClearColor(backgroundColor)
+    renderer.clear()
+    renderer.render(scene, camera)
+  })
+
+  for (const restoreItem of restore) restoreItem()
+}

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -376,6 +376,7 @@ describe('Load3d', () => {
           height: 600,
           state: { clearColor: new THREE.Color(0x000000), clearAlpha: 0 },
           renderer: {
+            state: { reset: vi.fn() },
             setViewport,
             setScissor,
             setScissorTest,
@@ -682,7 +683,7 @@ describe('Load3d', () => {
         view: {
           beginRender,
           blit,
-          renderer: { setScissorTest: vi.fn() }
+          renderer: { setScissorTest: vi.fn(), state: { reset: vi.fn() } }
         }
       })
 
@@ -1383,6 +1384,7 @@ describe('Load3d', () => {
       const view = {
         canvas,
         renderer: {
+          state: { reset: vi.fn() },
           setViewport: vi.fn(),
           setScissor: vi.fn(),
           setScissorTest: vi.fn(),

--- a/src/extensions/core/load3d/Viewport3d.test.ts
+++ b/src/extensions/core/load3d/Viewport3d.test.ts
@@ -555,7 +555,8 @@ describe('Viewport3d', () => {
         setScissorTest: vi.fn(),
         setClearColor: vi.fn(),
         clear: vi.fn(),
-        render: vi.fn()
+        render: vi.fn(),
+        state: { reset: vi.fn() }
       }
       const view = {
         canvas: document.createElement('canvas'),
@@ -623,6 +624,17 @@ describe('Viewport3d', () => {
       expect(view.blit).toHaveBeenCalledTimes(2)
       expect(viewport.INITIAL_RENDER_DONE).toBe(true)
     })
+
+    it('resyncs the shared GL state before every frame so texture uploads keep flipY', () => {
+      const { viewport, renderer } = makeConstructedViewport()
+
+      viewport.forceRender()
+
+      expect(renderer.state.reset).toHaveBeenCalledOnce()
+      expect(renderer.state.reset.mock.invocationCallOrder[0]).toBeLessThan(
+        renderer.render.mock.invocationCallOrder[0]
+      )
+    })
   })
 
   describe('render callback dispatch', () => {
@@ -682,7 +694,7 @@ describe('Viewport3d', () => {
       const order: string[] = []
       Object.assign(ctx.viewport, {
         view: {
-          renderer: { setScissorTest: vi.fn() },
+          renderer: { setScissorTest: vi.fn(), state: { reset: vi.fn() } },
           beginRender: () => order.push('begin'),
           blit: vi.fn()
         },

--- a/src/extensions/core/load3d/Viewport3d.ts
+++ b/src/extensions/core/load3d/Viewport3d.ts
@@ -222,6 +222,7 @@ export class Viewport3d {
   }
 
   private renderView(): void {
+    this.renderer.state.reset()
     this.view.beginRender()
     this.runPreRenderCallbacks()
     this.renderMainScene()

--- a/src/extensions/core/load3d/nodeTypes.test.ts
+++ b/src/extensions/core/load3d/nodeTypes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isLoad3dNode,
+  isLoad3dResultViewerNode,
+  isThreeJsNode
+} from './nodeTypes'
+
+describe('load3d node types', () => {
+  it('treats the camera tool nodes as three.js nodes without making them Load3D nodes', () => {
+    for (const nodeType of ['CreateCameraInfo', 'CameraAngle']) {
+      expect(isThreeJsNode(nodeType)).toBe(true)
+      expect(isLoad3dNode(nodeType)).toBe(false)
+      expect(isLoad3dResultViewerNode(nodeType)).toBe(false)
+    }
+  })
+
+  it('keeps Load3D viewers as three.js nodes and ignores unrelated nodes', () => {
+    expect(isThreeJsNode('Preview3D')).toBe(true)
+    expect(isLoad3dResultViewerNode('Preview3D')).toBe(true)
+    expect(isThreeJsNode('KSampler')).toBe(false)
+  })
+})

--- a/src/extensions/core/load3d/nodeTypes.ts
+++ b/src/extensions/core/load3d/nodeTypes.ts
@@ -25,5 +25,7 @@ export const isLoad3dResultViewerNode = (nodeType: string): boolean =>
 export const isLoad3dNode = (nodeType: string): boolean =>
   LOAD3D_ALL_NODES.has(nodeType)
 
+const CAMERA_TOOL_NODES = new Set(['CreateCameraInfo', 'CameraAngle'])
+
 export const isThreeJsNode = (nodeType: string): boolean =>
-  isLoad3dNode(nodeType) || nodeType === 'CreateCameraInfo'
+  isLoad3dNode(nodeType) || CAMERA_TOOL_NODES.has(nodeType)

--- a/src/extensions/core/load3dLazy.ts
+++ b/src/extensions/core/load3dLazy.ts
@@ -40,7 +40,8 @@ async function loadLoad3dExtensions(): Promise<ComfyExtension[]> {
       import('./load3dAdvanced'),
       import('./load3dPreviewExtensions'),
       import('./saveMesh'),
-      import('./cameraInfo')
+      import('./cameraInfo'),
+      import('./cameraAngle')
     ])
     load3dExtensionsLoaded = true
     return useExtensionStore().enabledExtensions.filter(

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2343,6 +2343,46 @@
     "monotone_cubic": "Smooth",
     "linear": "Linear"
   },
+  "cameraAngle": {
+    "cameraView": "Camera",
+    "objectView": "Object",
+    "cameraViewTooltip": "Move the camera around the subject",
+    "objectViewTooltip": "Look through the camera and turn the subject",
+    "horizontalLabel": "Horizontal angle",
+    "verticalLabel": "Vertical angle",
+    "zoomLabel": "Shot size",
+    "preview": "Preview",
+    "showPreview": "Show shot preview",
+    "hidePreview": "Hide shot preview",
+    "horizontal": {
+      "front": "Front",
+      "frontRight": "Front right",
+      "right": "Right side",
+      "backRight": "Back right",
+      "back": "Back",
+      "backLeft": "Back left",
+      "left": "Left side",
+      "frontLeft": "Front left"
+    },
+    "vertical": {
+      "lowAngle": "Low angle",
+      "eyeLevel": "Eye level",
+      "elevated": "Elevated",
+      "highAngle": "High angle"
+    },
+    "zoom": {
+      "wide": "Wide shot",
+      "medium": "Medium shot",
+      "closeUp": "Close-up"
+    },
+    "faces": {
+      "back": "BACK",
+      "left": "LEFT",
+      "right": "RIGHT",
+      "top": "TOP",
+      "bottom": "BOTTOM"
+    }
+  },
   "boundingBoxes": {
     "clearAll": "Clear all",
     "clickRegionToEdit": "Click a region to edit it.",
@@ -2470,6 +2510,7 @@
     "failedToConvertToSubgraph": "Failed to convert items to subgraph",
     "failedToInitializeLoad3dViewer": "Failed to initialize 3D Viewer",
     "failedToInitializeCameraInfoViewer": "Failed to initialize Camera Info viewer. Try reloading the page.",
+    "failedToInitializeCameraAngleViewer": "Failed to initialize Camera Angle viewer. Try reloading the page.",
     "failedToLoadBackgroundImage": "Failed to load background image",
     "failedToLoadModel": "Failed to load 3D model",
     "modelLoadedSuccessfully": "3D model loaded successfully",

--- a/src/locales/en/nodeDefs.json
+++ b/src/locales/en/nodeDefs.json
@@ -1959,6 +1959,41 @@
       }
     }
   },
+  "CameraAngle": {
+    "display_name": "Camera Angle",
+    "description": "Pick a camera angle around a subject with a 3D preview. Outputs a camera_info for 3D nodes and a plain-English shot description for prompts.",
+    "inputs": {
+      "horizontal_angle": {
+        "name": "horizontal_angle",
+        "tooltip": "Azimuth around the subject in degrees. 0 is the front, 90 the right side, 180 the back."
+      },
+      "vertical_angle": {
+        "name": "vertical_angle",
+        "tooltip": "Elevation in degrees. Negative looks up from below, positive looks down from above."
+      },
+      "zoom": {
+        "name": "zoom",
+        "tooltip": "How close the camera is: 0 is a wide shot, 10 a close-up."
+      },
+      "image": {
+        "name": "image",
+        "tooltip": "Optional reference image shown on the front of the subject cube in the 3D preview."
+      },
+      "view": {
+        "name": "view"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "camera_info",
+        "tooltip": null
+      },
+      "1": {
+        "name": "prompt",
+        "tooltip": null
+      }
+    }
+  },
   "Canny": {
     "display_name": "Detect Edges (Canny)",
     "inputs": {

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -58,6 +58,9 @@ const Load3DAdvanced = defineAsyncComponent(
 const CameraInfo = defineAsyncComponent(
   () => import('@/components/cameraInfo/CameraInfo.vue')
 )
+const CameraAngle = defineAsyncComponent(
+  () => import('@/components/cameraAngle/CameraAngle.vue')
+)
 const WidgetImageCrop = defineAsyncComponent(
   () => import('@/components/imagecrop/WidgetImageCrop.vue')
 )
@@ -217,6 +220,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     }
   ],
   [
+    'cameraAngle',
+    {
+      component: CameraAngle,
+      aliases: ['CAMERA_ANGLE_VIEW'],
+      essential: false
+    }
+  ],
+  [
     'imagecrop',
     {
       component: WidgetImageCrop,
@@ -329,6 +340,7 @@ const EXPANDING_TYPES = [
   'load3D',
   'load3DAdvanced',
   'cameraInfo',
+  'cameraAngle',
   'curve',
   'painter',
   'compositor',


### PR DESCRIPTION
## Summary

Adds the frontend for the new CameraAngle backend node: a fixed-view 3D preview with a camera mode (orbit sphere, drag handles, camera marker and an optional inset of the shot) and an object mode (look through the camera and turn the subject). The subject is a unit cube with the upstream image centre-cropped onto its front face and labelled sides. Shot presets and a live prompt readout mirror the node's three widgets; the view mode is kept in the workflow but never sent to the backend.

Shares the orbit handles, picking and inset preview helpers with the CreateCameraInfo widget, which now takes its pitch range and yaw ring latitude as options.

Also resyncs three's GL state cache every Viewport3d frame: Spark's sorter writes UNPACK_FLIP_Y_WEBGL directly on the shared context, so textures uploaded afterwards rendered upside down.

Need BE https://github.com/Comfy-Org/ComfyUI/pull/16251

## Screenshots (if applicable)
https://github.com/user-attachments/assets/0e2e10bc-63ee-4a77-8a27-99415b701f37

