### PR TITLE
fix(telemetry): preserve assertion diagnostic fidelity (cloud 1.53 backport)

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -12,14 +12,33 @@
 
   ```typescript
   reportError(error, {
-    errorType: 'workspace_auth_gate_initialization_failure'
+    errorType: 'failure_initializing_workspace_auth_gate'
   })
   ```
 
-  `errorType` is a stable slug. It lands as the `error_type` Sentry tag and the
-  `error_type` RUM context field, so one query works against either console.
-  Pick a slug that names the failure, not the symptom, and reuse the existing
-  one if the failure already has a name.
+  `errorType` is a stable slug. It lands as native RUM `error.type` and the
+  `error_type` Sentry tag. The legacy `error_type` RUM context field is retained
+  for existing queries; prefer `@error.type` for new Datadog queries.
+
+### Error Type Naming
+
+- Name error types from generic to specific in lowercase `snake_case`:
+  `<category>_<operation>_<subject>[_detail]`. Put the category first, then
+  the operation as a present participle, then the affected subject so related
+  failures sort together.
+- Examples: `error_loading_resource`, `error_loading_asset`,
+  `error_rendering_foo`, `error_rendering_bar`, and
+  `failure_initializing_workspace_auth_gate`. Here `workspace_auth_gate`
+  names the `WorkspaceAuthGate` component and stays together as one subject.
+- Search existing `errorType` values before adding one. Reuse the same slug
+  for the same failure mode across call sites. Keep vocabulary consistent
+  within a family; do not introduce synonyms such as `error_loading_asset`
+  and `failure_loading_asset` for the same failure.
+- Keep filenames, timestamps, IDs, URLs, and other instance-specific values
+  in the error message or context, never in the type.
+- Treat existing emitted types as telemetry contracts. Rename them only with
+  a migration of affected queries and alerts that accounts for old and new
+  releases reporting different names.
 
 ## Security
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,11 +11,13 @@ import { computed, onMounted, watch } from 'vue'
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
 import { isDesktop } from '@/platform/distribution/types'
-import { reportError } from '@/platform/telemetry/reportError'
+import {
+  reportPreloadError,
+  reportResourceLoadError
+} from '@/platform/telemetry/assetLoadErrorReporting'
 import { app } from '@/scripts/app'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { electronAPI } from '@/utils/envUtil'
-import { parsePreloadError } from '@/utils/preloadErrorUtil'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
 
 const workspaceStore = useWorkspaceStore()
@@ -45,17 +47,6 @@ const showContextMenu = (event: MouseEvent) => {
   }
 }
 
-function handleResourceError(url: string, tagName: string) {
-  console.error('[resource:loadError]', { url, tagName })
-
-  if (__DISTRIBUTION__ === 'cloud') {
-    reportError(new Error(`Resource load failed: ${url}`), {
-      errorType: 'resource_load_error',
-      tags: { tag_name: tagName }
-    })
-  }
-}
-
 onMounted(() => {
   window['__COMFYUI_FRONTEND_VERSION__'] = config.app_version
 
@@ -67,32 +58,12 @@ onMounted(() => {
   // See: https://vite.dev/guide/build#load-error-handling
   window.addEventListener('vite:preloadError', (event) => {
     event.preventDefault()
-    const info = parsePreloadError(event.payload)
-    console.error('[vite:preloadError]', {
-      url: info.url,
-      fileType: info.fileType,
-      chunkName: info.chunkName,
-      message: info.message
-    })
-    if (__DISTRIBUTION__ === 'cloud') {
-      reportError(event.payload, {
-        errorType: 'vite_preload_error',
-        tags: {
-          file_type: info.fileType,
-          chunk_name: info.chunkName ?? undefined
-        },
-        context: {
-          url: info.url,
-          fileType: info.fileType,
-          chunkName: info.chunkName
-        }
-      })
-    }
+    reportPreloadError(event.payload)
     // Disabled: Third-party custom node extensions frequently trigger this toast
     // (e.g., bare "vue" imports, wrong relative paths to scripts/app.js, missing
     // core dependencies). These are plugin bugs, not ComfyUI core failures, but
     // the generic error message alarms users and offers no actionable guidance.
-    // The console.error above still logs the details for developers to debug.
+    // The reporter above still logs the details for developers to debug.
     // useToastStore().add({
     //   severity: 'error',
     //   summary: t('g.preloadErrorTitle'),
@@ -108,12 +79,12 @@ onMounted(() => {
       (event) => {
         const target = event.target
         if (target instanceof HTMLScriptElement) {
-          handleResourceError(target.src, 'script')
+          reportResourceLoadError(target.src, 'script')
         } else if (
           target instanceof HTMLLinkElement &&
           target.rel === 'stylesheet'
         ) {
-          handleResourceError(target.href, 'link')
+          reportResourceLoadError(target.href, 'link')
         }
       },
       true

--- a/src/base/assert.test.ts
+++ b/src/base/assert.test.ts
@@ -50,7 +50,21 @@ describe('assert', () => {
     setAssertReporter(reporter)
     assert(false, 'reporter message')
     expect(reporter).toHaveBeenCalledWith(
-      '[Assertion failed]: reporter message'
+      '[Assertion failed]: reporter message',
+      undefined
+    )
+  })
+
+  it('forwards structured context without adding it to the message', () => {
+    vi.stubEnv('DEV', false)
+    const reporter = vi.fn()
+    setAssertReporter(reporter)
+
+    assert(false, 'tracker is inactive', { workflowPath: 'a/b.json' })
+
+    expect(reporter).toHaveBeenCalledWith(
+      '[Assertion failed]: tracker is inactive',
+      { workflowPath: 'a/b.json' }
     )
   })
 

--- a/src/base/assert.ts
+++ b/src/base/assert.ts
@@ -1,14 +1,25 @@
+export const ASSERTION_FAILURE_PREFIX = '[Assertion failed]: '
+
 type AssertReporter = (message: string) => void
 
 let reporter: AssertReporter | null = null
+let reporterForwardsToRum = false
 
 /**
  * Register a reporter for assertion failures in non-DEV environments.
  * Called once at app startup by platform/ or higher layers to wire in
  * Sentry, toast notifications, etc.
  */
-export function setAssertReporter(fn: AssertReporter | null): void {
+export function setAssertReporter(
+  fn: AssertReporter | null,
+  options: { forwardsToRum?: boolean } = {}
+): void {
   reporter = fn
+  reporterForwardsToRum = fn !== null && options.forwardsToRum === true
+}
+
+export function hasRumAssertReporter(): boolean {
+  return reporterForwardsToRum
 }
 
 /**
@@ -25,7 +36,7 @@ export function setAssertReporter(fn: AssertReporter | null): void {
 export function assert(condition: unknown, message: string): asserts condition {
   if (condition) return
 
-  const formatted = `[Assertion failed]: ${message}`
+  const formatted = `${ASSERTION_FAILURE_PREFIX}${message}`
   console.error(formatted)
 
   if (import.meta.env.DEV) {

--- a/src/base/assert.ts
+++ b/src/base/assert.ts
@@ -1,6 +1,9 @@
 export const ASSERTION_FAILURE_PREFIX = '[Assertion failed]: '
 
-type AssertReporter = (message: string) => void
+type AssertReporter = (
+  message: string,
+  context?: Record<string, unknown>
+) => void
 
 let reporter: AssertReporter | null = null
 let reporterForwardsToRum = false
@@ -30,10 +33,14 @@ export function hasRumAssertReporter(): boolean {
  * - Otherwise: delegates to registered reporter (Sentry, toast, etc.)
  *
  * Reporters forward `message` to external telemetry, so it must be a static
- * description of the invariant. Never interpolate user data (workflow names,
- * paths, prompts) into it.
+ * description of the invariant. Put diagnostic values in `context` so they do
+ * not affect grouping or deduplication.
  */
-export function assert(condition: unknown, message: string): asserts condition {
+export function assert(
+  condition: unknown,
+  message: string,
+  context?: Record<string, unknown>
+): asserts condition {
   if (condition) return
 
   const formatted = `${ASSERTION_FAILURE_PREFIX}${message}`
@@ -44,7 +51,7 @@ export function assert(condition: unknown, message: string): asserts condition {
   }
 
   try {
-    reporter?.(formatted)
+    reporter?.(formatted, context)
   } catch (error) {
     console.error('[Assertion reporter failed]', error)
   }

--- a/src/core/graph/nodeShell/nodeShellState.test.ts
+++ b/src/core/graph/nodeShell/nodeShellState.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { toRaw } from 'vue'
 
+import { setAssertReporter } from '@/base/assert'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { Subgraph } from '@/lib/litegraph/src/litegraph'
 import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
@@ -129,6 +130,8 @@ describe('node registration invariants', () => {
 
   it('drops the previous root entry rather than stranding it', () => {
     vi.stubEnv('DEV', false)
+    const reporter = vi.fn()
+    setAssertReporter(reporter)
     const first = new LGraph()
     first.id = createUuidv4()
     const second = new LGraph()
@@ -142,6 +145,15 @@ describe('node registration invariants', () => {
     const owningGraphId = node._state.graphId
     expect(store.getGraphNodesFor(first.id, owningGraphId)).toEqual([])
     expect(store.getGraphNodesFor(second.id, owningGraphId)).toHaveLength(1)
+    expect(reporter).toHaveBeenCalledWith(
+      expect.stringContaining('different root graph'),
+      {
+        nodeId: node.id,
+        previousRootGraphId: first.id,
+        nextRootGraphId: second.id
+      }
+    )
+    setAssertReporter(null)
   })
 
   it('reports a state that drifted out of its bucket before unregistering', () => {
@@ -158,5 +170,29 @@ describe('node registration invariants', () => {
 
     expect(() => unregisterNodeState(node)).toThrow(/identity drift/)
     expect(node._graphScope).toBeUndefined()
+  })
+
+  it('reports the drifted node and graph as structured context', () => {
+    vi.stubEnv('DEV', false)
+    const reporter = vi.fn()
+    setAssertReporter(reporter)
+    const graph = new LGraph()
+    const node = new LGraphNode('Node')
+    graph.add(node)
+    node._state = createNodeShellState(
+      node,
+      createInputSlotView,
+      'Node',
+      'test',
+      undefined
+    )
+
+    unregisterNodeState(node)
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.stringContaining('identity drift'),
+      { nodeId: node.id, rootGraphId: graph.id }
+    )
+    setAssertReporter(null)
   })
 })

--- a/src/core/graph/nodeShell/nodeShellState.ts
+++ b/src/core/graph/nodeShell/nodeShellState.ts
@@ -107,7 +107,12 @@ export function registerNodeState(
   }
   assert(
     strandedScope === undefined,
-    'registerNodeState: node already registered under a different root graph'
+    'registerNodeState: node already registered under a different root graph',
+    {
+      nodeId: node.id,
+      previousRootGraphId: strandedScope?.rootGraphId,
+      nextRootGraphId: graphScope.rootGraphId
+    }
   )
 
   node._state.graphId = graph.id
@@ -125,11 +130,13 @@ export function registerNodeState(
  */
 export function unregisterNodeState(node: LGraphNode): void {
   if (!node._graphScope) return
-  const deleted = useNodeDataStore().deleteNode(node._graphScope, node._state)
+  const graphScope = node._graphScope
+  const deleted = useNodeDataStore().deleteNode(graphScope, node._state)
   node._graphScope = undefined
   assert(
     deleted,
-    'unregisterNodeState: node state not found in bucket (identity drift)'
+    'unregisterNodeState: node state not found in bucket (identity drift)',
+    { nodeId: node.id, rootGraphId: graphScope.rootGraphId }
   )
 }
 

--- a/src/core/graph/nodeShell/nodeShellState.ts
+++ b/src/core/graph/nodeShell/nodeShellState.ts
@@ -107,7 +107,7 @@ export function registerNodeState(
   }
   assert(
     strandedScope === undefined,
-    `registerNodeState: node ${node.id} already registered under a different root graph (${strandedScope?.rootGraphId})`
+    'registerNodeState: node already registered under a different root graph'
   )
 
   node._state.graphId = graph.id
@@ -129,7 +129,7 @@ export function unregisterNodeState(node: LGraphNode): void {
   node._graphScope = undefined
   assert(
     deleted,
-    `unregisterNodeState: state for node ${node.id} not found in bucket (identity drift)`
+    'unregisterNodeState: node state not found in bucket (identity drift)'
   )
 }
 

--- a/src/extensions/core/agentPanel.ts
+++ b/src/extensions/core/agentPanel.ts
@@ -86,7 +86,6 @@ async function setupFlagGate(): Promise<void> {
     if (import.meta.env.MODE === 'development') settle()
     else setTimeout(settle, FLAG_SETTLE_TIMEOUT_MS)
   } catch (error) {
-    console.error('[Comfy.AgentPanel] feature-flag gate failed to load', error)
     settle()
     reportError(error, { errorType: 'agent_flag_gate_load_failure' })
   }

--- a/src/extensions/core/agentPanelGateDependencyFailure.test.ts
+++ b/src/extensions/core/agentPanelGateDependencyFailure.test.ts
@@ -74,6 +74,7 @@ describe('the agent panel gate under a dependency-chunk failure', () => {
   })
 
   it('settles fail-closed, reports, and resolves the setup promise', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.stubGlobal('__DISTRIBUTION__', 'cloud')
     vi.resetModules()
     const { registerAgentPanelExtension } = await import('./agentPanel')
@@ -90,5 +91,6 @@ describe('the agent panel gate under a dependency-chunk failure', () => {
     expect(reportErrorMock).toHaveBeenCalledWith(expect.any(Error), {
       errorType: 'agent_flag_gate_load_failure'
     })
+    expect(consoleError).not.toHaveBeenCalled()
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,21 +113,24 @@ flushErrorReports()
 // Assertion reporter receives pre-formatted messages (with "[Assertion failed]: " prefix).
 // Strings here are intentionally not i18n'd: they're developer/nightly diagnostics,
 // not user-facing in stable releases.
-setAssertReporter((message) => {
-  if (isDesktop) {
-    captureMessage(message, { level: 'warning' })
-  }
-  if (isCloud) {
-    reportAssertFailure(message)
-  }
-  if (isNightly) {
-    useToastStore(pinia).add({
-      severity: 'warn',
-      summary: 'Assertion failed',
-      detail: message
-    })
-  }
-})
+setAssertReporter(
+  (message) => {
+    if (isDesktop) {
+      captureMessage(message, { level: 'warning' })
+    }
+    if (isCloud) {
+      reportAssertFailure(message)
+    }
+    if (isNightly) {
+      useToastStore(pinia).add({
+        severity: 'warn',
+        summary: 'Assertion failed',
+        detail: message
+      })
+    }
+  },
+  { forwardsToRum: isCloud }
+)
 
 app.directive('tooltip', Tooltip)
 app

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,12 +114,12 @@ flushErrorReports()
 // Strings here are intentionally not i18n'd: they're developer/nightly diagnostics,
 // not user-facing in stable releases.
 setAssertReporter(
-  (message) => {
+  (message, context) => {
     if (isDesktop) {
-      captureMessage(message, { level: 'warning' })
+      captureMessage(message, { level: 'warning', extra: context })
     }
     if (isCloud) {
-      reportAssertFailure(message)
+      reportAssertFailure(message, context)
     }
     if (isNightly) {
       useToastStore(pinia).add({

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -128,6 +128,7 @@ describe('useSessionCookie', () => {
   })
 
   it('reports a swallowed createSession failure as session_cookie_creation_failure', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockGetIdToken.mockResolvedValue('firebase-id-token')
     vi.mocked(globalThis.fetch).mockResolvedValue(
       new Response(JSON.stringify({ message: 'session denied' }), {
@@ -141,8 +142,10 @@ describe('useSessionCookie', () => {
     await useSessionCookie().createSession()
 
     expect(mockReportError).toHaveBeenCalledExactlyOnceWith(expect.any(Error), {
-      errorType: 'session_cookie_creation_failure'
+      errorType: 'session_cookie_creation_failure',
+      level: 'warning'
     })
+    expect(consoleWarn).not.toHaveBeenCalled()
   })
 
   it('serializes strict session creation after the previous user response', async () => {

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -126,8 +126,10 @@ export const useSessionCookie = () => {
     } catch (error) {
       // The session cookie is the only credential <img>/media loads carry, so
       // a swallowed creation failure means images break with no other signal.
-      reportError(error, { errorType: 'session_cookie_creation_failure' })
-      console.warn('Failed to create session cookie:', error)
+      reportError(error, {
+        errorType: 'session_cookie_creation_failure',
+        level: 'warning'
+      })
     }
   }
 

--- a/src/platform/telemetry/assertFailureReporter.test.ts
+++ b/src/platform/telemetry/assertFailureReporter.test.ts
@@ -26,7 +26,11 @@ describe('reportAssertFailure', () => {
       expect.objectContaining({
         message: '[Assertion failed]: graph must exist'
       }),
-      { errorType: 'invariant_assert', logToConsole: false }
+      {
+        errorType: 'invariant_assert',
+        context: { graphId: 'root', occurrenceCount: 1 },
+        logToConsole: false
+      }
     )
   })
 

--- a/src/platform/telemetry/assertFailureReporter.test.ts
+++ b/src/platform/telemetry/assertFailureReporter.test.ts
@@ -18,24 +18,37 @@ describe('reportAssertFailure', () => {
   it('reports an assertion failure as an invariant error', async () => {
     const reportAssertFailure = await loadReporter()
 
-    reportAssertFailure('[Assertion failed]: graph must exist')
+    reportAssertFailure('[Assertion failed]: graph must exist', {
+      graphId: 'root'
+    })
 
     expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         message: '[Assertion failed]: graph must exist'
       }),
-      { errorType: 'invariant_assert' }
+      {
+        errorType: 'invariant_assert',
+        context: { graphId: 'root', occurrenceCount: 1 },
+        logToConsole: false
+      }
     )
   })
 
-  it('deduplicates repeats so a render-loop invariant reports once', async () => {
+  it('reports coarse recurrence thresholds without reporting every repeat', async () => {
     const reportAssertFailure = await loadReporter()
 
-    reportAssertFailure('same message')
-    reportAssertFailure('same message')
-    reportAssertFailure('same message')
+    for (let i = 0; i < 100; i++) {
+      reportAssertFailure('same message')
+    }
 
-    expect(mockReportError).toHaveBeenCalledOnce()
+    expect(mockReportError).toHaveBeenCalledTimes(3)
+    expect(
+      mockReportError.mock.calls.map(([, options]) => options.context)
+    ).toEqual([
+      { occurrenceCount: 1 },
+      { occurrenceCount: 10 },
+      { occurrenceCount: 100 }
+    ])
   })
 
   it('caps distinct reports per session', async () => {

--- a/src/platform/telemetry/assertFailureReporter.test.ts
+++ b/src/platform/telemetry/assertFailureReporter.test.ts
@@ -26,11 +26,7 @@ describe('reportAssertFailure', () => {
       expect.objectContaining({
         message: '[Assertion failed]: graph must exist'
       }),
-      {
-        errorType: 'invariant_assert',
-        context: { graphId: 'root', occurrenceCount: 1 },
-        logToConsole: false
-      }
+      { errorType: 'invariant_assert', logToConsole: false }
     )
   })
 

--- a/src/platform/telemetry/assertFailureReporter.ts
+++ b/src/platform/telemetry/assertFailureReporter.ts
@@ -29,7 +29,6 @@ export function reportAssertFailure(
 
   reportError(new Error(message), {
     errorType: 'invariant_assert',
-    context: { ...context, occurrenceCount },
     logToConsole: false
   })
 }

--- a/src/platform/telemetry/assertFailureReporter.ts
+++ b/src/platform/telemetry/assertFailureReporter.ts
@@ -29,6 +29,7 @@ export function reportAssertFailure(
 
   reportError(new Error(message), {
     errorType: 'invariant_assert',
+    context: { ...context, occurrenceCount },
     logToConsole: false
   })
 }

--- a/src/platform/telemetry/assertFailureReporter.ts
+++ b/src/platform/telemetry/assertFailureReporter.ts
@@ -1,21 +1,35 @@
 import { reportError } from './reportError'
 
 const MAX_REPORTS_PER_SESSION = 20
+const REPORTABLE_OCCURRENCE_COUNTS = new Set([1, 10, 100, 1000])
 
-const reportedMessages = new Set<string>()
+const occurrenceCounts = new Map<string, number>()
 
 /**
  * Send an assertion failure to diagnostic error reporting.
  *
- * Invariants can fire from render loops, so reports are deduplicated by exact
- * message and capped per session.
+ * Invariants can fire from render loops, so only coarse recurrence thresholds
+ * are reported and the number of distinct messages is capped per session.
  */
-export function reportAssertFailure(message: string): void {
-  if (reportedMessages.has(message)) return
-  if (reportedMessages.size >= MAX_REPORTS_PER_SESSION) return
-  reportedMessages.add(message)
+export function reportAssertFailure(
+  message: string,
+  context?: Record<string, unknown>
+): void {
+  const previousCount = occurrenceCounts.get(message)
+  if (
+    previousCount === undefined &&
+    occurrenceCounts.size >= MAX_REPORTS_PER_SESSION
+  ) {
+    return
+  }
+
+  const occurrenceCount = (previousCount ?? 0) + 1
+  occurrenceCounts.set(message, occurrenceCount)
+  if (!REPORTABLE_OCCURRENCE_COUNTS.has(occurrenceCount)) return
 
   reportError(new Error(message), {
-    errorType: 'invariant_assert'
+    errorType: 'invariant_assert',
+    context: { ...context, occurrenceCount },
+    logToConsole: false
   })
 }

--- a/src/platform/telemetry/assetLoadErrorReporting.test.ts
+++ b/src/platform/telemetry/assetLoadErrorReporting.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock('./reportError', () => ({
+  reportError: mockReportError
+}))
+
+import {
+  reportPreloadError,
+  reportResourceLoadError
+} from './assetLoadErrorReporting'
+
+describe('asset load error reporting', () => {
+  let consoleError: MockInstance<typeof console.error>
+
+  beforeEach(() => {
+    mockReportError.mockClear()
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('on cloud, where a sink exists', () => {
+    beforeEach(() => {
+      vi.stubGlobal('__DISTRIBUTION__', 'cloud')
+    })
+
+    it('reports a resource failure once and leaves the console to reportError', () => {
+      reportResourceLoadError('https://cloud.comfy.org/assets/app.css', 'link')
+
+      expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          message:
+            'Resource load failed: https://cloud.comfy.org/assets/app.css'
+        }),
+        expect.objectContaining({
+          errorType: 'resource_load_error',
+          tags: { tag_name: 'link' }
+        })
+      )
+      expect(consoleError).not.toHaveBeenCalled()
+    })
+
+    it('reports a preload failure once and leaves the console to reportError', () => {
+      const error = new Error(
+        'Failed to fetch dynamically imported module: https://cloud.comfy.org/assets/app-123.js'
+      )
+
+      reportPreloadError(error)
+
+      expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+        error,
+        expect.objectContaining({ errorType: 'vite_preload_error' })
+      )
+      expect(consoleError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('off cloud, where no sink exists', () => {
+    beforeEach(() => {
+      vi.stubGlobal('__DISTRIBUTION__', 'localhost')
+    })
+
+    it('logs a resource failure locally instead of reporting it', () => {
+      reportResourceLoadError('http://localhost:5173/assets/app.css', 'link')
+
+      expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+        '[resource:loadError]',
+        { url: 'http://localhost:5173/assets/app.css', tagName: 'link' }
+      )
+      expect(mockReportError).not.toHaveBeenCalled()
+    })
+
+    it('logs a preload failure locally instead of reporting it', () => {
+      reportPreloadError(
+        new Error(
+          'Failed to fetch dynamically imported module: http://localhost:5173/assets/app-123.js'
+        )
+      )
+
+      expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+        '[vite:preloadError]',
+        expect.objectContaining({
+          url: 'http://localhost:5173/assets/app-123.js',
+          fileType: 'js'
+        })
+      )
+      expect(mockReportError).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/platform/telemetry/assetLoadErrorReporting.ts
+++ b/src/platform/telemetry/assetLoadErrorReporting.ts
@@ -1,0 +1,47 @@
+import { parsePreloadError } from '@/utils/preloadErrorUtil'
+
+import { reportError } from './reportError'
+
+/**
+ * Asset failures reach a sink only on cloud builds, and `reportError` writes
+ * the console line there. Every other distribution logs locally instead, so
+ * one failure never produces two console lines or two RUM events.
+ */
+export function reportResourceLoadError(url: string, tagName: string): void {
+  if (__DISTRIBUTION__ !== 'cloud') {
+    console.error('[resource:loadError]', { url, tagName })
+    return
+  }
+
+  reportError(new Error(`Resource load failed: ${url}`), {
+    errorType: 'resource_load_error',
+    tags: { tag_name: tagName }
+  })
+}
+
+export function reportPreloadError(error: Error): void {
+  const info = parsePreloadError(error)
+
+  if (__DISTRIBUTION__ !== 'cloud') {
+    console.error('[vite:preloadError]', {
+      url: info.url,
+      fileType: info.fileType,
+      chunkName: info.chunkName,
+      message: info.message
+    })
+    return
+  }
+
+  reportError(error, {
+    errorType: 'vite_preload_error',
+    tags: {
+      file_type: info.fileType,
+      chunk_name: info.chunkName ?? undefined
+    },
+    context: {
+      url: info.url,
+      fileType: info.fileType,
+      chunkName: info.chunkName
+    }
+  })
+}

--- a/src/platform/telemetry/datadogRumBeforeSend.test.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.test.ts
@@ -1,23 +1,85 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import type { RumErrorEvent } from '@datadog/browser-rum'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setAssertReporter } from '@/base/assert'
 
 import { classifyRumErrorOrigin, rumBeforeSend } from './datadogRumBeforeSend'
 
-function createErrorEvent(message: string, stack?: string): RumErrorEvent {
+function createErrorEvent(
+  message: string,
+  stack?: string,
+  source: RumErrorEvent['error']['source'] = 'source'
+): RumErrorEvent {
   return fromPartial<RumErrorEvent>({
     type: 'error',
-    error: { message, source: 'source', stack }
+    error: { message, source, stack }
   })
 }
 
 describe('rumBeforeSend', () => {
+  beforeEach(() => {
+    setAssertReporter(vi.fn(), { forwardsToRum: true })
+  })
+
+  afterEach(() => {
+    setAssertReporter(null)
+  })
+
   it('drops known third-party network noise', () => {
     const event = createErrorEvent(
       'Failed to fetch https://px.ads.linkedin.com/pixel'
     )
 
     expect(rumBeforeSend(event, fromPartial({}))).toBe(false)
+  })
+
+  it('drops the console echo of an assertion the reporter also reports', () => {
+    const event = createErrorEvent(
+      '[Assertion failed]: graph is corrupt',
+      undefined,
+      'console'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(false)
+  })
+
+  it('keeps the reported copy of an assertion failure', () => {
+    const event = createErrorEvent(
+      '[Assertion failed]: graph is corrupt',
+      undefined,
+      'custom'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(true)
+  })
+
+  it('keeps ordinary console errors that are not assertion failures', () => {
+    const event = createErrorEvent('Application failed', undefined, 'console')
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(true)
+  })
+
+  it('keeps the console copy while no reporter exists to replace it', () => {
+    setAssertReporter(null)
+    const event = createErrorEvent(
+      '[Assertion failed]: fired before boot finished',
+      undefined,
+      'console'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(true)
+  })
+
+  it('keeps the console copy when the installed reporter does not forward to RUM', () => {
+    setAssertReporter(vi.fn())
+    const event = createErrorEvent(
+      '[Assertion failed]: handled by another telemetry sink',
+      undefined,
+      'console'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(true)
   })
 
   it('keeps application errors and tags their origin', () => {

--- a/src/platform/telemetry/datadogRumBeforeSend.test.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.test.ts
@@ -44,6 +44,16 @@ describe('rumBeforeSend', () => {
     expect(rumBeforeSend(event, fromPartial({}))).toBe(false)
   })
 
+  it('drops the console echo of an error reportError already sent', () => {
+    const event = createErrorEvent(
+      '[Reported error]: canvas_layout_listener_failed Error: listener failed',
+      undefined,
+      'console'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(false)
+  })
+
   it('keeps the reported copy of an assertion failure', () => {
     const event = createErrorEvent(
       '[Assertion failed]: graph is corrupt',

--- a/src/platform/telemetry/datadogRumBeforeSend.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.ts
@@ -1,5 +1,7 @@
 import type { RumBeforeSend, RumErrorEvent } from '@datadog/browser-rum'
 
+import { ASSERTION_FAILURE_PREFIX, hasRumAssertReporter } from '@/base/assert'
+
 const RUM_NOISE_HOSTS = [
   'facebook.com',
   'px.ads.linkedin.com',
@@ -33,8 +35,21 @@ export function classifyRumErrorOrigin(stack?: string): RumErrorOrigin {
   return { origin: 'third_party' }
 }
 
+/**
+ * RUM collects `console.error` on its own, so a reported assertion arrives
+ * twice — untagged from the console, and tagged.
+ */
+function isConsoleEchoOfReportedAssertion(event: RumErrorEvent): boolean {
+  return (
+    hasRumAssertReporter() &&
+    event.error.source === 'console' &&
+    event.error.message.startsWith(ASSERTION_FAILURE_PREFIX)
+  )
+}
+
 function shouldKeepRumEvent(event: Parameters<RumBeforeSend>[0]): boolean {
   if (event.type !== 'error') return true
+  if (isConsoleEchoOfReportedAssertion(event)) return false
 
   const message = event.error.message
   if (message.startsWith('intervention:')) return false

--- a/src/platform/telemetry/datadogRumBeforeSend.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.ts
@@ -2,6 +2,8 @@ import type { RumBeforeSend, RumErrorEvent } from '@datadog/browser-rum'
 
 import { ASSERTION_FAILURE_PREFIX, hasRumAssertReporter } from '@/base/assert'
 
+import { REPORTED_ERROR_PREFIX } from './reportError'
+
 const RUM_NOISE_HOSTS = [
   'facebook.com',
   'px.ads.linkedin.com',
@@ -47,9 +49,21 @@ function isConsoleEchoOfReportedAssertion(event: RumErrorEvent): boolean {
   )
 }
 
+/**
+ * `reportError` logs every report, so its console line arrives here as a
+ * second, untagged copy of an error RUM already has.
+ */
+function isConsoleEchoOfReportedError(event: RumErrorEvent): boolean {
+  return (
+    event.error.source === 'console' &&
+    event.error.message.startsWith(REPORTED_ERROR_PREFIX)
+  )
+}
+
 function shouldKeepRumEvent(event: Parameters<RumBeforeSend>[0]): boolean {
   if (event.type !== 'error') return true
   if (isConsoleEchoOfReportedAssertion(event)) return false
+  if (isConsoleEchoOfReportedError(event)) return false
 
   const message = event.error.message
   if (message.startsWith('intervention:')) return false

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -49,11 +49,44 @@ describe('reportError', () => {
       })
     )
     expect(addError).toHaveBeenCalledWith(
-      error,
+      expect.objectContaining({
+        name: 'workspace_auth_gate_initialization_failure',
+        message: error.message
+      }),
       expect.objectContaining({
         error_type: 'workspace_auth_gate_initialization_failure'
       })
     )
+  })
+
+  it('names a Datadog copy without changing the original error', async () => {
+    const { reportError } = await loadReportError()
+    const cause = new Error('Connection closed')
+    const error = Object.freeze(
+      Object.assign(
+        new TypeError('Failed to fetch /assets/app-123.js', { cause }),
+        {
+          dd_fingerprint: 'asset_load',
+          dd_context: { asset: '/assets/app-123.js' }
+        }
+      )
+    )
+
+    reportError(error, { errorType: 'resource_load_error' })
+
+    const [datadogError] = addError.mock.calls[0]
+    expect(datadogError).toBeInstanceOf(Error)
+    expect(datadogError).not.toBe(error)
+    expect(datadogError).toMatchObject({
+      name: 'resource_load_error',
+      message: error.message,
+      stack: error.stack,
+      cause,
+      dd_fingerprint: error.dd_fingerprint,
+      dd_context: error.dd_context
+    })
+    expect(captureException.mock.calls[0][0]).toBe(error)
+    expect(error.name).toBe('TypeError')
   })
 
   it('still reports to Datadog when Sentry is inert', async () => {
@@ -78,7 +111,10 @@ describe('reportError', () => {
     flushErrorReports()
 
     expect(addError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'early' }),
+      expect.objectContaining({
+        name: 'resource_load_error',
+        message: 'early'
+      }),
       expect.objectContaining({ error_type: 'resource_load_error' })
     )
   })
@@ -118,7 +154,10 @@ describe('reportError', () => {
     reportError('just a string', { errorType: 'bootstrap_auth_wait_timeout' })
 
     expect(addError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'just a string' }),
+      expect.objectContaining({
+        name: 'bootstrap_auth_wait_timeout',
+        message: 'just a string'
+      }),
       expect.anything()
     )
   })

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -218,40 +218,6 @@ describe('reportError', () => {
     expect(() => flushErrorReports()).not.toThrow()
   })
 
-  it('does not resend to Sentry when a buffered Datadog delivery fails', async () => {
-    mockIsCloud.value = true
-    sentryLive(false)
-    datadogLive(false)
-    const { reportError, flushErrorReports } = await loadReportError()
-
-    reportError(new Error('cold boot'), { errorType: 'invariant_assert' })
-
-    sentryLive(true)
-    datadogLive(true)
-    addError.mockImplementationOnce(() => {
-      throw new Error('datadog exploded')
-    })
-    flushErrorReports()
-    flushErrorReports()
-
-    expect(captureException).toHaveBeenCalledOnce()
-    expect(addError).toHaveBeenCalledTimes(2)
-  })
-
-  it('retries only Sentry when its cloud delivery fails', async () => {
-    mockIsCloud.value = true
-    captureException.mockImplementationOnce(() => {
-      throw new Error('sentry exploded')
-    })
-    const { reportError, flushErrorReports } = await loadReportError()
-
-    reportError(new Error('boom'), { errorType: 'invariant_assert' })
-    flushErrorReports()
-
-    expect(captureException).toHaveBeenCalledTimes(2)
-    expect(addError).toHaveBeenCalledOnce()
-  })
-
   it('writes the failure to the console so callers need no second sink', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { reportError, REPORTED_ERROR_PREFIX } = await loadReportError()
@@ -308,7 +274,7 @@ describe('reportError', () => {
     expect(consoleError).toHaveBeenCalledOnce()
   })
 
-  it('still reports to Datadog when Sentry throws', async () => {
+  it('does not throw when a sink throws', async () => {
     captureException.mockImplementation(() => {
       throw new Error('sentry exploded')
     })

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -4,6 +4,13 @@ const captureException = vi.fn()
 const isEnabled = vi.fn()
 const addError = vi.fn()
 const getInitConfiguration = vi.fn()
+const mockIsCloud = { value: false }
+
+vi.mock(import('@/platform/distribution/types'), () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
 
 vi.mock('@sentry/vue', () => ({
   captureException: (...args: unknown[]) => captureException(...args),
@@ -28,6 +35,7 @@ const datadogLive = (live: boolean) =>
 
 describe('reportError', () => {
   beforeEach(() => {
+    mockIsCloud.value = false
     sentryLive(true)
     datadogLive(true)
   })
@@ -133,6 +141,26 @@ describe('reportError', () => {
     expect(addError).toHaveBeenCalledOnce()
   })
 
+  it('retains the Datadog delivery when Sentry starts first on cloud', async () => {
+    mockIsCloud.value = true
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+    const error = new Error('early assertion')
+
+    reportError(error, { errorType: 'invariant_assert' })
+    flushErrorReports()
+
+    expect(captureException).toHaveBeenCalledOnce()
+    expect(addError).not.toHaveBeenCalled()
+
+    datadogLive(true)
+    flushErrorReports()
+    flushErrorReports()
+
+    expect(captureException).toHaveBeenCalledOnce()
+    expect(addError).toHaveBeenCalledOnce()
+  })
+
   it('bounds the buffer so a boot-time error storm cannot grow without limit', async () => {
     sentryLive(false)
     datadogLive(false)
@@ -190,7 +218,97 @@ describe('reportError', () => {
     expect(() => flushErrorReports()).not.toThrow()
   })
 
-  it('does not throw when a sink throws', async () => {
+  it('does not resend to Sentry when a buffered Datadog delivery fails', async () => {
+    mockIsCloud.value = true
+    sentryLive(false)
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    reportError(new Error('cold boot'), { errorType: 'invariant_assert' })
+
+    sentryLive(true)
+    datadogLive(true)
+    addError.mockImplementationOnce(() => {
+      throw new Error('datadog exploded')
+    })
+    flushErrorReports()
+    flushErrorReports()
+
+    expect(captureException).toHaveBeenCalledOnce()
+    expect(addError).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries only Sentry when its cloud delivery fails', async () => {
+    mockIsCloud.value = true
+    captureException.mockImplementationOnce(() => {
+      throw new Error('sentry exploded')
+    })
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    reportError(new Error('boom'), { errorType: 'invariant_assert' })
+    flushErrorReports()
+
+    expect(captureException).toHaveBeenCalledTimes(2)
+    expect(addError).toHaveBeenCalledOnce()
+  })
+
+  it('writes the failure to the console so callers need no second sink', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { reportError, REPORTED_ERROR_PREFIX } = await loadReportError()
+    const error = new Error('listener failed')
+
+    reportError(error, { errorType: 'canvas_layout_listener_failed' })
+
+    expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+      `${REPORTED_ERROR_PREFIX}canvas_layout_listener_failed`,
+      error
+    )
+  })
+
+  it('logs a warning-level report through console.warn', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { reportError, REPORTED_ERROR_PREFIX } = await loadReportError()
+
+    reportError(new Error('cookie denied'), {
+      errorType: 'session_cookie_creation_failure',
+      level: 'warning'
+    })
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      `${REPORTED_ERROR_PREFIX}session_cookie_creation_failure`,
+      expect.any(Error)
+    )
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('skips the console line for a caller that already logged', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { reportError } = await loadReportError()
+
+    reportError(new Error('[Assertion failed]: graph must exist'), {
+      errorType: 'invariant_assert',
+      logToConsole: false
+    })
+
+    expect(consoleError).not.toHaveBeenCalled()
+    expect(addError).toHaveBeenCalledOnce()
+  })
+
+  it('logs a buffered report once, when it is raised', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    sentryLive(false)
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    reportError(new Error('early'), { errorType: 'resource_load_error' })
+    datadogLive(true)
+    flushErrorReports()
+
+    expect(consoleError).toHaveBeenCalledOnce()
+  })
+
+  it('still reports to Datadog when Sentry throws', async () => {
     captureException.mockImplementation(() => {
       throw new Error('sentry exploded')
     })
@@ -201,5 +319,6 @@ describe('reportError', () => {
         errorType: 'bootstrap_auth_wait_timeout'
       })
     ).not.toThrow()
+    expect(addError).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -8,8 +8,8 @@ import { toError } from '@/utils/errorUtil'
 export interface ReportErrorOptions {
   /**
    * Stable machine-readable slug for this failure mode. Lands as the
-   * `error_type` Sentry tag and the `error_type` RUM context field, so the
-   * same query works against either console.
+   * native RUM `error.type`, the `error_type` Sentry tag, and the legacy
+   * `error_type` RUM context field.
    */
   errorType: string
   tags?: Record<string, string | number | boolean | undefined>
@@ -55,7 +55,12 @@ function dispatch(error: Error, options: ReportErrorOptions): boolean {
     })
   }
   if (datadogLive) {
-    datadogRum.addError(error, {
+    const datadogError = Object.assign(
+      new Error(error.message, { cause: error.cause }),
+      error,
+      { name: errorType, stack: error.stack }
+    )
+    datadogRum.addError(datadogError, {
       ...context,
       ...tags,
       error_type: errorType,

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -3,6 +3,7 @@ import { datadogRum } from '@datadog/browser-rum'
 // eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { captureException, isEnabled as isSentryEnabled } from '@sentry/vue'
 
+import { isCloud } from '@/platform/distribution/types'
 import { toError } from '@/utils/errorUtil'
 
 export interface ReportErrorOptions {
@@ -20,14 +21,14 @@ export interface ReportErrorOptions {
 interface PendingReport {
   error: Error
   options: ReportErrorOptions
+  sentryDelivered: boolean
+  datadogDelivered: boolean
 }
 
 /**
  * Reports raised before any sink is live are held here rather than dropped.
- * Sentry initializes synchronously in main.ts but Datadog RUM arrives behind
- * `initTelemetry()`'s dynamic imports, so early-boot failures — the ones that
- * leave a user on the splash screen — would otherwise vanish exactly when
- * they matter most.
+ * On cloud, Datadog RUM arrives behind `initTelemetry()`'s dynamic imports, so
+ * its delivery remains pending even when Sentry received the report first.
  */
 const pendingReports: PendingReport[] = []
 const MAX_PENDING_REPORTS = 25
@@ -41,34 +42,65 @@ const definedEntriesOf = (
     Object.entries(tags ?? {}).filter(([, value]) => value !== undefined)
   ) as Record<string, string | number | boolean>
 
-function dispatch(error: Error, options: ReportErrorOptions): boolean {
+function dispatch(
+  error: Error,
+  options: ReportErrorOptions,
+  sentryAlreadyDelivered = false,
+  datadogAlreadyDelivered = false
+): { sentry: boolean; datadog: boolean } {
   const { errorType, context, level } = options
   const tags = definedEntriesOf(options.tags)
-  const sentryLive = isSentryEnabled()
-  const datadogLive = isDatadogRumLive()
+  const sentryLive = !sentryAlreadyDelivered && isSentryEnabled()
+  const datadogLive = !datadogAlreadyDelivered && isDatadogRumLive()
+  let sentryDelivered = false
+  let datadogDelivered = false
 
   if (sentryLive) {
-    captureException(error, {
-      tags: { ...tags, error_type: errorType },
-      extra: context,
-      level
-    })
+    try {
+      captureException(error, {
+        tags: { ...tags, error_type: errorType },
+        extra: context,
+        level
+      })
+      sentryDelivered = true
+    } catch (reporterFailure) {
+      console.error(
+        '[reportError] Sentry delivery failed',
+        reporterFailure,
+        error
+      )
+    }
   }
   if (datadogLive) {
-    const datadogError = Object.assign(
-      new Error(error.message, { cause: error.cause }),
-      error,
-      { name: errorType, stack: error.stack }
-    )
-    datadogRum.addError(datadogError, {
-      ...context,
-      ...tags,
-      error_type: errorType,
-      ...(level ? { level } : {})
-    })
+    try {
+      const datadogError = Object.assign(
+        new Error(error.message, { cause: error.cause }),
+        error,
+        { name: errorType, stack: error.stack }
+      )
+      datadogRum.addError(datadogError, {
+        ...context,
+        ...tags,
+        error_type: errorType,
+        ...(level ? { level } : {})
+      })
+      datadogDelivered = true
+    } catch (reporterFailure) {
+      console.error(
+        '[reportError] Datadog delivery failed',
+        reporterFailure,
+        error
+      )
+    }
   }
 
-  return sentryLive || datadogLive
+  return { sentry: sentryDelivered, datadog: datadogDelivered }
+}
+
+function enqueuePendingReport(report: PendingReport): void {
+  if (pendingReports.length < MAX_PENDING_REPORTS) {
+    pendingReports.push(report)
+  }
 }
 
 /**
@@ -84,10 +116,27 @@ export function flushErrorReports(): void {
   if (!isSentryEnabled() && !isDatadogRumLive()) return
 
   const drained = pendingReports.splice(0, pendingReports.length)
-  for (const { error, options } of drained) {
+  for (const report of drained) {
+    const { error, options } = report
     try {
-      dispatch(error, options)
+      const delivered = dispatch(
+        error,
+        options,
+        report.sentryDelivered,
+        report.datadogDelivered
+      )
+      const sentryDelivered = report.sentryDelivered || delivered.sentry
+      const datadogDelivered = report.datadogDelivered || delivered.datadog
+      if (isCloud && (!sentryDelivered || !datadogDelivered)) {
+        enqueuePendingReport({
+          error,
+          options,
+          sentryDelivered,
+          datadogDelivered
+        })
+      }
     } catch (reporterFailure) {
+      enqueuePendingReport(report)
       console.error('[reportError] failed to flush', reporterFailure, error)
     }
   }
@@ -108,11 +157,24 @@ export function reportError(cause: unknown, options: ReportErrorOptions): void {
     flushErrorReports()
 
     const error = toError(cause)
-    if (dispatch(error, options)) return
-
-    if (pendingReports.length < MAX_PENDING_REPORTS) {
-      pendingReports.push({ error, options })
+    const delivered = dispatch(error, options)
+    if (isCloud && (!delivered.sentry || !delivered.datadog)) {
+      enqueuePendingReport({
+        error,
+        options,
+        sentryDelivered: delivered.sentry,
+        datadogDelivered: delivered.datadog
+      })
+      return
     }
+    if (delivered.sentry || delivered.datadog) return
+
+    enqueuePendingReport({
+      error,
+      options,
+      sentryDelivered: false,
+      datadogDelivered: false
+    })
   } catch (reporterFailure) {
     console.error('[reportError] failed to report', reporterFailure, cause)
   }

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -6,6 +6,13 @@ import { captureException, isEnabled as isSentryEnabled } from '@sentry/vue'
 import { isCloud } from '@/platform/distribution/types'
 import { toError } from '@/utils/errorUtil'
 
+/**
+ * Marks the console line `reportError()` writes for every report. RUM collects
+ * `console.error` on its own, so `datadogRumBeforeSend` matches on this to drop
+ * the untagged console copy of a failure it already received tagged.
+ */
+export const REPORTED_ERROR_PREFIX = '[Reported error]: '
+
 export interface ReportErrorOptions {
   /**
    * Stable machine-readable slug for this failure mode. Lands as the
@@ -16,6 +23,11 @@ export interface ReportErrorOptions {
   tags?: Record<string, string | number | boolean | undefined>
   context?: Record<string, unknown>
   level?: 'warning' | 'error'
+  /**
+   * Opt out of the console line for callers that already wrote one — only
+   * `assert()`, which logs before any reporter is registered.
+   */
+  logToConsole?: boolean
 }
 
 interface PendingReport {
@@ -150,10 +162,19 @@ export function flushErrorReports(): void {
  * `workspace_auth_gate_initialization_failure` stayed invisible on every
  * Datadog dashboard while it was firing in production.
  *
+ * Also writes the failure to the console, so callers never pair this with a
+ * `console.error` of their own: Sentry is off in DEV, RUM only comes up behind
+ * `initTelemetry()`, and a caller that forgot the pair went silent on dev and
+ * self-hosted installs.
+ *
  * Never throws — a failing error reporter must not become a second failure.
  */
 export function reportError(cause: unknown, options: ReportErrorOptions): void {
   try {
+    if (options.logToConsole !== false) {
+      const log = options.level === 'warning' ? console.warn : console.error
+      log(`${REPORTED_ERROR_PREFIX}${options.errorType}`, cause)
+    }
     flushErrorReports()
 
     const error = toError(cause)

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -727,25 +727,17 @@ describe('useWorkflowService', () => {
           return true
         })
 
-      const consoleError = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => undefined)
       const firstOpen = useWorkflowService().openWorkflow(first)
       const secondOpen = useWorkflowService().openWorkflow(second)
 
       await expect(firstOpen).rejects.toBe(error)
       await expect(secondOpen).resolves.toBe(true)
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining('queued workflow load failed'),
-        error
-      )
       expect(reportErrorMock).toHaveBeenCalledWith(error, {
         errorType: 'workflow_load_failure'
       })
       expect(
         subgraphNavigationMocks.endWorkflowNavigation
       ).toHaveBeenCalledWith(1)
-      consoleError.mockRestore()
       expect(
         vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
       ).toEqual([first, second])

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -108,7 +108,6 @@ function queueWorkflowLoad<T>(
   const settledResult = result
     .catch((error) => {
       // Keep fire-and-forget load failures observable.
-      console.error('[workflowService] queued workflow load failed', error)
       reportError(error, { errorType: 'workflow_load_failure' })
       return undefined
     })

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -181,7 +181,6 @@ async function initialize(): Promise<void> {
     }
   } catch (error) {
     if (generation !== initializationGeneration) return
-    console.error('[WorkspaceAuthGate] Initialization failed:', error)
     reportError(error, {
       errorType: 'workspace_auth_gate_initialization_failure'
     })

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -2,7 +2,7 @@ import { toGroupId } from '@/types/groupId'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -19,6 +19,11 @@ import type {
   LayoutOperation,
   NodeLayout
 } from '@/renderer/core/layout/types'
+
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
+}))
 
 const GRAPH = createUuidv4()
 
@@ -299,6 +304,130 @@ describe('layoutStore CRDT operations', () => {
 
     unsubscribeNode()
     unsubscribeGlobal()
+  })
+
+  it('reports listener failures by scope and continues fan-out', async () => {
+    const nodeId = toNodeId('failing-listener-node')
+    const layout = createTestNode(nodeId)
+
+    layoutStore.applyOperation({
+      type: 'createNode',
+      graphId: GRAPH,
+      nodeId,
+      layout,
+      timestamp: Date.now(),
+      source: LayoutSource.Canvas,
+      actor: 'test'
+    })
+
+    const errors = {
+      geometry: new Error('geometry listener failed'),
+      global: new Error('global listener failed'),
+      node: new Error('node listener failed')
+    }
+    const listenersBefore = {
+      geometry: vi.fn(),
+      global: vi.fn(),
+      node: vi.fn()
+    }
+    const listenersAfter = {
+      geometry: vi.fn(),
+      global: vi.fn(),
+      node: vi.fn()
+    }
+    const stopBeforeGeometry = layoutStore.onGeometryChange(
+      listenersBefore.geometry
+    )
+    const stopFailingGeometry = layoutStore.onGeometryChange(() => {
+      throw errors.geometry
+    })
+    const stopAfterGeometry = layoutStore.onGeometryChange(
+      listenersAfter.geometry
+    )
+    const stopBeforeGlobal = layoutStore.onChange(listenersBefore.global)
+    const stopFailingGlobal = layoutStore.onChange(() => {
+      throw errors.global
+    })
+    const stopAfterGlobal = layoutStore.onChange(listenersAfter.global)
+    const stopBeforeNode = layoutStore.onNodeChange(
+      GRAPH,
+      nodeId,
+      listenersBefore.node
+    )
+    const stopFailingNode = layoutStore.onNodeChange(GRAPH, nodeId, () => {
+      throw errors.node
+    })
+    const stopAfterNode = layoutStore.onNodeChange(
+      GRAPH,
+      nodeId,
+      listenersAfter.node
+    )
+    onTestFinished(() => {
+      stopBeforeGeometry()
+      stopFailingGeometry()
+      stopAfterGeometry()
+      stopBeforeGlobal()
+      stopFailingGlobal()
+      stopAfterGlobal()
+      stopBeforeNode()
+      stopFailingNode()
+      stopAfterNode()
+    })
+
+    layoutStore.applyOperation({
+      type: 'moveNode',
+      graphId: GRAPH,
+      nodeId,
+      position: { x: 300, y: 200 },
+      timestamp: Date.now(),
+      source: LayoutSource.Canvas,
+      actor: 'test'
+    })
+
+    await vi.waitFor(() => {
+      expect(mockReportError).toHaveBeenCalledTimes(3)
+    })
+
+    for (const listener of Object.values(listenersBefore)) {
+      expect(listener).toHaveBeenCalledOnce()
+    }
+    for (const listener of Object.values(listenersAfter)) {
+      expect(listener).toHaveBeenCalledOnce()
+    }
+    for (const scope of ['geometry', 'global', 'node'] as const) {
+      expect(mockReportError).toHaveBeenCalledWith(errors[scope], {
+        errorType: 'canvas_layout_listener_failed',
+        tags: {
+          failure_kind: 'caught_unexpected',
+          feature_area: 'canvas',
+          operation: 'sync',
+          outcome: 'failed',
+          listener_scope: scope
+        },
+        level: 'error'
+      })
+    }
+
+    layoutStore.applyOperation({
+      type: 'moveNode',
+      graphId: GRAPH,
+      nodeId,
+      position: { x: 400, y: 300 },
+      timestamp: Date.now(),
+      source: LayoutSource.Canvas,
+      actor: 'test'
+    })
+
+    await vi.waitFor(() => {
+      expect(listenersAfter.geometry).toHaveBeenCalledTimes(2)
+    })
+    expect(mockReportError).toHaveBeenCalledTimes(3)
+    for (const listener of Object.values(listenersBefore)) {
+      expect(listener).toHaveBeenCalledTimes(2)
+    }
+    for (const listener of Object.values(listenersAfter)) {
+      expect(listener).toHaveBeenCalledTimes(2)
+    }
   })
 
   it('clears node-scoped listeners when the viewed graph changes', () => {

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -6,6 +6,7 @@ import * as Y from 'yjs'
 import { toGroupId } from '@/types/groupId'
 import { toNodeId } from '@/types/nodeId'
 import type { GroupId } from '@/types/groupId'
+import { reportError } from '@/platform/telemetry/reportError'
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
 import { toRerouteId } from '@/types/rerouteId'
 import type { UUID } from '@/utils/uuid'
@@ -161,6 +162,11 @@ function isSlotOffsetSnapshotEqual(
   return true
 }
 
+type LayoutListenerScope = 'geometry' | 'global' | 'node'
+type LayoutListener =
+  | ((change: LayoutChange) => void)
+  | ((graphIds: ReadonlySet<UUID>) => void)
+
 class LayoutStoreImpl {
   private static readonly REROUTE_DEFAULTS: RerouteData = {
     id: toRerouteId(0),
@@ -195,6 +201,14 @@ class LayoutStoreImpl {
   private geometryListeners = new Set<(graphIds: ReadonlySet<UUID>) => void>()
   private pendingGeometryChanges: ReadonlySet<UUID>[] = []
   private isGeometryDispatchQueued = false
+  private readonly reportedListenerFailures: Record<
+    LayoutListenerScope,
+    WeakSet<LayoutListener>
+  > = {
+    geometry: new WeakSet(),
+    global: new WeakSet(),
+    node: new WeakSet()
+  }
 
   // New data structures for hit testing
   private linkLayouts = new Map<LinkId, LinkLayout>()
@@ -1263,10 +1277,32 @@ class LayoutStoreImpl {
           try {
             listener(change)
           } catch (error) {
-            console.error('Error in layout geometry listener:', error)
+            this.reportListenerFailure(error, 'geometry', listener)
           }
         }
       }
+    })
+  }
+
+  private reportListenerFailure(
+    error: unknown,
+    scope: LayoutListenerScope,
+    listener: LayoutListener
+  ): void {
+    const reportedFailures = this.reportedListenerFailures[scope]
+    if (reportedFailures.has(listener)) return
+    reportedFailures.add(listener)
+
+    reportError(error, {
+      errorType: 'canvas_layout_listener_failed',
+      tags: {
+        failure_kind: 'caught_unexpected',
+        feature_area: 'canvas',
+        operation: 'sync',
+        outcome: 'failed',
+        listener_scope: scope
+      },
+      level: 'error'
     })
   }
 
@@ -1275,7 +1311,7 @@ class LayoutStoreImpl {
       try {
         listener(change)
       } catch (error) {
-        console.error('Error in layout change listener:', error)
+        this.reportListenerFailure(error, 'global', listener)
       }
     })
   }
@@ -1292,7 +1328,7 @@ class LayoutStoreImpl {
         try {
           listener(change)
         } catch (error) {
-          console.error('Error in node-scoped layout change listener:', error)
+          this.reportListenerFailure(error, 'node', listener)
         }
       })
     }

--- a/src/schemas/nodeDef/inputSpecUtil.test.ts
+++ b/src/schemas/nodeDef/inputSpecUtil.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { setAssertReporter } from '@/base/assert'
 import { flattenInputSpecs } from '@/schemas/nodeDef/inputSpecUtil'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -207,7 +208,14 @@ describe('flattenInputSpecs', () => {
     )
 
     vi.stubEnv('DEV', false)
+    const reporter = vi.fn()
+    setAssertReporter(reporter)
     const result = flattenInputSpecs(nodeDefImpl.inputs)
     expect(result.map((spec) => spec.name)).toEqual(['model'])
+    expect(reporter).toHaveBeenCalledWith(
+      expect.stringContaining('expected an options array'),
+      { specName: 'model' }
+    )
+    setAssertReporter(null)
   })
 })

--- a/src/schemas/nodeDef/inputSpecUtil.ts
+++ b/src/schemas/nodeDef/inputSpecUtil.ts
@@ -33,7 +33,7 @@ export function flattenInputSpecs(
     if (!Array.isArray(options)) {
       assert(
         false,
-        `flattenInputSpecs: expected an options array on dynamic combo "${spec.name}"`
+        'flattenInputSpecs: expected an options array on dynamic combo'
       )
       continue
     }

--- a/src/schemas/nodeDef/inputSpecUtil.ts
+++ b/src/schemas/nodeDef/inputSpecUtil.ts
@@ -33,7 +33,8 @@ export function flattenInputSpecs(
     if (!Array.isArray(options)) {
       assert(
         false,
-        'flattenInputSpecs: expected an options array on dynamic combo'
+        'flattenInputSpecs: expected an options array on dynamic combo',
+        { specName: spec.name }
       )
       continue
     }

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -277,7 +277,7 @@ describe('ChangeTracker', () => {
         expect(app.rootGraph.serialize).not.toHaveBeenCalled()
         expect(mockAssert).toHaveBeenCalledWith(
           false,
-          expect.stringContaining('captureCanvasState')
+          'ChangeTracker.captureCanvasState() called on inactive tracker'
         )
       })
     })
@@ -1210,7 +1210,7 @@ describe('ChangeTracker', () => {
       expect(mockNodeOutputStore.snapshotOutputs).not.toHaveBeenCalled()
       expect(mockAssert).toHaveBeenCalledWith(
         false,
-        expect.stringContaining('deactivate')
+        'ChangeTracker.deactivate() called on inactive tracker'
       )
     })
   })

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -231,18 +231,11 @@ function getExecutionGraphState(value: unknown): unknown {
 
 const reportedInactiveCalls = new Set<string>()
 
-/**
- * Report a ChangeTracker method being called on an inactive tracker.
- * Deduplicates per method+workflow per session to avoid signal noise on hot paths.
- */
 function reportInactiveTrackerCall(method: string, workflowPath: string) {
   const key = `${method}:${workflowPath}`
   if (reportedInactiveCalls.has(key)) return
   reportedInactiveCalls.add(key)
-  assert(
-    false,
-    `ChangeTracker.${method}() called on inactive tracker for: ${workflowPath}`
-  )
+  assert(false, `ChangeTracker.${method}() called on inactive tracker`)
 }
 
 export class ChangeTracker {

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -184,6 +184,9 @@ describe('bootstrapStore', () => {
 
     it('gives up after a second timeout, reports it, and continues bootstrap unauthenticated', async () => {
       vi.useFakeTimers()
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
       try {
         const store = useBootstrapStore()
         const settingStore = useSettingStore()
@@ -197,6 +200,7 @@ describe('bootstrapStore', () => {
         expect(mockReportError).toHaveBeenCalledWith(expect.anything(), {
           errorType: 'bootstrap_auth_wait_timeout'
         })
+        expect(consoleError).not.toHaveBeenCalled()
         // Bootstrap must not stay stuck: stores load even when Firebase never fires.
         expect(settingStore.isReady).toBe(true)
       } finally {

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -65,10 +65,6 @@ async function waitForCloudAuth(): Promise<void> {
     try {
       await waitForResolution()
     } catch (retryError) {
-      console.error(
-        '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
-        retryError
-      )
       reportError(retryError, { errorType: 'bootstrap_auth_wait_timeout' })
     }
   }

--- a/src/stores/subgraphNavigationStore.navigateToHash.test.ts
+++ b/src/stores/subgraphNavigationStore.navigateToHash.test.ts
@@ -349,7 +349,9 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
         expect.stringContaining('workflow load failed')
       )
       expect(reportErrorMock).toHaveBeenCalledWith(expect.any(Error), {
-        errorType: 'workflow_navigation_failure'
+        errorType: 'workflow_navigation_failure',
+        level: 'warning',
+        context: { stage: 'recovery' }
       })
     })
     warnSpy.mockRestore()

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -329,11 +329,11 @@ export const useSubgraphNavigationStore = defineStore(
             )
           } catch (err) {
             if (navigationId !== navigationIntentId) return
-            console.warn(
-              '[subgraphNavigation] openWorkflow rejected during recovery',
-              err
-            )
-            reportError(err, { errorType: 'workflow_navigation_failure' })
+            reportError(err, {
+              errorType: 'workflow_navigation_failure',
+              level: 'warning',
+              context: { stage: 'recovery' }
+            })
             return redirectToRoot('workflow load failed', navigationId)
           }
           if (navigationId !== navigationIntentId) return

--- a/src/workbench/extensions/agent/crdt/schemaGuard.test.ts
+++ b/src/workbench/extensions/agent/crdt/schemaGuard.test.ts
@@ -53,8 +53,9 @@ describe('assertReadableSchema (KA-11, fail-closed on read)', () => {
       FollowerSchemaError
     )
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('schema_version=99')
+      expect.stringContaining('meta.schema_version is not the layout')
     )
+    expect(consoleError).not.toHaveBeenCalledWith(expect.stringContaining('99'))
   })
 
   it('never writes the doc it refuses (KA-6: the follower is read-only)', () => {

--- a/src/workbench/extensions/agent/crdt/schemaGuard.test.ts
+++ b/src/workbench/extensions/agent/crdt/schemaGuard.test.ts
@@ -2,6 +2,8 @@ import { SCHEMA_VERSION, mint } from '@comfyorg/comfy-multi-player'
 import { describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
 
+import { setAssertReporter } from '@/base/assert'
+
 import { FollowerSchemaError, assertReadableSchema } from './schemaGuard'
 
 function docAtVersion(version: unknown): Y.Doc {
@@ -56,6 +58,21 @@ describe('assertReadableSchema (KA-11, fail-closed on read)', () => {
       expect.stringContaining('meta.schema_version is not the layout')
     )
     expect(consoleError).not.toHaveBeenCalledWith(expect.stringContaining('99'))
+  })
+
+  it('reports the rejected version as structured context', () => {
+    vi.stubEnv('DEV', false)
+    const reporter = vi.fn()
+    setAssertReporter(reporter)
+
+    expect(() => assertReadableSchema(docAtVersion(99))).toThrow(
+      FollowerSchemaError
+    )
+    expect(reporter).toHaveBeenCalledWith(
+      expect.stringContaining('meta.schema_version is not the layout'),
+      { found: 99 }
+    )
+    setAssertReporter(null)
   })
 
   it('never writes the doc it refuses (KA-6: the follower is read-only)', () => {

--- a/src/workbench/extensions/agent/crdt/schemaGuard.ts
+++ b/src/workbench/extensions/agent/crdt/schemaGuard.ts
@@ -61,7 +61,8 @@ export function assertReadableSchema(doc: Y.Doc): void {
     // every environment, Sentry reporter in production.
     assert(
       false,
-      'CRDT follower: doc meta.schema_version is not the layout this build reads — refusing to project it (fail-closed, keep-alive invariant KA-11)'
+      'CRDT follower: doc meta.schema_version is not the layout this build reads — refusing to project it (fail-closed, keep-alive invariant KA-11)',
+      { found }
     )
   } catch {
     // Swallowed on purpose. `assert` throws only under DEV, so it is NOT a

--- a/src/workbench/extensions/agent/crdt/schemaGuard.ts
+++ b/src/workbench/extensions/agent/crdt/schemaGuard.ts
@@ -59,7 +59,10 @@ export function assertReadableSchema(doc: Y.Doc): void {
   try {
     // Route through the repo's central invariant channel: console.error in
     // every environment, Sentry reporter in production.
-    assert(false, message)
+    assert(
+      false,
+      'CRDT follower: doc meta.schema_version is not the layout this build reads — refusing to project it (fail-closed, keep-alive invariant KA-11)'
+    )
   } catch {
     // Swallowed on purpose. `assert` throws only under DEV, so it is NOT a
     // fail-closed mechanism by itself — outside DEV it returns normally and


### PR DESCRIPTION
Backport of the telemetry assertion-fidelity fix to cloud/1.53, with its prerequisites. Sibling of the already-merged [core/1.53 backport](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17425).

- Backports [preserve assertion diagnostic fidelity](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15671) (merged to main as `3d7c5d4df3`).
- Pulls in the three commits it depends on that were not yet on cloud/1.53: [report each assertion failure to RUM exactly once](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16333), [report stable native Datadog error types](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17085), and [report layout listener failures to telemetry](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17040).
- Targeted vitest (`src/platform/telemetry`: 29 files, 393 tests) passes on this branch.

<details><summary>Full context for agent readers</summary>

Cherry-picked with `-x`, in dependency order, onto `35c46f0ec9` (origin/cloud/1.53):

1. `83fb266a6e` (RUM exactly-once) — required by the assertion code path.
2. `74564e32d3` (stable native error types) — required by the assertion code path.
3. `3d7c5d4df3` (the fix itself).
4. `cf15ffd685` (layout listener failures) — required because three `reportError.test.ts` tests introduced by the fix rely on the layout-listener `reportError()` behavior.
5. `e2a2cd419f` alignment commit, cloud-only: the cherry-pick of `cf15ffd685` conflicted in `assertFailureReporter.ts` and the automatic resolution dropped `occurrenceCount` from the reported `context`. This commit restores `context: { ...context, occurrenceCount }` and the matching test expectation, so the file now matches the core/1.53 version byte-for-byte.

Not pulled: `606fb5eedf` (already present on 1.53), and unrelated main.ts changes `ee86e426ef` / `05672356c6`.

<!-- authored-by:agent supreme-operator w3-w42 -->
</details>
