### PR TITLE
test(group-node): assert widget pairing, not set membership

### DIFF
--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -30,28 +30,48 @@ test.describe('Group node migration', { tag: '@node' }, () => {
     expect(state.hasGroupNodesExtra).toBe(false)
   })
 
+  // QA found this broken on 2026-09-10 while running the 1.54 test plan:
+  // converting a v1.3.3 group node misaligns widget values by two positions, so
+  // denoise receives 'euler' and filename_prefix receives 'normal'. Saving then
+  // writes the wrong values back, silently corrupting the workflow. Pinned with
+  // test.fail() so the fix flips this to passing.
   test('Preserves group node widget values through subgraph conversion', async ({
     comfyPage
   }) => {
+    test.fail()
     await comfyPage.workflow.loadWorkflow('groupnodes/group_node_v1.3.3')
 
-    const interiorValues = await comfyPage.page.evaluate(() =>
+    const interiorNodes = await comfyPage.page.evaluate(() =>
       [...window.app!.graph.subgraphs.values()].flatMap((subgraph) =>
-        subgraph.nodes.flatMap(
-          (node) => node.widgets?.map((widget) => widget.value) ?? []
-        )
+        subgraph.nodes.map((node) => ({
+          type: node.type,
+          widgets: Object.fromEntries(
+            (node.widgets ?? []).map((widget) => [widget.name, widget.value])
+          )
+        }))
       )
     )
 
-    expect(interiorValues).toHaveLength(14)
-    expect(interiorValues).toEqual(
-      expect.arrayContaining([
-        156680208700286,
-        'euler',
-        'v1-5-pruned-emaonly.ckpt',
-        expect.stringContaining('purple galaxy bottle')
-      ])
-    )
+    const ksampler = interiorNodes.find((node) => node.type === 'KSampler')
+    expect(
+      ksampler,
+      'converted subgraph should contain a KSampler'
+    ).toBeDefined()
+    expect(ksampler!.widgets).toMatchObject({
+      seed: 156680208700286,
+      steps: 20,
+      cfg: 8,
+      sampler_name: 'euler',
+      scheduler: 'normal',
+      denoise: 1
+    })
+
+    const saveImage = interiorNodes.find((node) => node.type === 'SaveImage')
+    expect(
+      saveImage,
+      'converted subgraph should contain a SaveImage'
+    ).toBeDefined()
+    expect(saveImage!.widgets).toMatchObject({ filename_prefix: 'ComfyUI' })
   })
 
   test(


### PR DESCRIPTION
## Summary

The test I added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/17393 **could not fail on the bug it was written for**. This replaces the assertion and pins the real defect QA found.

## Changes

- **What**: rewrites `Preserves group node widget values through subgraph conversion` in `groupNode.spec.ts` to assert widget *pairing*, pinned with `test.fail()`.

## Review Focus

**Why the old assertion was vacuous.** It flattened every interior widget value into a single array and asserted `arrayContaining([...])` plus `toHaveLength(14)`. Misalignment shuffles values *between* widgets — the multiset is identical and the length is unchanged. It passes on corrupted data.

**The bug is real, deterministic, and corrupts files.** QA hit it on 2026-09-10 running the 1.54 plan: converting a v1.3.3 group node shifts widget values two positions, so `denoise` receives `'euler'` and `filename_prefix` receives `'normal'`. On a group node wrapping two samplers, six values land wrong on one node — including strings in numeric fields (`noise_seed = 'enable'`, `end_at_step = 'euler'`) and a number in a combo (`control_after_generate = 0`). Reproduced across 16 loads through the Workflows sidebar, no scripting. **Saving writes the wrong values back to disk**, so the workflow executes with values its author never set.

Ground truth from the asset's own `extra.groupNodes`:

```
KSampler  -> [156680208700286, 'randomize', 20, 8, 'euler', 'normal', 1]
SaveImage -> ['ComfyUI']
```

So `denoise` is `1` and `filename_prefix` is `'ComfyUI'` — exactly the two QA reported landing wrong.

**Now asserts name → value pairing** per interior node, with `toBeDefined()` first so a missing node cannot make `toMatchObject` vacuous.

**Pinned with `test.fail()`**, matching `subgraphPromotion.spec.ts:235` and `subgraphConvertAutogrowInputs.spec.ts:124`. CI stays green while the bug exists and flips red the moment the conversion is fixed — which is the signal to delete the marker.

Worth deciding separately: this is a silent data-corruption bug on a legacy-workflow path and probably wants its own issue and a fix, not just a pin.
