### PR TITLE
test: add e2e coverage for identity-scoped draft persistence

### DIFF
--- a/browser_tests/fixtures/identityScopedDraftFixture.ts
+++ b/browser_tests/fixtures/identityScopedDraftFixture.ts
@@ -1,0 +1,148 @@
+import type { Page } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import {
+  cloudAppExpect as expect,
+  cloudAppFixture,
+  waitForCloudApp
+} from '@e2e/fixtures/cloudAppFixture'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import type { WorkspaceStore } from '@e2e/types/globals'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const USER_ID = 'test-user-e2e'
+const WORKSPACE_ID = 'personal'
+const SCOPE = `${USER_ID}:${WORKSPACE_ID}`
+const BOOT_FEATURES = {} satisfies RemoteConfig
+const BOOT_SETTINGS = {
+  'Comfy.TutorialCompleted': true,
+  'Comfy.Workflow.Persist': true
+}
+
+type StorageSnapshot = Record<string, string | null>
+
+class IdentityScopedDraftHelper {
+  readonly scope = SCOPE
+  readonly workspaceId = WORKSPACE_ID
+
+  constructor(private readonly page: Page) {}
+
+  async seedStorage(entries: Record<string, string>): Promise<void> {
+    await this.page.addInitScript((seedEntries) => {
+      for (const [key, value] of Object.entries(seedEntries)) {
+        localStorage.setItem(key, value)
+      }
+    }, entries)
+  }
+
+  async boot(): Promise<void> {
+    await mockCloudBoot(this.page, {
+      features: BOOT_FEATURES,
+      settings: BOOT_SETTINGS
+    })
+    await bootCloud(this.page)
+    await this.page.goto(APP_URL)
+    await waitForCloudApp(this.page)
+    await this.page.waitForFunction(() => {
+      const app = window.app
+      return (
+        !!app &&
+        !!(app.extensionManager as WorkspaceStore).workflow.activeWorkflow
+          ?.activeState
+      )
+    })
+  }
+
+  async touchGraph(): Promise<string> {
+    return await this.page.evaluate(() => {
+      const app = window.app
+      if (!app) throw new Error('app is not ready')
+      const activeState = (app.extensionManager as WorkspaceStore).workflow
+        .activeWorkflow?.activeState
+      if (!activeState) throw new Error('no active workflow to persist')
+
+      const marker = crypto.randomUUID()
+      app.rootGraph.extra = { ...app.rootGraph.extra, marker }
+      app.api.dispatchCustomEvent('graphChanged', activeState)
+      return marker
+    })
+  }
+
+  async waitForMarker(scope: string, marker: string): Promise<void> {
+    await this.page.waitForFunction(
+      ({ expectedMarker, expectedScope }) => {
+        const prefix = `Comfy.Workflow.Draft.v2:${expectedScope}:`
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i)
+          if (!key?.startsWith(prefix)) continue
+          const raw = localStorage.getItem(key)
+          if (!raw) continue
+          const payload: unknown = JSON.parse(raw)
+          if (
+            typeof payload !== 'object' ||
+            payload === null ||
+            !('data' in payload) ||
+            typeof payload.data !== 'string'
+          )
+            continue
+          const graph: unknown = JSON.parse(payload.data)
+          if (
+            typeof graph === 'object' &&
+            graph !== null &&
+            'extra' in graph &&
+            typeof graph.extra === 'object' &&
+            graph.extra !== null &&
+            'marker' in graph.extra &&
+            graph.extra.marker === expectedMarker
+          )
+            return true
+        }
+        return false
+      },
+      { expectedMarker: marker, expectedScope: scope }
+    )
+  }
+
+  readStorage(keys: string[]): Promise<StorageSnapshot> {
+    return this.page.evaluate(
+      (storageKeys) =>
+        Object.fromEntries(
+          storageKeys.map((key) => [key, localStorage.getItem(key)])
+        ),
+      keys
+    )
+  }
+
+  readStorageKeys(): Promise<string[]> {
+    return this.page.evaluate(() => Object.keys(localStorage).sort())
+  }
+
+  async logout(): Promise<void> {
+    await this.page.route('**/cloud/login', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<!doctype html><html><body></body></html>'
+      })
+    )
+    await this.page.getByTestId(TestIds.user.currentUserButton).click()
+    await this.page.getByTestId('logout-menu-item').click()
+    const confirmLogout = this.page.getByRole('button', {
+      name: 'Sign out anyway'
+    })
+    if (await confirmLogout.isVisible()) await confirmLogout.click()
+    await this.page.waitForURL('**/cloud/login')
+  }
+}
+
+export const identityScopedDraftFixture = cloudAppFixture.extend<{
+  identityDraft: IdentityScopedDraftHelper
+}>({
+  identityDraft: async ({ page }, use) => {
+    await use(new IdentityScopedDraftHelper(page))
+  }
+})
+
+export { expect }

--- a/browser_tests/tests/workspace/identityScopedDraftPersistence.spec.ts
+++ b/browser_tests/tests/workspace/identityScopedDraftPersistence.spec.ts
@@ -1,0 +1,124 @@
+import {
+  expect,
+  identityScopedDraftFixture as test
+} from '@e2e/fixtures/identityScopedDraftFixture'
+import type { Page } from '@playwright/test'
+
+const DRAFT_KEY = 'legacy-draft'
+const DRAFT_PATH = 'workflows/Legacy.json'
+
+test.describe('identity-scoped workflow drafts', { tag: '@cloud' }, () => {
+  test('writes draft changes only to the signed-in identity scope', async ({
+    identityDraft
+  }) => {
+    await identityDraft.boot()
+
+    const marker = await identityDraft.touchGraph()
+    await identityDraft.waitForMarker(identityDraft.scope, marker)
+
+    const keys = await identityDraft.readStorage([
+      `Comfy.Workflow.DraftIndex.v2:${identityDraft.scope}`,
+      `Comfy.Workflow.DraftIndex.v2:${identityDraft.workspaceId}`
+    ])
+    expect(
+      keys[`Comfy.Workflow.DraftIndex.v2:${identityDraft.scope}`]
+    ).not.toBe(null)
+    expect(
+      keys[`Comfy.Workflow.DraftIndex.v2:${identityDraft.workspaceId}`]
+    ).toBe(null)
+  })
+
+  test('removes departing drafts and blocks a pending write after logout', async ({
+    identityDraft
+  }) => {
+    await identityDraft.boot()
+    const initialMarker = await identityDraft.touchGraph()
+    await identityDraft.waitForMarker(identityDraft.scope, initialMarker)
+
+    await identityDraft.touchGraph()
+    await identityDraft.logout()
+
+    const prefix = `Comfy.Workflow.Draft.v2:${identityDraft.scope}:`
+    const scopedDrafts = await identityDraft.readStorage([
+      `Comfy.Workflow.DraftIndex.v2:${identityDraft.scope}`
+    ])
+    expect(
+      scopedDrafts[`Comfy.Workflow.DraftIndex.v2:${identityDraft.scope}`]
+    ).toBe(null)
+    expect(
+      (await identityDraft.readStorageKeys()).some((key) =>
+        key.startsWith(prefix)
+      )
+    ).toBe(false)
+  })
+
+  test('migrates a legacy workspace draft once without clobbering it on reload', async ({
+    identityDraft,
+    page
+  }) => {
+    const updatedAt = Date.now() - 1_000
+    const legacyIndex = JSON.stringify({
+      v: 2,
+      updatedAt,
+      order: [DRAFT_KEY],
+      entries: {
+        [DRAFT_KEY]: {
+          path: DRAFT_PATH,
+          name: 'Legacy',
+          isTemporary: true,
+          updatedAt
+        }
+      }
+    })
+    const legacyPayload = JSON.stringify({
+      data: JSON.stringify({ version: 0.4, nodes: [], links: [] }),
+      updatedAt
+    })
+    const sourceIndexKey = `Comfy.Workflow.DraftIndex.v2:${identityDraft.workspaceId}`
+    const sourcePayloadKey = `Comfy.Workflow.Draft.v2:${identityDraft.workspaceId}:${DRAFT_KEY}`
+    const destinationIndexKey = `Comfy.Workflow.DraftIndex.v2:${identityDraft.scope}`
+    const destinationPayloadKey = `Comfy.Workflow.Draft.v2:${identityDraft.scope}:${DRAFT_KEY}`
+    const completionKey = `Comfy.Workflow.MigrationCompletion:${identityDraft.workspaceId}`
+
+    await identityDraft.seedStorage({
+      [sourceIndexKey]: legacyIndex,
+      [sourcePayloadKey]: legacyPayload
+    })
+    await identityDraft.boot()
+
+    await expect
+      .poll(() =>
+        identityDraft.readStorage([
+          sourceIndexKey,
+          sourcePayloadKey,
+          destinationIndexKey,
+          destinationPayloadKey,
+          completionKey
+        ])
+      )
+      .toMatchObject({
+        [sourceIndexKey]: null,
+        [sourcePayloadKey]: null,
+        [destinationPayloadKey]: legacyPayload
+      })
+
+    const beforeReload = await identityDraft.readStorage([
+      destinationPayloadKey,
+      completionKey
+    ])
+    const migratedIndex = await identityDraft.readStorage([destinationIndexKey])
+    expect(migratedIndex[destinationIndexKey]).toContain(DRAFT_KEY)
+    expect(beforeReload[completionKey]).not.toBeNull()
+
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await waitForApp(page)
+
+    expect(
+      await identityDraft.readStorage([destinationPayloadKey, completionKey])
+    ).toEqual(beforeReload)
+  })
+})
+
+async function waitForApp(page: Page): Promise<void> {
+  await page.waitForFunction(() => !!window.app?.extensionManager)
+}


### PR DESCRIPTION
Stacked on [pull request 17313](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17313).
Adds cloud e2e coverage for scoped writes, logout fencing, and legacy migration.
New fixture: `identityScopedDraftFixture`.

<details><summary>Full context for agent readers</summary>

The cloud Playwright spec verifies that graph changes write only under the signed-in user and workspace scope, that logout clears the departing scope and prevents a queued graph change from writing afterward, and that a legacy workspace-keyed draft moves to the identity-scoped destination with its source removed and completion recorded. Reload coverage verifies the migrated payload and completion record remain unchanged.

The fixture boots the existing fully mocked cloud auth and workspace harness, provides deterministic graph touches, seeds and reads localStorage, and drives the real logout UI.

Run locally with a cloud-distribution dev server and backend:

```bash
PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5199 PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:8188 DISTRIBUTION=cloud pnpm exec playwright test browser_tests/tests/workspace/identityScopedDraftPersistence.spec.ts --project=cloud --workers=1
```

Known gap: this suite covers the personal workspace scope and does not drive a team-workspace or second-user switch. Those paths share the same scope resolver exercised by the scoped-write assertion.

</details>
