### PR TITLE
chore: delete stale ignore and CODEOWNERS path literals

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -11,7 +11,6 @@
     "scripts/registry-census/corpus.pins.json",
     "scripts/registry-census/detection-proof/**",
     "src/__ecs_matrix__/**",
-    "src/types/generatedManagerTypes.ts",
     "src/locales/**/*.json",
     "**/__fixtures__/**/*.json",
     "apps/website/src/content/**/*.mdx",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -13,8 +13,6 @@
     "src/__ecs_matrix__/**",
     "src/extensions/core/*",
     "src/scripts/*",
-    "src/types/generatedManagerTypes.ts",
-    "src/types/vue-shim.d.ts",
     "test-results/*",
     "vitest.setup.ts"
   ],

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,6 @@
 
 # Mask Editor
 /src/extensions/core/maskeditor.ts                @trsommer @brucew4yn3rp @jtydhr88 @Comfy-Org/comfy_frontend_devs
-/src/extensions/core/maskEditorLayerFilenames.ts  @trsommer @brucew4yn3rp @jtydhr88 @Comfy-Org/comfy_frontend_devs
 /src/components/maskeditor/                       @trsommer @brucew4yn3rp @jtydhr88 @Comfy-Org/comfy_frontend_devs
 /src/composables/maskeditor/                      @trsommer @brucew4yn3rp @jtydhr88 @Comfy-Org/comfy_frontend_devs
 /src/stores/maskEditorStore.ts                    @trsommer @brucew4yn3rp @jtydhr88 @Comfy-Org/comfy_frontend_devs

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -180,8 +180,6 @@ export default defineConfig([
       'src/__ecs_matrix__/**',
       'src/extensions/core/*',
       'src/scripts/*',
-      'src/types/generatedManagerTypes.ts',
-      'src/types/vue-shim.d.ts',
       'packages/design-system/src/css/lucideStrokePlugin.js',
       'test-results/*',
       'vitest.setup.ts'
@@ -533,9 +531,7 @@ export default defineConfig([
       'src/**/{generated,vendor}/**',
       'src/__ecs_matrix__/**',
       'src/extensions/core/**',
-      'src/scripts/**',
-      'src/types/generatedManagerTypes.ts',
-      'src/types/vue-shim.d.ts'
+      'src/scripts/**'
     ],
     plugins: {
       comfy: { rules: { 'no-new-error-throw': noNewErrorThrow } }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delete ignore/CODEOWNERS path literals for files that no longer exist on `main`. Generated manager types live at `src/workbench/extensions/manager/types/generatedManagerTypes.ts`; `vue-shim.d.ts` and `maskEditorLayerFilenames.ts` are already gone. Removing the dead literals does not change lint coverage or ownership of remaining files.

Fixes #15622

## Verification

```bash
# paths must stay absent
test ! -e src/types/generatedManagerTypes.ts
test ! -e src/types/vue-shim.d.ts
test ! -e src/extensions/core/maskEditorLayerFilenames.ts
test -e src/workbench/extensions/manager/types/generatedManagerTypes.ts

rg -n 'src/types/generatedManagerTypes\.ts|src/types/vue-shim\.d\.ts|maskEditorLayerFilenames' \
  eslint.config.ts .oxlintrc.json .oxfmtrc.json CODEOWNERS
# expected: no hits

pnpm exec eslint -c eslint.config.ts --print-config src/main.ts >/dev/null
```

Locally: all four path tests passed, `rg` had no hits, `eslint --print-config` resolved, `pnpm format:check` passed, `pnpm lint` exited 0 (0 errors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d66885f-dea5-4f93-b432-68d332164d17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d66885f-dea5-4f93-b432-68d332164d17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

