### PR TITLE
feat(agent): animate a step as it arrives and cheapen the scroll trigger

### DIFF
--- a/src/workbench/extensions/agent/agentPanel.css
+++ b/src/workbench/extensions/agent/agentPanel.css
@@ -27,6 +27,22 @@
   }
 }
 
+/* A step animates once, as it arrives. Motion that repeats on a re-render or a
+   scroll would claim an arrival that did not happen. */
+.agent-row-enter {
+  animation: agent-row-enter 160ms ease-out;
+}
+
+.disable-animations :where(#agent-panel-root, .agent-scope) .agent-row-enter {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-row-enter {
+    animation: none;
+  }
+}
+
 /* Tailwind Preflight is disabled host-wide (PrimeVue + litegraph coexistence), so raw form
    elements in the panel inherit UA chrome: a <button> gets the buttonface fill + 2px outset
    border, a <textarea>/<input> gets its own border, font and padding. Re-apply Preflight's

--- a/src/workbench/extensions/agent/agentTheme.css
+++ b/src/workbench/extensions/agent/agentTheme.css
@@ -41,6 +41,17 @@
   }
 }
 
+/* Opacity only. The panel is bottom-anchored and scrolls to the newest row, so
+   a rise would move the row upward a second time. */
+@keyframes agent-row-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @keyframes agent-shimmer {
   from {
     background-position: 150% center;

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -111,29 +111,37 @@ describe('ConversationView', () => {
   })
 
   it('follows the reply as each kind of content lands', async () => {
+    // The watcher is post-flush and awaits a tick of its own before it
+    // scrolls, so one tick lets the previous event's scroll answer for this
+    // one. Settle both ticks, then clear, so each assertion stands alone.
+    const settle = async () => {
+      await nextTick()
+      await nextTick()
+    }
+
     const { store } = mountHarness()
     store.recordUser(T, 'make a cat')
     store.startTurn(T)
-    await nextTick()
+    await settle()
 
     const scrollIntoView = vi.fn()
     Element.prototype.scrollIntoView = scrollIntoView
 
     // a new part
     store.ingest(thinking('msg-1', 'pondering'))
-    await nextTick()
+    await settle()
     expect(scrollIntoView).toHaveBeenCalled()
 
     // the tail part growing
     scrollIntoView.mockClear()
     store.ingest(delta('msg-1', 'Here is a cat'))
-    await nextTick()
+    await settle()
     expect(scrollIntoView).toHaveBeenCalled()
 
     // a tool call settling
     scrollIntoView.mockClear()
     store.ingest(toolCall('msg-1', 'add_node', 'success'))
-    await nextTick()
+    await settle()
     expect(scrollIntoView).toHaveBeenCalled()
   })
 

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -110,6 +110,33 @@ describe('ConversationView', () => {
     })
   })
 
+  it('follows the reply as each kind of content lands', async () => {
+    const { store } = mountHarness()
+    store.recordUser(T, 'make a cat')
+    store.startTurn(T)
+    await nextTick()
+
+    const scrollIntoView = vi.fn()
+    Element.prototype.scrollIntoView = scrollIntoView
+
+    // a new part
+    store.ingest(thinking('msg-1', 'pondering'))
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalled()
+
+    // the tail part growing
+    scrollIntoView.mockClear()
+    store.ingest(delta('msg-1', 'Here is a cat'))
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalled()
+
+    // a tool call settling
+    scrollIntoView.mockClear()
+    store.ingest(toolCall('msg-1', 'add_node', 'success'))
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalled()
+  })
+
   it('shows a scroll-to-latest button when scrolled up and returns to bottom on click', async () => {
     const assistant: AssistantMessage = {
       id: 'msg-1' as TurnId,

--- a/src/workbench/extensions/agent/components/agent/ConversationView.vue
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.vue
@@ -57,11 +57,20 @@ function scrollToLatest(): void {
   bottom.value?.scrollIntoView({ block: 'end' })
 }
 
+// Enough to answer "did the tail grow?" without serializing the transcript to
+// measure it. Serializing costs the whole message on every update, which grows
+// with the turn.
 const latestContentSignal = computed(() => {
   const last = entries.at(-1)
-  if (!last) return '0'
-  const size = 'parts' in last ? JSON.stringify(last.parts).length : 0
-  return `${entries.length}:${size}`
+  if (!last || !('parts' in last)) return `${entries.length}`
+  const tail = last.parts.at(-1)
+  const tailSize =
+    tail && 'text' in tail
+      ? tail.text.length
+      : tail && tail.type === 'tool'
+        ? `${tail.state}:${tail.ok}:${tail.durationMs}`
+        : ''
+  return `${entries.length}:${last.parts.length}:${tailSize}`
 })
 
 watch(

--- a/src/workbench/extensions/agent/components/agent/message/ActivityTrace.vue
+++ b/src/workbench/extensions/agent/components/agent/message/ActivityTrace.vue
@@ -13,8 +13,10 @@ import type {
 import { toolGlyph, toolLabel } from '../../../services/agent/agentToolGlyph'
 import { formatDurationCompact } from '../../../utils/formatDuration'
 
-const { parts } = defineProps<{
+const { parts, live = false } = defineProps<{
   parts: readonly ActivityPart[]
+  /** The turn is still running, so a newly mounted row is a real arrival. */
+  live?: boolean
 }>()
 
 const { t } = useI18n()
@@ -50,7 +52,7 @@ function rowSignature(row: ActivityRow): string {
       :key="index"
       v-memo="[rowSignature(row), index === rows.length - 1]"
       role="listitem"
-      class="flex gap-2 px-2"
+      :class="cn('flex gap-2 px-2', live && 'agent-row-enter')"
     >
       <div class="flex w-4 shrink-0 flex-col items-center">
         <span

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.stories.ts
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { defineComponent, onMounted, onUnmounted, ref } from 'vue'
 
 import type { TurnId } from '../../../schemas/agentApiSchema'
 import type {
@@ -141,4 +142,53 @@ export const FailedCall: Story = {
       false
     )
   }
+}
+
+/**
+ * The steps arrive one at a time, the way a turn delivers them. Each row fades
+ * in as it lands and the rows already on screen hold still. The other stories
+ * mount every row at once, which shows the fade but not this.
+ */
+const ArrivingTurn = defineComponent({
+  components: { AgentMessage },
+  setup() {
+    const parts = ref<MessagePart[]>([])
+    let timer: number | undefined
+
+    const next = () => {
+      if (parts.value.length >= trace.length) return
+      parts.value = trace.slice(0, parts.value.length + 1)
+      timer = window.setTimeout(next, 900)
+    }
+
+    const replay = () => {
+      window.clearTimeout(timer)
+      parts.value = []
+      timer = window.setTimeout(next, 300)
+    }
+
+    onMounted(replay)
+    onUnmounted(() => window.clearTimeout(timer))
+
+    return { parts, replay, message }
+  },
+  template: `
+    <div>
+      <button
+        class="text-agent-fg-muted border-agent-border mb-3 cursor-pointer rounded-lg border px-2 py-1 text-xs"
+        @click="replay"
+      >
+        Replay
+      </button>
+      <AgentMessage :message="message(parts, true)" />
+    </div>
+  `
+})
+
+export const StepsArriving: Story = {
+  name: 'DES-1032 Each step fades in as it arrives',
+  render: () => ({
+    components: { ArrivingTurn },
+    template: '<ArrivingTurn />'
+  })
 }

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
@@ -142,7 +142,7 @@ const status = computed(() => {
     <template v-for="(group, index) in groups" :key="index">
       <MarkdownStream v-if="group.kind === 'text'" :text="group.part.text" />
       <template v-else-if="group.kind === 'trace'">
-        <ActivityTrace v-if="message.streaming" :parts="activityParts" />
+        <ActivityTrace v-if="message.streaming" :parts="activityParts" live />
         <WorkSummary v-else :parts="activityParts" />
       </template>
       <div

--- a/src/workbench/extensions/agent/components/agent/message/WorkSummary.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/WorkSummary.test.ts
@@ -229,3 +229,24 @@ describe('WorkSummary', () => {
     ).toBeInTheDocument()
   })
 })
+
+describe('step entrance', () => {
+  it('marks a step as arriving while the turn runs', () => {
+    render(ActivityTrace, {
+      props: { parts: [tool('c1', 'add_node', 'streaming')], live: true },
+      global: { plugins: [i18n] }
+    })
+
+    expect(screen.getByRole('listitem')).toHaveClass('agent-row-enter')
+  })
+
+  it('leaves a finished trace still', async () => {
+    render(WorkSummary, {
+      props: { parts: [tool('c1', 'add_node', 'done', true, 200)] },
+      global: { plugins: [i18n] }
+    })
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByRole('listitem')).not.toHaveClass('agent-row-enter')
+  })
+})

--- a/src/workbench/extensions/agent/components/agent/message/WorkSummary.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/WorkSummary.test.ts
@@ -231,6 +231,39 @@ describe('WorkSummary', () => {
 })
 
 describe('step entrance', () => {
+  it('keeps the rows already on screen when a step arrives', async () => {
+    const { rerender } = render(ActivityTrace, {
+      props: {
+        parts: [
+          tool('c1', 'add_node', 'done', true, 100),
+          tool('c2', 'set_widget', 'done', true, 200)
+        ],
+        live: true
+      },
+      global: { plugins: [i18n] }
+    })
+
+    const before = screen.getAllByRole('listitem')
+    expect(before).toHaveLength(2)
+
+    await rerender({
+      parts: [
+        tool('c1', 'add_node', 'done', true, 100),
+        tool('c2', 'set_widget', 'done', true, 200),
+        tool('c3', 'ls_nodes', 'streaming')
+      ],
+      live: true
+    })
+
+    // The settled rows are the same nodes, so their entrance never replays.
+    // Only the arriving step is a new element, and only it animates.
+    const after = screen.getAllByRole('listitem')
+    expect(after).toHaveLength(3)
+    expect(after[0]).toBe(before[0])
+    expect(after[1]).toBe(before[1])
+    expect(before).not.toContain(after[2])
+  })
+
   it('marks a step as arriving while the turn runs', () => {
     render(ActivityTrace, {
       props: { parts: [tool('c1', 'add_node', 'streaming')], live: true },


### PR DESCRIPTION
## Summary

Steps in the agent trace fade in as they arrive, and the scroll-follow trigger no longer serializes the transcript.

Fixes [DES-1032](https://linear.app/comfyorg/issue/DES-1032/agent-panel-animate-steps-as-they-arrive)

## Changes

- **What**:
  - A step fades in over 160ms as it arrives. The animation uses opacity only.
  - The panel is bottom-anchored and scrolls to the newest row. A rise would move the row upward a second time.
  - The `live` prop gates the animation. `AgentMessage` passes it for a running turn. `WorkSummary` does not pass it.
  - Reduced motion and `.disable-animations` turn the animation off, the same as the shimmer.
  - The scroll-follow trigger reads the entry count, the part count, and the size of the tail part. Before this change it ran `JSON.stringify` over every part of the newest message and measured the string it built.
  - A new story, `DES-1032 Each step fades in as it arrives`, appends a step every 900ms. The other stories mount every row at once, so they show the fade but not the arrival.

## Review Focus

- Open the new story to see the animation. Each row fades in as it lands, and the rows already on screen hold still.
- Only the newest row animates, and an older row does not restart when the list re-renders around it. Measured with `getAnimations()` across five arrivals in that story: exactly one row animated each time, and it was always the newest. A local turn added nothing to this. That turn used no tools, so no trace rendered.
- The `live` gate is where an error hides. When you open a finished turn and expand the summary, no row fades. The same is true for a conversation you reopen. Both paths mount every row at once.
- The scroll change is invisible. The review surface is the scroll behavior: the panel follows the bottom during a turn, a scroll up releases it, and the jump button returns.
- Measured cost of the trigger on a 5.9KB transcript: 1.6µs per call before, 0.08µs after. The old cost grew with the transcript, so a long turn paid it again on each update.
- A test covers the trigger. I flattened the signal on purpose to make sure that the test fails, then restored it.
- DES-1032 also asked for paced reply text and a guard for an unfinished code fence. Both are dropped. The backend sends the whole reply in one `agent_message_delta` event, so there is no stream to smooth and no fence is ever half-typed. DES-1034 records the backend ask.

## Screenshots (if applicable)

Storybook: Agent/AgentMessage -> "DES-1032 Each step fades in as it arrives"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

