### PR TITLE
test: cover U+2028/U+2029 escaping in escapeJsonLd

### DIFF
--- a/apps/website/src/utils/jsonLd.test.ts
+++ b/apps/website/src/utils/jsonLd.test.ts
@@ -318,4 +318,24 @@ describe('escapeJsonLd on a built graph', () => {
     expect(serialized).not.toContain('</script>')
     expect(serialized).toContain('\\u003c')
   })
+
+  it('escapes a U+2028 line separator in a page name', () => {
+    const graph = buildPageGraph(
+      { siteUrl, locale: 'en' },
+      { url: `${siteUrl}/x/`, name: 'before\u2028after' }
+    )
+    const serialized = escapeJsonLd(graph)
+    expect(serialized).not.toContain('\u2028')
+    expect(serialized).toContain('\\u2028')
+  })
+
+  it('escapes a U+2029 paragraph separator in a page name', () => {
+    const graph = buildPageGraph(
+      { siteUrl, locale: 'en' },
+      { url: `${siteUrl}/x/`, name: 'before\u2029after' }
+    )
+    const serialized = escapeJsonLd(graph)
+    expect(serialized).not.toContain('\u2029')
+    expect(serialized).toContain('\\u2029')
+  })
 })

--- a/apps/website/src/utils/jsonLd.test.ts
+++ b/apps/website/src/utils/jsonLd.test.ts
@@ -319,23 +319,24 @@ describe('escapeJsonLd on a built graph', () => {
     expect(serialized).toContain('\\u003c')
   })
 
-  it('escapes a U+2028 line separator in a page name', () => {
-    const graph = buildPageGraph(
-      { siteUrl, locale: 'en' },
-      { url: `${siteUrl}/x/`, name: 'before\u2028after' }
-    )
-    const serialized = escapeJsonLd(graph)
-    expect(serialized).not.toContain('\u2028')
-    expect(serialized).toContain('\\u2028')
-  })
-
-  it('escapes a U+2029 paragraph separator in a page name', () => {
-    const graph = buildPageGraph(
-      { siteUrl, locale: 'en' },
-      { url: `${siteUrl}/x/`, name: 'before\u2029after' }
-    )
-    const serialized = escapeJsonLd(graph)
-    expect(serialized).not.toContain('\u2029')
-    expect(serialized).toContain('\\u2029')
-  })
+  it.for([
+    { description: 'U+2028 line', separator: '\u2028', escaped: '\\u2028' },
+    {
+      description: 'U+2029 paragraph',
+      separator: '\u2029',
+      escaped: '\\u2029'
+    }
+  ] as const)(
+    'escapes a $description separator in a page name',
+    ({ separator, escaped }) => {
+      const name = `before${separator}after`
+      const graph = buildPageGraph(
+        { siteUrl, locale: 'en' },
+        { url: `${siteUrl}/x/`, name }
+      )
+      const serialized = escapeJsonLd(graph)
+      expect(serialized).not.toContain(separator)
+      expect(serialized).toContain(`before${escaped}after`)
+    }
+  )
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit coverage for U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR escaping in `escapeJsonLd`, which docs already claim and the implementation already performs. Existing tests only covered `</script>`.

## Verification

```bash
pnpm test:unit -- apps/website/src/utils/jsonLd.test.ts
```

Expected: new LS/PS cases pass alongside existing `</script>` coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95fcbd65-e4c9-4181-b7ac-66fd6f4f536b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95fcbd65-e4c9-4181-b7ac-66fd6f4f536b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

