### PR TITLE
fix(graph): scope untitled reconcile title keep to subgraphs

### DIFF
--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -290,25 +290,6 @@ describe('graphMutations', () => {
     expect(createLayout).not.toHaveBeenCalled()
   })
 
-  it('untitled catalog add persists the type so configure cannot fall back to display_name', () => {
-    const { title: _title, ...untitled } = node(1)
-    expect(mutations().addNode(untitled, context)).toBe(true)
-
-    const [state] = useNodeDataStore().getGraphNodesFor('root', 'root')
-    expect(state.title).toBe('Type1')
-    expect(state.lastSerialization?.title).toBe('Type1')
-  })
-
-  it('untitled subgraph add leaves lastSerialization without a title', () => {
-    const type = '00000000-0000-4000-8000-000000000002'
-    const { title: _title, ...untitled } = { ...node(1), type }
-    expect(mutations().addNode(untitled, context)).toBe(true)
-
-    const [state] = useNodeDataStore().getGraphNodesFor('root', 'root')
-    expect(state.title).toBe(type)
-    expect(state.lastSerialization?.title).toBeUndefined()
-  })
-
   it('untitled reconcile of a display-named regular node uses the type as title and keeps the output wire', () => {
     const graph = mutations()
     graph.batch(context, (batch) => {

--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -290,6 +290,19 @@ describe('graphMutations', () => {
     expect(createLayout).not.toHaveBeenCalled()
   })
 
+  it('untitled catalog reconcile without an incumbent persists the type as lastSerialization title', () => {
+    const { title: _title, ...untitled } = node(1)
+    expect(
+      mutations().batch(context, (batch) => {
+        batch.reconcileNode(untitled)
+      })
+    ).toBe(true)
+
+    const [state] = useNodeDataStore().getGraphNodesFor('root', 'root')
+    expect(state.title).toBe('Type1')
+    expect(state.lastSerialization?.title).toBe('Type1')
+  })
+
   it('untitled reconcile of a display-named regular node uses the type as title and keeps the output wire', () => {
     const graph = mutations()
     graph.batch(context, (batch) => {

--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -290,36 +290,83 @@ describe('graphMutations', () => {
     expect(createLayout).not.toHaveBeenCalled()
   })
 
-  it('keeps the incumbent title when a reconcile payload carries none', () => {
+  it('untitled reconcile of a display-named regular node uses the type as title and keeps the output wire', () => {
     const graph = mutations()
-    graph.addNode({ ...node(1), title: 'Load Checkpoint' }, context)
-    const [existing] = useNodeDataStore().getGraphNodesFor('root', 'root')
-    expect(existing.title).toBe('Load Checkpoint')
+    graph.batch(context, (batch) => {
+      batch.addNode({ ...node(1), title: 'Load Checkpoint' })
+      batch.addNode(node(2))
+      batch.connect({
+        id: 9,
+        originNodeId: 1,
+        originSlot: 0,
+        targetNodeId: 2,
+        targetSlot: 0,
+        type: 'IMAGE',
+        originOutputs: [{ name: 'out', type: 'IMAGE', links: [9] }],
+        targetInputs: [{ name: 'in', type: 'IMAGE', link: 9 }]
+      })
+    })
 
     expect(
       graph.batch({ ...context, opId: 'bootstrap' }, (batch) => {
-        const { title: _title, ...untitled } = node(1, { seed: 7 })
+        const { title: _title, ...untitled } = {
+          ...node(1, { seed: 7 }),
+          outputs: [{ name: 'out', type: 'IMAGE', links: [9] }]
+        }
         batch.reconcileNode(untitled)
       })
     ).toBe(true)
 
-    const [reconciled] = useNodeDataStore().getGraphNodesFor('root', 'root')
-    expect(reconciled).toBe(existing)
-    expect(reconciled.title).toBe('Load Checkpoint')
-    expect(reconciled.lastSerialization?.title).toBe('Load Checkpoint')
+    const origin = useNodeDataStore().getNode(scope.rootGraphId, toNodeId(1))
+    expect(origin?.title).toBe('Type1')
+    expect(origin?.outputs[0]?.links).toEqual([toLinkId(9)])
+    expect(
+      useLinkStore().getTopology(scope.rootGraphId, toLinkId(9))
+    ).toMatchObject({
+      originNodeId: toNodeId(1),
+      targetNodeId: toNodeId(2)
+    })
     expect(
       useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'seed'))
         ?.value
     ).toBe(7)
   })
 
-  it('keeps a title introduced earlier in the same batch', () => {
+  it('keeps a subgraph instance title when a reconcile payload carries none', () => {
     const graph = mutations()
+    const type = '00000000-0000-4000-8000-000000000002'
+    graph.addNode({ ...node(1), type, title: 'Test Subgraph' }, context)
+    const [existing] = useNodeDataStore().getGraphNodesFor('root', 'root')
+    expect(existing.title).toBe('Test Subgraph')
+
+    expect(
+      graph.batch({ ...context, opId: 'bootstrap' }, (batch) => {
+        const { title: _title, ...untitled } = {
+          ...node(1, { seed: 7 }),
+          type
+        }
+        batch.reconcileNode(untitled)
+      })
+    ).toBe(true)
+
+    const [reconciled] = useNodeDataStore().getGraphNodesFor('root', 'root')
+    expect(reconciled).toBe(existing)
+    expect(reconciled.title).toBe('Test Subgraph')
+    expect(reconciled.lastSerialization?.title).toBe('Test Subgraph')
+    expect(
+      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'seed'))
+        ?.value
+    ).toBe(7)
+  })
+
+  it('keeps a subgraph title introduced earlier in the same batch', () => {
+    const graph = mutations()
+    const type = '00000000-0000-4000-8000-000000000002'
 
     expect(
       graph.batch(context, (batch) => {
-        batch.addNode({ ...node(1), title: 'Batch title' })
-        const { title: _title, ...untitled } = node(1, { seed: 7 })
+        batch.addNode({ ...node(1), type, title: 'Batch title' })
+        const { title: _title, ...untitled } = { ...node(1, { seed: 7 }), type }
         batch.reconcileNode(untitled)
       })
     ).toBe(true)

--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -290,6 +290,25 @@ describe('graphMutations', () => {
     expect(createLayout).not.toHaveBeenCalled()
   })
 
+  it('untitled catalog add persists the type so configure cannot fall back to display_name', () => {
+    const { title: _title, ...untitled } = node(1)
+    expect(mutations().addNode(untitled, context)).toBe(true)
+
+    const [state] = useNodeDataStore().getGraphNodesFor('root', 'root')
+    expect(state.title).toBe('Type1')
+    expect(state.lastSerialization?.title).toBe('Type1')
+  })
+
+  it('untitled subgraph add leaves lastSerialization without a title', () => {
+    const type = '00000000-0000-4000-8000-000000000002'
+    const { title: _title, ...untitled } = { ...node(1), type }
+    expect(mutations().addNode(untitled, context)).toBe(true)
+
+    const [state] = useNodeDataStore().getGraphNodesFor('root', 'root')
+    expect(state.title).toBe(type)
+    expect(state.lastSerialization?.title).toBeUndefined()
+  })
+
   it('untitled reconcile of a display-named regular node uses the type as title and keeps the output wire', () => {
     const graph = mutations()
     graph.batch(context, (batch) => {
@@ -319,6 +338,7 @@ describe('graphMutations', () => {
 
     const origin = useNodeDataStore().getNode(scope.rootGraphId, toNodeId(1))
     expect(origin?.title).toBe('Type1')
+    expect(origin?.lastSerialization?.title).toBe('Type1')
     expect(origin?.outputs[0]?.links).toEqual([toLinkId(9)])
     expect(
       useLinkStore().getTopology(scope.rootGraphId, toLinkId(9))

--- a/src/core/graph/graphMutations.ts
+++ b/src/core/graph/graphMutations.ts
@@ -3,6 +3,7 @@ import type {
   ISerialisableNodeOutput,
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
+import { isUuidShapedSubgraphId } from '@/schemas/subgraphIdSchema'
 import { useLinkPresentationStore } from '@/stores/linkPresentationStore'
 import { useLinkStore } from '@/stores/linkStore'
 import { useNodeDataStore } from '@/stores/nodeDataStore'
@@ -362,14 +363,11 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
             return `node id ${key} belongs to graph ${registered.graphId}`
           }
           const incumbent = nodes.get(key)
-          // A reconcile payload without a title leaves the title unspecified;
-          // it does not rename the node to its type. The incumbent's title
-          // may have come from the node class (`configure()` falls back to
-          // the constructor's static title) rather than from any payload.
           if (
             mutation.kind === 'reconcileNode' &&
             incumbent &&
-            !hasTitle(mutation.payload)
+            !hasTitle(mutation.payload) &&
+            isUuidShapedSubgraphId(mutation.payload.type)
           ) {
             node.state.title = incumbent.title
             if (node.state.lastSerialization) {

--- a/src/core/graph/graphMutations.ts
+++ b/src/core/graph/graphMutations.ts
@@ -365,13 +365,17 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
           const incumbent = nodes.get(key)
           if (
             mutation.kind === 'reconcileNode' &&
-            incumbent &&
             !hasTitle(mutation.payload)
           ) {
-            if (isUuidShapedSubgraphId(mutation.payload.type)) {
+            if (incumbent && isUuidShapedSubgraphId(mutation.payload.type)) {
               node.state.title = incumbent.title
-            }
-            if (node.state.lastSerialization) {
+              if (node.state.lastSerialization) {
+                node.state.lastSerialization.title = incumbent.title
+              }
+            } else if (
+              !isUuidShapedSubgraphId(mutation.payload.type) &&
+              node.state.lastSerialization
+            ) {
               node.state.lastSerialization.title = node.state.title
             }
           }

--- a/src/core/graph/graphMutations.ts
+++ b/src/core/graph/graphMutations.ts
@@ -238,24 +238,17 @@ function prepareNode(
   const [x, y] = readPair(payload.pos, [0, 0])
   const [width, height] = readPair(payload.size, [270, 100])
   const mode = Number(payload.mode)
-  const title = hasTitle(payload) ? payload.title : payload.type
-  const lastSerialization = structuredClone(
-    payload
-  ) as unknown as ISerialisedNode
-  if (!hasTitle(payload) && !isUuidShapedSubgraphId(payload.type)) {
-    lastSerialization.title = title
-  }
   const state: NodeState = {
     id,
     graphId: scope.owningGraphId,
     type: payload.type,
-    title,
+    title: hasTitle(payload) ? payload.title : payload.type,
     flags: cloneRecord(payload.flags),
     inputs: prepareInputSlots(payload.inputs),
     outputs: prepareOutputSlots(payload.outputs),
     mode: Number.isInteger(mode) ? mode : 0,
     properties: cloneRecord(payload.properties) as NodeState['properties'],
-    lastSerialization,
+    lastSerialization: structuredClone(payload) as unknown as ISerialisedNode,
     ...(typeof payload.bgcolor === 'string' && { bgcolor: payload.bgcolor }),
     ...(typeof payload.boxcolor === 'string' && { boxcolor: payload.boxcolor }),
     ...(typeof payload.color === 'string' && { color: payload.color }),

--- a/src/core/graph/graphMutations.ts
+++ b/src/core/graph/graphMutations.ts
@@ -238,17 +238,24 @@ function prepareNode(
   const [x, y] = readPair(payload.pos, [0, 0])
   const [width, height] = readPair(payload.size, [270, 100])
   const mode = Number(payload.mode)
+  const title = hasTitle(payload) ? payload.title : payload.type
+  const lastSerialization = structuredClone(
+    payload
+  ) as unknown as ISerialisedNode
+  if (!hasTitle(payload) && !isUuidShapedSubgraphId(payload.type)) {
+    lastSerialization.title = title
+  }
   const state: NodeState = {
     id,
     graphId: scope.owningGraphId,
     type: payload.type,
-    title: hasTitle(payload) ? payload.title : payload.type,
+    title,
     flags: cloneRecord(payload.flags),
     inputs: prepareInputSlots(payload.inputs),
     outputs: prepareOutputSlots(payload.outputs),
     mode: Number.isInteger(mode) ? mode : 0,
     properties: cloneRecord(payload.properties) as NodeState['properties'],
-    lastSerialization: structuredClone(payload) as unknown as ISerialisedNode,
+    lastSerialization,
     ...(typeof payload.bgcolor === 'string' && { bgcolor: payload.bgcolor }),
     ...(typeof payload.boxcolor === 'string' && { boxcolor: payload.boxcolor }),
     ...(typeof payload.color === 'string' && { color: payload.color }),
@@ -366,12 +373,13 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
           if (
             mutation.kind === 'reconcileNode' &&
             incumbent &&
-            !hasTitle(mutation.payload) &&
-            isUuidShapedSubgraphId(mutation.payload.type)
+            !hasTitle(mutation.payload)
           ) {
-            node.state.title = incumbent.title
+            if (isUuidShapedSubgraphId(mutation.payload.type)) {
+              node.state.title = incumbent.title
+            }
             if (node.state.lastSerialization) {
-              node.state.lastSerialization.title = incumbent.title
+              node.state.lastSerialization.title = node.state.title
             }
           }
           if (mutation.kind === 'addNode' && nodes.has(key)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Untitled catalog reconcile was keeping a `configure()` display name (`Load Checkpoint`) on the canvas; the committed cloud screenshot expects the type (`CheckpointLoaderSimple`). Incumbent-title keep is now limited to UUID subgraph instances (PM-827). Untitled catalog reconcile also writes `type` onto `lastSerialization` so catch-up rematerialize cannot fall back to `display_name`. Agent `addNode` is unchanged so newly added nodes still show their class display name.

## Verification

Unit (green):

```
pnpm test:unit src/core/graph/graphMutations.test.ts src/workbench/extensions/agent/crdt/agentNodeMaterializer.test.ts
```

62 passed. Catalog untitled reconcile uses type as title and keeps the output wire; subgraph instance title / promoted widgets / output-connectivity (PM-827) still pass.

E2E — `@cloud` `agentConversationReplay.spec.ts` cannot run against a live Comfy backend here (no Docker `/ComfyUI`). Local stand-in: merge-queue-equivalent tree (`main` + #16964 + this branch), `pnpm build:cloud`, stub `/api/object_info` with `CheckpointLoaderSimple.display_name = "Load Checkpoint"`, `PLAYWRIGHT_TEST_URL=http://127.0.0.1:8188`.

```
DISTRIBUTION=cloud PLAYWRIGHT_TEST_URL=http://127.0.0.1:8188 RECORD_VIDEO=true \
  pnpm exec playwright test browser_tests/tests/agent/_evidenceTwoTurnWired.spec.ts --project=cloud
```

Passed. Expected: Vue/canvas title `CheckpointLoaderSimple` (not `Load Checkpoint`); CLIPTextEncode → KSampler `targetSlot === 2` wire present.

```
DISTRIBUTION=cloud PLAYWRIGHT_TEST_URL=http://127.0.0.1:8188 \
  pnpm exec playwright test browser_tests/tests/agent/agentConversationReplay.spec.ts --project=cloud --grep "paints the wire"
```

Failed `toHaveScreenshot` with 25638 px (ratio 0.01) — local fonts/viewport/stub vs CI cloud snapshot. Title text in the local actual is `CheckpointLoaderSimple` (the #16964 504 px regression was `Load Checkpoint`). Committed Playwright snapshots were not bumped.

Before (UUID-gate only; title still `Load Checkpoint`):

[Before fix: checkpoint chrome still reads Load Checkpoint](https://cursor.com/agents/bc-016961ff-6417-4a58-b7f1-d97f73a2410e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftwo-turn-wired-uuid-gate-only.png)

After (catalog lastSerialization persist; title `CheckpointLoaderSimple`, second-turn wire present):

[After fix: checkpoint chrome reads CheckpointLoaderSimple and the negative CLIP wire is present](https://cursor.com/agents/bc-016961ff-6417-4a58-b7f1-d97f73a2410e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftwo-turn-wired-after-fix.png)

[Checkpoint node title after fix is CheckpointLoaderSimple](https://cursor.com/agents/bc-016961ff-6417-4a58-b7f1-d97f73a2410e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftwo-turn-wired-after-fix-titles.png)

Official spec local actual (title matches baseline; pixel delta is environment):

[Official replay spec local actual: CheckpointLoaderSimple](https://cursor.com/agents/bc-016961ff-6417-4a58-b7f1-d97f73a2410e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fofficial-replay-actual-local.png)

[two-turn-wired-after-fix.webm](https://cursor.com/agents/bc-016961ff-6417-4a58-b7f1-d97f73a2410e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvideos%2Ftwo-turn-wired-after-fix.webm)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-016961ff-6417-4a58-b7f1-d97f73a2410e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-016961ff-6417-4a58-b7f1-d97f73a2410e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

