### PR TITLE
fix: restore workflow references on composer cut and paste

### DIFF
--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -428,6 +428,7 @@ defineExpose({
                 ? `agent-reference-item-${mentionActive}`
                 : undefined
             "
+            :editable-workflow-id
             @keydown="onComposerKeydown"
             @update:model-value="composer.replacePrompt"
             @keyup="onComposerKeyup"

--- a/src/workbench/extensions/agent/components/agent/Composer.workflowClipboard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.workflowClipboard.test.ts
@@ -171,6 +171,15 @@ describe('workflow reference clipboard', () => {
     await user.click(editor)
     await user.keyboard('{Control>}a{/Control}')
     const clipboard = await user.copy()
+    clipboard?.setData(
+      'text/html',
+      clipboard
+        .getData('text/html')
+        .replace(
+          'data-workflow-id="workflow-B"',
+          'data-workflow-id=" workflow-B "'
+        )
+    )
     target.value = 'workflow-B'
     store.replaceDraft({ text: '', workflowReferences: [], attachments: [] })
     await waitFor(() => expect(editor.textContent).toBe(''))
@@ -195,6 +204,15 @@ describe('workflow reference clipboard', () => {
     await user.click(editor)
     await user.keyboard('{Control>}a{/Control}')
     const clipboard = await user.copy()
+    clipboard?.setData(
+      'text/html',
+      clipboard
+        .getData('text/html')
+        .replace(
+          'data-workflow-id="workflow-B"',
+          'data-workflow-id=" workflow-B "'
+        )
+    )
     const caret = document.createRange()
     caret.selectNodeContents(editor)
     caret.collapse(false)
@@ -211,7 +229,9 @@ describe('workflow reference clipboard', () => {
     await user.keyboard('{Control>}a{/Control}')
     await user.paste(clipboard)
     expect(editor.textContent).toBe('Use Reference B')
-    expect(store.workflowReferences).toHaveLength(1)
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: 'Reference B', textOffset: 4 }
+    ])
   })
 
   it.for([

--- a/src/workbench/extensions/agent/components/agent/Composer.workflowClipboard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.workflowClipboard.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import { i18n } from '@/i18n'
+import { useAgentComposerStore } from '../../stores/agent/agentComposerStore'
+import Composer from './Composer.vue'
+import { setupInlinePromptEditorDom } from './composer/inlinePromptEditorTestSetup'
+
+setupInlinePromptEditorDom()
+
+function renderComposer() {
+  const store = useAgentComposerStore()
+  const target = ref('target-A')
+  const Host = defineComponent({
+    setup: () => () =>
+      h(Composer, {
+        hasWorkflowTarget: true,
+        editableWorkflowId: target.value
+      })
+  })
+  render(Host, {
+    global: { plugins: [i18n], directives: { tooltip: () => {} } }
+  })
+  return { store, target, editor: screen.getByRole('textbox') }
+}
+
+describe('workflow reference clipboard', () => {
+  beforeEach(() => vi.useRealTimers())
+
+  it.for(['copy', 'cut'] as const)(
+    'preserves newlines and indentation around workflow chips on %s and paste',
+    async (operation) => {
+      const user = userEvent.setup()
+      const { store, editor } = renderComposer()
+      const before = '\t Before\n  '
+      const after = '\n\n after  '
+      const reference = {
+        id: 'workflow-B',
+        name: 'Reference B',
+        textOffset: before.length
+      }
+      store.replaceDraft({
+        text: before + after,
+        workflowReferences: [reference],
+        attachments: []
+      })
+      await screen.findByTestId('workflow-reference-chip')
+      await user.click(editor)
+      await user.keyboard('{Control>}a{/Control}')
+      const clipboard = await user[operation]()
+      expect(clipboard?.getData('text/plain')).toBe(
+        `${before}@[Workflow: Reference B]${after}`
+      )
+      if (operation === 'copy') await user.keyboard('{Backspace}')
+      await user.paste(clipboard)
+      expect(store.draft).toBe(before + after)
+      expect(store.workflowReferences).toEqual([reference])
+      expect(editor.textContent).toBe(`${before}Reference B${after}`)
+    }
+  )
+
+  it('cuts and pastes workflow chips at the caret with their text, metadata and Undo history', async () => {
+    const user = userEvent.setup()
+    const { store, editor } = renderComposer()
+    store.replaceDraft({
+      text: 'Before  between  after',
+      workflowReferences: [
+        { id: 'workflow-B', name: '参考 🐈', textOffset: 7 },
+        { id: 'workflow-C', name: 'Missing', textOffset: 16, unavailable: true }
+      ],
+      attachments: []
+    })
+    await waitFor(() =>
+      expect(editor).toHaveTextContent('Before 参考 🐈 between Missing after')
+    )
+    await user.click(editor)
+    await user.keyboard('{Control>}a{/Control}')
+    const clipboard = await user.cut()
+    expect(clipboard?.getData('text/plain')).toBe(
+      'Before @[Workflow: 参考 🐈] between @[Workflow: Missing] after'
+    )
+    expect(editor.textContent).toBe('')
+    expect(store.workflowReferences).toEqual([])
+
+    await user.type(editor, 'New: ')
+    await user.paste(clipboard)
+    expect(editor.textContent).toBe('New: Before 参考 🐈 between Missing after')
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: '参考 🐈', textOffset: 12 },
+      { id: 'workflow-C', name: 'Missing', textOffset: 21, unavailable: true }
+    ])
+    await user.keyboard('{Control>}z{/Control}')
+    expect(editor.textContent).toBe('New: ')
+    expect(store.workflowReferences).toEqual([])
+    await user.keyboard('{Control>}y{/Control}')
+    expect(store.workflowReferences).toHaveLength(2)
+    expect(editor.textContent).toBe('New: Before 参考 🐈 between Missing after')
+  })
+
+  it('does not infer workflow identity from plain text', async () => {
+    const user = userEvent.setup()
+    const { store, editor } = renderComposer()
+    await user.click(editor)
+    await user.paste('Use @[Workflow: Reference B]')
+    expect(editor.textContent).toBe('Use @[Workflow: Reference B]')
+    expect(store.workflowReferences).toEqual([])
+  })
+
+  it('honors paste as plain text when the clipboard contains a workflow chip', async () => {
+    const user = userEvent.setup()
+    const { store, editor } = renderComposer()
+    store.replaceDraft({
+      text: 'Use ',
+      workflowReferences: [
+        { id: 'workflow-B', name: 'Reference B', textOffset: 4 }
+      ],
+      attachments: []
+    })
+    await screen.findByTestId('workflow-reference-chip')
+    await user.click(editor)
+    await user.keyboard('{Control>}a{/Control}')
+    const clipboard = await user.cut()
+    await user.keyboard('{Shift>}')
+    await user.paste(clipboard)
+    await user.keyboard('{/Shift}')
+    expect(editor.textContent).toBe('Use @[Workflow: Reference B]')
+    expect(store.workflowReferences).toEqual([])
+  })
+
+  it('cuts only a selected workflow chip and restores it between untouched text', async () => {
+    const user = userEvent.setup()
+    const { store, editor } = renderComposer()
+    store.replaceDraft({
+      text: 'Left  right',
+      workflowReferences: [
+        { id: 'workflow-B', name: 'Reference B', textOffset: 5 }
+      ],
+      attachments: []
+    })
+    const chip = await screen.findByTestId('workflow-reference-chip')
+    await user.click(editor)
+    const selection = document.createRange()
+    selection.selectNode(chip)
+    document.getSelection()?.removeAllRanges()
+    document.getSelection()?.addRange(selection)
+    document.dispatchEvent(new Event('selectionchange'))
+    const clipboard = await user.cut()
+    expect(editor.textContent).toBe('Left  right')
+    expect(store.workflowReferences).toEqual([])
+    await user.paste(clipboard)
+    expect(editor.textContent).toBe('Left Reference B right')
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: 'Reference B', textOffset: 5 }
+    ])
+  })
+
+  it('pastes a reference to the new target as readable text without changing that target', async () => {
+    const user = userEvent.setup()
+    const { store, target, editor } = renderComposer()
+    store.replaceDraft({
+      text: 'Use ',
+      workflowReferences: [
+        { id: 'workflow-B', name: 'Reference B', textOffset: 4 }
+      ],
+      attachments: []
+    })
+    await screen.findByTestId('workflow-reference-chip')
+    await user.click(editor)
+    await user.keyboard('{Control>}a{/Control}')
+    const clipboard = await user.copy()
+    target.value = 'workflow-B'
+    store.replaceDraft({ text: '', workflowReferences: [], attachments: [] })
+    await waitFor(() => expect(editor.textContent).toBe(''))
+    await user.click(editor)
+    await user.paste(clipboard)
+    expect(editor.textContent).toBe('Use @[Workflow: Reference B]')
+    expect(store.workflowReferences).toEqual([])
+    expect(target.value).toBe('workflow-B')
+  })
+
+  it('keeps existing references unique while preserving the pasted label', async () => {
+    const user = userEvent.setup()
+    const { store, editor } = renderComposer()
+    store.replaceDraft({
+      text: 'Use ',
+      workflowReferences: [
+        { id: 'workflow-B', name: 'Reference B', textOffset: 4 }
+      ],
+      attachments: []
+    })
+    await screen.findByTestId('workflow-reference-chip')
+    await user.click(editor)
+    await user.keyboard('{Control>}a{/Control}')
+    const clipboard = await user.copy()
+    const caret = document.createRange()
+    caret.selectNodeContents(editor)
+    caret.collapse(false)
+    document.getSelection()?.removeAllRanges()
+    document.getSelection()?.addRange(caret)
+    document.dispatchEvent(new Event('selectionchange'))
+    await user.paste(clipboard)
+    expect(editor.textContent).toBe(
+      'Use Reference BUse @[Workflow: Reference B]'
+    )
+    expect(store.workflowReferences).toEqual([
+      { id: 'workflow-B', name: 'Reference B', textOffset: 4 }
+    ])
+    await user.keyboard('{Control>}a{/Control}')
+    await user.paste(clipboard)
+    expect(editor.textContent).toBe('Use Reference B')
+    expect(store.workflowReferences).toHaveLength(1)
+  })
+
+  it.for([
+    '<span data-workflow-id="workflow-B">Reference B</span>',
+    '<span data-comfy-workflow="2" data-workflow-id="workflow-B">Reference B</span>',
+    '<span data-comfy-workflow="1" data-workflow-id="">Reference B</span>'
+  ])(
+    'uses plain text for unrecognized or malformed clipboard HTML: %s',
+    async (html) => {
+      const user = userEvent.setup()
+      const { store, editor } = renderComposer()
+      await user.type(editor, 'Readable fallback')
+      await user.keyboard('{Control>}a{/Control}')
+      const clipboard = await user.copy()
+      clipboard?.setData('text/html', html)
+      await user.paste(clipboard)
+      expect(editor.textContent).toBe('Readable fallback')
+      expect(store.workflowReferences).toEqual([])
+    }
+  )
+})

--- a/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { DOMParser, Fragment, Slice } from '@tiptap/pm/model'
 import { baseKeymap } from '@tiptap/pm/commands'
 import { closeHistory, history, redo, undo } from '@tiptap/pm/history'
 import { keymap } from '@tiptap/pm/keymap'
 import { EditorState, TextSelection } from '@tiptap/pm/state'
 import { EditorView } from '@tiptap/pm/view'
 import { onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
+import DOMPurify from 'dompurify'
 import { useI18n } from 'vue-i18n'
 
 import type { PromptEditor } from '../../../types/promptEditor'
@@ -24,11 +26,13 @@ defineOptions({ inheritAttrs: false })
 const {
   label,
   expanded = false,
-  activeDescendant
+  activeDescendant,
+  editableWorkflowId
 } = defineProps<{
   label: string
   expanded?: boolean
   activeDescendant?: string
+  editableWorkflowId?: string
 }>()
 const model = defineModel<PromptSnapshot>({
   default: () => ({ text: '', workflowReferences: [] })
@@ -158,15 +162,58 @@ onMounted(() => {
         return false
       }
     },
-    handlePaste(editor, event) {
-      const text = event.clipboardData?.getData('text/plain')
-      if (text === undefined) return false
-      editor.dispatch(editor.state.tr.insertText(text).scrollIntoView())
+    transformPastedHTML: (html) => DOMPurify.sanitize(html),
+    handlePaste(editor, event, slice) {
+      const clipboard = event.clipboardData
+      if (!clipboard) return false
+      const text = clipboard.getData('text/plain')
+      const { state } = editor
+      const hasWorkflows = slice.content.content.some(
+        (node) => node.type === inlinePromptSchema.nodes.workflow
+      )
+      if (!hasWorkflows) {
+        editor.dispatch(state.tr.insertText(text).scrollIntoView())
+        return true
+      }
+      const usedIds = new Set([editableWorkflowId])
+      state.doc.forEach((node, position) => {
+        if (
+          node.type === inlinePromptSchema.nodes.workflow &&
+          (position < state.selection.from || position >= state.selection.to)
+        )
+          usedIds.add(node.attrs.id)
+      })
+      // The default clipboard parser collapses whitespace in inline slices.
+      const pasted = DOMParser.fromSchema(inlinePromptSchema).parseSlice(
+        DOMPurify.sanitize(clipboard.getData('text/html'), {
+          RETURN_DOM_FRAGMENT: true
+        }),
+        { preserveWhitespace: 'full' }
+      )
+      const content = pasted.content.content.map((node) => {
+        if (node.type !== inlinePromptSchema.nodes.workflow) return node
+        if (usedIds.has(node.attrs.id))
+          return inlinePromptSchema.text(
+            `@[Workflow: ${String(node.attrs.name ?? '')}]`
+          )
+        usedIds.add(node.attrs.id)
+        return node
+      })
+      editor.dispatch(
+        state.tr
+          .replaceSelection(new Slice(Fragment.from(content), 0, 0))
+          .setMeta('paste', true)
+          .setMeta('uiEvent', 'paste')
+          .scrollIntoView()
+      )
       return true
     },
     clipboardTextSerializer: (slice) =>
-      slice.content.textBetween(0, slice.content.size, '', (node) =>
-        String(node.attrs.name ?? '')
+      slice.content.textBetween(
+        0,
+        slice.content.size,
+        '',
+        (node) => `@[Workflow: ${String(node.attrs.name ?? '')}]`
       ),
     nodeViews: {
       workflow(node, editor, getPos) {

--- a/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
@@ -4,7 +4,7 @@ import { baseKeymap } from '@tiptap/pm/commands'
 import { closeHistory, history, redo, undo } from '@tiptap/pm/history'
 import { keymap } from '@tiptap/pm/keymap'
 import { EditorState, TextSelection } from '@tiptap/pm/state'
-import { EditorView } from '@tiptap/pm/view'
+import { Decoration, DecorationSet, EditorView } from '@tiptap/pm/view'
 import { onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
 import DOMPurify from 'dompurify'
 import { useI18n } from 'vue-i18n'
@@ -86,8 +86,25 @@ onMounted(() => {
         ? { 'aria-activedescendant': activeDescendant }
         : {}),
       class:
-        'text-agent-fg min-h-7 w-full cursor-text font-inter text-[14px]/5 font-normal wrap-anywhere whitespace-pre-wrap outline-none [&_.ProseMirror-selectednode]:outline-1'
+        'text-agent-fg min-h-7 w-full cursor-text font-inter text-[14px]/5 font-normal wrap-anywhere whitespace-pre-wrap outline-none'
     }),
+    decorations(state) {
+      if (state.selection.empty) return null
+      const decorations: Decoration[] = []
+      state.doc.nodesBetween(
+        state.selection.from,
+        state.selection.to,
+        (node, position) => {
+          if (node.type === inlinePromptSchema.nodes.workflow)
+            decorations.push(
+              Decoration.node(position, position + node.nodeSize, {
+                'data-selected': 'true'
+              })
+            )
+        }
+      )
+      return DecorationSet.create(state.doc, decorations)
+    },
     dispatchTransaction(transaction) {
       if (!view) return
       const previousReferences = promptDraft(view.state.doc).references
@@ -223,7 +240,8 @@ onMounted(() => {
         if (typeof id !== 'string' || typeof name !== 'string') return { dom }
         dom.contentEditable = 'false'
         dom.dataset.testid = 'workflow-reference-chip'
-        dom.className = 'group/workflow inline'
+        dom.className =
+          'group/workflow inline selection:bg-transparent selection:text-inherit'
         const open = document.createElement('span')
         open.setAttribute('role', 'button')
         open.tabIndex = 0
@@ -244,7 +262,7 @@ onMounted(() => {
           open.title = reason
         }
         open.className =
-          'inline cursor-pointer rounded-sm bg-primary-background/30 box-decoration-clone px-1 py-0.5 font-inter text-xs/[15px] font-normal break-all whitespace-normal text-primary-background-hover ring-1 ring-primary-background/30 transition-colors ring-inset hover:bg-primary-background/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-background aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
+          'inline cursor-pointer rounded-sm bg-primary-background/30 box-decoration-clone px-1 py-0.5 font-inter text-xs/[15px] font-normal break-all whitespace-normal text-primary-background-hover ring-1 ring-primary-background/30 transition-colors ring-inset group-data-selected/workflow:bg-primary-background/60 group-data-selected/workflow:text-base-foreground group-data-selected/workflow:ring-primary-background hover:bg-primary-background/40 group-data-selected/workflow:hover:bg-primary-background/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-background aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
         const icon = document.createElement('span')
         icon.className =
           'icon-[comfy--workflow] mr-1 inline-block size-3 align-middle'

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.test.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.test.ts
@@ -1,9 +1,11 @@
+import { DOMParser } from '@tiptap/pm/model'
 import { EditorState } from '@tiptap/pm/state'
 import { describe, expect, it } from 'vitest'
 
 import { parseWorkflowReferences } from '../../../utils/workflowReferenceText'
 
 import {
+  inlinePromptSchema,
   promptDocument,
   promptDocumentPosition,
   promptDraft,
@@ -11,6 +13,24 @@ import {
 } from './inlinePrompt'
 
 describe('inline workflow prompt', () => {
+  it('normalizes clipboard workflow IDs while preserving labels and availability', () => {
+    const content = document.createElement('div')
+    const chip = document.createElement('span')
+    chip.dataset.comfyWorkflow = '1'
+    chip.dataset.workflowId = ' \tworkflow-B\n '
+    chip.dataset.workflowUnavailable = 'true'
+    chip.textContent = ' Reference B '
+    content.append(chip)
+
+    const doc = DOMParser.fromSchema(inlinePromptSchema).parse(content)
+
+    expect(doc.firstChild?.attrs).toEqual({
+      id: 'workflow-B',
+      name: ' Reference B ',
+      unavailable: true
+    })
+  })
+
   it('restores references before, between and after text, including adjacent tokens', () => {
     const draft = {
       text: 'before 😀\nafter',

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
@@ -15,8 +15,29 @@ export const inlinePromptSchema = new Schema({
       attrs: { id: {}, name: {}, unavailable: { default: false } },
       toDOM: (node) => [
         'span',
-        { 'data-workflow-id': node.attrs.id },
+        {
+          'data-comfy-workflow': '1',
+          'data-workflow-id': node.attrs.id,
+          'data-workflow-unavailable': String(node.attrs.unavailable)
+        },
         node.attrs.name
+      ],
+      parseDOM: [
+        {
+          tag: 'span[data-comfy-workflow="1"]',
+          getAttrs(element) {
+            const id = element.getAttribute('data-workflow-id')
+            const name = element.textContent
+            return id?.trim() && name.trim()
+              ? {
+                  id,
+                  name,
+                  unavailable:
+                    element.getAttribute('data-workflow-unavailable') === 'true'
+                }
+              : false
+          }
+        }
       ]
     }
   }

--- a/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
+++ b/src/workbench/extensions/agent/components/agent/composer/inlinePrompt.ts
@@ -26,9 +26,9 @@ export const inlinePromptSchema = new Schema({
         {
           tag: 'span[data-comfy-workflow="1"]',
           getAttrs(element) {
-            const id = element.getAttribute('data-workflow-id')
+            const id = element.getAttribute('data-workflow-id')?.trim()
             const name = element.textContent
-            return id?.trim() && name.trim()
+            return id && name.trim()
               ? {
                   id,
                   name,


### PR DESCRIPTION
Fixes workflow chips turning into plain text after cutting/copying and pasting in the composer. References keep their identity and position, and surrounding whitespace and Undo/Redo still work.

Selected workflow chips highlight as a whole, including wrapped lines. Duplicate references and references to the current target paste as readable text.

This lands before #17437. No backend changes.

93 related tests pass, along with lint and typechecks.
