### PR TITLE
FE-2209: inline node and asset references with readable Copy

### DIFF
--- a/browser_tests/fixtures/agentInlineReferencesFixture.ts
+++ b/browser_tests/fixtures/agentInlineReferencesFixture.ts
@@ -1,0 +1,63 @@
+import type { UploadImageResponse } from '@comfyorg/ingest-types'
+import { mergeTests } from '@playwright/test'
+
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { agentTest } from '@e2e/fixtures/agentPanelFixture'
+import { workflowSelectionTest } from '@e2e/fixtures/agentWorkflowSelectionFixture'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+export const referenceNode: ComfyNodeDef = {
+  name: 'ColorBalance',
+  display_name: 'Color balance',
+  description: 'A node used to verify scoped Agent references.',
+  category: 'image',
+  python_module: 'tests.color_balance',
+  output_node: false,
+  input: { required: {} },
+  output: []
+}
+
+export const referenceWorkflow: ComfyWorkflowJSON = {
+  last_node_id: 12,
+  last_link_id: 0,
+  version: 0.4,
+  nodes: [
+    {
+      id: 12,
+      type: 'ColorBalance',
+      pos: [400, 250],
+      size: [240, 80],
+      flags: {},
+      order: 0,
+      mode: 0,
+      properties: {}
+    }
+  ],
+  links: []
+}
+
+const base = mergeTests(agentTest, workflowSelectionTest, webSocketFixture)
+
+export const inlineReferencesTest = base.extend<{
+  assetUpload: { finish: () => void }
+}>({
+  assetUpload: async ({ page }, use) => {
+    let finish = () => {}
+    const pending = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    const response: UploadImageResponse = {
+      name: 'reference.png',
+      subfolder: '',
+      type: 'input'
+    }
+    await page.route('**/api/upload/image', async (route) => {
+      await pending
+      return route.fulfill(jsonRoute(response))
+    })
+    await use({ finish })
+    finish()
+  }
+})

--- a/browser_tests/fixtures/agentWorkflowSelectionFixture.ts
+++ b/browser_tests/fixtures/agentWorkflowSelectionFixture.ts
@@ -1,6 +1,7 @@
 import { networkIsolationFixture as base } from '@e2e/fixtures/networkIsolationFixture'
 
 import type { UserDataFullInfo } from '@/schemas/apiSchema'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { CloudWorkflowEntry } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
 import { bootAgentApp } from '@e2e/fixtures/agentPanelFixture'
@@ -16,10 +17,18 @@ type WorkflowSelection = {
 }
 
 export const workflowSelectionTest = base.extend<{
+  nodeDefinitions: Record<string, ComfyNodeDef> | undefined
   workflowSelection: WorkflowSelection
 }>({
-  workflowSelection: async ({ page }, use) => {
-    await bootAgentApp(page, true)
+  nodeDefinitions: [undefined, { option: true }],
+  workflowSelection: async ({ page, nodeDefinitions }, use) => {
+    if (nodeDefinitions)
+      await page.route('**/api/object_info', (route) =>
+        route.fulfill(jsonRoute(nodeDefinitions))
+      )
+    await bootAgentApp(page, true, {
+      objectInfo: nodeDefinitions ? 'server' : undefined
+    })
     const workflows: CloudWorkflowEntry[] = []
     const savedFiles: UserDataFullInfo[] = []
     const savedContent = new Map<string, string>()

--- a/browser_tests/tests/agent/agentInlineReferences.spec.ts
+++ b/browser_tests/tests/agent/agentInlineReferences.spec.ts
@@ -1,0 +1,111 @@
+import { expect } from '@playwright/test'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import {
+  inlineReferencesTest as test,
+  referenceNode,
+  referenceWorkflow
+} from '@e2e/fixtures/agentInlineReferencesFixture'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+
+test.use({
+  connectWebSocketToServer: false,
+  nodeDefinitions: { ColorBalance: referenceNode },
+  permissions: ['clipboard-read', 'clipboard-write']
+})
+
+test(
+  'keeps inline node and asset removal synchronized with the upper rows and Undo',
+  { tag: ['@cloud', '@ui'] },
+  async ({ page, workflowSelection, assetUpload }) => {
+    await page.locator('#comfy-file-input').setInputFiles({
+      name: 'Portrait study.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(referenceWorkflow))
+    })
+    await page
+      .getByRole('button', { name: enMessages.agent.askComfyAgent })
+      .click()
+    const panel = page.locator('#agent-panel-root')
+    const editor = panel.getByRole('textbox')
+    await panel
+      .getByRole('button', { name: enMessages.agent.switchWorkflow })
+      .click()
+    await page.getByRole('menuitemradio', { name: /Portrait study/ }).click()
+    await expect.poll(() => workflowSelection.savedPaths.length).toBe(1)
+    workflowSelection.finishSave(true)
+    await editor.fill('Adjust @')
+    await panel
+      .getByRole('menuitem', { name: enMessages.agent.nodes, exact: true })
+      .click()
+    await panel.getByRole('menuitem', { name: /Color balance/ }).click()
+    await expect(editor).toHaveText('Adjust Color balance #12 ')
+    await editor.pressSequentially('to match ')
+    await panel
+      .getByTestId('agent-file-input')
+      .setInputFiles(assetPath('test_upload_image.png'))
+    const text = 'Adjust Color balance #12 to match test_upload_image.png '
+    await expect(editor).toHaveText(text)
+    await expect(
+      panel.getByRole('button', { name: enMessages.agent.send, exact: true })
+    ).toBeDisabled()
+    await panel
+      .getByTestId('composer-asset-section')
+      .getByRole('button', { name: enMessages.agent.remove, exact: true })
+      .click()
+    assetUpload.finish()
+    await expect(editor.getByTestId('asset-reference-chip')).toHaveCount(0)
+    await editor.press('ControlOrMeta+z')
+    await expect(editor).toHaveText(text)
+    await expect(
+      panel.getByRole('button', { name: enMessages.agent.send, exact: true })
+    ).toBeEnabled()
+    await panel
+      .getByRole('button', { name: 'Remove Color balance #12 reference' })
+      .click()
+    await expect(editor).toHaveText('Adjust  to match test_upload_image.png ')
+    await expect(panel.getByTestId('composer-node-section')).toHaveCount(0)
+    await editor.press('ControlOrMeta+z')
+    await expect(editor).toHaveText(text)
+    await expect(panel.getByTestId('composer-node-section')).toHaveText(
+      'Color balance'
+    )
+
+    await editor.press('ControlOrMeta+a')
+    await editor.press('ControlOrMeta+c')
+    await expect
+      .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe(
+        'Adjust @[Node: Color balance #12] to match @[Image: test_upload_image.png] '
+      )
+    await editor.press('ArrowRight')
+    await page
+      .getByRole('button', {
+        name: enMessages.sideToolbar.newBlankWorkflow,
+        exact: true
+      })
+      .click()
+    await panel
+      .getByRole('button', { name: enMessages.agent.switchWorkflow })
+      .click()
+    await page
+      .getByRole('menuitemradio', { name: 'Unsaved Workflow (2)', exact: true })
+      .click()
+    await expect.poll(() => workflowSelection.savedPaths.length).toBe(2)
+    workflowSelection.finishSave(true)
+    await expect(editor.getByTestId('node-reference-chip')).toHaveCount(0)
+    await editor.press('ControlOrMeta+a')
+    await editor.press('Backspace')
+    await editor.press('ControlOrMeta+v')
+    await expect(editor).toHaveText(
+      'Adjust @[Node: Color balance #12] to match @[Image: test_upload_image.png] '
+    )
+    await expect(editor.getByTestId('node-reference-chip')).toHaveCount(0)
+    await expect(editor.getByTestId('asset-reference-chip')).toHaveCount(0)
+    await expect(panel.getByTestId('composer-node-section')).toHaveCount(0)
+    await expect(panel.getByTestId('composer-asset-section')).toHaveCount(0)
+    await expect(
+      panel.getByRole('button', { name: enMessages.agent.switchWorkflow })
+    ).toHaveText('Unsaved Workflow (2)')
+  }
+)

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -2004,7 +2004,13 @@ describe('AgentPanelRoot transcript copy', () => {
     const convo = useAgentConversationStore()
     const turnId = 'turn-1' as TurnId
     convo.setThreadId('th-1')
-    convo.recordUser(turnId, 'make a cat')
+    convo.recordUser(
+      turnId,
+      'make a cat with ',
+      [{ name: 'brief.txt', ref: 'brief.txt' }],
+      ['KSampler #12'],
+      [{ id: 'reference', name: 'Portrait', textOffset: 16 }]
+    )
     convo.startTurn(turnId)
     convo.ingest(
       zAgentWsEventForTest({
@@ -2050,7 +2056,7 @@ describe('AgentPanelRoot transcript copy', () => {
     )
 
     expect(clipboard.copy).toHaveBeenCalledWith(
-      '**You:** make a cat\n\n**Agent:** Here is a cat.'
+      '**You:** make a cat with @[Workflow: Portrait]\n@[Node: KSampler #12]\n@[File: brief.txt]\n\n**Agent:** Here is a cat.'
     )
   })
 })

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -912,14 +912,18 @@ describe('AgentPanelRoot attach flow', () => {
     const input = screen.getByTestId<HTMLInputElement>('agent-file-input')
     await userEvent.upload(input, file)
 
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'cat.png'
+      )
+    ).toBeInTheDocument()
 
     await userEvent.type(screen.getByRole('textbox'), 'make it pop')
     await userEvent.click(screen.getByRole('button', { name: 'Send' }))
 
     expect(messageBodies).toHaveLength(1)
     expect(messageBodies[0]).toMatchObject({
-      content: 'make it pop',
+      content: 'make it pop@[Image: cat.png]',
       attachments: ['uploaded_cat.png']
     })
     expect(telemetry.trackAgentMessageSent).toHaveBeenCalledWith({
@@ -948,7 +952,11 @@ describe('AgentPanelRoot attach flow', () => {
       movie
     )
 
-    expect(await screen.findByText('movie.mp4')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'movie.mp4'
+      )
+    ).toBeInTheDocument()
     await vi.waitFor(() => expect(uploaded).toEqual(['movie.mp4']))
   })
 
@@ -1060,7 +1068,11 @@ describe('AgentPanelRoot attach flow', () => {
       dispatchDrag(screen.getByRole('textbox'), 'drop', { files: [movie] })
     ).toBe(true)
 
-    expect(await screen.findByText('movie.mp4')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'movie.mp4'
+      )
+    ).toBeInTheDocument()
     await vi.waitFor(() => expect(uploaded).toEqual(['movie.mp4']))
   })
 
@@ -1087,7 +1099,11 @@ describe('AgentPanelRoot attach flow', () => {
       })
     ).toBe(true)
 
-    expect(await screen.findByText(name)).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        name
+      )
+    ).toBeInTheDocument()
     await vi.waitFor(() => expect(uploaded).toEqual([name]))
   })
 
@@ -1262,14 +1278,18 @@ describe('AgentPanelRoot attach flow', () => {
       await nextTick()
       expect(screen.queryByRole('status')).not.toBeInTheDocument()
 
-      expect(await screen.findByText(filename)).toBeInTheDocument()
+      expect(
+        within(await screen.findByTestId('composer-asset-section')).getByText(
+          filename
+        )
+      ).toBeInTheDocument()
 
       await userEvent.type(screen.getByRole('textbox'), 'describe this')
       await userEvent.click(screen.getByRole('button', { name: 'Send' }))
 
       expect(messageBodies).toHaveLength(1)
       expect(messageBodies[0]).toMatchObject({
-        content: 'describe this',
+        content: `describe this@[${mime === 'image/png' ? 'Image' : 'Video'}: ${filename}]`,
         attachments: [`uploaded_${filename}`]
       })
     }
@@ -1317,8 +1337,16 @@ describe('AgentPanelRoot attach flow', () => {
 
       expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
       expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-      expect(await screen.findByText(filename)).toBeInTheDocument()
-      expect(screen.getAllByText(filename)).toHaveLength(1)
+      expect(
+        within(await screen.findByTestId('composer-asset-section')).getByText(
+          filename
+        )
+      ).toBeInTheDocument()
+      expect(
+        within(screen.getByTestId('composer-asset-section')).getAllByText(
+          filename
+        )
+      ).toHaveLength(1)
       expect(
         screen.queryByLabelText(i18n.global.t('agent.uploading'))
       ).not.toBeInTheDocument()
@@ -1372,7 +1400,11 @@ describe('AgentPanelRoot attach flow', () => {
     }
 
     expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-    expect(await screen.findByText('gen.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'gen.png'
+      )
+    ).toBeInTheDocument()
     expect(
       screen.getByLabelText(i18n.global.t('agent.uploading'))
     ).toBeInTheDocument()
@@ -1401,7 +1433,11 @@ describe('AgentPanelRoot attach flow', () => {
 
     const asset = new File(['x'], 'cat.png', { type: 'image/png' })
     expect(dispatchDrag(target, 'drop', { files: [asset] })).toBe(true)
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'cat.png'
+      )
+    ).toBeInTheDocument()
   })
 
   it('attaches only the assets out of a mixed drop', async () => {
@@ -1419,7 +1455,11 @@ describe('AgentPanelRoot attach flow', () => {
     ]
     dispatchDrag(screen.getByRole('textbox'), 'drop', { files })
 
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'cat.png'
+      )
+    ).toBeInTheDocument()
     await vi.waitFor(() => expect(uploaded).toEqual(['cat.png']))
   })
 
@@ -1451,7 +1491,11 @@ describe('AgentPanelRoot attach flow', () => {
       file
     )
 
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'cat.png'
+      )
+    ).toBeInTheDocument()
     expect(
       screen.getByLabelText(i18n.global.t('agent.uploading'))
     ).toBeInTheDocument()
@@ -1499,7 +1543,9 @@ describe('AgentPanelRoot attach flow', () => {
       screen.getByTestId<HTMLInputElement>('agent-file-input'),
       file
     )
-    await screen.findByText('cat.png')
+    within(await screen.findByTestId('composer-asset-section')).getByText(
+      'cat.png'
+    )
     await sendFromComposer('second message')
 
     const thumbs = screen.getAllByAltText('cat.png')
@@ -1541,7 +1587,11 @@ describe('AgentPanelRoot attach flow', () => {
       screen.getByTestId<HTMLInputElement>('agent-file-input'),
       file
     )
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'cat.png'
+      )
+    ).toBeInTheDocument()
 
     executionErrors.showErrorOverlay.mockClear()
     failUpload()
@@ -1561,7 +1611,7 @@ describe('AgentPanelRoot attach flow', () => {
     revoke.mockRestore()
   })
 
-  it('dismissing a staged chip removes it and releases its preview', async () => {
+  it('keeps a dismissed preview available for Undo until the editor unmounts', async () => {
     const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.stubGlobal(
       'fetch',
@@ -1583,19 +1633,25 @@ describe('AgentPanelRoot attach flow', () => {
       })
     )
 
-    renderWithSelectedTarget()
+    const view = renderWithSelectedTarget()
 
     const file = new File(['x'], 'cat.png', { type: 'image/png' })
     await userEvent.upload(
       screen.getByTestId<HTMLInputElement>('agent-file-input'),
       file
     )
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
+    expect(
+      within(await screen.findByTestId('composer-asset-section')).getByText(
+        'cat.png'
+      )
+    ).toBeInTheDocument()
 
     await userEvent.click(
       screen.getByRole('button', { name: i18n.global.t('agent.remove') })
     )
     expect(screen.queryByText('cat.png')).not.toBeInTheDocument()
+    expect(revoke).not.toHaveBeenCalled()
+    view.unmount()
     expect(revoke).toHaveBeenCalledTimes(1)
     revoke.mockRestore()
   })
@@ -4575,7 +4631,7 @@ describe('AgentPanelRoot workflow binding', () => {
         workflowStore.openWorkflows.some((tab) => tab.path === reference.path)
       ).toBe(true)
       expect(useAgentPanelStore().selectedWorkflow?.path).toBe(current.path)
-      expect(useAgentComposerStore().draft).toBe(' Keep this draft')
+      expect(useAgentComposerStore().draft).toBe('  Keep this draft')
       expect(
         screen.getByRole('button', { name: 'Open reference' })
       ).toBeVisible()
@@ -4595,7 +4651,7 @@ describe('AgentPanelRoot workflow binding', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Send' }))
       await vi.waitFor(() => expect(bodies).toHaveLength(1))
       expect(bodies[0]).toMatchObject({
-        content: 'Keep this draft',
+        content: '@[Node: KSampler #12]  Keep this draft',
         workflow_id: 'wf-cloud-current',
         selection: { node_ids: ['12'] },
         workflow_references: []
@@ -4894,14 +4950,14 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(screen.getByText('#7')).toBeInTheDocument()
     await userEvent.keyboard('{ArrowDown}{ArrowDown}{Tab}')
 
-    expect(useAgentComposerStore().draft).toBe('')
+    expect(useAgentComposerStore().draft).toBe(' ')
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     expect(screen.getAllByText('KSampler')).toHaveLength(1)
     expect(screen.getByText('#7')).toBeInTheDocument()
     await sendFromComposer('tune it')
 
     expect(bodies[0]).toMatchObject({
-      content: 'tune it',
+      content: '@[Node: KSampler #7] tune it',
       selection: { node_ids: ['7'] }
     })
   })
@@ -5321,7 +5377,7 @@ describe('AgentPanelRoot workflow binding', () => {
       )
       if (nextAction === 'untouched') {
         expect(useAgentComposerStore().draft).toBe(
-          '  Compare    Keep this draft  '
+          '   Compare     Keep this draft  '
         )
         expect(composer.workflowReferences).toEqual(originalReferences)
         expect(composer.attachments).toMatchObject([
@@ -5338,7 +5394,7 @@ describe('AgentPanelRoot workflow binding', () => {
         expect(bodies[1]).toMatchObject({
           workflow_id: 'wf-42',
           content:
-            'Compare [reference](workflow://wf-reference)   Keep this draft',
+            '@[Node: KSampler #12]   Compare [reference](workflow://wf-reference) @[Image: cat.png]   Keep this draft',
           selection: { node_ids: ['12'] },
           attachments: ['uploaded_cat.png'],
           workflow_references: [
@@ -5349,7 +5405,8 @@ describe('AgentPanelRoot workflow binding', () => {
         expect(useAgentComposerStore().draft).toBe(
           nextAction === 'new-draft'
             ? 'New input'
-            : nextAction === 'removed-reference'
+            : nextAction === 'removed-reference' ||
+                nextAction === 'removed-attachment'
               ? ' '
               : ''
         )

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -91,6 +91,7 @@ import { resolveAgentPaywallPresentation } from './services/agent/agentPaywallPr
 import { createAgentEventSource } from './services/agent/agentEventSource'
 import { createStandaloneAgentEventSource } from './services/agent/standaloneAgentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
+import { agentMessageText } from './utils/agentMessageText'
 import { useAgentComposerStore } from './stores/agent/agentComposerStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
 import {
@@ -744,7 +745,7 @@ async function onSelectHistory(id: string): Promise<void> {
 function buildTranscriptMarkdown(entries: ConversationEntry[]): string {
   return entries
     .map((entry) => {
-      if (entry.role === 'user') return `**You:** ${entry.text}`
+      if (entry.role === 'user') return `**You:** ${agentMessageText(entry)}`
       const text = entry.parts
         .filter((part) => part.type === 'text')
         .map((part) => part.text)

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -279,6 +279,7 @@ const nodeReferenceDisabledReason = computed(() => {
 const selectedNodes = computed<SelectedNode[]>(() =>
   canvasStore.selectedItems.filter(isLGraphNode).map(toSelectedNode)
 )
+composerStore.setNodeScope(selectedTarget.value?.path ?? null)
 const {
   staged: selectionTags,
   consume: consumeSelection,
@@ -286,6 +287,11 @@ const {
   add: addSelectionTag,
   replace: replaceSelectionTags
 } = useCanvasSelection({
+  staged: computed({
+    get: () => composerStore.nodes,
+    set: composerStore.setNodes
+  }),
+  retainWhenNotLive: true,
   selection: selectedNodes,
   enabled: () => agentEnabled.value && selectedTarget.value !== null,
   isLive: () => agentPanelStore.isOpen,
@@ -804,6 +810,7 @@ function onNewChat(): void {
   cancelWorkflowSelection()
   exitNodeSelectionMode()
   composerStore.setWorkflowReferences([])
+  composerStore.resetPromptHistory()
   newChat()
 }
 
@@ -861,7 +868,7 @@ watch(
   selectedTarget,
   (target, previous) => {
     exitNodeSelectionMode()
-    replaceSelectionTags([])
+    composerStore.setNodeScope(target?.path ?? null)
     nodeReferenceWorkflow = null
     agentNodeSelectionStore.saveNodeIds(previous?.path, [])
     agentNodeSelectionStore.saveNodeIds(target?.path, [])
@@ -931,9 +938,9 @@ const attachment = useAttachment({
   // must not raise the server-error overlay.
   onError: (message) =>
     toast.add({ severity: 'warn', detail: message, life: 5000 }),
-  stage: (staged) => panelRef.value?.addAttachment(staged),
-  update: (id, patch) => panelRef.value?.updateAttachment(id, patch),
-  remove: (id) => panelRef.value?.removeAttachment(id)
+  stage: composerStore.addAttachment,
+  update: composerStore.updateAttachment,
+  remove: composerStore.removeAttachment
 })
 
 function onAttach(): void {

--- a/src/workbench/extensions/agent/components/agent/Composer.inlineReferences.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.inlineReferences.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor, within } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, defineComponent, h, ref } from 'vue'
+
+import { i18n } from '@/i18n'
+import type { SelectedNode } from '../../composables/agent/useCanvasSelection'
+import { useCanvasSelection } from '../../composables/agent/useCanvasSelection'
+import { useAgentComposerStore } from '../../stores/agent/agentComposerStore'
+import Composer from './Composer.vue'
+import { setupInlinePromptEditorDom } from './composer/inlinePromptEditorTestSetup'
+
+setupInlinePromptEditorDom()
+
+function renderComposer() {
+  const store = useAgentComposerStore()
+  store.setNodeScope('workflow-A')
+  const selected = ref<SelectedNode[]>([])
+  const send = vi.fn()
+  const Host = defineComponent({
+    setup() {
+      const selection = useCanvasSelection({
+        staged: computed({ get: () => store.nodes, set: store.setNodes }),
+        selection: selected,
+        scope: () => store.nodeScope,
+        isLive: true
+      })
+      return () =>
+        h(Composer, {
+          hasWorkflowTarget: true,
+          selectionTags: selection.staged.value,
+          onRemoveTag: selection.remove,
+          onSend: send
+        })
+    }
+  })
+  const view = render(Host, {
+    global: { plugins: [i18n], directives: { tooltip: () => {} } }
+  })
+  return { ...view, store, selected, send, editor: screen.getByRole('textbox') }
+}
+
+describe('inline node and asset references', () => {
+  beforeEach(() => vi.useRealTimers())
+
+  it('keeps upper-row removal and Undo synchronized with inline references', async () => {
+    const { store, selected, editor, send } = renderComposer()
+    await userEvent.type(editor, 'Use ')
+    selected.value = [{ id: '12', title: 'KSampler' }]
+    await waitFor(() => expect(editor.textContent).toBe('Use KSampler #12 '))
+    await userEvent.keyboard('with ')
+    store.addAttachment({
+      id: 'image',
+      name: 'source.png',
+      ref: 'uploaded.png'
+    })
+    await waitFor(() =>
+      expect(editor.textContent).toBe('Use KSampler #12 with source.png ')
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove KSampler #12 reference' })
+    )
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('composer-node-section')
+      ).not.toBeInTheDocument()
+    )
+    expect(editor.textContent).toBe('Use  with source.png ')
+    expect(store.nodes).toEqual([])
+    editor.focus()
+    await userEvent.keyboard('{Control>}z{/Control}')
+    await waitFor(() =>
+      expect(screen.getByTestId('composer-node-section')).toHaveTextContent(
+        'KSampler'
+      )
+    )
+    expect(editor.textContent).toBe('Use KSampler #12 with source.png ')
+
+    await userEvent.click(
+      within(screen.getByTestId('composer-asset-section')).getByRole('button', {
+        name: 'Remove'
+      })
+    )
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('composer-asset-section')
+      ).not.toBeInTheDocument()
+    )
+    expect(editor.textContent).toBe('Use KSampler #12 with  ')
+    editor.focus()
+    await userEvent.keyboard('{Control>}z{/Control}')
+    await waitFor(() =>
+      expect(screen.getByTestId('composer-asset-section')).toHaveTextContent(
+        'source.png'
+      )
+    )
+    expect(editor.textContent).toBe('Use KSampler #12 with source.png ')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(send).toHaveBeenCalledWith(
+      'Use @[Node: KSampler #12] with @[Image: source.png]',
+      [{ id: 'image', name: 'source.png', ref: 'uploaded.png' }]
+    )
+  })
+
+  it('does not reinsert a removed asset when its upload completes', async () => {
+    const { store, editor } = renderComposer()
+    await userEvent.type(editor, 'Inspect ')
+    store.addAttachment({
+      id: 'image',
+      name: 'pending.png',
+      ref: '',
+      uploading: true
+    })
+    await screen.findByTestId('asset-reference-chip')
+    await userEvent.click(
+      within(screen.getByTestId('composer-asset-section')).getByRole('button', {
+        name: 'Remove'
+      })
+    )
+    store.updateAttachment('image', { ref: 'complete.png', uploading: false })
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('asset-reference-chip')
+      ).not.toBeInTheDocument()
+    )
+    expect(
+      screen.queryByTestId('composer-asset-section')
+    ).not.toBeInTheDocument()
+    editor.focus()
+    await userEvent.keyboard('{Control>}z{/Control}')
+    await screen.findByTestId('asset-reference-chip')
+    expect(store.attachments).toEqual([
+      {
+        id: 'image',
+        name: 'pending.png',
+        ref: 'complete.png',
+        uploading: false
+      }
+    ])
+  })
+
+  it('deletes a node from the sentence without restaging the selected canvas node', async () => {
+    const { store, selected, editor } = renderComposer()
+    await userEvent.type(editor, 'Use ')
+    selected.value = [{ id: '12', title: 'KSampler' }]
+    await screen.findByTestId('node-reference-chip')
+    await userEvent.keyboard('{Backspace}{Backspace}')
+    expect(editor.textContent).toBe('Use ')
+    expect(store.nodes).toEqual([])
+    expect(
+      screen.queryByTestId('composer-node-section')
+    ).not.toBeInTheDocument()
+    selected.value = [{ id: '12', title: 'KSampler' }]
+    await userEvent.keyboard('another node')
+    expect(store.nodes).toEqual([])
+  })
+
+  it('copies mixed references as readable text and pastes text after a target change', async () => {
+    const user = userEvent.setup()
+    const { store, selected, editor } = renderComposer()
+    await user.type(editor, '参考 🐈 ')
+    selected.value = [{ id: '12', title: 'KSampler' }]
+    await screen.findByTestId('node-reference-chip')
+    store.addAttachment({ id: 'image', name: 'source.png', ref: 'source.png' })
+    await screen.findByTestId('asset-reference-chip')
+    await user.keyboard('{Control>}a{/Control}')
+    const clipboard = await user.copy()
+    const text = '参考 🐈 @[Node: KSampler #12] @[Image: source.png] '
+    expect(clipboard?.getData('text/plain')).toBe(text)
+
+    selected.value = []
+    store.setNodeScope('workflow-B')
+    store.replaceDraft({ text: '', workflowReferences: [], attachments: [] })
+    await waitFor(() => expect(editor.textContent).toBe(''))
+    await user.click(editor)
+    await user.paste(text)
+    expect(editor.textContent).toBe(text)
+    expect(store.nodeScope).toBe('workflow-B')
+    expect(store.prompt.references).toEqual([])
+    expect(
+      screen.queryByTestId('composer-asset-section')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('composer-node-section')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/workbench/extensions/agent/components/agent/Composer.inlineReferences.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.inlineReferences.test.ts
@@ -172,6 +172,15 @@ describe('inline node and asset references', () => {
 
     selected.value = []
     store.setNodeScope('workflow-B')
+    await waitFor(() => expect(editor.textContent).toBe('参考 🐈  source.png '))
+    await user.click(editor)
+    await user.keyboard('{Control>}z{/Control}')
+    expect(editor.textContent).toBe('参考 🐈  source.png ')
+    expect(store.nodes).toEqual([])
+    expect(screen.queryByTestId('node-reference-chip')).not.toBeInTheDocument()
+    expect(screen.getByTestId('asset-reference-chip')).toHaveTextContent(
+      'source.png'
+    )
     store.replaceDraft({ text: '', workflowReferences: [], attachments: [] })
     await waitFor(() => expect(editor.textContent).toBe(''))
     await user.click(editor)

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -434,9 +434,9 @@ defineExpose({
                 ? `agent-reference-item-${mentionActive}`
                 : undefined
             "
+            :history-epoch="composer.promptEpoch.value"
             :editable-workflow-id
             @keydown="onComposerKeydown"
-            :history-epoch="composer.promptEpoch.value"
             @update:model-value="composer.applyEditorPrompt"
             @keyup="onComposerKeyup"
             @input="syncMention"

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -17,6 +17,7 @@ import { useI18n } from 'vue-i18n'
 import { buildAgentTooltipConfig } from '@/composables/useTooltipConfig'
 
 import InlinePromptEditor from './composer/InlinePromptEditor.vue'
+import { composerPromptForSend } from '../../utils/composerPrompt'
 import { useAgentMentionPicker } from '../../composables/agent/useAgentMentionPicker'
 import { useWorkflowReferencePicker } from '../../composables/agent/useWorkflowReferencePicker'
 import type { ComposerAttachment } from '../../composables/agent/useComposer'
@@ -99,10 +100,9 @@ const composer = useComposer({
       return
     }
     if (workflowReferences.value.length > 0) {
-      const draft = composer.draft.value
-      const offsets = workflowReferences.value.map(
-        (reference) => reference.textOffset
-      )
+      const { text: draft, workflowReferences: references } =
+        composerPromptForSend(composer.prompt.value)
+      const offsets = references.map((reference) => reference.textOffset)
       const start = Math.min(
         draft.length - draft.trimStart().length,
         ...offsets
@@ -112,7 +112,7 @@ const composer = useComposer({
         'send',
         draft.slice(start, end),
         attachments,
-        workflowReferences.value.map((reference) => ({
+        references.map((reference) => ({
           ...reference,
           textOffset: Math.min(
             end - start,
@@ -185,6 +185,12 @@ function onWorkflowSubmenuOpenChange(open: boolean): void {
 
 async function pickWorkflow(workflow: WorkflowReferenceOption): Promise<void> {
   if (await selectWorkflow(workflow)) addMenuOpen.value = false
+}
+
+function onEditorSelectionChange(): void {
+  const point = editorRef.value?.insertionPoint()
+  if (point) composer.setInsertionPoint(point)
+  syncMention()
 }
 
 function onComposerKeydown(event: KeyboardEvent): void {
@@ -401,7 +407,7 @@ defineExpose({
           :name="item.name"
           :preview-url="item.previewUrl"
           :uploading="item.uploading"
-          @remove="composer.removeAttachment(item.id)"
+          @remove="composer.removeReference(`asset:${item.id}`)"
         />
       </div>
 
@@ -430,20 +436,24 @@ defineExpose({
             "
             :editable-workflow-id
             @keydown="onComposerKeydown"
-            @update:model-value="composer.replacePrompt"
+            :history-epoch="composer.promptEpoch.value"
+            @update:model-value="composer.applyEditorPrompt"
             @keyup="onComposerKeyup"
             @input="syncMention"
-            @selection-change="syncMention"
+            @selection-change="onEditorSelectionChange"
             @click="syncMention"
             @blur="closeMention()"
             @open-reference-workflow="
               (id, name) => emit('openReferenceWorkflow', id, name)
             "
+            @remove-node-reference="emit('removeTag', $event)"
             @remove-workflow-reference="emit('removeWorkflowReference', $event)"
           />
 
           <div
-            v-if="!composer.draft.value && !workflowReferences.length"
+            v-if="
+              !composer.draft.value && !composer.prompt.value.references.length
+            "
             class="text-agent-fg-muted pointer-events-none relative z-10 -mt-7 font-inter text-[14px]/[20px] font-normal"
           >
             <span>{{ placeholderHint.text }} </span>

--- a/src/workbench/extensions/agent/components/agent/Composer.workflowClipboard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.workflowClipboard.test.ts
@@ -100,6 +100,50 @@ describe('workflow reference clipboard', () => {
     expect(editor.textContent).toBe('New: Before 参考 🐈 between Missing after')
   })
 
+  it('restores only workflows from a mixed-reference copy and leaves node and asset labels as text', async () => {
+    const user = userEvent.setup()
+    const { store, editor } = renderComposer()
+    store.setNodeScope('target-A')
+    store.restorePrompt({
+      text: 'Use   ',
+      references: [
+        {
+          kind: 'workflow',
+          id: 'workflow-B',
+          name: 'Reference B',
+          textOffset: 4
+        },
+        {
+          kind: 'node',
+          scope: 'target-A',
+          node: { id: '12', title: 'Sampler' },
+          textOffset: 5
+        },
+        {
+          kind: 'asset',
+          attachment: { id: 'image', name: 'source.png', ref: 'source.png' },
+          textOffset: 6
+        }
+      ]
+    })
+    await screen.findByTestId('workflow-reference-chip')
+    await user.click(editor)
+    await user.keyboard('{Control>}a{/Control}')
+    const clipboard = await user.copy()
+    store.replaceDraft({ text: '', workflowReferences: [], attachments: [] })
+    await waitFor(() => expect(editor.textContent).toBe(''))
+    await user.click(editor)
+    await user.paste(clipboard)
+    expect(editor.textContent).toBe(
+      'Use Reference B @[Node: Sampler #12] @[Image: source.png]'
+    )
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: 'Reference B', textOffset: 4 }
+    ])
+    expect(store.nodes).toEqual([])
+    expect(store.attachments).toEqual([])
+  })
+
   it('does not infer workflow identity from plain text', async () => {
     const user = userEvent.setup()
     const { store, editor } = renderComposer()

--- a/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Node } from '@tiptap/pm/model'
 import { DOMParser, Fragment, Slice } from '@tiptap/pm/model'
 import { baseKeymap } from '@tiptap/pm/commands'
 import { closeHistory, history, redo, undo } from '@tiptap/pm/history'
@@ -9,15 +10,25 @@ import { onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
 import DOMPurify from 'dompurify'
 import { useI18n } from 'vue-i18n'
 
+import type { ComposerPrompt } from '../../../types/composerPrompt'
+import {
+  composerReferenceKey,
+  composerReferenceName
+} from '../../../types/composerPrompt'
+import { sameComposerReferenceOrder } from '../../../utils/composerPrompt'
+import {
+  assetReferenceText,
+  nodeReferenceText
+} from '../../../utils/agentMessageText'
+import { selectedNodeKey } from '../../../composables/agent/useCanvasSelection'
 import type { PromptEditor } from '../../../types/promptEditor'
-import type {
-  PromptSnapshot,
-  WorkflowReferenceMetadata
-} from '../../../types/workflowReference'
+import type { WorkflowReferenceMetadata } from '../../../types/workflowReference'
 import {
   inlinePromptSchema,
   promptDocument,
   promptDocumentPosition,
+  promptInsertionPoint,
+  promptNodeReference,
   promptDraft,
   promptTextOffset
 } from './inlinePrompt'
@@ -27,15 +38,17 @@ const {
   label,
   expanded = false,
   activeDescendant,
+  historyEpoch = 0,
   editableWorkflowId
 } = defineProps<{
   label: string
   expanded?: boolean
   activeDescendant?: string
+  historyEpoch?: number
   editableWorkflowId?: string
 }>()
-const model = defineModel<PromptSnapshot>({
-  default: () => ({ text: '', workflowReferences: [] })
+const model = defineModel<ComposerPrompt>({
+  default: () => ({ text: '', references: [] })
 })
 const emit = defineEmits<{
   input: []
@@ -46,6 +59,7 @@ const emit = defineEmits<{
   blur: []
   openReferenceWorkflow: [id: string, name: string]
   removeWorkflowReference: [id: string]
+  removeNodeReference: [id: string]
 }>()
 const { t } = useI18n()
 const host = useTemplateRef<HTMLDivElement>('host')
@@ -67,9 +81,36 @@ const plugins = [
 
 function createState(): EditorState {
   return EditorState.create({
-    doc: promptDocument(model.value.text, model.value.workflowReferences),
+    doc: promptDocument(model.value),
     plugins
   })
+}
+
+function referenceClipboardText(node: Node): string {
+  const reference = promptNodeReference(node, 0)
+  if (!reference) return ''
+  const name = composerReferenceName(reference)
+  if (reference.kind === 'workflow') return `@[Workflow: ${name}]`
+  return reference.kind === 'node'
+    ? nodeReferenceText(name)
+    : assetReferenceText(name)
+}
+
+function passiveReferenceView(node: Node, iconClass: string) {
+  const dom = document.createElement('span')
+  const reference = promptNodeReference(node, 0)
+  if (!reference) return { dom }
+  dom.contentEditable = 'false'
+  dom.dataset.testid = `${reference.kind}-reference-chip`
+  dom.className =
+    'inline rounded-sm bg-primary-background/30 box-decoration-clone px-1 py-0.5 font-inter text-xs/[15px] font-normal break-all whitespace-normal text-primary-background-hover ring-1 ring-primary-background/30 ring-inset'
+  const icon = document.createElement('span')
+  icon.className = `${iconClass} mr-1 inline-block size-3 align-middle`
+  icon.setAttribute('aria-hidden', 'true')
+  const label = document.createElement('span')
+  label.textContent = composerReferenceName(reference)
+  dom.append(icon, label)
+  return { dom, ignoreMutation: () => true }
 }
 
 onMounted(() => {
@@ -112,7 +153,9 @@ onMounted(() => {
       if (
         previousReferences.length !== nextReferences.length ||
         previousReferences.some(
-          (reference, index) => reference.id !== nextReferences[index]?.id
+          (reference, index) =>
+            composerReferenceKey(reference) !==
+            composerReferenceKey(nextReferences[index])
         )
       )
         closeHistory(transaction)
@@ -127,13 +170,25 @@ onMounted(() => {
       view.updateState(view.state.apply(transaction))
       if (transaction.docChanged) {
         const draft = promptDraft(view.state.doc)
-        model.value = { text: draft.text, workflowReferences: draft.references }
-        for (const previous of previousReferences)
-          if (!draft.references.some(({ id }) => id === previous.id))
+        model.value = draft
+        for (const previous of previousReferences) {
+          if (
+            draft.references.some(
+              (reference) =>
+                composerReferenceKey(reference) ===
+                composerReferenceKey(previous)
+            )
+          )
+            continue
+          if (previous.kind === 'workflow')
             emit('removeWorkflowReference', previous.id)
+          if (previous.kind === 'node')
+            emit('removeNodeReference', selectedNodeKey(previous.node))
+        }
         emit('input')
       }
-      if (transaction.selectionSet) emit('selectionChange')
+      if (transaction.selectionSet || transaction.docChanged)
+        emit('selectionChange')
     },
     handleKeyDown(editor, event) {
       emit('keydown', event)
@@ -149,7 +204,7 @@ onMounted(() => {
             : event.key === 'Delete'
               ? $from.nodeAfter
               : null
-        if (adjacent?.type.name === 'workflow') {
+        if (adjacent?.isAtom && !adjacent.isText) {
           const start =
             event.key === 'Backspace' ? from - adjacent.nodeSize : from
           editor.dispatch(
@@ -210,9 +265,7 @@ onMounted(() => {
       const content = pasted.content.content.map((node) => {
         if (node.type !== inlinePromptSchema.nodes.workflow) return node
         if (usedIds.has(node.attrs.id))
-          return inlinePromptSchema.text(
-            `@[Workflow: ${String(node.attrs.name ?? '')}]`
-          )
+          return inlinePromptSchema.text(referenceClipboardText(node))
         usedIds.add(node.attrs.id)
         return node
       })
@@ -226,13 +279,12 @@ onMounted(() => {
       return true
     },
     clipboardTextSerializer: (slice) =>
-      slice.content.textBetween(
-        0,
-        slice.content.size,
-        '',
-        (node) => `@[Workflow: ${String(node.attrs.name ?? '')}]`
+      slice.content.textBetween(0, slice.content.size, '', (node) =>
+        referenceClipboardText(node)
       ),
     nodeViews: {
+      node: (node) => passiveReferenceView(node, 'icon-[comfy--node]'),
+      asset: (node) => passiveReferenceView(node, 'icon-[lucide--paperclip]'),
       workflow(node, editor, getPos) {
         const id: unknown = node.attrs.id
         const name: unknown = node.attrs.name
@@ -314,26 +366,42 @@ onMounted(() => {
 })
 
 watch(
-  model,
-  () => {
-    if (
-      !view ||
-      view.state.doc.eq(
-        promptDocument(model.value.text, model.value.workflowReferences)
+  [model, () => historyEpoch],
+  ([next, epoch], [, previousEpoch]) => {
+    if (!view) return
+    const doc = promptDocument(next)
+    if (epoch !== previousEpoch) {
+      insertions.clear()
+      const state = createState()
+      const position = Math.min(view.state.selection.head, doc.content.size)
+      view.updateState(
+        state.apply(
+          state.tr.setSelection(TextSelection.create(state.doc, position))
+        )
       )
-    )
+      emit('selectionChange')
       return
-    insertions.clear()
-    const state = createState()
-    const position = Math.min(view.state.selection.head, state.doc.content.size)
-    view.updateState(
-      state.apply(
-        state.tr.setSelection(TextSelection.create(state.doc, position))
-      )
+    }
+    const start = view.state.doc.content.findDiffStart(doc.content)
+    if (start === null) return
+    const end = view.state.doc.content.findDiffEnd(doc.content)
+    if (!end) return
+    const overlap = Math.max(0, start - Math.min(end.a, end.b))
+    const before = promptDraft(view.state.doc)
+    const metadataOnly =
+      before.text === next.text && sameComposerReferenceOrder(before, next)
+    const transaction = view.state.tr.replace(
+      start,
+      end.a + overlap,
+      doc.slice(start, end.b + overlap)
+    )
+    view.dispatch(
+      closeHistory(transaction.setMeta('addToHistory', !metadataOnly))
     )
   },
-  { deep: true, flush: 'post' }
+  { flush: 'post', deep: true }
 )
+
 watch(
   () => [label, expanded, activeDescendant],
   () => view?.setProps({})
@@ -404,6 +472,10 @@ function captureInsertion(from?: number, to?: number) {
 }
 
 defineExpose({
+  insertionPoint: () =>
+    view
+      ? promptInsertionPoint(view.state.doc, view.state.selection.head)
+      : { textOffset: 0, referenceIndex: 0 },
   focus: () => view?.focus(),
   selection,
   replaceText,

--- a/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
@@ -103,7 +103,7 @@ function passiveReferenceView(node: Node, iconClass: string) {
   dom.contentEditable = 'false'
   dom.dataset.testid = `${reference.kind}-reference-chip`
   dom.className =
-    'inline rounded-sm bg-primary-background/30 box-decoration-clone px-1 py-0.5 font-inter text-xs/[15px] font-normal break-all whitespace-normal text-primary-background-hover ring-1 ring-primary-background/30 ring-inset'
+    'inline rounded-sm bg-primary-background/30 box-decoration-clone px-1 py-0.5 font-inter text-xs/[15px] font-normal break-all whitespace-normal text-primary-background-hover ring-1 ring-primary-background/30 ring-inset [&.ProseMirror-selectednode]:outline-1'
   const icon = document.createElement('span')
   icon.className = `${iconClass} mr-1 inline-block size-3 align-middle`
   icon.setAttribute('aria-hidden', 'true')

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.test.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.test.ts
@@ -2,6 +2,9 @@ import { DOMParser } from '@tiptap/pm/model'
 import { EditorState } from '@tiptap/pm/state'
 import { describe, expect, it } from 'vitest'
 
+import { toNodeId } from '@/types/nodeId'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
+
 import type { ComposerPrompt } from '../../../types/composerPrompt'
 import { parseWorkflowReferences } from '../../../utils/workflowReferenceText'
 
@@ -13,7 +16,7 @@ import {
   promptTextOffset
 } from './inlinePrompt'
 
-describe('inline workflow prompt', () => {
+describe('inline prompt', () => {
   it('normalizes clipboard workflow IDs while preserving labels and availability', () => {
     const content = document.createElement('div')
     const chip = document.createElement('span')
@@ -31,6 +34,43 @@ describe('inline workflow prompt', () => {
       unavailable: true
     })
   })
+
+  it.for([true, false])(
+    'round-trips adjacent scoped nodes and assets with uploading=%s',
+    (uploading) => {
+      const draft: ComposerPrompt = {
+        text: 'before 😀 after',
+        references: [
+          {
+            kind: 'node',
+            textOffset: 7,
+            scope: 'workflow-A',
+            node: {
+              id: '12',
+              title: 'KSampler',
+              locatorId: createNodeLocatorId(
+                'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+                toNodeId('12')
+              )
+            }
+          },
+          {
+            kind: 'asset',
+            textOffset: 7,
+            attachment: {
+              id: 'image',
+              name: 'source.png',
+              ref: uploading ? '' : 'uploaded.png',
+              previewUrl: 'blob:source',
+              ...(uploading ? { uploading: true } : {})
+            }
+          }
+        ]
+      }
+
+      expect(promptDraft(promptDocument(draft))).toEqual(draft)
+    }
+  )
 
   it('restores references before, between and after text, including adjacent tokens', () => {
     const draft: ComposerPrompt = {

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.test.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.test.ts
@@ -2,6 +2,7 @@ import { DOMParser } from '@tiptap/pm/model'
 import { EditorState } from '@tiptap/pm/state'
 import { describe, expect, it } from 'vitest'
 
+import type { ComposerPrompt } from '../../../types/composerPrompt'
 import { parseWorkflowReferences } from '../../../utils/workflowReferenceText'
 
 import {
@@ -32,16 +33,22 @@ describe('inline workflow prompt', () => {
   })
 
   it('restores references before, between and after text, including adjacent tokens', () => {
-    const draft = {
+    const draft: ComposerPrompt = {
       text: 'before 😀\nafter',
       references: [
-        { id: 'a', name: 'A', textOffset: 0 },
-        { id: 'b', name: 'B', textOffset: 7, unavailable: true },
-        { id: 'c', name: 'C', textOffset: 7 },
-        { id: 'd', name: 'D', textOffset: 15 }
+        { kind: 'workflow', id: 'a', name: 'A', textOffset: 0 },
+        {
+          kind: 'workflow',
+          id: 'b',
+          name: 'B',
+          textOffset: 7,
+          unavailable: true
+        },
+        { kind: 'workflow', id: 'c', name: 'C', textOffset: 7 },
+        { kind: 'workflow', id: 'd', name: 'D', textOffset: 15 }
       ]
     }
-    const doc = promptDocument(draft.text, draft.references)
+    const doc = promptDocument(draft)
     expect(
       doc.textBetween(0, doc.content.size, '', (node) =>
         String(node.attrs.name)
@@ -52,14 +59,15 @@ describe('inline workflow prompt', () => {
 
   it('moves a token with preceding edits and removes it with a spanning selection', () => {
     let state = EditorState.create({
-      doc: promptDocument('before  after', [
-        { id: 'b', name: 'B', textOffset: 7 }
-      ])
+      doc: promptDocument({
+        text: 'before  after',
+        references: [{ kind: 'workflow', id: 'b', name: 'B', textOffset: 7 }]
+      })
     })
     state = state.apply(state.tr.insertText('new ', 0))
     expect(promptDraft(state.doc)).toEqual({
       text: 'new before  after',
-      references: [{ id: 'b', name: 'B', textOffset: 11 }]
+      references: [{ kind: 'workflow', id: 'b', name: 'B', textOffset: 11 }]
     })
     const afterToken = promptDocumentPosition(state.doc, 11)
     expect(promptTextOffset(state.doc, afterToken)).toBe(11)
@@ -70,10 +78,18 @@ describe('inline workflow prompt', () => {
   it('opens older drafts without recorded positions without losing references', () => {
     const restored = parseWorkflowReferences('prompt', [{ id: 'b', name: 'B' }])
     expect(
-      promptDraft(promptDocument(restored.text, restored.references))
+      promptDraft(
+        promptDocument({
+          text: restored.text,
+          references: restored.references.map((reference) => ({
+            ...reference,
+            kind: 'workflow'
+          }))
+        })
+      )
     ).toEqual({
       text: 'prompt',
-      references: [{ id: 'b', name: 'B', textOffset: 0 }]
+      references: [{ kind: 'workflow', id: 'b', name: 'B', textOffset: 0 }]
     })
   })
 })

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
@@ -7,6 +7,10 @@ import type {
   ComposerPrompt,
   ComposerReference
 } from '../../../types/composerPrompt'
+import {
+  assetReferenceText,
+  nodeReferenceText
+} from '../../../utils/agentMessageText'
 
 export const inlinePromptSchema = new Schema({
   nodes: {
@@ -52,7 +56,7 @@ export const inlinePromptSchema = new Schema({
       toDOM: (node) => [
         'span',
         { 'data-node-id': node.attrs.id },
-        `${node.attrs.name} #${node.attrs.id}`
+        nodeReferenceText(`${node.attrs.name} #${node.attrs.id}`)
       ]
     },
     asset: {
@@ -69,7 +73,7 @@ export const inlinePromptSchema = new Schema({
       toDOM: (node) => [
         'span',
         { 'data-asset-id': node.attrs.id },
-        node.attrs.name
+        assetReferenceText(node.attrs.name)
       ]
     }
   }

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
@@ -1,8 +1,12 @@
 import { Schema } from '@tiptap/pm/model'
 import type { Node } from '@tiptap/pm/model'
 
-import type { WorkflowReference } from '../../../types/workflowReference'
-import { workflowReferenceParts } from '../../../utils/workflowReferenceParts'
+import { isNodeLocatorId } from '@/types/nodeIdentification'
+import type {
+  ComposerInsertionPoint,
+  ComposerPrompt,
+  ComposerReference
+} from '../../../types/composerPrompt'
 
 export const inlinePromptSchema = new Schema({
   nodes: {
@@ -39,43 +43,129 @@ export const inlinePromptSchema = new Schema({
           }
         }
       ]
+    },
+    node: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: { id: {}, name: {}, scope: {}, locatorId: { default: null } },
+      toDOM: (node) => [
+        'span',
+        { 'data-node-id': node.attrs.id },
+        `${node.attrs.name} #${node.attrs.id}`
+      ]
+    },
+    asset: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        id: {},
+        name: {},
+        ref: {},
+        previewUrl: { default: null },
+        uploading: { default: false }
+      },
+      toDOM: (node) => [
+        'span',
+        { 'data-asset-id': node.attrs.id },
+        node.attrs.name
+      ]
     }
   }
 })
 
-export function promptDocument(
-  text: string,
-  references: WorkflowReference[]
-): Node {
-  const content = workflowReferenceParts(text, references).map((part) =>
-    part.type === 'text'
-      ? inlinePromptSchema.text(part.text)
-      : inlinePromptSchema.nodes.workflow.create({
-          id: part.reference.id,
-          name: part.reference.name,
-          unavailable: part.reference.unavailable === true
-        })
-  )
+export function promptReferenceNode(reference: ComposerReference): Node {
+  switch (reference.kind) {
+    case 'workflow':
+      return inlinePromptSchema.nodes.workflow.create({
+        id: reference.id,
+        name: reference.name,
+        unavailable: reference.unavailable === true
+      })
+    case 'node':
+      return inlinePromptSchema.nodes.node.create({
+        id: reference.node.id,
+        name: reference.node.title,
+        locatorId: reference.node.locatorId,
+        scope: reference.scope
+      })
+    case 'asset':
+      return inlinePromptSchema.nodes.asset.create({ ...reference.attachment })
+  }
+}
+
+export function promptDocument(prompt: ComposerPrompt): Node {
+  const content: Node[] = []
+  let offset = 0
+  for (const reference of prompt.references) {
+    const next = Math.max(
+      offset,
+      Math.min(prompt.text.length, reference.textOffset)
+    )
+    if (next > offset)
+      content.push(inlinePromptSchema.text(prompt.text.slice(offset, next)))
+    content.push(promptReferenceNode(reference))
+    offset = next
+  }
+  if (offset < prompt.text.length)
+    content.push(inlinePromptSchema.text(prompt.text.slice(offset)))
   return inlinePromptSchema.nodes.doc.create(null, content)
 }
 
-export function promptDraft(doc: Node): {
-  text: string
-  references: WorkflowReference[]
-} {
+export function promptNodeReference(
+  node: Node,
+  textOffset: number
+): ComposerReference | undefined {
+  const { id, name } = node.attrs
+  if (typeof id !== 'string' || typeof name !== 'string') return
+  if (node.type.name === 'workflow')
+    return {
+      kind: 'workflow',
+      id,
+      name,
+      textOffset,
+      ...(node.attrs.unavailable === true ? { unavailable: true } : {})
+    }
+  if (node.type.name === 'node') {
+    const { scope, locatorId } = node.attrs
+    if (typeof scope !== 'string') return
+    return {
+      kind: 'node',
+      scope,
+      textOffset,
+      node: {
+        id,
+        title: name,
+        ...(isNodeLocatorId(locatorId) ? { locatorId } : {})
+      }
+    }
+  }
+  if (node.type.name === 'asset') {
+    const { ref, previewUrl, uploading } = node.attrs
+    if (typeof ref !== 'string') return
+    return {
+      kind: 'asset',
+      textOffset,
+      attachment: {
+        id,
+        name,
+        ref,
+        ...(typeof previewUrl === 'string' ? { previewUrl } : {}),
+        ...(uploading === true ? { uploading: true } : {})
+      }
+    }
+  }
+}
+
+export function promptDraft(doc: Node): ComposerPrompt {
   let text = ''
-  const references: WorkflowReference[] = []
+  const references: ComposerReference[] = []
   doc.forEach((node) => {
     if (node.isText) text += node.text
-    else if (node.type.name === 'workflow') {
-      const { id, name, unavailable } = node.attrs
-      if (typeof id === 'string' && typeof name === 'string')
-        references.push({
-          id,
-          name,
-          textOffset: text.length,
-          ...(unavailable === true ? { unavailable: true } : {})
-        })
+    else {
+      const reference = promptNodeReference(node, text.length)
+      if (reference) references.push(reference)
     }
   })
   return { text, references }
@@ -83,6 +173,17 @@ export function promptDraft(doc: Node): {
 
 export function promptTextOffset(doc: Node, position: number): number {
   return doc.textBetween(0, position, '', '').length
+}
+
+export function promptInsertionPoint(
+  doc: Node,
+  position: number
+): ComposerInsertionPoint {
+  let referenceIndex = 0
+  doc.forEach((node, offset) => {
+    if (!node.isText && offset < position) referenceIndex++
+  })
+  return { textOffset: promptTextOffset(doc, position), referenceIndex }
 }
 
 export function promptDocumentPosition(doc: Node, textOffset: number): number {

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
@@ -75,7 +75,7 @@ export const inlinePromptSchema = new Schema({
   }
 })
 
-export function promptReferenceNode(reference: ComposerReference): Node {
+function promptReferenceNode(reference: ComposerReference): Node {
   switch (reference.kind) {
     case 'workflow':
       return inlinePromptSchema.nodes.workflow.create({

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.clipboard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.clipboard.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { i18n } from '@/i18n'
+import { useAgentComposerStore } from '../../../stores/agent/agentComposerStore'
+import type { ReplyAsset } from '../../../utils/replyAssets'
+import Composer from '../Composer.vue'
+import { setupInlinePromptEditorDom } from '../composer/inlinePromptEditorTestSetup'
+import UserMessage from './UserMessage.vue'
+
+vi.mock(import('./ReplyAssetGroup.vue'), () => ({
+  default: defineComponent<{ assets: ReplyAsset[] }>({
+    setup: () => () => null
+  })
+}))
+
+setupInlinePromptEditorDom()
+
+// jsdom lacks ClipboardItem; user-event provides the clipboard itself.
+class TestClipboardItem {
+  constructor(
+    private readonly data: Record<
+      string,
+      Blob | string | Promise<Blob | string>
+    >
+  ) {}
+
+  get types() {
+    return Object.keys(this.data)
+  }
+
+  async getType(type: string): Promise<Blob> {
+    const value = await this.data[type]
+    return typeof value === 'string' ? new Blob([value], { type }) : value
+  }
+}
+
+function renderComposer() {
+  const store = useAgentComposerStore()
+  render(Composer, {
+    props: { hasWorkflowTarget: true, editableWorkflowId: 'target-A' },
+    global: { plugins: [i18n], directives: { tooltip: () => {} } }
+  })
+  return { store, editor: screen.getByRole('textbox') }
+}
+
+describe('sent message workflow clipboard', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.stubGlobal('ClipboardItem', TestClipboardItem)
+    const descriptor = Object.getOwnPropertyDescriptor(navigator, 'permissions')
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: async () =>
+          Object.assign(new EventTarget(), { state: 'granted' })
+      }
+    })
+    return () => {
+      if (descriptor)
+        Object.defineProperty(navigator, 'permissions', descriptor)
+      else Reflect.deleteProperty(navigator, 'permissions')
+    }
+  })
+
+  it('copies a sent message and restores workflows at the caret with readable node and asset labels', async () => {
+    const user = userEvent.setup()
+    const references = [
+      { id: 'workflow-B', name: '参考 <B> 🐈', textOffset: 4 },
+      { id: 'workflow-C', name: 'Missing', textOffset: 7, unavailable: true }
+    ]
+    render(UserMessage, {
+      props: {
+        text: 'Use \n  !',
+        workflowReferences: references,
+        tags: ['Sampler #12'],
+        attachments: [{ name: 'notes.txt' }]
+      },
+      global: { plugins: [i18n] }
+    })
+    const { store, editor } = renderComposer()
+    await user.click(
+      screen.getByRole('button', { name: i18n.global.t('agent.copy') })
+    )
+    expect(await navigator.clipboard.readText()).toBe(
+      'Use @[Workflow: 参考 <B> 🐈]\n  @[Workflow: Missing]!\n@[Node: Sampler #12]\n@[File: notes.txt]'
+    )
+
+    await user.type(editor, 'New: ')
+    await user.paste()
+    expect(store.draft).toBe(
+      'New: Use \n  !\n@[Node: Sampler #12]\n@[File: notes.txt]'
+    )
+    expect(store.workflowReferences).toEqual(
+      references.map((reference) => ({
+        ...reference,
+        textOffset: reference.textOffset + 5
+      }))
+    )
+    expect(store.nodes).toEqual([])
+    expect(store.attachments).toEqual([])
+    await user.keyboard('{Control>}z{/Control}')
+    expect(store.draft).toBe('New: ')
+    expect(store.workflowReferences).toEqual([])
+  })
+
+  it('copies only selected content and treats a partially selected workflow label as one reference', async () => {
+    const user = userEvent.setup()
+    render(UserMessage, {
+      props: {
+        text: 'Before  between  after',
+        workflowReferences: [
+          { id: 'workflow-B', name: 'Reference B', textOffset: 7 },
+          { id: 'workflow-C', name: 'Reference C', textOffset: 16 }
+        ]
+      },
+      global: { plugins: [i18n] }
+    })
+    await user.tab()
+    const label = document
+      .createTreeWalker(screen.getByText('Reference B'), NodeFilter.SHOW_TEXT)
+      .nextNode()
+    if (!label) throw new Error('Expected workflow label text')
+    const range = document.createRange()
+    range.setStart(label, 2)
+    range.setEndBefore(screen.getByRole('button', { name: 'Open Reference C' }))
+    document.getSelection()?.removeAllRanges()
+    document.getSelection()?.addRange(range)
+    const clipboard = await user.copy()
+    expect(clipboard?.getData('text/plain')).toBe(
+      '@[Workflow: Reference B] between '
+    )
+
+    const { store, editor } = renderComposer()
+    await user.click(editor)
+    await user.paste(clipboard)
+    expect(store.draft).toBe(' between ')
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: 'Reference B', textOffset: 0 }
+    ])
+  })
+
+  it('keeps current-target and duplicate workflow references as readable text', async () => {
+    const user = userEvent.setup()
+    render(UserMessage, {
+      props: {
+        text: ' and ',
+        workflowReferences: [
+          { id: 'target-A', name: 'Target', textOffset: 0 },
+          { id: 'workflow-B', name: 'Reference B', textOffset: 5 }
+        ]
+      },
+      global: { plugins: [i18n] }
+    })
+    await user.click(
+      screen.getByRole('button', { name: i18n.global.t('agent.copy') })
+    )
+    const { store, editor } = renderComposer()
+    store.replaceDraft({
+      text: 'Existing: ',
+      workflowReferences: [
+        { id: 'workflow-B', name: 'Reference B', textOffset: 0 }
+      ],
+      attachments: []
+    })
+    await waitFor(() =>
+      expect(editor).toHaveTextContent('Reference BExisting:')
+    )
+    await user.click(editor)
+    await user.keyboard('{Control>}a{/Control}{ArrowRight}')
+    await user.paste()
+    expect(store.draft).toBe(
+      'Existing: @[Workflow: Target] and @[Workflow: Reference B]'
+    )
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: 'Reference B', textOffset: 0 }
+    ])
+  })
+
+  it('leaves a selection spanning outside the message to native copying', async () => {
+    const user = userEvent.setup()
+    render(UserMessage, {
+      props: {
+        text: ' after',
+        workflowReferences: [
+          { id: 'workflow-B', name: 'Reference B', textOffset: 0 }
+        ]
+      },
+      global: { plugins: [i18n] }
+    })
+    render({ template: '<p>Outside message</p>' })
+    await user.tab()
+    const range = document.createRange()
+    range.setStartBefore(
+      screen.getByRole('button', { name: 'Open Reference B' })
+    )
+    range.setEndAfter(screen.getByText('Outside message'))
+    document.getSelection()?.removeAllRanges()
+    document.getSelection()?.addRange(range)
+    const selectedText = range.toString()
+    const clipboard = await user.copy()
+    expect(clipboard?.getData('text/plain')).toBe(selectedText)
+    expect(clipboard?.getData('text/plain')).toContain('Outside message')
+  })
+
+  it('falls back to readable text when rich clipboard writing is rejected', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, 'write').mockRejectedValueOnce(
+      new Error('Clipboard denied')
+    )
+    render(UserMessage, {
+      props: {
+        text: '',
+        workflowReferences: [
+          { id: 'workflow-B', name: 'Reference B', textOffset: 0 }
+        ]
+      },
+      global: { plugins: [i18n] }
+    })
+    await user.click(
+      screen.getByRole('button', { name: i18n.global.t('agent.copy') })
+    )
+    expect(await navigator.clipboard.readText()).toBe(
+      '@[Workflow: Reference B]'
+    )
+    expect(
+      screen.getByRole('button', { name: i18n.global.t('agent.copied') })
+    ).toBeVisible()
+  })
+})

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -211,6 +211,27 @@ describe('UserMessage', () => {
     expect(clipboard.copy).toHaveBeenCalledWith('@[Workflow: Portrait]')
   })
 
+  it.for([true, false])(
+    'respects Edit eligibility for a workflow-reference-only message: %s',
+    async (editable) => {
+      const workflowReferences = [{ id: 'wf', name: 'Portrait', textOffset: 0 }]
+      const { emitted } = renderMessage({
+        text: '',
+        workflowReferences,
+        editable
+      })
+      if (!editable) {
+        expect(
+          screen.queryByRole('button', { name: t('g.edit') })
+        ).not.toBeInTheDocument()
+        return
+      }
+
+      await userEvent.click(screen.getByRole('button', { name: t('g.edit') }))
+      expect(emitted().edit).toEqual([[{ text: '', workflowReferences }]])
+    }
+  )
+
   it('reaches and triggers the copy action by keyboard alone', async () => {
     const user = userEvent.setup()
     renderMessage({ text: 'make it cinematic' })

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -28,6 +28,11 @@ vi.mock<unknown>(import('@vueuse/core'), () => ({
     isSupported: ref(true),
     text: ref('')
   }),
+  useClipboardItems: () => ({
+    copy: vi.fn(),
+    copied: ref(false),
+    isSupported: ref(false)
+  }),
   useDocumentVisibility: () => ref('visible'),
   useStorage: (_key: string, defaultValue: unknown) => ref(defaultValue)
 }))

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -202,6 +202,15 @@ describe('UserMessage', () => {
     expect(clipboard.copy).toHaveBeenCalledWith('make it cinematic')
   })
 
+  it('copies a reference-only message with readable workflow names', async () => {
+    renderMessage({
+      text: '',
+      workflowReferences: [{ id: 'wf', name: 'Portrait', textOffset: 0 }]
+    })
+    await userEvent.click(screen.getByRole('button', { name: t('agent.copy') }))
+    expect(clipboard.copy).toHaveBeenCalledWith('@[Workflow: Portrait]')
+  })
+
   it('reaches and triggers the copy action by keyboard alone', async () => {
     const user = userEvent.setup()
     renderMessage({ text: 'make it cinematic' })
@@ -236,9 +245,10 @@ describe('UserMessage', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('offers no copy action on an attachment-only message', () => {
+  it('copies the filename on an attachment-only message', async () => {
     renderMessage({ text: '', attachments: [{ name: 'clip.bin' }] })
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: t('agent.copy') }))
+    expect(clipboard.copy).toHaveBeenCalledWith('@[File: clip.bin]')
   })
 })

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import userEvent from '@testing-library/user-event'
 import { render, screen, within } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
@@ -24,6 +24,11 @@ const clipboard = vi.hoisted(() => ({
     clipboard.text = value
   })
 }))
+
+beforeEach(() => {
+  clipboard.text = ''
+  clipboard.copy.mockClear()
+})
 
 vi.mock<unknown>(import('@vueuse/core'), () => ({
   createSharedComposable: (composable: () => unknown) => composable,

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -18,7 +18,12 @@ import { i18n } from '@/i18n'
 
 import UserMessage from './UserMessage.vue'
 
-const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
+const clipboard = vi.hoisted(() => ({
+  text: '',
+  copy: vi.fn((value: string) => {
+    clipboard.text = value
+  })
+}))
 
 vi.mock<unknown>(import('@vueuse/core'), () => ({
   createSharedComposable: (composable: () => unknown) => composable,
@@ -213,7 +218,7 @@ describe('UserMessage', () => {
       workflowReferences: [{ id: 'wf', name: 'Portrait', textOffset: 0 }]
     })
     await userEvent.click(screen.getByRole('button', { name: t('agent.copy') }))
-    expect(clipboard.copy).toHaveBeenCalledWith('@[Workflow: Portrait]')
+    expect(clipboard.text).toBe('@[Workflow: Portrait]')
   })
 
   it.for([true, false])(
@@ -275,6 +280,6 @@ describe('UserMessage', () => {
     renderMessage({ text: '', attachments: [{ name: 'clip.bin' }] })
 
     await userEvent.click(screen.getByRole('button', { name: t('agent.copy') }))
-    expect(clipboard.copy).toHaveBeenCalledWith('@[File: clip.bin]')
+    expect(clipboard.text).toBe('@[File: clip.bin]')
   })
 })

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useClipboard } from '@vueuse/core'
-import { computed } from 'vue'
+import { useClipboard, useClipboardItems } from '@vueuse/core'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { cn } from '@comfyorg/tailwind-utils'
@@ -18,6 +18,10 @@ import { agentMessageText } from '../../../utils/agentMessageText'
 import { workflowReferenceParts } from '../../../utils/workflowReferenceParts'
 import AgentTooltip from '../AgentTooltip.vue'
 import ReplyAssetGroup from './ReplyAssetGroup.vue'
+import {
+  selectedUserMessageClipboard,
+  userMessageClipboard
+} from './userMessageClipboard'
 
 const {
   text,
@@ -44,7 +48,53 @@ const promptParts = computed(() =>
 const readableText = computed(() =>
   agentMessageText({ text, workflowReferences, tags, attachments })
 )
-const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
+const bubble = useTemplateRef<HTMLElement>('bubble')
+const plainClipboard = useClipboard({ copiedDuring: 2000, legacy: true })
+const richClipboard = useClipboardItems({ copiedDuring: 2000 })
+const copied = computed(
+  () => plainClipboard.copied.value || richClipboard.copied.value
+)
+
+async function copyMessage(): Promise<void> {
+  if (
+    workflowReferences.length &&
+    richClipboard.isSupported.value &&
+    typeof ClipboardItem !== 'undefined'
+  ) {
+    const content = userMessageClipboard({
+      text,
+      workflowReferences,
+      tags,
+      attachments
+    })
+    try {
+      await richClipboard.copy([
+        new ClipboardItem({
+          'text/plain': new Blob([content.text], { type: 'text/plain' }),
+          'text/html': new Blob([content.html], { type: 'text/html' })
+        })
+      ])
+      return
+    } catch {
+      await plainClipboard.copy(content.text)
+      return
+    }
+  }
+  await plainClipboard.copy(readableText.value)
+}
+
+function copySelection(event: ClipboardEvent): void {
+  if (!bubble.value || !event.clipboardData) return
+  const content = selectedUserMessageClipboard(
+    bubble.value,
+    document.getSelection()
+  )
+  if (!content) return
+  event.clipboardData.setData('text/plain', content.text)
+  event.clipboardData.setData('text/html', content.html)
+  event.preventDefault()
+  event.stopPropagation()
+}
 
 function openReference(reference: WorkflowReference): void {
   if (reference.unavailable) return
@@ -90,7 +140,7 @@ const splitAttachments = computed(() => {
 </script>
 
 <template>
-  <div class="group flex flex-col items-end gap-2 pl-16">
+  <div class="group flex flex-col items-end gap-2 pl-16" @copy="copySelection">
     <div v-if="tags.length" class="flex flex-wrap justify-end gap-1">
       <span
         v-for="(tag, index) in tags"
@@ -129,6 +179,7 @@ const splitAttachments = computed(() => {
     </div>
     <div
       v-if="text || workflowReferences.length"
+      ref="bubble"
       data-testid="user-message-bubble"
       class="border-agent-border bg-agent-surface-raised text-agent-fg-muted w-fit max-w-full rounded-[10px] border px-2.5 py-1.5 text-sm/5 font-normal wrap-break-word whitespace-pre-wrap"
     >
@@ -145,6 +196,11 @@ const splitAttachments = computed(() => {
               : t('agent.openWorkflowTab', { name: part.reference.name })
           "
           data-testid="workflow-reference-chip"
+          data-comfy-workflow="1"
+          :data-workflow-id="part.reference.id"
+          :data-workflow-unavailable="
+            part.reference.unavailable ? 'true' : undefined
+          "
           :aria-disabled="part.reference.unavailable"
           :aria-description="
             part.reference.unavailable
@@ -192,7 +248,7 @@ const splitAttachments = computed(() => {
           type="button"
           :aria-label="copied ? t('agent.copied') : t('agent.copy')"
           class="hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 cursor-pointer items-center justify-center rounded-lg p-1 transition-colors"
-          @click="copy(readableText)"
+          @click="copyMessage"
         >
           <span
             :class="

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
@@ -174,7 +174,10 @@ const splitAttachments = computed(() => {
       v-if="readableText"
       class="text-agent-fg-subtle flex opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 touch:opacity-100"
     >
-      <AgentTooltip v-if="editable && text" :label="t('g.edit')">
+      <AgentTooltip
+        v-if="editable && (text || workflowReferences.length)"
+        :label="t('g.edit')"
+      >
         <button
           type="button"
           :aria-label="t('g.edit')"

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
@@ -14,6 +14,7 @@ import type {
   WorkflowReference
 } from '../../../types/workflowReference'
 import type { ReplyAsset } from '../../../utils/replyAssets'
+import { agentMessageText } from '../../../utils/agentMessageText'
 import { workflowReferenceParts } from '../../../utils/workflowReferenceParts'
 import AgentTooltip from '../AgentTooltip.vue'
 import ReplyAssetGroup from './ReplyAssetGroup.vue'
@@ -39,6 +40,9 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const promptParts = computed(() =>
   workflowReferenceParts(text, workflowReferences)
+)
+const readableText = computed(() =>
+  agentMessageText({ text, workflowReferences, tags, attachments })
 )
 const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
 
@@ -167,10 +171,10 @@ const splitAttachments = computed(() => {
       </template>
     </div>
     <div
-      v-if="text"
+      v-if="readableText"
       class="text-agent-fg-subtle flex opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 touch:opacity-100"
     >
-      <AgentTooltip v-if="editable" :label="t('g.edit')">
+      <AgentTooltip v-if="editable && text" :label="t('g.edit')">
         <button
           type="button"
           :aria-label="t('g.edit')"
@@ -185,7 +189,7 @@ const splitAttachments = computed(() => {
           type="button"
           :aria-label="copied ? t('agent.copied') : t('agent.copy')"
           class="hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 cursor-pointer items-center justify-center rounded-lg p-1 transition-colors"
-          @click="copy(text)"
+          @click="copy(readableText)"
         >
           <span
             :class="

--- a/src/workbench/extensions/agent/components/agent/message/userMessageClipboard.ts
+++ b/src/workbench/extensions/agent/components/agent/message/userMessageClipboard.ts
@@ -1,0 +1,58 @@
+import { DOMParser, DOMSerializer } from '@tiptap/pm/model'
+
+import { agentMessageText } from '../../../utils/agentMessageText'
+import {
+  inlinePromptSchema,
+  promptDocument,
+  promptDraft
+} from '../composer/inlinePrompt'
+
+export function userMessageClipboard(
+  message: Parameters<typeof agentMessageText>[0]
+) {
+  const { text, workflowReferences = [] } = message
+  const plainText = agentMessageText(message)
+  const prompt = promptDocument({
+    text,
+    references: [...workflowReferences]
+      .sort((a, b) => a.textOffset - b.textOffset)
+      .map((reference) => ({ ...reference, kind: 'workflow' }))
+  })
+  const container = document.createElement('span')
+  container.style.whiteSpace = 'pre-wrap'
+  container.append(
+    DOMSerializer.fromSchema(inlinePromptSchema).serializeFragment(
+      prompt.content
+    ),
+    plainText.slice(agentMessageText({ text, workflowReferences }).length)
+  )
+  return { text: plainText, html: container.outerHTML }
+}
+
+export function selectedUserMessageClipboard(
+  bubble: HTMLElement,
+  selection: Selection | null
+) {
+  if (!selection || selection.isCollapsed || selection.rangeCount !== 1) return
+  const range = selection.getRangeAt(0).cloneRange()
+  if (
+    !bubble.contains(range.startContainer) ||
+    !bubble.contains(range.endContainer)
+  )
+    return
+
+  for (const chip of bubble.querySelectorAll('[data-comfy-workflow="1"]')) {
+    if (chip.contains(range.startContainer)) range.setStartBefore(chip)
+    if (chip.contains(range.endContainer)) range.setEndAfter(chip)
+  }
+  const prompt = promptDraft(
+    DOMParser.fromSchema(inlinePromptSchema).parse(range.cloneContents(), {
+      preserveWhitespace: 'full'
+    })
+  )
+  const workflowReferences = prompt.references.filter(
+    (reference) => reference.kind === 'workflow'
+  )
+  if (!workflowReferences.length) return
+  return userMessageClipboard({ text: prompt.text, workflowReferences })
+}

--- a/src/workbench/extensions/agent/composables/agent/useAgentDraftSubmission.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentDraftSubmission.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, ref, shallowRef } from 'vue'
+import { computed, effectScope, nextTick, ref, shallowRef, watch } from 'vue'
 import type { EffectScope } from 'vue'
 
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
@@ -39,7 +39,12 @@ function setup() {
     const nodeWorkflow = shallowRef(target.value)
     const editableWorkflowId = ref<string | undefined>('wf-target')
     const canSubmit = ref(true)
+    watch(target, (workflow) => composer.setNodeScope(workflow?.path ?? null), {
+      immediate: true,
+      flush: 'sync'
+    })
     const selection = useCanvasSelection({
+      staged: computed({ get: () => composer.nodes, set: composer.setNodes }),
       selection: [],
       isLive: true,
       isTracking: false

--- a/src/workbench/extensions/agent/composables/agent/useAgentDraftSubmission.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentDraftSubmission.ts
@@ -5,6 +5,7 @@ import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyW
 import { useAgentComposerStore } from '../../stores/agent/agentComposerStore'
 import type { WorkflowReference } from '../../types/workflowReference'
 import type { SelectedNode, useCanvasSelection } from './useCanvasSelection'
+import { selectedNodeKey } from './useCanvasSelection'
 import type { ComposerAttachment } from './useComposer'
 
 interface UseAgentDraftSubmissionOptions {
@@ -32,24 +33,26 @@ export function useAgentDraftSubmission(
 ) {
   const composer = useAgentComposerStore()
   const { selection } = options
-  watch(
-    selection.staged,
-    (nodes, previous) => {
-      if (nodes.length > 0 || previous.length > 0) composer.markEdited()
-    },
-    { deep: true, flush: 'sync' }
-  )
 
   function recoverFailedSubmission(): void {
     const snapshot = composer.takeFailedSubmission()
     if (!snapshot || selection.staged.value.length > 0) return
 
-    composer.replaceDraft({
-      text: snapshot.draft,
-      attachments: snapshot.attachments,
-      workflowReferences: snapshot.references.filter(
-        ({ id }) => id !== options.editableWorkflowId()
-      )
+    composer.restorePrompt({
+      text: snapshot.prompt.text,
+      references: snapshot.prompt.references.filter((reference) => {
+        if (reference.kind === 'workflow')
+          return reference.id !== options.editableWorkflowId()
+        if (reference.kind === 'node')
+          return (
+            options.target() === snapshot.target &&
+            snapshot.nodes.some(
+              (node) =>
+                selectedNodeKey(node) === selectedNodeKey(reference.node)
+            )
+          )
+        return true
+      })
     })
     if (options.target() === snapshot.target) selection.replace(snapshot.nodes)
   }
@@ -74,8 +77,7 @@ export function useAgentDraftSubmission(
     )
       return
 
-    const draft = composer.draft
-    const draftReferences = [...composer.workflowReferences]
+    const prompt = composer.prompt
     const sentAttachments = [...attachments]
     const sentReferences = [...references]
     selection.exit()
@@ -84,8 +86,7 @@ export function useAgentDraftSubmission(
 
     selection.consume()
     const submissionId = composer.startSubmission({
-      draft,
-      references: draftReferences,
+      prompt,
       attachments: sentAttachments,
       nodes,
       target

--- a/src/workbench/extensions/agent/composables/agent/useAgentMentionPicker.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentMentionPicker.ts
@@ -251,22 +251,10 @@ export function useAgentMentionPicker(options: MentionPickerOptions) {
         dispatchMention({ type: 'closed' })
       return
     }
-    const draft = options.draft()
+    options
+      .editor()
+      ?.replaceText(state.start, state.start + 1 + state.query.length, '')
     options.pickNode(match.node)
-    const current = mention.value
-    if (
-      options.draft() !== draft ||
-      current.status === 'closed' ||
-      current.start !== state.start ||
-      current.query !== state.query
-    )
-      return
-    const before = draft.slice(0, state.start)
-    const end = state.start + 1 + state.query.length
-    let after = draft.slice(end)
-    if (after.startsWith(' ') && (before === '' || before.endsWith(' ')))
-      after = after.slice(1)
-    options.editor()?.replaceText(state.start, draft.length - after.length, '')
     dispatchMention({ type: 'closed' })
     options.editor()?.focus()
   }

--- a/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
+++ b/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
@@ -14,6 +14,8 @@ export function selectedNodeKey(node: SelectedNode): string {
 }
 
 export interface UseCanvasSelectionOptions {
+  staged?: Ref<SelectedNode[]>
+  retainWhenNotLive?: boolean
   selection: MaybeRefOrGetter<SelectedNode[]>
   isLive: MaybeRefOrGetter<boolean>
   enabled?: MaybeRefOrGetter<boolean>
@@ -28,7 +30,7 @@ function signature(scope: string | null, nodes: SelectedNode[]): string {
 }
 
 export function useCanvasSelection(options: UseCanvasSelectionOptions) {
-  const staged = ref<SelectedNode[]>([])
+  const staged = options.staged ?? ref<SelectedNode[]>([])
   const consumedSig = ref<string | null>(null)
   const stagedSig = ref<string | null>(null)
   const dismissedSig = options.dismissedSignature ?? ref<string | null>(null)
@@ -61,6 +63,7 @@ export function useCanvasSelection(options: UseCanvasSelectionOptions) {
         ([isLive, isTracking, isPaused, scope, nodes]) => {
           if (isPaused) return
           if (!isLive) {
+            if (options.retainWhenNotLive) return
             staged.value = []
             consumedSig.value = null
             stagedSig.value = null

--- a/src/workbench/extensions/agent/composables/agent/useComposer.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useComposer.test.ts
@@ -28,8 +28,10 @@ describe('useComposer', () => {
 
     composer.submit()
 
-    expect(onSend).toHaveBeenCalledWith('make a cat', [attachment])
-    expect(composer.draft.value).toBe('  make a cat  ')
+    expect(onSend).toHaveBeenCalledWith('make a cat  @[Image: cat.png]', [
+      attachment
+    ])
+    expect(composer.draft.value).toBe('  make a cat   ')
     expect(composer.attachments.value).toEqual([attachment])
   })
 
@@ -86,7 +88,7 @@ describe('useComposer', () => {
     expect(composer.canSend.value).toBe(true)
     composer.submit()
 
-    expect(onSend).toHaveBeenCalledWith('', [
+    expect(onSend).toHaveBeenCalledWith('@[Image: cat.png]', [
       { id: 'a1', name: 'cat.png', ref: 'r' }
     ])
   })
@@ -127,14 +129,14 @@ describe('useComposer', () => {
     first.addAttachment({ id: 'a1', name: 'cat.png', ref: 'r' })
 
     const { composer: second, onSend } = setup()
-    expect(second.draft.value).toBe('still here')
+    expect(second.draft.value).toBe('still here ')
     expect(second.attachments.value.map((a) => a.id)).toEqual(['a1'])
 
     second.submit()
-    expect(onSend).toHaveBeenCalledWith('still here', [
+    expect(onSend).toHaveBeenCalledWith('still here@[Image: cat.png]', [
       { id: 'a1', name: 'cat.png', ref: 'r' }
     ])
-    expect(first.draft.value).toBe('still here')
+    expect(first.draft.value).toBe('still here ')
     expect(first.attachments.value.map((attachment) => attachment.id)).toEqual([
       'a1'
     ])

--- a/src/workbench/extensions/agent/composables/agent/useComposer.ts
+++ b/src/workbench/extensions/agent/composables/agent/useComposer.ts
@@ -1,6 +1,7 @@
 import { storeToRefs } from 'pinia'
-import { computed } from 'vue'
+import { computed, getCurrentScope, onScopeDispose } from 'vue'
 
+import { composerPromptForSend } from '../../utils/composerPrompt'
 import { useAgentComposerStore } from '../../stores/agent/agentComposerStore'
 
 export interface ComposerAttachment {
@@ -19,11 +20,13 @@ export interface UseComposerOptions {
 
 export function useComposer(options: UseComposerOptions) {
   const store = useAgentComposerStore()
-  const { draft, attachments, prompt, workflowReferences } = storeToRefs(store)
+  const { draft, attachments, prompt, workflowReferences, promptEpoch } =
+    storeToRefs(store)
+  if (getCurrentScope()) onScopeDispose(store.releaseUnusedAssets)
 
   const canSend = computed(
     () =>
-      (draft.value.trim().length > 0 || attachments.value.length > 0) &&
+      (draft.value.trim().length > 0 || prompt.value.references.length > 0) &&
       !attachments.value.some((item) => item.uploading)
   )
 
@@ -33,23 +36,24 @@ export function useComposer(options: UseComposerOptions) {
       return
     }
     if (!canSend.value) return
-    options.onSend(draft.value.trim(), attachments.value)
+    options.onSend(
+      composerPromptForSend(prompt.value).text.trim(),
+      attachments.value
+    )
   }
 
   function insert(text: string): void {
     store.setText(draft.value ? `${draft.value} ${text}` : text)
   }
 
-  function removeAttachment(id: string): void {
-    const removed = store.removeAttachment(id)
-    if (removed?.previewUrl?.startsWith('blob:'))
-      URL.revokeObjectURL(removed.previewUrl)
-  }
-
   return {
     draft,
     attachments,
     prompt,
+    promptEpoch,
+    applyEditorPrompt: store.applyEditorPrompt,
+    setInsertionPoint: store.setInsertionPoint,
+    removeReference: store.removeReference,
     workflowReferences,
     canSend,
     submit,
@@ -58,6 +62,6 @@ export function useComposer(options: UseComposerOptions) {
     replacePrompt: store.replacePrompt,
     addAttachment: store.addAttachment,
     updateAttachment: store.updateAttachment,
-    removeAttachment
+    removeAttachment: store.removeAttachment
   }
 }

--- a/src/workbench/extensions/agent/stores/agent/agentComposerStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentComposerStore.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { useAgentComposerStore } from './agentComposerStore'
+
+describe('composer reference ownership', () => {
+  it('updates detached uploads without attaching them until an explicit Undo', () => {
+    const store = useAgentComposerStore()
+    store.addAttachment({
+      id: 'image',
+      name: 'source.png',
+      ref: '',
+      uploading: true
+    })
+    const snapshot = store.prompt
+    store.removeReference('asset:image')
+    store.updateAttachment('image', { ref: 'uploaded.png', uploading: false })
+    expect(store.attachments).toEqual([])
+    store.applyEditorPrompt(snapshot)
+    expect(store.attachments).toEqual([
+      { id: 'image', name: 'source.png', ref: 'uploaded.png', uploading: false }
+    ])
+    expect(store.prompt.references).toHaveLength(1)
+  })
+
+  it('does not restore failed or expired uploads through stale editor history', () => {
+    const store = useAgentComposerStore()
+    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    store.addAttachment({
+      id: 'image',
+      name: 'source.png',
+      ref: '',
+      uploading: true,
+      previewUrl: 'blob:source'
+    })
+    const snapshot = store.prompt
+    store.removeAttachment('image')
+    store.updateAttachment('image', { ref: 'too-late.png', uploading: false })
+    store.applyEditorPrompt(snapshot)
+    expect(store.attachments).toEqual([])
+    expect(revoke).toHaveBeenCalledExactlyOnceWith('blob:source')
+  })
+
+  it('retains previews for Undo, then releases only unused previews on unmount', () => {
+    const store = useAgentComposerStore()
+    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    store.addAttachment({
+      id: 'first',
+      name: 'first.png',
+      ref: 'first.png',
+      previewUrl: 'blob:first'
+    })
+    store.addAttachment({
+      id: 'second',
+      name: 'second.png',
+      ref: 'second.png',
+      previewUrl: 'blob:second'
+    })
+    store.removeReference('asset:first')
+    expect(revoke).not.toHaveBeenCalled()
+    store.releaseUnusedAssets()
+    expect(revoke).toHaveBeenCalledExactlyOnceWith('blob:first')
+    expect(store.attachments.map(({ id }) => id)).toEqual(['second'])
+  })
+
+  it('rejects node history from a different target even when node IDs collide', () => {
+    const store = useAgentComposerStore()
+    store.setNodeScope('workflow-A')
+    store.setNodes([{ id: '12', title: 'Source node' }])
+    const snapshot = store.prompt
+    const epoch = store.promptEpoch
+    store.setNodeScope('workflow-B')
+    expect(store.promptEpoch).toBeGreaterThan(epoch)
+    store.applyEditorPrompt(snapshot)
+    expect(store.nodes).toEqual([])
+    store.setNodes([{ id: '12', title: 'Other node' }])
+    expect(store.nodes).toEqual([{ id: '12', title: 'Other node' }])
+  })
+})

--- a/src/workbench/extensions/agent/stores/agent/agentComposerStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentComposerStore.ts
@@ -1,40 +1,64 @@
 import { defineStore } from 'pinia'
-import { computed, shallowRef } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
 
 import type { ComposerAttachment } from '../../composables/agent/useComposer'
 import type { SelectedNode } from '../../composables/agent/useCanvasSelection'
+import { selectedNodeKey } from '../../composables/agent/useCanvasSelection'
+import type {
+  ComposerInsertionPoint,
+  ComposerPrompt,
+  ComposerReference
+} from '../../types/composerPrompt'
+import { composerReferenceKey } from '../../types/composerPrompt'
 import type {
   PromptSnapshot,
   WorkflowReference
 } from '../../types/workflowReference'
+import { insertComposerReference } from '../../utils/composerPrompt'
 
 interface ComposerDraft extends PromptSnapshot {
   attachments: ComposerAttachment[]
 }
 
 interface SubmittedDraft {
-  draft: string
   attachments: ComposerAttachment[]
-  references: WorkflowReference[]
   nodes: SelectedNode[]
   target: ComfyWorkflow
+  prompt: ComposerPrompt
 }
 
 export const useAgentComposerStore = defineStore('agentComposer', () => {
-  const draftState = shallowRef<ComposerDraft>({
-    text: '',
-    workflowReferences: [],
-    attachments: []
+  const draftState = shallowRef<ComposerPrompt>({ text: '', references: [] })
+  const prompt = computed(() => draftState.value)
+  const draft = computed(() => prompt.value.text)
+  const attachments = computed(() =>
+    prompt.value.references.flatMap((item) =>
+      item.kind === 'asset' ? [item.attachment] : []
+    )
+  )
+  const workflowReferences = computed(() =>
+    prompt.value.references.flatMap((item) => {
+      if (item.kind !== 'workflow') return []
+      const { kind: _kind, ...reference } = item
+      return [reference]
+    })
+  )
+  const nodes = computed(() =>
+    prompt.value.references.flatMap((item) =>
+      item.kind === 'node' ? [item.node] : []
+    )
+  )
+  const nodeScope = ref<string | null>(null)
+  const promptEpoch = ref(0)
+  const insertionPoint = shallowRef<ComposerInsertionPoint>({
+    textOffset: 0,
+    referenceIndex: 0
   })
-  const draft = computed(() => draftState.value.text)
-  const attachments = computed(() => draftState.value.attachments)
-  const workflowReferences = computed(() => draftState.value.workflowReferences)
-  const prompt = computed<PromptSnapshot>(() => ({
-    text: draftState.value.text,
-    workflowReferences: draftState.value.workflowReferences
-  }))
+  // Detached assets stay available to the editor's Undo history until it unmounts.
+  const undoAssets = new Map<string, ComposerAttachment>()
+  const retiredAssets = new Set<string>()
   const submission = shallowRef<{
     id: number
     phase: 'pending' | 'failed'
@@ -45,84 +69,251 @@ export const useAgentComposerStore = defineStore('agentComposer', () => {
   let revision = 0
   let nextSubmissionId = 0
 
-  function markEdited(): void {
+  function updateDraft(next: ComposerPrompt): void {
     ++revision
-  }
-
-  function updateDraft(next: ComposerDraft): void {
-    markEdited()
     draftState.value = next
   }
 
+  function setInsertionPoint(point: ComposerInsertionPoint): void {
+    insertionPoint.value = point
+  }
+
+  function resetPromptHistory(): void {
+    ++promptEpoch.value
+  }
+
   function setText(text: string): void {
-    if (text !== draft.value) updateDraft({ ...draftState.value, text })
+    if (text === draft.value) return
+    updateDraft({
+      text,
+      references: prompt.value.references.map((item) => ({
+        ...item,
+        textOffset: Math.min(text.length, item.textOffset)
+      }))
+    })
+    insertionPoint.value = {
+      textOffset: text.length,
+      referenceIndex: prompt.value.references.length
+    }
+  }
+
+  function applyEditorPrompt(next: ComposerPrompt): void {
+    const seen = new Set<string>()
+    const references = next.references.flatMap((item): ComposerReference[] => {
+      const key = composerReferenceKey(item)
+      if (seen.has(key)) return []
+      seen.add(key)
+      if (item.kind === 'node' && item.scope !== nodeScope.value) return []
+      if (item.kind !== 'asset') return [item]
+      if (retiredAssets.has(item.attachment.id)) return []
+      const attachment = undoAssets.get(item.attachment.id) ?? item.attachment
+      undoAssets.set(attachment.id, attachment)
+      return [{ ...item, attachment }]
+    })
+    updateDraft({ text: next.text, references })
   }
 
   function replacePrompt(next: PromptSnapshot): void {
+    resetPromptHistory()
     updateDraft({
-      ...draftState.value,
       text: next.text,
-      workflowReferences: next.workflowReferences.map((reference) => ({
-        ...reference
-      }))
+      references: [
+        ...next.workflowReferences.map(
+          (item): ComposerReference => ({ ...item, kind: 'workflow' })
+        ),
+        ...prompt.value.references
+          .filter((item) => item.kind !== 'workflow')
+          .map((item) => ({
+            ...item,
+            textOffset: Math.min(item.textOffset, next.text.length)
+          }))
+      ].sort((a, b) => a.textOffset - b.textOffset)
     })
   }
 
+  function restorePrompt(next: ComposerPrompt): void {
+    resetPromptHistory()
+    applyEditorPrompt(next)
+  }
+
   function replaceDraft(next: ComposerDraft): void {
-    updateDraft({
+    for (const attachment of next.attachments) {
+      undoAssets.set(attachment.id, { ...attachment })
+      retiredAssets.delete(attachment.id)
+    }
+    restorePrompt({
       text: next.text,
-      workflowReferences: next.workflowReferences.map((reference) => ({
-        ...reference
-      })),
-      attachments: next.attachments.map((attachment) => ({ ...attachment }))
+      references: [
+        ...next.workflowReferences.map(
+          (item): ComposerReference => ({ ...item, kind: 'workflow' })
+        ),
+        ...next.attachments.map(
+          (attachment): ComposerReference => ({
+            kind: 'asset',
+            attachment: { ...attachment },
+            textOffset: next.text.length
+          })
+        )
+      ].sort((a, b) => a.textOffset - b.textOffset)
     })
   }
 
   function setWorkflowReferences(references: WorkflowReference[]): void {
-    replacePrompt({ text: draft.value, workflowReferences: references })
+    updateDraft({
+      text: draft.value,
+      references: [
+        ...references.map(
+          (item): ComposerReference => ({ ...item, kind: 'workflow' })
+        ),
+        ...prompt.value.references.filter((item) => item.kind !== 'workflow')
+      ].sort((a, b) => a.textOffset - b.textOffset)
+    })
+  }
+
+  function removeReference(key: string): void {
+    const references = prompt.value.references.filter(
+      (item) => composerReferenceKey(item) !== key
+    )
+    if (references.length !== prompt.value.references.length)
+      updateDraft({ text: draft.value, references })
   }
 
   function removeWorkflowReference(id: string): void {
-    const references = workflowReferences.value.filter(
-      (reference) => reference.id !== id
+    removeReference(`workflow:${id}`)
+  }
+
+  function setNodeScope(scope: string | null): void {
+    if (scope === nodeScope.value) return
+    nodeScope.value = scope
+    resetPromptHistory()
+    if (nodes.value.length === 0) return
+    updateDraft({
+      text: draft.value,
+      references: prompt.value.references.filter((item) => item.kind !== 'node')
+    })
+  }
+
+  function setNodes(next: SelectedNode[]): void {
+    if (
+      next.length === nodes.value.length &&
+      next.every((node, index) => {
+        const previous = nodes.value[index]
+        return (
+          node.id === previous.id &&
+          node.locatorId === previous.locatorId &&
+          node.title === previous.title
+        )
+      })
     )
-    if (references.length !== workflowReferences.value.length)
-      setWorkflowReferences(references)
+      return
+    const byKey = new Map(next.map((node) => [selectedNodeKey(node), node]))
+    let result: ComposerPrompt = {
+      text: draft.value,
+      references: prompt.value.references.flatMap(
+        (item): ComposerReference[] => {
+          if (item.kind !== 'node') return [item]
+          const node = byKey.get(selectedNodeKey(item.node))
+          return node ? [{ ...item, node }] : []
+        }
+      )
+    }
+    if (nodeScope.value !== null) {
+      for (const node of next) {
+        if (
+          result.references.some(
+            (item) =>
+              item.kind === 'node' &&
+              selectedNodeKey(item.node) === selectedNodeKey(node)
+          )
+        )
+          continue
+        const inserted = insertComposerReference(
+          result,
+          {
+            kind: 'node',
+            node: { ...node },
+            scope: nodeScope.value,
+            textOffset: 0
+          },
+          insertionPoint.value
+        )
+        result = inserted.prompt
+        insertionPoint.value = inserted.insertion
+      }
+    }
+    updateDraft(result)
   }
 
   function addAttachment(attachment: ComposerAttachment): void {
-    if (attachments.value.some((item) => item.id === attachment.id)) return
-    updateDraft({
-      ...draftState.value,
-      attachments: [...attachments.value, { ...attachment }]
-    })
+    if (undoAssets.has(attachment.id) || retiredAssets.has(attachment.id))
+      return
+    undoAssets.set(attachment.id, { ...attachment })
+    const inserted = insertComposerReference(
+      prompt.value,
+      { kind: 'asset', attachment: { ...attachment }, textOffset: 0 },
+      insertionPoint.value
+    )
+    insertionPoint.value = inserted.insertion
+    updateDraft(inserted.prompt)
+  }
+
+  function revokePreview(attachment: ComposerAttachment): void {
+    if (attachment.previewUrl?.startsWith('blob:'))
+      URL.revokeObjectURL(attachment.previewUrl)
   }
 
   function updateAttachment(
     id: string,
     patch: Partial<ComposerAttachment>
   ): void {
+    const previous = undoAssets.get(id)
+    if (!previous) {
+      if (patch.previewUrl?.startsWith('blob:'))
+        URL.revokeObjectURL(patch.previewUrl)
+      return
+    }
+    if (
+      patch.previewUrl !== undefined &&
+      patch.previewUrl !== previous.previewUrl
+    )
+      revokePreview(previous)
+    const attachment = { ...previous, ...patch, id }
+    undoAssets.set(id, attachment)
     if (!attachments.value.some((item) => item.id === id)) return
     updateDraft({
-      ...draftState.value,
-      attachments: attachments.value.map((item) =>
-        item.id === id ? { ...item, ...patch } : item
+      text: draft.value,
+      references: prompt.value.references.map((item) =>
+        item.kind === 'asset' && item.attachment.id === id
+          ? { ...item, attachment }
+          : item
       )
     })
   }
 
-  function removeAttachment(id: string): ComposerAttachment | undefined {
-    const removed = attachments.value.find((item) => item.id === id)
-    if (removed)
-      updateDraft({
-        ...draftState.value,
-        attachments: attachments.value.filter((item) => item.id !== id)
-      })
-    return removed
+  function removeAttachment(id: string): void {
+    const attachment = undoAssets.get(id)
+    if (attachment) revokePreview(attachment)
+    undoAssets.delete(id)
+    retiredAssets.add(id)
+    removeReference(`asset:${id}`)
+  }
+
+  function releaseUnusedAssets(): void {
+    const retained = new Set(attachments.value.map(({ id }) => id))
+    for (const attachment of submission.value?.snapshot.attachments ?? [])
+      retained.add(attachment.id)
+    for (const [id, attachment] of undoAssets)
+      if (!retained.has(id)) {
+        revokePreview(attachment)
+        undoAssets.delete(id)
+        retiredAssets.add(id)
+      }
   }
 
   function startSubmission(snapshot: SubmittedDraft): number {
-    replaceDraft({ text: '', workflowReferences: [], attachments: [] })
+    resetPromptHistory()
+    updateDraft({ text: '', references: [] })
+    insertionPoint.value = { textOffset: 0, referenceIndex: 0 }
     const id = ++nextSubmissionId
     submission.value = {
       id,
@@ -148,6 +339,7 @@ export const useAgentComposerStore = defineStore('agentComposer', () => {
       sent || pending.revision !== revision
         ? null
         : { ...pending, phase: 'failed' }
+    releaseUnusedAssets()
   }
 
   function takeFailedSubmission(): SubmittedDraft | undefined {
@@ -167,16 +359,27 @@ export const useAgentComposerStore = defineStore('agentComposer', () => {
     attachments,
     workflowReferences,
     prompt,
+    nodes,
+    nodeScope,
+    promptEpoch,
+    insertionPoint,
     submission,
     setText,
+    setInsertionPoint,
+    resetPromptHistory,
+    applyEditorPrompt,
     replacePrompt,
+    restorePrompt,
     replaceDraft,
     setWorkflowReferences,
     removeWorkflowReference,
+    removeReference,
+    setNodeScope,
+    setNodes,
     addAttachment,
     updateAttachment,
     removeAttachment,
-    markEdited,
+    releaseUnusedAssets,
     startSubmission,
     requestSubmissionStop,
     settleSubmission,

--- a/src/workbench/extensions/agent/types/composerPrompt.ts
+++ b/src/workbench/extensions/agent/types/composerPrompt.ts
@@ -1,0 +1,50 @@
+import type { SelectedNode } from '../composables/agent/useCanvasSelection'
+import { selectedNodeKey } from '../composables/agent/useCanvasSelection'
+import type { ComposerAttachment } from '../composables/agent/useComposer'
+import type { WorkflowReference } from './workflowReference'
+
+export type ComposerReference =
+  | (WorkflowReference & { kind: 'workflow' })
+  | {
+      kind: 'node'
+      node: SelectedNode
+      scope: string
+      textOffset: number
+    }
+  | {
+      kind: 'asset'
+      attachment: ComposerAttachment
+      textOffset: number
+    }
+
+export interface ComposerPrompt {
+  text: string
+  references: ComposerReference[]
+}
+
+export interface ComposerInsertionPoint {
+  textOffset: number
+  referenceIndex: number
+}
+
+export function composerReferenceKey(reference: ComposerReference): string {
+  switch (reference.kind) {
+    case 'workflow':
+      return `workflow:${reference.id}`
+    case 'node':
+      return `node:${JSON.stringify([reference.scope, selectedNodeKey(reference.node)])}`
+    case 'asset':
+      return `asset:${reference.attachment.id}`
+  }
+}
+
+export function composerReferenceName(reference: ComposerReference): string {
+  switch (reference.kind) {
+    case 'workflow':
+      return reference.name
+    case 'node':
+      return `${reference.node.title} #${reference.node.id}`
+    case 'asset':
+      return reference.attachment.name
+  }
+}

--- a/src/workbench/extensions/agent/types/promptEditor.ts
+++ b/src/workbench/extensions/agent/types/promptEditor.ts
@@ -1,6 +1,8 @@
+import type { ComposerInsertionPoint } from './composerPrompt'
 import type { WorkflowReferenceMetadata } from './workflowReference'
 
 export interface PromptEditor {
+  insertionPoint?: () => ComposerInsertionPoint
   focus: () => void
   selection: () => { start: number; end: number }
   replaceText: (from: number, to: number, text: string) => void

--- a/src/workbench/extensions/agent/utils/agentMessageText.test.ts
+++ b/src/workbench/extensions/agent/utils/agentMessageText.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { agentMessageText } from './agentMessageText'
+
+describe('readable agent message', () => {
+  it('preserves inline workflow order and all available node and asset context', () => {
+    expect(
+      agentMessageText({
+        text: 'Compare  with .',
+        workflowReferences: [
+          { id: 'a', name: 'Portrait', textOffset: 8 },
+          { id: 'b', name: 'Landscape', textOffset: 14 }
+        ],
+        tags: ['KSampler #12'],
+        attachments: [{ name: 'reference.png' }, { name: 'notes.txt' }]
+      })
+    ).toBe(
+      'Compare @[Workflow: Portrait] with @[Workflow: Landscape].\n@[Node: KSampler #12]\n@[Image: reference.png]\n@[File: notes.txt]'
+    )
+  })
+
+  it('does not duplicate context already included inline', () => {
+    const text = 'Use @[Node: KSampler #12] with @[Image: reference.png].'
+    expect(
+      agentMessageText({
+        text,
+        tags: ['KSampler #12'],
+        attachments: [{ name: 'reference.png' }]
+      })
+    ).toBe(text)
+  })
+
+  it('copies context-only messages and preserves ordinary prompt whitespace', () => {
+    expect(agentMessageText({ text: '', tags: ['Load Image #2'] })).toBe(
+      '@[Node: Load Image #2]'
+    )
+    expect(agentMessageText({ text: '  first\nsecond  ' })).toBe(
+      '  first\nsecond  '
+    )
+  })
+})

--- a/src/workbench/extensions/agent/utils/agentMessageText.ts
+++ b/src/workbench/extensions/agent/utils/agentMessageText.ts
@@ -1,0 +1,42 @@
+import { getMediaTypeFromFilename } from '@comfyorg/shared-frontend-utils/formatUtil'
+
+import type { ConversationEntry } from '../stores/agent/agentConversationStore'
+import { workflowReferenceParts } from './workflowReferenceParts'
+
+export function nodeReferenceText(name: string): string {
+  return `@[Node: ${name}]`
+}
+
+export function assetReferenceText(name: string): string {
+  const kind = getMediaTypeFromFilename(name)
+  const label = {
+    image: 'Image',
+    video: 'Video',
+    audio: 'Audio',
+    '3D': '3D',
+    text: 'File',
+    other: 'File'
+  }[kind]
+  return `@[${label}: ${name}]`
+}
+
+export function agentMessageText(
+  message: Pick<
+    Extract<ConversationEntry, { role: 'user' }>,
+    'text' | 'workflowReferences' | 'tags' | 'attachments'
+  >
+): string {
+  const text = workflowReferenceParts(
+    message.text,
+    message.workflowReferences ?? []
+  )
+    .map((part) =>
+      part.type === 'text' ? part.text : `@[Workflow: ${part.reference.name}]`
+    )
+    .join('')
+  const context = [
+    ...(message.tags ?? []).map(nodeReferenceText),
+    ...(message.attachments ?? []).map(({ name }) => assetReferenceText(name))
+  ].filter((label) => !text.includes(label))
+  return [text, ...new Set(context)].filter(Boolean).join('\n')
+}

--- a/src/workbench/extensions/agent/utils/composerPrompt.test.ts
+++ b/src/workbench/extensions/agent/utils/composerPrompt.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComposerPrompt } from '../types/composerPrompt'
+import {
+  composerPromptForSend,
+  insertComposerReference
+} from './composerPrompt'
+
+describe('composer prompt boundaries', () => {
+  it('expands node and asset labels while retaining the workflow position', () => {
+    const prompt: ComposerPrompt = {
+      text: 'Use  with  in .',
+      references: [
+        {
+          kind: 'node',
+          scope: 'A',
+          node: { id: '12', title: 'KSampler' },
+          textOffset: 4
+        },
+        {
+          kind: 'asset',
+          attachment: { id: 'asset', name: 'source.png', ref: 'uploaded.png' },
+          textOffset: 10
+        },
+        { kind: 'workflow', id: 'B', name: 'Portrait', textOffset: 14 }
+      ]
+    }
+    expect(composerPromptForSend(prompt)).toEqual({
+      text: 'Use @[Node: KSampler #12] with @[Image: source.png] in .',
+      workflowReferences: [{ id: 'B', name: 'Portrait', textOffset: 55 }]
+    })
+  })
+
+  it('inserts between adjacent references and makes room for the following cursor', () => {
+    const prompt: ComposerPrompt = {
+      text: 'Use .',
+      references: [
+        { kind: 'workflow', id: 'A', name: 'First', textOffset: 4 },
+        { kind: 'workflow', id: 'B', name: 'Last', textOffset: 4 }
+      ]
+    }
+    expect(
+      insertComposerReference(
+        prompt,
+        {
+          kind: 'node',
+          scope: 'A',
+          node: { id: '12', title: 'KSampler' },
+          textOffset: 0
+        },
+        { textOffset: 4, referenceIndex: 1 }
+      )
+    ).toEqual({
+      prompt: {
+        text: 'Use  .',
+        references: [
+          prompt.references[0],
+          {
+            kind: 'node',
+            scope: 'A',
+            node: { id: '12', title: 'KSampler' },
+            textOffset: 4
+          },
+          { ...prompt.references[1], textOffset: 5 }
+        ]
+      },
+      insertion: { textOffset: 5, referenceIndex: 2 }
+    })
+  })
+})

--- a/src/workbench/extensions/agent/utils/composerPrompt.ts
+++ b/src/workbench/extensions/agent/utils/composerPrompt.ts
@@ -1,0 +1,84 @@
+import type {
+  ComposerInsertionPoint,
+  ComposerPrompt,
+  ComposerReference
+} from '../types/composerPrompt'
+import {
+  composerReferenceKey,
+  composerReferenceName
+} from '../types/composerPrompt'
+import type { PromptSnapshot } from '../types/workflowReference'
+import { assetReferenceText, nodeReferenceText } from './agentMessageText'
+
+export function insertComposerReference(
+  prompt: ComposerPrompt,
+  reference: ComposerReference,
+  insertion: ComposerInsertionPoint
+): { prompt: ComposerPrompt; insertion: ComposerInsertionPoint } {
+  const textOffset = Math.min(
+    prompt.text.length,
+    Math.max(0, insertion.textOffset)
+  )
+  const referenceIndex = Math.min(
+    prompt.references.length,
+    Math.max(0, insertion.referenceIndex)
+  )
+  const needsSpace = prompt.text[textOffset] !== ' '
+  const references = prompt.references.map((item, index) => ({
+    ...item,
+    textOffset:
+      needsSpace &&
+      (item.textOffset > textOffset ||
+        (item.textOffset === textOffset && index >= referenceIndex))
+        ? item.textOffset + 1
+        : item.textOffset
+  }))
+  references.splice(referenceIndex, 0, { ...reference, textOffset })
+  return {
+    prompt: {
+      text: needsSpace
+        ? `${prompt.text.slice(0, textOffset)} ${prompt.text.slice(textOffset)}`
+        : prompt.text,
+      references
+    },
+    insertion: {
+      textOffset: textOffset + 1,
+      referenceIndex: referenceIndex + 1
+    }
+  }
+}
+
+export function composerPromptForSend(prompt: ComposerPrompt): PromptSnapshot {
+  let text = ''
+  let offset = 0
+  const workflowReferences: PromptSnapshot['workflowReferences'] = []
+  for (const reference of prompt.references) {
+    text += prompt.text.slice(offset, reference.textOffset)
+    offset = reference.textOffset
+    if (reference.kind === 'workflow') {
+      const { kind: _kind, ...workflow } = reference
+      workflowReferences.push({ ...workflow, textOffset: text.length })
+    } else {
+      const name = composerReferenceName(reference)
+      text +=
+        reference.kind === 'node'
+          ? nodeReferenceText(name)
+          : assetReferenceText(name)
+    }
+  }
+  return { text: text + prompt.text.slice(offset), workflowReferences }
+}
+
+export function sameComposerReferenceOrder(
+  a: ComposerPrompt,
+  b: ComposerPrompt
+): boolean {
+  return (
+    a.references.length === b.references.length &&
+    a.references.every(
+      (reference, index) =>
+        composerReferenceKey(reference) ===
+        composerReferenceKey(b.references[index])
+    )
+  )
+}


### PR DESCRIPTION
Node and asset references now sit inline at the cursor, alongside workflows. The node summary and asset previews stay above the composer; removing a reference from either place removes it from both, and Undo restores it.

Copying a sent message now brings its workflow references back when pasted into the composer. This works through the Copy button or by selecting content and pressing Cmd+C. Workflow identity, position and unavailable status are preserved. Node and asset labels stay readable text, and references to the current target or an already-attached workflow paste as text.

Assets are staged before upload, and completion cannot reattach an asset the user removed. Nodes remain scoped to the target workflow, with Undo reset when the target changes. Message Copy and Markdown export include readable reference labels.

Stacked on #17443, which lands first. Tracks [FE-2209](https://linear.app/comfyorg/issue/FE-2209), where the existing screenshots and design/PM feedback request live. Two-way removal/Undo and node/asset Paste scope still await Uy and Jo's feedback.

Frontend only: no backend changes, file transfer, functional node/asset restoration on Paste, or reconstruction of missing historical metadata. Selection spanning outside a single message keeps native copying behavior; unsupported rich clipboard writing falls back to readable text.

120 related tests pass, along with full lint, app/account types and normal commit checks. The earlier restack passed 1,423 Agent tests. No new browser verification was run. The previously observed History/Edit append flake passed on retry; its cause remains unresolved.
