### PR TITLE
fix: address dev agent harness reviewer findings

### DIFF
--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -39,8 +39,8 @@ async function assertWorkspacePackage(): Promise<void> {
     )
   }
   if (!dependency.startsWith('workspace:')) {
-    console.warn(
-      '[dev-agent-integration] @comfyorg/comfy-multi-player is the published package; edits to it will not hot-reload until it is an in-workspace dependency'
+    throw new Error(
+      '@comfyorg/comfy-multi-player must use a workspace: dependency'
     )
   }
 }

--- a/scripts/dev-agent-record-mode.ts
+++ b/scripts/dev-agent-record-mode.ts
@@ -29,7 +29,6 @@ const TEMPORAL_INSTALL =
 const RECORD_USER_ID = 'rec-local-user'
 const RECORD_WORKSPACE_ID = 'w-1f2e3d4c-5b6a-4798-8899-aabbccddeeff'
 
-// Neither Postgres nor Redis speaks HTTP, so a TCP connect is the whole check.
 function assertListening(portNumber: number, label: string): Promise<void> {
   return new Promise((resolveCheck, rejectCheck) => {
     const socket = createConnection({ host: '127.0.0.1', port: portNumber })
@@ -51,7 +50,6 @@ function assertListening(portNumber: number, label: string): Promise<void> {
   })
 }
 
-// Polls because the Temporal dev server binds a second or two after it starts.
 async function waitForPort(
   portNumber: number,
   label: string,
@@ -93,7 +91,6 @@ export function containerNamesPublishing(
     .map(([name]) => name)
 }
 
-// Neither psql nor redis-cli is on PATH here, so each service is reached through its container.
 async function containerFor(
   portNumber: number,
   service: string,
@@ -127,7 +124,6 @@ async function redisExecCommand(): Promise<string> {
   return `docker exec -i ${name} redis-cli`
 }
 
-// Every value is a module constant, so the statement carries no caller input.
 export function parseExecCommand(command: string): string[] {
   const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((part) => {
     const quoted = part.match(/^(?:"([^"]*)"|'([^']*)')$/)

--- a/scripts/dev-agent-record-mode.ts
+++ b/scripts/dev-agent-record-mode.ts
@@ -87,7 +87,7 @@ export function containerNamesPublishing(
     .map((line) => line.split(' '))
     .filter(
       ([, imageName, ...ports]) =>
-        imageName.includes(image) &&
+        imageName.replace(/@.+$/, '').replace(/:[^/]+$/, '') === image &&
         ports.join(' ').includes(`:${portNumber}->`)
     )
     .map(([name]) => name)


### PR DESCRIPTION
- Carries the remaining reviewer fixes without rewriting the original author's branch.
- Rejects non-workspace multi-player dependencies and lookalike service images.
- Stacked on PR 16877; merge after that PR.

<details><summary>Full context for agent readers</summary>

This carries fixes for reviewer findings on [PR 16877](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16877) to a contributor-owned branch.

## Findings addressed

- Require `@comfyorg/comfy-multi-player` to use the `workspace:` protocol so the harness cannot silently bypass the source-tree hot-reload contract.
- Match the requested Postgres or Redis image repository exactly while still accepting tags and digests, preventing lookalike images from being selected for identity seeding.
- Preserve the base branch's shared teardown behavior: every repeated `stop()` call awaits the same cleanup promise before returning.

## Verification

- `pnpm typecheck` — passed
- focused supervisor and record-mode unit tests — 18/18 passed
- changed-file ESLint — passed

## Stack

Base: `fix/dev-agent-supervised-spawn` from PR 16877, whose harness implementation is not on `main`. This PR should merge after PR 16877; alternatively, PR 16877 can be closed in favor of a separately rebased full carrier.

</details>
