### PR TITLE
chore: add website orb service

### DIFF
--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -67,3 +67,10 @@ services:
     portal:
       title: ComfyUI Frontend
       description: ComfyUI frontend development server.
+
+  website:
+    port: 4321
+    command: pnpm --filter @comfyorg/website dev --host 0.0.0.0 --port "$PORT"
+    portal:
+      title: Comfy.org Website
+      description: Astro development server for apps/website.

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
     server: {
+      allowedHosts: process.env.AMP_ORB ? true : undefined,
       watch: {
         ignored: ['**/playwright-report/**']
       }


### PR DESCRIPTION
## Summary

Add a persistent orb service and portal for developing the Astro website.

## Changes

- **What**: Runs `@comfyorg/website` on port 4321 and exposes it as the Comfy.org Website portal.

## Review Focus

Confirm the service name, port, and portal metadata fit the existing orb setup.