### PR TITLE
test: cover fail-safe workflow recovery

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -318,6 +318,11 @@ const PAYMENT_METHOD_REQUIRED_RESPONSE = {
   payment_method_url: 'https://pay.test/method'
 } satisfies SubscribeResponse
 
+const PAYMENT_METHOD_URL_MISSING_RESPONSE = {
+  billing_op_id: 'creator-payment-method-url-missing',
+  status: 'needs_payment_method'
+} satisfies SubscribeResponse
+
 const RETRIED_SUBSCRIPTION_OPERATION_ID = 'retried-subscription'
 const RETRIED_SUBSCRIPTION_ACTION_URL =
   'https://verify.example/retried-subscription'
@@ -651,6 +656,70 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     ).toBeVisible()
     expect(subscribeRequests).toHaveLength(0)
     await expect(page).not.toHaveURL(/[?&](pricing|cycle)=/)
+  })
+
+  test.describe('when checkout has no payment method URL', () => {
+    let operationPollRequests: Request[]
+
+    test.beforeEach(async ({ page }) => {
+      operationPollRequests = []
+      await page.addInitScript(() => {
+        window.open = () => {
+          sessionStorage.setItem('unexpected-payment-popup', 'opened')
+          return null
+        }
+      })
+      await setupCloudApp(page, workspace('personal', 'owner'), [])
+      await page.route('**/api/billing/status', (route) =>
+        route.fulfill(jsonRoute(LEGACY_ACTIVE_STANDARD_STATUS))
+      )
+      await page.route('**/api/billing/plans', (route) =>
+        route.fulfill(
+          jsonRoute({
+            plans: [CREATOR_ANNUAL_PLAN]
+          } satisfies BillingPlansResponse)
+        )
+      )
+      await page.route('**/api/billing/preview-subscribe', (route) =>
+        route.fulfill(jsonRoute(NEW_CREATOR_SUBSCRIPTION))
+      )
+      await page.route('**/api/billing/subscribe', (route) =>
+        route.fulfill(jsonRoute(PAYMENT_METHOD_URL_MISSING_RESPONSE))
+      )
+      await page.route('**/api/billing/ops/**', (route) => {
+        operationPollRequests.push(route.request())
+        return route.fulfill(jsonRoute(UNEXPECTED_OPERATION_RESPONSE))
+      })
+    })
+
+    test('retains the operation and stops checkout', async ({ page }) => {
+      await page.goto(`${APP_URL}/?pricing=creator&cycle=yearly`)
+      const subscribeButton = page.getByRole('button', {
+        name: 'Subscribe to Creator'
+      })
+      await cloudAppExpect(subscribeButton).toBeVisible()
+      await subscribeButton.click()
+
+      await expect(
+        page.locator('.p-toast-message.p-toast-message-error').filter({
+          hasText:
+            'Payment options are unavailable. Please refresh and try again.'
+        })
+      ).toBeVisible()
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            sessionStorage.getItem('comfy:pending-subscription-checkout')
+          )
+        )
+        .toContain(PAYMENT_METHOD_URL_MISSING_RESPONSE.billing_op_id)
+      expect(operationPollRequests).toHaveLength(0)
+      expect(
+        await page.evaluate(() =>
+          sessionStorage.getItem('unexpected-payment-popup')
+        )
+      ).toBeNull()
+    })
   })
 
   test('restores pending checkout when retrying a timed-out operation', async ({

--- a/browser_tests/tests/workflow/failureRecovery.spec.ts
+++ b/browser_tests/tests/workflow/failureRecovery.spec.ts
@@ -1,0 +1,225 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+test.describe('Workflow failure recovery', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Sidebar'
+    )
+
+    await comfyPage.page.route('**/api/userdata/**', async (route) => {
+      const request = route.request()
+      const path = decodeURIComponent(new URL(request.url()).pathname)
+
+      if (
+        request.method() === 'GET' &&
+        (path.endsWith('/userdata/workflows/unavailable.json') ||
+          path.endsWith('/userdata/workflows/boot-failure.json'))
+      ) {
+        await route.fulfill({ status: 503 })
+        return
+      }
+      if (
+        request.method() === 'GET' &&
+        path.endsWith('/userdata/workflows/malformed.json')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: '{invalid'
+        })
+        return
+      }
+      if (
+        request.method() === 'POST' &&
+        path.endsWith(
+          '/userdata/workflows/rename.json/move/workflows/renamed.json'
+        )
+      ) {
+        await route.fulfill({ status: 500 })
+        return
+      }
+      if (
+        request.method() === 'DELETE' &&
+        path.endsWith('/userdata/workflows/delete.json')
+      ) {
+        await route.fulfill({ status: 500 })
+        return
+      }
+
+      await route.fallback()
+    })
+
+    await comfyPage.workflow.setupWorkflowsDirectory({
+      'stable.json': 'nodes/single_ksampler.json',
+      'configure-failure.json': 'default.json',
+      'unavailable.json': 'default.json',
+      'boot-failure.json': 'default.json',
+      'malformed.json': 'default.json',
+      'rename.json': 'default.json',
+      'delete.json': 'default.json'
+    })
+    await comfyPage.menu.workflowsTab.open()
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    const appReady = await comfyPage.page.evaluate(
+      () => window.app?.extensionManager !== undefined
+    )
+    if (!appReady) return
+    await comfyPage.workflow.setupWorkflowsDirectory({})
+  })
+
+  test('keeps the active workflow when another workflow is unavailable', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.getPersistedItem('stable').click()
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)
+
+    await tab.getPersistedItem('unavailable').click()
+    await comfyPage.workflow.waitForWorkflowIdle()
+
+    expect(await tab.getActiveWorkflowName()).toBe('stable')
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)
+    expect(await tab.getOpenedWorkflowNames()).not.toContain('unavailable')
+  })
+
+  test('keeps the active workflow when another workflow is malformed', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.getPersistedItem('stable').click()
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)
+
+    await tab.getPersistedItem('malformed').click()
+    await comfyPage.workflow.waitForWorkflowIdle()
+
+    expect(await tab.getActiveWorkflowName()).toBe('stable')
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)
+    expect(await tab.getOpenedWorkflowNames()).not.toContain('malformed')
+  })
+
+  test('restores the active workflow when graph configuration fails', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.getPersistedItem('stable').click()
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)
+    await comfyPage.page.evaluate(() => {
+      ;(window.graph as { configure: () => void }).configure = () => {
+        throw new Error('Configure failed')
+      }
+    })
+
+    await tab.getPersistedItem('configure-failure').click()
+    await comfyPage.workflow.waitForWorkflowIdle()
+
+    expect(await tab.getActiveWorkflowName()).toBe('stable')
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)
+  })
+
+  test('keeps the workflow name when its rename request fails', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.getPersistedItem('rename').click()
+
+    await tab.renameWorkflow(tab.getOpenedItem('rename'), 'renamed')
+
+    await expect(tab.getOpenedItem('rename')).toBeVisible()
+    await expect(tab.getOpenedItem('renamed')).toBeHidden()
+
+    test.fail(true, 'A failed workflow rename has no specific error message')
+    await expect(comfyPage.toast.toastErrors).toContainText(
+      'Failed to rename workflow. Please try again.',
+      { timeout: 1000 }
+    )
+  })
+
+  test('keeps a workflow in the sidebar when deletion fails', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    const workflow = tab.getPersistedItem('delete')
+    await workflow.click({ button: 'right' })
+    await comfyPage.contextMenu.clickMenuItem('Delete')
+    await comfyPage.confirmDialog.delete.click()
+
+    await expect(workflow).toBeVisible()
+    await expect(comfyPage.toast.visibleToasts).not.toContainText(
+      'Workflow deleted'
+    )
+  })
+
+  test('does not insert a workflow when its source cannot be loaded', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    const originalNodeCount = await comfyPage.nodeOps.getNodeCount()
+
+    await tab.insertWorkflow(tab.getPersistedItem('unavailable'))
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(originalNodeCount)
+  })
+
+  test('does not duplicate a workflow when its source cannot be loaded', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    const originalNames = await tab.getOpenedWorkflowNames()
+    await tab.getPersistedItem('unavailable').click({ button: 'right' })
+
+    await comfyPage.contextMenu.clickMenuItem('Duplicate')
+
+    await expect.poll(() => tab.getOpenedWorkflowNames()).toEqual(originalNames)
+  })
+
+  test.describe('startup recovery', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
+      await comfyPage.menu.workflowsTab.getPersistedItem('stable').click()
+      await comfyPage.page.evaluate(() => {
+        window.app!.graph.add(
+          window.LiteGraph!.createNode('Note', undefined, {})
+        )
+        const workflow = window.app!.extensionManager.workflow.activeWorkflow
+        workflow?.changeTracker.captureCanvasState()
+      })
+      await comfyPage.workflow.waitForDraftPersisted()
+      await comfyPage.page.evaluate(() => {
+        for (let i = 0; i < sessionStorage.length; i++) {
+          const key = sessionStorage.key(i)
+          if (!key?.startsWith('Comfy.Workflow.ActivePath:')) continue
+
+          const pointer = JSON.parse(sessionStorage.getItem(key)!) as {
+            path: string
+          }
+          pointer.path = 'workflows/boot-failure.json'
+          sessionStorage.setItem(key, JSON.stringify(pointer))
+          return
+        }
+        throw new Error('Missing active workflow persistence key')
+      })
+    })
+
+    test('falls back to the latest valid draft', async ({ comfyPage }) => {
+      test.slow()
+      await comfyPage.page.reload({ waitUntil: 'domcontentloaded' })
+
+      test.fail(
+        true,
+        'Startup stops after the saved active workflow fails to load'
+      )
+      await expect(comfyPage.menu.workflowsTab.activeWorkflowLabel).toHaveText(
+        'stable',
+        { timeout: 5000 }
+      )
+      await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add Playwright coverage for user-visible failure recovery paths changed by #15971, targeting current main behavior.

## Changes

- **What**: Covers unavailable and malformed workflow loads, configure rollback, failed rename/delete/insert/duplicate operations, startup draft fallback, and checkout responses missing a payment URL.

## Review Focus

The rename error message and startup draft fallback are marked with `test.fail()` exactly where current main diverges. Those markers should be removed when #15971 makes the assertions pass.
