### PR TITLE
fix: unexport unused workspace types

### DIFF
--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -26,7 +26,7 @@ export interface DowngradeToPersonalResult {
   response: SubscribeResponse
 }
 
-export interface DowngradePreview {
+interface DowngradePreview {
   preview: PreviewSubscribeResponse
   /** Cancelled subscription + a real plan change: the BE requires
    *  `confirm_reactivation` on the subscribe call or it rejects the change. */

--- a/src/platform/workspace/composables/useWorkspaceActivity.ts
+++ b/src/platform/workspace/composables/useWorkspaceActivity.ts
@@ -15,7 +15,7 @@ export interface ActivityEvent {
   credited?: boolean
 }
 
-export interface UserSummary {
+interface UserSummary {
   totalCredits: number
   lastActivity: Date
 }

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -62,7 +62,7 @@ type OperationStatus =
   | 'timeout'
   | 'reconciliation_needed'
 
-export interface StartOperationMetadata {
+interface StartOperationMetadata {
   tier?: SubscriptionCheckoutTier
   cycle?: BillingCycle
   checkoutType?: SubscriptionCheckoutType

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -14,7 +14,7 @@ import type {
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
-export type PartnerNodePolicyStatus =
+type PartnerNodePolicyStatus =
   | 'inactive'
   | 'loading'
   | 'unconfigured'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove `export` from four workspace types that fallow marks unused (`DowngradePreview`, `UserSummary`, `StartOperationMetadata`, `PartnerNodePolicyStatus`). Types stay for in-file use; no runtime or rename changes.

## Verification

Importer gate on tip `b632879f33` (`rg -n 'DowngradePreview|UserSummary|StartOperationMetadata|PartnerNodePolicyStatus' src packages apps --glob '!**/node_modules/**'`): each name appears only in its defining file. No external importers; none skipped.

- **`DowngradePreview`** — `src/platform/workspace/composables/useDowngradeToPersonal.ts:29` (`interface DowngradePreview`). Hits: L29 definition, L126 `Promise<DowngradePreview>` in-file. No other `src`/`packages`/`apps` hits.
- **`UserSummary`** — `src/platform/workspace/composables/useWorkspaceActivity.ts:18` (`interface UserSummary`). Hits: L18 definition, L111 `Map<string, UserSummary>` in-file. No other `src`/`packages`/`apps` hits.
- **`StartOperationMetadata`** — `src/platform/workspace/stores/billingOperationStore.ts:65` (`interface StartOperationMetadata`). Hits: L65 definition, L114 indexed access, L232 `metadata?` param — all in-file. No other `src`/`packages`/`apps` hits.
- **`PartnerNodePolicyStatus`** — `src/platform/workspace/stores/partnerNodeGovernanceStore.ts:17` (`type PartnerNodePolicyStatus`). Hits: L17 definition, L33 `ref<PartnerNodePolicyStatus>` in-file. No other `src`/`packages`/`apps` hits.

`pnpm typecheck` — green (`vue-tsc --noEmit` + `@comfyorg/account`).
`pnpm lint` — green (0 errors; pre-existing warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36d48754-ff2a-471c-bd9e-a67868e82fa6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36d48754-ff2a-471c-bd9e-a67868e82fa6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

