### PR TITLE
test: add unit coverage for planDuration helpers

### DIFF
--- a/src/platform/cloud/subscription/utils/planDuration.test.ts
+++ b/src/platform/cloud/subscription/utils/planDuration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAnnualDuration, isYearlyCheckout } from './planDuration'
+
+describe('isAnnualDuration', () => {
+  it.for([
+    { duration: 'ANNUAL', expected: true },
+    { duration: 'MONTHLY', expected: false },
+    { duration: undefined, expected: false }
+  ] as const)(
+    'returns $expected when duration is $duration',
+    ({ duration, expected }) => {
+      expect(isAnnualDuration(duration)).toBe(expected)
+    }
+  )
+})
+
+describe('isYearlyCheckout', () => {
+  it.for([
+    {
+      duration: 'ANNUAL',
+      billingCycle: 'yearly',
+      expected: true
+    },
+    {
+      duration: 'ANNUAL',
+      billingCycle: 'monthly',
+      expected: true
+    },
+    {
+      duration: 'MONTHLY',
+      billingCycle: 'yearly',
+      expected: false
+    },
+    {
+      duration: 'MONTHLY',
+      billingCycle: 'monthly',
+      expected: false
+    }
+  ] as const)(
+    'prefers duration $duration over billingCycle $billingCycle',
+    ({ duration, billingCycle, expected }) => {
+      expect(isYearlyCheckout(duration, billingCycle)).toBe(expected)
+    }
+  )
+
+  it.for([
+    { billingCycle: 'yearly', expected: true },
+    { billingCycle: 'monthly', expected: false }
+  ] as const)(
+    'falls back to billingCycle $billingCycle when duration is undefined',
+    ({ billingCycle, expected }) => {
+      expect(isYearlyCheckout(undefined, billingCycle)).toBe(expected)
+    }
+  )
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds dedicated Vitest coverage for `isAnnualDuration` and `isYearlyCheckout` in `src/platform/cloud/subscription/utils/planDuration.ts`, including the `undefined` duration → `billingCycle` fallback that component fixtures do not exercise. Tests only; no production callers migrated.

## Verification

```bash
pnpm test:unit -- src/platform/cloud/subscription/utils/planDuration.test.ts
```

Expected: all cases pass; both exports covered including undefined fallback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543bd836-c5e5-4643-9e04-c3412916b6b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543bd836-c5e5-4643-9e04-c3412916b6b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

