### PR TITLE
BE-11470: feat(agent): import a Langfuse trace or session as a replay fixture

### DIFF
--- a/browser_tests/fixtures/data/agent/README.md
+++ b/browser_tests/fixtures/data/agent/README.md
@@ -105,6 +105,46 @@ PLAYWRIGHT_TEST_URL=http://localhost:5173 DISTRIBUTION=cloud \
   --project=cloud -g '<case-id>'
 ```
 
+## Import a Langfuse session
+
+A conversation that already ran on a hosted agent becomes the same fixture
+from its Langfuse trace, without re-recording:
+
+```bash
+AGENT_CLOUD_SHA=<cloud sha> pnpm exec tsx scripts/agentConversationFromLangfuse.ts <caseId> <seedFixture.json> --trace <traceId> --workflow <cloudWorkflowId> --out browser_tests/fixtures/data/agent/conversations/<caseId>.json
+```
+
+`--session <sessionId>` takes every trace of a session. Credentials come from
+`~/.config/comfy-agent/langfuse.env` (`LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`,
+`LANGFUSE_SECRET_KEY`; `--env-file` points elsewhere) and never reach an
+artifact.
+
+The importer reads what the agent's instrumentation emits (cloud
+`harness/telemetry/attrs.go`, `loop/host.go`): the turn span, marked
+`gen_ai.operation.name: invoke_agent`, carries `comfy.thread_id` and
+`comfy.turn_id` (the launch span above it carries the ids but no text); a tool
+span carries `gen_ai.tool.call.id`, `gen_ai.tool.name` and `comfy.tool.ok` and
+reaches its turn through `parentObservationId`; the turn's input and output
+exist only with content capture on. A turn without recorded output is refused;
+`--prompt` supplies turn inputs positionally from turn 1 and replaces the
+captured input at those positions. It rebuilds
+the tool-call and message frames, reads the audit rows with the recorder's own
+query (`AGENT_PG_EXEC` must reach that environment's Postgres), and runs the
+same assembly gates as a recording. So it imports a session whose audit
+database is still reachable, not any Langfuse session.
+
+UNVERIFIED until the first real trace: that `comfy.turn_id` is the message id
+the audit rows carry; that attributes arrive under `metadata.attributes` (a
+flattened `metadata` key is the fallback); that the page meta carries
+`totalPages` (a short page ends the walk otherwise).
+
+An import keeps `response_side: recorded`: the replies and accepted ops are the
+agent's, only the socket framing was rebuilt, and the replay suite lists
+recorded fixtures only. Thinking frames are absent; the trace does not carry
+them. The trace carries no active-tab frame either, so the importer rebuilds
+one for the opening turn (the `--workflow` id and the seed's name) for assembly
+to bind the workflow through.
+
 ## Capture
 
 The recorder keeps the `/ws` frames of the thread with their receipt times and,

--- a/scripts/agentConversationAssemble.ts
+++ b/scripts/agentConversationAssemble.ts
@@ -560,7 +560,15 @@ function buildConversation(options: {
   const { input, threadId, workflowId, turns } = options
   const { raw, rows, provenance } = input
   const { workflow } = input.seed.json
-  const note = `RECORDED from Comfy-Org/cloud services/agent running ${STACK} at ${raw.base} (frames: ${raw.frame_source}); NOT a production capture. cloud commit ${provenance.cloudSha}; model ${provenance.model}; thread ${threadId}; messages ${turns.map((turn) => turn.message_id).join(', ')}; workflow ${workflowId} (seeded by throwaway turn ${options.seedMessageId}; turn 1 opens on a fresh workflow and switches to it first because the replay subscribes only on an agent_active_tab frame); agent_tool_calls parent rows ${list(rows.flatMap((set) => set.parents.map((row) => row.id)))}; rows ${rows.map((set) => basename(set.path)).join(', ')}; raw capture sha256 ${input.rawSha256}`
+  const origin =
+    raw.seed_turn === null
+      ? `IMPORTED from ${raw.frame_source} via ${raw.base}; the agent ran on the deployment the trace came from`
+      : `RECORDED from Comfy-Org/cloud services/agent running ${STACK} at ${raw.base} (frames: ${raw.frame_source})`
+  const seeded =
+    options.seedMessageId === null
+      ? 'no seed turn, workflow id given at import'
+      : `seeded by throwaway turn ${options.seedMessageId}`
+  const note = `${origin}; NOT a production capture. cloud commit ${provenance.cloudSha}; model ${provenance.model}; thread ${threadId}; messages ${turns.map((turn) => turn.message_id).join(', ')}; workflow ${workflowId} (${seeded}; turn 1 opens on a fresh workflow and switches to it first because the replay subscribes only on an agent_active_tab frame); agent_tool_calls parent rows ${list(rows.flatMap((set) => set.parents.map((row) => row.id)))}; rows ${rows.map((set) => basename(set.path)).join(', ')}; raw capture sha256 ${input.rawSha256}`
 
   return parseOrRefuse(
     zAgentConversation,

--- a/scripts/agentConversationFromLangfuse.test.ts
+++ b/scripts/agentConversationFromLangfuse.test.ts
@@ -1,0 +1,655 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
+
+import { RecordRefusal } from './agentConversationAssemble'
+import type { Observation } from './agentConversationFromLangfuse'
+import {
+  LangfuseRequestError,
+  attributeOf,
+  captureFromObservations,
+  fetchObservations,
+  main,
+  readEnvFile
+} from './agentConversationFromLangfuse'
+import {
+  assertOpsApply,
+  zAgentConversation
+} from '../browser_tests/fixtures/data/agent/agentConversation'
+import { HostDoc } from '../browser_tests/fixtures/agentConversationHostDoc'
+
+const THREAD = 'thread-1'
+const WORKFLOW = '6f1c2c1e-3b1c-4c88-9d9c-0d6e9b8e1a01'
+
+const span = (
+  id: string,
+  attributes: Record<string, unknown>,
+  extra: Partial<Observation> = {}
+): Observation => ({
+  id,
+  traceId: 'trace-1',
+  type: 'span',
+  name: id,
+  startTime: '2026-09-04T10:00:00.000Z',
+  endTime: '2026-09-04T10:00:01.000Z',
+  input: undefined,
+  output: undefined,
+  metadata: { attributes },
+  parentObservationId: null,
+  ...extra
+})
+
+// Only the turn span carries the thread and turn ids; children do not inherit them.
+const turnRoot = (turnId: string, start: string, end: string): Observation =>
+  span(
+    `root-${turnId}`,
+    {
+      'comfy.thread_id': THREAD,
+      'comfy.turn_id': turnId,
+      'gen_ai.operation.name': 'invoke_agent'
+    },
+    {
+      name: 'agent.turn',
+      startTime: start,
+      endTime: end,
+      input: 'Add a sampler',
+      output: 'Added a KSampler.',
+      parentObservationId: `launch-${turnId}`
+    }
+  )
+
+// The engine's launch span sits above the turn, carries the ids, and has no input or output.
+const launchSpan = (turnId: string, start: string): Observation =>
+  span(
+    `launch-${turnId}`,
+    { 'comfy.thread_id': THREAD, 'comfy.turn_id': turnId },
+    { name: 'agent.launch', startTime: start, endTime: null }
+  )
+
+const roundSpan = (turnId: string): Observation =>
+  span(
+    `round-${turnId}`,
+    { 'gen_ai.operation.name': 'chat' },
+    { name: 'agent.model_round', parentObservationId: `root-${turnId}` }
+  )
+
+const toolSpan = (
+  turnId: string,
+  callId: string,
+  ok: boolean,
+  start: string,
+  end: string
+): Observation =>
+  span(
+    `tool-${callId}`,
+    {
+      'gen_ai.tool.call.id': callId,
+      'gen_ai.tool.name': 'apply_ops',
+      'comfy.tool.ok': ok
+    },
+    {
+      name: 'agent.tool apply_ops',
+      startTime: start,
+      endTime: end,
+      parentObservationId: `round-${turnId}`
+    }
+  )
+
+const options = {
+  caseId: 'agent-lf-example',
+  attempt: 'a1',
+  host: 'https://langfuse.example',
+  threadId: THREAD,
+  workflowId: WORKFLOW,
+  seed: {
+    workflow: {
+      id: WORKFLOW,
+      name: 'Text to image',
+      catalog: { types: {} },
+      seed: { nodes: [{ id: 3, type: 'CheckpointLoaderSimple' }], links: [] }
+    }
+  },
+  seedSha256: 'a'.repeat(64)
+}
+
+describe('captureFromObservations', () => {
+  it('attaches tool spans to their turn through the parent chain', () => {
+    const raw = captureFromObservations(
+      [
+        launchSpan('message-1', '2026-09-04T09:59:59.000Z'),
+        toolSpan(
+          'message-1',
+          'tool-1',
+          true,
+          '2026-09-04T10:00:00.200Z',
+          '2026-09-04T10:00:00.700Z'
+        ),
+        roundSpan('message-1'),
+        turnRoot(
+          'message-1',
+          '2026-09-04T10:00:00.000Z',
+          '2026-09-04T10:00:01.000Z'
+        )
+      ],
+      options
+    )
+    expect(raw.turns).toEqual([
+      {
+        prompt: 'Add a sampler',
+        accepted: {
+          status: 202,
+          body: { thread_id: THREAD, message_id: 'message-1' }
+        }
+      }
+    ])
+    expect(
+      raw.frames.map((frame) => [frame.type, frame.data.status, frame.at_ms])
+    ).toEqual([
+      ['agent_active_tab', undefined, Date.parse('2026-09-04T10:00:00.000Z')],
+      ['agent_tool_call', 'running', Date.parse('2026-09-04T10:00:00.200Z')],
+      ['agent_tool_call', 'success', Date.parse('2026-09-04T10:00:00.700Z')],
+      [
+        'agent_message_delta',
+        undefined,
+        Date.parse('2026-09-04T10:00:01.000Z')
+      ],
+      ['agent_message_done', undefined, Date.parse('2026-09-04T10:00:01.000Z')]
+    ])
+    expect(raw.frames[1].data).toMatchObject({
+      thread_id: THREAD,
+      message_id: 'message-1',
+      tool_call_id: 'tool-1',
+      tool_name: 'apply_ops'
+    })
+    expect(raw.frames[3].data.delta).toBe('Added a KSampler.')
+    expect(raw.seed_workflow_id).toBe(WORKFLOW)
+    expect(raw.seed_node_ids).toEqual([3])
+  })
+
+  it('orders turns by start time and marks a failed tool as error', () => {
+    const raw = captureFromObservations(
+      [
+        turnRoot(
+          'message-2',
+          '2026-09-04T10:01:00.000Z',
+          '2026-09-04T10:01:02.000Z'
+        ),
+        roundSpan('message-2'),
+        toolSpan(
+          'message-2',
+          'tool-2',
+          false,
+          '2026-09-04T10:01:00.500Z',
+          '2026-09-04T10:01:01.000Z'
+        ),
+        turnRoot(
+          'message-1',
+          '2026-09-04T10:00:00.000Z',
+          '2026-09-04T10:00:01.000Z'
+        )
+      ],
+      options
+    )
+    expect(raw.turns.map((turn) => turn.accepted?.body)).toEqual([
+      { thread_id: THREAD, message_id: 'message-1' },
+      { thread_id: THREAD, message_id: 'message-2' }
+    ])
+    const terminal = raw.frames.find(
+      (frame) =>
+        frame.data.tool_call_id === 'tool-2' && frame.data.status !== 'running'
+    )
+    expect(terminal?.data.status).toBe('error')
+    expect(terminal?.data.message_id).toBe('message-2')
+  })
+
+  it('opens the thread with the tab frame the assembler binds the replay through', () => {
+    const raw = captureFromObservations(
+      [
+        launchSpan('turn-1', '2026-09-04T10:00:00.000Z'),
+        turnRoot(
+          'turn-1',
+          '2026-09-04T10:00:00.000Z',
+          '2026-09-04T10:00:05.000Z'
+        )
+      ],
+      options
+    )
+    expect(raw.frames[0]).toEqual({
+      type: 'agent_active_tab',
+      data: {
+        thread_id: THREAD,
+        message_id: 'turn-1',
+        workflow_id: WORKFLOW,
+        name: 'Text to image'
+      },
+      at_ms: Date.parse('2026-09-04T10:00:00.000Z')
+    })
+  })
+
+  it('refuses a tool span that carries no terminal outcome', () => {
+    const start = '2026-09-04T10:00:00.000Z'
+    const end = '2026-09-04T10:00:05.000Z'
+    const thread = (tool: Observation) => [
+      launchSpan('turn-1', start),
+      turnRoot('turn-1', start, end),
+      roundSpan('turn-1'),
+      tool
+    ]
+    const complete = toolSpan('turn-1', 'call-1', true, start, end)
+    for (const partial of [
+      { ...complete, endTime: null },
+      {
+        ...complete,
+        metadata: {
+          attributes: {
+            'gen_ai.tool.call.id': 'call-1',
+            'gen_ai.tool.name': 'apply_ops'
+          }
+        }
+      },
+      {
+        ...complete,
+        metadata: {
+          attributes: {
+            'gen_ai.tool.call.id': 'call-1',
+            'gen_ai.tool.name': 'apply_ops',
+            'comfy.tool.ok': 'maybe'
+          }
+        }
+      }
+    ])
+      expect(() => captureFromObservations(thread(partial), options)).toThrow(
+        'tool call call-1 (apply_ops) in turn turn-1 has no terminal outcome'
+      )
+    expect(
+      captureFromObservations(thread(complete), options).frames.filter(
+        (frame) => frame.type === 'agent_tool_call'
+      )
+    ).toHaveLength(2)
+  })
+
+  it('refuses a turn exported without its invoke_agent span', () => {
+    expect(() =>
+      captureFromObservations(
+        [launchSpan('message-1', '2026-09-04T09:59:59.000Z')],
+        options
+      )
+    ).toThrow(
+      'turn message-1 has no span marked gen_ai.operation.name invoke_agent'
+    )
+  })
+
+  it('refuses a tool span that reaches no turn of the thread', () => {
+    const orphan = toolSpan(
+      'message-9',
+      'tool-9',
+      true,
+      '2026-09-04T10:00:00.200Z',
+      '2026-09-04T10:00:00.700Z'
+    )
+    expect(() =>
+      captureFromObservations(
+        [
+          orphan,
+          turnRoot(
+            'message-1',
+            '2026-09-04T10:00:00.000Z',
+            '2026-09-04T10:00:01.000Z'
+          )
+        ],
+        options
+      )
+    ).toThrow('tool span tool-tool-9 (apply_ops) is not under any turn')
+  })
+
+  it('takes the prompts from the command line when content capture was off', () => {
+    const root = turnRoot(
+      'message-1',
+      '2026-09-04T10:00:00.000Z',
+      '2026-09-04T10:00:01.000Z'
+    )
+    const raw = captureFromObservations([{ ...root, input: undefined }], {
+      ...options,
+      prompts: ['Add a sampler please']
+    })
+    expect(raw.turns[0].prompt).toBe('Add a sampler please')
+    expect(() =>
+      captureFromObservations([{ ...root, input: undefined }], options)
+    ).toThrow('pass --prompt for each turn')
+    expect(() =>
+      captureFromObservations([{ ...root, output: undefined }], options)
+    ).toThrow('no recorded output')
+  })
+
+  it('ignores turns of other threads and refuses when none match', () => {
+    const foreign = span('x', {
+      'comfy.thread_id': 'thread-2',
+      'comfy.turn_id': 'message-9'
+    })
+    expect(() => captureFromObservations([foreign], options)).toThrow(
+      'no observation carries comfy.thread_id thread-1'
+    )
+  })
+})
+
+describe('attributeOf', () => {
+  it('reads nested OTel attributes and flattened metadata keys', () => {
+    const nested = span('n', { 'comfy.turn_id': 'm-1', 'comfy.tool.ok': false })
+    expect(attributeOf(nested, 'comfy.turn_id')).toBe('m-1')
+    expect(attributeOf(nested, 'comfy.tool.ok')).toBe('false')
+    const flat: Observation = {
+      ...nested,
+      metadata: { 'comfy.turn_id': 'm-2' }
+    }
+    expect(attributeOf(flat, 'comfy.turn_id')).toBe('m-2')
+    expect(
+      attributeOf({ ...nested, metadata: null }, 'comfy.turn_id')
+    ).toBeUndefined()
+  })
+})
+
+describe('readEnvFile', () => {
+  it('parses KEY=VALUE lines, skipping comments and the export prefix', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'langfuse-env-'))
+    onTestFinished(() => rmSync(dir, { recursive: true, force: true }))
+    const path = join(dir, 'langfuse.env')
+    writeFileSync(
+      path,
+      '# comfy-agent langfuse\nexport LANGFUSE_HOST=https://langfuse.example\nLANGFUSE_PUBLIC_KEY=pk-test\nLANGFUSE_SECRET_KEY=sk-test\n'
+    )
+    expect(readEnvFile(path)).toEqual({
+      LANGFUSE_HOST: 'https://langfuse.example',
+      LANGFUSE_PUBLIC_KEY: 'pk-test',
+      LANGFUSE_SECRET_KEY: 'sk-test'
+    })
+    writeFileSync(path, 'LANGFUSE_HOST=https://langfuse.example\n')
+    expect(() => readEnvFile(path)).toThrow('LANGFUSE_PUBLIC_KEY')
+    writeFileSync(
+      path,
+      'LANGFUSE_HOST=https://user:hunter2@langfuse.example\nLANGFUSE_PUBLIC_KEY=pk-test\nLANGFUSE_SECRET_KEY=sk-test\n'
+    )
+    const refusal = (() => {
+      try {
+        readEnvFile(path)
+        return null
+      } catch (error) {
+        return error
+      }
+    })()
+    expect(refusal).toBeInstanceOf(RecordRefusal)
+    expect(refusal instanceof RecordRefusal && refusal.message).toBe(
+      `Langfuse env file ${path}: LANGFUSE_HOST must not carry credentials`
+    )
+  })
+})
+
+describe('fetchObservations', () => {
+  const env = {
+    LANGFUSE_HOST: 'https://langfuse.example',
+    LANGFUSE_PUBLIC_KEY: 'pk-test',
+    LANGFUSE_SECRET_KEY: 'sk-test'
+  }
+  const page = (data: unknown[], totalPages: number) =>
+    new Response(JSON.stringify({ data, meta: { totalPages } }), {
+      status: 200
+    })
+
+  it('walks every page of a trace with basic auth', async () => {
+    const calls: string[] = []
+    const observations = await fetchObservations(
+      env,
+      { traceId: 'trace-1' },
+      async (url, init) => {
+        calls.push(url)
+        expect(new Headers(init.headers).get('authorization')).toBe(
+          `Basic ${Buffer.from('pk-test:sk-test').toString('base64')}`
+        )
+        const pageNumber = new URL(url).searchParams.get('page')
+        return page([span(`o-${pageNumber}`, {})], 2)
+      }
+    )
+    expect(observations.map((observation) => observation.id)).toEqual([
+      'o-1',
+      'o-2'
+    ])
+    expect(calls.map((url) => new URL(url).pathname)).toEqual([
+      '/api/public/observations',
+      '/api/public/observations'
+    ])
+    expect(new URL(calls[0]).searchParams.get('traceId')).toBe('trace-1')
+  })
+
+  it('resolves a session to its traces first', async () => {
+    const paths: string[] = []
+    const observations = await fetchObservations(
+      env,
+      { sessionId: 'session-1' },
+      async (url) => {
+        const parsed = new URL(url)
+        paths.push(parsed.pathname)
+        if (parsed.pathname === '/api/public/traces') {
+          expect(parsed.searchParams.get('sessionId')).toBe('session-1')
+          return page([{ id: 't-1' }, { id: 't-2' }], 1)
+        }
+        return page([span(`o-${parsed.searchParams.get('traceId')}`, {})], 1)
+      }
+    )
+    expect(paths).toEqual([
+      '/api/public/traces',
+      '/api/public/observations',
+      '/api/public/observations'
+    ])
+    expect(observations.map((observation) => observation.id)).toEqual([
+      'o-t-1',
+      'o-t-2'
+    ])
+  })
+
+  it('reports a non-2xx page as a request failure, not a capture refusal', async () => {
+    const fetchImpl = async () =>
+      new Response('upstream detail that must not be echoed', {
+        status: 503
+      })
+    const failure = await fetchObservations(
+      env,
+      { traceId: 'trace-1' },
+      fetchImpl
+    ).catch((error: unknown) => error)
+    expect(failure).toBeInstanceOf(LangfuseRequestError)
+    expect(failure).not.toBeInstanceOf(RecordRefusal)
+    expect(failure instanceof LangfuseRequestError && failure.message).toBe(
+      'Langfuse /api/public/observations returned 503 on page 1'
+    )
+  })
+})
+
+describe('main', () => {
+  const { workflow } = zAgentConversation.parse(
+    JSON.parse(
+      readFileSync(
+        'browser_tests/fixtures/data/agent/conversations/agent-rec-text-only-answer.json',
+        'utf8'
+      )
+    )
+  )
+  const T0 = '2026-09-04T10:00:00.000Z'
+  const T1 = '2026-09-04T10:00:01.000Z'
+  const T2 = '2026-09-04T10:00:02.000Z'
+  const T5 = '2026-09-04T10:00:05.000Z'
+
+  const stage = (host = 'https://langfuse.example') => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-langfuse-import-'))
+    onTestFinished(() => rmSync(dir, { recursive: true, force: true }))
+    const seedPath = join(dir, 'seed.json')
+    writeFileSync(seedPath, JSON.stringify({ workflow }))
+    const rowsScript = join(dir, 'rows.cjs')
+    writeFileSync(
+      rowsScript,
+      "process.stdout.write(JSON.stringify(require('./rows.json')))\n"
+    )
+    const envPath = join(dir, 'langfuse.env')
+    writeFileSync(
+      envPath,
+      `LANGFUSE_HOST=${host}\nLANGFUSE_PUBLIC_KEY=pk-test\nLANGFUSE_SECRET_KEY=sk-test\n`
+    )
+    vi.stubEnv('AGENT_CLOUD_SHA', 'abc1234')
+    vi.stubEnv('AGENT_ATTEMPT', 'a1')
+    vi.stubEnv('AGENT_PG_EXEC', `${process.execPath}  ${rowsScript}`)
+    const stdout = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true)
+    onTestFinished(() => {
+      stdout.mockRestore()
+      vi.unstubAllEnvs()
+    })
+    const outPath = join(dir, 'out', 'agent-lf-example.json')
+    const workDir = join(dir, 'work')
+    return {
+      envPath,
+      workDir,
+      outPath,
+      argv: [
+        'agent-lf-example',
+        seedPath,
+        '--trace',
+        'trace-1',
+        '--workflow',
+        workflow.id,
+        '--out',
+        outPath,
+        '--work',
+        workDir,
+        '--env-file',
+        envPath
+      ],
+      rows: (dump: { parents: unknown[]; draft: unknown }) =>
+        writeFileSync(
+          join(dir, 'rows.json'),
+          JSON.stringify({ source: 'postgres', ...dump })
+        ),
+      page: (observations: Observation[]) => async (url: string) => {
+        expect(new URL(url).pathname).toBe('/api/public/observations')
+        return new Response(
+          JSON.stringify({ data: observations, meta: { totalPages: 1 } }),
+          { status: 200 }
+        )
+      },
+      written: () =>
+        zAgentConversation.parse(JSON.parse(readFileSync(outPath, 'utf8')))
+    }
+  }
+
+  it('imports a text-only trace into a fixture the replay accepts', async () => {
+    const s = stage()
+    s.rows({
+      parents: [],
+      draft: { nodes: workflow.seed.nodes, links: workflow.seed.links }
+    })
+    await main(
+      s.argv,
+      s.page([launchSpan('turn-1', T0), turnRoot('turn-1', T0, T5)])
+    )
+    const conversation = s.written()
+    expect(() => assertOpsApply(conversation)).not.toThrow()
+    expect(conversation.workflow.id).toBe(workflow.id)
+    expect(conversation.turns.map((turn) => turn.message_id)).toEqual([
+      'turn-1'
+    ])
+    expect(conversation.turns[0].request).toEqual({ content: 'Add a sampler' })
+    expect(
+      conversation.turns[0].response.map((entry) =>
+        entry.kind === 'event' ? entry.event.type : entry.kind
+      )
+    ).toEqual(['agent_active_tab', 'agent_message_delta', 'agent_message_done'])
+    expect(readdirSync(s.workDir).sort()).toEqual([
+      'agent-lf-example.a1.raw.json',
+      'agent-lf-example.a1.receipt.json',
+      'agent-lf-example.a1.rows.1.json'
+    ])
+    for (const file of [
+      s.outPath,
+      ...readdirSync(s.workDir).map((name) => join(s.workDir, name))
+    ])
+      expect(readFileSync(file, 'utf8')).not.toMatch(/pk-test|sk-test/)
+  })
+
+  it('imports a tool turn whose audit rows and draft agree with the op it applied', async () => {
+    const s = stage()
+    const op = {
+      op: 'set_widget' as const,
+      node_id: 3,
+      widget: 'steps',
+      value: 30,
+      old: 20
+    }
+    const host = new HostDoc(workflow.id, workflow.seed, workflow.catalog)
+    host.apply([op])
+    s.rows({
+      parents: [
+        {
+          id: 'parent-1',
+          tool_call_id: 'call-1',
+          tool_name: 'apply_ops',
+          status: 'ok',
+          workflow_id: workflow.id,
+          result: { ok: true, data: { ops: [{ op_id: 'op-1', ...op }] } },
+          children: [{ op_id: 'op-1', status: 'ok' }]
+        }
+      ],
+      draft: host.projection()
+    })
+    await main(
+      s.argv,
+      s.page([
+        launchSpan('turn-1', T0),
+        turnRoot('turn-1', T0, T5),
+        roundSpan('turn-1'),
+        toolSpan('turn-1', 'call-1', true, T1, T2)
+      ])
+    )
+    const conversation = s.written()
+    expect(
+      conversation.turns[0].response.map((entry) =>
+        entry.kind === 'event' ? entry.event.type : entry.kind
+      )
+    ).toEqual([
+      'agent_active_tab',
+      'agent_tool_call',
+      'graph_ops',
+      'agent_tool_call',
+      'agent_message_delta',
+      'agent_message_done'
+    ])
+    expect(
+      conversation.turns[0].response.find((entry) => entry.kind === 'graph_ops')
+    ).toEqual({
+      kind: 'graph_ops',
+      ops: [op],
+      at_ms: Date.parse(T2) - Date.parse(T0)
+    })
+    expect(assertOpsApply(conversation).projection()).toEqual(host.projection())
+  })
+
+  it('refuses a Langfuse host that carries credentials before the network or the disk', async () => {
+    const s = stage('https://user:hunter2@langfuse.example')
+    const fetchImpl = vi.fn()
+    const failure = await main(s.argv, fetchImpl).catch(
+      (error: unknown) => error
+    )
+    expect(failure).toBeInstanceOf(RecordRefusal)
+    expect(failure instanceof RecordRefusal && failure.message).toBe(
+      `Langfuse env file ${s.envPath}: LANGFUSE_HOST must not carry credentials`
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(existsSync(s.workDir)).toBe(false)
+  })
+})

--- a/scripts/agentConversationFromLangfuse.ts
+++ b/scripts/agentConversationFromLangfuse.ts
@@ -1,0 +1,523 @@
+#!/usr/bin/env tsx
+
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { z } from 'zod'
+
+import {
+  RecordRefusal,
+  assembleConversation,
+  parseOrRefuse,
+  refuse,
+  zSeedFixture
+} from './agentConversationAssemble'
+import { zAgentTurnAccepted } from '../src/workbench/extensions/agent/schemas/agentApiSchema'
+import type {
+  RawCapture,
+  RecordedFrame,
+  RecordedTurn,
+  SeedFixture
+} from './agentConversationAssemble'
+import { readRows } from './agentConversationRecord'
+
+const USAGE =
+  'usage: pnpm exec tsx scripts/agentConversationFromLangfuse.ts <caseId> <seedFixture.json> (--trace <traceId> | --session <sessionId>) --workflow <cloudWorkflowId> --out <fixture.json> [--work <dir>] [--env-file <path>] [--prompt "<turn 1>" ...]'
+
+const DEFAULT_ENV_FILE = join(
+  process.env.HOME ?? '',
+  '.config/comfy-agent/langfuse.env'
+)
+
+export const zLangfuseEnv = z.object({
+  LANGFUSE_HOST: z
+    .string()
+    .url()
+    .refine((host) => {
+      const url = new URL(host)
+      return url.username === '' && url.password === ''
+    }, 'must not carry credentials'),
+  LANGFUSE_PUBLIC_KEY: z.string().min(1),
+  LANGFUSE_SECRET_KEY: z.string().min(1)
+})
+export type LangfuseEnv = z.infer<typeof zLangfuseEnv>
+
+const zEnv = z.object({
+  AGENT_CLOUD_SHA: z.string().regex(/^[0-9a-f]{7,40}$/),
+  AGENT_PG_EXEC: z.string().default('psql -U postgres -d postgres -At -c'),
+  AGENT_ATTEMPT: z.string().default('')
+})
+
+export const zObservation = z
+  .object({
+    id: z.string(),
+    traceId: z.string(),
+    type: z.string().nullish(),
+    name: z.string().nullish(),
+    startTime: z.string(),
+    endTime: z.string().nullish(),
+    input: z.unknown(),
+    output: z.unknown(),
+    metadata: z.unknown(),
+    parentObservationId: z.string().nullish()
+  })
+  .passthrough()
+export type Observation = z.infer<typeof zObservation>
+
+const zPage = z.object({
+  data: z.array(zObservation),
+  meta: z.object({ totalPages: z.number().optional() }).passthrough().optional()
+})
+
+const zTracePage = z.object({
+  data: z.array(z.object({ id: z.string() }).passthrough()),
+  meta: z.object({ totalPages: z.number().optional() }).passthrough().optional()
+})
+
+// The values are secrets: never logged, never written into an artifact.
+export function readEnvFile(path: string): LangfuseEnv {
+  const pairs = readFileSync(path, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+    .map((line) => line.replace(/^export\s+/, ''))
+    .flatMap((line) => {
+      const eq = line.indexOf('=')
+      return eq === -1
+        ? []
+        : [[line.slice(0, eq).trim(), line.slice(eq + 1).trim()] as const]
+    })
+  return parseOrRefuse(
+    zLangfuseEnv,
+    Object.fromEntries(pairs),
+    `Langfuse env file ${path}`
+  )
+}
+
+// Langfuse keeps unmapped OTel attributes under metadata.attributes; flattened metadata is the fallback.
+export function attributeOf(
+  observation: Observation,
+  key: string
+): string | undefined {
+  const metadata = z
+    .record(z.string(), z.unknown())
+    .safeParse(observation.metadata)
+  if (!metadata.success) return undefined
+  const nested = z
+    .record(z.string(), z.unknown())
+    .safeParse(metadata.data.attributes)
+  const value = nested.success ? nested.data[key] : metadata.data[key]
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean' || typeof value === 'number')
+    return String(value)
+  return undefined
+}
+
+function textOf(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  return value === undefined || value === null
+    ? undefined
+    : JSON.stringify(value)
+}
+
+export interface CaptureOptions {
+  caseId: string
+  attempt: string
+  host: string
+  threadId: string
+  workflowId: string
+  seed: SeedFixture
+  seedSha256: string
+  prompts?: string[]
+}
+
+interface TurnSpans {
+  root: Observation
+  tools: Observation[]
+}
+
+const atMs = (iso: string): number => Date.parse(iso)
+
+// Children inherit no attributes, so a tool span finds its turn through parentObservationId.
+function groupTurns(
+  observations: Observation[],
+  threadId: string
+): TurnSpans[] {
+  const byId = new Map(
+    observations.map((observation) => [observation.id, observation])
+  )
+  const byTurn = new Map<string, TurnSpans>()
+  const turnOf = new Map<string, TurnSpans>()
+  // The launch span carries the ids but no text; invoke_agent marks the turn span (cloud loop/host.go:265).
+  const isTurnSpan = (observation: Observation): boolean =>
+    attributeOf(observation, 'gen_ai.operation.name') === 'invoke_agent'
+  for (const observation of observations) {
+    if (attributeOf(observation, 'comfy.thread_id') !== threadId) continue
+    const turnId = attributeOf(observation, 'comfy.turn_id')
+    if (turnId === undefined) continue
+    const existing = byTurn.get(turnId)
+    const replaces =
+      existing === undefined ||
+      (isTurnSpan(observation) &&
+        (!isTurnSpan(existing.root) ||
+          atMs(observation.startTime) < atMs(existing.root.startTime)))
+    const turn = replaces
+      ? { root: observation, tools: existing?.tools ?? [] }
+      : existing
+    byTurn.set(turnId, turn)
+    turnOf.set(observation.id, turn)
+  }
+  for (const [turnId, turn] of byTurn)
+    if (!isTurnSpan(turn.root))
+      refuse(
+        `turn ${turnId} has no span marked gen_ai.operation.name invoke_agent; only its launch or analytics spans were exported`
+      )
+  for (const observation of observations) {
+    if (attributeOf(observation, 'gen_ai.tool.call.id') === undefined) continue
+    let cursor = observation.parentObservationId ?? null
+    let turn: TurnSpans | undefined
+    for (let hops = 0; cursor !== null && hops < 32; hops += 1) {
+      turn = turnOf.get(cursor)
+      if (turn !== undefined) break
+      cursor = byId.get(cursor)?.parentObservationId ?? null
+    }
+    if (turn === undefined)
+      refuse(
+        `tool span ${observation.id} (${attributeOf(observation, 'gen_ai.tool.name') ?? observation.name}) is not under any turn of thread ${threadId}`
+      )
+    turn.tools.push(observation)
+  }
+  return [...byTurn.values()].sort(
+    (a, b) => atMs(a.root.startTime) - atMs(b.root.startTime)
+  )
+}
+
+function turnFrames(
+  turn: TurnSpans,
+  threadId: string,
+  turnId: string
+): RecordedFrame[] {
+  const ids = { thread_id: threadId, message_id: turnId }
+  const frames: RecordedFrame[] = []
+  for (const tool of turn.tools) {
+    const toolCallId = attributeOf(tool, 'gen_ai.tool.call.id')!
+    const toolName = attributeOf(tool, 'gen_ai.tool.name') ?? tool.name ?? ''
+    const ok = attributeOf(tool, 'comfy.tool.ok')
+    if ((ok !== 'true' && ok !== 'false') || tool.endTime == null)
+      refuse(
+        `tool call ${toolCallId} (${toolName}) in turn ${turnId} has no terminal outcome: comfy.tool.ok=${ok ?? 'missing'}, endTime=${tool.endTime ?? 'missing'}`
+      )
+    frames.push({
+      type: 'agent_tool_call',
+      data: {
+        ...ids,
+        tool_call_id: toolCallId,
+        tool_name: toolName,
+        status: 'running'
+      },
+      at_ms: atMs(tool.startTime)
+    })
+    frames.push({
+      type: 'agent_tool_call',
+      data: {
+        ...ids,
+        tool_call_id: toolCallId,
+        tool_name: toolName,
+        status: ok === 'true' ? 'success' : 'error'
+      },
+      at_ms: atMs(tool.endTime)
+    })
+  }
+  const end = atMs(turn.root.endTime ?? turn.root.startTime)
+  const text = textOf(turn.root.output)
+  if (text !== undefined)
+    frames.push({
+      type: 'agent_message_delta',
+      data: { ...ids, delta: text },
+      at_ms: end
+    })
+  frames.push({ type: 'agent_message_done', data: { ...ids }, at_ms: end })
+  return frames.sort((a, b) => (a.at_ms ?? 0) - (b.at_ms ?? 0))
+}
+
+export function captureFromObservations(
+  observations: Observation[],
+  options: CaptureOptions
+): RawCapture {
+  const turns = groupTurns(observations, options.threadId)
+  if (turns.length === 0)
+    refuse(
+      `no observation carries comfy.thread_id ${options.threadId} with a comfy.turn_id`
+    )
+  const recordedTurns: RecordedTurn[] = []
+  const frames: RecordedFrame[] = []
+  for (const [index, turn] of turns.entries()) {
+    const turnId = attributeOf(turn.root, 'comfy.turn_id')!
+    const prompt = options.prompts?.[index] ?? textOf(turn.root.input)
+    if (prompt === undefined)
+      refuse(
+        `turn ${index + 1} (${turnId}) has no recorded input; content capture was off, pass --prompt for each turn`
+      )
+    if (textOf(turn.root.output) === undefined)
+      refuse(
+        `turn ${index + 1} (${turnId}) has no recorded output; content capture was off on the agent, so the reply text cannot be replayed`
+      )
+    recordedTurns.push({
+      prompt,
+      accepted: {
+        status: 202,
+        body: { thread_id: options.threadId, message_id: turnId }
+      }
+    })
+    // Langfuse never sees the socket's tab frame, and the assembler binds through it.
+    if (index === 0)
+      frames.push({
+        type: 'agent_active_tab',
+        data: {
+          thread_id: options.threadId,
+          message_id: turnId,
+          workflow_id: options.workflowId,
+          name: options.seed.workflow.name
+        },
+        at_ms: atMs(turn.root.startTime)
+      })
+    frames.push(...turnFrames(turn, options.threadId, turnId))
+  }
+  return {
+    case_id: options.caseId,
+    attempt: options.attempt,
+    base: options.host,
+    frame_source: `langfuse observations, ${observations.length} spans`,
+    channel: `langfuse:${observations[0]?.traceId ?? ''}`,
+    seed_sha256: options.seedSha256,
+    seed_name: options.seed.workflow.name,
+    seed_node_ids: options.seed.workflow.seed.nodes.map((node) => node.id),
+    saw_stream: true,
+    stream_closed: true,
+    seed_turn: null,
+    seed_workflow_id: options.workflowId,
+    turns: recordedTurns,
+    timed_out: false,
+    frames,
+    error: null
+  }
+}
+
+export type Fetch = (url: string, init: RequestInit) => Promise<Response>
+
+// A transport or server failure: the run failed, the capture was not refused.
+export class LangfuseRequestError extends Error {
+  constructor(path: string, status: number, page: number) {
+    super(`Langfuse ${path} returned ${status} on page ${page}`)
+    this.name = 'LangfuseRequestError'
+  }
+}
+
+async function pages<T>(
+  env: LangfuseEnv,
+  path: string,
+  query: Record<string, string>,
+  schema: z.ZodType<{ data: T[]; meta?: { totalPages?: number } }>,
+  fetchImpl: Fetch
+): Promise<T[]> {
+  const auth = Buffer.from(
+    `${env.LANGFUSE_PUBLIC_KEY}:${env.LANGFUSE_SECRET_KEY}`
+  ).toString('base64')
+  const items: T[] = []
+  for (let page = 1; ; page += 1) {
+    const url = new URL(path, env.LANGFUSE_HOST)
+    for (const [key, value] of Object.entries({
+      ...query,
+      page: String(page),
+      limit: '100'
+    }))
+      url.searchParams.set(key, value)
+    const response = await fetchImpl(url.toString(), {
+      headers: { authorization: `Basic ${auth}` }
+    })
+    if (!response.ok)
+      throw new LangfuseRequestError(path, response.status, page)
+    const parsed = parseOrRefuse(
+      schema,
+      await response.json(),
+      `Langfuse ${path} page ${page}`
+    )
+    items.push(...parsed.data)
+    const totalPages = parsed.meta?.totalPages
+    if (
+      parsed.data.length === 0 ||
+      (totalPages !== undefined ? page >= totalPages : parsed.data.length < 100)
+    )
+      return items
+  }
+}
+
+export async function fetchObservations(
+  env: LangfuseEnv,
+  selector: { traceId?: string; sessionId?: string },
+  fetchImpl: Fetch = (url, init) => fetch(url, init)
+): Promise<Observation[]> {
+  const traceIds =
+    selector.traceId !== undefined
+      ? [selector.traceId]
+      : (
+          await pages(
+            env,
+            '/api/public/traces',
+            { sessionId: selector.sessionId ?? '' },
+            zTracePage,
+            fetchImpl
+          )
+        ).map((trace) => trace.id)
+  const observations: Observation[] = []
+  for (const traceId of traceIds)
+    observations.push(
+      ...(await pages(
+        env,
+        '/api/public/observations',
+        { traceId },
+        zPage,
+        fetchImpl
+      ))
+    )
+  return observations
+}
+
+const sha256 = (bytes: Buffer | string): string =>
+  createHash('sha256').update(bytes).digest('hex')
+const sha256OfFile = (path: string): string => sha256(readFileSync(path))
+const writeJson = (path: string, value: unknown): void =>
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`)
+
+function parseArgs(argv: string[]) {
+  const positional: string[] = []
+  const flags: Partial<Record<string, string>> = {}
+  const prompts: string[] = []
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--prompt') prompts.push(argv[(index += 1)] ?? '')
+    else if (arg.startsWith('--')) flags[arg] = argv[(index += 1)] ?? ''
+    else positional.push(arg)
+  }
+  return { positional, flags, prompts }
+}
+
+export async function main(
+  argv: string[],
+  fetchImpl: Fetch = (url, init) => fetch(url, init)
+): Promise<void> {
+  const { positional, flags, prompts } = parseArgs(argv)
+  const [caseId, seedPath] = positional
+  const traceId = flags['--trace']
+  const sessionId = flags['--session']
+  const workflowId = flags['--workflow']
+  const outPath = flags['--out']
+  if (
+    !caseId ||
+    !seedPath ||
+    !workflowId ||
+    !outPath ||
+    (traceId === undefined) === (sessionId === undefined)
+  )
+    refuse(USAGE)
+
+  const langfuse = readEnvFile(flags['--env-file'] ?? DEFAULT_ENV_FILE)
+  const env = parseOrRefuse(zEnv, process.env, 'environment')
+  const attempt = (
+    env.AGENT_ATTEMPT.trim() || new Date().toISOString().replace(/[:.]/g, '-')
+  ).replace(/[^A-Za-z0-9_-]/g, '-')
+  const seed = parseOrRefuse(
+    zSeedFixture,
+    JSON.parse(readFileSync(seedPath, 'utf8')),
+    `seed fixture ${seedPath}`
+  )
+  const workDir = flags['--work'] || join(dirname(outPath), 'recordings')
+  mkdirSync(workDir, { recursive: true })
+  mkdirSync(dirname(resolve(outPath)), { recursive: true })
+  const sidecar = (suffix: string): string =>
+    join(workDir, `${caseId}.${attempt}.${suffix}`)
+
+  const observations = await fetchObservations(
+    langfuse,
+    { traceId, sessionId },
+    fetchImpl
+  )
+  const threadIds = new Set(
+    observations.flatMap((observation) => {
+      const id = attributeOf(observation, 'comfy.thread_id')
+      return id === undefined ? [] : [id]
+    })
+  )
+  if (threadIds.size !== 1)
+    refuse(
+      `expected exactly one comfy.thread_id across the observations, found ${[...threadIds].join(', ') || 'none'}`
+    )
+  const [threadId] = threadIds
+  const raw = captureFromObservations(observations, {
+    caseId,
+    attempt,
+    host: langfuse.LANGFUSE_HOST,
+    threadId,
+    workflowId,
+    seed,
+    seedSha256: sha256OfFile(seedPath),
+    prompts: prompts.length > 0 ? prompts : undefined
+  })
+  const rawPath = sidecar('raw.json')
+  writeJson(rawPath, raw)
+
+  try {
+    const rows = raw.turns.map((turn, index) =>
+      readRows(
+        env.AGENT_PG_EXEC.split(' ').filter(Boolean),
+        sidecar(`rows.${index + 1}.json`),
+        {
+          threadId,
+          messageId: zAgentTurnAccepted.parse(turn.accepted?.body).message_id,
+          workflowId
+        }
+      )
+    )
+    const model =
+      observations
+        .map((observation) => attributeOf(observation, 'gen_ai.response.model'))
+        .find((value) => value !== undefined) ?? 'unknown'
+    const { conversation, receipt } = assembleConversation({
+      raw,
+      rows,
+      seed: { json: seed, path: seedPath, sha256: raw.seed_sha256 },
+      provenance: {
+        cloudSha: env.AGENT_CLOUD_SHA,
+        model,
+        exportedAt: new Date().toISOString()
+      },
+      rawSha256: sha256OfFile(rawPath),
+      rawPath
+    })
+    writeJson(outPath, conversation)
+    writeJson(sidecar('receipt.json'), receipt)
+    process.stdout.write(
+      `imported ${outPath} sha256=${sha256OfFile(outPath)} attempt=${attempt} turns=${receipt.turns.length} dropped=${JSON.stringify(receipt.frames_dropped)}\nsidecars in ${workDir}\n`
+    )
+  } catch (error) {
+    writeFileSync(
+      join(workDir, `${caseId}.refused.jsonl`),
+      `${JSON.stringify({ at: new Date().toISOString(), attempt, refused: error instanceof Error ? error.message : String(error) })}\n`,
+      { flag: 'a' }
+    )
+    throw error
+  }
+}
+
+const entry = process.argv.at(1)
+if (entry !== undefined && import.meta.url === pathToFileURL(entry).href) {
+  main(process.argv.slice(2)).catch((error: unknown) => {
+    const refused = error instanceof RecordRefusal
+    process.stderr.write(
+      `import: ${refused ? 'REFUSED' : 'FAILED'}: ${error instanceof Error ? error.message : String(error)}\n`
+    )
+    process.exitCode = 1
+  })
+}

--- a/scripts/agentConversationRecord.ts
+++ b/scripts/agentConversationRecord.ts
@@ -79,7 +79,7 @@ const writeJson = (path: string, value: unknown): void =>
 const ROWS_MAX_BYTES = 64 * 1024 * 1024
 const ROWS_TIMEOUT_MS = 60_000
 
-function readRows(
+export function readRows(
   exec: string[],
   path: string,
   ids: TurnIds & { workflowId: string }


### PR DESCRIPTION
<!-- authored-by:agent lane-test-harness-stack -->
Helper PR carrying the reviewed diff of https://github.com/Comfy-Org/ComfyUI_frontend/pull/17018 (head 42b5748f478c4dd6c7c4e436c262aca3a8d8d8dd) rebased onto current main on a christian-byrne branch so it can enter the merge queue. Code is Nathaniel's, carried over with co-author credit. Reviewer verdict at that head: ready to approve (https://github.com/Comfy-Org/ComfyUI_frontend/pull/17018#pullrequestreview-5163888879).

<details><summary>Full context for agent readers</summary>

Why a helper PR: the original lives on a `fu/*` branch that this lane does not push to, and the original still carries an earlier changes-requested review that blocks the queue even though the follow-up review at the current head says ready to approve. Rebasing the identical diff onto main on an owned branch lets the agreed plan (merge the integration test stack now, follow up on remaining polish immediately after) proceed without rewriting anyone's branch.

What is carried: the Langfuse trace/session importer that writes a replay fixture for `comfy-test agent-replay`, exactly as reviewed at 42b5748f47. The credential-boundary fix (host allow-list, no key leakage into fixtures) from the final review round is included.

Verification on this branch after rebase, Node 25: `pnpm install` clean, `pnpm oxlint:main` clean, `pnpm vitest run` for the importer tests 16/16 passing, `pnpm typecheck` in `tools/test-recorder` exit 0.

Follow-ups tracked in the program repo (`plans/test-followups-2026-09-10.md`): temp-dir cleanup and narration-comment removal called out by reviewers, to be applied after the stack lands.

</details>
