### PR TITLE
test(widgets): an emptied promoted text widget stays empty across a round-trip

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -44,5 +44,42 @@ test.describe(
         )
       ).toHaveValue('')
     })
+
+    test('an emptied promoted text widget stays empty across a round-trip', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/subgraph-with-promoted-text-widget'
+      )
+
+      const promotedTextbox = () =>
+        comfyPage.vueNodes
+          .getNodeLocator('11')
+          .getByRole('textbox', { name: 'text' })
+
+      async function roundTrip() {
+        const serialized = await comfyPage.workflow.getExportedWorkflow()
+        await comfyPage.workflow.loadGraphData(serialized)
+        await comfyPage.vueNodes.waitForNodes()
+      }
+
+      // The fixture ships this widget empty on the host AND on the interior
+      // CLIPTextEncode, so "empty after a round-trip" is also satisfied by a
+      // reset to that default. Round-tripping a non-empty value first is what
+      // lets the second one tell the two apart: if the clear is dropped as
+      // falsy, the reload brings this string back instead of an empty one.
+      const baseline = 'promoted value that must be cleared'
+      await promotedTextbox().fill(baseline)
+      await expect(promotedTextbox()).toHaveValue(baseline)
+
+      await roundTrip()
+      await expect(promotedTextbox()).toHaveValue(baseline)
+
+      await promotedTextbox().fill('')
+      await expect(promotedTextbox()).toHaveValue('')
+
+      await roundTrip()
+      await expect(promotedTextbox()).toHaveValue('')
+    })
   }
 )

--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -63,11 +63,6 @@ test.describe(
         await comfyPage.vueNodes.waitForNodes()
       }
 
-      // The fixture ships this widget empty on the host AND on the interior
-      // CLIPTextEncode, so "empty after a round-trip" is also satisfied by a
-      // reset to that default. Round-tripping a non-empty value first is what
-      // lets the second one tell the two apart: if the clear is dropped as
-      // falsy, the reload brings this string back instead of an empty one.
       const baseline = 'promoted value that must be cleared'
       await promotedTextbox().fill(baseline)
       await expect(promotedTextbox()).toHaveValue(baseline)


### PR DESCRIPTION
## Summary

Clearing a **promoted** text widget and reloading is an unchecked row in the ECS migration
test plan (Area 3, "Clear a promoted text widget (empty it), save, reload. It is still empty —
not reset to a default"). Nothing in the suite asserts it.

The closest existing spec — `an emptied text widget remains empty after save and reopen`, in
this same file — clears a **plain** widget. A promoted widget serializes through the subgraph
host instead, and an empty string is exactly the value a falsy check drops on the way there.

## What it does

1. Load `subgraphs/subgraph-with-promoted-text-widget`.
2. Fill the promoted textbox with a non-empty value, round-trip, assert it came back.
3. Clear it, round-trip again, assert it is still empty.

The round-trip is `getExportedWorkflow()` → `loadGraphData()`, the same shape
`comboWidget.spec.ts` and `floatWidget.spec.ts` already use for this question.

## Why step 2 is not redundant

The fixture ships this widget empty (`widgets_values: ['']` on both the host and the interior
`CLIPTextEncode`). So "empty after a round-trip" on its own is vacuous — a reset to the
interior default satisfies the assertion just as well as a correctly preserved empty value.

Round-tripping a non-empty value first fixes that, and does two jobs at once:

- **Control.** If promoted text were not surviving serialization at all, step 2 fails, so a
  green run means the mechanism is live rather than silently absent.
- **Discrimination.** It gives the final assertion something else to come back as. If the
  clear is dropped as falsy, the widget reads `promoted value that must be cleared`, not `''`,
  and the test fails with the actual wrong value in the diff.

## Note on the earlier revision

The first version of this test used `waitForDraftIndexUpdatedSince` + a full page reload, and
timed out in CI at the wait. What I can state from the blob report is the observation, not the
cause: after `fill()` on a text widget, no `Comfy.Workflow.DraftIndex.v2:*` entry reported an
`updatedAt` newer than the edit inside the 45 s timeout, while the structural mutations in
`collapse.spec.ts` and `resize.spec.ts` do satisfy the same wait. Focus is still in the
textarea at that point, so a commit-on-blur checkpoint would explain it, but I have not
confirmed that and am not claiming it.

Either way it is a separate question from this row — serialization is the layer the plan row
concerns — so the test now uses the round-trip helper the sibling widget specs use.

## Test plan

```
$ pnpm exec playwright test --list browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
  [chromium] › … › an emptied promoted text widget stays empty across a round-trip

$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts               # exit 0
```

Test-only change; no source files touched.
