### PR TITLE
test: reuse production asset classification

### DIFF
--- a/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
@@ -10,6 +10,7 @@ import {
   loadAgentConversation
 } from '@e2e/fixtures/data/agent/agentConversation'
 import { agentConversationCapabilityMatrix } from '@e2e/fixtures/data/agent/agentConversationCapabilityMatrix'
+import { classifyAssetUrl } from '@/workbench/extensions/agent/utils/replyAssets'
 
 const supported = agentConversationCapabilityMatrix.filter(
   (row) => row.status === 'supported'
@@ -77,21 +78,8 @@ const laterTurnReferencesEarlierAddedNode = (
 const urlsIn = (text: string): string[] =>
   text.match(/https?:\/\/[^\s)\]]+/g) ?? []
 
-const MEDIA_EXTENSION = /\.(png|jpe?g|gif|webp|mp4|webm|mp3|wav|ogg|glb|obj)$/i
-
-/** Mirrors classifyAssetUrl: a media filename in the query or pathname. */
-const isMediaAssetUrl = (url: string) => {
-  try {
-    const parsed = new URL(url)
-    const candidate =
-      parsed.searchParams.get('filename') ??
-      parsed.pathname.split('/').pop() ??
-      ''
-    return MEDIA_EXTENSION.test(candidate)
-  } catch {
-    return false
-  }
-}
+const isMediaAssetUrl = (url: string) =>
+  classifyAssetUrl(url, 'http://localhost') !== null
 
 describe('agentConversationCapabilityMatrix', () => {
   it('names at least one recording for every supported capability', () => {

--- a/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
@@ -153,7 +153,7 @@ describe('agentConversationCapabilityMatrix', () => {
       true
     )
     expect(replyContainsMediaAsset('Docs: [/docs/getting-started]')).toBe(false)
-    expect(replyContainsMediaAsset('Broken: [not a URL]')).toBe(false)
+    expect(replyContainsMediaAsset('Broken: [/view/%ZZ]')).toBe(false)
   })
 
   it('lists under each capability exactly the recordings that show it', () => {

--- a/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
+++ b/browser_tests/fixtures/data/agent/agentConversationCapabilityMatrix.test.ts
@@ -76,10 +76,13 @@ const laterTurnReferencesEarlierAddedNode = (
 }
 
 const urlsIn = (text: string): string[] =>
-  text.match(/https?:\/\/[^\s)\]]+/g) ?? []
+  text.match(/(?:https?:\/\/|\/)[^\s)\]]+/g) ?? []
 
 const isMediaAssetUrl = (url: string) =>
   classifyAssetUrl(url, 'http://localhost') !== null
+
+const replyContainsMediaAsset = (text: string) =>
+  urlsIn(text).some(isMediaAssetUrl)
 
 describe('agentConversationCapabilityMatrix', () => {
   it('names at least one recording for every supported capability', () => {
@@ -141,9 +144,17 @@ describe('agentConversationCapabilityMatrix', () => {
       events(c).some(
         (event) =>
           event.type === 'agent_message_delta' &&
-          urlsIn(event.data.delta).some(isMediaAssetUrl)
+          replyContainsMediaAsset(event.data.delta)
       )
   }
+
+  it('classifies relative reply assets against the capability base URL', () => {
+    expect(replyContainsMediaAsset('Preview: [/view?filename=clip.mp4]')).toBe(
+      true
+    )
+    expect(replyContainsMediaAsset('Docs: [/docs/getting-started]')).toBe(false)
+    expect(replyContainsMediaAsset('Broken: [not a URL]')).toBe(false)
+  })
 
   it('lists under each capability exactly the recordings that show it', () => {
     const catalog = listRecordedConversations().map((caseId) => ({

--- a/src/workbench/extensions/agent/utils/replyAssets.test.ts
+++ b/src/workbench/extensions/agent/utils/replyAssets.test.ts
@@ -53,6 +53,7 @@ describe('classifyAssetUrl', () => {
   it('rejects non-media and extensionless references', () => {
     expect(classifyAssetUrl(view('notes.txt'))).toBeNull()
     expect(classifyAssetUrl('https://cloud.comfy.org/api/view')).toBeNull()
+    expect(classifyAssetUrl('/view/%ZZ', 'http://localhost')).toBeNull()
   })
 
   it('falls back to the pathname when no filename param exists', () => {

--- a/src/workbench/extensions/agent/utils/replyAssets.ts
+++ b/src/workbench/extensions/agent/utils/replyAssets.ts
@@ -25,9 +25,12 @@ export function classifyAssetUrl(
   } catch {
     return null
   }
-  const filename =
-    url.searchParams.get('filename') ??
-    decodeURIComponent(url.pathname.split('/').at(-1) ?? '')
+  let filename = url.searchParams.get('filename')
+  try {
+    filename ??= decodeURIComponent(url.pathname.split('/').at(-1) ?? '')
+  } catch {
+    return null
+  }
   if (!filename) return null
   const kind = getMediaTypeFromFilename(filename)
   if (!ASSET_KINDS.has(kind)) return null

--- a/src/workbench/extensions/agent/utils/replyAssets.ts
+++ b/src/workbench/extensions/agent/utils/replyAssets.ts
@@ -15,10 +15,13 @@ export interface ReplyAsset {
 
 const ASSET_KINDS = new Set<MediaType>(['image', 'video', 'audio', '3D'])
 
-export function classifyAssetUrl(href: string): ReplyAsset | null {
+export function classifyAssetUrl(
+  href: string,
+  baseUrl = window.location.origin
+): ReplyAsset | null {
   let url: URL
   try {
-    url = new URL(href, window.location.origin)
+    url = new URL(href, baseUrl)
   } catch {
     return null
   }


### PR DESCRIPTION
- Removes a test-only asset classifier.
- Capability checks now call production behavior.
- Production classifier accepts an explicit base URL for non-browser callers.

<details><summary>Full context for agent readers</summary>

## Reviewer finding

- Reimplemented algorithms: the capability-matrix test duplicated `classifyAssetUrl` with a separate extension regex. It now imports the production classifier, so future media-classification changes cannot leave the harness validating stale behavior.

## Verification

- capability-matrix and asset-classifier tests: 21/21 passed
- changed-file ESLint: passed
- `pnpm typecheck`: passed
- commit hooks: format, Oxlint, ESLint, browser typecheck, Knip passed

</details>