### PR TITLE
fix(litegraph): keep promoted dynamic combo child links on load (FE-258)

### DIFF
--- a/browser_tests/assets/subgraphs/subgraph-dynamic-combo-promoted-child.json
+++ b/browser_tests/assets/subgraphs/subgraph-dynamic-combo-promoted-child.json
@@ -1,0 +1,241 @@
+{
+  "id": "f1e2d3c4-0000-4000-8000-fe25800258ff",
+  "revision": 0,
+  "last_node_id": 67,
+  "last_link_id": 2,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadImage",
+      "pos": [80, 120],
+      "size": [274, 314],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "localized_name": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1]
+        },
+        {
+          "localized_name": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["watch_macro_shot.png", "image"]
+    },
+    {
+      "id": 66,
+      "type": "7c0d9e16-1d55-4f2e-9a61-fe2580258001",
+      "pos": [460, 120],
+      "size": [280, 120],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "image",
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1
+        },
+        {
+          "localized_name": "resize_type.multiplier",
+          "name": "resize_type.multiplier",
+          "type": "FLOAT",
+          "label": "scale_multiplier",
+          "widget": {
+            "name": "resize_type.multiplier"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "resized",
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [2]
+        }
+      ],
+      "properties": {},
+      "widgets_values": [4]
+    },
+    {
+      "id": 67,
+      "type": "PreviewImage",
+      "pos": [820, 120],
+      "size": [210, 246],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 2
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    {
+      "id": 1,
+      "origin_id": 1,
+      "origin_slot": 0,
+      "target_id": 66,
+      "target_slot": 0,
+      "type": "IMAGE"
+    },
+    {
+      "id": 2,
+      "origin_id": 66,
+      "origin_slot": 0,
+      "target_id": 67,
+      "target_slot": 0,
+      "type": "IMAGE"
+    }
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "7c0d9e16-1d55-4f2e-9a61-fe2580258001",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 57,
+          "lastLinkId": 50,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Resize Image Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [420, 60, 190, 80]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [980, 100, 128, 68]
+        },
+        "inputs": [
+          {
+            "id": "e981cdcd-e740-4932-91e0-06392d5ac526",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [45],
+            "localized_name": "image",
+            "pos": [587, 85]
+          },
+          {
+            "id": "df3b8dbd-5649-4dbd-8551-c5cb254eafc5",
+            "name": "resize_type.multiplier",
+            "type": "FLOAT",
+            "linkIds": [50],
+            "label": "scale_multiplier",
+            "pos": [587, 105]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "517ebe35-9129-4f66-a88e-2fdca4c417cf",
+            "name": "resized",
+            "type": "IMAGE",
+            "linkIds": [24],
+            "localized_name": "resized",
+            "pos": [1000, 130]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 57,
+            "type": "ResizeImageMaskNode",
+            "pos": [700, 120],
+            "size": [270, 106],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "input",
+                "name": "input",
+                "type": "IMAGE,MASK",
+                "link": 45
+              },
+              {
+                "localized_name": "resize_type.multiplier",
+                "name": "resize_type.multiplier",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "resize_type.multiplier"
+                },
+                "link": 50
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "resized",
+                "name": "resized",
+                "type": "IMAGE",
+                "links": [24]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.27.0",
+              "Node name for S&R": "ResizeImageMaskNode"
+            },
+            "widgets_values": ["scale by multiplier", 4, "lanczos"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 45,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 57,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 50,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 57,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 24,
+            "origin_id": 57,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/browser_tests/assets/subgraphs/subgraph-dynamic-combo-promoted-child.json
+++ b/browser_tests/assets/subgraphs/subgraph-dynamic-combo-promoted-child.json
@@ -93,22 +93,8 @@
     }
   ],
   "links": [
-    {
-      "id": 1,
-      "origin_id": 1,
-      "origin_slot": 0,
-      "target_id": 66,
-      "target_slot": 0,
-      "type": "IMAGE"
-    },
-    {
-      "id": 2,
-      "origin_id": 66,
-      "origin_slot": 0,
-      "target_id": 67,
-      "target_slot": 0,
-      "type": "IMAGE"
-    }
+    [1, 1, 0, 66, 0, "IMAGE"],
+    [2, 66, 0, 67, 0, "IMAGE"]
   ],
   "groups": [],
   "definitions": {

--- a/browser_tests/assets/subgraphs/subgraph-dynamic-combo-promoted-child.json
+++ b/browser_tests/assets/subgraphs/subgraph-dynamic-combo-promoted-child.json
@@ -32,7 +32,7 @@
         "ver": "0.27.0",
         "Node name for S&R": "LoadImage"
       },
-      "widgets_values": ["watch_macro_shot.png", "image"]
+      "widgets_values": ["example.png", "image"]
     },
     {
       "id": 66,
@@ -68,7 +68,9 @@
           "links": [2]
         }
       ],
-      "properties": {},
+      "properties": {
+        "proxyWidgets": [["57", "resize_type.multiplier"]]
+      },
       "widgets_values": [4]
     },
     {

--- a/browser_tests/tests/subgraph/subgraphPromotedDynamicComboChild.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotedDynamicComboChild.spec.ts
@@ -38,5 +38,23 @@ test.describe(
         .poll(() => getPromotedWidgetNames(comfyPage, HOST_NODE_ID))
         .toEqual([PROMOTED_INPUT_NAME])
     })
+
+    test('keeps the links of the nodes around it', async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() =>
+            [...window.app!.graph.links.values()]
+              .map(
+                (link) =>
+                  `${link.origin_id}:${link.origin_slot}->${link.target_id}:${link.target_slot}`
+              )
+              .sort()
+          )
+        )
+        .toEqual(['1:0->66:0', '66:0->67:0'])
+    })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphPromotedDynamicComboChild.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotedDynamicComboChild.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { getPromotedWidgetNames } from '@e2e/fixtures/utils/promotedWidgets'
+
+// Reduced from the `utility_seedvr2_3b_int8_upscale_image` template (FE-258):
+// a `ResizeImageMaskNode` whose `resize_type` dynamic combo is set to a
+// non-default option, with that option's `multiplier` child widget promoted
+// through the subgraph boundary.
+const WORKFLOW = 'subgraphs/subgraph-dynamic-combo-promoted-child'
+const HOST_NODE_TITLE = 'Resize Image Subgraph'
+const HOST_NODE_ID = '66'
+const PROMOTED_WIDGET_LABEL = 'scale_multiplier'
+const PROMOTED_INPUT_NAME = 'resize_type.multiplier'
+
+test.describe(
+  'Promoted dynamic combo child widget',
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    })
+
+    test('survives a workflow load', async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+      await comfyPage.vueNodes.waitForNodes()
+
+      const multiplier = comfyPage.vueNodes.getWidgetRowByLabel(
+        HOST_NODE_TITLE,
+        PROMOTED_WIDGET_LABEL
+      )
+      await expect(multiplier).toBeVisible()
+      await expect(
+        comfyPage.vueNodes.getInputNumberControls(multiplier).input
+      ).toHaveValue('4.00')
+
+      await expect
+        .poll(() => getPromotedWidgetNames(comfyPage, HOST_NODE_ID))
+        .toEqual([PROMOTED_INPUT_NAME])
+    })
+  }
+)

--- a/browser_tests/tests/subgraph/subgraphPromotedDynamicComboChild.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotedDynamicComboChild.spec.ts
@@ -1,7 +1,17 @@
 import { expect } from '@playwright/test'
 
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { getPromotedWidgetNames } from '@e2e/fixtures/utils/promotedWidgets'
+import { toNodeId } from '@/types/nodeId'
+
+function getInputNames(comfyPage: ComfyPage, nodeId: string) {
+  return comfyPage.page.evaluate(
+    (id) =>
+      window.app!.graph.getNodeById(id)?.inputs.map((input) => input.name),
+    toNodeId(nodeId)
+  )
+}
 
 // Reduced from the `utility_seedvr2_3b_int8_upscale_image` template (FE-258):
 // a `ResizeImageMaskNode` whose `resize_type` dynamic combo is set to a
@@ -37,6 +47,10 @@ test.describe(
       await expect
         .poll(() => getPromotedWidgetNames(comfyPage, HOST_NODE_ID))
         .toEqual([PROMOTED_INPUT_NAME])
+
+      await expect
+        .poll(() => getInputNames(comfyPage, HOST_NODE_ID))
+        .toEqual(['image', PROMOTED_INPUT_NAME])
     })
 
     test('keeps the links of the nodes around it', async ({ comfyPage }) => {

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -8,6 +8,7 @@ import {
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
   normalizeConfiguredTopology,
+  realignGroupWidgetChildLinks,
   realignInputLinkSlots
 } from '@/lib/litegraph/src/linkDeduplication'
 import type {
@@ -782,5 +783,86 @@ describe('realignInputLinkSlots', () => {
     realignInputLinkSlots(graph, [[target.id, nodeData]])
 
     expect(movable.target_slot).toBe(4)
+  })
+})
+
+describe('realignGroupWidgetChildLinks (FE-258)', () => {
+  function groupWidgetSetup(inputNames: string[], groupWidgetName: string) {
+    const graph = new LGraph()
+    const source = new LGraphNode('Source')
+    source.addOutput('out', 'number')
+    const target = new LGraphNode('Target')
+    for (const name of inputNames) target.addInput(name, 'number')
+    target.addWidget('combo', groupWidgetName, 'scale dimensions', () => {}, {
+      values: ['scale dimensions', 'scale by multiplier']
+    })
+    graph.add(source)
+    graph.add(target)
+    return { graph, source, target }
+  }
+
+  function serializedInputs(
+    target: LGraphNode,
+    links: Record<string, number | null>
+  ) {
+    return target.inputs.map((input) => ({
+      name: input.name,
+      type: 'number',
+      link: links[input.name] ?? null
+    }))
+  }
+
+  it('moves a child link off the slot the default option laid out', () => {
+    const { graph, source, target } = groupWidgetSetup(
+      ['input', 'resize_type.width', 'resize_type', 'resize_type.multiplier'],
+      'resize_type'
+    )
+    const link = source.connect(0, target, 1)!
+
+    realignGroupWidgetChildLinks(target, {
+      id: target.id,
+      inputs: serializedInputs(target, { 'resize_type.multiplier': link.id })
+    })
+
+    expect(link.target_slot).toBe(3)
+    expect(
+      useLinkStore().getInputSlotLink(graphScopeOf(graph), target.id, 3)?.id
+    ).toBe(link.id)
+  })
+
+  it('leaves inputs that no group widget owns', () => {
+    const { source, target } = groupWidgetSetup(
+      ['first', 'second', 'resize_type'],
+      'resize_type'
+    )
+    const link = source.connect(0, target, 0)!
+
+    realignGroupWidgetChildLinks(target, {
+      id: target.id,
+      inputs: serializedInputs(target, { second: link.id })
+    })
+
+    expect(link.target_slot).toBe(0)
+  })
+
+  it('leaves the children of a group nested inside a group widget', () => {
+    const { source, target } = groupWidgetSetup(
+      [
+        'model.reference_images.image_1',
+        'other',
+        'model.reference_images.mask'
+      ],
+      'model'
+    )
+    const link = source.connect(0, target, 1)!
+
+    realignGroupWidgetChildLinks(target, {
+      id: target.id,
+      inputs: serializedInputs(target, {
+        'model.reference_images.image_1': link.id
+      })
+    })
+
+    expect(link.target_slot).toBe(1)
   })
 })

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -21,6 +21,7 @@ import { useLinkStore } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import type { LinkId } from '@/lib/litegraph/src/LLink'
 import type { NodeId } from '@/types/nodeId'
 
 const DEFINITION_ORDER = ['in_a', 'in_b', 'in_c']
@@ -44,6 +45,54 @@ class SourceNode extends LGraphNode {
   constructor(title?: string) {
     super(title ?? 'Source')
     this.addOutput('out', 'number')
+  }
+}
+
+/**
+ * Mirrors the two app behaviours FE-258 needs: `ComfyNode.configure` rewrites
+ * `data.inputs` into node-definition order and appends the serialized inputs
+ * the definition lacks, and a dynamic combo rebuilds its child inputs when its
+ * value is applied. Records the link on the child's slot at that moment.
+ */
+class GroupWidgetTargetNode extends LGraphNode {
+  static readonly DEFINITION_INPUTS = ['image', 'resize_type.width']
+  childLinkIdOnValueApply?: LinkId
+
+  constructor(title?: string) {
+    super(title ?? 'GroupWidgetTarget')
+    for (const name of GroupWidgetTargetNode.DEFINITION_INPUTS)
+      this.addInput(name, 'number')
+    const widget = this.addWidget(
+      'combo',
+      'resize_type',
+      'scale dimensions',
+      () => {},
+      { values: ['scale dimensions', 'scale by multiplier'] }
+    )
+    let value = widget.value
+    Object.defineProperty(widget, 'value', {
+      get: () => value,
+      set: (next: string) => {
+        value = next
+        const slot = this.inputs.findIndex(
+          (input) => input.name === 'resize_type.multiplier'
+        )
+        this.childLinkIdOnValueApply = this.getInputLink(slot)?.id
+      }
+    })
+  }
+
+  override configure(data: ISerialisedNode): void {
+    const serialized = data.inputs ?? []
+    const defined = this.inputs.map(
+      (input) => serialized.find((entry) => entry.name === input.name) ?? input
+    )
+    const definedNames = new Set(this.inputs.map((input) => input.name))
+    data.inputs = [
+      ...defined,
+      ...serialized.filter((entry) => !definedNames.has(entry.name))
+    ]
+    super.configure(data)
   }
 }
 
@@ -830,7 +879,35 @@ describe('realignGroupWidgetChildLinks (FE-258)', () => {
     ).toBe(link.id)
   })
 
-  it('leaves inputs that no group widget owns', () => {
+  it('moves an ordinary input link that holds a child destination slot', () => {
+    const { source, target } = groupWidgetSetup(
+      [
+        'image',
+        'resize_type.width',
+        'resize_type',
+        'roll',
+        'resize_type.multiplier'
+      ],
+      'resize_type'
+    )
+    const child = source.connect(0, target, 1)!
+    const ordinary = source.connect(0, target, 4)!
+
+    realignGroupWidgetChildLinks(target, {
+      id: target.id,
+      inputs: serializedInputs(target, {
+        'resize_type.multiplier': child.id,
+        roll: ordinary.id
+      })
+    })
+
+    expect({
+      child: child.target_slot,
+      ordinary: ordinary.target_slot
+    }).toEqual({ child: 4, ordinary: 3 })
+  })
+
+  it('leaves a node that has no group widget child input', () => {
     const { source, target } = groupWidgetSetup(
       ['first', 'second', 'resize_type'],
       'resize_type'
@@ -845,24 +922,88 @@ describe('realignGroupWidgetChildLinks (FE-258)', () => {
     expect(link.target_slot).toBe(0)
   })
 
-  it('leaves the children of a group nested inside a group widget', () => {
+  it('leaves the links of a group nested inside a group widget', () => {
     const { source, target } = groupWidgetSetup(
       [
         'model.reference_images.image_1',
-        'other',
-        'model.reference_images.mask'
+        'model.generate_audio',
+        'model.reference_images.image_2'
       ],
       'model'
     )
-    const link = source.connect(0, target, 1)!
+    const nested = source.connect(0, target, 0)!
 
     realignGroupWidgetChildLinks(target, {
       id: target.id,
       inputs: serializedInputs(target, {
-        'model.reference_images.image_1': link.id
+        'model.reference_images.image_2': nested.id
       })
     })
 
-    expect(link.target_slot).toBe(1)
+    expect(nested.target_slot).toBe(0)
+  })
+})
+
+describe('LGraphNode.configure realignment ordering (FE-258)', () => {
+  beforeEach(() => {
+    LiteGraph.registerNodeType('test/RealignSource', SourceNode)
+    LiteGraph.registerNodeType('test/GroupWidgetTarget', GroupWidgetTargetNode)
+  })
+
+  it('realigns a child link before the group widget value is applied', () => {
+    const graph = new LGraph()
+    const workflow: SerialisableGraph = {
+      id: 'ab000000-0000-4000-8000-000000000004',
+      version: 1,
+      revision: 0,
+      state: { lastNodeId: 2, lastLinkId: 1, lastGroupId: 0, lastRerouteId: 0 },
+      nodes: [
+        {
+          id: 1,
+          type: 'test/RealignSource',
+          pos: [0, 0],
+          size: [140, 60],
+          flags: {},
+          order: 0,
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: 'out', type: 'number', links: [1] }],
+          properties: {}
+        },
+        {
+          id: 2,
+          type: 'test/GroupWidgetTarget',
+          pos: [300, 0],
+          size: [140, 80],
+          flags: {},
+          order: 1,
+          mode: 0,
+          inputs: [
+            { name: 'image', type: 'number', link: null },
+            { name: 'resize_type.multiplier', type: 'number', link: 1 }
+          ],
+          outputs: [],
+          properties: {},
+          widgets_values: ['scale by multiplier']
+        }
+      ],
+      links: [
+        {
+          id: toLinkId(1),
+          origin_id: 1,
+          origin_slot: 0,
+          target_id: 2,
+          target_slot: 1,
+          type: 'number'
+        }
+      ]
+    }
+    graph.configure(workflow)
+
+    const target = graph.getNodeById(toNodeId(2))
+    expect(target).toBeInstanceOf(GroupWidgetTargetNode)
+    expect((target as GroupWidgetTargetNode).childLinkIdOnValueApply).toBe(
+      toLinkId(1)
+    )
   })
 })

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -55,6 +55,7 @@ import { badgeDrawObjects, badgeRows } from './nodeBadgeDraw'
 import { LGraphButton } from './LGraphButton'
 import type { LGraphButtonOptions } from './LGraphButton'
 import { LGraphCanvas } from './LGraphCanvas'
+import { realignGroupWidgetChildLinks } from './linkDeduplication'
 import { LLink, replaceLinkTopology, slotFloatingLinks } from './LLink'
 import {
   inputHasLink,
@@ -1164,6 +1165,8 @@ export class LGraphNode
 
     // SubgraphNode callback.
     this._internalConfigureAfterSlots?.()
+
+    realignGroupWidgetChildLinks(this, info)
 
     const restoration = createWidgetRestorationState(
       info,

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -177,39 +177,57 @@ export function detachSerialisedLinks(
   return linkByInputName
 }
 
+function groupNameOf(inputName: string): string | undefined {
+  const separator = inputName ? inputName.lastIndexOf('.') : -1
+  return separator < 1 ? undefined : inputName.slice(0, separator)
+}
+
 /**
- * Whether `inputName` is a child input of a group widget on `node`.
- *
- * Group widgets (dynamic combos) name their child inputs
- * `<group widget name>.<key>` and replace the whole set whenever their own
- * value changes. The group is the segment before the *last* dot, so inputs of
- * a nested dynamic group — autogrow names its children
- * `<group>.<nested>.<ordinal>` — resolve to their own group and are excluded.
+ * Whether a group widget on `node` owns `inputName`'s slot. Group widgets
+ * (dynamic combos) name their child inputs `<group widget name>.<key>` and
+ * replace the whole set whenever their own value changes.
  */
 function isGroupWidgetChildInput(node: LGraphNode, inputName: string): boolean {
-  if (!inputName) return false
+  const groupName = groupNameOf(inputName)
+  if (groupName === undefined) return false
 
-  const separator = inputName.lastIndexOf('.')
-  if (separator < 1) return false
-
-  const groupName = inputName.slice(0, separator)
   return node.widgets?.some((widget) => widget.name === groupName) ?? false
 }
 
 /**
- * Realigns the links of a node's group widget child inputs, before the group
- * widget's serialized value is applied.
+ * Whether a dynamic group that is not a widget owns `inputName`'s slot —
+ * autogrow names its children `<group>.<nested>.<ordinal>`, so their group is
+ * a nested input spec rather than a widget.
  *
- * Applying that value rebuilds every child input of the group and hands each
- * surviving link to the new input of the same name. A link sitting on the
- * wrong slot — the node definition lays out the default option's children,
- * while `target_slot` counts the serialized layout — is handed to an input
- * that the selected option does not define, and is dropped.
+ * Those groups grow and renumber their own slots while the graph configures,
+ * and realigning their links by name that early destroys them (see
+ * `browser_tests/tests/subgraph/subgraphConvertAutogrowInputs.spec.ts`, "loads
+ * with both reference images connected").
+ */
+function isNestedDynamicGroupInput(
+  node: LGraphNode,
+  inputName: string
+): boolean {
+  const groupName = groupNameOf(inputName)
+  return groupName !== undefined && !isGroupWidgetChildInput(node, inputName)
+}
+
+/**
+ * Realigns a node's input links by name before its group widget values are
+ * applied, for nodes that have a group widget child input.
  *
- * Only group widget children are realigned: {@link LGraph.configure} runs the
- * full pass once every node is configured, which is what lets it resolve
- * contention for a slot between nodes. Realigning a node's other inputs here
- * would claim slots from nodes that have not configured yet.
+ * Applying a group widget's value rebuilds every child input of the group and
+ * hands each surviving link to the new input of the same name. A link sitting
+ * on the wrong slot — the node definition lays out the default option's
+ * children, while `target_slot` counts the serialized layout — is handed to an
+ * input that the selected option does not define, and is dropped. Through a
+ * subgraph boundary that demotes the promoted widget to a disconnected input
+ * slot.
+ *
+ * The node's ordinary inputs join the batch so that a link still occupying a
+ * child's destination slot is moved in the same atomic update instead of
+ * blocking it. Links owned by a nested dynamic group are left to
+ * {@link LGraph.configure}'s final pass.
  */
 export function realignGroupWidgetChildLinks(
   node: LGraphNode,
@@ -218,10 +236,11 @@ export function realignGroupWidgetChildLinks(
   const { graph } = node
   if (!graph) return
 
-  const inputs = nodeData.inputs?.filter((input) =>
-    isGroupWidgetChildInput(node, input.name)
+  const inputs = nodeData.inputs?.filter(
+    (input) => !isNestedDynamicGroupInput(node, input.name)
   )
-  if (!inputs?.length) return
+  if (!inputs?.some((input) => isGroupWidgetChildInput(node, input.name)))
+    return
 
   realignInputLinkSlots(graph, [[node.id, { id: nodeData.id, inputs }]])
 }

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -7,6 +7,7 @@ import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import cloneDeep from 'es-toolkit/compat/cloneDeep'
 import type { LGraph } from './LGraph'
+import type { LGraphNode } from './LGraphNode'
 import type { LinkId, LLink, SerialisedLLinkArray } from './LLink'
 import type {
   ExportedSubgraph,
@@ -174,6 +175,55 @@ export function detachSerialisedLinks(
   }
   for (const output of nodeData.outputs ?? []) output.links = []
   return linkByInputName
+}
+
+/**
+ * Whether `inputName` is a child input of a group widget on `node`.
+ *
+ * Group widgets (dynamic combos) name their child inputs
+ * `<group widget name>.<key>` and replace the whole set whenever their own
+ * value changes. The group is the segment before the *last* dot, so inputs of
+ * a nested dynamic group — autogrow names its children
+ * `<group>.<nested>.<ordinal>` — resolve to their own group and are excluded.
+ */
+function isGroupWidgetChildInput(node: LGraphNode, inputName: string): boolean {
+  if (!inputName) return false
+
+  const separator = inputName.lastIndexOf('.')
+  if (separator < 1) return false
+
+  const groupName = inputName.slice(0, separator)
+  return node.widgets?.some((widget) => widget.name === groupName) ?? false
+}
+
+/**
+ * Realigns the links of a node's group widget child inputs, before the group
+ * widget's serialized value is applied.
+ *
+ * Applying that value rebuilds every child input of the group and hands each
+ * surviving link to the new input of the same name. A link sitting on the
+ * wrong slot — the node definition lays out the default option's children,
+ * while `target_slot` counts the serialized layout — is handed to an input
+ * that the selected option does not define, and is dropped.
+ *
+ * Only group widget children are realigned: {@link LGraph.configure} runs the
+ * full pass once every node is configured, which is what lets it resolve
+ * contention for a slot between nodes. Realigning a node's other inputs here
+ * would claim slots from nodes that have not configured yet.
+ */
+export function realignGroupWidgetChildLinks(
+  node: LGraphNode,
+  nodeData: Pick<ISerialisedNode, 'id' | 'inputs'>
+): void {
+  const { graph } = node
+  if (!graph) return
+
+  const inputs = nodeData.inputs?.filter((input) =>
+    isGroupWidgetChildInput(node, input.name)
+  )
+  if (!inputs?.length) return
+
+  realignInputLinkSlots(graph, [[node.id, { id: nodeData.id, inputs }]])
 }
 
 /**


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Fixes the `scale_multiplier` widget on the `utility_seedvr2_3b_int8_upscale_image` template rendering as a disconnected input slot, with a duplicate `resize_type.multiplier_1` appended below it. Reproduces on current `main`; neither #16717 nor its backport #16751 touched the failing path.

- Fixes FE-258

## Root cause

A node is constructed with its dynamic combo's **default** option laid out (`resize_type.width/height/crop`), and `ComfyNode.configure` rewrites `data.inputs` into that definition order, appending the serialized inputs the definition lacks. Serialized `target_slot` values count the **saved** layout, so link `50` — saved on `resize_type.multiplier` at slot 1 — lands on slot 1 of the rebuilt layout, which is a different input.

Applying the combo's serialized value then tears the group down and hands each surviving link to the new input of the same name. The link is sitting on `resize_type.width`, which the selected option does not define, so it is dropped. Across a subgraph boundary the promoted input is demoted to a bare slot and a duplicate `_1` promotion is auto-created.

## Fix

Realign the node's input links by name in `LGraphNode.configure`, after slots are wired and before widget values are applied — the window in which the correct slot exists. Scoped to nodes that have a group widget child input; `LGraph.configure`'s existing pass still runs for everything else once all nodes are configured.

The node's ordinary inputs join the batch so a link still occupying a child's destination slot moves in the same atomic update instead of blocking it. Inputs owned by a group that is not a widget (autogrow) stay out: their slots grow and renumber during configure, and realigning them this early destroys their links — measured, 1/1 failing on `subgraphConvertAutogrowInputs` "loads with both reference images connected".

## Verification

- New e2e spec on a fixture reduced from the real template: fails against `main`'s sources on both symptoms (widget missing, duplicate input), passes here. A second case asserts the neighbouring root links survive.
- 5 new unit cases, each mutation-checked — removing the call site, the realignment, the nested-group exclusion, the group-child gate, or the ordinary-input widening each turns one red.
- Verified in a browser against the real template: `resize_type.multiplier` promoted as a widget with value 4, link `50` intact, 10 host inputs, no duplicate. A differential sweep over 80 templates with dotted input names found 76 byte-identical to `main` and 4 improved (3 duplicate-input fixes, 1 restored link).
- typecheck, typecheck:browser, lint, oxfmt, knip clean. Full unit suite and the full `browser_tests/tests/subgraph/` suite show only failures that reproduce against `main`'s sources in this sandbox.

## Known residuals (pre-existing, not introduced)

- When an excluded autogrow link occupies a batched link's destination, the batch is rejected and `realignInputLinkSlots` logs `Failed to realign input link slots`. No link is lost — the late pass repairs the slot — but the log is new noise on those workflows.
- A nested dynamic combo under a **non-default** outer option is excluded, because its widget does not exist yet at this point in configure. Those links can still dangle. Reproduces identically on `main`; the durable fix is to derive group ownership from the input spec rather than instantiated widgets, which is worth its own ticket.

## Screenshots

![Before, on main: scale_multiplier is a bare disconnected input slot and a duplicate resize_type.multiplier_1 widget is appended at the bottom of the node](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/a48037af157a30f246f73578b4cedea7fcb7acb6473a9fc84046508377963380/pr-images/1789169961897-4970176d-8c5d-45dc-8ac6-c46125b400c4.png)

![After the fix: scale_multiplier renders as a widget with value 4.00 in its correct position, with no duplicate input](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/a48037af157a30f246f73578b4cedea7fcb7acb6473a9fc84046508377963380/pr-images/1789169962235-4c9befc5-08de-46f2-a42a-7927a3e8224d.png)