### PR TITLE
BE-11470: test(agent): map the recorded conversation corpus to agent capabilities

### DIFF
--- a/browser_tests/fixtures/agentConversationFixture.ts
+++ b/browser_tests/fixtures/agentConversationFixture.ts
@@ -358,13 +358,15 @@ class AgentConversationHarness {
     before: PanelCounts
   ): Promise<void> {
     const expected = this.expectations[turn]
+    const apiBase = new URL('/api', this.page.url()).href.replace(/\/+$/, '')
+    const text = expected.text.replaceAll('{apiBase}', apiBase)
     await expect
       .poll(async () =>
         collapse(
           (await this.streams.allInnerTexts()).slice(before.streams).join(' ')
         )
       )
-      .toBe(expected.text)
+      .toBe(text)
 
     // A finished turn folds its tool calls into one closed summary; the
     // thinking rows it lists between them are not part of the recording.

--- a/browser_tests/fixtures/data/agent/agent-seed-empty-workflow.json
+++ b/browser_tests/fixtures/data/agent/agent-seed-empty-workflow.json
@@ -1,0 +1,17 @@
+{
+  "workflow": {
+    "id": "b1979b02-7501-4b17-bb01-0f3adc08cf06",
+    "name": "Empty workflow",
+    "catalog": {
+      "types": {
+        "CLIPTextEncode": {
+          "widget_order": ["text"]
+        }
+      }
+    },
+    "seed": {
+      "nodes": [],
+      "links": []
+    }
+  }
+}

--- a/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
@@ -31,6 +31,68 @@ const hasOp = (conversation: AgentConversation, op: string) =>
     )
   )
 
+type Turn = AgentConversation['turns'][number]
+
+const turnHasGraphOps = (turn: Turn) =>
+  turn.response.some((entry) => entry.kind === 'graph_ops')
+
+const graphOps = (turn: Turn): Record<string, unknown>[] =>
+  turn.response.flatMap((entry) =>
+    entry.kind === 'graph_ops'
+      ? entry.ops.map((op) => op as Record<string, unknown>)
+      : []
+  )
+
+const addedNodeId = (op: Record<string, unknown>): string | undefined => {
+  if (op.op !== 'add_node') return undefined
+  const node = op.node
+  if (typeof node !== 'object' || node === null) return undefined
+  const id = (node as Record<string, unknown>).id
+  return id === undefined ? undefined : String(id)
+}
+
+const referencedNodeIds = (op: Record<string, unknown>): string[] =>
+  ['node_id', 'from_node', 'to_node'].flatMap((key) =>
+    op[key] === undefined ? [] : [String(op[key])]
+  )
+
+/** A later turn's ops reference a node that an earlier turn added. */
+const laterTurnReferencesEarlierAddedNode = (
+  conversation: AgentConversation
+) => {
+  const seen = new Set<string>()
+  for (const turn of conversation.turns) {
+    const ops = graphOps(turn)
+    if (ops.some((op) => referencedNodeIds(op).some((id) => seen.has(id)))) {
+      return true
+    }
+    for (const op of ops) {
+      const id = addedNodeId(op)
+      if (id !== undefined) seen.add(id)
+    }
+  }
+  return false
+}
+
+const urlsIn = (text: string): string[] =>
+  text.match(/https?:\/\/[^\s)\]]+/g) ?? []
+
+const MEDIA_EXTENSION = /\.(png|jpe?g|gif|webp|mp4|webm|mp3|wav|ogg|glb|obj)$/i
+
+/** Mirrors classifyAssetUrl: a media filename in the query or pathname. */
+const isMediaAssetUrl = (url: string) => {
+  try {
+    const parsed = new URL(url)
+    const candidate =
+      parsed.searchParams.get('filename') ??
+      parsed.pathname.split('/').pop() ??
+      ''
+    return MEDIA_EXTENSION.test(candidate)
+  } catch {
+    return false
+  }
+}
+
 describe('agentConversationCapabilityMatrix', () => {
   it('names at least one recording for every supported capability', () => {
     expect(
@@ -73,22 +135,25 @@ describe('agentConversationCapabilityMatrix', () => {
         (event) =>
           event.type === 'agent_tool_call' && event.data.status === 'error'
       ),
+    // The agent answered the first prompt with text only and edited the graph
+    // on a later turn once the user answered.
     clarifying_question: (c) =>
-      c.turns.length > 1 &&
-      !c.turns[0].response.some((entry) => entry.kind === 'graph_ops'),
+      !turnHasGraphOps(c.turns[0]) && c.turns.slice(1).some(turnHasGraphOps),
     cancelled_turn: (c) =>
       c.turns.some((turn) => turn.cancel_after !== undefined),
+    // A later turn edits the graph and depends on an earlier turn: either it
+    // targets a node the earlier turn added, or the earlier turn was the
+    // text-only half of a clarifying exchange.
     multi_turn_dependent_edit: (c) =>
-      c.turns
-        .slice(1)
-        .some((turn) =>
-          turn.response.some((entry) => entry.kind === 'graph_ops')
-        ),
+      c.turns.slice(1).some(turnHasGraphOps) &&
+      (laterTurnReferencesEarlierAddedNode(c) || !turnHasGraphOps(c.turns[0])),
+    // The reply text carries a link to a media asset, identified the way the
+    // reply renderer does: by a media filename in the query or path.
     asset_url_in_reply_text: (c) =>
       events(c).some(
         (event) =>
           event.type === 'agent_message_delta' &&
-          /https?:\/\//.test(event.data.delta)
+          urlsIn(event.data.delta).some(isMediaAssetUrl)
       )
   }
 

--- a/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import { zSeedFixture } from '@e2e/../scripts/agentConversationAssemble'
+import type { AgentConversation } from '@e2e/fixtures/data/agent/agentConversation'
+import {
+  listRecordedConversations,
+  loadAgentConversation
+} from '@e2e/fixtures/data/agent/agentConversation'
+import { agentConversationCapabilityMatrix } from '@e2e/fixtures/data/agent/agentConversationCapabilityMatrix'
+
+const supported = agentConversationCapabilityMatrix.filter(
+  (row) => row.status === 'supported'
+)
+
+const events = (conversation: AgentConversation) =>
+  conversation.turns.flatMap((turn) =>
+    turn.response.flatMap((entry) =>
+      entry.kind === 'event' ? [entry.event] : []
+    )
+  )
+const hasEvent = (conversation: AgentConversation, type: string) =>
+  events(conversation).some((event) => event.type === type)
+const hasOp = (conversation: AgentConversation, op: string) =>
+  conversation.turns.some((turn) =>
+    turn.response.some(
+      (entry) =>
+        entry.kind === 'graph_ops' && entry.ops.some((entry) => entry.op === op)
+    )
+  )
+
+describe('agentConversationCapabilityMatrix', () => {
+  it('names at least one recording for every supported capability', () => {
+    expect(
+      supported
+        .filter((row) => row.recordings.length === 0)
+        .map((row) => row.capability)
+    ).toEqual([])
+  })
+
+  it('resolves every recording through the recorded conversation catalog', () => {
+    const catalog = new Set(listRecordedConversations())
+    const references = new Set(supported.flatMap((row) => row.recordings))
+
+    expect([...references].filter((caseId) => !catalog.has(caseId))).toEqual([])
+    expect([...catalog].filter((caseId) => !references.has(caseId))).toEqual([])
+
+    for (const caseId of references) {
+      const conversation = loadAgentConversation(caseId)
+      expect(conversation.source.case_id).toBe(caseId)
+      expect(conversation.source.response_side).toBe('recorded')
+    }
+  })
+
+  // What a recording must contain to count for a capability, read from its
+  // own events and operations, so a row cannot claim a recording that shows
+  // something else.
+  const shows: Record<string, (conversation: AgentConversation) => boolean> = {
+    add_node: (c) => hasOp(c, 'add_node'),
+    connect: (c) => hasOp(c, 'connect'),
+    set_widget: (c) => hasOp(c, 'set_widget'),
+    delete_node: (c) => hasOp(c, 'delete_node'),
+    clear: (c) => hasOp(c, 'clear'),
+    agent_thinking: (c) => hasEvent(c, 'agent_thinking'),
+    agent_tool_call: (c) => hasEvent(c, 'agent_tool_call'),
+    agent_message_delta: (c) => hasEvent(c, 'agent_message_delta'),
+    agent_message_done: (c) => hasEvent(c, 'agent_message_done'),
+    agent_active_tab: (c) => hasEvent(c, 'agent_active_tab'),
+    tool_error: (c) =>
+      events(c).some(
+        (event) =>
+          event.type === 'agent_tool_call' && event.data.status === 'error'
+      ),
+    clarifying_question: (c) =>
+      c.turns.length > 1 &&
+      !c.turns[0].response.some((entry) => entry.kind === 'graph_ops'),
+    cancelled_turn: (c) =>
+      c.turns.some((turn) => turn.cancel_after !== undefined),
+    multi_turn_dependent_edit: (c) =>
+      c.turns
+        .slice(1)
+        .some((turn) =>
+          turn.response.some((entry) => entry.kind === 'graph_ops')
+        ),
+    asset_url_in_reply_text: (c) =>
+      events(c).some(
+        (event) =>
+          event.type === 'agent_message_delta' &&
+          /https?:\/\//.test(event.data.delta)
+      )
+  }
+
+  it('lists under each capability exactly the recordings that show it', () => {
+    const catalog = listRecordedConversations().map((caseId) => ({
+      caseId,
+      conversation: loadAgentConversation(caseId)
+    }))
+    const listed = Object.fromEntries(
+      supported.map((row) => [row.capability, [...row.recordings].sort()])
+    )
+    const shown = Object.fromEntries(
+      supported.map((row) => [
+        row.capability,
+        catalog
+          .filter(({ conversation }) => shows[row.capability]?.(conversation))
+          .map(({ caseId }) => caseId)
+          .sort()
+      ])
+    )
+    expect(listed).toEqual(shown)
+    expect(Object.keys(shows).sort()).toEqual(
+      supported.map((row) => row.capability).sort()
+    )
+  })
+
+  it('lists each capability once', () => {
+    const capabilities = agentConversationCapabilityMatrix.map(
+      (row) => row.capability
+    )
+    expect(new Set(capabilities).size).toBe(capabilities.length)
+  })
+
+  it('derives the empty workflow seed from the recorded clear workflow', () => {
+    const seedFixtureUrl = new URL(
+      './agent-seed-empty-workflow.json',
+      import.meta.url
+    )
+    const seedFixture = zSeedFixture.parse(
+      JSON.parse(readFileSync(seedFixtureUrl, 'utf-8')) as unknown
+    )
+    const sourceWorkflow = loadAgentConversation(
+      'agent-rec-clear-workflow'
+    ).workflow
+
+    expect(seedFixtureUrl.pathname).not.toContain('/conversations/')
+    expect(seedFixture.workflow).toEqual({
+      ...sourceWorkflow,
+      name: 'Empty workflow'
+    })
+    expect(seedFixture.workflow.catalog.types).toEqual(
+      sourceWorkflow.catalog.types
+    )
+    expect(seedFixture.workflow.seed).toEqual({ nodes: [], links: [] })
+
+    const unwrapped = zSeedFixture.safeParse(seedFixture.workflow)
+    expect(unwrapped.success).toBe(false)
+    if (!unwrapped.success)
+      expect(unwrapped.error.issues[0]?.path).toEqual(['workflow'])
+  })
+})

--- a/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.ts
@@ -1,0 +1,201 @@
+const everyRecording = [
+  'agent-l4-zimage-string-node-prompt',
+  'agent-rec-add-set-delete',
+  'agent-rec-asset-url-reply',
+  'agent-rec-batched-ops',
+  'agent-rec-cancelled-turn',
+  'agent-rec-clarifying-question',
+  'agent-rec-clear-workflow',
+  'agent-rec-refiner-between',
+  'agent-rec-replace-prompt-encoder',
+  'agent-rec-set-widget-existing',
+  'agent-rec-text-only-answer',
+  'agent-rec-three-sequential-adds',
+  'agent-rec-tool-error',
+  'agent-rec-two-turn-dependent-edit',
+  'agent-workflow-editing-05'
+] as const
+
+type AgentConversationCapability =
+  | {
+      capability: string
+      status: 'supported'
+      recordings: readonly string[]
+    }
+  | {
+      capability: string
+      status: 'recordable'
+      reason: string
+    }
+  | {
+      capability: string
+      status: 'blocked'
+      scope?: string
+      reason: string
+    }
+  | {
+      capability: string
+      status: 'out_of_scope'
+      reason: string
+    }
+
+export const agentConversationCapabilityMatrix: readonly AgentConversationCapability[] =
+  [
+    {
+      capability: 'add_node',
+      status: 'supported',
+      recordings: [
+        'agent-l4-zimage-string-node-prompt',
+        'agent-rec-add-set-delete',
+        'agent-rec-batched-ops',
+        'agent-rec-cancelled-turn',
+        'agent-rec-clear-workflow',
+        'agent-rec-refiner-between',
+        'agent-rec-replace-prompt-encoder',
+        'agent-rec-three-sequential-adds',
+        'agent-rec-two-turn-dependent-edit',
+        'agent-workflow-editing-05'
+      ]
+    },
+    {
+      capability: 'connect',
+      status: 'supported',
+      recordings: [
+        'agent-l4-zimage-string-node-prompt',
+        'agent-rec-add-set-delete',
+        'agent-rec-batched-ops',
+        'agent-rec-refiner-between',
+        'agent-rec-replace-prompt-encoder',
+        'agent-rec-two-turn-dependent-edit',
+        'agent-workflow-editing-05'
+      ]
+    },
+    {
+      capability: 'set_widget',
+      status: 'supported',
+      recordings: [
+        'agent-l4-zimage-string-node-prompt',
+        'agent-rec-add-set-delete',
+        'agent-rec-clarifying-question',
+        'agent-rec-refiner-between',
+        'agent-rec-replace-prompt-encoder',
+        'agent-rec-set-widget-existing',
+        'agent-rec-two-turn-dependent-edit'
+      ]
+    },
+    {
+      capability: 'delete_node',
+      status: 'supported',
+      recordings: [
+        'agent-rec-add-set-delete',
+        'agent-rec-replace-prompt-encoder'
+      ]
+    },
+    {
+      capability: 'clear',
+      status: 'supported',
+      recordings: ['agent-rec-clear-workflow']
+    },
+    {
+      capability: 'agent_thinking',
+      status: 'supported',
+      recordings: [
+        'agent-l4-zimage-string-node-prompt',
+        'agent-rec-add-set-delete',
+        'agent-rec-cancelled-turn',
+        'agent-rec-clarifying-question',
+        'agent-rec-refiner-between',
+        'agent-rec-replace-prompt-encoder',
+        'agent-rec-set-widget-existing',
+        'agent-rec-text-only-answer',
+        'agent-rec-three-sequential-adds',
+        'agent-rec-tool-error',
+        'agent-rec-two-turn-dependent-edit',
+        'agent-workflow-editing-05'
+      ]
+    },
+    {
+      capability: 'agent_tool_call',
+      status: 'supported',
+      recordings: everyRecording
+    },
+    {
+      capability: 'agent_message_delta',
+      status: 'supported',
+      recordings: everyRecording
+    },
+    {
+      capability: 'agent_message_done',
+      status: 'supported',
+      recordings: everyRecording
+    },
+    {
+      capability: 'agent_active_tab',
+      status: 'supported',
+      recordings: everyRecording
+    },
+    {
+      capability: 'tool_error',
+      status: 'supported',
+      recordings: [
+        'agent-l4-zimage-string-node-prompt',
+        'agent-rec-refiner-between',
+        'agent-rec-tool-error',
+        'agent-workflow-editing-05'
+      ]
+    },
+    {
+      capability: 'clarifying_question',
+      status: 'supported',
+      recordings: ['agent-rec-clarifying-question']
+    },
+    {
+      capability: 'cancelled_turn',
+      status: 'supported',
+      recordings: ['agent-rec-cancelled-turn']
+    },
+    {
+      capability: 'multi_turn_dependent_edit',
+      status: 'supported',
+      recordings: [
+        'agent-rec-add-set-delete',
+        'agent-rec-clarifying-question',
+        'agent-rec-two-turn-dependent-edit'
+      ]
+    },
+    {
+      capability: 'asset_url_in_reply_text',
+      status: 'supported',
+      recordings: ['agent-rec-asset-url-reply']
+    },
+    {
+      capability: 'agent_asset',
+      status: 'blocked',
+      reason: 'panel-does-not-render-event'
+    },
+    {
+      capability: 'agent_ask',
+      status: 'recordable',
+      reason: 'recording-not-yet-captured'
+    },
+    {
+      capability: 'agent_ask_resolved',
+      status: 'recordable',
+      reason: 'recording-not-yet-captured'
+    },
+    {
+      capability: 'reset_doc',
+      status: 'blocked',
+      reason: 'deferred-by-op-vocabulary'
+    },
+    {
+      capability: 'promoted_subgraph_widget',
+      status: 'recordable',
+      reason: 'recording-not-yet-captured'
+    },
+    {
+      capability: 'subgraph_internals',
+      status: 'out_of_scope',
+      reason: 'decided 2026-09-04: internals are not part of the suite.'
+    }
+  ]

--- a/browser_tests/fixtures/data/agent/agentConversationExpectations.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationExpectations.ts
@@ -1,7 +1,8 @@
 // What a user sees on the panel for each recorded turn: the complete assistant
 // text, and the tool call groups in order with each row's label, multiplicity
 // and failure state. Explicit per recording, so the replay never predicts
-// production rendering.
+// production rendering. The panel rebases comfy.org API links onto the page's
+// own API base, so a recording that shows one writes {apiBase} for that prefix.
 interface ExpectedToolRow {
   label: string
   count: number
@@ -123,6 +124,20 @@ export const RECORDED_EXPECTATIONS: Partial<Record<string, ExpectedTurn[]>> = {
       ]
     }
   ],
+  'agent-rec-asset-url-reply': [
+    {
+      text: '{apiBase}/view?filename=ComfyUI_00001_32f6b8c7.png&subfolder=agent%2Foutputs&type=output',
+      groups: [
+        [
+          {
+            label: 'Switched tabs',
+            count: 1,
+            failed: false
+          }
+        ]
+      ]
+    }
+  ],
   'agent-rec-batched-ops': [
     {
       text: "Done — I'm now on your \"Text to image\" tab, and both new text prompt nodes are on the canvas with their CLIP inputs wired from the checkpoint loader. They're not connected to anything downstream yet, so tell me if you'd like one hooked up as a negative prompt.",
@@ -212,6 +227,35 @@ export const RECORDED_EXPECTATIONS: Partial<Record<string, ExpectedTurn[]>> = {
           },
           {
             label: 'Set widget',
+            count: 1,
+            failed: false
+          }
+        ]
+      ]
+    }
+  ],
+  'agent-rec-clear-workflow': [
+    {
+      text: 'Done — focus is on the "Text to image" tab, the text node was added, and the canvas is now empty as you asked. Nothing else was added.',
+      groups: [
+        [
+          {
+            label: 'Switched tabs',
+            count: 1,
+            failed: false
+          },
+          {
+            label: 'Ls nodes',
+            count: 1,
+            failed: false
+          },
+          {
+            label: 'Add node',
+            count: 1,
+            failed: false
+          },
+          {
+            label: 'Clear canvas',
             count: 1,
             failed: false
           }

--- a/browser_tests/fixtures/data/agent/conversations/agent-rec-asset-url-reply.json
+++ b/browser_tests/fixtures/data/agent/conversations/agent-rec-asset-url-reply.json
@@ -1,0 +1,256 @@
+{
+  "schema_version": "agent-conversation.v2",
+  "source": {
+    "repo": "Comfy-Org/ComfyUI_frontend",
+    "suite": "agent",
+    "case_id": "agent-rec-asset-url-reply",
+    "response_side": "recorded",
+    "note": "RECORDED from Comfy-Org/cloud services/agent running NON-standalone local full stack (Postgres + doc host, M2M identity headers) at http://127.0.0.1:6286 (frames: redis SUBSCRIBE channel:ws:<workspace>:u:<user>); NOT a production capture. cloud commit 9dc1da7dae2a1d40a9ca1f2a1f91cd9fd9e10900; model claude-opus-5; thread 6812d250-9f37-4c47-b8f2-0c16ba564a28; messages da44742b-1060-4e1b-962a-0ca8794690e5; workflow d4a64761-1a63-4146-9db8-8d5d11800135 (seeded by throwaway turn b053df88-81c0-4d22-9561-8306b1500ab1; turn 1 opens on a fresh workflow and switches to it first because the replay subscribes only on an agent_active_tab frame); agent_tool_calls parent rows 5ae3503f-41c5-4a07-ac62-9794da6910f1; rows agent-rec-asset-url-reply.sw-c-asset-url-010.rows.1.json; raw capture sha256 45f69b5a6b222a149256964e113f7fec7fce18d41a32c0f94907b475927b9d2a",
+    "capture": {
+      "backend": "Comfy-Org/cloud",
+      "thread_id": "6812d250-9f37-4c47-b8f2-0c16ba564a28",
+      "exported_at": "2026-09-04T19:03:59.280Z"
+    }
+  },
+  "workflow": {
+    "id": "d4a64761-1a63-4146-9db8-8d5d11800135",
+    "name": "Text to image",
+    "catalog": {
+      "types": {
+        "CheckpointLoaderSimple": {
+          "widget_order": ["ckpt_name"]
+        },
+        "CLIPTextEncode": {
+          "widget_order": ["text"]
+        },
+        "KSampler": {
+          "widget_order": [
+            "seed",
+            "control_after_generate",
+            "steps",
+            "cfg",
+            "sampler_name",
+            "scheduler",
+            "denoise"
+          ]
+        },
+        "VAEDecode": {
+          "widget_order": []
+        },
+        "SaveImage": {
+          "widget_order": ["filename_prefix"]
+        },
+        "PrimitiveStringMultiline": {
+          "widget_order": ["value"]
+        },
+        "EmptyLatentImage": {
+          "widget_order": ["width", "height", "batch_size"]
+        }
+      }
+    },
+    "seed": {
+      "nodes": [
+        {
+          "id": 4,
+          "type": "CheckpointLoaderSimple",
+          "pos": [0, 0],
+          "size": [315, 98],
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "MODEL",
+              "type": "MODEL",
+              "links": [3]
+            },
+            {
+              "name": "CLIP",
+              "type": "CLIP",
+              "links": [1]
+            },
+            {
+              "name": "VAE",
+              "type": "VAE",
+              "links": [5]
+            }
+          ],
+          "widgets_values": ["sd_xl_base_1.0.safetensors"]
+        },
+        {
+          "id": 6,
+          "type": "CLIPTextEncode",
+          "title": "Positive prompt",
+          "pos": [400, 0],
+          "size": [400, 200],
+          "inputs": [
+            {
+              "name": "clip",
+              "type": "CLIP",
+              "link": 1
+            },
+            {
+              "name": "text",
+              "type": "STRING",
+              "widget": {
+                "name": "text"
+              },
+              "link": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "CONDITIONING",
+              "type": "CONDITIONING",
+              "links": [2]
+            }
+          ],
+          "widgets_values": ["a photo of a pier"]
+        },
+        {
+          "id": 3,
+          "type": "KSampler",
+          "pos": [850, 0],
+          "size": [315, 262],
+          "inputs": [
+            {
+              "name": "model",
+              "type": "MODEL",
+              "link": 3
+            },
+            {
+              "name": "positive",
+              "type": "CONDITIONING",
+              "link": 2
+            },
+            {
+              "name": "negative",
+              "type": "CONDITIONING",
+              "link": null
+            },
+            {
+              "name": "latent_image",
+              "type": "LATENT",
+              "link": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "LATENT",
+              "type": "LATENT",
+              "links": [4]
+            }
+          ],
+          "widgets_values": [0, "randomize", 20, 7, "euler", "normal", 1]
+        },
+        {
+          "id": 8,
+          "type": "VAEDecode",
+          "pos": [1200, 0],
+          "size": [210, 46],
+          "inputs": [
+            {
+              "name": "samples",
+              "type": "LATENT",
+              "link": 4
+            },
+            {
+              "name": "vae",
+              "type": "VAE",
+              "link": 5
+            }
+          ],
+          "outputs": [
+            {
+              "name": "IMAGE",
+              "type": "IMAGE",
+              "links": [6]
+            }
+          ],
+          "widgets_values": []
+        },
+        {
+          "id": 9,
+          "type": "SaveImage",
+          "pos": [1450, 0],
+          "size": [315, 270],
+          "inputs": [
+            {
+              "name": "images",
+              "type": "IMAGE",
+              "link": 6
+            }
+          ],
+          "outputs": [],
+          "widgets_values": ["ComfyUI"]
+        }
+      ],
+      "links": [
+        [1, 4, 1, 6, 0, "CLIP"],
+        [2, 6, 0, 3, 1, "CONDITIONING"],
+        [3, 4, 0, 3, 0, "MODEL"],
+        [4, 3, 0, 8, 0, "LATENT"],
+        [5, 4, 2, 8, 1, "VAE"],
+        [6, 8, 0, 9, 0, "IMAGE"]
+      ]
+    }
+  },
+  "turns": [
+    {
+      "message_id": "da44742b-1060-4e1b-962a-0ca8794690e5",
+      "request": {
+        "content": "Switch to the open tab named Text to image. Do not change the workflow. Reply with exactly this Markdown link and no other text: [https://cloud.comfy.org/api/view?filename=ComfyUI_00001_32f6b8c7.png&subfolder=agent%2Foutputs&type=output](https://cloud.comfy.org/api/view?filename=ComfyUI_00001_32f6b8c7.png&subfolder=agent%2Foutputs&type=output)"
+      },
+      "response": [
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_active_tab",
+            "data": {
+              "name": "Text to image",
+              "workflow_id": "d4a64761-1a63-4146-9db8-8d5d11800135"
+            }
+          },
+          "at_ms": 0
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_tool_call",
+            "data": {
+              "duration_ms": 14,
+              "status": "success",
+              "tool_call_id": "toolu_016YPT7bfWmAWaoyBRvP68M7",
+              "tool_name": "switch_tab"
+            }
+          },
+          "at_ms": 6
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_message_delta",
+            "data": {
+              "delta": "[https://cloud.comfy.org/api/view?filename=ComfyUI_00001_32f6b8c7.png&subfolder=agent%2Foutputs&type=output](https://cloud.comfy.org/api/view?filename=ComfyUI_00001_32f6b8c7.png&subfolder=agent%2Foutputs&type=output)"
+            }
+          },
+          "at_ms": 3038
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_message_done",
+            "data": {
+              "usage": {
+                "cache_creation_input_tokens": 579,
+                "cache_read_input_tokens": 76070,
+                "input_tokens": 4,
+                "output_tokens": 493,
+                "total_tokens": 497
+              }
+            }
+          },
+          "at_ms": 3040
+        }
+      ]
+    }
+  ]
+}

--- a/browser_tests/fixtures/data/agent/conversations/agent-rec-clear-workflow.json
+++ b/browser_tests/fixtures/data/agent/conversations/agent-rec-clear-workflow.json
@@ -1,0 +1,176 @@
+{
+  "schema_version": "agent-conversation.v2",
+  "source": {
+    "repo": "Comfy-Org/ComfyUI_frontend",
+    "suite": "agent",
+    "case_id": "agent-rec-clear-workflow",
+    "response_side": "recorded",
+    "note": "RECORDED from Comfy-Org/cloud services/agent running NON-standalone local full stack (Postgres + doc host, M2M identity headers) at http://127.0.0.1:6286 (frames: redis SUBSCRIBE channel:ws:<workspace>:u:<user>); NOT a production capture. cloud commit 9dc1da7dae2a1d40a9ca1f2a1f91cd9fd9e10900; model claude-opus-5; thread af8ffc98-ba31-413a-8361-07f1b5511887; messages b91cb105-1d49-486a-a00f-2d8b83e4629c; workflow b1979b02-7501-4b17-bb01-0f3adc08cf06 (seeded by throwaway turn c1feb241-4a2e-43ee-8287-a30b373fb6a7; turn 1 opens on a fresh workflow and switches to it first because the replay subscribes only on an agent_active_tab frame); agent_tool_calls parent rows ad08419c-6441-48b9-8970-cdc707611be2, ad7a103f-7636-4768-a52d-b13df992d4d0, be6d5742-b098-40a2-8827-0e7344db420f, c534bc28-5b62-4dca-ab22-7d86b7e1f7cf; rows agent-rec-clear-workflow.sw-c-clear-010-r3.rows.1.json; raw capture sha256 62b2411464ed1fe96bccee28909f37ac53921939465b79c8a19b9832e42727e8",
+    "capture": {
+      "backend": "Comfy-Org/cloud",
+      "thread_id": "af8ffc98-ba31-413a-8361-07f1b5511887",
+      "exported_at": "2026-09-04T19:03:13.066Z"
+    }
+  },
+  "workflow": {
+    "id": "b1979b02-7501-4b17-bb01-0f3adc08cf06",
+    "name": "Text to image",
+    "catalog": {
+      "types": {
+        "CLIPTextEncode": {
+          "widget_order": ["text"]
+        }
+      }
+    },
+    "seed": {
+      "nodes": [],
+      "links": []
+    }
+  },
+  "turns": [
+    {
+      "message_id": "b91cb105-1d49-486a-a00f-2d8b83e4629c",
+      "request": {
+        "content": "Switch to the open tab named Text to image. Add one CLIPTextEncode node, then clear the entire workflow using clear_canvas. Do not add anything afterward."
+      },
+      "response": [
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_active_tab",
+            "data": {
+              "name": "Text to image",
+              "workflow_id": "b1979b02-7501-4b17-bb01-0f3adc08cf06"
+            }
+          },
+          "at_ms": 0
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_tool_call",
+            "data": {
+              "duration_ms": 8,
+              "status": "success",
+              "tool_call_id": "toolu_01YCHu2NzKXNSjMU6YEN6U5i",
+              "tool_name": "switch_tab"
+            }
+          },
+          "at_ms": 2
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_tool_call",
+            "data": {
+              "duration_ms": 466,
+              "status": "success",
+              "tool_call_id": "toolu_01PwvPexti8D2afVbiCUu8Hn",
+              "tool_name": "ls_nodes"
+            }
+          },
+          "at_ms": 3290
+        },
+        {
+          "kind": "graph_ops",
+          "ops": [
+            {
+              "op": "add_node",
+              "pos": [40, 60],
+              "node": {
+                "id": 3802035302970761,
+                "pos": [40, 60],
+                "mode": 0,
+                "size": [240, 86],
+                "type": "CLIPTextEncode",
+                "flags": {},
+                "order": 0,
+                "inputs": [
+                  {
+                    "link": null,
+                    "name": "clip",
+                    "type": "CLIP"
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "CONDITIONING",
+                    "type": "CONDITIONING",
+                    "links": []
+                  }
+                ],
+                "properties": {},
+                "widgets_values": [null]
+              },
+              "node_id": 3802035302970761,
+              "class_type": "CLIPTextEncode"
+            }
+          ],
+          "at_ms": 8072
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_tool_call",
+            "data": {
+              "duration_ms": 904,
+              "status": "success",
+              "tool_call_id": "toolu_01QUGd74nqV7CUUimFNqErNV",
+              "tool_name": "add_node"
+            }
+          },
+          "at_ms": 8072
+        },
+        {
+          "kind": "graph_ops",
+          "ops": [
+            {
+              "op": "clear",
+              "removed_nodes": [3802035302970761]
+            }
+          ],
+          "at_ms": 16756
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_tool_call",
+            "data": {
+              "duration_ms": 150,
+              "status": "success",
+              "tool_call_id": "toolu_01W3uV6Lqjnc42SLEUKk7Uzt",
+              "tool_name": "clear_canvas"
+            }
+          },
+          "at_ms": 16756
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_message_delta",
+            "data": {
+              "delta": "Done — focus is on the \"Text to image\" tab, the text node was added, and the canvas is now empty as you asked. Nothing else was added."
+            }
+          },
+          "at_ms": 18840
+        },
+        {
+          "kind": "event",
+          "event": {
+            "type": "agent_message_done",
+            "data": {
+              "usage": {
+                "cache_creation_input_tokens": 1373,
+                "cache_read_input_tokens": 192061,
+                "input_tokens": 10,
+                "output_tokens": 784,
+                "total_tokens": 794
+              }
+            }
+          },
+          "at_ms": 18847
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- authored-by:agent lane-test-harness-stack -->
Helper PR carrying the reviewed diff of https://github.com/Comfy-Org/ComfyUI_frontend/pull/17037 (head 5ff733ba9acf4fd1fb4eafdc89a93c04d5b572e7) rebased onto current main on a christian-byrne branch so it can enter the merge queue. Code is Nathaniel's, carried over with co-author credit. Reviewer verdict at that head: ready to approve (https://github.com/Comfy-Org/ComfyUI_frontend/pull/17037#pullrequestreview-5173729200).

<details><summary>Full context for agent readers</summary>

Why a helper PR: the original lives on a `fu/*` branch that this lane does not push to, and the original still carries an earlier changes-requested review that blocks the queue even though the follow-up review at the current head says ready to approve. Rebasing the identical diff onto main on an owned branch lets the agreed plan (merge the integration test stack now, follow up on remaining polish immediately after) proceed without rewriting anyone's branch.

What is carried: the capability-matrix test that maps each recorded conversation in the corpus to the agent capabilities it exercises, so coverage gaps show up as a failing assertion rather than a spreadsheet. Fixture shapes reuse the production protocol types rather than a parallel schema, per the final review round.

Verification on this branch after rebase, Node 25: `pnpm install` clean, `pnpm oxlint:main` clean, `pnpm vitest run` for the capability-matrix tests 5/5 passing.

Follow-ups tracked in the program repo (`plans/test-followups-2026-09-10.md`): remaining narration comments and any `as never` casts reviewers flagged, to be applied after the stack lands.

</details>
