### PR TITLE
fix: preserve saved remote widget selections

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -2,6 +2,10 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import { WidgetSelectDropdownFixture } from '@e2e/fixtures/components/WidgetSelectDropdown'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+import { mockViewFiles } from '@e2e/fixtures/utils/viewFileMocks'
 
 test.describe(
   'Widget value persistence',
@@ -43,6 +47,110 @@ test.describe(
           'string_input'
         )
       ).toHaveValue('')
+    })
+
+    test.describe('LoadImageOutput', { tag: '@oss' }, () => {
+      test.beforeEach(async ({ comfyPage }) => {
+        await comfyPage.page.route(
+          '**/internal/files/output**',
+          async (route) => {
+            if (route.request().method() !== 'GET') {
+              await route.fallback()
+              return
+            }
+            await route.fulfill({
+              json: [
+                'first-output.webp [output]',
+                'selected-output.webp [output]'
+              ]
+            })
+          }
+        )
+        const image = {
+          contentType: 'image/webp',
+          path: assetPath('image64x64.webp')
+        }
+        await mockViewFiles(comfyPage.page, {
+          'first-output.webp': image,
+          'first-output.webp [output]': image,
+          'selected-output.webp': image,
+          'selected-output.webp [output]': image
+        })
+        await comfyPage.menu.topbar.newWorkflowButton.click()
+        await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
+        await comfyPage.searchBoxV2.addNode('Load Image (from Outputs)')
+        await comfyPage.vueNodes.waitForNodes()
+      })
+
+      test.afterEach(async ({ comfyPage }) => {
+        await comfyPage.canvasOps.resetView()
+      })
+
+      test('keeps a selected non-first output and its preview after save and reload', async ({
+        comfyPage
+      }) => {
+        const selectedValue = 'selected-output.webp [output]'
+        const node = comfyPage.vueNodes.getNodeByTitle(
+          'Load Image (from Outputs)'
+        )
+        await WidgetSelectDropdownFixture.fromTrigger(
+          node.getByRole('button', {
+            name: 'first-output.webp [output]',
+            exact: true
+          })
+        ).selectOption(selectedValue)
+        await expect(
+          node.getByRole('button', { name: selectedValue, exact: true })
+        ).toBeVisible()
+        const nodes =
+          await comfyPage.nodeOps.getNodeRefsByType('LoadImageOutput')
+        expect(nodes, 'Workflow has one output image loader').toHaveLength(1)
+        const imageWidget = await nodes[0].getWidgetByName('image')
+        await expect.poll(() => imageWidget.getValue()).toBe(selectedValue)
+
+        await comfyPage.menu.topbar.saveWorkflow('remote-output-selection')
+        await comfyPage.workflow.reloadAndWaitForApp()
+        await comfyPage.vueNodes.waitForNodes()
+
+        const restoredNode = comfyPage.vueNodes.getNodeByTitle(
+          'Load Image (from Outputs)'
+        )
+        await WidgetSelectDropdownFixture.fromTrigger(
+          restoredNode.getByRole('button', {
+            name: /^(first|selected)-output\.webp \[output\]$/
+          })
+        ).open()
+        const menu = comfyPage.page.getByTestId(
+          TestIds.widgets.formDropdownMenu
+        )
+        await expect(
+          menu.getByText('first-output.webp [output]', { exact: true })
+        ).toBeVisible()
+        await expect(
+          menu.getByText(selectedValue, { exact: true })
+        ).toBeVisible()
+        await comfyPage.page.keyboard.press('Escape')
+        await expect(menu).toBeHidden()
+
+        const restoredNodes =
+          await comfyPage.nodeOps.getNodeRefsByType('LoadImageOutput')
+        expect(
+          restoredNodes,
+          'Reload restores one output image loader'
+        ).toHaveLength(1)
+        const restoredWidget = await restoredNodes[0].getWidgetByName('image')
+        await expect.poll(() => restoredWidget.getValue()).toBe(selectedValue)
+        await expect(
+          restoredNode.getByRole('button', { name: selectedValue, exact: true })
+        ).toBeVisible()
+        const preview = restoredNode.getByTestId(TestIds.node.mainImage)
+        await expect(preview).toBeVisible()
+        await expect(preview).toHaveAttribute(
+          'src',
+          /[?&]filename=selected-output\.webp(?:&|$)/
+        )
+        await expect(preview).toHaveJSProperty('naturalWidth', 64)
+      })
     })
   }
 )

--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -3,6 +3,7 @@ import {
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
 import { WidgetSelectDropdownFixture } from '@e2e/fixtures/components/WidgetSelectDropdown'
+import { createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { assetPath } from '@e2e/fixtures/utils/paths'
 import { mockViewFiles } from '@e2e/fixtures/utils/viewFileMocks'
@@ -76,6 +77,21 @@ test.describe(
           'selected-output.webp': image,
           'selected-output.webp [output]': image
         })
+        await comfyPage.assets.mockOutputHistory([
+          createMockJob({
+            id: 'job-selected-output',
+            create_time: 1000,
+            execution_start_time: 1000,
+            execution_end_time: 1010,
+            preview_output: {
+              filename: 'selected-output.webp',
+              subfolder: '',
+              type: 'output',
+              nodeId: '1',
+              mediaType: 'images'
+            }
+          })
+        ])
         await comfyPage.menu.topbar.newWorkflowButton.click()
         await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
         await comfyPage.searchBoxV2.addNode('Load Image (from Outputs)')
@@ -98,7 +114,17 @@ test.describe(
             name: 'first-output.webp [output]',
             exact: true
           })
-        ).selectOption(selectedValue)
+        ).open()
+        const menu = comfyPage.page.getByTestId(
+          TestIds.widgets.formDropdownMenu
+        )
+        await menu
+          .getByRole('button', { name: 'Imported', exact: true })
+          .click()
+        const selectedOption = menu.getByText(selectedValue, { exact: true })
+        await expect(selectedOption).toHaveCount(1)
+        await selectedOption.click()
+        await expect(menu).toBeHidden()
         await expect(
           node.getByRole('button', { name: selectedValue, exact: true })
         ).toBeVisible()
@@ -120,15 +146,14 @@ test.describe(
             name: /^(first|selected)-output\.webp \[output\]$/
           })
         ).open()
-        const menu = comfyPage.page.getByTestId(
-          TestIds.widgets.formDropdownMenu
-        )
+        await menu
+          .getByRole('button', { name: 'Imported', exact: true })
+          .click()
         await expect(
           menu.getByText('first-output.webp [output]', { exact: true })
         ).toBeVisible()
-        await expect(
-          menu.getByText(selectedValue, { exact: true })
-        ).toBeVisible()
+        await expect(selectedOption).toHaveCount(1)
+        await expect(selectedOption).toBeVisible()
         await comfyPage.page.keyboard.press('Escape')
         await expect(menu).toBeHidden()
 
@@ -145,10 +170,14 @@ test.describe(
         ).toBeVisible()
         const preview = restoredNode.getByTestId(TestIds.node.mainImage)
         await expect(preview).toBeVisible()
-        await expect(preview).toHaveAttribute(
-          'src',
-          /[?&]filename=selected-output\.webp(?:&|$)/
-        )
+        await expect
+          .poll(async () => {
+            const src = await preview.getAttribute('src')
+            return src
+              ? new URL(src, comfyPage.page.url()).searchParams.get('filename')
+              : null
+          })
+          .toBe(selectedValue)
         await expect(preview).toHaveJSProperty('naturalWidth', 64)
       })
     })

--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -50,7 +50,7 @@ test.describe(
       ).toHaveValue('')
     })
 
-    test.describe('LoadImageOutput', { tag: '@oss' }, () => {
+    test.describe('LoadImageOutput', { tag: ['@oss', '@slow'] }, () => {
       test.beforeEach(async ({ comfyPage }) => {
         await comfyPage.page.route(
           '**/internal/files/output**',
@@ -72,7 +72,6 @@ test.describe(
           path: assetPath('image64x64.webp')
         }
         await mockViewFiles(comfyPage.page, {
-          'first-output.webp': image,
           'first-output.webp [output]': image,
           'selected-output.webp': image,
           'selected-output.webp [output]': image
@@ -122,7 +121,6 @@ test.describe(
           .getByRole('button', { name: 'Imported', exact: true })
           .click()
         const selectedOption = menu.getByText(selectedValue, { exact: true })
-        await expect(selectedOption).toHaveCount(1)
         await selectedOption.click()
         await expect(menu).toBeHidden()
         await expect(
@@ -138,11 +136,8 @@ test.describe(
         await comfyPage.workflow.reloadAndWaitForApp()
         await comfyPage.vueNodes.waitForNodes()
 
-        const restoredNode = comfyPage.vueNodes.getNodeByTitle(
-          'Load Image (from Outputs)'
-        )
         await WidgetSelectDropdownFixture.fromTrigger(
-          restoredNode.getByRole('button', {
+          node.getByRole('button', {
             name: /^(first|selected)-output\.webp \[output\]$/
           })
         ).open()
@@ -152,23 +147,15 @@ test.describe(
         await expect(
           menu.getByText('first-output.webp [output]', { exact: true })
         ).toBeVisible()
-        await expect(selectedOption).toHaveCount(1)
         await expect(selectedOption).toBeVisible()
         await comfyPage.page.keyboard.press('Escape')
         await expect(menu).toBeHidden()
 
-        const restoredNodes =
-          await comfyPage.nodeOps.getNodeRefsByType('LoadImageOutput')
-        expect(
-          restoredNodes,
-          'Reload restores one output image loader'
-        ).toHaveLength(1)
-        const restoredWidget = await restoredNodes[0].getWidgetByName('image')
-        await expect.poll(() => restoredWidget.getValue()).toBe(selectedValue)
+        await expect.poll(() => imageWidget.getValue()).toBe(selectedValue)
         await expect(
-          restoredNode.getByRole('button', { name: selectedValue, exact: true })
+          node.getByRole('button', { name: selectedValue, exact: true })
         ).toBeVisible()
-        const preview = restoredNode.getByTestId(TestIds.node.mainImage)
+        const preview = node.getByTestId(TestIds.node.mainImage)
         await expect(preview).toBeVisible()
         await expect
           .poll(async () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -103,6 +103,36 @@ beforeEach(() => {
 
 describe('useRemoteWidget', () => {
   describe('initialization', () => {
+    it('preserves a saved non-first option and initializes its callback once', async () => {
+      const options = createMockOptions({ control_after_refresh: 'first' })
+      options.widget.callback = vi.fn()
+      const hook = useRemoteWidget(options)
+      options.widget.value = 'optionB'
+      mockAxiosResponse(['optionA', 'optionB'])
+
+      await getResolvedValue(hook)
+      await getResolvedValue(hook)
+
+      expect(options.widget.value).toBe('optionB')
+      expect(options.widget.callback).toHaveBeenCalledWith('optionB')
+      expect(options.widget.callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('selects the first option when the saved value is unavailable', async () => {
+      const options = createMockOptions()
+      options.widget = createMockWidget({
+        value: 'unavailable',
+        callback: vi.fn()
+      })
+      const hook = useRemoteWidget(options)
+      mockAxiosResponse(['optionA', 'optionB'])
+
+      await getResolvedValue(hook)
+
+      expect(options.widget.value).toBe('optionA')
+      expect(options.widget.callback).toHaveBeenCalledWith('optionA')
+    })
+
     it('should create hook with default values', () => {
       const hook = useRemoteWidget(createMockOptions())
       expect(hook.getCachedValue()).toBeUndefined()
@@ -167,8 +197,15 @@ describe('useRemoteWidget', () => {
     })
 
     it('should handle empty array responses', async () => {
-      const { result } = await setupHookWithResponse([])
+      const options = createMockOptions()
+      options.widget.value = 'unavailable'
+      const hook = useRemoteWidget(options)
+      mockAxiosResponse([])
+
+      const result = await getResolvedValue(hook)
+
       expect(result).toEqual([])
+      expect(options.widget.value).toBe(DEFAULT_VALUE)
     })
 
     it('should handle malformed response data', async () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { IWidget, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -32,7 +33,7 @@ async function getAuthHeaders() {
   return {}
 }
 
-const dataCache = new Map<string, CacheEntry<unknown>>()
+const dataCache = shallowReactive(new Map<string, CacheEntry<unknown>>())
 
 const createCacheKey = (config: RemoteWidgetConfig): string => {
   const { route, query_params = {}, refresh = 0 } = config
@@ -131,8 +132,9 @@ export function useRemoteWidget<
 
   const onFirstLoad = (data: T | T[]) => {
     isLoaded = true
-    const nextValue =
-      Array.isArray(data) && data.length > 0 ? data[0] : undefined
+    const nextValue = Array.isArray(data)
+      ? (data.find((value) => value === widget.value) ?? data[0])
+      : undefined
     widget.value = nextValue ?? (Array.isArray(data) ? defaultValue : data)
     widget.callback?.(widget.value)
     node.graph?.setDirtyCanvas(true)
@@ -148,9 +150,9 @@ export function useRemoteWidget<
     if (isValid || isBackingOff(entry) || isFetching(entry))
       return entry!.data as T
 
-    const currentEntry: CacheEntry<T> = (entry as
-      | CacheEntry<T>
-      | undefined) || { data: defaultValue }
+    const currentEntry: CacheEntry<T> = shallowReactive(
+      (entry as CacheEntry<T> | undefined) || { data: defaultValue }
+    )
     dataCache.set(cacheKey, currentEntry)
 
     try {


### PR DESCRIPTION
## ELI5

Saving and reopening a workflow should keep the image you chose. This fix preserves that choice while loading the available images, so the next execution uses the intended input.

## Summary

[Restore the previously selected remote value in useRemoteWidget after reload (#17411)](https://github.com/Comfy-Org/ComfyUI_frontend/issues/17411): the initial remote response overwrote a saved non-first selection with the first option.

## Changes

- Preserve the current selection when it exists in the first remote response; retain the existing fallback and explicit-refresh behavior.
- Make the existing cache and entries shallow-reactive so Vue refreshes the option list even when the selected value stays the same.
- Add unit coverage for saved selections and fallback, plus a LoadImageOutput save/reload E2E that checks Imported options, the restored value and its preview.

## Review Focus

Initialization still invokes the callback once. Cached response identities and explicit first/last refresh behavior remain intact.

## Red-green proof

| Phase | Commit | Unit | E2E |
| --- | --- | --- | --- |
| Red | [`21269ba66d`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/21269ba66dcc4b5fd00f7a0400412e562a4a60e6) | [Failed: optionB reset to optionA](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34562793845/job/103148824034) | [Failed: selected output reset to first output](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34562793878/job/103149398524) |
| Green | [`10e1958e45`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/10e1958e45da25bb30d2413b8b6f50a333d740b3) | [Passed: 21,139 tests](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34565145140/job/103155681536) | [Passed: all 123 tests in the affected shard](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34565145522/job/103156267238) |
| Cleanup | [`5365a11da8`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/5365a11da866ac5620df0008700b7a92f5f342f1) | [Passed: 21,139 tests](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34568199835/job/103164584807) | [Passed: all 123 tests in the affected shard](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34568199989/job/103165219114) |

At the recorded Red and Green commits, the tests are identical. The E2E passed on its first attempt, and the full E2E workflow passed. The subsequent [E2E cleanup](https://github.com/Comfy-Org/ComfyUI_frontend/commit/5365a11da866ac5620df0008700b7a92f5f342f1) removes one unused image mock, redundant count assertions and repeated node/widget lookups, and adds the organizational `@slow` tag. The cleaned-up tests were rechecked locally: reverting the production fix reproduced both selection-reset failures; restoring it passed all 37 unit tests and all 3 selected E2E cases on their first attempt.

## Provenance

- **Authored by:** interactive session
- **Verified:** Targeted `pnpm test:unit`: 37 passed; targeted `pnpm test:browser`: 3 passed, including existing explicit-refresh and text-persistence cases. `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint`, `pnpm format:check` and `pnpm knip` passed. Independent code reviews and rendered-output inspection completed.

Fixes #17411

