### PR TITLE
refactor: reuse isAnnualDuration at inlined ANNUAL checks

### DIFF
--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -233,6 +233,7 @@ import {
   getTierCredits
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { usePendingTopup } from '@/composables/billing/usePendingTopup'
@@ -277,8 +278,8 @@ const tierKey = computed(() => {
   return toTierKey(tier) ?? DEFAULT_TIER_KEY
 })
 
-const isAnnualBilling = computed(
-  () => subscription.value?.duration === 'ANNUAL'
+const isAnnualBilling = computed(() =>
+  isAnnualDuration(subscription.value?.duration ?? undefined)
 )
 
 const creditPoolTotalCredits = computed<number | null>(() => {

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -278,6 +278,7 @@ import type {
   TierKey,
   TierPricing
 } from '@/platform/cloud/subscription/constants/tierPricing'
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import {
   recordPendingSubscriptionCheckoutAttempt,
   withPendingCheckoutAttemptId
@@ -379,8 +380,8 @@ const {
   subscription
 } = useBillingContext()
 
-const isYearlySubscription = computed(
-  () => subscription.value?.duration === 'ANNUAL'
+const isYearlySubscription = computed(() =>
+  isAnnualDuration(subscription.value?.duration ?? undefined)
 )
 const telemetry = useTelemetry()
 const { userId } = storeToRefs(useAuthStore())

--- a/src/platform/cloud/subscription/composables/useBillingPlans.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPlans.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import type {
   Plan,
   TeamCreditStops
@@ -45,7 +46,7 @@ export function useBillingPlans() {
   )
 
   const annualPlans = computed(() =>
-    plans.value.filter((p) => p.duration === 'ANNUAL')
+    plans.value.filter((p) => isAnnualDuration(p.duration))
   )
 
   function getPlanBySlug(slug: string) {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -26,6 +26,7 @@ import { useDialogService } from '@/services/dialogService'
 import { toTierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { operations } from '@/types/comfyRegistryTypes'
 import { parseErrorResponse } from '@/platform/remote/comfyui/errors'
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import {
   PENDING_SUBSCRIPTION_CHECKOUT_EVENT,
   PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
@@ -100,8 +101,8 @@ function useSubscriptionInternal() {
     () => subscriptionStatus.value?.subscription_duration ?? null
   )
 
-  const isYearlySubscription = computed(
-    () => subscriptionDuration.value === 'ANNUAL'
+  const isYearlySubscription = computed(() =>
+    isAnnualDuration(subscriptionDuration.value ?? undefined)
   )
 
   const subscriptionTierName = computed(() => {
@@ -261,7 +262,7 @@ function useSubscriptionInternal() {
       cycle: 'monthly',
       checkout_type: canAccessSubscriptionFeatures.value ? 'change' : 'new',
       ...(previousTierKey ? { previous_tier: previousTierKey } : {}),
-      ...(subscriptionDuration.value === 'ANNUAL'
+      ...(isAnnualDuration(subscriptionDuration.value ?? undefined)
         ? { previous_cycle: 'yearly' as const }
         : subscriptionDuration.value === 'MONTHLY'
           ? { previous_cycle: 'monthly' as const }

--- a/src/platform/cloud/subscription/utils/subscriptionCancellationTelemetry.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCancellationTelemetry.ts
@@ -1,3 +1,4 @@
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import type { SubscriptionCancellationMetadata } from '@/platform/telemetry/types'
 import type {
   SubscriptionDuration,
@@ -22,7 +23,7 @@ export function getSubscriptionCancellationMetadata({
     source: 'cancel_plan_menu',
     current_tier: tier?.toLowerCase(),
     ...(duration
-      ? { cycle: duration === 'ANNUAL' ? 'yearly' : 'monthly' }
+      ? { cycle: isAnnualDuration(duration) ? 'yearly' : 'monthly' }
       : {}),
     ...(effectiveEndDate ? { end_date: effectiveEndDate } : {})
   }

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -7,6 +7,7 @@ import type {
   IngestSubscriptionTier,
   TierKey
 } from '@/platform/cloud/subscription/constants/tierPricing'
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type {
   BeginCheckoutMetadata,
@@ -152,7 +153,7 @@ const getTierFromStatus = (
 const getCycleFromStatus = (
   status: SubscriptionStatusSnapshot
 ): BillingCycle | null => {
-  if (status.subscription_duration === 'ANNUAL') {
+  if (isAnnualDuration(status.subscription_duration ?? undefined)) {
     return 'yearly'
   }
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -410,6 +410,7 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useFreeTierQuota } from '@/platform/cloud/subscription/composables/useFreeTierQuota'
 import { isSalesManagedTier } from '@/platform/cloud/subscription/constants/tierPricing'
+import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { isCloud } from '@/platform/distribution/types'
@@ -563,8 +564,8 @@ async function handleRetry() {
   await initialize()
 }
 
-const isYearlySubscription = computed(
-  () => subscription.value?.duration === 'ANNUAL'
+const isYearlySubscription = computed(() =>
+  isAnnualDuration(subscription.value?.duration ?? undefined)
 )
 
 const formattedRenewalDate = computed(() =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reuse `isAnnualDuration` from `src/platform/cloud/subscription/utils/planDuration.ts` at inlined `=== 'ANNUAL'` (and equivalent) call sites. Checkout preview already uses `isYearlyCheckout`; this PR only replaces duration checks the helper already encodes. `?? undefined` is a type adapter for nullable duration fields — same boolean outcomes as `=== 'ANNUAL'`.

## Verification

```bash
pnpm test:unit -- src/platform/cloud/subscription/utils/planDuration.test.ts
# plus any existing unit tests for the touched modules if present
pnpm typecheck
```

Expected: planDuration tests still pass; typecheck green; behavior unchanged (same boolean outcomes).

`planDuration.test.ts` is not on `main` yet (characterization in #17490). Ran existing tests for touched modules instead:

```bash
pnpm test:unit \
  src/platform/cloud/subscription/composables/useSubscription.test.ts \
  src/platform/cloud/subscription/composables/useBillingPlans.test.ts \
  src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.test.ts \
  src/platform/cloud/subscription/components/CreditsTile.test.ts \
  src/platform/cloud/subscription/components/PricingTable.test.ts \
  src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts \
  src/platform/cloud/subscription/launchCancellationFlow.test.ts \
  src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
pnpm typecheck
```

Result: 8 files / 198 tests passed; `pnpm typecheck` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b00ba86c-4f65-4e69-9007-2670b990d4c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b00ba86c-4f65-4e69-9007-2670b990d4c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

