### PR TITLE
Rename the built-in manager UI from "Extensions" to "Custom Nodes"

### DIFF
--- a/browser_tests/tests/dialogs/managerDialog.spec.ts
+++ b/browser_tests/tests/dialogs/managerDialog.spec.ts
@@ -373,7 +373,7 @@ test.describe('ManagerDialog', { tag: '@ui' }, () => {
     await expect(dialog).toBeVisible()
 
     const nav = dialog.locator('nav')
-    await expect(nav.getByText('All Extensions')).toBeVisible()
+    await expect(nav.getByText('All Custom Nodes')).toBeVisible()
     await expect(nav.getByText('Not Installed')).toBeVisible()
     await expect(nav.getByText('All Installed')).toBeVisible()
     await expect(nav.getByText('Updates Available')).toBeVisible()

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -960,7 +960,7 @@ export function useCoreCommands(): ComfyCommand[] {
     {
       id: 'Comfy.Manager.CustomNodesManager.ShowCustomNodesMenu',
       icon: 'pi pi-puzzle',
-      label: 'Custom Nodes Manager',
+      label: 'Show Custom Nodes',
       versionAdded: '1.12.10',
       function: async () => {
         await useManagerState().openManager({
@@ -1097,7 +1097,7 @@ export function useCoreCommands(): ComfyCommand[] {
     {
       id: 'Comfy.OpenManagerDialog',
       icon: 'mdi mdi-puzzle-outline',
-      label: 'Manager',
+      label: 'Open Custom Nodes',
       function: async () => {
         await useManagerState().openManager({
           initialTab: ManagerTab.All,

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -183,7 +183,7 @@
     "label": "Load Default Workflow"
   },
   "Comfy_Manager_CustomNodesManager_ShowCustomNodesMenu": {
-    "label": "Custom Nodes Manager"
+    "label": "Show Custom Nodes"
   },
   "Comfy_Manager_CustomNodesManager_ShowLegacyCustomNodesMenu": {
     "label": "Custom Nodes (Legacy)"
@@ -234,7 +234,7 @@
     "label": "Clipspace"
   },
   "Comfy_OpenManagerDialog": {
-    "label": "Manager"
+    "label": "Open Custom Nodes"
   },
   "Comfy_OpenWorkflow": {
     "label": "Open Workflow"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -486,7 +486,7 @@
     "clickToFinishSetup": "Click",
     "toFinishSetup": "to finish setup",
     "restartingBackend": "Restarting backend to apply changes...",
-    "extensionsSuccessfullyInstalled": "Extension(s) successfully installed and are ready to use!",
+    "extensionsSuccessfullyInstalled": "Custom node(s) successfully installed and are ready to use!",
     "installingDependencies": "Installing dependencies...",
     "loadingVersions": "Loading versions...",
     "selectVersion": "Select Version",
@@ -514,20 +514,20 @@
     "tryDifferentSearch": "Please try a different search query.",
     "emptyState": {
       "allInstalled": {
-        "title": "No Extensions Installed",
-        "message": "You haven't installed any extensions yet."
+        "title": "No Custom Nodes Installed",
+        "message": "You haven't installed any custom nodes yet."
       },
       "updateAvailable": {
         "title": "All Up to Date",
-        "message": "All your extensions are up to date."
+        "message": "All your custom nodes are up to date."
       },
       "conflicting": {
         "title": "No Conflicts Detected",
-        "message": "All your extensions are compatible."
+        "message": "All your custom nodes are compatible."
       },
       "workflow": {
-        "title": "No Extensions in Workflow",
-        "message": "This workflow doesn't use any extension nodes."
+        "title": "No Custom Nodes in Workflow",
+        "message": "This workflow doesn't use any custom nodes."
       },
       "missing": {
         "title": "No Missing Nodes",
@@ -574,18 +574,18 @@
     },
     "conflicts": {
       "title": "Node Pack Issues Detected!",
-      "description": "We've detected conflicts between some of your extensions and the new version of ComfyUI. By updating you risk breaking workflows that rely on those extensions.",
-      "info": "If you continue with the update, the conflicting extensions will be disabled automatically. You can review and manage them anytime in the ComfyUI Manager.",
-      "extensionAtRisk": "Extension at Risk",
+      "description": "We've detected conflicts between some of your custom nodes and the new version of ComfyUI. By updating you risk breaking workflows that rely on those custom nodes.",
+      "info": "If you continue with the update, the conflicting custom nodes will be disabled automatically. You can review and manage them anytime under Custom Nodes.",
+      "extensionAtRisk": "Custom Node at Risk",
       "conflicts": "Conflicts",
-      "importFailedExtensions": "Import Failed Extensions",
+      "importFailedExtensions": "Import Failed Custom Nodes",
       "conflictInfoTitle": "Why is this happening?",
       "installAnyway": "Install Anyway",
       "enableAnyway": "Enable Anyway",
       "understood": "Understood",
       "warningBanner": {
-        "title": "Some extensions are disabled due to incompatibility with your current setup",
-        "message": "These extensions require versions of system packages  that differ from your current setup. Installing them may override core dependencies and affect other extensions or workflows.",
+        "title": "Some custom nodes are disabled due to incompatibility with your current setup",
+        "message": "These custom nodes require versions of system packages  that differ from your current setup. Installing them may override core dependencies and affect other custom nodes or workflows.",
         "button": "Learn More..."
       },
       "conflictMessages": {
@@ -1549,7 +1549,7 @@
     "Interrupt": "Interrupt",
     "Open Layer Editor for Selected Node": "Open Layer Editor for Selected Node",
     "Load Default Workflow": "Load Default Workflow",
-    "Custom Nodes Manager": "Custom Nodes Manager",
+    "Show Custom Nodes": "Show Custom Nodes",
     "Custom Nodes (Legacy)": "Custom Nodes (Legacy)",
     "Manager Menu (Legacy)": "Manager Menu (Legacy)",
     "Install Missing Custom Nodes": "Install Missing Custom Nodes",
@@ -1566,7 +1566,7 @@
     "Unload Models and Execution Cache": "Unload Models and Execution Cache",
     "New": "New",
     "Clipspace": "Clipspace",
-    "Manager": "Manager",
+    "Open Custom Nodes": "Open Custom Nodes",
     "Open": "Open",
     "Publish": "Publish",
     "Job History": "Job History",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -163,7 +163,7 @@
     "defaultBanner": "default banner",
     "enableOrDisablePack": "Enable or disable pack",
     "openManager": "Open Manager",
-    "manageExtensions": "Manage extensions",
+    "manageExtensions": "Manage Custom Nodes",
     "gallery": "Gallery",
     "graphNavigation": "Graph navigation",
     "dropYourFileOr": "Drop your file or",
@@ -440,7 +440,7 @@
     "inf": "Inf"
   },
   "manager": {
-    "title": "Nodes Manager",
+    "title": "Custom Nodes",
     "survey": {
       "title": "Join the waitlist",
       "intro": "Installing custom nodes is coming soon to Comfy Cloud. Answer a few quick questions to join the waitlist and help shape this feature.",
@@ -469,7 +469,7 @@
     "dependencies": "Dependencies",
     "inWorkflow": "In Workflow",
     "nav": {
-      "allExtensions": "All Extensions",
+      "allExtensions": "All Custom Nodes",
       "notInstalled": "Not Installed",
       "installedSection": "INSTALLED",
       "allInstalled": "All installed",
@@ -1080,7 +1080,7 @@
     "github": "Github",
     "help": "Help & Support",
     "systemStatus": "System Status",
-    "managerExtension": "Manager Extension",
+    "managerExtension": "Custom Nodes",
     "more": "More...",
     "whatsNew": "What's New?",
     "clickToLearnMore": "Click to learn more →",
@@ -1134,7 +1134,7 @@
     "theme": "Theme",
     "dark": "Dark",
     "light": "Light",
-    "manageExtensions": "Extensions",
+    "manageExtensions": "Custom Nodes",
     "customNodesManager": "Custom Nodes Manager",
     "settings": "Settings",
     "help": "Help",

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -107,7 +107,7 @@ export type RemoteConfig = {
   onboarding_survey_enabled?: boolean
   onboarding_survey?: OnboardingSurvey
   onboarding_tour_enabled?: boolean
-  /** Full hosted (external) survey URL embedded in the Nodes Manager modal on Cloud. */
+  /** Full hosted (external) survey URL embedded in the Custom Nodes modal on Cloud. */
   manager_survey_url?: string
   linear_toggle_enabled?: boolean
   partner_node_governance_enabled?: boolean

--- a/src/workbench/extensions/manager/components/manager/NodeConflictDialogContent.test.ts
+++ b/src/workbench/extensions/manager/components/manager/NodeConflictDialogContent.test.ts
@@ -117,8 +117,8 @@ describe('NodeConflictDialogContent', () => {
       const { container } = renderComponent()
 
       expect(container.textContent).not.toContain('Conflicts')
-      expect(container.textContent).not.toContain('Extensions at Risk')
-      expect(container.textContent).not.toContain('Import Failed Extensions')
+      expect(container.textContent).not.toContain('Custom Node at Risk')
+      expect(container.textContent).not.toContain('Import Failed Custom Nodes')
     })
 
     it('should render with conflict data from composable', () => {
@@ -128,8 +128,8 @@ describe('NodeConflictDialogContent', () => {
 
       expect(container.textContent).toContain('3')
       expect(container.textContent).toContain('Conflicts')
-      expect(container.textContent).toContain('Extension at Risk')
-      expect(container.textContent).toContain('Import Failed Extensions')
+      expect(container.textContent).toContain('Custom Node at Risk')
+      expect(container.textContent).toContain('Import Failed Custom Nodes')
       expect(container.textContent).toContain('1')
     })
 
@@ -139,10 +139,10 @@ describe('NodeConflictDialogContent', () => {
       })
 
       expect(container.textContent).toContain(
-        "We've detected conflicts between some of your extensions"
+        "We've detected conflicts between some of your custom nodes"
       )
       expect(container.textContent).toContain(
-        'the conflicting extensions will be disabled automatically'
+        'the conflicting custom nodes will be disabled automatically'
       )
     })
 
@@ -152,10 +152,10 @@ describe('NodeConflictDialogContent', () => {
       })
 
       expect(container.textContent).not.toContain(
-        "We've detected conflicts between some of your extensions"
+        "We've detected conflicts between some of your custom nodes"
       )
       expect(container.textContent).not.toContain(
-        'the conflicting extensions will be disabled automatically'
+        'the conflicting custom nodes will be disabled automatically'
       )
     })
 
@@ -169,9 +169,9 @@ describe('NodeConflictDialogContent', () => {
         '.w-full.flex.flex-col.bg-base-background'
       )
 
-      // Import Failed Extensions section
+      // Import Failed Custom Nodes section
       expect(sections[0].textContent).toContain('1')
-      expect(sections[0].textContent).toContain('Import Failed Extensions')
+      expect(sections[0].textContent).toContain('Import Failed Custom Nodes')
 
       // Conflicts section
       expect(sections[1].textContent).toContain('3')
@@ -325,8 +325,8 @@ describe('NodeConflictDialogContent', () => {
       const { container } = renderComponent()
 
       expect(container.textContent).not.toContain('Conflicts')
-      expect(container.textContent).not.toContain('Extensions at Risk')
-      expect(container.textContent).not.toContain('Import Failed Extensions')
+      expect(container.textContent).not.toContain('Custom Node at Risk')
+      expect(container.textContent).not.toContain('Import Failed Custom Nodes')
     })
 
     it('should handle conflicts without import_failed', () => {
@@ -335,7 +335,7 @@ describe('NodeConflictDialogContent', () => {
 
       expect(container.textContent).toContain('3')
       expect(container.textContent).toContain('2')
-      expect(container.textContent).not.toContain('Import Failed Extensions')
+      expect(container.textContent).not.toContain('Import Failed Custom Nodes')
     })
   })
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Proposal + implementation for the naming half of a #dev-core-engine thread about `docs.comfy.org/manager/overview` being unreadable: you cannot tell whether it documents the **ComfyUI-Manager custom node** or the **built-in integration**.

Companion PR (Portable default-enable) in `Comfy-Org/ComfyUI`.

## The problem

One feature had five names, and two of them collided with unrelated things:

| Surface | Before |
|---|---|
| Toolbar button | **Extensions** |
| Dialog title | Nodes Manager |
| Dialog nav | All Extensions |
| Command palette | Manager / Custom Nodes Manager |
| Help Center | Manager Extension |

- **"Extensions"** is already ComfyUI's *JavaScript extension system* — `app.registerExtension()`, the `/extensions` route, and the Settings → Extension panel. Two unrelated features, one word.
- **"Manager"** is the separately-distributed ComfyUI-Manager custom node, which we are explicitly not renaming. Naming the built-in UI "Manager" makes the original complaint worse, not better.

## Why "Custom Nodes"

It collides with neither, and it is already the vocabulary everywhere else in the codebase: `custom_nodes/`, `CustomNodesPanel.vue`, `RootCategory.Custom`, "Install Missing Custom Nodes", "Check for Custom Node Updates". The toolbar label was the outlier, not the vocabulary.

**`--enable-manager` is deliberately unchanged.** It is a public documented flag and ComfyUI Desktop hardcodes it (`DEFAULT_LAUNCH_ARGS`). The layering is: *Manager* = the component/package/flag/docs-path, *Custom Nodes* = the thing the user sees and manages. Suggested docs line: "**Custom Nodes** is the built-in interface powered by ComfyUI-Manager. The `--enable-manager` flag enables it."

## Changes

English values only, plus the two command labels at their source. No i18n keys, command ids, or CLI flags change, so nothing external breaks.

`src/locales/en/main.json` — `menu.manageExtensions` → `Custom Nodes`, `g.manageExtensions` → `Manage Custom Nodes`, `manager.title` → `Custom Nodes`, `manager.nav.allExtensions` → `All Custom Nodes`, `helpCenter.managerExtension` → `Custom Nodes`, plus the `manager.emptyState.*` / `manager.conflicts.*` copy rendered inside the dialog.

`src/composables/useCoreCommands.ts` — `'Custom Nodes Manager'` → `'Show Custom Nodes'`, `'Manager'` → `'Open Custom Nodes'`.

> Note: `src/locales/en/commands.json` and `main.json`'s `menuLabels` block are **generated** by `scripts/collect-i18n-general.ts` from the live command registry. Editing them alone gets silently reverted at the next release version-bump. The labels are therefore changed at source, with the generated output updated to match.

**Intentionally left alone:** `settingsCategories.Extension`, `g.extensionName`, `g.extensions`, `templateWorkflows.category.Extensions` (JS extension system / node-search taxonomy); `manager.incompatibleVersion.*` and `manager.legacyManagerSearchTip` (these correctly name the ComfyUI-Manager *package*); `manager.noNodesFoundDescription` ("frontend extension only" genuinely means the JS extension system).

## Verification

Ran against a live ComfyUI backend with `--enable-manager` and the real `comfyui_manager` package installed.

- `pnpm typecheck` → exit 0; `pnpm lint` → exit 0 (229 pre-existing warnings, 0 errors); `pnpm format:check` → clean
- `pnpm test:unit` → **21077 passed**. `NodeConflictDialogContent.test.ts` 19/19. The 9 remaining failures are pre-existing and unrelated — `AgentPanelRoot` ×3 and a CI-script file fail identically on `main`; `vitestSetup`, `ErrorPanelSurveyCta`, `NightlySurveyPopover`, `GettingStartedScreen` pass in isolation on this branch and reference none of the renamed strings (full-suite ordering flakiness).
- Live command registry now returns a coherent set: `Show Custom Nodes`, `Open Custom Nodes`, `Check for Custom Node Updates`, `Install Missing Custom Nodes`.

Two test files pinned old literals and are updated: `managerDialog.spec.ts` (`All Extensions`) and `NodeConflictDialogContent.test.ts`, which mounts against the real `en/main.json`. In the latter, two negative assertions checked a plural `'Extensions at Risk'` that never matched the singular value — they were already vacuous and now guard the real string.

## Deferred on purpose — please read before merging

**This is English-only.** The other 14 locales still show the old names until the next release cut. `i18n-update-core.yaml` only regenerates translations on `workflow_dispatch` or a `version-bump-*` branch, and 10 of the last 12 commits touching `en/main.json` touched zero other locales — so hand-editing them here would deviate from house practice and be overwritten anyway. Until then German renders the toolbar button as "Erweiterungen" and the palette as "Manager", i.e. the exact collisions this PR targets. `pnpm locale:check` passes. If you want them simultaneous, `workflow_dispatch` the i18n workflow against this branch before merge.

## Open question

`Show Custom Nodes` and `Open Custom Nodes` sit next to each other in the keybindings panel. They are genuinely different (one restores your last tab, one forces the All tab), but the labels are hard to tell apart. Not a regression from `Custom Nodes Manager` / `Manager`, just an opportunity — happy to relabel if you have a preference.

## Screenshots

![Toolbar after the rename: the button reads Custom Nodes instead of Extensions](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/72a638ed06be325e982f34971c447a7fc50adf431a981eaf0f7b01190a2798be/pr-images/1789111331645-42ce27b4-732f-445e-9ebf-7aae979fc9b5.png)

![Manager dialog titled Custom Nodes with All Custom Nodes in the nav](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/72a638ed06be325e982f34971c447a7fc50adf431a981eaf0f7b01190a2798be/pr-images/1789111331982-0a1bf110-749b-4bba-b603-ce5be53a2207.png)

![Help Center menu entry renamed from Manager Extension to Custom Nodes](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/72a638ed06be325e982f34971c447a7fc50adf431a981eaf0f7b01190a2798be/pr-images/1789111332449-10d08ee3-31cd-434a-b710-c4506890cee6.png)