### PR TITLE
fix(agent): drop stale workflow tab bindings before resolving graph scope

### DIFF
--- a/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.test.ts
@@ -291,4 +291,29 @@ describe('Agent workflow resolution', () => {
       { id: 'updated', name: 'Current' }
     ])
   })
+
+  it('rejects a stale binding that points a cloud id at a differently named saved tab', async () => {
+    const portrait = workflow('workflows/portrait.json', 'Portrait')
+    const { resolver, bindings, workflows } = setup(
+      [portrait],
+      [
+        { id: 'cloud-zimage', name: 'image_z_image_turbo' },
+        { id: 'cloud-portrait', name: 'Portrait' }
+      ]
+    )
+    bindings.bind('cloud-zimage', 'workflows/portrait.json')
+    await resolver.refreshCloudWorkflowIds()
+    expect(resolver.cloudIdFor(portrait)).toBe('cloud-portrait')
+    expect(resolver.boundOrOpenWorkflowFor('cloud-zimage')).toBeNull()
+    expect(resolver.storedWorkflowFor('cloud-zimage')).toBeNull()
+    expect(resolver.openWorkflowFor('cloud-zimage')).toBeNull()
+    expect(resolver.boundOrOpenWorkflowFor('cloud-portrait')).toBe(
+      workflows.openWorkflows[0]
+    )
+    expect(bindings.tabPathFor('cloud-zimage')).toBeUndefined()
+    expect(resolver.availableWorkflowReferences.value).toEqual([
+      { id: 'cloud-portrait', name: 'Portrait' },
+      { id: 'cloud-zimage', name: 'image_z_image_turbo' }
+    ])
+  })
 })

--- a/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentWorkflowResolver.ts
@@ -21,7 +21,7 @@ type WorkflowResolverDeps = {
   >
   bindings: Pick<
     ReturnType<typeof useAgentWorkflowTabBindingStore>,
-    'workflowIdFor' | 'tabPathFor' | 'matchesWorkflow'
+    'workflowIdFor' | 'tabPathFor' | 'matchesWorkflow' | 'unbind'
   >
   listCloudWorkflows: AgentRestClient['listCloudWorkflows']
 }
@@ -92,13 +92,38 @@ export function useAgentWorkflowResolver({
       : undefined
   }
 
+  function indexedNameFor(workflowId: string): string | undefined {
+    for (const [name, id] of cloudIdsByName.value) {
+      if (id === workflowId) return name
+    }
+    return undefined
+  }
+
+  /**
+   * A persisted binding is stale when the cloud index says `workflowId` is
+   * a different saved workflow than the tab it points at, and the tab's own
+   * name resolves to another cloud id. Applying mutations through such a
+   * binding would write one workflow's edits into another workflow's graph.
+   */
+  function bindingIsStale(workflowId: string, bound: ComfyWorkflow): boolean {
+    if (bound.isTemporary) return false
+    const indexedName = indexedNameFor(workflowId)
+    const boundName = cloudWorkflowName(bound)
+    if (indexedName === undefined || indexedName === boundName) return false
+    const boundId = cloudIdsByName.value.get(boundName)
+    return boundId !== undefined && boundId !== workflowId
+  }
+
   function resolveWorkflow(
     workflowId: string,
     nameCandidates: ComfyWorkflow[]
   ): ComfyWorkflow | null {
     const path = bindings.tabPathFor(workflowId)
     const bound = path === undefined ? null : workflows.getWorkflowByPath(path)
-    if (bound && bindings.matchesWorkflow(workflowId, bound)) return bound
+    if (bound && bindings.matchesWorkflow(workflowId, bound)) {
+      if (!bindingIsStale(workflowId, bound)) return bound
+      bindings.unbind(bound.path)
+    }
     for (const [name, id] of cloudIdsByName.value) {
       if (id !== workflowId) continue
       const matches = savedMatches(name, nameCandidates)


### PR DESCRIPTION
## Summary

Saved text-to-image workflows durably acquired unrelated `LoadImage` / `ByteDance2ReferenceNodeV2` / `SaveVideo` nodes bound to docs named `image_z_image_turbo*`, persisting across reload (nightly FE 1.55.3; program row ecw-465).

**Root cause.** `useAgentWorkflowTabBindingStore` persists `Comfy.Agent.WorkflowTabBindings` (cloud workflow id -> tab path) in localStorage. `matchesWorkflow` is true for any saved tab, so a stale entry such as `cloud-zimage -> <Portrait tab path>` survives after the tab comes to hold a different saved workflow. `useAgentWorkflowResolver.resolveWorkflow` returned that bound tab first, so `AgentPanelRoot` (`graphMutations(workflowId).getScope()`) applied one cloud workflow's mutations to another workflow's canvas, which was then saved.

**Fix.** Before trusting a persisted binding, compare it against the cloud name index: a binding is stale when the bound tab is not temporary, the id's indexed name differs from the tab's cloud name, and the tab's name resolves to a different cloud id. Stale bindings are unbound and resolution falls through to the existing name-based loop. Temporary tabs and legitimately renamed tabs are untouched.

Distinct from QAF-68 (cross-tab bleed while a mutation stream is in flight, #17331): that is a runtime scope switch; this is a durable persisted-binding mismatch that reproduces on a fresh reload.

## Evidence

- Resolution before: binding `cloud-zimage -> Portrait tab` + `matchesWorkflow` true -> Portrait tab returned -> zimage doc ops mutate the Portrait graph.
- Resolution after: `bindingIsStale('cloud-zimage', Portrait)` is true (index name `image_z_image_turbo` != `Portrait`, `Portrait -> cloud-portrait`) -> binding removed -> name loop returns the `image_z_image_turbo` tab; `tabPathFor('cloud-zimage')` is `undefined` afterwards.
- New test: `rejects a stale binding that points a cloud id at a differently named saved tab` in `useAgentWorkflowResolver.test.ts`.
- `pnpm vitest run src/workbench/extensions/agent`: 93 files, 1406 tests passed.
- `pnpm typecheck`: exit 0, no errors.
- `pnpm adr:check`: passed.
- Live nightly repro not re-run here: agent.comfy.org is behind Cloudflare Access (program OOS-1). Verification is at the resolver boundary with the same inputs the panel passes.

## Notes

- Touches the same resolver file as #17509 (workflow listing cache); land this after #17509 or expect a trivial rebase.
- Severity stays data-loss: the phantom nodes were written into the user's saved workflow.

<!-- authored-by:agent role-hard-problem -->
