### PR TITLE
test: verify DynamicGroup against the companion backend

### DIFF
--- a/.github/actions/start-comfyui-server/action.yaml
+++ b/.github/actions/start-comfyui-server/action.yaml
@@ -14,10 +14,22 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Check out the DynamicGroup backend contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Comfy-Org/ComfyUI
+        ref: 47e136368149719a3ceb078ce605c5636bfccb87
+        path: .ci-backend
+        persist-credentials: false
+
+    - name: Install the pinned backend requirements
+      shell: bash
+      run: python3 -m pip install -r "$GITHUB_WORKSPACE/.ci-backend/requirements.txt"
+
     - name: Copy devtools and start server
       shell: bash
       run: |
         set -euo pipefail
         cp -r ./tools/devtools/* /ComfyUI/custom_nodes/ComfyUI_devtools/
-        cd /ComfyUI && python3 main.py --cpu --multi-user --front-end-root "${{ inputs.front_end_root }}" &
+        cd "$GITHUB_WORKSPACE/.ci-backend" && python3 main.py --base-directory /ComfyUI --cpu --multi-user --front-end-root "${{ inputs.front_end_root }}" &
         wait-for-it --service 127.0.0.1:8188 -t ${{ inputs.timeout }}

--- a/.github/actions/start-comfyui-server/action.yaml
+++ b/.github/actions/start-comfyui-server/action.yaml
@@ -22,9 +22,15 @@ runs:
         path: .ci-backend
         persist-credentials: false
 
+    - name: Set up uv for the container's Python environment
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      with:
+        version: '0.12.13'
+        enable-cache: false
+
     - name: Install the pinned backend requirements
       shell: bash
-      run: python3 -m pip install -r "$GITHUB_WORKSPACE/.ci-backend/requirements.txt"
+      run: uv pip install --python /opt/venv/bin/python3 -r "$GITHUB_WORKSPACE/.ci-backend/requirements.txt"
 
     - name: Copy devtools and start server
       shell: bash

--- a/browser_tests/assets/inputs/dynamic_group.json
+++ b/browser_tests/assets/inputs/dynamic_group.json
@@ -1,0 +1,58 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "DevToolsNodeWithDynamicGroup",
+      "pos": [100, 150],
+      "size": [350, 140],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "rows",
+          "type": "STRING",
+          "links": [1]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DevToolsNodeWithDynamicGroup"
+      },
+      "widgets_values": ["first", 0, "last"]
+    },
+    {
+      "id": 2,
+      "type": "PreviewAny",
+      "pos": [500, 150],
+      "size": [350, 300],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [[1, 1, 0, 2, 0, "STRING"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/vueNodes/widgets/dynamicGroup.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/dynamicGroup.spec.ts
@@ -1,0 +1,121 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'DynamicGroup',
+  { tag: ['@widget', '@vue-nodes', '@oss'] },
+  () => {
+    test.use({ initialSettings: { 'Comfy.VueNodes.Enabled': true } })
+
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('inputs/dynamic_group')
+      await comfyPage.vueNodes.waitForNodes(2)
+    })
+
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.setupWorkflowsDirectory({})
+      await comfyPage.canvasOps.resetView()
+    })
+
+    test('executes an empty group as an empty list', async ({ comfyPage }) => {
+      const node = comfyPage.vueNodes.getNodeByTitle('Node With Dynamic Group')
+      await expect(node.getByRole('button', { name: 'Add LoRA' })).toBeVisible()
+      await expect(
+        node.getByRole('button', { name: /Remove LoRA/ })
+      ).toHaveCount(0)
+
+      await comfyPage.command.executeCommand('Comfy.QueuePrompt')
+
+      await expect(
+        comfyPage.vueNodes.getNodeLocator('2').getByRole('textbox')
+      ).toHaveValue('{"before": "first", "loras": [], "after": "last"}')
+    })
+
+    test('preserves edited rows through removal, save, reopen and execution', async ({
+      comfyPage
+    }) => {
+      test.slow()
+      const node = comfyPage.vueNodes.getNodeByTitle('Node With Dynamic Group')
+      await node.getByLabel('before', { exact: true }).fill('head')
+      await node.getByLabel('after', { exact: true }).fill('tail')
+      await node.getByRole('button', { name: 'Add LoRA' }).click()
+      await node.getByRole('button', { name: 'Add LoRA' }).click()
+      await node.getByRole('button', { name: 'Add LoRA' }).click()
+      await expect(
+        node.getByRole('button', { name: 'Add LoRA' })
+      ).toBeDisabled()
+      await expect(
+        node.getByRole('combobox', { name: 'lora_name', exact: true })
+      ).toHaveCount(3)
+      await node
+        .getByRole('combobox', { name: 'lora_name', exact: true })
+        .nth(1)
+        .click()
+      await comfyPage.page
+        .getByRole('option', { name: 'B.safetensors', exact: true })
+        .click()
+      await node
+        .getByRole('combobox', { name: 'lora_name', exact: true })
+        .nth(2)
+        .click()
+      await comfyPage.page
+        .getByRole('option', { name: 'C.safetensors', exact: true })
+        .click()
+      const strength = comfyPage.vueNodes.getInputNumberControls(
+        node.getByLabel('loras.2.strength', { exact: true })
+      ).input
+      await strength.fill('0.5')
+      await strength.blur()
+      await node.getByLabel('loras.2.enabled', { exact: true }).click()
+      await node
+        .getByRole('button', { name: 'Remove LoRA #2', exact: true })
+        .click()
+      await comfyPage.command.executeCommand('Comfy.Undo')
+      await expect(
+        node.getByRole('combobox', { name: 'lora_name', exact: true })
+      ).toHaveText(['A.safetensors', 'B.safetensors', 'C.safetensors'])
+      await comfyPage.command.executeCommand('Comfy.Redo')
+      await expect(
+        node.getByRole('combobox', { name: 'lora_name', exact: true }).nth(1)
+      ).toHaveText('C.safetensors')
+      await expect(
+        node.getByLabel('loras.1.enabled', { exact: true })
+      ).not.toBeChecked()
+      await expect(node.getByRole('button', { name: 'Add LoRA' })).toBeEnabled()
+
+      await comfyPage.menu.topbar.saveWorkflow('dynamic-group-rows')
+      await comfyPage.menu.topbar.closeWorkflowTab('dynamic-group-rows')
+      await comfyPage.page.keyboard.press('w')
+      await comfyPage.menu.workflowsTab
+        .getPersistedItem('dynamic-group-rows')
+        .dblclick()
+      await expect
+        .poll(() => comfyPage.workflow.getActiveWorkflowPath())
+        .toContain('dynamic-group-rows')
+      await comfyPage.vueNodes.waitForNodes(2)
+      await comfyPage.menu.workflowsTab.close()
+      await expect(node.getByLabel('before', { exact: true })).toHaveValue(
+        'head'
+      )
+      await expect(node.getByLabel('after', { exact: true })).toHaveValue(
+        'tail'
+      )
+      await expect(
+        node.getByRole('combobox', { name: 'lora_name', exact: true })
+      ).toHaveText(['A.safetensors', 'C.safetensors'])
+      await expect(
+        node.getByLabel('loras.1.enabled', { exact: true })
+      ).not.toBeChecked()
+
+      await comfyPage.command.executeCommand('Comfy.QueuePrompt')
+
+      await expect(
+        comfyPage.vueNodes.getNodeLocator('2').getByRole('textbox')
+      ).toHaveValue(
+        '{"before": "head", "loras": [{"lora_name": "A.safetensors", "strength": 1.0, "enabled": true}, {"lora_name": "C.safetensors", "strength": 0.5, "enabled": false}], "after": "tail"}'
+      )
+    })
+  }
+)

--- a/browser_tests/tests/widgets/dynamicGroup.spec.ts
+++ b/browser_tests/tests/widgets/dynamicGroup.spec.ts
@@ -1,0 +1,29 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'DynamicGroup canvas controls',
+  { tag: ['@widget', '@oss'] },
+  () => {
+    test.use({ initialSettings: { 'Comfy.VueNodes.Enabled': false } })
+
+    test('adds and removes rows with the canvas buttons', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('inputs/dynamic_group')
+      const node = await comfyPage.nodeOps.getNodeRefById('1')
+      const count = await node.getWidgetByName('loras')
+
+      await (await node.getWidgetByName('loras.$add')).click()
+      await expect.poll(() => count.getValue()).toBe(1)
+      await (await node.getWidgetByName('loras.$add')).click()
+      await expect.poll(() => count.getValue()).toBe(2)
+      await (await node.getWidgetByName('loras.0')).click()
+      await expect.poll(() => count.getValue()).toBe(1)
+      await (await node.getWidgetByName('loras.0')).click()
+      await expect.poll(() => count.getValue()).toBe(0)
+    })
+  }
+)


### PR DESCRIPTION
## ELI5

This checks that the expandable rows in a Node 2.0 node survive editing, saving, reopening and execution when the frontend and backend use the same contract. The tests run against a real backend without loading LoRA models.

## Motivation

The frontend implementation can be reviewed independently, but its backend-dependent browser tests cannot run against the older backend bundled in the default CI image. This stacked PR carries those tests together with the temporary backend selection so the implementation PR no longer fails for a missing development node.

## Reviewer context

- **Type:** integration tests and temporary CI configuration.
- **Parent:** [#17441 — feat: support DynamicGroup widget inputs](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17441). This PR targets its branch.
- **Backend:** pinned to the original combined snapshot [`ded3c4496f4d925b824c93cc2cd04881c1e1d9eb`](https://github.com/Comfy-Org/ComfyUI/commit/ded3c4496f4d925b824c93cc2cd04881c1e1d9eb). It contains [Comfy-Org/ComfyUI#16260 — feat: add DynamicGroup widget input](https://github.com/Comfy-Org/ComfyUI/pull/16260), the 20-row cap, and the shared execution fixes now reviewed independently in [Comfy-Org/ComfyUI#16377 — fix: preserve dynamic input validation and lazy execution](https://github.com/Comfy-Org/ComfyUI/pull/16377). The pin remains unchanged when the execution PR is retargeted to `master`, because that standalone branch does not contain DynamicGroup.

## Summary

- Keep the Node 2.0 DynamicGroup browser spec and its workflow fixture in this stack. Remove the legacy canvas spec to match the parent's Node 2.0-only scope.
- Check out the pinned backend, install its requirements, and run that source with the CI container's existing `/ComfyUI` base directory for models, custom nodes and user data. Copy the frontend's devtools as usual.
- Exercise real `/object_info`, workflow storage and prompt execution: empty groups; edited rows, middle-row removal, undo/redo, save/reopen and execution; a single legacy notice per group with values preserved across renderer switches.

## Temporary configuration

The backend pin in `.github/actions/start-comfyui-server/action.yaml` applies to the E2E jobs that use this action. Keep this PR in draft while the companion backend is unmerged. Once both backend PRs are merged and their changes are available in the standard CI image, remove the temporary checkout/requirements/startup override and retain the browser coverage. Retarget this PR to `main` after the parent merges.

## Test plan

- Run `browser_tests/tests/vueNodes/widgets/dynamicGroup.spec.ts` against the pinned backend with `tools/devtools` installed and Modern Node Design enabled.
- Confirm the CI Chromium shards execute all three scenarios and the default backend dependency no longer fails the parent PR.

## Provenance

- **Authored by:** interactive session.
- **Previous verification:** The original three browser scenarios passed locally and in the recording job of [CI run 34804289011](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34804289011). The canvas add/remove scenario has been removed. A new scenario checks one non-interactive notice for zero and multiple rows, then switches back to Node 2.0 and verifies the values survive. Results for the updated three-scenario suite are pending CI.
- **Verified:** CI action YAML parsed successfully and its shell blocks passed `bash -n`. Normal commit checks and push hooks remain enabled. The temporary CI checkout/install path reached and passed the DynamicGroup tests in the prior run; that run had unrelated failures elsewhere.


## CI environment correction

The first CI run stopped before starting ComfyUI: the `0.0.22` container's uv-created `/opt/venv` has no `pip` module. The temporary setup now installs a pinned uv release and targets that existing interpreter explicitly. Backend checkout succeeded in the failed run; it did not reach the integration assertions. The corrected path subsequently ran the DynamicGroup tests successfully. That environment correction preserved the backend SHA and temporary setup; the backend pin has since been updated as noted above.

- **Verified after adding the notice scenario:** `pnpm test:browser browser_tests/tests/vueNodes/widgets/dynamicGroup.spec.ts --project=chromium --workers=1 --reporter=line`: 3 passed (15.7s) against the pinned backend with isolated local servers. Updated CI results are pending. This tests a notice, not legacy row editing.

## Backend pin update

Only the backend SHA changed in this update; the frontend implementation and browser scenarios are unchanged. Action YAML parsing, `pnpm format:check .github/actions/start-comfyui-server/action.yaml`, normal commit hooks, and the `pnpm knip` push hook passed. The existing three scenarios will run against the new backend in CI; their earlier results above apply to the previous pin. The new backend regression cases cover custom validators and lazy scheduling separately.
