### PR TITLE
[agent] Cache cloud workflow index and dedupe concurrent refreshes

### DIFF
--- a/browser_tests/tests/agent/agentWorkflowSelection.spec.ts
+++ b/browser_tests/tests/agent/agentWorkflowSelection.spec.ts
@@ -41,6 +41,8 @@ test.describe(
       await composer.fill('Keep this interrupted draft')
       workflowSelection.pauseWorkflowLookups()
       const lookups = workflowSelection.workflowLookups()
+      await page.clock.install({ time: new Date() })
+      await page.clock.fastForward(30_001)
       await composer.press('Enter')
       await expect
         .poll(() => workflowSelection.workflowLookups())

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -3900,7 +3900,7 @@ describe('AgentPanelRoot workflow binding', () => {
     })
   })
 
-  it('refreshes the cloud index before each send, not just on mount', async () => {
+  it('refreshes a persisted target missing from the cached cloud index', async () => {
     makeTab()
     const bodies: unknown[] = []
     let workflowsCalls = 0
@@ -3939,6 +3939,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     await renderAndSend('first message')
 
+    expect(workflowsCalls).toBe(2)
     expect(bodies[0]).toMatchObject({ workflow_id: 'wf-cloud-current' })
   })
 
@@ -5342,6 +5343,7 @@ describe('AgentPanelRoot workflow binding', () => {
   )
 
   it('cancels and restores the draft when its target closes during preparation', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     const origin = makeTab('wf-origin')
     origin.activeState = fromPartial<ComfyWorkflowJSON>({ id: 'origin-draft' })
     const replacement = addTab('workflows/replacement.json', {
@@ -5377,6 +5379,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     renderWithSelectedTarget()
     await vi.waitFor(() => expect(workflowRequests).toBe(1))
+    await vi.advanceTimersByTimeAsync(30_001)
     await userEvent.type(screen.getByRole('textbox'), 'build a graph')
     await userEvent.click(screen.getByRole('button', { name: 'Send' }))
     await vi.waitFor(() => expect(workflowRequests).toBe(2))

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -459,7 +459,13 @@ const {
     adopted: onWorkflowAdopted,
     restored: onWorkflowRestored,
     prepare: async () => {
-      await refreshCloudWorkflowIds()
+      const target = selectedTarget.value
+      await refreshCloudWorkflowIds({
+        force:
+          target !== null &&
+          !target.isTemporary &&
+          cloudIdFor(target) === undefined
+      })
     },
     tabs: openTabsSnapshot,
     activeTab: enqueueActiveTab,

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -587,7 +587,7 @@ async function onNavigateToReferenceWorkflow(
     let target = openWorkflowFor(workflowId)
     if (target === null) {
       await Promise.all([
-        refreshCloudWorkflowIds(),
+        refreshCloudWorkflowIds({ force: true }),
         workflowStore.syncWorkflows()
       ])
       target = storedWorkflowFor(workflowId)

--- a/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.test.ts
@@ -256,7 +256,7 @@ describe('Agent workflow resolution', () => {
         { id: 'latest', name: 'Current' }
       ])
       const first = resolver.refreshCloudWorkflowIds()
-      expect(await resolver.refreshCloudWorkflowIds()).toBe(true)
+      expect(await resolver.refreshCloudWorkflowIds({ force: true })).toBe(true)
       if (outcome === 'success')
         resolveFirst([{ id: 'stale', name: 'Current' }])
       else rejectFirst(new Error('Stale failure'))
@@ -276,7 +276,7 @@ describe('Agent workflow resolution', () => {
     await resolver.refreshCloudWorkflowIds()
     const error = new Error('Unavailable')
     listCloudWorkflows.mockRejectedValueOnce(error)
-    expect(await resolver.refreshCloudWorkflowIds()).toBe(false)
+    expect(await resolver.refreshCloudWorkflowIds({ force: true })).toBe(false)
     expect(resolver.availableWorkflowReferences.value).toEqual([
       { id: 'known', name: 'Current' }
     ])
@@ -286,9 +286,50 @@ describe('Agent workflow resolution', () => {
     listCloudWorkflows.mockResolvedValueOnce([
       { id: 'updated', name: 'Current' }
     ])
+    // A failed refresh must not arm the freshness window.
     expect(await resolver.refreshCloudWorkflowIds()).toBe(true)
+    expect(listCloudWorkflows).toHaveBeenCalledTimes(3)
     expect(resolver.availableWorkflowReferences.value).toEqual([
       { id: 'updated', name: 'Current' }
     ])
+  })
+
+  it('shares one cloud listing between concurrent non-forced refreshes', async () => {
+    const { resolver, listCloudWorkflows } = setup(
+      [workflow('workflows/current.json', 'Current')],
+      [{ id: 'current', name: 'Current' }]
+    )
+    const [first, second] = await Promise.all([
+      resolver.refreshCloudWorkflowIds(),
+      resolver.refreshCloudWorkflowIds()
+    ])
+    expect(first).toBe(true)
+    expect(second).toBe(true)
+    expect(listCloudWorkflows).toHaveBeenCalledTimes(1)
+    expect(resolver.availableWorkflowReferences.value).toEqual([
+      { id: 'current', name: 'Current' }
+    ])
+  })
+
+  it('reuses a fresh cloud index until forced or expired', async () => {
+    vi.useFakeTimers()
+    const { resolver, listCloudWorkflows } = setup(
+      [workflow('workflows/current.json', 'Current')],
+      [{ id: 'current', name: 'Current' }]
+    )
+    expect(await resolver.refreshCloudWorkflowIds()).toBe(true)
+    expect(await resolver.refreshCloudWorkflowIds()).toBe(true)
+    expect(listCloudWorkflows).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(29_999)
+    expect(await resolver.refreshCloudWorkflowIds()).toBe(true)
+    expect(listCloudWorkflows).toHaveBeenCalledTimes(1)
+
+    expect(await resolver.refreshCloudWorkflowIds({ force: true })).toBe(true)
+    expect(listCloudWorkflows).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(30_001)
+    expect(await resolver.refreshCloudWorkflowIds()).toBe(true)
+    expect(listCloudWorkflows).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.ts
@@ -26,6 +26,9 @@ type WorkflowResolverDeps = {
   listCloudWorkflows: AgentRestClient['listCloudWorkflows']
 }
 
+/** How long a successful cloud index fetch satisfies non-forced refreshes. */
+const CLOUD_INDEX_TTL_MS = 30_000
+
 export function useAgentWorkflowResolver({
   workflows,
   bindings,
@@ -33,6 +36,8 @@ export function useAgentWorkflowResolver({
 }: WorkflowResolverDeps) {
   const cloudIndex = ref<WorkflowReferenceMetadata[]>([])
   let refreshGeneration = 0
+  let lastSuccessfulRefreshAt: number | null = null
+  let inFlightRefresh: Promise<boolean> | null = null
   const cloudIdsByName = computed(() => {
     const counts = new Map<string, number>()
     for (const { name } of cloudIndex.value)
@@ -44,22 +49,48 @@ export function useAgentWorkflowResolver({
     )
   })
 
-  async function refreshCloudWorkflowIds(): Promise<boolean> {
-    const generation = ++refreshGeneration
-    try {
-      const entries = await listCloudWorkflows()
-      if (generation !== refreshGeneration) return false
-      cloudIndex.value = entries.flatMap(({ id, name }) =>
-        name === undefined ? [] : [{ id, name }]
+  /**
+   * Refreshes the cloud workflow index. Non-forced calls reuse an in-flight
+   * request and skip the network entirely while the last successful fetch is
+   * younger than {@link CLOUD_INDEX_TTL_MS}, so routine callers (mount, every
+   * message send, tab switches) do not each re-list every cloud workflow.
+   * Callers that just observed a miss should pass `force: true`. A failed
+   * fetch clears the freshness window so the next routine call retries.
+   */
+  async function refreshCloudWorkflowIds({
+    force = false
+  }: { force?: boolean } = {}): Promise<boolean> {
+    if (!force) {
+      if (inFlightRefresh) return inFlightRefresh
+      if (
+        lastSuccessfulRefreshAt !== null &&
+        Date.now() - lastSuccessfulRefreshAt < CLOUD_INDEX_TTL_MS
       )
-      return true
-    } catch (error) {
-      if (generation !== refreshGeneration) return false
-      reportError(error, {
-        errorType: 'agent_cloud_workflow_ids_refresh_failed'
-      })
-      return false
+        return true
     }
+    const generation = ++refreshGeneration
+    const request = (async () => {
+      try {
+        const entries = await listCloudWorkflows()
+        if (generation !== refreshGeneration) return false
+        cloudIndex.value = entries.flatMap(({ id, name }) =>
+          name === undefined ? [] : [{ id, name }]
+        )
+        lastSuccessfulRefreshAt = Date.now()
+        return true
+      } catch (error) {
+        if (generation !== refreshGeneration) return false
+        lastSuccessfulRefreshAt = null
+        reportError(error, {
+          errorType: 'agent_cloud_workflow_ids_refresh_failed'
+        })
+        return false
+      } finally {
+        if (generation === refreshGeneration) inFlightRefresh = null
+      }
+    })()
+    inFlightRefresh = request
+    return request
   }
 
   function cloudWorkflowName(workflow: ComfyWorkflow): string {

--- a/src/workbench/extensions/agent/composables/agent/useAgentWorkflowSelection.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentWorkflowSelection.ts
@@ -90,7 +90,7 @@ export function useAgentWorkflowSelection({
       if (!isCurrent()) return
       let workflowId = cloudIdFor(tab)
       if (workflowId === undefined) {
-        if (!(await refreshCloudWorkflowIds())) return fail()
+        if (!(await refreshCloudWorkflowIds({ force: true }))) return fail()
         if (!isCurrent()) return
         workflowId = cloudIdFor(tab)
       }


### PR DESCRIPTION
## Summary

Stop re-fetching the complete cloud workflow listing (`GET /workflows?limit=100`, paginated) on every agent send, tab switch and panel mount.

`useAgentWorkflowResolver.refreshCloudWorkflowIds()` was called unconditionally from six sites (`AgentPanelRoot.vue` per-send and mount, `useAgentWorkflowSelection.ts` on every tab change and selection) and each concurrent caller issued its own listing. This is the source of the frequent top-level `workflows?limit=100` calls observed at runtime.

Changes in `useAgentWorkflowResolver.ts`:

- 30 s freshness window (`CLOUD_INDEX_TTL_MS`): a non-forced refresh returns immediately when the last successful refresh is younger than the TTL.
- Concurrent non-forced callers share the single in-flight refresh promise.
- `refreshCloudWorkflowIds({ force: true })` bypasses the window; used only at the two call sites that observed an actual miss (`useAgentWorkflowSelection.ts` after a missed lookup, `AgentPanelRoot.vue` after an observed miss).
- A failed refresh clears the freshness window (so the next routine call retries) and reports `agent_cloud_workflow_ids_refresh_failed`.
- A superseded refresh (a later generation started) does not overwrite the index.

No behavioral change to name/path resolution; only fetch frequency.

## Evidence

Head: `c35e75681b4549ce3c1cc0dc548114568bf5ad5c` on top of `origin/main` `18cda72e42cffe7ed5ba502bef9ad8bc9677ee54`.

- `pnpm vitest run src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.test.ts` → 13/13 pass. New tests: concurrent non-forced callers share one listing; fresh index reused until forced or expired (fake timers: 29 999 ms → 1 call, `force` → 2, 30 001 ms → 3); failure then retry.
- Resolver + `useAgentSession.test.ts` → 85/85 pass.
- `pnpm typecheck` → exit 0.
- `pnpm adr:check` → exit 0.
- Pre-commit hooks (oxlint type-aware, oxfmt) ran normally; the first attempt was rejected by `comfy(no-redundant-vitest-cleanup)` and fixed rather than bypassed.

## Review notes (vetoable choices)

- TTL 30 s chosen to cover a burst of sends/tab switches while still picking up workflows saved from another tab within a reasonable time; lower or raise freely.
- Failure clears the window rather than backing off; a flapping server would retry at the next routine call.

<!-- authored-by:agent role-hard-problem -->
