### PR TITLE
test(interaction): pinned node resists dragging and survives reload

### DIFF
--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -19,19 +19,25 @@ test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.nextFrame()
 })
 
-test.describe('Item Interaction', { tag: ['@screenshot', '@node'] }, () => {
-  test('Can select/delete all items', async ({ comfyPage }) => {
-    await comfyPage.workflow.loadWorkflow('groups/mixed_graph_items')
-    await comfyPage.canvas.press('Control+a')
-    await expect(comfyPage.canvas).toHaveScreenshot('selected-all.png')
-    await comfyPage.canvas.press('Delete')
-    await expect(comfyPage.canvas).toHaveScreenshot('deleted-all.png')
-  })
+test.describe('Item Interaction', { tag: ['@node'] }, () => {
+  test(
+    'Can select/delete all items',
+    { tag: ['@screenshot'] },
+    async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('groups/mixed_graph_items')
+      await comfyPage.canvas.press('Control+a')
+      await expect(comfyPage.canvas).toHaveScreenshot('selected-all.png')
+      await comfyPage.canvas.press('Delete')
+      await expect(comfyPage.canvas).toHaveScreenshot('deleted-all.png')
+    }
+  )
 
   test('A pinned node resists dragging and stays pinned across a reload', async ({
     comfyPage
   }) => {
-    const title = 'CLIP Text Encode (Prompt)'
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+
+    const title = 'KSampler'
     async function readPos() {
       const node = await comfyPage.nodeOps.getNodeRefByTitle(title)
       return node.getProperty<[number, number]>('pos')
@@ -40,49 +46,63 @@ test.describe('Item Interaction', { tag: ['@screenshot', '@node'] }, () => {
     const node = await comfyPage.nodeOps.getNodeRefByTitle(title)
     const pinnedOrigin = await readPos()
 
-    await comfyPage.nodeOps.selectNodes([title])
-    await comfyPage.command.executeCommand(
-      'Comfy.Canvas.ToggleSelectedNodes.Pin'
-    )
-    await expect.poll(() => node.isPinned()).toBe(true)
-
     const dragDelta = { x: 90, y: 70 }
-    await node.dragBy(dragDelta)
-    await expect.poll(readPos).toEqual(pinnedOrigin)
 
-    // Control: the same gesture must move the node once it is unpinned.
-    // Without this, "did not move" could simply mean the drag never landed.
-    await comfyPage.command.executeCommand(
-      'Comfy.Canvas.ToggleSelectedNodes.Pin'
-    )
-    await expect.poll(() => node.isPinned()).toBe(false)
-    await node.dragBy(dragDelta)
-    await expect.poll(readPos).not.toEqual(pinnedOrigin)
-    const movedPos = await readPos()
+    await test.step('Pinned node resists dragging', async () => {
+      await comfyPage.nodeOps.selectNodes([title])
+      await comfyPage.command.executeCommand(
+        'Comfy.Canvas.ToggleSelectedNodes.Pin'
+      )
+      await expect.poll(() => node.isPinned()).toBe(true)
 
-    const beforeRepin = Date.now()
-    await comfyPage.command.executeCommand(
-      'Comfy.Canvas.ToggleSelectedNodes.Pin'
-    )
-    await expect.poll(() => node.isPinned()).toBe(true)
+      await node.dragBy(dragDelta)
+      await expect.poll(readPos).toEqual(pinnedOrigin)
+    })
 
-    await comfyPage.workflow.waitForDraftIndexUpdatedSince(beforeRepin)
-    await comfyPage.workflow.reloadAndWaitForApp()
+    const movedPos =
+      await test.step('Unpinned node moves with the same drag', async () => {
+        // Control: the same gesture must move the node once it is unpinned.
+        // Without this, "did not move" could simply mean the drag never landed.
+        await comfyPage.command.executeCommand(
+          'Comfy.Canvas.ToggleSelectedNodes.Pin'
+        )
+        await expect.poll(() => node.isPinned()).toBe(false)
+        await node.dragBy(dragDelta)
+        await expect.poll(readPos).not.toEqual(pinnedOrigin)
+        return await readPos()
+      })
 
-    const reloaded = await comfyPage.nodeOps.getNodeRefByTitle(title)
-    expect(reloaded.id).toBe(node.id)
-    await expect.poll(() => reloaded.isPinned()).toBe(true)
-    await expect.poll(readPos).toEqual(movedPos)
+    await test.step('Repin and save the moved node', async () => {
+      const beforeRepin = Date.now()
+      await comfyPage.command.executeCommand(
+        'Comfy.Canvas.ToggleSelectedNodes.Pin'
+      )
+      await expect.poll(() => node.isPinned()).toBe(true)
+      await comfyPage.workflow.waitForDraftIndexUpdatedSince(beforeRepin)
+    })
+
+    await test.step('Reload restores the pinned node at its moved position', async () => {
+      await comfyPage.workflow.reloadAndWaitForApp()
+
+      const reloaded = await comfyPage.nodeOps.getNodeRefByTitle(title)
+      expect(reloaded.id).toBe(node.id)
+      await expect.poll(() => reloaded.isPinned()).toBe(true)
+      await expect.poll(readPos).toEqual(movedPos)
+    })
   })
 
-  test('Can pin/unpin items with keyboard shortcut', async ({ comfyPage }) => {
-    await comfyPage.workflow.loadWorkflow('groups/mixed_graph_items')
-    await comfyPage.canvas.press('Control+a')
-    await comfyPage.keyboard.press('KeyP')
-    await expect(comfyPage.canvas).toHaveScreenshot('pinned-all.png')
-    await comfyPage.keyboard.press('KeyP')
-    await expect(comfyPage.canvas).toHaveScreenshot('unpinned-all.png')
-  })
+  test(
+    'Can pin/unpin items with keyboard shortcut',
+    { tag: ['@screenshot'] },
+    async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('groups/mixed_graph_items')
+      await comfyPage.canvas.press('Control+a')
+      await comfyPage.keyboard.press('KeyP')
+      await expect(comfyPage.canvas).toHaveScreenshot('pinned-all.png')
+      await comfyPage.keyboard.press('KeyP')
+      await expect(comfyPage.canvas).toHaveScreenshot('unpinned-all.png')
+    }
+  )
 })
 
 test.describe('Node Interaction', () => {

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -32,12 +32,12 @@ test.describe('Item Interaction', { tag: ['@screenshot', '@node'] }, () => {
     comfyPage
   }) => {
     const title = 'CLIP Text Encode (Prompt)'
-    const readPos = async () => {
-      const [node] = await comfyPage.nodeOps.getNodeRefsByTitle(title)
+    async function readPos() {
+      const node = await comfyPage.nodeOps.getNodeRefByTitle(title)
       return node.getProperty<[number, number]>('pos')
     }
 
-    const [node] = await comfyPage.nodeOps.getNodeRefsByTitle(title)
+    const node = await comfyPage.nodeOps.getNodeRefByTitle(title)
     const pinnedOrigin = await readPos()
 
     await comfyPage.nodeOps.selectNodes([title])
@@ -58,17 +58,21 @@ test.describe('Item Interaction', { tag: ['@screenshot', '@node'] }, () => {
     await expect.poll(() => node.isPinned()).toBe(false)
     await node.dragBy(dragDelta)
     await expect.poll(readPos).not.toEqual(pinnedOrigin)
+    const movedPos = await readPos()
 
-    // Re-pin, then confirm the flag survives a reload from the draft.
+    const beforeRepin = Date.now()
     await comfyPage.command.executeCommand(
       'Comfy.Canvas.ToggleSelectedNodes.Pin'
     )
     await expect.poll(() => node.isPinned()).toBe(true)
 
+    await comfyPage.workflow.waitForDraftIndexUpdatedSince(beforeRepin)
     await comfyPage.workflow.reloadAndWaitForApp()
 
-    const [reloaded] = await comfyPage.nodeOps.getNodeRefsByTitle(title)
+    const reloaded = await comfyPage.nodeOps.getNodeRefByTitle(title)
+    expect(reloaded.id).toBe(node.id)
     await expect.poll(() => reloaded.isPinned()).toBe(true)
+    await expect.poll(readPos).toEqual(movedPos)
   })
 
   test('Can pin/unpin items with keyboard shortcut', async ({ comfyPage }) => {

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -28,6 +28,49 @@ test.describe('Item Interaction', { tag: ['@screenshot', '@node'] }, () => {
     await expect(comfyPage.canvas).toHaveScreenshot('deleted-all.png')
   })
 
+  test('A pinned node resists dragging and stays pinned across a reload', async ({
+    comfyPage
+  }) => {
+    const title = 'CLIP Text Encode (Prompt)'
+    const readPos = async () => {
+      const [node] = await comfyPage.nodeOps.getNodeRefsByTitle(title)
+      return node.getProperty<[number, number]>('pos')
+    }
+
+    const [node] = await comfyPage.nodeOps.getNodeRefsByTitle(title)
+    const pinnedOrigin = await readPos()
+
+    await comfyPage.nodeOps.selectNodes([title])
+    await comfyPage.command.executeCommand(
+      'Comfy.Canvas.ToggleSelectedNodes.Pin'
+    )
+    await expect.poll(() => node.isPinned()).toBe(true)
+
+    const dragDelta = { x: 90, y: 70 }
+    await node.dragBy(dragDelta)
+    await expect.poll(readPos).toEqual(pinnedOrigin)
+
+    // Control: the same gesture must move the node once it is unpinned.
+    // Without this, "did not move" could simply mean the drag never landed.
+    await comfyPage.command.executeCommand(
+      'Comfy.Canvas.ToggleSelectedNodes.Pin'
+    )
+    await expect.poll(() => node.isPinned()).toBe(false)
+    await node.dragBy(dragDelta)
+    await expect.poll(readPos).not.toEqual(pinnedOrigin)
+
+    // Re-pin, then confirm the flag survives a reload from the draft.
+    await comfyPage.command.executeCommand(
+      'Comfy.Canvas.ToggleSelectedNodes.Pin'
+    )
+    await expect.poll(() => node.isPinned()).toBe(true)
+
+    await comfyPage.workflow.reloadAndWaitForApp()
+
+    const [reloaded] = await comfyPage.nodeOps.getNodeRefsByTitle(title)
+    await expect.poll(() => reloaded.isPinned()).toBe(true)
+  })
+
   test('Can pin/unpin items with keyboard shortcut', async ({ comfyPage }) => {
     await comfyPage.workflow.loadWorkflow('groups/mixed_graph_items')
     await comfyPage.canvas.press('Control+a')


### PR DESCRIPTION
## Summary

Covers ECS migration test plan Area 1: "pin a node, save, reload. It is still pinned **and cannot be dragged**." Neither half is asserted today.

## Changes

- **What**: one test in `interaction.spec.ts` → `Item Interaction`.

## Review Focus

**What existing coverage stops short of.** `Can pin/unpin nodes` and `Can pin/unpin items with keyboard shortcut` both toggle the flag and then compare screenshots. Neither drags a pinned node, and neither reloads. So the two behaviours the plan actually names have no assertion behind them.

**The control is the part worth reviewing.** After asserting the pinned node did not move, the test unpins and repeats the *identical* gesture, asserting it now does move. Without that, "did not move" is indistinguishable from a drag that never landed — it would pass with a broken drag helper, a wrong coordinate, or a node that was never draggable in the first place. The negative assertion only means something once the positive one is established.

**Reads raw graph `pos`** via `getProperty`, not a converted canvas position, so the before/after comparison is not sensitive to viewport or zoom drift across the reload.

Sequence is pin → drag → assert still → unpin → drag → assert moved → re-pin → reload → assert still pinned.

Eighth in a series from mining QA plans against the suite. The ECS plan's own "Already signed off per-PR" table was verified accurate and used as a pre-built COVERED list.
