### PR TITLE
test: cover subgraph recovery and floating reroutes

### DIFF
--- a/browser_tests/tests/subgraph/subgraphUnpackRecovery.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphUnpackRecovery.spec.ts
@@ -8,7 +8,6 @@ import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
 const test = mergeTests(comfyPageFixture, webSocketFixture)
-const SUBGRAPH_NODE_TITLE = 'New Subgraph'
 
 test.describe(
   'Subgraph unpack recovery',
@@ -32,7 +31,7 @@ test.describe(
         subgraphNode.subgraph.nodes[0].type = type
       }, missingType)
 
-      await comfyPage.subgraph.unpackViaContextMenu(SUBGRAPH_NODE_TITLE)
+      await comfyPage.subgraph.unpackViaContextMenu('New Subgraph')
 
       await expect
         .poll(() =>
@@ -63,27 +62,28 @@ test.describe(
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-with-preview-node'
       )
-      new ExecutionHelper(comfyPage, await getWebSocket()).latentPreview(
-        'preview-job',
-        '5:10'
+      const execution = new ExecutionHelper(comfyPage, await getWebSocket())
+      execution.latentPreview('preview-job', '5:10')
+      execution.latentPreview('unrelated-preview-job', '11')
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() =>
+            Object.keys(window.app!.nodePreviewImages)
+          )
+        )
+        .toHaveLength(3)
+      const unrelatedPreviews = await comfyPage.page.evaluate(
+        () => window.app!.nodePreviewImages['11']
       )
-      await expect
-        .poll(() =>
-          comfyPage.page.evaluate(() =>
-            Object.keys(window.app!.nodePreviewImages)
-          )
-        )
-        .toHaveLength(2)
+      expect(unrelatedPreviews).toHaveLength(1)
 
-      await comfyPage.subgraph.unpackViaContextMenu(SUBGRAPH_NODE_TITLE)
+      await comfyPage.subgraph.unpackViaContextMenu('New Subgraph')
 
       await expect
         .poll(() =>
-          comfyPage.page.evaluate(() =>
-            Object.keys(window.app!.nodePreviewImages)
-          )
+          comfyPage.page.evaluate(() => window.app!.nodePreviewImages)
         )
-        .toEqual([])
+        .toEqual({ '11': unrelatedPreviews })
     })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphUnpackRecovery.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphUnpackRecovery.spec.ts
@@ -1,0 +1,89 @@
+import { mergeTests } from '@playwright/test'
+
+import {
+  comfyExpect as expect,
+  comfyPageFixture
+} from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const test = mergeTests(comfyPageFixture, webSocketFixture)
+const SUBGRAPH_NODE_TITLE = 'New Subgraph'
+
+test.describe(
+  'Subgraph unpack recovery',
+  { tag: ['@subgraph', '@vue-nodes'] },
+  () => {
+    test('replaces an unavailable interior node with a placeholder', async ({
+      comfyPage
+    }) => {
+      const missingType = 'test/UnavailableInteriorNode'
+      await comfyPage.page.route('**/comfy-nodes/**', (route) =>
+        route.fulfill({ status: 404 })
+      )
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      await comfyPage.page.evaluate((type) => {
+        const subgraphNode = window.app!.graph.nodes.find((node) =>
+          node.isSubgraphNode()
+        )
+        if (!subgraphNode?.isSubgraphNode()) {
+          throw new Error('Subgraph node not found')
+        }
+        subgraphNode.subgraph.nodes[0].type = type
+      }, missingType)
+
+      await comfyPage.subgraph.unpackViaContextMenu(SUBGRAPH_NODE_TITLE)
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate((type) => {
+            const placeholder = window.app!.graph.nodes.find(
+              (node) => node.type === type
+            )
+            return {
+              hostExists: window.app!.graph.nodes.some((node) =>
+                node.isSubgraphNode()
+              ),
+              placeholderHasErrors: placeholder?.has_errors ?? false,
+              placeholderType: placeholder?.last_serialization?.type
+            }
+          }, missingType)
+        )
+        .toEqual({
+          hostExists: false,
+          placeholderHasErrors: true,
+          placeholderType: missingType
+        })
+    })
+
+    test('clears transient previews for the host and interior nodes', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/subgraph-with-preview-node'
+      )
+      new ExecutionHelper(comfyPage, await getWebSocket()).latentPreview(
+        'preview-job',
+        '5:10'
+      )
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() =>
+            Object.keys(window.app!.nodePreviewImages)
+          )
+        )
+        .toHaveLength(2)
+
+      await comfyPage.subgraph.unpackViaContextMenu(SUBGRAPH_NODE_TITLE)
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() =>
+            Object.keys(window.app!.nodePreviewImages)
+          )
+        )
+        .toEqual([])
+    })
+  }
+)

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1289,3 +1289,60 @@ test('Floating reroutes', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
     )
     .toBe(false)
 })
+
+test(
+  'Extends a floating reroute chain',
+  { tag: '@vue-nodes' },
+  async ({ comfyPage }) => {
+    await comfyPage.nodeOps.clearGraph()
+    await comfyPage.searchBoxV2.addNode('Int', {
+      position: { x: 800, y: 200 }
+    })
+    const primitiveNode = await comfyPage.vueNodes.getFixtureByTitle('Int')
+
+    await primitiveNode
+      .getSlot('INT')
+      .first()
+      .dragTo(comfyPage.canvas, {
+        targetPosition: { x: 700, y: 400 }
+      })
+    await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
+
+    const rerouteOutputSlotOffset = 17
+    const reroutePosition = await comfyPage.page.evaluate((slotOffset) => {
+      const reroute = [...window.app!.graph.reroutes.values()][0]
+      const [x, y] = window.app!.canvasPosToClientPos([
+        reroute.pos[0] + slotOffset,
+        reroute.pos[1]
+      ])
+      return { x, y }
+    }, rerouteOutputSlotOffset)
+    await comfyPage.page.mouse.move(reroutePosition.x, reroutePosition.y)
+    await comfyPage.nextFrame()
+    await comfyPage.canvasOps.dragAndDrop(reroutePosition, {
+      x: reroutePosition.x - 120,
+      y: reroutePosition.y + 80
+    })
+    await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
+
+    await expect
+      .poll(() =>
+        comfyPage.page.evaluate(() => {
+          const graph = window.app!.graph
+          const reroutes = [...graph.reroutes.values()]
+          const tip = reroutes.find((reroute) => reroute.floating)
+          const link = [...graph.floatingLinks.values()][0]
+          return {
+            rerouteCount: reroutes.length,
+            floatingLinkCount: graph.floatingLinks.size,
+            linkEndsAtTip: link.parentId === tip?.id
+          }
+        })
+      )
+      .toEqual({
+        rerouteCount: 2,
+        floatingLinkCount: 1,
+        linkEndsAtTip: true
+      })
+  }
+)

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test'
 
 import type { NodeId } from '@/types/nodeId'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 import {
   comfyExpect as expect,
@@ -1299,6 +1300,7 @@ test(
       position: { x: 800, y: 200 }
     })
     const primitiveNode = await comfyPage.vueNodes.getFixtureByTitle('Int')
+    const sourceNode = await comfyPage.nodeOps.getNodeRefByTitle('Int')
 
     await primitiveNode
       .getSlot('INT')
@@ -1308,15 +1310,15 @@ test(
       })
     await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
 
-    const rerouteOutputSlotOffset = 17
-    const reroutePosition = await comfyPage.page.evaluate((slotOffset) => {
+    const firstReroute = await comfyPage.page.evaluate(() => {
       const reroute = [...window.app!.graph.reroutes.values()][0]
       const [x, y] = window.app!.canvasPosToClientPos([
-        reroute.pos[0] + slotOffset,
+        reroute.pos[0] + window.LiteGraph!.Reroute.slotOffset,
         reroute.pos[1]
       ])
-      return { x, y }
-    }, rerouteOutputSlotOffset)
+      return { id: reroute.id, position: { x, y } }
+    })
+    const reroutePosition = firstReroute.position
     await comfyPage.page.mouse.move(reroutePosition.x, reroutePosition.y)
     await comfyPage.nextFrame()
     await comfyPage.canvasOps.dragAndDrop(reroutePosition, {
@@ -1335,14 +1337,30 @@ test(
           return {
             rerouteCount: reroutes.length,
             floatingLinkCount: graph.floatingLinks.size,
-            linkEndsAtTip: link.parentId === tip?.id
+            regularLinkCount: graph.links.size,
+            linkEndsAtTip: link.parentId === tip?.id,
+            tipParentId: tip?.parentId,
+            originId: link.origin_id,
+            originSlot: link.origin_slot,
+            targetId: link.target_id,
+            targetSlot: link.target_slot,
+            chainMembership: reroutes.every((reroute) =>
+              reroute.floatingLinkIds.has(link.id)
+            )
           }
         })
       )
       .toEqual({
         rerouteCount: 2,
         floatingLinkCount: 1,
-        linkEndsAtTip: true
+        regularLinkCount: 0,
+        linkEndsAtTip: true,
+        tipParentId: firstReroute.id,
+        originId: sourceNode.id,
+        originSlot: 0,
+        targetId: UNASSIGNED_NODE_ID,
+        targetSlot: -1,
+        chainMembership: true
       })
   }
 )

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1294,73 +1294,81 @@ test('Floating reroutes', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
 test(
   'Extends a floating reroute chain',
   { tag: '@vue-nodes' },
-  async ({ comfyPage }) => {
+  async ({ comfyPage, comfyMouse }) => {
     await comfyPage.nodeOps.clearGraph()
-    await comfyPage.searchBoxV2.addNode('Int', {
-      position: { x: 800, y: 200 }
-    })
-    const primitiveNode = await comfyPage.vueNodes.getFixtureByTitle('Int')
-    const sourceNode = await comfyPage.nodeOps.getNodeRefByTitle('Int')
 
-    await primitiveNode
-      .getSlot('INT')
-      .first()
-      .dragTo(comfyPage.canvas, {
-        targetPosition: { x: 700, y: 400 }
+    const sourceNode = await test.step('Add an Int node', async () => {
+      await comfyPage.searchBoxV2.addNode('Int', {
+        position: { x: 800, y: 200 }
       })
-    await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
-
-    const firstReroute = await comfyPage.page.evaluate(() => {
-      const reroute = [...window.app!.graph.reroutes.values()][0]
-      const [x, y] = window.app!.canvasPosToClientPos([
-        reroute.pos[0] + window.LiteGraph!.Reroute.slotOffset,
-        reroute.pos[1]
-      ])
-      return { id: reroute.id, position: { x, y } }
+      return comfyPage.nodeOps.getNodeRefByTitle('Int')
     })
-    const reroutePosition = firstReroute.position
-    await comfyPage.page.mouse.move(reroutePosition.x, reroutePosition.y)
-    await comfyPage.nextFrame()
-    await comfyPage.canvasOps.dragAndDrop(reroutePosition, {
-      x: reroutePosition.x - 120,
-      y: reroutePosition.y + 80
-    })
-    await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
 
-    await expect
-      .poll(() =>
-        comfyPage.page.evaluate(() => {
-          const graph = window.app!.graph
-          const reroutes = [...graph.reroutes.values()]
-          const tip = reroutes.find((reroute) => reroute.floating)
-          const link = [...graph.floatingLinks.values()][0]
-          return {
-            rerouteCount: reroutes.length,
-            floatingLinkCount: graph.floatingLinks.size,
-            regularLinkCount: graph.links.size,
-            linkEndsAtTip: link.parentId === tip?.id,
-            tipParentId: tip?.parentId,
-            originId: link.origin_id,
-            originSlot: link.origin_slot,
-            targetId: link.target_id,
-            targetSlot: link.target_slot,
-            chainMembership: reroutes.every((reroute) =>
-              reroute.floatingLinkIds.has(link.id)
-            )
-          }
+    const firstReroute =
+      await test.step('Create a floating reroute from the Int output', async () => {
+        const primitiveNode = await comfyPage.vueNodes.getFixtureByTitle('Int')
+        await primitiveNode
+          .getSlot('INT')
+          .first()
+          .dragTo(comfyPage.canvas, {
+            targetPosition: { x: 700, y: 400 }
+          })
+        await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
+
+        return comfyPage.page.evaluate(() => {
+          const reroute = [...window.app!.graph.reroutes.values()][0]
+          const [x, y] = window.app!.canvasPosToClientPos([
+            reroute.pos[0] + window.LiteGraph!.Reroute.slotOffset,
+            reroute.pos[1]
+          ])
+          return { id: reroute.id, position: { x, y } }
         })
-      )
-      .toEqual({
-        rerouteCount: 2,
-        floatingLinkCount: 1,
-        regularLinkCount: 0,
-        linkEndsAtTip: true,
-        tipParentId: firstReroute.id,
-        originId: sourceNode.id,
-        originSlot: 0,
-        targetId: UNASSIGNED_NODE_ID,
-        targetSlot: -1,
-        chainMembership: true
       })
+
+    await test.step('Extend the reroute while keeping the chain connected', async () => {
+      const reroutePosition = firstReroute.position
+      await comfyMouse.move(reroutePosition)
+      await comfyPage.canvasOps.dragAndDrop(reroutePosition, {
+        x: reroutePosition.x - 120,
+        y: reroutePosition.y + 80
+      })
+      await comfyPage.contextMenu.clickLitegraphMenuItem('Add Reroute')
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const graph = window.app!.graph
+            const reroutes = [...graph.reroutes.values()]
+            const tip = reroutes.find((reroute) => reroute.floating)
+            const link = [...graph.floatingLinks.values()][0]
+            return {
+              rerouteCount: reroutes.length,
+              floatingLinkCount: graph.floatingLinks.size,
+              regularLinkCount: graph.links.size,
+              linkEndsAtTip: link.parentId === tip?.id,
+              tipParentId: tip?.parentId,
+              originId: link.origin_id,
+              originSlot: link.origin_slot,
+              targetId: link.target_id,
+              targetSlot: link.target_slot,
+              chainMembership: reroutes.every((reroute) =>
+                reroute.floatingLinkIds.has(link.id)
+              )
+            }
+          })
+        )
+        .toEqual({
+          rerouteCount: 2,
+          floatingLinkCount: 1,
+          regularLinkCount: 0,
+          linkEndsAtTip: true,
+          tipParentId: firstReroute.id,
+          originId: sourceNode.id,
+          originSlot: 0,
+          targetId: UNASSIGNED_NODE_ID,
+          targetSlot: -1,
+          chainMembership: true
+        })
+    })
   }
 )


### PR DESCRIPTION
## Summary

Add independent Playwright coverage for user-visible recovery paths and floating reroute extension identified while auditing #16323.

## Changes

- **What**: Verify unavailable subgraph nodes become placeholders when unpacked, transient previews are removed during unpack, and output-side floating reroute chains extend without orphaning links.

## Review Focus

The tests target `main` independently. Malformed transaction state remains better covered by focused unit tests in #16323 because those defensive branches do not exist on `main`.

## Screenshots (if applicable)

Not applicable; test-only change.
