### PR TITLE
feat(agent): show truthful follower synchronization status

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5169,6 +5169,10 @@
   "agent": {
     "title": "Comfy Agent",
     "loadFailed": "The agent panel failed to load.",
+    "syncStatus": "Workflow synchronization",
+    "syncChecking": "Checking workflow synchronization…",
+    "syncRecovering": "Restoring workflow synchronization…",
+    "syncFailed": "Workflow synchronization could not be restored. Changes from the agent or other windows may be missing.",
     "askComfyAgent": "Ask Comfy Agent",
     "caption": "The AI agent can make mistakes",
     "captionExpanded": "The AI agent can make mistakes. Double check your response.",

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1159,13 +1159,16 @@ describe('AgentPanelRoot attach flow', () => {
     dispatchDrag(target, 'dragenter', data)
     await nextTick()
 
-    const dropTarget = screen.getByRole('status')
+    expect(
+      screen.getByRole('status', { name: 'Workflow synchronization' })
+    ).toBeEmptyDOMElement()
+    const dropTarget = screen.getByRole('status', { name: '' })
     expect(dropTarget).toHaveTextContent('Drag and drop assets here')
 
     dispatchDrag(dropTarget, 'dragleave', data)
     await nextTick()
 
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status', { name: '' })).not.toBeInTheDocument()
   })
 
   it('rejects URI-only drags without showing or claiming the asset target', async () => {
@@ -1180,7 +1183,7 @@ describe('AgentPanelRoot attach flow', () => {
 
     expect(dispatchDrag(target, 'dragenter', data)).toBe(false)
     await nextTick()
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status', { name: '' })).not.toBeInTheDocument()
     expect(dispatchDrag(target, 'dragover', data)).toBe(false)
     expect(dispatchDrag(target, 'drop', data)).toBe(false)
     expect(uploaded).toEqual([])
@@ -1235,7 +1238,7 @@ describe('AgentPanelRoot attach flow', () => {
 
       dispatchDrag(target, 'dragenter', dragData)
       await nextTick()
-      expect(screen.getByRole('status')).toHaveTextContent(
+      expect(screen.getByRole('status', { name: '' })).toHaveTextContent(
         'Drag and drop assets here'
       )
 
@@ -1244,7 +1247,7 @@ describe('AgentPanelRoot attach flow', () => {
       const claimed = dispatchDrag(target, 'drop', dragData)
       expect(claimed).toBe(true)
       await nextTick()
-      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+      expect(screen.queryByRole('status', { name: '' })).not.toBeInTheDocument()
 
       expect(await screen.findByText(filename)).toBeInTheDocument()
 
@@ -2354,7 +2357,7 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(
       screen.getByRole('menuitemradio', { name: 'scratch' })
     ).not.toHaveAttribute('aria-disabled', 'true')
-    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.queryByRole('status', { name: '' })).toBeNull()
     expect(useAgentComposerStore().draft).toBe('keep draft')
     await userEvent.click(
       screen.getByRole('menuitemradio', { name: 'scratch' })
@@ -4380,7 +4383,9 @@ describe('AgentPanelRoot workflow binding', () => {
       await vi.waitFor(() =>
         expect(workflowService.saveWorkflowAs).toHaveBeenCalledOnce()
       )
-      expect(screen.getByRole('status')).toHaveTextContent('Saving workflow')
+      expect(screen.getByRole('status', { name: '' })).toHaveTextContent(
+        'Saving workflow'
+      )
       expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
       expect(
         screen.getByRole('button', {

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -101,6 +101,7 @@ import {
 } from './crdt/crdtDebugGate'
 import { attachMintPortWiring } from './crdt/mintPortWiring'
 import { useAgentCrdtFollower } from './crdt/useAgentCrdtFollower'
+import AgentSyncStatus from './crdt/AgentSyncStatus.vue'
 
 const CrdtDevPanel = defineAsyncComponent(
   () => import('./crdt/CrdtDevPanel.vue')
@@ -487,6 +488,7 @@ const isBoundWorkflowActive = computed(() => {
 // workflow's serialized activeState has hydrated the transient stores.
 const {
   status: crdtStatus,
+  syncStatus: crdtSyncStatus,
   debugSnapshot: crdtDebugSnapshot,
   enqueueHumanOperations
 } = useAgentCrdtFollower(
@@ -1135,8 +1137,13 @@ function onPanelDrop(event: DragEvent): void {
       @rename-chat="onRenameChat"
       @copy-history="onCopyMarkdown"
     >
-      <template v-if="isCrdtDevPanelEnabled" #instrument>
-        <CrdtDevPanel :status="crdtStatus" :snapshot="crdtDebugSnapshot" />
+      <template #instrument>
+        <AgentSyncStatus :status="crdtSyncStatus" />
+        <CrdtDevPanel
+          v-if="isCrdtDevPanelEnabled"
+          :status="crdtStatus"
+          :snapshot="crdtDebugSnapshot"
+        />
       </template>
     </AgentPanel>
     <OnboardingCoach

--- a/src/workbench/extensions/agent/crdt/AgentSyncStatus.test.ts
+++ b/src/workbench/extensions/agent/crdt/AgentSyncStatus.test.ts
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import en from '@/locales/en/main.json'
+
+import AgentSyncStatus from './AgentSyncStatus.vue'
+
+describe('AgentSyncStatus', () => {
+  it('updates a persistent polite live region without adding focusable controls', async () => {
+    const { rerender } = render(AgentSyncStatus, {
+      props: { status: null },
+      global: {
+        plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })]
+      }
+    })
+    const region = screen.getByRole('status')
+    expect(region).toHaveAttribute('aria-live', 'polite')
+    expect(region).toHaveAttribute('aria-atomic', 'true')
+    expect(region).toBeEmptyDOMElement()
+
+    await rerender({ status: 'checking' })
+    expect(region).toHaveTextContent('Checking workflow synchronization…')
+    expect(region).not.toHaveTextContent('could not')
+    await rerender({ status: 'recovering' })
+    expect(region).toHaveTextContent('Restoring workflow synchronization…')
+    await rerender({ status: 'failed' })
+    expect(region).toHaveTextContent(
+      'Workflow synchronization could not be restored. Changes from the agent or other windows may be missing.'
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(region).not.toHaveAttribute('tabindex')
+    await rerender({ status: null })
+    expect(screen.getByRole('status')).toBe(region)
+    expect(region).toBeEmptyDOMElement()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/AgentSyncStatus.vue
+++ b/src/workbench/extensions/agent/crdt/AgentSyncStatus.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { useI18n } from 'vue-i18n'
+
+import type { AgentSyncStatus } from './useAgentCrdtFollower'
+
+defineProps<{ status: AgentSyncStatus }>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    role="status"
+    :aria-label="t('agent.syncStatus')"
+    aria-live="polite"
+    aria-atomic="true"
+    class="shrink-0"
+  >
+    <p
+      v-if="status !== null"
+      :class="
+        cn(
+          'm-0 px-4 py-2 text-sm',
+          status === 'failed'
+            ? 'text-warning-foreground'
+            : 'text-muted-foreground'
+        )
+      "
+    >
+      <template v-if="status === 'checking'">
+        {{ t('agent.syncChecking') }}
+      </template>
+      <template v-else-if="status === 'recovering'">
+        {{ t('agent.syncRecovering') }}
+      </template>
+      <template v-else>
+        {{ t('agent.syncFailed') }}
+      </template>
+    </p>
+  </div>
+</template>

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -29,6 +29,7 @@ const bridgeState = vi.hoisted(() => {
     sendHumanOps = vi.fn()
     subscribedWorkflowId: string | null = 'wf-1'
     lastSequence = 41
+    lastSchemaError: Error | null = null
     follower = {
       updatesApplied: 0,
       doc: {
@@ -133,7 +134,7 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
 }))
 
 import { STALE_AFTER_MS, useAgentCrdtFollower } from './useAgentCrdtFollower'
-import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+import type { AgentCrdtStatus, AgentSyncStatus } from './useAgentCrdtFollower'
 
 const graphMutations = {} as GraphMutations
 const DOC_ID_KEY = 'Comfy.Agent.CrdtDocId'
@@ -172,25 +173,34 @@ function mountFollower(
   workflowId: Ref<string | null>
   isTargetActive: Ref<boolean>
   status: () => AgentCrdtStatus
+  syncStatus: () => AgentSyncStatus
 } {
   const workflowId = ref<string | null>(initial)
   const isTargetActive = ref(initiallyActive)
   let exposedStatus!: () => AgentCrdtStatus
+  let exposedSyncStatus!: () => AgentSyncStatus
   const host = defineComponent({
     setup() {
-      const { status } = useAgentCrdtFollower(
+      const follower = useAgentCrdtFollower(
         workflowId,
         graphMutations,
         () => null,
         isTargetActive,
         getGraph
       )
-      exposedStatus = () => status.value as AgentCrdtStatus
+      exposedStatus = () => follower.status.value as AgentCrdtStatus
+      exposedSyncStatus = () => follower.syncStatus.value
       return () => null
     }
   })
   const { unmount } = render(host)
-  return { unmount, workflowId, isTargetActive, status: exposedStatus }
+  return {
+    unmount,
+    workflowId,
+    isTargetActive,
+    status: exposedStatus,
+    syncStatus: exposedSyncStatus
+  }
 }
 
 function bridge(): InstanceType<(typeof bridgeState)['FakeBridge']> {
@@ -1042,6 +1052,92 @@ describe('useAgentCrdtFollower', () => {
 
     vi.advanceTimersByTime(STALE_AFTER_MS)
     expect(bridge().resubscribe).toHaveBeenCalledTimes(2)
+    unmount()
+  })
+
+  it('shows checking, never a warning, for quiet intervals without a probe response', () => {
+    vi.useFakeTimers()
+    const { unmount, syncStatus } = mountFollower('wf-1')
+    expect(syncStatus()).toBe('checking')
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(syncStatus()).toBeNull()
+    vi.advanceTimersByTime(STALE_AFTER_MS - 1)
+    expect(syncStatus()).toBeNull()
+    vi.advanceTimersByTime(1)
+    expect(syncStatus()).toBe('checking')
+    vi.advanceTimersByTime(STALE_AFTER_MS * 3)
+    expect(syncStatus()).toBe('checking')
+    dispatchFrame('doc_ops_result', { workflowId: 'wf-1' })
+    expect(syncStatus()).toBe('checking')
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(syncStatus()).toBeNull()
+    expect(adapterState.clearForReset).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('warns only after the last retry is refused, not while its response is pending', () => {
+    vi.useFakeTimers()
+    const { unmount, syncStatus } = mountFollower('wf-1')
+    for (let attempt = 0; attempt < 6; attempt++) {
+      dispatchFrame('doc_subscribed', { ok: false })
+      expect(syncStatus()).toBe('recovering')
+      vi.advanceTimersByTime(500 * 2 ** attempt)
+    }
+    vi.advanceTimersByTime(STALE_AFTER_MS * 2)
+    expect(syncStatus()).toBe('recovering')
+    dispatchFrame('doc_subscribed', { ok: false })
+    expect(syncStatus()).toBe('failed')
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(syncStatus()).toBeNull()
+    unmount()
+  })
+
+  it('shows recovery for a gap or reconnect and clears it on confirmation', () => {
+    const { unmount, syncStatus } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    dispatchFrame('doc_gap', { workflowId: 'wf-1', expected: 2, received: 4 })
+    expect(syncStatus()).toBe('recovering')
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(syncStatus()).toBeNull()
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(syncStatus()).toBe('recovering')
+    expect(adapterState.clearForReset).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('keeps a schema failure visible across acknowledgements and reconnects', () => {
+    const { unmount, syncStatus } = mountFollower('wf-1')
+    bridge().lastSchemaError = new Error('unreadable')
+    dispatchFrame('schema_error', { workflowId: 'wf-1' })
+    expect(syncStatus()).toBe('failed')
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(syncStatus()).toBe('failed')
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(syncStatus()).toBe('failed')
+    unmount()
+  })
+
+  it('drops status on detach or suspension and starts a new check on retarget', async () => {
+    const { unmount, workflowId, isTargetActive, syncStatus } = mountFollower()
+    expect(syncStatus()).toBeNull()
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(syncStatus()).toBeNull()
+    workflowId.value = 'wf-1'
+    await nextTick()
+    expect(syncStatus()).toBe('checking')
+    dispatchFrame('schema_error', { workflowId: 'wf-1' })
+    isTargetActive.value = false
+    await nextTick()
+    expect(syncStatus()).toBeNull()
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(syncStatus()).toBeNull()
+    isTargetActive.value = true
+    workflowId.value = 'wf-2'
+    await nextTick()
+    expect(syncStatus()).toBe('checking')
+    workflowId.value = null
+    await nextTick()
+    expect(syncStatus()).toBeNull()
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -127,6 +127,8 @@ function clearPersistedDocId(): void {
  */
 export const STALE_AFTER_MS = 30_000
 
+export type AgentSyncStatus = 'checking' | 'recovering' | 'failed' | null
+
 /**
  * s5-metrics-1: per-outcome counters for every `doc_update` the composable's
  * listeners observe, replacing the single overloaded `updatesApplied`
@@ -206,6 +208,7 @@ export function useAgentCrdtFollower(
   getGraph: () => MaterializableGraph | null = () => null
 ) {
   const connected = ref(false)
+  const syncStatus = ref<AgentSyncStatus>(null)
   const updatesApplied = ref(0)
   const lastFrameType = ref<string | null>(null)
   const subscribedWorkflowId = ref<string | null>(null)
@@ -335,6 +338,7 @@ export function useAgentCrdtFollower(
       recordDevEvent('stale_probe', {
         workflowId: subscribedWorkflowId.value
       })
+      if (syncStatus.value === null) syncStatus.value = 'checking'
       bridge.resubscribe()
       armStaleProbe()
     }, STALE_AFTER_MS)
@@ -350,9 +354,13 @@ export function useAgentCrdtFollower(
 
   const scheduleSubscribeRetry = (): void => {
     if (subscribeRetryTimer !== null) return
-    if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) return
     const target = subscribedWorkflowId.value
     if (target === null) return
+    if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) {
+      syncStatus.value = 'failed'
+      return
+    }
+    syncStatus.value = bridge.lastSchemaError ? 'failed' : 'recovering'
     const delay = SUBSCRIBE_RETRY_BASE_MS * 2 ** subscribeRetryAttempt
     subscribeRetryAttempt += 1
     subscribeRetryTimer = setTimeout(() => {
@@ -376,6 +384,7 @@ export function useAgentCrdtFollower(
     recordDevEvent('doc_subscribed', event.detail ?? null)
     if (ok) {
       clearSubscribeRetry()
+      syncStatus.value = bridge.lastSchemaError ? 'failed' : null
       armStaleProbe()
       // FE-1902 (poc-3): only a CONFIRMED binding is worth rebinding to after
       // a remount — persist on ok, not on intent.
@@ -471,6 +480,7 @@ export function useAgentCrdtFollower(
     // -- until some later frame happens to arrive.
     reconcileLiveGraph(detail.workflowId)
     connected.value = false
+    syncStatus.value = 'recovering'
     updatesApplied.value = 0
     lastFrameType.value = event.type
     clearStaleProbe()
@@ -512,6 +522,7 @@ export function useAgentCrdtFollower(
     // nothing was projected. Surface it as its own status rather than as a
     // generic "disconnected", which is indistinguishable from "never connected".
     connected.value = false
+    syncStatus.value = 'failed'
     lastFrameType.value = event.type
     clearStaleProbe()
     const detail =
@@ -527,6 +538,7 @@ export function useAgentCrdtFollower(
     )
   }
   const onGap: EventListener = (event) => {
+    syncStatus.value = 'recovering'
     outcomes.value = { ...outcomes.value, gap: outcomes.value.gap + 1 }
     recordDevEvent(
       'doc_gap',
@@ -542,6 +554,8 @@ export function useAgentCrdtFollower(
   }
   const onReconnected: EventListener = () => {
     connected.value = false
+    if (subscribedWorkflowId.value !== null)
+      syncStatus.value = bridge.lastSchemaError ? 'failed' : 'recovering'
     clearStaleProbe()
     recordDevEvent('reconnected', null)
     bridge.resubscribe()
@@ -622,6 +636,8 @@ export function useAgentCrdtFollower(
   const retarget = (next: string | null): void => {
     if (next === null) bridge.unsubscribe()
     else bridge.subscribe(next)
+    syncStatus.value =
+      next === null ? null : bridge.lastSchemaError ? 'failed' : 'checking'
     sender.abortIfUnbound()
   }
   watch(
@@ -728,6 +744,7 @@ export function useAgentCrdtFollower(
 
   return {
     status: readonly(status),
+    syncStatus: readonly(syncStatus),
     debugSnapshot,
     enqueueHumanOperations: (operations: GraphOperation[]) =>
       sender.enqueue(operations)


### PR DESCRIPTION
## Summary

Show synchronization progress without treating quiet workflows as stale. Warn on exhausted subscription retries or unreadable document state.

<details><summary>Full context for agent readers</summary>

## Changes

- **What**: Add a named, polite, atomic live region in the agent panel. Show checking for a subscription/probe and recovery for retries, reconnects and sequence gaps. Clear on subscription acknowledgement without claiming the canvas is current.
- Warn only after the existing six retries are actually refused, or the schema read gate fails. Keep schema failure visible across acknowledgements/reconnects. Silence, including an unanswered probe, never becomes a warning by itself.
- Keep transport, retry scheduling, document ownership and state-vector recovery unchanged. No edit blocking, automatic refresh or document replacement is introduced.

Related: [silent workflow subscription staleness](https://linear.app/comfyorg/issue/BE-9740). This status change does not fix or close the delivery defect.

## Review Focus

- A 30-second quiet interval is a probe trigger, not proof of divergence.
- Subscription acknowledgement does not prove catch-up projection. There is deliberately no “up to date” label.
- The last retry being sent is not exhaustion: the warning requires its refusal.
- The live region stays mounted and does not take focus. Save/drop status tests distinguish it by its accessible name.
- Existing [follower-layer refactor](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16908) preserves behavior and does not implement this status feature.

## Verification

- Failing-first: five new status tests failed; existing 50 composable tests passed.
- Final `NODE_OPTIONS='--no-experimental-webstorage --max-old-space-size=8192' pnpm exec vitest run src/workbench/extensions/agent/crdt src/workbench/extensions/agent/AgentPanelRoot.test.ts`: 708 tests in 36 files passed.
- Frontend/account typecheck, ESLint, type-aware oxlint, stylelint, oxfmt, unused translation-key check, and pre-push Knip passed through normal hooks.
- Node 25.9.0 emitted an engine warning against the repository's Node 26 requirement; no tool checks were bypassed.

## Screenshots (if applicable)

The real Vue component and repository CSS were rendered in installed Chromium at 420px width. Checking, recovering, warning and cleared states passed browser text/live-region/focus assertions, and screenshots were inspected for wrapping and clipping. No page errors occurred. This is isolated component verification, not full-page or live delivery QA.

Authenticated paired-window QA is blocked at the nightly Cloudflare Access login. No authenticated session was supplied, served frontend/backend revisions are unknown, and no paired traces or diagnostic exports were generated. Leave this draft unmerged pending that evidence; unit/component tests do not establish live delivery.

Glossary: follower means the browser's host-authored workflow replica; state vector describes replicated document state for catch-up; schema gate checks document readability; QA means quality assurance; PR means pull request.

</details>
<!-- authored-by:agent follower-staleness-602 -->
