### PR TITLE
test: add link, execution mode and regression sanity e2e coverage for the ECS migration QA plan

### DIFF
--- a/browser_tests/tests/ecsLinksExecution.spec.ts
+++ b/browser_tests/tests/ecsLinksExecution.spec.ts
@@ -1,0 +1,149 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+
+test.describe(
+  'ECS migration: links, execution modes and regression sanity',
+  { tag: ['@canvas', '@workflow'] },
+  () => {
+    test.use({
+      initialSettings: {
+        'Comfy.UseNewMenu': 'Disabled',
+        'Comfy.Canvas.MouseWheelScroll': 'zoom',
+        'Comfy.Canvas.LeftMouseClickBehavior': 'select'
+      }
+    })
+
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.canvasOps.resetView()
+    })
+
+    test('muting a middle node excludes it from the API prompt before queueing', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+      const node = await comfyPage.nodeOps.getNodeRefById(3)
+      await node.click('title')
+      await comfyPage.keyboard.press('Control+KeyM')
+
+      await expect.poll(() => node.getProperty<number>('mode')).toBe(2)
+      const prompt = await comfyPage.workflow.getExportedWorkflow({ api: true })
+      expect(prompt).not.toHaveProperty('3')
+
+      const execution = new ExecutionHelper(comfyPage)
+      await expect(execution.run()).resolves.toMatch(/^test-job-/)
+    })
+
+    test('bypassing a middle node preserves downstream API links before queueing', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+      const node = await comfyPage.nodeOps.getNodeRefById(3)
+      await node.click('title')
+      await comfyPage.keyboard.press('Control+KeyB')
+
+      await expect.poll(() => node.getProperty<number>('mode')).toBe(4)
+      const prompt = await comfyPage.workflow.getExportedWorkflow({ api: true })
+      expect(prompt).not.toHaveProperty('3')
+      expect(prompt['8']?.inputs.samples).toEqual(['5', 0])
+
+      const execution = new ExecutionHelper(comfyPage)
+      await expect(execution.run()).resolves.toMatch(/^test-job-/)
+    })
+
+    test('loads the default template with its expected node types', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+
+      await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(7)
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() =>
+            window.app!.graph.nodes.map((node) => node.type).sort()
+          )
+        )
+        .toEqual([
+          'CLIPTextEncode',
+          'CLIPTextEncode',
+          'CheckpointLoaderSimple',
+          'EmptyLatentImage',
+          'KSampler',
+          'SaveImage',
+          'VAEDecode'
+        ])
+    })
+
+    test('places a node from canvas search at the double-click position', async ({
+      comfyPage
+    }) => {
+      await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
+      await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
+      await comfyPage.canvasOps.doubleClick()
+      await expect(comfyPage.searchBox.input).toBeVisible()
+      await comfyPage.searchBox.fillAndSelectFirstNode('KSampler', {
+        exact: true
+      })
+
+      await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(1)
+      const node = await comfyPage.nodeOps.getNodeRefByType('KSampler')
+      const position = await node.getPosition()
+      expect(position.x).toBeGreaterThan(0)
+      expect(position.y).toBeGreaterThan(0)
+    })
+
+    test('pans, zooms and box-selects the expected nodes', async ({
+      comfyPage,
+      comfyMouse
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+      const checkpoint = await comfyPage.nodeOps.getNodeRefById(4)
+      const offsetBefore = await comfyPage.canvasOps.getOffset()
+      const scaleBefore = await comfyPage.canvasOps.getScale()
+
+      await comfyMouse.middleDragFromCenter(
+        comfyPage.canvas,
+        { x: 100, y: 80 },
+        { steps: 10 }
+      )
+      await expect
+        .poll(() => comfyPage.canvasOps.getOffset())
+        .not.toEqual(offsetBefore)
+
+      await comfyPage.page.mouse.move(400, 400)
+      await comfyPage.page.mouse.wheel(0, -120)
+      await comfyPage.nextFrame()
+      await expect
+        .poll(() => comfyPage.canvasOps.getScale())
+        .not.toBe(scaleBefore)
+
+      await comfyPage.canvasOps.resetView()
+      const position = await checkpoint.getPosition()
+      const from = await comfyPage.canvasOps.toAbsolute({
+        x: position.x - 20,
+        y: position.y - 20
+      })
+      const to = await comfyPage.canvasOps.toAbsolute({
+        x: position.x + 340,
+        y: position.y + 160
+      })
+      await comfyPage.canvasOps.dragAndDrop(from, to)
+      await expect
+        .poll(() => comfyPage.nodeOps.getSelectedGraphNodesCount())
+        .toBe(1)
+    })
+
+    test('shows no error toast after loading, queueing and switching workflows', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+      const execution = new ExecutionHelper(comfyPage)
+      await execution.run()
+      await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
+
+      await expect(comfyPage.toast.toastErrors).toHaveCount(0)
+    })
+  }
+)

--- a/browser_tests/tests/ecsLinksExecution.spec.ts
+++ b/browser_tests/tests/ecsLinksExecution.spec.ts
@@ -4,6 +4,8 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 
+type QueuedNode = { inputs: Record<string, unknown> }
+
 test.describe(
   'ECS migration: links, execution modes and regression sanity',
   { tag: ['@canvas', '@workflow'] },
@@ -29,11 +31,19 @@ test.describe(
       await comfyPage.keyboard.press('Control+KeyM')
 
       await expect.poll(() => node.getProperty<number>('mode')).toBe(2)
-      const prompt = await comfyPage.workflow.getExportedWorkflow({ api: true })
-      expect(prompt).not.toHaveProperty('3')
 
+      let queuedPrompt: Record<string, unknown> | undefined
       const execution = new ExecutionHelper(comfyPage)
-      await expect(execution.run()).resolves.toMatch(/^test-job-/)
+      await expect(
+        execution.run({
+          onPromptRequest: (body) => {
+            queuedPrompt = (body as { prompt: Record<string, unknown> }).prompt
+          }
+        })
+      ).resolves.toMatch(/^test-job-/)
+
+      expect(queuedPrompt).toBeDefined()
+      expect(queuedPrompt).not.toHaveProperty('3')
     })
 
     test('bypassing a middle node preserves downstream API links before queueing', async ({
@@ -45,12 +55,21 @@ test.describe(
       await comfyPage.keyboard.press('Control+KeyB')
 
       await expect.poll(() => node.getProperty<number>('mode')).toBe(4)
-      const prompt = await comfyPage.workflow.getExportedWorkflow({ api: true })
-      expect(prompt).not.toHaveProperty('3')
-      expect(prompt['8']?.inputs.samples).toEqual(['5', 0])
 
+      let queuedPrompt: Record<string, QueuedNode> | undefined
       const execution = new ExecutionHelper(comfyPage)
-      await expect(execution.run()).resolves.toMatch(/^test-job-/)
+      await expect(
+        execution.run({
+          onPromptRequest: (body) => {
+            queuedPrompt = (body as { prompt: Record<string, QueuedNode> })
+              .prompt
+          }
+        })
+      ).resolves.toMatch(/^test-job-/)
+
+      expect(queuedPrompt).toBeDefined()
+      expect(queuedPrompt).not.toHaveProperty('3')
+      expect(queuedPrompt?.['8']?.inputs.samples).toEqual(['5', 0])
     })
 
     test('loads the default template with its expected node types', async ({
@@ -81,17 +100,21 @@ test.describe(
     }) => {
       await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
       await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
-      await comfyPage.canvasOps.doubleClick()
-      await expect(comfyPage.searchBox.input).toBeVisible()
-      await comfyPage.searchBox.fillAndSelectFirstNode('KSampler', {
-        exact: true
+      await comfyPage.searchBoxV2.ensureV2Search()
+      const clickPosition = { x: 200, y: 200 }
+      await comfyPage.searchBoxV2.addNode('KSampler', {
+        position: clickPosition
       })
 
       await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(1)
       const node = await comfyPage.nodeOps.getNodeRefByType('KSampler')
+      // getPosition() already returns client-space coordinates, so compare
+      // directly against the client-space double-click position. The node
+      // anchor is offset from the click point (title bar + node centering),
+      // so allow a generous but bounded tolerance.
       const position = await node.getPosition()
-      expect(position.x).toBeGreaterThan(0)
-      expect(position.y).toBeGreaterThan(0)
+      expect(Math.abs(position.x - clickPosition.x)).toBeLessThan(200)
+      expect(Math.abs(position.y - clickPosition.y)).toBeLessThan(200)
     })
 
     test('pans, zooms and box-selects the expected nodes', async ({

--- a/browser_tests/tests/ecsMigration/linksExecution.spec.ts
+++ b/browser_tests/tests/ecsMigration/linksExecution.spec.ts
@@ -3,6 +3,10 @@ import {
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import {
+  expectNoVisibleErrors,
+  trackVisibleErrors
+} from '@e2e/fixtures/utils/errorSurfaces'
 
 import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 
@@ -174,24 +178,7 @@ test.describe(
     test('shows no error toast after loading, queueing and switching workflows', async ({
       comfyPage
     }) => {
-      await comfyPage.page.evaluate(() => {
-        const errors: Element[] = []
-        new MutationObserver((mutations) => {
-          for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-              if (
-                node instanceof Element &&
-                node.matches('.p-toast-message.p-toast-message-error')
-              ) {
-                errors.push(node)
-              }
-            }
-          }
-        }).observe(document.body, { childList: true, subtree: true })
-        ;(
-          window as typeof window & { __ecsMigrationToastErrors: Element[] }
-        ).__ecsMigrationToastErrors = errors
-      })
+      await trackVisibleErrors(comfyPage.page)
       await comfyPage.workflow.loadWorkflow('default')
       const execution = new ExecutionHelper(comfyPage)
       await execution.run()
@@ -199,16 +186,10 @@ test.describe(
       await comfyPage.workflow.waitForActiveWorkflow()
       await comfyPage.nextFrame()
 
-      expect(
-        await comfyPage.page.evaluate(
-          () =>
-            (
-              window as typeof window & {
-                __ecsMigrationToastErrors: Element[]
-              }
-            ).__ecsMigrationToastErrors.length
-        )
-      ).toBe(0)
+      await expectNoVisibleErrors(
+        comfyPage.page,
+        'after loading, queueing and switching workflows'
+      )
     })
   }
 )

--- a/browser_tests/tests/ecsMigration/linksExecution.spec.ts
+++ b/browser_tests/tests/ecsMigration/linksExecution.spec.ts
@@ -4,7 +4,20 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 
-type QueuedNode = { inputs: Record<string, unknown> }
+import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+function getQueuedPrompt(body: unknown): ComfyApiWorkflow {
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    !('prompt' in body) ||
+    typeof body.prompt !== 'object' ||
+    body.prompt === null
+  ) {
+    throw new Error('Expected /api/prompt body to contain a prompt object')
+  }
+  return body.prompt as ComfyApiWorkflow
+}
 
 test.describe(
   'ECS migration: links, execution modes and regression sanity',
@@ -37,7 +50,7 @@ test.describe(
       await expect(
         execution.run({
           onPromptRequest: (body) => {
-            queuedPrompt = (body as { prompt: Record<string, unknown> }).prompt
+            queuedPrompt = getQueuedPrompt(body)
           }
         })
       ).resolves.toMatch(/^test-job-/)
@@ -56,43 +69,21 @@ test.describe(
 
       await expect.poll(() => node.getProperty<number>('mode')).toBe(4)
 
-      let queuedPrompt: Record<string, QueuedNode> | undefined
+      let queuedPrompt: ComfyApiWorkflow | undefined
       const execution = new ExecutionHelper(comfyPage)
       await expect(
         execution.run({
           onPromptRequest: (body) => {
-            queuedPrompt = (body as { prompt: Record<string, QueuedNode> })
-              .prompt
+            queuedPrompt = getQueuedPrompt(body)
           }
         })
       ).resolves.toMatch(/^test-job-/)
 
       expect(queuedPrompt).toBeDefined()
       expect(queuedPrompt).not.toHaveProperty('3')
-      expect(queuedPrompt?.['8']?.inputs.samples).toEqual(['5', 0])
-    })
-
-    test('loads the default template with its expected node types', async ({
-      comfyPage
-    }) => {
-      await comfyPage.workflow.loadWorkflow('default')
-
-      await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(7)
-      await expect
-        .poll(() =>
-          comfyPage.page.evaluate(() =>
-            window.app!.graph.nodes.map((node) => node.type).sort()
-          )
-        )
-        .toEqual([
-          'CLIPTextEncode',
-          'CLIPTextEncode',
-          'CheckpointLoaderSimple',
-          'EmptyLatentImage',
-          'KSampler',
-          'SaveImage',
-          'VAEDecode'
-        ])
+      const samples = queuedPrompt?.['8']?.inputs.samples
+      expect(Array.isArray(samples)).toBe(true)
+      expect(samples).toEqual(['5', 0])
     })
 
     test('places a node from canvas search at the double-click position', async ({
@@ -107,14 +98,17 @@ test.describe(
       })
 
       await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(1)
-      const node = await comfyPage.nodeOps.getNodeRefByType('KSampler')
-      // getPosition() already returns client-space coordinates, so compare
-      // directly against the client-space double-click position. The node
-      // anchor is offset from the click point (title bar + node centering),
-      // so allow a generous but bounded tolerance.
-      const position = await node.getPosition()
-      expect(Math.abs(position.x - clickPosition.x)).toBeLessThan(200)
-      expect(Math.abs(position.y - clickPosition.y)).toBeLessThan(200)
+      const placement = await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          ({ type }) => type === 'KSampler'
+        )
+        return {
+          graphMouse: window.app!.canvas.graph_mouse,
+          position: node?.pos
+        }
+      })
+      expect(placement.position?.[0]).toBeCloseTo(placement.graphMouse[0] - 135)
+      expect(placement.position?.[1]).toBeCloseTo(placement.graphMouse[1] + 10)
     })
 
     test('pans, zooms and box-selects the expected nodes', async ({
@@ -154,19 +148,48 @@ test.describe(
       })
       await comfyPage.canvasOps.dragAndDrop(from, to)
       await expect
-        .poll(() => comfyPage.nodeOps.getSelectedGraphNodesCount())
-        .toBe(1)
+        .poll(() => comfyPage.nodeOps.getSelectedNodeIds())
+        .toEqual(['4'])
     })
 
     test('shows no error toast after loading, queueing and switching workflows', async ({
       comfyPage
     }) => {
+      await comfyPage.page.evaluate(() => {
+        const errors: Element[] = []
+        new MutationObserver((mutations) => {
+          for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+              if (
+                node instanceof Element &&
+                node.matches('.p-toast-message.p-toast-message-error')
+              ) {
+                errors.push(node)
+              }
+            }
+          }
+        }).observe(document.body, { childList: true, subtree: true })
+        ;(
+          window as typeof window & { __ecsMigrationToastErrors: Element[] }
+        ).__ecsMigrationToastErrors = errors
+      })
       await comfyPage.workflow.loadWorkflow('default')
       const execution = new ExecutionHelper(comfyPage)
       await execution.run()
       await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
+      await comfyPage.workflow.waitForActiveWorkflow()
+      await comfyPage.nextFrame()
 
-      await expect(comfyPage.toast.toastErrors).toHaveCount(0)
+      expect(
+        await comfyPage.page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __ecsMigrationToastErrors: Element[]
+              }
+            ).__ecsMigrationToastErrors.length
+        )
+      ).toBe(0)
     })
   }
 )

--- a/browser_tests/tests/ecsMigration/linksExecution.spec.ts
+++ b/browser_tests/tests/ecsMigration/linksExecution.spec.ts
@@ -16,6 +16,21 @@ function getQueuedPrompt(body: unknown): ComfyApiWorkflow {
   ) {
     throw new Error('Expected /api/prompt body to contain a prompt object')
   }
+  for (const node of Object.values(body.prompt)) {
+    if (
+      typeof node !== 'object' ||
+      node === null ||
+      !('inputs' in node) ||
+      typeof node.inputs !== 'object' ||
+      node.inputs === null ||
+      !('class_type' in node) ||
+      typeof node.class_type !== 'string'
+    ) {
+      throw new Error(
+        'Expected every queued node to have inputs and class_type'
+      )
+    }
+  }
   return body.prompt as ComfyApiWorkflow
 }
 
@@ -57,6 +72,10 @@ test.describe(
 
       expect(queuedPrompt).toBeDefined()
       expect(queuedPrompt).not.toHaveProperty('3')
+      expect(queuedPrompt?.['9']).toMatchObject({
+        class_type: 'SaveImage',
+        inputs: { images: ['8', 0] }
+      })
     })
 
     test('bypassing a middle node preserves downstream API links before queueing', async ({

--- a/browser_tests/tests/ecsMigration/linksExecution.spec.ts
+++ b/browser_tests/tests/ecsMigration/linksExecution.spec.ts
@@ -9,33 +9,13 @@ import {
 } from '@e2e/fixtures/utils/errorSurfaces'
 
 import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { zComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 
 function getQueuedPrompt(body: unknown): ComfyApiWorkflow {
-  if (
-    typeof body !== 'object' ||
-    body === null ||
-    !('prompt' in body) ||
-    typeof body.prompt !== 'object' ||
-    body.prompt === null
-  ) {
+  if (typeof body !== 'object' || body === null || !('prompt' in body)) {
     throw new Error('Expected /api/prompt body to contain a prompt object')
   }
-  for (const node of Object.values(body.prompt)) {
-    if (
-      typeof node !== 'object' ||
-      node === null ||
-      !('inputs' in node) ||
-      typeof node.inputs !== 'object' ||
-      node.inputs === null ||
-      !('class_type' in node) ||
-      typeof node.class_type !== 'string'
-    ) {
-      throw new Error(
-        'Expected every queued node to have inputs and class_type'
-      )
-    }
-  }
-  return body.prompt as ComfyApiWorkflow
+  return zComfyApiWorkflow.parse(body.prompt)
 }
 
 test.describe(

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -569,5 +569,5 @@ const zNodeData = z.object({
   })
 })
 
-const zComfyApiWorkflow = z.record(zNodeId, zNodeData)
+export const zComfyApiWorkflow = z.record(zNodeId, zNodeData)
 export type ComfyApiWorkflow = z.infer<typeof zComfyApiWorkflow>


### PR DESCRIPTION
- Covers queued mute/bypass semantics, search placement, canvas navigation, and visible-error sanity.
- Five focused Chromium cases pass at `b98e7bf41c`.
- Real backend outputs, un-bypass, two-node drag, and autosave remain manual.

<details><summary>Full context for agent readers</summary>

Mute and bypass inspect the intercepted `/api/prompt` body. Prompt entries are structurally validated; mute also proves the retained `SaveImage` output remains wired to `VAEDecode`, while bypass proves the downstream sampler link. Search asserts graph-space placement, canvas coverage asserts the exact selected node, and the final case uses the shared transient/class-added visible-error recorder through workflow-switch readiness.

Verification: Oxfmt, Oxlint, ESLint, browser typecheck, and Knip passed. Focused Chromium: 5/5. Mutating the retained output link from node `8` to `7` failed the mute oracle. Logs: `/tmp/ecs-wake1/logs/pr-17457-static.log`, `pr-17457-targeted.log`, and `pr-17457-mutation.log`.

</details>

## Feature flag

- **Flag**: None. Test-only change; no production behavior is introduced.
