### PR TITLE
feat(workshop): credits gate opens the universal Stripe checkout

### DIFF
--- a/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
@@ -12,6 +12,12 @@ const hoistedSession = vi.hoisted(() => ({
   session: undefined as { value: unknown } | undefined
 }))
 
+const credits = vi.hoisted(() => ({ watchForTopUp: vi.fn() }))
+
+vi.mock<unknown>(import('../../config/workshop-credits'), () => ({
+  watchForTopUp: credits.watchForTopUp
+}))
+
 vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
   const { ref } = await import('vue')
   const session = ref<unknown>(undefined)
@@ -103,6 +109,35 @@ describe('BuyCreditsDialog', () => {
     })
     expect(JSON.parse(String(init.body))).toEqual({
       amount_cents: 5000,
+      return_url: `${window.location.origin}/models/checkout-complete`
+    })
+    expect(credits.watchForTopUp).toHaveBeenCalled()
+  })
+
+  it('returns through Cloud while this origin is outside the allowlist', async () => {
+    const user = userEvent.setup()
+    const tab = claimTab()
+    const fetchCheckout = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 400 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ checkout_url: 'https://checkout.stripe.com/c/s_2' }),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchCheckout)
+    renderOpenDialog()
+
+    await user.click(await screen.findByTestId('buy-credits-continue'))
+
+    await vi.waitFor(() =>
+      expect(tab.location.assign).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/c/s_2'
+      )
+    )
+    const retry = fetchCheckout.mock.calls[1] as [URL, RequestInit]
+    expect(JSON.parse(String(retry[1].body))).toMatchObject({
       return_url: `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
     })
   })

--- a/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
@@ -189,6 +189,30 @@ describe('BuyCreditsDialog', () => {
     })
   })
 
+  it('still reaches Stripe when the return host is rejected with a 404', async () => {
+    const user = userEvent.setup()
+    const tab = claimTab()
+    const fetchCheckout = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ checkout_url: 'https://checkout.stripe.com/c/s_3' }),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchCheckout)
+    renderOpenDialog()
+
+    await user.click(await screen.findByTestId('buy-credits-continue'))
+
+    await vi.waitFor(() =>
+      expect(tab.location.assign).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/c/s_3'
+      )
+    )
+  })
+
   it('falls back to the platform rail while the checkout flag is dark', async () => {
     const user = userEvent.setup()
     const tab = claimTab()

--- a/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
@@ -12,11 +12,22 @@ const hoistedSession = vi.hoisted(() => ({
   session: undefined as { value: unknown } | undefined
 }))
 
-const credits = vi.hoisted(() => ({ watchForTopUp: vi.fn() }))
-
-vi.mock<unknown>(import('../../config/workshop-credits'), () => ({
-  watchForTopUp: credits.watchForTopUp
+const credits = vi.hoisted(() => ({
+  watchForTopUp: vi.fn(),
+  clearTopUpWatch: vi.fn(),
+  topUp: undefined as { value: unknown } | undefined
 }))
+
+vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
+  const { ref, computed } = await import('vue')
+  const topUp = ref<unknown>({ status: 'idle' })
+  credits.topUp = topUp
+  return {
+    watchForTopUp: credits.watchForTopUp,
+    clearTopUpWatch: credits.clearTopUpWatch,
+    useTopUpWatch: () => computed(() => topUp.value)
+  }
+})
 
 vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
   const { ref } = await import('vue')
@@ -57,6 +68,42 @@ function renderOpenDialog() {
 describe('BuyCreditsDialog', () => {
   beforeEach(() => {
     hoistedSession.session!.value = credential
+    credits.topUp!.value = { status: 'idle' }
+    credits.watchForTopUp.mockReset()
+    credits.clearTopUpWatch.mockReset()
+  })
+
+  it('walks waiting to the landed receipt and closes on Done', async () => {
+    const user = userEvent.setup()
+    renderOpenDialog()
+
+    credits.topUp!.value = { status: 'waiting', previousCredits: 100 }
+    expect(await screen.findByTestId('buy-credits-polling')).toBeTruthy()
+
+    credits.topUp!.value = {
+      status: 'landed',
+      previousCredits: 100,
+      newCredits: 5375
+    }
+    const done = await screen.findByTestId('buy-credits-done')
+    expect(done.textContent).toContain('5,275 credits added')
+    expect(screen.getByTestId('buy-credits-ledger').textContent).toContain(
+      '5,375'
+    )
+
+    await user.click(screen.getByTestId('buy-credits-resume'))
+    expect(credits.clearTopUpWatch).toHaveBeenCalled()
+  })
+
+  it('holds with a support handle when the credits never arrive', async () => {
+    renderOpenDialog()
+
+    credits.topUp!.value = { status: 'unresolved', previousCredits: 100 }
+
+    expect(await screen.findByTestId('buy-credits-held')).toBeTruthy()
+    expect(
+      screen.getByTestId('buy-credits-support').getAttribute('href')
+    ).toBeTruthy()
   })
 
   it('offers the packs and clamps the custom stepper', async () => {
@@ -109,7 +156,7 @@ describe('BuyCreditsDialog', () => {
     })
     expect(JSON.parse(String(init.body))).toEqual({
       amount_cents: 5000,
-      return_url: `${window.location.origin}/models/checkout-complete`
+      return_url: `${window.location.origin}/payment/success`
     })
     expect(credits.watchForTopUp).toHaveBeenCalled()
   })

--- a/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import { WORKSHOP_CLOUD_BASE_URL } from '../../config/workshop-env'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
+import BuyCreditsDialog from './BuyCreditsDialog.vue'
+
+const hoistedSession = vi.hoisted(() => ({
+  session: undefined as { value: unknown } | undefined
+}))
+
+vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
+  const { ref } = await import('vue')
+  const session = ref<unknown>(undefined)
+  hoistedSession.session = session
+  return { useWorkshopSession: () => ({ session }) }
+})
+
+const credential = {
+  token: 'workspace-jwt',
+  expiresAt: Number.MAX_SAFE_INTEGER,
+  uid: 'user-1',
+  workspace: { id: 'workspace-1', name: 'Personal', type: 'personal' },
+  role: 'owner',
+  permissions: []
+}
+
+function claimTab() {
+  const tab = { location: { assign: vi.fn() }, close: vi.fn() }
+  const open = vi
+    .spyOn(window, 'open')
+    .mockReturnValue(tab as unknown as Window)
+  onTestFinished(() => {
+    open.mockRestore()
+    vi.unstubAllGlobals()
+  })
+  return tab
+}
+
+function renderOpenDialog() {
+  return render(
+    defineComponent({
+      setup: () => () => h(BuyCreditsDialog, { open: true })
+    })
+  )
+}
+
+describe('BuyCreditsDialog', () => {
+  beforeEach(() => {
+    hoistedSession.session!.value = credential
+  })
+
+  it('offers the packs and clamps the custom stepper', async () => {
+    const user = userEvent.setup()
+    renderOpenDialog()
+
+    const pack25 = await screen.findByTestId('buy-credits-pack-25')
+    expect(pack25.textContent).toContain('5,275')
+    await user.click(screen.getByTestId('buy-credits-pack-10'))
+    expect(screen.getByTestId('buy-credits-custom').textContent).toContain(
+      '$10 · 2,110'
+    )
+    await user.click(screen.getByTestId('buy-credits-less'))
+    expect(screen.getByTestId('buy-credits-custom').textContent).toContain(
+      '$5 · 1,055'
+    )
+    expect(
+      screen.getByTestId('buy-credits-less').hasAttribute('disabled')
+    ).toBe(true)
+  })
+
+  it('creates a checkout session for the picked amount and sends the buyer to it', async () => {
+    const user = userEvent.setup()
+    const tab = claimTab()
+    const fetchCheckout = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ checkout_url: 'https://checkout.stripe.com/c/s_1' }),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchCheckout)
+    renderOpenDialog()
+
+    await user.click(await screen.findByTestId('buy-credits-pack-50'))
+    await user.click(screen.getByTestId('buy-credits-continue'))
+
+    await vi.waitFor(() =>
+      expect(tab.location.assign).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/c/s_1'
+      )
+    )
+    const [target, init] = fetchCheckout.mock.calls[0] as [URL, RequestInit]
+    expect(String(target)).toBe(
+      `${WORKSHOP_CLOUD_BASE_URL}/api/billing/topup/checkout`
+    )
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer workspace-jwt'
+    })
+    expect(JSON.parse(String(init.body))).toEqual({
+      amount_cents: 5000,
+      return_url: `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
+    })
+  })
+
+  it('falls back to the platform rail while the checkout flag is dark', async () => {
+    const user = userEvent.setup()
+    const tab = claimTab()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 404 }))
+    )
+    renderOpenDialog()
+
+    await user.click(await screen.findByTestId('buy-credits-continue'))
+
+    await vi.waitFor(() =>
+      expect(tab.location.assign).toHaveBeenCalledWith(
+        platformTopUpHref('workspace-1')
+      )
+    )
+    expect(screen.queryByTestId('checkout-error')).toBeNull()
+  })
+
+  it('keeps the dialog open with a retry line when checkout errors', async () => {
+    const user = userEvent.setup()
+    const tab = claimTab()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 500 }))
+    )
+    renderOpenDialog()
+
+    await user.click(await screen.findByTestId('buy-credits-continue'))
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId('checkout-error')).toBeTruthy()
+    )
+    expect(tab.close).toHaveBeenCalled()
+  })
+})

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -56,10 +56,22 @@ const previousCredits = computed(() =>
   topUp.value.status === 'idle' ? 0 : topUp.value.previousCredits
 )
 
+// A receipt nobody acknowledged within a minute was read off the chip
+// instead; greeting the next visit with it would look like a fresh grant.
+const STALE_RECEIPT_MS = 60_000
+
 watch(open, (value) => {
-  if (value) return
-  usd.value = 25
-  state.value = 'amount'
+  if (!value) {
+    usd.value = 25
+    state.value = 'amount'
+    return
+  }
+  if (
+    topUp.value.status === 'landed' &&
+    Date.now() - topUp.value.landedAt > STALE_RECEIPT_MS
+  ) {
+    clearTopUpWatch()
+  }
 })
 
 function finish() {

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -43,10 +43,20 @@ const topUp = useTopUpWatch()
 const lastCheckout = ref<TopUpCheckoutSession | undefined>(undefined)
 
 // The hand-off owns the step from the moment it happens: waiting is 4a,
-// landed 4b, unresolved 4c. Before that, the amount card and its errors.
-const step = computed(() =>
-  topUp.value.status === 'idle' ? state.value : topUp.value.status
+// landed 4b, unresolved 4c; before that, the amount card and its errors.
+// The step latches: once the return flow is showing, a transient idle from
+// the watch must not flash the amount card between two of its states.
+const latchedReturn = ref<'waiting' | 'landed' | 'unresolved' | undefined>(
+  undefined
 )
+watch(
+  topUp,
+  (value) => {
+    if (value.status !== 'idle') latchedReturn.value = value.status
+  },
+  { immediate: true }
+)
+const step = computed(() => latchedReturn.value ?? state.value)
 const landedDelta = computed(() =>
   topUp.value.status === 'landed'
     ? topUp.value.newCredits - topUp.value.previousCredits
@@ -71,12 +81,16 @@ watch(open, (value) => {
     Date.now() - topUp.value.landedAt > STALE_RECEIPT_MS
   ) {
     clearTopUpWatch()
+    latchedReturn.value = undefined
+  } else if (topUp.value.status === 'idle') {
+    latchedReturn.value = undefined
   }
 })
 
 function finish() {
   stopAutoClose()
   clearTopUpWatch()
+  latchedReturn.value = undefined
   lastCheckout.value = undefined
   open.value = false
 }

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ExternalLink, Minus, Plus } from '@lucide/vue'
-import { computed, ref, watch } from 'vue'
+import { Check, Clock, ExternalLink, Loader2, Minus, Plus } from '@lucide/vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
 import Button from '@/components/ui/button/Button.vue'
+import { externalLinks } from '../../config/routes'
 import {
   MAX_TOP_UP_USD,
   MIN_TOP_UP_USD,
@@ -12,10 +13,15 @@ import {
   clampTopUp,
   usdToCredits
 } from '../../config/credits'
-import { watchForTopUp } from '../../config/workshop-credits'
+import {
+  clearTopUpWatch,
+  useTopUpWatch,
+  watchForTopUp
+} from '../../config/workshop-credits'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
+import type { TopUpCheckoutSession } from '../../lib/workshop/buy-credits'
 import {
   TopUpCheckoutError,
   createTopUpCheckout,
@@ -33,11 +39,78 @@ const { session } = useWorkshopSession()
 const usd = ref(25)
 const credits = computed(() => usdToCredits(usd.value))
 const state = ref<'amount' | 'pending' | 'failed'>('amount')
+const topUp = useTopUpWatch()
+const lastCheckout = ref<TopUpCheckoutSession | undefined>(undefined)
+
+// The hand-off owns the step from the moment it happens: waiting is 4a,
+// landed 4b, unresolved 4c. Before that, the amount card and its errors.
+const step = computed(() =>
+  topUp.value.status === 'idle' ? state.value : topUp.value.status
+)
+const landedDelta = computed(() =>
+  topUp.value.status === 'landed'
+    ? topUp.value.newCredits - topUp.value.previousCredits
+    : 0
+)
+const previousCredits = computed(() =>
+  topUp.value.status === 'idle' ? 0 : topUp.value.previousCredits
+)
 
 watch(open, (value) => {
   if (value) return
   usd.value = 25
   state.value = 'amount'
+})
+
+function finish() {
+  stopAutoClose()
+  clearTopUpWatch()
+  lastCheckout.value = undefined
+  open.value = false
+}
+
+// The landed card closes itself after a beat - the one state with nothing
+// left to decide. The countdown runs only while the tab is being looked at,
+// and any interaction cancels it, so nobody loses the ledger mid-read.
+const AUTO_CLOSE_MS = 3_600
+let autoCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+function stopAutoClose() {
+  if (autoCloseTimer) clearTimeout(autoCloseTimer)
+  autoCloseTimer = undefined
+}
+
+function scheduleAutoClose() {
+  stopAutoClose()
+  if (typeof document !== 'undefined' && document.hidden) return
+  autoCloseTimer = setTimeout(() => finish(), AUTO_CLOSE_MS)
+}
+
+function onVisibilityChange() {
+  if (step.value !== 'landed') return
+  if (document.hidden) stopAutoClose()
+  else scheduleAutoClose()
+}
+
+function cancelAutoClose() {
+  if (step.value === 'landed') stopAutoClose()
+}
+
+watch(step, (value) => {
+  if (value !== 'landed' || !open.value) {
+    stopAutoClose()
+    return
+  }
+  scheduleAutoClose()
+})
+
+onMounted(() => {
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+
+onBeforeUnmount(() => {
+  stopAutoClose()
+  document.removeEventListener('visibilitychange', onVisibilityChange)
 })
 
 function setAmount(next: number) {
@@ -52,19 +125,24 @@ async function continueToCheckout() {
   if (state.value === 'pending' || !session.value) return
   const forWorkspace = session.value
   state.value = 'pending'
-  const tab = window.open('about:blank', '_blank')
+  const tab = window.open('/checkout-opening', '_blank')
   try {
-    const url = await createTopUpCheckout(forWorkspace.token, usd.value * 100)
+    const checkout = await createTopUpCheckout(
+      forWorkspace.token,
+      usd.value * 100
+    )
     state.value = 'amount'
-    open.value = false
+    lastCheckout.value = checkout
     watchForTopUp()
-    if (tab) tab.location.assign(url)
-    else window.location.assign(url)
+    if (tab) tab.location.assign(checkout.url)
+    else window.location.assign(checkout.url)
   } catch (error) {
     if (error instanceof TopUpCheckoutError && error.status === 404) {
       state.value = 'amount'
       open.value = false
       const fallback = platformTopUpHref(forWorkspace.workspace.id)
+      state.value = 'amount'
+      lastCheckout.value = { url: fallback }
       watchForTopUp()
       if (tab) tab.location.assign(fallback)
       else window.location.assign(fallback)
@@ -93,103 +171,266 @@ const stepperClass =
       :close-label="t('workshop.credits.close', locale)"
       class="flex flex-col gap-6 sm:max-w-xl"
       data-testid="buy-credits-dialog"
+      @pointerdown="cancelAutoClose"
+      @keydown="cancelAutoClose"
     >
-      <DialogTitle class="pr-16">
-        {{ t('workshop.credits.title', locale) }}
-      </DialogTitle>
-      <DialogDescription class="text-base text-primary-comfy-canvas/70">
-        {{ t('workshop.credits.body', locale) }}
-      </DialogDescription>
-
-      <div
-        class="grid grid-cols-2 gap-2 sm:grid-cols-4"
-        data-testid="buy-credits-packs"
-      >
-        <button
-          v-for="pack in TOP_UP_PACKS"
-          :key="pack"
-          type="button"
-          :aria-pressed="usd === pack"
-          :class="packClass(usd === pack)"
-          :data-testid="`buy-credits-pack-${pack}`"
-          @click="setAmount(pack)"
+      <template v-if="step === 'waiting'">
+        <DialogTitle class="pr-16">
+          {{ t('workshop.credits.waitingTitle', locale) }}
+        </DialogTitle>
+        <DialogDescription class="text-base text-primary-comfy-canvas/70">
+          {{ t('workshop.credits.waitingBody', locale) }}
+        </DialogDescription>
+        <p
+          class="bg-transparency-white-t4 flex items-center gap-3 rounded-2xl px-4 py-3 text-sm text-primary-comfy-canvas"
+          data-testid="buy-credits-polling"
         >
-          <span class="text-lg font-bold">${{ pack }}</span>
-          <span class="text-xs tabular-nums opacity-70">
-            {{ format(usdToCredits(pack)) }}
-          </span>
-        </button>
-      </div>
-
-      <div
-        class="bg-transparency-white-t4 flex items-center justify-between gap-3 rounded-2xl px-4 py-3"
-        data-testid="buy-credits-custom"
-      >
-        <span class="text-sm text-primary-warm-gray">
-          {{ t('workshop.credits.custom', locale) }}
-        </span>
-        <span class="flex items-center gap-3">
-          <button
-            type="button"
-            :class="stepperClass"
-            :disabled="usd <= MIN_TOP_UP_USD"
-            :aria-label="t('workshop.credits.less', locale)"
-            data-testid="buy-credits-less"
-            @click="setAmount(usd - 5)"
+          <Loader2
+            class="text-primary-comfy-yellow size-4 animate-spin"
+            aria-hidden="true"
+          />
+          {{ t('workshop.credits.waitingPolling', locale) }}
+        </p>
+        <p
+          v-if="lastCheckout"
+          class="flex flex-wrap items-center gap-2 text-sm text-primary-warm-gray"
+        >
+          {{ t('workshop.credits.reopenPrompt', locale) }}
+          <a
+            :href="lastCheckout.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-primary-comfy-yellow underline-offset-4 hover:underline"
+            data-testid="buy-credits-reopen"
           >
-            <Minus class="size-3.5" aria-hidden="true" />
-          </button>
+            {{ t('workshop.credits.reopen', locale) }}
+          </a>
+        </p>
+        <p class="text-sm text-primary-warm-gray">
+          {{ t('workshop.credits.closingIsSafe', locale) }}
+        </p>
+      </template>
+
+      <template v-else-if="step === 'landed'">
+        <span
+          class="border-primary-comfy-yellow text-primary-comfy-yellow -mb-2 grid size-16 shrink-0 place-items-center self-center rounded-full border-2"
+          aria-hidden="true"
+        >
+          <Check class="size-7" :stroke-width="2.5" />
+        </span>
+        <DialogTitle class="px-8 text-center" data-testid="buy-credits-done">
+          {{
+            t('workshop.credits.done', locale).replace(
+              '{n}',
+              format(landedDelta)
+            )
+          }}
+        </DialogTitle>
+        <DialogDescription
+          class="px-8 text-center text-base text-primary-comfy-canvas/70"
+        >
+          {{
+            t('workshop.credits.addedTo', locale).replace(
+              '{workspace}',
+              () => session?.workspace.name ?? ''
+            )
+          }}
+        </DialogDescription>
+        <dl
+          class="bg-transparency-white-t4 flex flex-col gap-2 rounded-2xl px-4 py-3 text-sm"
+          data-testid="buy-credits-ledger"
+        >
+          <div class="flex items-baseline justify-between">
+            <dt class="text-primary-warm-gray">
+              {{ t('workshop.credits.previousBalance', locale) }}
+            </dt>
+            <dd class="text-primary-warm-gray tabular-nums">
+              {{ format(previousCredits) }}
+            </dd>
+          </div>
+          <div class="flex items-baseline justify-between">
+            <dt class="text-primary-warm-gray">
+              {{ t('workshop.credits.added', locale) }}
+            </dt>
+            <dd class="text-primary-warm-gray tabular-nums">
+              +{{ format(landedDelta) }}
+            </dd>
+          </div>
+          <div
+            class="flex items-baseline justify-between border-t border-transparency-white-t8 pt-2"
+          >
+            <dt class="text-primary-comfy-canvas">
+              {{ t('workshop.credits.newBalance', locale) }}
+            </dt>
+            <dd
+              class="flex items-center gap-1.5 font-bold text-primary-warm-white tabular-nums"
+            >
+              <Coins class="size-4" aria-hidden="true" />
+              {{ format(previousCredits + landedDelta) }}
+            </dd>
+          </div>
+        </dl>
+        <Button
+          size="lg"
+          class="mt-2 ml-auto w-fit px-5"
+          data-testid="buy-credits-resume"
+          @click="finish"
+        >
+          {{ t('workshop.credits.resume', locale) }}
+        </Button>
+      </template>
+
+      <template v-else-if="step === 'unresolved'">
+        <span
+          class="-mb-2 grid size-16 shrink-0 place-items-center self-center rounded-full border-2 border-primary-comfy-canvas/70 text-primary-comfy-canvas/70"
+          aria-hidden="true"
+        >
+          <Clock class="size-7" />
+        </span>
+        <DialogTitle class="px-8 text-center" data-testid="buy-credits-held">
+          {{ t('workshop.credits.heldTitle', locale) }}
+        </DialogTitle>
+        <DialogDescription
+          class="px-8 text-center text-base text-primary-comfy-canvas/70"
+        >
+          {{ t('workshop.credits.heldBody', locale) }}
+        </DialogDescription>
+        <div
+          v-if="lastCheckout?.sessionId"
+          class="bg-transparency-white-t4 flex flex-col gap-1 rounded-2xl px-4 py-3"
+        >
+          <span class="text-xs text-primary-warm-gray">
+            {{ t('workshop.credits.heldSupport', locale) }}
+          </span>
           <span
-            class="w-28 text-right text-sm text-primary-comfy-canvas tabular-nums"
+            class="font-mono text-sm text-primary-warm-white"
+            data-testid="buy-credits-session-id"
           >
-            ${{ format(usd) }} · {{ format(credits) }}
+            {{ lastCheckout.sessionId }}
           </span>
-          <button
-            type="button"
-            :class="stepperClass"
-            :disabled="usd >= MAX_TOP_UP_USD"
-            :aria-label="t('workshop.credits.more', locale)"
-            data-testid="buy-credits-more"
-            @click="setAmount(usd + 5)"
+        </div>
+        <div class="mt-2 flex flex-wrap items-center justify-end gap-3">
+          <Button
+            variant="outline"
+            size="lg"
+            class="px-5"
+            data-testid="buy-credits-held-close"
+            @click="finish"
           >
-            <Plus class="size-3.5" aria-hidden="true" />
+            {{ t('workshop.credits.close', locale) }}
+          </Button>
+          <Button
+            as="a"
+            :href="externalLinks.support"
+            target="_blank"
+            rel="noopener noreferrer"
+            size="lg"
+            class="px-5"
+            data-testid="buy-credits-support"
+          >
+            {{ t('workshop.credits.contactSupport', locale) }}
+          </Button>
+        </div>
+      </template>
+
+      <template v-else>
+        <DialogTitle class="pr-16">
+          {{ t('workshop.credits.title', locale) }}
+        </DialogTitle>
+        <DialogDescription class="text-base text-primary-comfy-canvas/70">
+          {{ t('workshop.credits.body', locale) }}
+        </DialogDescription>
+
+        <div
+          class="grid grid-cols-2 gap-2 sm:grid-cols-4"
+          data-testid="buy-credits-packs"
+        >
+          <button
+            v-for="pack in TOP_UP_PACKS"
+            :key="pack"
+            type="button"
+            :aria-pressed="usd === pack"
+            :class="packClass(usd === pack)"
+            :data-testid="`buy-credits-pack-${pack}`"
+            @click="setAmount(pack)"
+          >
+            <span class="text-lg font-bold">${{ pack }}</span>
+            <span class="text-xs tabular-nums opacity-70">
+              {{ format(usdToCredits(pack)) }}
+            </span>
           </button>
-        </span>
-      </div>
+        </div>
 
-      <p
-        v-if="state === 'failed'"
-        role="status"
-        class="text-sm text-red-400"
-        data-testid="checkout-error"
-      >
-        {{ t('workshop.error.checkoutFailed', locale) }}
-      </p>
+        <div
+          class="bg-transparency-white-t4 flex items-center justify-between gap-3 rounded-2xl px-4 py-3"
+          data-testid="buy-credits-custom"
+        >
+          <span class="text-sm text-primary-warm-gray">
+            {{ t('workshop.credits.custom', locale) }}
+          </span>
+          <span class="flex items-center gap-3">
+            <button
+              type="button"
+              :class="stepperClass"
+              :disabled="usd <= MIN_TOP_UP_USD"
+              :aria-label="t('workshop.credits.less', locale)"
+              data-testid="buy-credits-less"
+              @click="setAmount(usd - 5)"
+            >
+              <Minus class="size-3.5" aria-hidden="true" />
+            </button>
+            <span
+              class="w-28 text-right text-sm text-primary-comfy-canvas tabular-nums"
+            >
+              ${{ format(usd) }} · {{ format(credits) }}
+            </span>
+            <button
+              type="button"
+              :class="stepperClass"
+              :disabled="usd >= MAX_TOP_UP_USD"
+              :aria-label="t('workshop.credits.more', locale)"
+              data-testid="buy-credits-more"
+              @click="setAmount(usd + 5)"
+            >
+              <Plus class="size-3.5" aria-hidden="true" />
+            </button>
+          </span>
+        </div>
 
-      <div class="mt-2 flex flex-wrap items-center justify-end gap-3">
-        <Button
-          variant="outline"
-          size="lg"
-          class="px-5"
-          :disabled="state === 'pending'"
-          data-testid="buy-credits-cancel"
-          @click="open = false"
+        <p
+          v-if="state === 'failed'"
+          role="status"
+          class="text-sm text-red-400"
+          data-testid="checkout-error"
         >
-          {{ t('workshop.credits.cancel', locale) }}
-        </Button>
-        <Button
-          size="lg"
-          class="px-5"
-          :disabled="state === 'pending'"
-          data-testid="buy-credits-continue"
-          @click="continueToCheckout"
-        >
-          {{ t('workshop.credits.continue', locale) }}
-          <template #append>
-            <ExternalLink class="size-4" aria-hidden="true" />
-          </template>
-        </Button>
-      </div>
+          {{ t('workshop.error.checkoutFailed', locale) }}
+        </p>
+
+        <div class="mt-2 flex flex-wrap items-center justify-end gap-3">
+          <Button
+            variant="outline"
+            size="lg"
+            class="px-5"
+            :disabled="state === 'pending'"
+            data-testid="buy-credits-cancel"
+            @click="open = false"
+          >
+            {{ t('workshop.credits.cancel', locale) }}
+          </Button>
+          <Button
+            size="lg"
+            class="px-5"
+            :disabled="state === 'pending'"
+            data-testid="buy-credits-continue"
+            @click="continueToCheckout"
+          >
+            {{ t('workshop.credits.continue', locale) }}
+            <template #append>
+              <ExternalLink class="size-4" aria-hidden="true" />
+            </template>
+          </Button>
+        </div>
+      </template>
     </DialogContent>
   </Dialog>
 </template>

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -12,6 +12,7 @@ import {
   clampTopUp,
   usdToCredits
 } from '../../config/credits'
+import { watchForTopUp } from '../../config/workshop-credits'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
@@ -56,6 +57,7 @@ async function continueToCheckout() {
     const url = await createTopUpCheckout(forWorkspace.token, usd.value * 100)
     state.value = 'amount'
     open.value = false
+    watchForTopUp()
     if (tab) tab.location.assign(url)
     else window.location.assign(url)
   } catch (error) {
@@ -63,6 +65,7 @@ async function continueToCheckout() {
       state.value = 'amount'
       open.value = false
       const fallback = platformTopUpHref(forWorkspace.workspace.id)
+      watchForTopUp()
       if (tab) tab.location.assign(fallback)
       else window.location.assign(fallback)
       return

--- a/apps/website/src/components/workshop/BuyCreditsDialog.vue
+++ b/apps/website/src/components/workshop/BuyCreditsDialog.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { ExternalLink, Minus, Plus } from '@lucide/vue'
+import { computed, ref, watch } from 'vue'
+
+import { cn } from '@comfyorg/tailwind-utils'
+
+import Button from '@/components/ui/button/Button.vue'
+import {
+  MAX_TOP_UP_USD,
+  MIN_TOP_UP_USD,
+  TOP_UP_PACKS,
+  clampTopUp,
+  usdToCredits
+} from '../../config/credits'
+import { useWorkshopSession } from '../../config/workshop-session-state'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import {
+  TopUpCheckoutError,
+  createTopUpCheckout,
+  platformTopUpHref
+} from '../../lib/workshop/buy-credits'
+import Dialog from '../ui/dialog/Dialog.vue'
+import DialogContent from '../ui/dialog/DialogContent.vue'
+import DialogDescription from '../ui/dialog/DialogDescription.vue'
+import DialogTitle from '../ui/dialog/DialogTitle.vue'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const open = defineModel<boolean>('open', { default: false })
+
+const { session } = useWorkshopSession()
+const usd = ref(25)
+const credits = computed(() => usdToCredits(usd.value))
+const state = ref<'amount' | 'pending' | 'failed'>('amount')
+
+watch(open, (value) => {
+  if (value) return
+  usd.value = 25
+  state.value = 'amount'
+})
+
+function setAmount(next: number) {
+  usd.value = clampTopUp(next)
+}
+
+// The tab opens empty inside the click, before the awaited create - a window
+// opened after the await would meet the popup blocker. A 404 is the dark
+// rollout saying the flag has not reached this caller; the tab then carries
+// the platform rail instead of an error.
+async function continueToCheckout() {
+  if (state.value === 'pending' || !session.value) return
+  const forWorkspace = session.value
+  state.value = 'pending'
+  const tab = window.open('about:blank', '_blank')
+  try {
+    const url = await createTopUpCheckout(forWorkspace.token, usd.value * 100)
+    state.value = 'amount'
+    open.value = false
+    if (tab) tab.location.assign(url)
+    else window.location.assign(url)
+  } catch (error) {
+    if (error instanceof TopUpCheckoutError && error.status === 404) {
+      state.value = 'amount'
+      open.value = false
+      const fallback = platformTopUpHref(forWorkspace.workspace.id)
+      if (tab) tab.location.assign(fallback)
+      else window.location.assign(fallback)
+      return
+    }
+    tab?.close()
+    state.value = 'failed'
+  }
+}
+
+const format = (value: number) => value.toLocaleString(locale)
+const packClass = (selected: boolean) =>
+  cn(
+    'flex cursor-pointer flex-col gap-1 rounded-2xl px-4 py-3 text-left transition-colors',
+    selected
+      ? 'bg-primary-comfy-yellow text-primary-comfy-ink'
+      : 'bg-transparency-white-t4 text-primary-comfy-canvas hover:bg-transparency-white-t8'
+  )
+const stepperClass =
+  'grid size-7 cursor-pointer place-items-center rounded-full bg-transparency-white-t8 text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t20 disabled:opacity-40'
+</script>
+
+<template>
+  <Dialog v-model:open="open">
+    <DialogContent
+      :close-label="t('workshop.credits.close', locale)"
+      class="flex flex-col gap-6 sm:max-w-xl"
+      data-testid="buy-credits-dialog"
+    >
+      <DialogTitle class="pr-16">
+        {{ t('workshop.credits.title', locale) }}
+      </DialogTitle>
+      <DialogDescription class="text-base text-primary-comfy-canvas/70">
+        {{ t('workshop.credits.body', locale) }}
+      </DialogDescription>
+
+      <div
+        class="grid grid-cols-2 gap-2 sm:grid-cols-4"
+        data-testid="buy-credits-packs"
+      >
+        <button
+          v-for="pack in TOP_UP_PACKS"
+          :key="pack"
+          type="button"
+          :aria-pressed="usd === pack"
+          :class="packClass(usd === pack)"
+          :data-testid="`buy-credits-pack-${pack}`"
+          @click="setAmount(pack)"
+        >
+          <span class="text-lg font-bold">${{ pack }}</span>
+          <span class="text-xs tabular-nums opacity-70">
+            {{ format(usdToCredits(pack)) }}
+          </span>
+        </button>
+      </div>
+
+      <div
+        class="bg-transparency-white-t4 flex items-center justify-between gap-3 rounded-2xl px-4 py-3"
+        data-testid="buy-credits-custom"
+      >
+        <span class="text-sm text-primary-warm-gray">
+          {{ t('workshop.credits.custom', locale) }}
+        </span>
+        <span class="flex items-center gap-3">
+          <button
+            type="button"
+            :class="stepperClass"
+            :disabled="usd <= MIN_TOP_UP_USD"
+            :aria-label="t('workshop.credits.less', locale)"
+            data-testid="buy-credits-less"
+            @click="setAmount(usd - 5)"
+          >
+            <Minus class="size-3.5" aria-hidden="true" />
+          </button>
+          <span
+            class="w-28 text-right text-sm text-primary-comfy-canvas tabular-nums"
+          >
+            ${{ format(usd) }} · {{ format(credits) }}
+          </span>
+          <button
+            type="button"
+            :class="stepperClass"
+            :disabled="usd >= MAX_TOP_UP_USD"
+            :aria-label="t('workshop.credits.more', locale)"
+            data-testid="buy-credits-more"
+            @click="setAmount(usd + 5)"
+          >
+            <Plus class="size-3.5" aria-hidden="true" />
+          </button>
+        </span>
+      </div>
+
+      <p
+        v-if="state === 'failed'"
+        role="status"
+        class="text-sm text-red-400"
+        data-testid="checkout-error"
+      >
+        {{ t('workshop.error.checkoutFailed', locale) }}
+      </p>
+
+      <div class="mt-2 flex flex-wrap items-center justify-end gap-3">
+        <Button
+          variant="outline"
+          size="lg"
+          class="px-5"
+          :disabled="state === 'pending'"
+          data-testid="buy-credits-cancel"
+          @click="open = false"
+        >
+          {{ t('workshop.credits.cancel', locale) }}
+        </Button>
+        <Button
+          size="lg"
+          class="px-5"
+          :disabled="state === 'pending'"
+          data-testid="buy-credits-continue"
+          @click="continueToCheckout"
+        >
+          {{ t('workshop.credits.continue', locale) }}
+          <template #append>
+            <ExternalLink class="size-4" aria-hidden="true" />
+          </template>
+        </Button>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/website/src/components/workshop/HeaderAccount.ssr.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.ssr.test.ts
@@ -24,8 +24,14 @@ vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
 })
 
 vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
-  const { ref } = await import('vue')
-  return { useWorkshopCredits: () => ({ balance: ref({ status: 'unknown' }) }) }
+  const { computed, ref } = await import('vue')
+  return {
+    useWorkshopCredits: () => ({ balance: ref({ status: 'unknown' }) }),
+    refreshWorkshopCredits: vi.fn(),
+    watchForTopUp: vi.fn(),
+    clearTopUpWatch: vi.fn(),
+    useTopUpWatch: () => computed(() => ({ status: 'idle' }))
+  }
 })
 
 describe('HeaderAccount on the server', () => {

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
-import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import HeaderAccount from './HeaderAccount.vue'
 
 const h = vi.hoisted(() => ({
@@ -139,15 +138,15 @@ describe('HeaderAccount', () => {
       h.balance!.value = { status: 'ok', credits }
       render(HeaderAccount)
 
-      await userEvent
-        .setup()
-        .click(screen.getByRole('button', { name: /account/i }))
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /account/i }))
       const buy = await screen.findByRole('menuitem', {
         name: /add credits/i
       })
-      expect(buy.getAttribute('href')).toBe(platformTopUpHref(workspace.id))
-      expect(buy.getAttribute('target')).toBe('_blank')
       expect(screen.getByRole('menuitem', { name: /log out/i })).toBeTruthy()
+
+      await user.click(buy)
+      expect(await screen.findByTestId('buy-credits-dialog')).toBeTruthy()
     }
   )
 
@@ -211,19 +210,23 @@ describe('HeaderAccount menu', () => {
     h.balance!.value = { status: 'ok', credits: 42 }
   }
 
-  it('links Add credits to platform for this workspace and settings to Cloud', async () => {
+  it('opens the amount picker from Add credits and links settings to Cloud', async () => {
     signIn()
     const user = userEvent.setup()
     render(HeaderAccount)
 
     await user.click(screen.getByTestId('header-account'))
 
-    const topUp = await screen.findByTestId('account-add-credits')
-    expect(topUp.getAttribute('href')).toBe(platformTopUpHref(workspace.id))
-    expect(topUp.getAttribute('target')).toBe('_blank')
     expect(
-      screen.getByTestId('account-workspace-settings').getAttribute('href')
+      (await screen.findByTestId('account-workspace-settings')).getAttribute(
+        'href'
+      )
     ).toBe('https://cloud.comfy.org')
+    expect(screen.queryByTestId('buy-credits-dialog')).toBeNull()
+
+    await user.click(screen.getByTestId('account-add-credits'))
+
+    expect(await screen.findByTestId('buy-credits-dialog')).toBeTruthy()
   })
 
   it('hides the top-up row from a member', async () => {

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -47,9 +47,13 @@ vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
   const { ref } = await import('vue')
   const balance = ref<unknown>({ status: 'unknown' })
   h.balance = balance
+  const { computed } = await import('vue')
   return {
     useWorkshopCredits: () => ({ balance }),
-    refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined)
+    refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined),
+    watchForTopUp: vi.fn(),
+    clearTopUpWatch: vi.fn(),
+    useTopUpWatch: () => computed(() => ({ status: 'idle' }))
   }
 })
 

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -27,7 +27,6 @@ import {
   useWorkshopCredits
 } from '../../config/workshop-credits'
 import { externalLinks } from '../../config/routes'
-import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import type { WorkspaceWithRole } from '../../lib/workshop/workspaces'
 import { listWorkspaces } from '../../lib/workshop/workspaces'
 import { runBeforeSignInLeave } from '../../config/workshop-return'
@@ -35,6 +34,7 @@ import { useWorkshopSession } from '../../config/workshop-session-state'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import { useWorkshopAuthFlag } from '../../scripts/posthog'
+import BuyCreditsDialog from './BuyCreditsDialog.vue'
 
 const { locale = 'en' } = defineProps<{
   locale?: Locale
@@ -73,6 +73,7 @@ function goToSignIn(event: MouseEvent): void {
 }
 
 const menuOpen = ref(false)
+const buyingCredits = ref(false)
 
 // Mar's switcher from #16556, on real rails: the list is the account's own
 // workspaces, the switch is a remint for the picked one, and the balance
@@ -358,23 +359,16 @@ const surfaceClass =
             {{ t('auth.header.balanceError', locale) }}
           </p>
 
-          <DropdownMenuItem v-if="canTopUp" as-child>
-            <a
-              :href="platformTopUpHref(session.workspace.id)"
-              target="_blank"
-              rel="noopener noreferrer"
-              :class="itemClass"
-              data-testid="account-add-credits"
-            >
-              <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
-              <span class="flex flex-1 items-center gap-3">
-                {{ t('workshop.run.buyCredits', locale) }}
-                <ExternalLink
-                  class="size-5 text-primary-warm-gray"
-                  aria-hidden="true"
-                />
-              </span>
-            </a>
+          <DropdownMenuItem
+            v-if="canTopUp"
+            :class="itemClass"
+            data-testid="account-add-credits"
+            @select="buyingCredits = true"
+          >
+            <Coins class="size-5 text-primary-warm-gray" aria-hidden="true" />
+            <span class="flex-1">{{
+              t('workshop.run.buyCredits', locale)
+            }}</span>
           </DropdownMenuItem>
 
           <DropdownMenuItem as-child>
@@ -428,5 +422,7 @@ const surfaceClass =
         </DropdownMenuContent>
       </DropdownMenuPortal>
     </DropdownMenuRoot>
+
+    <BuyCreditsDialog v-model:open="buyingCredits" :locale />
   </div>
 </template>

--- a/apps/website/src/components/workshop/HeaderAccountSignIn.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccountSignIn.test.ts
@@ -48,9 +48,13 @@ vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
   const { ref } = await import('vue')
   const balance = ref<unknown>({ status: 'unknown' })
   h.balance = balance
+  const { computed } = await import('vue')
   return {
     useWorkshopCredits: () => ({ balance }),
-    refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined)
+    refreshWorkshopCredits: vi.fn().mockResolvedValue(undefined),
+    watchForTopUp: vi.fn(),
+    clearTopUpWatch: vi.fn(),
+    useTopUpWatch: () => computed(() => ({ status: 'idle' }))
   }
 })
 

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen, within } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick, ref } from 'vue'
 
 import type {
@@ -17,6 +17,7 @@ import { getRouterWorkshopModelDetail } from '../../config/workshop-router-conte
 import { refreshWorkshopCredits } from '../../config/workshop-credits'
 import type { useWorkshopCredits } from '../../config/workshop-credits'
 import { WORKSHOP_CLOUD_BASE_URL } from '../../config/workshop-env'
+import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import ModelDetail from './ModelDetail.vue'
 
 const auth = vi.hoisted(() => ({
@@ -471,23 +472,92 @@ describe('ModelDetail', () => {
       'A red teapot'
     )
 
-    const buy = screen.getByRole('link', { name: 'Add credits' })
-    expect(buy.getAttribute('href')).toBe(
-      `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
-    )
-    expect(buy.getAttribute('target')).toBe('_blank')
+    const buy = screen.getByRole('button', { name: /Add credits/ })
+    expect(buy.getAttribute('data-gate')).toBe('noCredits')
     expect(screen.getByTestId('gate-note').textContent).toContain('Personal')
+    expect(screen.getByTestId('gate-note').textContent).toContain('Stripe')
     expect(screen.queryByRole('button', { name: 'Run' })).toBeNull()
     expect(runWorkshopRouter).not.toHaveBeenCalled()
 
     credits.balance.value = { status: 'ok', credits: 100 }
     await nextTick()
     expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Add credits/ })).toBeNull()
     expect(screen.getByRole('textbox', { name: /Prompt/ })).toHaveProperty(
       'value',
       'A red teapot'
     )
+  })
+
+  it('creates a Stripe checkout session and sends the buyer to it', async () => {
+    auth.session.value = credential
+    credits.balance.value = { status: 'ok', credits: 0 }
+    const tab = { location: { assign: vi.fn() }, close: vi.fn() }
+    const open = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(tab as unknown as Window)
+    const fetchCheckout = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ checkout_url: 'https://checkout.stripe.com/c/s_1' }),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchCheckout)
+    onTestFinished(() => {
+      open.mockRestore()
+      vi.unstubAllGlobals()
+    })
+
+    mountDetail({ model: runnable })
+    await nextTick()
+    await user().click(screen.getByRole('button', { name: /Add credits/ }))
+
+    await vi.waitFor(() =>
+      expect(tab.location.assign).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/c/s_1'
+      )
+    )
+    const [target, init] = fetchCheckout.mock.calls[0] as [URL, RequestInit]
+    expect(String(target)).toBe(
+      `${WORKSHOP_CLOUD_BASE_URL}/api/billing/topup/checkout`
+    )
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer workspace-jwt'
+    })
+    expect(JSON.parse(String(init.body))).toEqual({
+      amount_cents: 1000,
+      return_url: `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
+    })
+  })
+
+  it('falls back to the platform rail while the checkout flag is dark', async () => {
+    auth.session.value = credential
+    credits.balance.value = { status: 'ok', credits: 0 }
+    const tab = { location: { assign: vi.fn() }, close: vi.fn() }
+    const open = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(tab as unknown as Window)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 404 }))
+    )
+    onTestFinished(() => {
+      open.mockRestore()
+      vi.unstubAllGlobals()
+    })
+
+    mountDetail({ model: runnable })
+    await nextTick()
+    await user().click(screen.getByRole('button', { name: /Add credits/ }))
+
+    await vi.waitFor(() =>
+      expect(tab.location.assign).toHaveBeenCalledWith(
+        platformTopUpHref('workspace-1')
+      )
+    )
+    expect(screen.queryByTestId('checkout-error')).toBeNull()
   })
 
   it.for(['unknown', 'error'] as const)(
@@ -606,7 +676,7 @@ describe('ModelDetail', () => {
     expect(
       screen.getByTestId('playground-output').getAttribute('data-state')
     ).toBe('cancelled')
-    expect(screen.getByRole('link', { name: 'Add credits' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Add credits/ })).toBeTruthy()
     pending.resolve(routerResult)
     await vi.waitFor(() => expect(refreshWorkshopCredits).toHaveBeenCalled())
   })

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen, within } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick, ref } from 'vue'
 
 import type {
@@ -17,7 +17,6 @@ import { getRouterWorkshopModelDetail } from '../../config/workshop-router-conte
 import { refreshWorkshopCredits } from '../../config/workshop-credits'
 import type { useWorkshopCredits } from '../../config/workshop-credits'
 import { WORKSHOP_CLOUD_BASE_URL } from '../../config/workshop-env'
-import { platformTopUpHref } from '../../lib/workshop/buy-credits'
 import ModelDetail from './ModelDetail.vue'
 
 const auth = vi.hoisted(() => ({
@@ -475,7 +474,6 @@ describe('ModelDetail', () => {
     const buy = screen.getByRole('button', { name: /Add credits/ })
     expect(buy.getAttribute('data-gate')).toBe('noCredits')
     expect(screen.getByTestId('gate-note').textContent).toContain('Personal')
-    expect(screen.getByTestId('gate-note').textContent).toContain('Stripe')
     expect(screen.queryByRole('button', { name: 'Run' })).toBeNull()
     expect(runWorkshopRouter).not.toHaveBeenCalled()
 
@@ -489,75 +487,17 @@ describe('ModelDetail', () => {
     )
   })
 
-  it('creates a Stripe checkout session and sends the buyer to it', async () => {
+  it('opens the amount picker from the gate', async () => {
     auth.session.value = credential
     credits.balance.value = { status: 'ok', credits: 0 }
-    const tab = { location: { assign: vi.fn() }, close: vi.fn() }
-    const open = vi
-      .spyOn(window, 'open')
-      .mockReturnValue(tab as unknown as Window)
-    const fetchCheckout = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(
-          JSON.stringify({ checkout_url: 'https://checkout.stripe.com/c/s_1' }),
-          { status: 200 }
-        )
-      )
-    vi.stubGlobal('fetch', fetchCheckout)
-    onTestFinished(() => {
-      open.mockRestore()
-      vi.unstubAllGlobals()
-    })
-
     mountDetail({ model: runnable })
     await nextTick()
+
+    expect(screen.queryByTestId('buy-credits-dialog')).toBeNull()
     await user().click(screen.getByRole('button', { name: /Add credits/ }))
 
-    await vi.waitFor(() =>
-      expect(tab.location.assign).toHaveBeenCalledWith(
-        'https://checkout.stripe.com/c/s_1'
-      )
-    )
-    const [target, init] = fetchCheckout.mock.calls[0] as [URL, RequestInit]
-    expect(String(target)).toBe(
-      `${WORKSHOP_CLOUD_BASE_URL}/api/billing/topup/checkout`
-    )
-    expect(init.headers).toMatchObject({
-      Authorization: 'Bearer workspace-jwt'
-    })
-    expect(JSON.parse(String(init.body))).toEqual({
-      amount_cents: 1000,
-      return_url: `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
-    })
-  })
-
-  it('falls back to the platform rail while the checkout flag is dark', async () => {
-    auth.session.value = credential
-    credits.balance.value = { status: 'ok', credits: 0 }
-    const tab = { location: { assign: vi.fn() }, close: vi.fn() }
-    const open = vi
-      .spyOn(window, 'open')
-      .mockReturnValue(tab as unknown as Window)
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response('', { status: 404 }))
-    )
-    onTestFinished(() => {
-      open.mockRestore()
-      vi.unstubAllGlobals()
-    })
-
-    mountDetail({ model: runnable })
-    await nextTick()
-    await user().click(screen.getByRole('button', { name: /Add credits/ }))
-
-    await vi.waitFor(() =>
-      expect(tab.location.assign).toHaveBeenCalledWith(
-        platformTopUpHref('workspace-1')
-      )
-    )
-    expect(screen.queryByTestId('checkout-error')).toBeNull()
+    expect(screen.getByTestId('buy-credits-dialog')).toBeTruthy()
+    expect(screen.getByTestId('buy-credits-pack-25')).toBeTruthy()
   })
 
   it.for(['unknown', 'error'] as const)(

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -36,12 +36,6 @@ import { createWorkshopUrlUploader } from '../../config/workshop-url-upload'
 import { WorkshopRouterError } from '../../config/workshop-router-errors'
 import { releaseRouterOutputs } from '../../config/workshop-response'
 import { retainRunHistory } from '../../config/workshop-run-history'
-import {
-  TOP_UP_AMOUNT_CENTS,
-  TopUpCheckoutError,
-  createTopUpCheckout,
-  platformTopUpHref
-} from '../../lib/workshop/buy-credits'
 import { modelDocsHref } from '../../lib/workshop/model-docs'
 import { useWorkshopSession } from '../../config/workshop-session-state'
 import { workshopIdempotencyKey } from '../../config/workshop-snippets'
@@ -52,6 +46,7 @@ import {
   useWorkshopAuthFlagSettled
 } from '../../scripts/posthog'
 import ApiTab from './ApiTab.vue'
+import BuyCreditsDialog from './BuyCreditsDialog.vue'
 import ExamplesTab from './ExamplesTab.vue'
 import PlaygroundForm from './PlaygroundForm.vue'
 import PlaygroundOutput from './PlaygroundOutput.vue'
@@ -176,34 +171,7 @@ const authFlagSettled = useWorkshopAuthFlagSettled()
 const mounted = useMounted()
 const signInHref = useSignInHref(locale)
 const docsHref = modelDocsHref(model)
-const checkout = ref<'idle' | 'pending' | 'failed'>('idle')
-// The tab opens empty inside the click, before the awaited create - a window
-// opened after the await would meet the popup blocker.
-async function startTopUpCheckout() {
-  if (checkout.value === 'pending' || !session.value) return
-  const forWorkspace = session.value
-  checkout.value = 'pending'
-  const tab = window.open('about:blank', '_blank')
-  try {
-    const url = await createTopUpCheckout(
-      forWorkspace.token,
-      TOP_UP_AMOUNT_CENTS
-    )
-    checkout.value = 'idle'
-    if (tab) tab.location.assign(url)
-    else window.location.assign(url)
-  } catch (error) {
-    if (error instanceof TopUpCheckoutError && error.status === 404) {
-      checkout.value = 'idle'
-      const fallback = platformTopUpHref(forWorkspace.workspace.id)
-      if (tab) tab.location.assign(fallback)
-      else window.location.assign(fallback)
-      return
-    }
-    tab?.close()
-    checkout.value = 'failed'
-  }
-}
+const buyCreditsOpen = ref(false)
 
 const gate = computed(() => {
   if (
@@ -574,7 +542,7 @@ function useInCode() {
               </p>
               <p class="text-xs text-primary-warm-gray">
                 {{
-                  t('workshop.error.noCreditsCheckout', locale).replace(
+                  t('workshop.error.noCreditsCloud', locale).replace(
                     '{workspace}',
                     () => session?.workspace.name ?? ''
                   )
@@ -584,24 +552,12 @@ function useInCode() {
             <Button
               size="lg"
               class="w-full px-5"
-              :disabled="checkout === 'pending'"
               data-testid="run-button"
               data-gate="noCredits"
-              @click="startTopUpCheckout"
+              @click="buyCreditsOpen = true"
             >
               {{ t('workshop.run.buyCredits', locale) }}
-              <template #append>
-                <ExternalLink class="size-5" aria-hidden="true" />
-              </template>
             </Button>
-            <p
-              v-if="checkout === 'failed'"
-              role="status"
-              class="text-center text-xs text-red-400"
-              data-testid="checkout-error"
-            >
-              {{ t('workshop.error.checkoutFailed', locale) }}
-            </p>
           </template>
           <template v-else-if="gate === 'memberNoCredits'">
             <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">
@@ -749,4 +705,5 @@ function useInCode() {
       <ApiTab :contract="model.execution" :values :locale />
     </section>
   </div>
+  <BuyCreditsDialog v-model:open="buyCreditsOpen" :locale />
 </template>

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -37,7 +37,9 @@ import { WorkshopRouterError } from '../../config/workshop-router-errors'
 import { releaseRouterOutputs } from '../../config/workshop-response'
 import { retainRunHistory } from '../../config/workshop-run-history'
 import {
-  TOP_UP_ON_PLATFORM,
+  TOP_UP_AMOUNT_CENTS,
+  TopUpCheckoutError,
+  createTopUpCheckout,
   platformTopUpHref
 } from '../../lib/workshop/buy-credits'
 import { modelDocsHref } from '../../lib/workshop/model-docs'
@@ -174,6 +176,35 @@ const authFlagSettled = useWorkshopAuthFlagSettled()
 const mounted = useMounted()
 const signInHref = useSignInHref(locale)
 const docsHref = modelDocsHref(model)
+const checkout = ref<'idle' | 'pending' | 'failed'>('idle')
+// The tab opens empty inside the click, before the awaited create - a window
+// opened after the await would meet the popup blocker.
+async function startTopUpCheckout() {
+  if (checkout.value === 'pending' || !session.value) return
+  const forWorkspace = session.value
+  checkout.value = 'pending'
+  const tab = window.open('about:blank', '_blank')
+  try {
+    const url = await createTopUpCheckout(
+      forWorkspace.token,
+      TOP_UP_AMOUNT_CENTS
+    )
+    checkout.value = 'idle'
+    if (tab) tab.location.assign(url)
+    else window.location.assign(url)
+  } catch (error) {
+    if (error instanceof TopUpCheckoutError && error.status === 404) {
+      checkout.value = 'idle'
+      const fallback = platformTopUpHref(forWorkspace.workspace.id)
+      if (tab) tab.location.assign(fallback)
+      else window.location.assign(fallback)
+      return
+    }
+    tab?.close()
+    checkout.value = 'failed'
+  }
+}
+
 const gate = computed(() => {
   if (
     model.incompleteReason ||
@@ -543,30 +574,34 @@ function useInCode() {
               </p>
               <p class="text-xs text-primary-warm-gray">
                 {{
-                  t(
-                    TOP_UP_ON_PLATFORM
-                      ? 'workshop.error.noCreditsPlatform'
-                      : 'workshop.error.noCreditsCloud',
-                    locale
-                  ).replace('{workspace}', () => session?.workspace.name ?? '')
+                  t('workshop.error.noCreditsCheckout', locale).replace(
+                    '{workspace}',
+                    () => session?.workspace.name ?? ''
+                  )
                 }}
               </p>
             </div>
             <Button
-              as="a"
-              :href="platformTopUpHref(session?.workspace.id)"
-              target="_blank"
-              rel="noopener"
               size="lg"
               class="w-full px-5"
+              :disabled="checkout === 'pending'"
               data-testid="run-button"
               data-gate="noCredits"
+              @click="startTopUpCheckout"
             >
               {{ t('workshop.run.buyCredits', locale) }}
               <template #append>
                 <ExternalLink class="size-5" aria-hidden="true" />
               </template>
             </Button>
+            <p
+              v-if="checkout === 'failed'"
+              role="status"
+              class="text-center text-xs text-red-400"
+              data-testid="checkout-error"
+            >
+              {{ t('workshop.error.checkoutFailed', locale) }}
+            </p>
           </template>
           <template v-else-if="gate === 'memberNoCredits'">
             <div class="mb-2 flex flex-col gap-1" data-testid="gate-note">

--- a/apps/website/src/config/credits.ts
+++ b/apps/website/src/config/credits.ts
@@ -1,0 +1,17 @@
+// Mirrors src/base/credits/comfyCredits.ts in the Cloud app.
+const CREDITS_PER_USD = 211
+
+export function usdToCredits(usd: number): number {
+  return Math.round(usd * CREDITS_PER_USD)
+}
+
+// The same packs and bounds ComfyUI's top-up dialog and platform.comfy.org use,
+// so someone who has bought credits there meets the same numbers here.
+export const TOP_UP_PACKS = [10, 25, 50, 100] as const
+export const MIN_TOP_UP_USD = 5
+export const MAX_TOP_UP_USD = 10_000
+
+export function clampTopUp(usd: number): number {
+  if (!Number.isFinite(usd)) return MIN_TOP_UP_USD
+  return Math.min(MAX_TOP_UP_USD, Math.max(MIN_TOP_UP_USD, Math.round(usd)))
+}

--- a/apps/website/src/config/workshop-credits.ts
+++ b/apps/website/src/config/workshop-credits.ts
@@ -118,6 +118,7 @@ export type TopUpWatchState =
       readonly status: 'landed'
       readonly previousCredits: number
       readonly newCredits: number
+      readonly landedAt: number
     }
   | { readonly status: 'unresolved'; readonly previousCredits: number }
 
@@ -133,12 +134,20 @@ export function clearTopUpWatch(): void {
 export function watchForTopUp(): void {
   if (typeof window === 'undefined') return
   clearTopUpWatch()
+  const { session } = useWorkshopSession()
+  // The checkout was made for this workspace; a balance from any other must
+  // never satisfy the watch, and switching away retires it.
+  const forWorkspace = session.value?.workspace.id
   const previousCredits =
     balance.value.status === 'ok' ? balance.value.credits : 0
   topUpWatch.value = { status: 'waiting', previousCredits }
   let ticks = 0
   topUpPoll = setInterval(() => {
     ticks += 1
+    if (session.value?.workspace.id !== forWorkspace) {
+      clearTopUpWatch()
+      return
+    }
     if (
       balance.value.status === 'ok' &&
       balance.value.credits > previousCredits
@@ -146,7 +155,12 @@ export function watchForTopUp(): void {
       const newCredits = balance.value.credits
       if (topUpPoll) clearInterval(topUpPoll)
       topUpPoll = undefined
-      topUpWatch.value = { status: 'landed', previousCredits, newCredits }
+      topUpWatch.value = {
+        status: 'landed',
+        previousCredits,
+        newCredits,
+        landedAt: Date.now()
+      }
       return
     }
     if (ticks > TOP_UP_POLL_LIMIT) {

--- a/apps/website/src/config/workshop-credits.ts
+++ b/apps/website/src/config/workshop-credits.ts
@@ -100,6 +100,36 @@ function start(): void {
   })
 }
 
+/**
+ * Stripe grants a top-up through its webhook seconds after the buyer pays,
+ * so the one refocus read usually races the grant and loses. While a
+ * checkout is in flight, keep re-reading until the balance moves or
+ * patience runs out.
+ */
+const TOP_UP_POLL_MS = 5_000
+const TOP_UP_POLL_LIMIT = 24
+
+let topUpPoll: ReturnType<typeof setInterval> | undefined
+
+export function watchForTopUp(): void {
+  if (typeof window === 'undefined') return
+  if (topUpPoll) clearInterval(topUpPoll)
+  const before = balance.value
+  let ticks = 0
+  topUpPoll = setInterval(() => {
+    ticks += 1
+    const landed =
+      balance.value.status === 'ok' &&
+      (before.status !== 'ok' || balance.value.credits > before.credits)
+    if (landed || ticks > TOP_UP_POLL_LIMIT) {
+      clearInterval(topUpPoll)
+      topUpPoll = undefined
+      return
+    }
+    void refreshWorkshopCredits({ force: true })
+  }, TOP_UP_POLL_MS)
+}
+
 export function useWorkshopCredits() {
   start()
   const { session } = useWorkshopSession()

--- a/apps/website/src/config/workshop-credits.ts
+++ b/apps/website/src/config/workshop-credits.ts
@@ -144,7 +144,11 @@ export function watchForTopUp(): void {
   let ticks = 0
   topUpPoll = setInterval(() => {
     ticks += 1
-    if (session.value?.workspace.id !== forWorkspace) {
+    // Only a definitely different workspace retires the watch: a snapshot
+    // mid-remint has no session for a beat, and that transient must not
+    // kill a checkout in flight.
+    const liveWorkspace = session.value?.workspace.id
+    if (liveWorkspace !== undefined && liveWorkspace !== forWorkspace) {
       clearTopUpWatch()
       return
     }

--- a/apps/website/src/config/workshop-credits.ts
+++ b/apps/website/src/config/workshop-credits.ts
@@ -104,30 +104,63 @@ function start(): void {
  * Stripe grants a top-up through its webhook seconds after the buyer pays,
  * so the one refocus read usually races the grant and loses. While a
  * checkout is in flight, keep re-reading until the balance moves or
- * patience runs out.
+ * patience runs out — and let the dialog watch the outcome: waiting is its
+ * 4a card, landed carries the receipt's ledger, unresolved is the held
+ * state that names a support handle.
  */
 const TOP_UP_POLL_MS = 5_000
 const TOP_UP_POLL_LIMIT = 24
 
+export type TopUpWatchState =
+  | { readonly status: 'idle' }
+  | { readonly status: 'waiting'; readonly previousCredits: number }
+  | {
+      readonly status: 'landed'
+      readonly previousCredits: number
+      readonly newCredits: number
+    }
+  | { readonly status: 'unresolved'; readonly previousCredits: number }
+
+const topUpWatch = ref<TopUpWatchState>({ status: 'idle' })
 let topUpPoll: ReturnType<typeof setInterval> | undefined
+
+export function clearTopUpWatch(): void {
+  if (topUpPoll) clearInterval(topUpPoll)
+  topUpPoll = undefined
+  topUpWatch.value = { status: 'idle' }
+}
 
 export function watchForTopUp(): void {
   if (typeof window === 'undefined') return
-  if (topUpPoll) clearInterval(topUpPoll)
-  const before = balance.value
+  clearTopUpWatch()
+  const previousCredits =
+    balance.value.status === 'ok' ? balance.value.credits : 0
+  topUpWatch.value = { status: 'waiting', previousCredits }
   let ticks = 0
   topUpPoll = setInterval(() => {
     ticks += 1
-    const landed =
+    if (
       balance.value.status === 'ok' &&
-      (before.status !== 'ok' || balance.value.credits > before.credits)
-    if (landed || ticks > TOP_UP_POLL_LIMIT) {
-      clearInterval(topUpPoll)
+      balance.value.credits > previousCredits
+    ) {
+      const newCredits = balance.value.credits
+      if (topUpPoll) clearInterval(topUpPoll)
       topUpPoll = undefined
+      topUpWatch.value = { status: 'landed', previousCredits, newCredits }
+      return
+    }
+    if (ticks > TOP_UP_POLL_LIMIT) {
+      if (topUpPoll) clearInterval(topUpPoll)
+      topUpPoll = undefined
+      topUpWatch.value = { status: 'unresolved', previousCredits }
       return
     }
     void refreshWorkshopCredits({ force: true })
   }, TOP_UP_POLL_MS)
+}
+
+export function useTopUpWatch() {
+  return computed(() => topUpWatch.value)
 }
 
 export function useWorkshopCredits() {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9400,6 +9400,68 @@ Enterprise`
     'zh-CN': '返回模型'
   },
   'workshop.credits.close': { en: 'Close', 'zh-CN': '关闭' },
+  'workshop.credits.waitingTitle': {
+    en: 'Waiting for your payment',
+    'zh-CN': '正在等待付款'
+  },
+  'workshop.credits.waitingBody': {
+    en: 'Complete the purchase in the tab that just opened. This page updates on its own.',
+    'zh-CN': '请在新标签页中完成购买，此处会自动更新。'
+  },
+  'workshop.credits.waitingPolling': {
+    en: 'Checking for credits…',
+    'zh-CN': '正在查询积分…'
+  },
+  'workshop.credits.reopenPrompt': {
+    en: 'Lost the tab?',
+    'zh-CN': '不小心关闭了？'
+  },
+  'workshop.credits.reopen': {
+    en: 'Reopen checkout',
+    'zh-CN': '重新打开结账页'
+  },
+  'workshop.credits.closingIsSafe': {
+    en: 'Closing this won’t affect your payment.',
+    'zh-CN': '关闭此窗口不会影响你的付款。'
+  },
+  'workshop.credits.addedTo': {
+    en: 'Added to {workspace}. Your inputs are as you left them.',
+    'zh-CN': '已添加到 {workspace}。你的输入保持原样。'
+  },
+  'workshop.credits.previousBalance': {
+    en: 'Previous balance',
+    'zh-CN': '原有余额'
+  },
+  'workshop.credits.added': { en: 'Added', 'zh-CN': '新增' },
+  'workshop.credits.newBalance': { en: 'New balance', 'zh-CN': '当前余额' },
+  'workshop.credits.heldTitle': {
+    en: 'Payment received',
+    'zh-CN': '已收到付款'
+  },
+  'workshop.credits.heldBody': {
+    en: 'Your payment went through, but the credits have not arrived yet. You will not be charged again.',
+    'zh-CN': '付款已成功，但积分尚未到账。不会重复扣款。'
+  },
+  'workshop.credits.heldSupport': {
+    en: 'If they do not appear, give support this ID',
+    'zh-CN': '若积分仍未到账，请将此 ID 提供给客服'
+  },
+  'workshop.credits.contactSupport': {
+    en: 'Contact support',
+    'zh-CN': '联系客服'
+  },
+  'workshop.credits.openingLabel': {
+    en: 'Secure checkout',
+    'zh-CN': '安全结账'
+  },
+  'workshop.credits.openingTitle': {
+    en: 'Taking you to Stripe',
+    'zh-CN': '正在前往 Stripe'
+  },
+  'workshop.credits.openingBody': {
+    en: 'Finish your purchase here. The page you came from is still open, and your credits will appear there.',
+    'zh-CN': '请在此完成购买。你来时的页面仍然打开，积分会显示在那里。'
+  },
   'workshop.credits.returnTitle': {
     en: 'All done here',
     'zh-CN': '这里已完成'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9400,6 +9400,14 @@ Enterprise`
     'zh-CN': '返回模型'
   },
   'workshop.credits.close': { en: 'Close', 'zh-CN': '关闭' },
+  'workshop.credits.returnTitle': {
+    en: 'All done here',
+    'zh-CN': '这里已完成'
+  },
+  'workshop.credits.returnBody': {
+    en: 'You can close this tab — your balance updates on the page you came from.',
+    'zh-CN': '可以关闭此标签页——你来时的页面会自动更新余额。'
+  },
   'workshop.media.label': {
     en: 'Browse by output',
     'zh-CN': '按输出浏览'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9926,6 +9926,14 @@ Enterprise`
     en: 'Not enough credits',
     'zh-CN': '积分不足'
   },
+  'workshop.error.checkoutFailed': {
+    en: 'Checkout could not start. Try again.',
+    'zh-CN': '无法启动结账，请重试。'
+  },
+  'workshop.error.noCreditsCheckout': {
+    en: 'Add credits to {workspace} through Stripe checkout.',
+    'zh-CN': '通过 Stripe 结账为 {workspace} 添加积分。'
+  },
   'workshop.error.noCreditsCloud': {
     en: 'Add credits to {workspace} to keep running models.',
     'zh-CN': '为 {workspace} 添加积分以继续运行模型。'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9362,19 +9362,21 @@ Enterprise`
     'zh-CN': '浏览全部'
   },
   'workshop.credits.title': {
-    en: 'Payment happens on Stripe',
-    'zh-CN': '支付在 Stripe 完成'
+    en: 'Add credits',
+    'zh-CN': '添加积分'
   },
   'workshop.credits.body': {
-    en: 'Pick a top-up here and finish the purchase on Stripe Checkout. We send the page you are on as the return address, so you land back here with your inputs as you left them:',
-    'zh-CN':
-      '在此选择充值额度，然后在 Stripe Checkout 完成支付。我们会带上当前页面作为返回地址，付款后你会回到这里，输入内容保持原样：'
+    en: 'Pick a bundle, or choose a custom amount.',
+    'zh-CN': '选择一个额度，或自定义金额。'
   },
-  'workshop.credits.continue': {
-    en: 'Continue to Stripe',
-    'zh-CN': '前往 Stripe'
+  'workshop.credits.continue': { en: 'Continue', 'zh-CN': '继续' },
+  'workshop.credits.custom': {
+    en: 'Custom · $5 – $10,000',
+    'zh-CN': '自定义 · $5 – $10,000'
   },
-  'workshop.credits.cancel': { en: 'Stay here', 'zh-CN': '留在此页' },
+  'workshop.credits.less': { en: 'Less', 'zh-CN': '减少' },
+  'workshop.credits.more': { en: 'More', 'zh-CN': '增加' },
+  'workshop.credits.cancel': { en: 'Cancel', 'zh-CN': '取消' },
   'workshop.credits.checkout': {
     en: 'Checkout',
     'zh-CN': '结账'
@@ -9929,10 +9931,6 @@ Enterprise`
   'workshop.error.checkoutFailed': {
     en: 'Checkout could not start. Try again.',
     'zh-CN': '无法启动结账，请重试。'
-  },
-  'workshop.error.noCreditsCheckout': {
-    en: 'Add credits to {workspace} through Stripe checkout.',
-    'zh-CN': '通过 Stripe 结账为 {workspace} 添加积分。'
   },
   'workshop.error.noCreditsCloud': {
     en: 'Add credits to {workspace} to keep running models.',

--- a/apps/website/src/integrations/workshop-release-gate.ts
+++ b/apps/website/src/integrations/workshop-release-gate.ts
@@ -23,7 +23,11 @@ export function modelsBuildRoutes(enabled: boolean) {
     ...(enabled
       ? [
           { pattern: '/models/[slug]', entrypoint: entry('[slug]') },
-          { pattern: '/models/showcase', entrypoint: entry('showcase') }
+          { pattern: '/models/showcase', entrypoint: entry('showcase') },
+          {
+            pattern: '/checkout-opening',
+            entrypoint: entry('checkout-opening')
+          }
         ]
       : [])
   ]

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -1,4 +1,7 @@
+import { z } from 'zod'
+
 import {
+  WORKSHOP_CLOUD_BASE_URL,
   WORKSHOP_CLOUD_ENV,
   WORKSHOP_CREDITS_URL
 } from '../../config/workshop-env'
@@ -17,11 +20,54 @@ import {
  */
 const PLATFORM_ORIGIN = 'https://platform.comfy.org'
 
-export const TOP_UP_ON_PLATFORM = WORKSHOP_CLOUD_ENV === 'prod'
-
 export function platformTopUpHref(workspaceId?: string): string {
   if (WORKSHOP_CLOUD_ENV !== 'prod') return WORKSHOP_CREDITS_URL
   const url = new URL('/billing', PLATFORM_ORIGIN)
   if (workspaceId) url.searchParams.set('workspace', workspaceId)
   return url.toString()
+}
+
+/**
+ * Hunter's universal top-up: `POST /api/billing/topup/checkout` on the
+ * session's own Cloud creates a hosted Stripe Checkout session and answers
+ * with its URL. Behind `topup_checkout_enabled` (dark rollout): a caller the
+ * flag has not reached gets a 404, not a refusal — branch on it and fall
+ * back rather than surfacing an error. The return address must be a host in
+ * ingest's own allowlist, which today means Cloud itself, so the buyer
+ * resurfaces on the cloud credits page and the model page re-reads its
+ * balance on refocus.
+ */
+export const TOP_UP_AMOUNT_CENTS = 1_000
+
+export class TopUpCheckoutError extends Error {
+  constructor(readonly status: number) {
+    super('Top-up checkout failed with status ' + String(status))
+  }
+}
+
+const zTopUpCheckout = z.object({ checkout_url: z.string().url() })
+
+export async function createTopUpCheckout(
+  token: string,
+  amountCents: number
+): Promise<string> {
+  const response = await fetch(
+    new URL('/api/billing/topup/checkout', WORKSHOP_CLOUD_BASE_URL),
+    {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + token,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        amount_cents: amountCents,
+        return_url: WORKSHOP_CREDITS_URL
+      })
+    }
+  )
+  if (!response.ok) throw new TopUpCheckoutError(response.status)
+  const body: unknown = await response.json().catch(() => undefined)
+  const parsed = zTopUpCheckout.safeParse(body)
+  if (!parsed.success) throw new TopUpCheckoutError(response.status)
+  return parsed.data.checkout_url
 }

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -45,9 +45,10 @@ export class TopUpCheckoutError extends Error {
 
 const zTopUpCheckout = z.object({ checkout_url: z.string().url() })
 
-export async function createTopUpCheckout(
+async function requestCheckout(
   token: string,
-  amountCents: number
+  amountCents: number,
+  returnUrl: string
 ): Promise<string> {
   const response = await fetch(
     new URL('/api/billing/topup/checkout', WORKSHOP_CLOUD_BASE_URL),
@@ -59,7 +60,7 @@ export async function createTopUpCheckout(
       },
       body: JSON.stringify({
         amount_cents: amountCents,
-        return_url: WORKSHOP_CREDITS_URL
+        return_url: returnUrl
       })
     }
   )
@@ -68,4 +69,29 @@ export async function createTopUpCheckout(
   const parsed = zTopUpCheckout.safeParse(body)
   if (!parsed.success) throw new TopUpCheckoutError(response.status)
   return parsed.data.checkout_url
+}
+
+/**
+ * The buyer should land on this site's own close-yourself page, which hands
+ * focus back to the tab they came from. Ingest allowlists return hosts and
+ * admits only Cloud's today; a 400 means this origin is not on the list yet,
+ * and the buyer returns through Cloud's credits page instead.
+ */
+export async function createTopUpCheckout(
+  token: string,
+  amountCents: number
+): Promise<string> {
+  if (typeof window === 'undefined')
+    return requestCheckout(token, amountCents, WORKSHOP_CREDITS_URL)
+  const ownReturn = new URL(
+    '/models/checkout-complete',
+    window.location.origin
+  ).toString()
+  try {
+    return await requestCheckout(token, amountCents, ownReturn)
+  } catch (error) {
+    if (error instanceof TopUpCheckoutError && error.status === 400)
+      return requestCheckout(token, amountCents, WORKSHOP_CREDITS_URL)
+    throw error
+  }
 }

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -37,8 +37,6 @@ export function platformTopUpHref(workspaceId?: string): string {
  * resurfaces on the cloud credits page and the model page re-reads its
  * balance on refocus.
  */
-export const TOP_UP_AMOUNT_CENTS = 1_000
-
 export class TopUpCheckoutError extends Error {
   constructor(readonly status: number) {
     super('Top-up checkout failed with status ' + String(status))

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -43,13 +43,21 @@ export class TopUpCheckoutError extends Error {
   }
 }
 
-const zTopUpCheckout = z.object({ checkout_url: z.string().url() })
+const zTopUpCheckout = z.object({
+  checkout_url: z.string().url(),
+  session_id: z.string().optional()
+})
+
+export interface TopUpCheckoutSession {
+  readonly url: string
+  readonly sessionId?: string
+}
 
 async function requestCheckout(
   token: string,
   amountCents: number,
   returnUrl: string
-): Promise<string> {
+): Promise<TopUpCheckoutSession> {
   const response = await fetch(
     new URL('/api/billing/topup/checkout', WORKSHOP_CLOUD_BASE_URL),
     {
@@ -68,23 +76,29 @@ async function requestCheckout(
   const body: unknown = await response.json().catch(() => undefined)
   const parsed = zTopUpCheckout.safeParse(body)
   if (!parsed.success) throw new TopUpCheckoutError(response.status)
-  return parsed.data.checkout_url
+  return {
+    url: parsed.data.checkout_url,
+    ...(parsed.data.session_id !== undefined
+      ? { sessionId: parsed.data.session_id }
+      : {})
+  }
 }
 
 /**
- * The buyer should land on this site's own close-yourself page, which hands
- * focus back to the tab they came from. Ingest allowlists return hosts and
- * admits only Cloud's today; a 400 means this origin is not on the list yet,
- * and the buyer returns through Cloud's credits page instead.
+ * The buyer should land on this site's own /payment/success, which hands
+ * focus back to the tab that opened checkout and closes itself, and renders
+ * as the ordinary thank-you page everywhere else. Ingest allowlists return
+ * hosts and admits only Cloud's today; a 400 means this origin is not on
+ * the list yet, and the buyer returns through Cloud's credits page instead.
  */
 export async function createTopUpCheckout(
   token: string,
   amountCents: number
-): Promise<string> {
+): Promise<TopUpCheckoutSession> {
   if (typeof window === 'undefined')
     return requestCheckout(token, amountCents, WORKSHOP_CREDITS_URL)
   const ownReturn = new URL(
-    '/models/checkout-complete',
+    '/payment/success',
     window.location.origin
   ).toString()
   try {

--- a/apps/website/src/lib/workshop/buy-credits.ts
+++ b/apps/website/src/lib/workshop/buy-credits.ts
@@ -104,7 +104,15 @@ export async function createTopUpCheckout(
   try {
     return await requestCheckout(token, amountCents, ownReturn)
   } catch (error) {
-    if (error instanceof TopUpCheckoutError && error.status === 400)
+    // A rejected return host may come back as 400 or 404 depending on the
+    // ingest build, and a plain 404 also means the feature flag is dark -
+    // indistinguishable from here. Retry once with the Cloud return either
+    // way: it answers the allowlist rejection, and a genuinely dark flag
+    // 404s again and surfaces as itself.
+    if (
+      error instanceof TopUpCheckoutError &&
+      (error.status === 400 || error.status === 404)
+    )
       return requestCheckout(token, amountCents, WORKSHOP_CREDITS_URL)
     throw error
   }

--- a/apps/website/src/pages/payment/failed.astro
+++ b/apps/website/src/pages/payment/failed.astro
@@ -10,3 +10,13 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
 >
   <PaymentStatusSection status="failed" />
 </BaseLayout>
+
+<script>
+  // A checkout opened with window.open returns here when it finishes; the
+  // tab may close itself and hand focus back. Everywhere else close() is
+  // silently refused and the page reads as the ordinary landing it is.
+  if (window.opener) {
+    window.opener.focus()
+    window.close()
+  }
+</script>

--- a/apps/website/src/pages/payment/success.astro
+++ b/apps/website/src/pages/payment/success.astro
@@ -10,3 +10,13 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
 >
   <PaymentStatusSection status="success" />
 </BaseLayout>
+
+<script>
+  // A checkout opened with window.open returns here when it finishes; the
+  // tab may close itself and hand focus back. Everywhere else close() is
+  // silently refused and the page reads as the ordinary landing it is.
+  if (window.opener) {
+    window.opener.focus()
+    window.close()
+  }
+</script>

--- a/apps/website/src/routes/models/checkout-complete.astro
+++ b/apps/website/src/routes/models/checkout-complete.astro
@@ -1,0 +1,29 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import { t } from '../../i18n/translations'
+---
+
+<BaseLayout
+  title="Checkout complete - Comfy"
+  description="Your credit top-up checkout has finished."
+>
+  <main class="grid min-h-[60vh] place-items-center px-6">
+    <div class="max-w-md text-center">
+      <h1 class="text-2xl font-bold text-primary-warm-white">
+        {t('workshop.credits.returnTitle')}
+      </h1>
+      <p class="mt-3 text-primary-warm-gray">
+        {t('workshop.credits.returnBody')}
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<script>
+  // A tab opened by window.open may close itself; the page it came from is
+  // refocused by the browser and re-reads its balance. The text above only
+  // matters when a blocker forced same-tab navigation, where close() is
+  // silently refused.
+  window.opener?.focus()
+  window.close()
+</script>

--- a/apps/website/src/routes/models/checkout-opening.astro
+++ b/apps/website/src/routes/models/checkout-opening.astro
@@ -1,0 +1,33 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import { t } from '../../i18n/translations'
+---
+
+<BaseLayout
+  title="Opening checkout - Comfy"
+  description="Taking you to the secure checkout."
+>
+  <main
+    class="flex min-h-[calc(100dvh-12rem)] items-center justify-center px-6 py-16"
+  >
+    <div class="flex max-w-2xl flex-col items-center gap-6 text-center">
+      <div
+        class="border-primary-comfy-yellow text-primary-comfy-yellow flex size-20 items-center justify-center rounded-full border-2"
+        aria-hidden="true"
+      >
+        <span class="text-3xl">↗</span>
+      </div>
+      <p
+        class="text-xs font-bold tracking-wider text-primary-warm-gray uppercase"
+      >
+        {t('workshop.credits.openingLabel')}
+      </p>
+      <h1 class="text-4xl font-bold text-primary-warm-white">
+        {t('workshop.credits.openingTitle')}
+      </h1>
+      <p class="text-primary-warm-gray">
+        {t('workshop.credits.openingBody')}
+      </p>
+    </div>
+  </main>
+</BaseLayout>


### PR DESCRIPTION
The same credits gate as #17400, with **Add credits** opening the universal Stripe checkout instead of linking platform billing. Stacked on `comfydesigner/workshop-add-credits-ui`.

## The flow

1. The gate's Add credits opens **Mar's DES-1013 amount step**, returned from the parked prototype (#17039) and stripped of its mocks: four packs ($10/$25/$50/$100) with their credit conversions, a clamped custom stepper ($5–$10,000, the cloud app's own bounds), Cancel, and Continue. The dialog never names Stripe — the leave marker on Continue carries "you are leaving."
2. Continue `POST`s `/api/billing/topup/checkout` on the session's own Cloud (`Bearer` session token, `{ amount_cents, return_url }`) and opens the returned hosted Checkout session in a tab claimed synchronously inside the click, so popup blockers stay quiet and the model page keeps its inputs.
3. `return_url` stays on Cloud (`/?settings=plan-credits`) — ingest's return allowlist covers Cloud's own hosts only today. The model page re-reads its balance on refocus.
4. Per Hunter's thread, `topup_checkout_enabled` is now **rolled out 100% in staging** (0% prod). If a caller still 404s — prod, or an environment the flag hasn't reached — the tab carries the **platform rail** from #17400 instead, mirroring [platform#1019](https://github.com/Comfy-Org/platform/pull/1019). Other errors keep the dialog open with an inline retry line.

## Testing note

Our `workshop-test` preview talks to **test** Cloud; Hunter's rollout note says *staging*. If test Cloud doesn't resolve the flag you'll see the (working) platform fallback rather than Stripe — one line to Hunter settles whether test is covered, or we flip this PR to the `workshop` label.

Rail decision platform-link vs checkout is Luke's per the Slack thread — this PR exists so both are testable.

Tests: pack selection and stepper clamping; the checkout call carries the token, picked amount and Cloud return address and navigates the claimed tab; the dark-rollout 404 lands on the platform rail; a real error keeps the dialog open with retry. 57 passing across the touched suites.

Base: `comfydesigner/workshop-add-credits-ui` — merge #17400 first.
