### PR TITLE
test: add custom node pack scenarios from the ECS migration QA plan

### DIFF
--- a/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
+++ b/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
@@ -71,7 +71,7 @@ first@first prompt
 second@second prompt`)
     })
 
-    test('VHS Load Video connects to Video Combine and persists widgets', async ({
+    test('VHS Load Video connects to Video Combine and persists frame_rate', async ({
       comfyPage
     }) => {
       // oxlint-disable-next-line playwright/no-skipped-test -- pack availability differs by manifest shard

--- a/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
+++ b/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
@@ -1,0 +1,158 @@
+/* oxlint-disable playwright/no-skipped-test, playwright/expect-expect -- QA rows stay visible as skipped tests when their packs are absent from the manifest. */
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import {
+  customNodesManifest,
+  loadManifest
+} from '@e2e/fixtures/customNode/manifest'
+import { customNodeSuiteSettings } from '@e2e/fixtures/utils/customNodeSuite'
+
+test.use({ initialSettings: customNodeSuiteSettings })
+
+test.describe(
+  'ECS migration custom-node scenarios',
+  { tag: '@custom-nodes' },
+  () => {
+    test('rgthree Fast Muter toggles target modes and persists its renamed label', async () => {
+      test.skip(true, 'rgthree is not present in customNodeManifest.cloud.json')
+    })
+
+    test('rgthree Fast Bypasser toggles target bypass modes', async () => {
+      test.skip(true, 'rgthree is not present in customNodeManifest.cloud.json')
+    })
+
+    test('rgthree boundary link-control disconnects a link', async () => {
+      test.skip(
+        true,
+        'rgthree is not present in customNodeManifest.cloud.json; known gap: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15501'
+      )
+    })
+
+    test('Prompt Combinator reordered entries persist after reload', async ({
+      comfyPage
+    }) => {
+      test.skip(
+        customNodesManifest() !== 'cloud' ||
+          !loadManifest().some(
+            ({ pack }) => pack === 'ComfyUI-Prompt-Combinator'
+          ),
+        'ComfyUI-Prompt-Combinator is not installed in this manifest shard'
+      )
+      test.setTimeout(60_000)
+      await comfyPage.nodeOps.clearGraph()
+
+      const created = await comfyPage.page.evaluate(() => {
+        const node = window.LiteGraph!.createNode('PromptCombinator')
+        if (!node) return null
+        node.pos = [300, 200]
+        window.app!.graph.add(node)
+        const widget = node.widgets?.find(({ name }) => name === 'input_list_1')
+        if (!widget) return null
+        widget.value =
+          'third@third prompt\nfirst@first prompt\nsecond@second prompt'
+        return {
+          id: node.id,
+          value: widget.value,
+          widgets: node.widgets?.map(({ name }) => name) ?? []
+        }
+      })
+
+      expect(created, 'PromptCombinator did not instantiate').not.toBeNull()
+      expect(created!.widgets).toContain('input_list_1')
+      expect(created!.value).toBe(
+        'third@third prompt\nfirst@first prompt\nsecond@second prompt'
+      )
+      await comfyPage.menu.topbar.saveWorkflow('ecs-prompt-combinator')
+      await comfyPage.page.reload({ waitUntil: 'domcontentloaded' })
+      await comfyPage.waitForAppReady()
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate((id) => {
+            const node = window.app!.graph.getNodeById(id)
+            return node?.widgets?.find(({ name }) => name === 'input_list_1')
+              ?.value
+          }, created!.id)
+        )
+        .toBe('third@third prompt\nfirst@first prompt\nsecond@second prompt')
+    })
+
+    test('rgthree Fix-in-place keeps the node and its links intact', async () => {
+      test.skip(true, 'rgthree is not present in customNodeManifest.cloud.json')
+    })
+
+    test('easy-use seed control persists its changed seed', async () => {
+      test.skip(
+        true,
+        'easy-use is not present in customNodeManifest.cloud.json; known gap: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15579'
+      )
+    })
+
+    test('VHS Load Video connects to Video Combine and persists widgets', async ({
+      comfyPage
+    }) => {
+      test.skip(
+        !loadManifest().some(({ pack }) =>
+          ['ComfyUI-VideoHelperSuite', 'comfyui-videohelpersuite'].includes(
+            pack
+          )
+        ),
+        'Video Helper Suite is not installed in this manifest shard'
+      )
+      test.setTimeout(60_000)
+      await comfyPage.nodeOps.clearGraph()
+
+      const created = await comfyPage.page.evaluate(() => {
+        const load = window.LiteGraph!.createNode('VHS_LoadVideo')
+        const combine = window.LiteGraph!.createNode('VHS_VideoCombine')
+        if (!load || !combine) return null
+        load.pos = [200, 200]
+        combine.pos = [650, 200]
+        window.app!.graph.add(load)
+        window.app!.graph.add(combine)
+        load.connect(0, combine, 0)
+        const frameRate = combine.widgets?.find(
+          ({ name }) => name === 'frame_rate'
+        )
+        if (!frameRate) return null
+        frameRate.value = 12
+        return {
+          loadId: load.id,
+          combineId: combine.id,
+          widgetNames: combine.widgets?.map(({ name }) => name) ?? [],
+          frameRate: frameRate.value,
+          linkCount: Object.keys(window.app!.graph.links).length
+        }
+      })
+
+      expect(
+        created,
+        'VHS nodes or frame_rate widget did not instantiate'
+      ).not.toBeNull()
+      expect(created!.widgetNames).toContain('frame_rate')
+      expect(created!.frameRate).toBe(12)
+      expect(created!.linkCount).toBe(1)
+      await comfyPage.menu.topbar.saveWorkflow('ecs-vhs-video-combine')
+      await comfyPage.page.reload({ waitUntil: 'domcontentloaded' })
+      await comfyPage.waitForAppReady()
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(({ combineId, loadId }) => {
+            const graph = window.app!.graph
+            const combine = graph.getNodeById(combineId)
+            return {
+              nodesPresent: Boolean(graph.getNodeById(loadId) && combine),
+              frameRate: combine?.widgets?.find(
+                ({ name }) => name === 'frame_rate'
+              )?.value,
+              linkCount: Object.keys(graph.links).length
+            }
+          }, created!)
+        )
+        .toEqual({ nodesPresent: true, frameRate: 12, linkCount: 1 })
+    })
+  }
+)

--- a/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
+++ b/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
@@ -40,8 +40,9 @@ test.describe(
         window.app!.graph.add(node)
         const widget = node.widgets?.find(({ name }) => name === 'input_list_1')
         if (!widget) throw new Error('input_list_1 widget is unavailable')
-        widget.value =
-          'third@third prompt\nfirst@first prompt\nsecond@second prompt'
+        widget.value = `third@third prompt
+first@first prompt
+second@second prompt`
         return {
           id: node.id,
           value: widget.value,
@@ -51,21 +52,23 @@ test.describe(
 
       expect(created.widgets).toContain('input_list_1')
       expect(created.value).toBe(
-        'third@third prompt\nfirst@first prompt\nsecond@second prompt'
+        `third@third prompt
+first@first prompt
+second@second prompt`
       )
       await comfyPage.menu.topbar.saveWorkflow('ecs-prompt-combinator')
       await comfyPage.page.reload({ waitUntil: 'domcontentloaded' })
       await comfyPage.waitForAppReady()
 
-      await expect
-        .poll(() =>
-          comfyPage.page.evaluate((id) => {
-            const node = window.app!.graph.getNodeById(id)
-            return node?.widgets?.find(({ name }) => name === 'input_list_1')
-              ?.value
-          }, created.id)
-        )
-        .toBe('third@third prompt\nfirst@first prompt\nsecond@second prompt')
+      await expect.poll(() =>
+        comfyPage.page.evaluate((id) => {
+          const node = window.app!.graph.getNodeById(id)
+          return node?.widgets?.find(({ name }) => name === 'input_list_1')
+            ?.value
+        }, created.id)
+      ).toBe(`third@third prompt
+first@first prompt
+second@second prompt`)
     })
 
     test('VHS Load Video connects to Video Combine and persists widgets', async ({

--- a/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
+++ b/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
@@ -121,9 +121,11 @@ second@second prompt`)
           comfyPage.page.evaluate(({ combineId, loadId }) => {
             const graph = window.app!.graph
             const combine = graph.getNodeById(combineId)
-            const link = Object.values(graph.links)[0]
+            const links = Object.values(graph.links)
+            const link = links[0]
             return {
               nodesPresent: Boolean(graph.getNodeById(loadId) && combine),
+              linkCount: links.length,
               frameRate: combine?.widgets?.find(
                 ({ name }) => name === 'frame_rate'
               )?.value,
@@ -138,6 +140,7 @@ second@second prompt`)
         )
         .toEqual({
           nodesPresent: true,
+          linkCount: 1,
           frameRate: 12,
           link: {
             originId: created.loadId,

--- a/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
+++ b/browser_tests/tests/customNodes/ecsMigrationScenarios.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable playwright/no-skipped-test, playwright/expect-expect -- QA rows stay visible as skipped tests when their packs are absent from the manifest. */
 import {
   comfyExpect as expect,
   comfyPageFixture as test
@@ -15,24 +14,15 @@ test.describe(
   'ECS migration custom-node scenarios',
   { tag: '@custom-nodes' },
   () => {
-    test('rgthree Fast Muter toggles target modes and persists its renamed label', async () => {
-      test.skip(true, 'rgthree is not present in customNodeManifest.cloud.json')
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.deleteWorkflow('ecs-prompt-combinator')
+      await comfyPage.workflow.deleteWorkflow('ecs-vhs-video-combine')
     })
 
-    test('rgthree Fast Bypasser toggles target bypass modes', async () => {
-      test.skip(true, 'rgthree is not present in customNodeManifest.cloud.json')
-    })
-
-    test('rgthree boundary link-control disconnects a link', async () => {
-      test.skip(
-        true,
-        'rgthree is not present in customNodeManifest.cloud.json; known gap: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15501'
-      )
-    })
-
-    test('Prompt Combinator reordered entries persist after reload', async ({
+    test('Prompt Combinator multiline entries persist after reload', async ({
       comfyPage
     }) => {
+      // oxlint-disable-next-line playwright/no-skipped-test -- pack availability differs by manifest shard
       test.skip(
         customNodesManifest() !== 'cloud' ||
           !loadManifest().some(
@@ -45,11 +35,11 @@ test.describe(
 
       const created = await comfyPage.page.evaluate(() => {
         const node = window.LiteGraph!.createNode('PromptCombinator')
-        if (!node) return null
+        if (!node) throw new Error('PromptCombinator did not instantiate')
         node.pos = [300, 200]
         window.app!.graph.add(node)
         const widget = node.widgets?.find(({ name }) => name === 'input_list_1')
-        if (!widget) return null
+        if (!widget) throw new Error('input_list_1 widget is unavailable')
         widget.value =
           'third@third prompt\nfirst@first prompt\nsecond@second prompt'
         return {
@@ -59,9 +49,8 @@ test.describe(
         }
       })
 
-      expect(created, 'PromptCombinator did not instantiate').not.toBeNull()
-      expect(created!.widgets).toContain('input_list_1')
-      expect(created!.value).toBe(
+      expect(created.widgets).toContain('input_list_1')
+      expect(created.value).toBe(
         'third@third prompt\nfirst@first prompt\nsecond@second prompt'
       )
       await comfyPage.menu.topbar.saveWorkflow('ecs-prompt-combinator')
@@ -74,25 +63,15 @@ test.describe(
             const node = window.app!.graph.getNodeById(id)
             return node?.widgets?.find(({ name }) => name === 'input_list_1')
               ?.value
-          }, created!.id)
+          }, created.id)
         )
         .toBe('third@third prompt\nfirst@first prompt\nsecond@second prompt')
-    })
-
-    test('rgthree Fix-in-place keeps the node and its links intact', async () => {
-      test.skip(true, 'rgthree is not present in customNodeManifest.cloud.json')
-    })
-
-    test('easy-use seed control persists its changed seed', async () => {
-      test.skip(
-        true,
-        'easy-use is not present in customNodeManifest.cloud.json; known gap: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15579'
-      )
     })
 
     test('VHS Load Video connects to Video Combine and persists widgets', async ({
       comfyPage
     }) => {
+      // oxlint-disable-next-line playwright/no-skipped-test -- pack availability differs by manifest shard
       test.skip(
         !loadManifest().some(({ pack }) =>
           ['ComfyUI-VideoHelperSuite', 'comfyui-videohelpersuite'].includes(
@@ -107,7 +86,7 @@ test.describe(
       const created = await comfyPage.page.evaluate(() => {
         const load = window.LiteGraph!.createNode('VHS_LoadVideo')
         const combine = window.LiteGraph!.createNode('VHS_VideoCombine')
-        if (!load || !combine) return null
+        if (!load || !combine) throw new Error('VHS nodes did not instantiate')
         load.pos = [200, 200]
         combine.pos = [650, 200]
         window.app!.graph.add(load)
@@ -116,7 +95,7 @@ test.describe(
         const frameRate = combine.widgets?.find(
           ({ name }) => name === 'frame_rate'
         )
-        if (!frameRate) return null
+        if (!frameRate) throw new Error('frame_rate widget is unavailable')
         frameRate.value = 12
         return {
           loadId: load.id,
@@ -127,13 +106,9 @@ test.describe(
         }
       })
 
-      expect(
-        created,
-        'VHS nodes or frame_rate widget did not instantiate'
-      ).not.toBeNull()
-      expect(created!.widgetNames).toContain('frame_rate')
-      expect(created!.frameRate).toBe(12)
-      expect(created!.linkCount).toBe(1)
+      expect(created.widgetNames).toContain('frame_rate')
+      expect(created.frameRate).toBe(12)
+      expect(created.linkCount).toBe(1)
       await comfyPage.menu.topbar.saveWorkflow('ecs-vhs-video-combine')
       await comfyPage.page.reload({ waitUntil: 'domcontentloaded' })
       await comfyPage.waitForAppReady()
@@ -143,16 +118,31 @@ test.describe(
           comfyPage.page.evaluate(({ combineId, loadId }) => {
             const graph = window.app!.graph
             const combine = graph.getNodeById(combineId)
+            const link = Object.values(graph.links)[0]
             return {
               nodesPresent: Boolean(graph.getNodeById(loadId) && combine),
               frameRate: combine?.widgets?.find(
                 ({ name }) => name === 'frame_rate'
               )?.value,
-              linkCount: Object.keys(graph.links).length
+              link: link && {
+                originId: link.origin_id,
+                originSlot: link.origin_slot,
+                targetId: link.target_id,
+                targetSlot: link.target_slot
+              }
             }
-          }, created!)
+          }, created)
         )
-        .toEqual({ nodesPresent: true, frameRate: 12, linkCount: 1 })
+        .toEqual({
+          nodesPresent: true,
+          frameRate: 12,
+          link: {
+            originId: created.loadId,
+            originSlot: 0,
+            targetId: created.combineId,
+            targetSlot: 0
+          }
+        })
     })
   }
 )


### PR DESCRIPTION
- Covers actual multiline Prompt Combinator persistence and VHS graph persistence.
- Unavailable rgthree and easy-use rows remain in the manual QA plan.
- Exact-head custom-node runtime remains blocked by unavailable dedicated packs.

<details><summary>Full context for agent readers</summary>

Prompt Combinator assigns and persists multiline widget content. It does not claim promptchain or reorder behavior. VHS persists exact endpoint IDs, slots, and the frame-rate widget. Each saved workflow is deleted in teardown.

The dedicated harness requires enrolled Prompt Combinator and VHS packs. Those packs are unavailable here, and the shared backend exposes neither node type. Chromium excludes `@custom-nodes`; the ecosystem matrix is not runtime evidence for this suite. No deployment or shared-state workflow was triggered.

Verification: formatting, lint, browser typecheck, Knip, and two-test custom-node discovery passed. Runtime is not claimed.

</details>
