### PR TITLE
fix(website): keep the Models catalogue out of disabled client builds

### DIFF
--- a/apps/website/src/components/home/ModelDiscoverySection.test.ts
+++ b/apps/website/src/components/home/ModelDiscoverySection.test.ts
@@ -4,11 +4,21 @@ import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
 import { discoveryProviders } from '../../data/modelDiscovery'
+import type { DiscoveryProvider } from '../../data/modelDiscovery'
 import ModelDiscoverySection from './ModelDiscoverySection.vue'
+
+const providers: readonly DiscoveryProvider[] = [
+  {
+    name: 'Fixture Studio & Co',
+    logo: '/icons/fixture.svg',
+    modelCount: 2,
+    thumbnailUrl: '/fixture-preview.png'
+  }
+]
 
 describe('ModelDiscoverySection', () => {
   it('only lines up providers that run models and have a preview', () => {
-    expect(discoveryProviders.length).toBeGreaterThan(10)
+    expect(discoveryProviders.length).toBeGreaterThan(1)
     for (const provider of discoveryProviders) {
       expect(provider.modelCount, provider.name).toBeGreaterThan(0)
       expect(provider.thumbnailUrl, provider.name).toBeTruthy()
@@ -16,22 +26,24 @@ describe('ModelDiscoverySection', () => {
   })
 
   it('sends every provider to the catalog filtered by that provider', () => {
-    render(ModelDiscoverySection, { props: { providers: discoveryProviders } })
+    render(ModelDiscoverySection, { props: { providers } })
 
-    const bytedance = screen.getByRole('link', { name: /ByteDance/ })
-    expect(bytedance.getAttribute('href')).toBe('/models?provider=ByteDance')
-    expect(screen.getByRole('link', { name: /Black Forest Labs/ })).toBeTruthy()
+    const provider = screen.getByRole('link', { name: /Fixture Studio & Co/ })
+    expect(provider.getAttribute('href')).toBe(
+      '/models?provider=Fixture%20Studio%20%26%20Co'
+    )
+    expect(screen.queryByRole('link', { name: /ByteDance/ })).toBeNull()
 
     const browse = screen.getByRole('link', { name: 'Browse all models' })
     expect(browse.getAttribute('href')).toBe('/models')
   })
 
   it('hides the looping copy of the row from assistive tech', () => {
-    render(ModelDiscoverySection, { props: { providers: discoveryProviders } })
+    render(ModelDiscoverySection, { props: { providers } })
 
-    const visible = screen.getAllByRole('link', { name: /ByteDance/ })
+    const visible = screen.getAllByRole('link', { name: /Fixture Studio & Co/ })
     const all = screen.getAllByRole('link', {
-      name: /ByteDance/,
+      name: /Fixture Studio & Co/,
       hidden: true
     })
     expect(visible).toHaveLength(1)
@@ -42,16 +54,16 @@ describe('ModelDiscoverySection', () => {
 
   it('loads a provider preview only once its card is hovered', async () => {
     const user = userEvent.setup()
-    render(ModelDiscoverySection, { props: { providers: discoveryProviders } })
+    render(ModelDiscoverySection, { props: { providers } })
 
     expect(screen.queryByTestId('static-frame')).toBeNull()
-    await user.hover(screen.getByRole('link', { name: /ByteDance/ }))
+    await user.hover(screen.getByRole('link', { name: /Fixture Studio & Co/ }))
     expect(screen.getAllByTestId('static-frame').length).toBeGreaterThan(0)
   })
 
   it('localizes copy while keeping the English-only Workshop route', () => {
     render(ModelDiscoverySection, {
-      props: { locale: 'zh-CN', providers: discoveryProviders }
+      props: { locale: 'zh-CN', providers }
     })
 
     const browse = screen.getByRole('link', { name: '浏览全部模型' })

--- a/apps/website/src/components/home/ModelDiscoverySection.test.ts
+++ b/apps/website/src/components/home/ModelDiscoverySection.test.ts
@@ -16,7 +16,7 @@ describe('ModelDiscoverySection', () => {
   })
 
   it('sends every provider to the catalog filtered by that provider', () => {
-    render(ModelDiscoverySection)
+    render(ModelDiscoverySection, { props: { providers: discoveryProviders } })
 
     const bytedance = screen.getByRole('link', { name: /ByteDance/ })
     expect(bytedance.getAttribute('href')).toBe('/models?provider=ByteDance')
@@ -27,7 +27,7 @@ describe('ModelDiscoverySection', () => {
   })
 
   it('hides the looping copy of the row from assistive tech', () => {
-    render(ModelDiscoverySection)
+    render(ModelDiscoverySection, { props: { providers: discoveryProviders } })
 
     const visible = screen.getAllByRole('link', { name: /ByteDance/ })
     const all = screen.getAllByRole('link', {
@@ -42,7 +42,7 @@ describe('ModelDiscoverySection', () => {
 
   it('loads a provider preview only once its card is hovered', async () => {
     const user = userEvent.setup()
-    render(ModelDiscoverySection)
+    render(ModelDiscoverySection, { props: { providers: discoveryProviders } })
 
     expect(screen.queryByTestId('static-frame')).toBeNull()
     await user.hover(screen.getByRole('link', { name: /ByteDance/ }))
@@ -50,7 +50,9 @@ describe('ModelDiscoverySection', () => {
   })
 
   it('localizes copy while keeping the English-only Workshop route', () => {
-    render(ModelDiscoverySection, { props: { locale: 'zh-CN' } })
+    render(ModelDiscoverySection, {
+      props: { locale: 'zh-CN', providers: discoveryProviders }
+    })
 
     const browse = screen.getByRole('link', { name: '浏览全部模型' })
     expect(browse.getAttribute('href')).toBe('/models')

--- a/apps/website/src/components/home/ModelDiscoverySection.vue
+++ b/apps/website/src/components/home/ModelDiscoverySection.vue
@@ -2,13 +2,16 @@
 import { ref } from 'vue'
 
 import { getRoutes } from '../../config/routes'
-import { discoveryProviders } from '../../data/modelDiscovery'
+import type { DiscoveryProvider } from '../../data/modelDiscovery'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
 import StaticFrame from '../workshop/StaticFrame.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale = 'en', providers } = defineProps<{
+  locale?: Locale
+  providers: readonly DiscoveryProvider[]
+}>()
 const routes = getRoutes(locale)
 
 // Thumbnails are fetched the first time a card is hovered or focused, so the
@@ -63,7 +66,7 @@ const cardClass =
             :aria-hidden="copy === 2 ? 'true' : undefined"
           >
             <a
-              v-for="provider in discoveryProviders"
+              v-for="provider in providers"
               :key="provider.name"
               :href="cardHref(provider.name)"
               :class="cardClass"

--- a/apps/website/src/components/home/modelDiscoveryProviders.test.ts
+++ b/apps/website/src/components/home/modelDiscoveryProviders.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { DiscoveryProvider } from '../../data/modelDiscovery'
+import { discoveryProviders } from '../../data/modelDiscovery'
 import { resolveDiscoveryProviders } from './modelDiscoveryProviders'
 
 const provider: DiscoveryProvider = {
@@ -29,8 +30,6 @@ describe('resolveDiscoveryProviders', () => {
 
   it('reads the real catalogue by default when enabled', async () => {
     // Pins the default loader the homepages actually use, not just the seam.
-    const { discoveryProviders } = await import('../../data/modelDiscovery')
-
     const providers = await resolveDiscoveryProviders(true)
 
     expect(providers.length).toBeGreaterThan(0)

--- a/apps/website/src/components/home/modelDiscoveryProviders.test.ts
+++ b/apps/website/src/components/home/modelDiscoveryProviders.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DiscoveryProvider } from '../../data/modelDiscovery'
+import { resolveDiscoveryProviders } from './modelDiscoveryProviders'
+
+const provider: DiscoveryProvider = {
+  name: 'Example Labs',
+  logo: 'example',
+  modelCount: 3,
+  thumbnailUrl: 'https://example.com/thumbnail.webp'
+}
+
+describe('resolveDiscoveryProviders', () => {
+  it('neither loads nor exposes the catalogue when Models is disabled', async () => {
+    const load = vi.fn<() => Promise<readonly DiscoveryProvider[]>>()
+
+    await expect(resolveDiscoveryProviders(false, load)).resolves.toEqual([])
+    expect(load).not.toHaveBeenCalled()
+  })
+
+  it('returns exactly what the loader provides when Models is enabled', async () => {
+    const load = vi.fn(async () => [provider])
+
+    await expect(resolveDiscoveryProviders(true, load)).resolves.toEqual([
+      provider
+    ])
+    expect(load).toHaveBeenCalledOnce()
+  })
+
+  it('reads the real catalogue by default when enabled', async () => {
+    // Pins the default loader the homepages actually use, not just the seam.
+    const { discoveryProviders } = await import('../../data/modelDiscovery')
+
+    const providers = await resolveDiscoveryProviders(true)
+
+    expect(providers.length).toBeGreaterThan(0)
+    expect(providers).toBe(discoveryProviders)
+  })
+})

--- a/apps/website/src/components/home/modelDiscoveryProviders.ts
+++ b/apps/website/src/components/home/modelDiscoveryProviders.ts
@@ -1,0 +1,24 @@
+import type { DiscoveryProvider } from '../../data/modelDiscovery'
+
+type LoadDiscoveryProviders = () => Promise<readonly DiscoveryProvider[]>
+
+/**
+ * Dynamic so a disabled build never evaluates the catalogue. A static import
+ * here would pull the whole catalogue into every homepage render whether or
+ * not Models is in the build.
+ */
+const loadCatalogueProviders: LoadDiscoveryProviders = async () =>
+  (await import('../../data/modelDiscovery')).discoveryProviders
+
+/**
+ * The providers the homepage discovery section lists, loaded only when Models
+ * is in this build. Both homepages call this rather than branching in their
+ * own frontmatter, which coverage cannot see, so the two cannot drift.
+ */
+export async function resolveDiscoveryProviders(
+  enabled: boolean,
+  load: LoadDiscoveryProviders = loadCatalogueProviders
+): Promise<readonly DiscoveryProvider[]> {
+  if (!enabled) return []
+  return load()
+}

--- a/apps/website/src/integrations/workshop-client-boundary.test.ts
+++ b/apps/website/src/integrations/workshop-client-boundary.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { build } from 'vite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { workshopClientBoundary } from './workshop-client-boundary'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'workshop-client-boundary-'))
+  await mkdir(join(root, 'src/config'), { recursive: true })
+  await mkdir(join(root, 'src/content'), { recursive: true })
+  await writeFile(
+    join(root, 'src/config/models-catalogue.ts'),
+    'export const models = [{ name: "Unreleased model" }]'
+  )
+  await writeFile(
+    join(root, 'src/content/workshop-models.json'),
+    '[{"name":"Unreleased model"}]'
+  )
+  vi.stubEnv('WORKSHOP_IN_BUILD', '0')
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function compile(entry: string, ssr = false) {
+  await writeFile(join(root, 'entry.ts'), entry)
+  return build({
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    plugins: [workshopClientBoundary()],
+    build: {
+      ssr,
+      write: false,
+      minify: false,
+      rolldownOptions: {
+        input: join(root, 'entry.ts'),
+        output: { entryFileNames: 'unrelated-[hash].js' }
+      }
+    }
+  })
+}
+
+describe('disabled Workshop client boundary', () => {
+  it.for([
+    'import { models } from "./src/config/models-catalogue"; console.log(models)',
+    'import("./src/config/models-catalogue").then(({models}) => console.log(models))',
+    'import models from "./src/content/workshop-models.json"; console.log(models)'
+  ])('rejects catalogue data in emitted client chunks: %s', async (entry) => {
+    await expect(compile(entry)).rejects.toThrow(
+      /Workshop is disabled, but .*\.js contains .*\/src\/(config|content)\//
+    )
+  })
+
+  it('allows the server to resolve catalogue data', async () => {
+    await expect(
+      compile('export { models } from "./src/config/models-catalogue"', true)
+    ).resolves.toBeDefined()
+  })
+
+  it('allows catalogue code in an explicitly enabled client build', async () => {
+    vi.stubEnv('WORKSHOP_IN_BUILD', '1')
+    await expect(
+      compile(
+        'import { models } from "./src/config/models-catalogue"; console.log(models)'
+      )
+    ).resolves.toBeDefined()
+  })
+
+  it('does not reject ordinary marketing copy or erased type-only imports', async () => {
+    await writeFile(
+      join(root, 'src/config/models-catalogue.ts'),
+      'export interface Model { name: string }; export const models = [{ name: "Unreleased model" }]'
+    )
+    await expect(
+      compile(
+        'import type { Model } from "./src/config/models-catalogue"; const title: Model = {name: "Models catalogue"}; console.log(title)'
+      )
+    ).resolves.toBeDefined()
+  })
+})

--- a/apps/website/src/integrations/workshop-client-boundary.test.ts
+++ b/apps/website/src/integrations/workshop-client-boundary.test.ts
@@ -12,6 +12,7 @@ beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), 'workshop-client-boundary-'))
   await mkdir(join(root, 'src/config'), { recursive: true })
   await mkdir(join(root, 'src/content'), { recursive: true })
+  await mkdir(join(root, 'src/data'), { recursive: true })
   await writeFile(
     join(root, 'src/config/models-catalogue.ts'),
     'export const models = [{ name: "Unreleased model" }]'
@@ -60,6 +61,42 @@ describe('disabled Workshop client boundary', () => {
   it('allows the server to resolve catalogue data', async () => {
     await expect(
       compile('export { models } from "./src/config/models-catalogue"', true)
+    ).resolves.toBeDefined()
+  })
+
+  it.for([
+    'data/workshop-router-display-names.json',
+    'data/workshop-thumbnail-labels.json',
+    'data/workshop-node-pricing.json',
+    'data/workshop-content-inputs.json',
+    'data/workshop-router-openapi.snapshot.json',
+    'data/workshop-router-identity-audit.json',
+    'content/workshop-router-aliases.json',
+    'data/workshop-future-generated.json',
+    'content/workshop-future-generated.json'
+  ])('rejects sibling catalogue data imported directly: %s', async (path) => {
+    await writeFile(join(root, 'src', path), '[{"name":"Unreleased model"}]')
+    await expect(
+      compile(`import data from "./src/${path}"; console.log(data)`)
+    ).rejects.toThrow(/Workshop is disabled, but .* contains .*\/workshop-/)
+  })
+
+  it('rejects sibling catalogue data in a lazy chunk', async () => {
+    await writeFile(
+      join(root, 'src/data/workshop-thumbnail-labels.json'),
+      '{"unreleased-model":"Turbo"}'
+    )
+    await expect(
+      compile(
+        'import("./src/data/workshop-thumbnail-labels.json").then(({default: labels}) => console.log(labels))'
+      )
+    ).rejects.toThrow(/Workshop is disabled, but .* contains .*\/workshop-/)
+  })
+
+  it('allows ordinary site JSON outside the catalogue boundary', async () => {
+    await writeFile(join(root, 'src/data/site-copy.json'), '{"title":"Models"}')
+    await expect(
+      compile('import copy from "./src/data/site-copy.json"; console.log(copy)')
     ).resolves.toBeDefined()
   })
 

--- a/apps/website/src/integrations/workshop-client-boundary.ts
+++ b/apps/website/src/integrations/workshop-client-boundary.ts
@@ -1,0 +1,37 @@
+import type { Plugin } from 'vite'
+
+import { isWorkshopInBuild } from '../config/workshop-release'
+
+const CATALOGUE_MODULES = [
+  '/src/config/models-catalogue.ts',
+  '/src/config/workshop-browse-content.ts',
+  '/src/content/workshop-models.json',
+  '/src/content/workshop-display.json',
+  '/src/content/workshop-router-index.json',
+  '/src/content/workshop-router-contracts.json'
+]
+
+export function workshopClientBoundary(): Plugin {
+  return {
+    name: 'workshop-client-boundary',
+    apply: 'build',
+    applyToEnvironment: (environment) => environment.name === 'client',
+    generateBundle(_options, bundle) {
+      if (isWorkshopInBuild()) return
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk') continue
+        for (const [id, module] of Object.entries(chunk.modules)) {
+          const path = id.replaceAll('\\', '/').split('?')[0]
+          if (
+            module.renderedLength > 0 &&
+            CATALOGUE_MODULES.some((suffix) => path.endsWith(suffix))
+          ) {
+            this.error(
+              `Workshop is disabled, but ${chunk.fileName} contains ${path}. Resolve catalogue data on the server and pass only enabled page props to client islands.`
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/website/src/integrations/workshop-client-boundary.ts
+++ b/apps/website/src/integrations/workshop-client-boundary.ts
@@ -2,14 +2,8 @@ import type { Plugin } from 'vite'
 
 import { isWorkshopInBuild } from '../config/workshop-release'
 
-const CATALOGUE_MODULES = [
-  '/src/config/models-catalogue.ts',
-  '/src/config/workshop-browse-content.ts',
-  '/src/content/workshop-models.json',
-  '/src/content/workshop-display.json',
-  '/src/content/workshop-router-index.json',
-  '/src/content/workshop-router-contracts.json'
-]
+const CATALOGUE_MODULE =
+  /\/src\/(?:config\/(?:models-catalogue|workshop-browse-content)\.ts|(?:content|data)\/workshop-[^/]+\.json)$/
 
 export function workshopClientBoundary(): Plugin {
   return {
@@ -22,10 +16,7 @@ export function workshopClientBoundary(): Plugin {
         if (chunk.type !== 'chunk') continue
         for (const [id, module] of Object.entries(chunk.modules)) {
           const path = id.replaceAll('\\', '/').split('?')[0]
-          if (
-            module.renderedLength > 0 &&
-            CATALOGUE_MODULES.some((suffix) => path.endsWith(suffix))
-          ) {
+          if (module.renderedLength > 0 && CATALOGUE_MODULE.test(path)) {
             this.error(
               `Workshop is disabled, but ${chunk.fileName} contains ${path}. Resolve catalogue data on the server and pass only enabled page props to client islands.`
             )

--- a/apps/website/src/integrations/workshop-release-gate.test.ts
+++ b/apps/website/src/integrations/workshop-release-gate.test.ts
@@ -1,4 +1,5 @@
-import type { AstroIntegrationLogger } from 'astro'
+import type { AstroIntegrationLogger, HookParameters } from 'astro'
+import { validateConfig } from 'astro/config'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -44,6 +45,36 @@ async function buildDone() {
 }
 
 describe('Workshop release output', () => {
+  it('registers the catalogue client boundary during Astro setup', async () => {
+    vi.stubEnv('WORKSHOP_IN_BUILD', '0')
+    const config = await validateConfig({}, root, 'build')
+    const updateConfig = vi.fn<
+      HookParameters<'astro:config:setup'>['updateConfig']
+    >(() => config)
+    const hook = workshopReleaseGate().hooks['astro:config:setup']
+    if (!hook) throw new Error('Missing config setup hook')
+    await hook({
+      config,
+      command: 'build',
+      isRestart: false,
+      updateConfig,
+      injectRoute: vi.fn(),
+      injectScript: vi.fn(),
+      addRenderer: vi.fn(),
+      addWatchFile: vi.fn(),
+      addClientDirective: vi.fn(),
+      addDevToolbarApp: vi.fn(),
+      addMiddleware: vi.fn(),
+      createCodegenDir: () => pathToFileURL(`${root}/.astro/`),
+      logger
+    })
+    expect(updateConfig).toHaveBeenCalledWith({
+      vite: {
+        plugins: [expect.objectContaining({ name: 'workshop-client-boundary' })]
+      }
+    })
+  })
+
   it('rejects an invalid Cloud family before building', () => {
     vi.stubEnv('VERCEL_ENV', 'preview')
     vi.stubEnv('WORKSHOP_IN_BUILD', '1')

--- a/apps/website/src/integrations/workshop-release-gate.test.ts
+++ b/apps/website/src/integrations/workshop-release-gate.test.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegrationLogger, HookParameters } from 'astro'
-import { validateConfig } from 'astro/config'
+import { mergeConfig, validateConfig } from 'astro/config'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -33,6 +33,18 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true })
 })
 
+/**
+ * Every plugin name in a Vite `plugins` option, however deeply nested. Walked by
+ * hand on `unknown`: `flat(Infinity)` on Vite's recursive `PluginOption` type
+ * exceeds TypeScript's instantiation depth.
+ */
+function pluginNames(option: unknown): unknown[] {
+  if (Array.isArray(option)) return option.flatMap(pluginNames)
+  return option !== null && typeof option === 'object' && 'name' in option
+    ? [option.name]
+    : []
+}
+
 async function buildDone() {
   const hook = workshopReleaseGate().hooks['astro:build:done']
   if (!hook) throw new Error('Missing build hook')
@@ -48,9 +60,16 @@ describe('Workshop release output', () => {
   it('registers the catalogue client boundary during Astro setup', async () => {
     vi.stubEnv('WORKSHOP_IN_BUILD', '0')
     const config = await validateConfig({}, root, 'build')
+    // Applies each update with the same merge Astro's hook runner uses, so the
+    // assertion is on the configuration Astro would actually build with, not
+    // on the argument the integration happened to pass.
+    let applied = config
     const updateConfig = vi.fn<
       HookParameters<'astro:config:setup'>['updateConfig']
-    >(() => config)
+    >((update) => {
+      applied = mergeConfig(applied, update)
+      return applied
+    })
     const hook = workshopReleaseGate().hooks['astro:config:setup']
     if (!hook) throw new Error('Missing config setup hook')
     await hook({
@@ -68,11 +87,10 @@ describe('Workshop release output', () => {
       createCodegenDir: () => pathToFileURL(`${root}/.astro/`),
       logger
     })
-    expect(updateConfig).toHaveBeenCalledWith({
-      vite: {
-        plugins: [expect.objectContaining({ name: 'workshop-client-boundary' })]
-      }
-    })
+    expect(updateConfig).toHaveBeenCalledOnce()
+    expect(pluginNames(applied.vite.plugins)).toContain(
+      'workshop-client-boundary'
+    )
   })
 
   it('rejects an invalid Cloud family before building', () => {

--- a/apps/website/src/integrations/workshop-release-gate.ts
+++ b/apps/website/src/integrations/workshop-release-gate.ts
@@ -7,6 +7,8 @@ import { readdir, rm } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 
+import { workshopClientBoundary } from './workshop-client-boundary'
+
 import {
   assertWorkshopCloudEnvForBuild,
   isWorkshopInBuild,
@@ -40,7 +42,8 @@ export function modelsBuildRoutes(enabled: boolean) {
  * earlier attempt filtered the route list at `astro:routes:resolved`, which
  * does not work: that hook reports the resolved routes, and mutating the
  * array does not stop them being generated. Deleting the output is
- * unambiguous. These checks cover route output, not shared CSS or translations.
+ * unambiguous. The client build rejects bundled catalogue modules when disabled;
+ * shared CSS and translations are not covered by that catalogue boundary.
  *
  * Preview builds are release builds too — a preview answers "what goes out if
  * we release right now?", so it excludes Models detail routes for the same reason.
@@ -56,7 +59,8 @@ export function workshopReleaseGate(): AstroIntegration {
   return {
     name: 'workshop-release-gate',
     hooks: {
-      'astro:config:setup': ({ injectRoute }) => {
+      'astro:config:setup': ({ injectRoute, updateConfig }) => {
+        updateConfig({ vite: { plugins: [workshopClientBoundary()] } })
         for (const route of modelsBuildRoutes(isWorkshopInBuild()))
           injectRoute(route)
       },

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -17,6 +17,7 @@ import { getCollection } from "astro:content";
 import { isWorkshopInBuild } from "../config/workshop-release";
 import { modelReleaseLinks } from "../config/model-release-links";
 import { resolveHomepageWorkshopModels } from "../config/workshop-homepage";
+import { resolveDiscoveryProviders } from "../components/home/modelDiscoveryProviders";
 import { t } from "../i18n/translations";
 import {
   comfyUiApplicationNode,
@@ -31,9 +32,7 @@ const { siteUrl } = pageContext(
   Astro.currentLocale,
 );
 
-const discoveryProviders = isWorkshopInBuild()
-  ? (await import("../data/modelDiscovery")).discoveryProviders
-  : [];
+const discoveryProviders = await resolveDiscoveryProviders(isWorkshopInBuild());
 
 // The same switch that decides whether Workshop is built at all. A release
 // build has no Workshop routes, so the homepage must not link to them; one

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -16,7 +16,6 @@ import GetStartedSection from "../components/home/GetStartedSection.vue";
 import { getCollection } from "astro:content";
 import { isWorkshopInBuild } from "../config/workshop-release";
 import { modelReleaseLinks } from "../config/model-release-links";
-import { discoveryProviders } from "../data/modelDiscovery";
 import { resolveHomepageWorkshopModels } from "../config/workshop-homepage";
 import { t } from "../i18n/translations";
 import {
@@ -31,6 +30,10 @@ const { siteUrl } = pageContext(
   Astro.url.pathname,
   Astro.currentLocale,
 );
+
+const discoveryProviders = isWorkshopInBuild()
+  ? (await import("../data/modelDiscovery")).discoveryProviders
+  : [];
 
 // The same switch that decides whether Workshop is built at all. A release
 // build has no Workshop routes, so the homepage must not link to them; one

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -16,6 +16,7 @@ import GetStartedSection from "../components/home/GetStartedSection.vue";
 import { getCollection } from "astro:content";
 import { isWorkshopInBuild } from "../config/workshop-release";
 import { modelReleaseLinks } from "../config/model-release-links";
+import { discoveryProviders } from "../data/modelDiscovery";
 import { resolveHomepageWorkshopModels } from "../config/workshop-homepage";
 import { t } from "../i18n/translations";
 import {
@@ -65,7 +66,7 @@ const workshopModels = await resolveHomepageWorkshopModels(
   <SocialProofBarSection />
   <DeveloperPlatformSection client:visible />
   <MinimaxLicenseHeroSection client:visible />
-  {isWorkshopInBuild() && <ModelDiscoverySection client:visible />}
+  {isWorkshopInBuild() && <ModelDiscoverySection providers={discoveryProviders} client:visible />}
   <FeaturedWorkflowsSection client:load />
   {workshopModels.length > 0 && <WorkshopSection models={workshopModels} />}
   <ProductShowcaseSection client:load />

--- a/apps/website/src/pages/zh-CN/index.astro
+++ b/apps/website/src/pages/zh-CN/index.astro
@@ -15,7 +15,6 @@ import GetStartedSection from '../../components/home/GetStartedSection.vue'
 import { t } from '../../i18n/translations'
 import { isWorkshopInBuild } from '../../config/workshop-release'
 import { modelReleaseLinks } from '../../config/model-release-links'
-import { discoveryProviders } from '../../data/modelDiscovery'
 import {
   comfyUiApplicationNode,
   comfyUiSoftwareId,
@@ -28,6 +27,10 @@ const { siteUrl } = pageContext(
   Astro.url.pathname,
   Astro.currentLocale,
 )
+
+const discoveryProviders = isWorkshopInBuild()
+  ? (await import('../../data/modelDiscovery')).discoveryProviders
+  : []
 ---
 
 <BaseLayout

--- a/apps/website/src/pages/zh-CN/index.astro
+++ b/apps/website/src/pages/zh-CN/index.astro
@@ -15,6 +15,7 @@ import GetStartedSection from '../../components/home/GetStartedSection.vue'
 import { t } from '../../i18n/translations'
 import { isWorkshopInBuild } from '../../config/workshop-release'
 import { modelReleaseLinks } from '../../config/model-release-links'
+import { discoveryProviders } from '../../data/modelDiscovery'
 import {
   comfyUiApplicationNode,
   comfyUiSoftwareId,
@@ -41,7 +42,7 @@ const { siteUrl } = pageContext(
   <DeveloperPlatformSection locale="zh-CN" client:visible />
   <MinimaxLicenseHeroSection locale="zh-CN" client:visible />
   <ModelReleaseSection locale="zh-CN" modelLinks={await modelReleaseLinks(isWorkshopInBuild())} client:visible />
-  {isWorkshopInBuild() && <ModelDiscoverySection locale="zh-CN" client:visible />}
+  {isWorkshopInBuild() && <ModelDiscoverySection locale="zh-CN" providers={discoveryProviders} client:visible />}
   <FeaturedWorkflowsSection locale="zh-CN" client:load />
   <ProductShowcaseSection locale="zh-CN" client:load />
   <IndustriesSection locale="zh-CN" client:load />

--- a/apps/website/src/pages/zh-CN/index.astro
+++ b/apps/website/src/pages/zh-CN/index.astro
@@ -15,6 +15,7 @@ import GetStartedSection from '../../components/home/GetStartedSection.vue'
 import { t } from '../../i18n/translations'
 import { isWorkshopInBuild } from '../../config/workshop-release'
 import { modelReleaseLinks } from '../../config/model-release-links'
+import { resolveDiscoveryProviders } from '../../components/home/modelDiscoveryProviders'
 import {
   comfyUiApplicationNode,
   comfyUiSoftwareId,
@@ -28,9 +29,7 @@ const { siteUrl } = pageContext(
   Astro.currentLocale,
 )
 
-const discoveryProviders = isWorkshopInBuild()
-  ? (await import('../../data/modelDiscovery')).discoveryProviders
-  : []
+const discoveryProviders = await resolveDiscoveryProviders(isWorkshopInBuild())
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary

Close the catalogue JavaScript leak left after #17382, reported in [review 5174310097](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17382#pullrequestreview-5174310097).

## Changes

- Resolve homepage discovery providers in Astro and pass them as props; remove the island's runtime catalogue import.
- Reject catalogue modules and packed catalogue JSON in disabled client builds, including lazy chunks. Server builds and explicitly enabled client builds remain allowed.
- Add real Vite build regressions; no mocked bundle metadata or filename-dependent assertion.

## Review Focus

The earlier homepage CTA fix was already on main, but `ModelDiscoverySection` still emitted the full catalogue even when its HTML was gated off. This patch changes neither header styling nor the Models/auth/run behavior.

Verified the guard fails the actual Astro release build before fixing the import, then passes afterward. The discovery chunk shrinks from 1,082,510 to 4,448 bytes; total disabled client JS drops by 1,078,062 bytes. Shared translations and unused non-catalogue assets are not claimed absent.

Local checks: 4,116 website unit tests; 31 homepage/Models browser tests without retries; website typecheck, changed-file lint and Knip. Both builds pass: disabled 749 HTML files with only the existing Models marketing page and no Models-detail homepage links; enabled 1,134 HTML files. CI must be checked on the pushed head.
