### PR TITLE
test(telemetry): cover normalizeEmail

### DIFF
--- a/src/platform/telemetry/utils/normalizeEmail.test.ts
+++ b/src/platform/telemetry/utils/normalizeEmail.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeEmail } from './normalizeEmail'
+
+describe('normalizeEmail', () => {
+  it('returns null for null', () => {
+    expect(normalizeEmail(null)).toBe(null)
+  })
+
+  it('returns null for undefined', () => {
+    expect(normalizeEmail(undefined)).toBe(null)
+  })
+
+  it('returns null for blank or whitespace-only input', () => {
+    expect(normalizeEmail('')).toBe(null)
+    expect(normalizeEmail('   ')).toBe(null)
+  })
+
+  it('lowercases a mixed-case email', () => {
+    expect(normalizeEmail('Alice@Example.COM')).toBe('alice@example.com')
+  })
+
+  it('returns an already-normalized email unchanged', () => {
+    expect(normalizeEmail('alice@example.com')).toBe('alice@example.com')
+  })
+
+  it('trims leading and trailing spaces', () => {
+    expect(normalizeEmail('  alice@example.com  ')).toBe('alice@example.com')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds colocated Vitest coverage for telemetry `normalizeEmail` (`trim().toLowerCase()`, empty/nullish → `null`). Distinct from workspace `inviteEmails.normalizeEmail`.

## Verification

```bash
pnpm test:unit -- src/platform/telemetry/utils/normalizeEmail.test.ts
```

Expected: all cases pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-738c5adc-1010-4739-8adb-0c6be96ba3ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-738c5adc-1010-4739-8adb-0c6be96ba3ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

