### PR TITLE
[DISPOSABLE] Verify #17526 test and tooling scope

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -134,7 +134,8 @@
         "allowInterfaces": "always"
       }
     ],
-    "vue/no-import-compiler-macros": "error"
+    "vue/no-import-compiler-macros": "error",
+    "no-debugger": "error"
   },
   "overrides": [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ Object.assign(globalThis, {
 
 const maybeLocalOptions: PlaywrightTestConfig = process.env.PLAYWRIGHT_LOCAL
   ? {
-      timeout: 30_000,
+      timeout: 31_000,
       retries: 0,
       workers: 1,
       use: {


### PR DESCRIPTION
Disposable verification fixture for #17526. **DO NOT MERGE.**

Changes only Playwright timeout and lint configuration.

Expected: neutral `not-applicable` for both `risk:high` and `risk:medium`, even while an intentionally failing metadata check exists. The synthetic failure is part of verification, not a product test failure.

Candidate: `e17f329bc54a5cb56038e18a16a74c5fdcd3091e`. The temporary runner executes that pinned policy, never this fixture's code. This PR will be closed after recording evidence.

Created by Codex
