### PR TITLE
feat: identify Datadog RUM users by account ID and email

### DIFF
--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 
 import type { BillingTelemetryEvent } from '../../types'
 import { TelemetryEvents } from '../../types'
@@ -8,12 +11,16 @@ const {
   addAction,
   addDurationVital,
   addFeatureFlagEvaluation,
-  getInternalContext
+  getInternalContext,
+  setUser,
+  clearUser
 } = vi.hoisted(() => ({
   addAction: vi.fn(),
   addDurationVital: vi.fn(),
   addFeatureFlagEvaluation: vi.fn(),
-  getInternalContext: vi.fn()
+  getInternalContext: vi.fn(),
+  setUser: vi.fn(),
+  clearUser: vi.fn()
 }))
 
 vi.mock<unknown>(import('@datadog/browser-rum'), () => ({
@@ -21,15 +28,69 @@ vi.mock<unknown>(import('@datadog/browser-rum'), () => ({
     addAction,
     addDurationVital,
     addFeatureFlagEvaluation,
-    getInternalContext
+    getInternalContext,
+    setUser,
+    clearUser
   }
 }))
+
+vi.mock(import('@/composables/auth/useCurrentUser'), () => ({
+  useCurrentUser: vi.fn()
+}))
+
+const onUserLogout = vi.fn<(callback: () => void) => void>()
+
+beforeEach(() => {
+  vi.mocked(useCurrentUser).mockReturnValue(
+    fromPartial({
+      resolvedUserInfo: { value: { id: 'restored-user' } },
+      userEmail: { value: 'restored@example.com' },
+      onUserLogout
+    })
+  )
+})
 
 const workflowExecutionIntent = {
   trigger_source: 'keybinding'
 } as const
 
 describe('DatadogRumTelemetryProvider', () => {
+  it('identifies restored sessions and replaces identity on account changes', () => {
+    const provider = new DatadogRumTelemetryProvider()
+    provider.trackUserLoggedIn()
+    provider.trackAuth({ user_id: 'new-user', email: 'new@example.com' })
+    provider.trackAuth({ user_id: 'user-without-email' })
+
+    expect(setUser).toHaveBeenNthCalledWith(1, {
+      id: 'restored-user',
+      email: 'restored@example.com'
+    })
+    expect(setUser).toHaveBeenNthCalledWith(2, {
+      id: 'new-user',
+      email: 'new@example.com'
+    })
+    expect(setUser).toHaveBeenNthCalledWith(3, { id: 'user-without-email' })
+    expect(onUserLogout).toHaveBeenCalledOnce()
+    onUserLogout.mock.calls[0][0]()
+    expect(clearUser).toHaveBeenCalledOnce()
+  })
+
+  it('does not identify an unresolved user or send email without an account ID', () => {
+    vi.mocked(useCurrentUser).mockReturnValue(
+      fromPartial({
+        resolvedUserInfo: { value: null },
+        userEmail: { value: null },
+        onUserLogout
+      })
+    )
+    const provider = new DatadogRumTelemetryProvider()
+    provider.trackUserLoggedIn()
+    provider.trackAuth({ email: 'unresolved@example.com' })
+
+    expect(setUser).not.toHaveBeenCalled()
+    expect(onUserLogout).not.toHaveBeenCalled()
+  })
+
   it('records fetch timeouts as RUM actions', () => {
     new DatadogRumTelemetryProvider().trackFetchTimeout({
       route: '/userdata/:resource',

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,7 +1,10 @@
 // eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { datadogRum } from '@datadog/browser-rum'
 
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+
 import type {
+  AuthMetadata,
   BillingTelemetryEvent,
   ExecutionOutcomeMetadata,
   FetchTimeoutMetadata,
@@ -17,6 +20,27 @@ import {
 } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  private isWatchingLogout = false
+
+  trackAuth({ user_id, email }: AuthMetadata): void {
+    this.setUser(user_id, email)
+  }
+
+  trackUserLoggedIn(): void {
+    const { resolvedUserInfo, userEmail } = useCurrentUser()
+    this.setUser(resolvedUserInfo.value?.id, userEmail.value)
+  }
+
+  private setUser(userId: string | undefined, email?: string | null): void {
+    if (!userId) return
+
+    datadogRum.setUser({ id: userId, ...(email && { email }) })
+    if (this.isWatchingLogout) return
+
+    this.isWatchingLogout = true
+    useCurrentUser().onUserLogout(() => datadogRum.clearUser())
+  }
+
   trackFetchTimeout(metadata: FetchTimeoutMetadata): void {
     datadogRum.addAction(TelemetryEvents.FETCH_TIMEOUT, metadata)
   }


### PR DESCRIPTION
## Summary

Attach account ID and email to Datadog RUM user context so support can find a customer's telemetry by email.

RUM query: https://us5.datadoghq.com/rum/sessions?query=%40type%3Asession%20%40usr.email%3Afoobar%40gmail.com&agg_m=count&agg_m_source=base&agg_t=count&cols=&fromUser=false&sort_by=&sort_order=&from_ts=1789346946740&to_ts=1789433346740&live=true

```
@usr.email:foobar@gmail.com
```

## Changes

- Identify users on explicit authentication and the existing restored-session login hook; omit email when unavailable.
- Replace user context on account changes and clear it on logout.
- Keep PostHog redaction and billing event payloads unchanged.

## Review Focus

This draft proposes sending account email to Datadog. Please confirm whether there are privacy or security objections before merging. Identity is attached after the existing auth/login hooks run; earlier anonymous events are not explicitly backfilled. Session replay remains disabled.

## Validation

- Datadog provider tests: 16 passed, including identity replacement, missing email/ID, restored sessions, and logout cleanup.
- Type checking, formatting, full repository lint (0 errors; existing warnings), and Knip passed.
- `autoreview --mode local`: clean, no actionable findings.
