### PR TITLE
fix(ci): keep repo-root tooling configs out of flag-policy runtime scope

### DIFF
--- a/.github/risk.json
+++ b/.github/risk.json
@@ -216,6 +216,31 @@
       ]
     },
     {
+      "class": "build-config",
+      "tier": "R1",
+      "why": "lint, format and test-runner configs plus git metadata steer developer tooling only — they cannot change what ships in the bundle. Kept out of the R2 build-config rule so a formatter tweak stays in the flagless lane, while the shared class keeps these paths exempt from the feature-flag policy's runtime scope (unmatched paths count as runtime there).",
+      "paths": [
+        "**/.oxfmtrc.json",
+        "**/.oxlintrc.json",
+        "**/eslint.config.*",
+        "eslint-suppressions.json",
+        "**/.stylelintrc*",
+        "**/lint-staged.config.*",
+        "**/knip.config.*",
+        "**/playwright*.config.*",
+        "**/vitest*.config.*",
+        "vitest.setup.ts",
+        "vitest.timer.setup.ts",
+        ".yamllint",
+        ".editorconfig",
+        ".nvmrc",
+        "**/.gitignore",
+        ".gitattributes",
+        ".git-blame-ignore-revs",
+        ".husky/**"
+      ]
+    },
+    {
       "class": "core-infra",
       "tier": "R2",
       "why": "cross-cutting state, API layer, routing, bootstrap, canvas engine and published packages \u2014 blast radius is every feature, and packages/** breaks consumers out of band",

--- a/scripts/cicd/feature-flag-policy.test.ts
+++ b/scripts/cicd/feature-flag-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import shippedRiskMap from '../../.github/risk.json'
 import {
   applyAiVerdict,
   buildReviewContext,
@@ -70,6 +71,46 @@ describe('runtimePathsFor', () => {
   it('treats unclassified files as runtime instead of silently exempting them', () => {
     expect(
       runtimePathsFor([{ filename: 'src/components/NewUi.vue' }], riskMap)
+    ).toEqual(['src/components/NewUi.vue'])
+  })
+
+  it('keeps repo-root tooling configs outside runtime scope in the shipped map', () => {
+    const toolingFiles = [
+      '.oxfmtrc.json',
+      '.oxlintrc.json',
+      'eslint.config.ts',
+      'eslint-suppressions.json',
+      '.stylelintrc.json',
+      'lint-staged.config.ts',
+      'knip.config.ts',
+      'playwright.config.ts',
+      'playwright.chrome.config.ts',
+      'playwright.i18n.config.ts',
+      'vitest.matrix.config.mts',
+      'vitest.setup.ts',
+      'vitest.timer.setup.ts',
+      '.yamllint',
+      '.editorconfig',
+      '.nvmrc',
+      '.gitignore',
+      '.gitattributes',
+      '.git-blame-ignore-revs',
+      '.husky/pre-commit'
+    ]
+    expect(
+      runtimePathsFor(
+        toolingFiles.map((filename) => ({ filename })),
+        shippedRiskMap
+      )
+    ).toEqual([])
+  })
+
+  it('still treats application source as runtime in the shipped map', () => {
+    expect(
+      runtimePathsFor(
+        [{ filename: 'src/components/NewUi.vue' }],
+        shippedRiskMap
+      )
     ).toEqual(['src/components/NewUi.vue'])
   })
 })


### PR DESCRIPTION
## Summary

`runtimePathsFor()` in the feature-flag policy (#17022) treats any path unmatched by `.github/risk.json` as Cloud runtime scope, so repo-root tooling configs (`.oxfmtrc.json`, `.oxlintrc.json`, `eslint.config.ts`, `playwright*.config.*`, `vitest*.config.*`, `lint-staged.config.ts`, `.gitignore`, `.editorconfig`, …) force any risk:high/xhigh PR touching them to declare a rollout flag — #16518, a website-only PR, is currently failing the gate over two added lines in `.oxfmtrc.json`'s ignore list.

## Changes

- **What**: Adds a `build-config` path rule at tier R1 covering lint/format/test-runner configs and git metadata. The class exempts them from the policy's runtime scope; the R1 tier keeps a formatter tweak in the flagless lane instead of inheriting the R2 floor of the existing build-config rule. Adds regression tests running `runtimePathsFor` against the shipped `.github/risk.json` (tooling paths stay non-runtime, `src/**` stays runtime).

## Review Focus

- Tier choice: R1 rather than R2 is deliberate — these files cannot change what ships in the bundle, and grading them R2 would put formatter-only PRs in the flag-required lane.
- The `flag-exempt` label referenced by the policy and PR template does not exist in the repo yet (404); someone with repo admin may want to create it as the documented escape hatch.

## Feature flag

- **Flag**:
