### PR TITLE
test(agent): reject empty response suites

### DIFF
--- a/browser_tests/fixtures/agentRequestResponseFixture.test.ts
+++ b/browser_tests/fixtures/agentRequestResponseFixture.test.ts
@@ -60,6 +60,12 @@ const scenarios = [
 ] as const satisfies readonly AgentRequestResponseScenario[]
 
 describe('AgentRequestResponseQueue', () => {
+  it('rejects a suite with no scenarios', () => {
+    expect(() => new AgentRequestResponseQueue([])).toThrow(
+      'Agent request queue requires at least one scenario'
+    )
+  })
+
   it('consumes requests and interleaved responses in declaration order', () => {
     const queue = new AgentRequestResponseQueue(scenarios)
 

--- a/browser_tests/fixtures/agentRequestResponseFixture.ts
+++ b/browser_tests/fixtures/agentRequestResponseFixture.ts
@@ -12,7 +12,11 @@ export class AgentRequestResponseQueue {
 
   constructor(
     private readonly scenarios: readonly AgentRequestResponseScenario[]
-  ) {}
+  ) {
+    if (scenarios.length === 0) {
+      throw new Error('Agent request queue requires at least one scenario')
+    }
+  }
 
   take(request: PostMessageInput): readonly AgentResponseStep[] {
     const requestNumber = this.nextScenarioIndex + 1


### PR DESCRIPTION
- Empty agent-response suites now fail during discovery.
- Focused fixture tests, lint, and typecheck are green.
- Existing non-empty suite behavior is unchanged.

<details><summary>Full context for agent readers</summary>

Addresses the false-confidence suite finding from reviewer findings on the test-harness stack. `AgentRequestResponseQueue` now rejects an empty scenario list at construction, and a focused regression test proves that a suite cannot pass without loading a scenario.

Evidence:
- `pnpm vitest run browser_tests/fixtures/agentRequestResponseFixture.test.ts`
- `pnpm eslint browser_tests/fixtures/agentRequestResponseFixture.ts browser_tests/fixtures/agentRequestResponseFixture.test.ts`
- `pnpm typecheck`

</details>
