### PR TITLE
BE-11470: docs(agent): agent-integration-replay skill and comfy-test agent-replay

### DIFF
--- a/.claude/skills/agent-integration-replay/SKILL.md
+++ b/.claude/skills/agent-integration-replay/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: agent-integration-replay
+description: 'Replay recorded agent conversations as Playwright tests against the real chat panel and canvas. Use when asked to replay agent recordings, run the agent replay suite, or debug an agent panel or graph-edit regression against a recording. Triggers on: replay agent conversation, agent replay suite, agent integration test.'
+---
+
+# Agent integration replay
+
+One job: replay the recorded conversations as tests. Replay needs only a
+ComfyUI backend on port 8188 and the dev server below. Recording a new
+conversation is the recorder's job, documented in
+`browser_tests/fixtures/data/agent/README.md`; the local stack launcher for
+the real agent is proposed in #16781 and is not in this tree.
+
+## Replay the recorded conversations as tests
+
+Every JSON under `browser_tests/fixtures/data/agent/conversations/` is one
+recorded conversation. The replay sends each recorded prompt through the real
+chat panel, plays the agent's side back from the recording, applies the
+recorded graph operations through the real multi-player library, and checks
+the canvas and the panel after every turn.
+
+```bash
+DISTRIBUTION=cloud DEV_SERVER_COMFYUI_URL=http://127.0.0.1:8188 pnpm dev
+```
+
+```bash
+pnpm comfy-test agent-replay
+```
+
+- On a terminal with no flags it asks which recording to replay and whether
+  to watch it. Any flag, or a non-interactive stdin, runs without prompts.
+- One case: `pnpm comfy-test agent-replay --case <case id> --headed` (the
+  case id is the JSON file name without `.json`); `--video` records it under
+  `test-results/`; `--url <origin>` points at a dev server other than
+  `http://localhost:5173`; `--help` prints usage and runs nothing.
+- Set `TEST_COMFYUI_DIR` to the ComfyUI install behind 8188 (or put it in
+  `.env`) so the suite backs up and restores its user data.
+- The command is a thin front for the raw invocation, which still works when
+  the CLI is not available:
+
+```bash
+PLAYWRIGHT_TEST_URL=http://localhost:5173 DISTRIBUTION=cloud pnpm exec playwright test agentConversation --project=cloud
+```
+
+Add `--headed` to watch it and `RECORD_VIDEO=true` for video. For one
+recording use `pnpm comfy-test agent-replay --case <case id>`.
+
+- A failing replay names the turn and the assertion. Compare that turn's
+  `response` entries with what the panel rendered; never edit a fixture to make
+  a test pass.
+
+## Conventions
+
+- A fix that changes what the agent's ops do to the graph or the panel ships
+  with a recording made before the fix, so it went red.
+- Fixtures validate against `zAgentConversation` in
+  `browser_tests/fixtures/data/agent/agentConversation.ts`; a schema change is
+  versioned, never silent.

--- a/tools/test-recorder/AGENTS.md
+++ b/tools/test-recorder/AGENTS.md
@@ -29,18 +29,19 @@ true.
 
 ## Interface parity
 
-| Capability             | Interactive `record` path                    | Non-interactive path                                                                         |
-| ---------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Target distribution    | Distribution selector with live versions     | `record --distribution <id>`; `check --distribution <id>` or `COMFY_TEST_DISTRIBUTION`       |
-| Custom backend         | “Custom backend…” selection and URL prompt   | `record --backend <url>`; `check --backend <url>` or `COMFY_TEST_BACKEND`                    |
-| Workflow search        | Searchable workflow autocomplete             | `list --filter <keyword>`                                                                    |
-| Add workflow from file | “(add from file…)” workflow option           | `add-workflow <file> [--name <n>]`                                                           |
-| Test tags              | Tag multiselect with hints                   | `tags` lists the registry with descriptions; `plan --tags` and `transform --tags` apply tags |
-| Record setup answers   | Guided prompts                               | `record --workflow --tags --feature-flags --use-case --description --name`                   |
-| Feature flags          | Feature-flag selector and custom flag prompt | `record`, `plan`, or `transform --feature-flags <specs>`                                     |
-| PR checkout            | Safe switch confirmation                     | `record --pr <number>`                                                                       |
-| Secret scrubbing       | Automatic during `record`, with a loud alert | Automatic in `transform <file>`; findings print as 🔒 lines in the summary                   |
-| Supervisor guidance    | Woven into `record` prompts and warnings     | `guide` prints the full operating manual for an agent helping a human                        |
+| Capability             | Interactive `record` path                                                           | Non-interactive path                                                                          |
+| ---------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Target distribution    | Distribution selector with live versions                                            | `record --distribution <id>`; `check --distribution <id>` or `COMFY_TEST_DISTRIBUTION`        |
+| Custom backend         | “Custom backend…” selection and URL prompt                                          | `record --backend <url>`; `check --backend <url>` or `COMFY_TEST_BACKEND`                     |
+| Workflow search        | Searchable workflow autocomplete                                                    | `list --filter <keyword>`                                                                     |
+| Add workflow from file | “(add from file…)” workflow option                                                  | `add-workflow <file> [--name <n>]`                                                            |
+| Test tags              | Tag multiselect with hints                                                          | `tags` lists the registry with descriptions; `plan --tags` and `transform --tags` apply tags  |
+| Record setup answers   | Guided prompts                                                                      | `record --workflow --tags --feature-flags --use-case --description --name`                    |
+| Feature flags          | Feature-flag selector and custom flag prompt                                        | `record`, `plan`, or `transform --feature-flags <specs>`                                      |
+| PR checkout            | Safe switch confirmation                                                            | `record --pr <number>`                                                                        |
+| Secret scrubbing       | Automatic during `record`, with a loud alert                                        | Automatic in `transform <file>`; findings print as 🔒 lines in the summary                    |
+| Supervisor guidance    | Woven into `record` prompts and warnings                                            | `guide` prints the full operating manual for an agent helping a human                         |
+| Agent replay           | `agent-replay` with no flags asks which recording to replay and whether to watch it | `agent-replay [--case <id>] [--url <dev server>] [--headed] [--video]`; `--help` runs nothing |
 
 ## Distribution-aware recording template
 

--- a/tools/test-recorder/README.md
+++ b/tools/test-recorder/README.md
@@ -57,6 +57,13 @@ convention-compliant spec directly — then `comfy-test pr <file>` opens
 the PR. See [Browser Tests README § For agents](../../browser_tests/README.md#for-agents)
 for the full chain.
 
+`agent-replay` runs the recorded agent conversations as tests against a
+running dev server. On a terminal with no flags it asks which recording to
+replay and whether to watch it; `--case <id>` narrows to one recording,
+`--headed` shows it, `--video` records it, and `--help` prints usage without
+running anything. The replay workflow is in
+`.claude/skills/agent-integration-replay/SKILL.md`.
+
 ## Development
 
 ```bash

--- a/tools/test-recorder/src/commands/agentReplay.test.ts
+++ b/tools/test-recorder/src/commands/agentReplay.test.ts
@@ -1,0 +1,278 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { runCommand } from '../cli/run'
+import {
+  AGENT_REPLAY_USAGE,
+  agentReplayCli,
+  agentReplayInvocation,
+  listReplayCases,
+  promptAgentReplayOptions,
+  runAgentReplay
+} from './agentReplay'
+
+describe('agentReplayInvocation', () => {
+  it('runs the whole replay suite against the default dev server, without video', () => {
+    const { args, env } = agentReplayInvocation({})
+    expect(args).toEqual([
+      'exec',
+      'playwright',
+      'test',
+      'agentConversation',
+      '--project=cloud'
+    ])
+    expect(env).toEqual({
+      PLAYWRIGHT_TEST_URL: 'http://localhost:5173',
+      DISTRIBUTION: 'cloud'
+    })
+  })
+
+  it('narrows to one recorded case, headed, with video, on another server', () => {
+    const { args, env } = agentReplayInvocation({
+      caseId: 'agent-rec-add-set-delete',
+      headed: true,
+      video: true,
+      url: 'http://127.0.0.1:6207'
+    })
+    expect(args.slice(-3)).toEqual([
+      '-g',
+      '(^|\\s)recorded agent-rec-add-set-delete(\\s|$)',
+      '--headed'
+    ])
+    const grep = new RegExp(args.at(-2)!)
+    const title = (caseId: string) =>
+      `cloud agentConversationReplay.spec.ts Agent conversation replay recorded ${caseId} replays every recorded turn onto the panel and the canvas`
+    expect(grep.test(title('agent-rec-add-set-delete'))).toBe(true)
+    expect(grep.test(title('prefix-agent-rec-add-set-delete'))).toBe(false)
+    expect(grep.test(title('agent-rec-add-set-delete.retry'))).toBe(false)
+    expect(grep.test(title('agent-rec-add-set-delete-2'))).toBe(false)
+    expect(env.PLAYWRIGHT_TEST_URL).toBe('http://127.0.0.1:6207')
+    expect(env.RECORD_VIDEO).toBe('true')
+  })
+})
+
+describe('runAgentReplay', () => {
+  it('returns the suite status when it runs', () => {
+    const run = vi.fn(() => ({ status: 3 }))
+    expect(runAgentReplay({ caseId: 'agent-rec-add-set-delete' }, run)).toBe(3)
+    expect(run).toHaveBeenCalledWith(
+      'pnpm',
+      expect.arrayContaining([
+        '-g',
+        '(^|\\s)recorded agent-rec-add-set-delete(\\s|$)'
+      ]),
+      expect.objectContaining({
+        env: expect.objectContaining({ DISTRIBUTION: 'cloud' })
+      })
+    )
+  })
+})
+
+describe('the interactive route', () => {
+  it('lists every recording by case id', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-replay-'))
+    try {
+      const dir = join(root, 'browser_tests/fixtures/data/agent/conversations')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'agent-rec-b.json'), '{}')
+      writeFileSync(join(dir, 'agent-rec-a.json'), '{}')
+      writeFileSync(join(dir, 'notes.md'), '')
+      expect(listReplayCases(root)).toEqual(['agent-rec-a', 'agent-rec-b'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('asks for the case and whether to watch it', async () => {
+    const select = vi.fn(async () => 'agent-rec-a')
+    const confirm = vi.fn(async () => true)
+    await expect(
+      promptAgentReplayOptions(['agent-rec-a', 'agent-rec-b'], {
+        select,
+        confirm
+      })
+    ).resolves.toEqual({ caseId: 'agent-rec-a', headed: true })
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          { value: '', label: 'All recordings' },
+          { value: 'agent-rec-a', label: 'agent-rec-a' },
+          { value: 'agent-rec-b', label: 'agent-rec-b' }
+        ]
+      })
+    )
+  })
+
+  it('replays every recording when "all" is chosen', async () => {
+    await expect(
+      promptAgentReplayOptions(['agent-rec-a'], {
+        select: async () => '',
+        confirm: async () => false
+      })
+    ).resolves.toEqual({ caseId: undefined, headed: false })
+  })
+})
+
+describe('agentReplayCli', () => {
+  it('prints the usage for --help and spawns nothing', async () => {
+    const run = vi.fn(() => ({ status: 0 }))
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await expect(agentReplayCli(['--help'], { run })).resolves.toBe(0)
+    expect(run).not.toHaveBeenCalled()
+    expect(out).toHaveBeenCalledWith(AGENT_REPLAY_USAGE)
+  })
+
+  it.for([['--case'], ['--url'], ['--case', '--headed']])(
+    'refuses %s without a value before spawning',
+    async (argv) => {
+      const run = vi.fn(() => ({ status: 0 }))
+      const err = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true)
+      await expect(
+        agentReplayCli(argv, { run, interactive: true })
+      ).resolves.toBe(1)
+      expect(run).not.toHaveBeenCalled()
+      expect(err).toHaveBeenCalledWith(
+        expect.stringContaining(`${argv[0]} needs a value`)
+      )
+    }
+  )
+
+  it.for([['--bogus'], ['stray'], ['--case', 'agent-rec-a', 'stray']])(
+    'refuses the unknown argument in %s before spawning',
+    async (argv) => {
+      const run = vi.fn(() => ({ status: 0 }))
+      const err = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true)
+      await expect(
+        agentReplayCli(argv, { run, cases: () => ['agent-rec-a'] })
+      ).resolves.toBe(1)
+      expect(run).not.toHaveBeenCalled()
+      expect(err).toHaveBeenCalledWith(
+        expect.stringContaining(`unknown argument ${argv.at(-1)}`)
+      )
+    }
+  )
+
+  it.for(['--video=false', '--headed=false', '--help=1'])(
+    'refuses a value on %s before spawning',
+    async (flag) => {
+      const run = vi.fn(() => ({ status: 0 }))
+      const err = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true)
+      await expect(
+        agentReplayCli(['--case', 'agent-rec-a', flag], {
+          run,
+          cases: () => ['agent-rec-a']
+        })
+      ).resolves.toBe(1)
+      expect(run).not.toHaveBeenCalled()
+      expect(err).toHaveBeenCalledWith(
+        expect.stringContaining(`${flag.split('=')[0]} takes no value`)
+      )
+    }
+  )
+
+  it.for([['agent-rec'], ['agent-rec-c']])(
+    'refuses %s, which names no recording, before spawning',
+    async ([caseId]) => {
+      const run = vi.fn(() => ({ status: 0 }))
+      const err = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true)
+      await expect(
+        agentReplayCli(['--case', caseId], {
+          run,
+          cases: () => ['agent-rec-a', 'agent-rec-b']
+        })
+      ).resolves.toBe(1)
+      expect(run).not.toHaveBeenCalled()
+      expect(err).toHaveBeenCalledWith(
+        `no recording named ${caseId}; recordings: agent-rec-a, agent-rec-b\n`
+      )
+    }
+  )
+
+  it('runs the flags without prompting, even on a terminal', async () => {
+    const run = vi.fn(() => ({ status: 2 }))
+    const select = vi.fn(async () => '')
+    await expect(
+      agentReplayCli(['--case', 'agent-rec-a', '--video'], {
+        run,
+        interactive: true,
+        cases: () => ['agent-rec-a'],
+        prompts: { select, confirm: async () => false }
+      })
+    ).resolves.toBe(2)
+    expect(select).not.toHaveBeenCalled()
+    expect(run).toHaveBeenCalledWith(
+      'pnpm',
+      expect.arrayContaining(['-g', '(^|\\s)recorded agent-rec-a(\\s|$)']),
+      expect.objectContaining({
+        env: expect.objectContaining({ RECORD_VIDEO: 'true' })
+      })
+    )
+  })
+
+  it('replays every recording without prompting off a terminal', async () => {
+    const run = vi.fn(() => ({ status: 0 }))
+    const select = vi.fn(async () => '')
+    await expect(
+      agentReplayCli([], {
+        run,
+        interactive: false,
+        prompts: { select, confirm: async () => false }
+      })
+    ).resolves.toBe(0)
+    expect(select).not.toHaveBeenCalled()
+    expect(run).toHaveBeenCalledWith(
+      'pnpm',
+      expect.not.arrayContaining(['-g']),
+      expect.anything()
+    )
+  })
+
+  it('asks on a terminal with no flags and runs the chosen recording', async () => {
+    const run = vi.fn(() => ({ status: 0 }))
+    await expect(
+      agentReplayCli([], {
+        run,
+        interactive: true,
+        cases: () => ['agent-rec-a', 'agent-rec-b'],
+        prompts: {
+          select: async () => 'agent-rec-b',
+          confirm: async () => true
+        }
+      })
+    ).resolves.toBe(0)
+    expect(run).toHaveBeenCalledWith(
+      'pnpm',
+      expect.arrayContaining([
+        '-g',
+        '(^|\\s)recorded agent-rec-b(\\s|$)',
+        '--headed'
+      ]),
+      expect.anything()
+    )
+  })
+})
+
+describe('the comfy-test entry', () => {
+  it('routes agent-replay --help to the usage', { timeout: 60_000 }, () => {
+    const result = runCommand('pnpm', [
+      'exec',
+      'tsx',
+      'tools/test-recorder/src/index.ts',
+      'agent-replay',
+      '--help'
+    ])
+    expect(result.status).toBe(0)
+    expect(String(result.stdout)).toContain('Usage: comfy-test agent-replay')
+  })
+})

--- a/tools/test-recorder/src/commands/agentReplay.ts
+++ b/tools/test-recorder/src/commands/agentReplay.ts
@@ -1,0 +1,178 @@
+import type { SpawnSyncOptions } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { confirm, isCancel, select } from '@clack/prompts'
+import type { ConfirmOptions, SelectOptions } from '@clack/prompts'
+
+import { parseFlags } from '../cli/flags'
+import { runCommand } from '../cli/run'
+
+export interface AgentReplayOptions {
+  caseId?: string
+  url?: string
+  headed?: boolean
+  video?: boolean
+  help?: boolean
+}
+
+export interface AgentReplayInvocation {
+  args: string[]
+  env: Record<string, string>
+}
+
+const DEFAULT_URL = 'http://localhost:5173'
+const CONVERSATIONS_DIR = 'browser_tests/fixtures/data/agent/conversations'
+
+export const AGENT_REPLAY_USAGE = `Usage: comfy-test agent-replay [--case <id>] [--url <dev server>] [--headed] [--video]
+
+Replays the recorded agent conversations under ${CONVERSATIONS_DIR}/ as
+Playwright tests against a running dev server (default ${DEFAULT_URL}).
+With no flags on a terminal it asks which recording to replay and whether
+to watch it; any flag, or a non-interactive stdin, runs without prompts.
+
+  --case <id>   one recording (the JSON file name without .json)
+  --url <url>   the dev server to test against
+  --headed      show the browser
+  --video       record each case under test-results/
+  --help        show this help and run nothing
+`
+
+export function listReplayCases(root: string = process.cwd()): string[] {
+  return readdirSync(join(root, CONVERSATIONS_DIR))
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => file.slice(0, -'.json'.length))
+    .sort()
+}
+
+export function agentReplayInvocation(
+  options: AgentReplayOptions
+): AgentReplayInvocation {
+  const args = [
+    'exec',
+    'playwright',
+    'test',
+    'agentConversation',
+    '--project=cloud'
+  ]
+  if (options.caseId)
+    args.push(
+      '-g',
+      `(^|\\s)recorded ${options.caseId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\s|$)`
+    )
+  if (options.headed) args.push('--headed')
+  // Video is the only local setting this command owns; PLAYWRIGHT_LOCAL would
+  // switch it on for every run, so it is not set here.
+  const env: Record<string, string> = {
+    PLAYWRIGHT_TEST_URL: options.url ?? DEFAULT_URL,
+    DISTRIBUTION: 'cloud'
+  }
+  if (options.video) env.RECORD_VIDEO = 'true'
+  return { args, env }
+}
+
+type Prompts = {
+  select: (opts: SelectOptions<string>) => Promise<string | symbol>
+  confirm: (opts: ConfirmOptions) => Promise<boolean | symbol>
+}
+
+export async function promptAgentReplayOptions(
+  cases: string[],
+  prompts: Prompts = { select, confirm }
+): Promise<AgentReplayOptions | null> {
+  const caseId = await prompts.select({
+    message: 'Which recorded conversation should replay?',
+    options: [
+      { value: '', label: 'All recordings' },
+      ...cases.map((id) => ({ value: id, label: id }))
+    ]
+  })
+  if (isCancel(caseId)) return null
+  const headed = await prompts.confirm({
+    message: 'Watch it in a headed browser?',
+    initialValue: false
+  })
+  if (isCancel(headed)) return null
+  return { caseId: caseId || undefined, headed }
+}
+
+type Runner = (
+  command: string,
+  args: string[],
+  options: SpawnSyncOptions
+) => { status: number | null }
+
+export function runAgentReplay(
+  options: AgentReplayOptions,
+  run: Runner = runCommand
+): number {
+  if (options.help) {
+    process.stdout.write(AGENT_REPLAY_USAGE)
+    return 0
+  }
+  const { args, env } = agentReplayInvocation(options)
+  const result = run('pnpm', args, {
+    stdio: 'inherit',
+    env: { ...process.env, ...env }
+  })
+  return result.status ?? 1
+}
+
+export interface AgentReplayCliDeps {
+  run?: Runner
+  prompts?: Prompts
+  cases?: () => string[]
+  interactive?: boolean
+}
+
+const VALUE_FLAGS = ['case', 'url'] as const
+const PRESENCE_FLAGS = ['headed', 'video', 'help'] as const
+const KNOWN_FLAGS = new Set<string>([...VALUE_FLAGS, ...PRESENCE_FLAGS])
+
+export async function agentReplayCli(
+  argv: string[],
+  deps: AgentReplayCliDeps = {}
+): Promise<number> {
+  const { positional, flags } = parseFlags(argv, VALUE_FLAGS)
+  const unknown = [
+    ...positional,
+    ...Object.keys(flags)
+      .filter((flag) => !KNOWN_FLAGS.has(flag))
+      .map((flag) => `--${flag}`)
+  ]
+  if (unknown.length > 0) {
+    process.stderr.write(
+      `unknown argument ${unknown.join(' ')}\n${AGENT_REPLAY_USAGE}`
+    )
+    return 1
+  }
+  const valued = PRESENCE_FLAGS.find((flag) => flags[flag])
+  if (valued !== undefined) {
+    process.stderr.write(`--${valued} takes no value\n${AGENT_REPLAY_USAGE}`)
+    return 1
+  }
+  if (flags.help !== undefined) return runAgentReplay({ help: true }, deps.run)
+  const missing = VALUE_FLAGS.find((flag) => flags[flag] === '')
+  if (missing !== undefined) {
+    process.stderr.write(`--${missing} needs a value\n${AGENT_REPLAY_USAGE}`)
+    return 1
+  }
+  const cases = (deps.cases ?? listReplayCases)()
+  if (flags.case !== undefined && !cases.includes(flags.case)) {
+    process.stderr.write(
+      `no recording named ${flags.case}; recordings: ${cases.join(', ')}\n`
+    )
+    return 1
+  }
+  const interactive =
+    (deps.interactive ?? process.stdin.isTTY) && Object.keys(flags).length === 0
+  const options = interactive
+    ? await promptAgentReplayOptions(cases, deps.prompts)
+    : {
+        caseId: flags.case,
+        url: flags.url,
+        headed: flags.headed !== undefined,
+        video: flags.video !== undefined
+      }
+  return options === null ? 0 : runAgentReplay(options, deps.run)
+}

--- a/tools/test-recorder/src/index.ts
+++ b/tools/test-recorder/src/index.ts
@@ -174,6 +174,11 @@ try {
       }
       break
     }
+    case 'agent-replay': {
+      const { agentReplayCli } = await import('./commands/agentReplay')
+      process.exitCode = await agentReplayCli(args.slice(1))
+      break
+    }
     case 'list': {
       const { parseFlags } = await import('./cli/flags')
       const { flags } = parseFlags(args.slice(1), ['filter'])
@@ -194,7 +199,7 @@ try {
     default: {
       // Help is a successful request; a typo is not.
       const askedForHelp =
-        command === undefined || command === '--help' || command === 'help'
+        !command || command === '--help' || command === 'help'
       if (!askedForHelp) {
         console.log(pc.red(`  Unknown command: ${command}`))
         process.exitCode = 1
@@ -214,6 +219,9 @@ Commands:
   pr          Open a pull request for a generated test
   check [--distribution cloud|cloud-staging|cloud-prod|local] [--backend <url>]
               Check environment prerequisites (defaults to cloud)
+  agent-replay [--case <id>] [--url <dev server>] [--headed] [--video] [--help]
+              Replay the recorded agent conversations as tests against a
+              running dev server (see .claude/skills/agent-integration-replay)
   list [--filter <keyword>]
               List available test workflows, optionally filtered by path
   tags        List test tags with their meanings
@@ -236,7 +244,7 @@ Transform flags:
   --feature-flags <specs>
               Seed comma-separated feature flags in the generated test
 
-'add-workflow', 'transform', 'pr', 'check', 'plan', 'list', and 'tags' work non-interactively.
+'add-workflow', 'transform', 'pr', 'check', 'plan', 'list', 'tags', and 'agent-replay' work non-interactively.
 `)
       break
     }


### PR DESCRIPTION
- Documents the agent replay command shipped with the test harness.
- Covers recorded conversation replay and divergence reporting.
- Keeps command scope and prerequisites explicit.

<details><summary>Full context for agent readers</summary>

This change adds the `agent-integration-replay` skill and the `comfy-test agent-replay` command. The command replays one recorded agent conversation fixture against a running frontend, reports panel or graph divergence, and exits non-zero when replay evidence does not match.

Scope: replay consumes existing fixtures; it does not record conversations, provision the backend, or replace browser-observable assertions. Run it after the frontend and required agent services are available.

This wording aligns the merged change with the current commands and limits identified in reviewer findings on the test-harness stack.

</details>