### PR TITLE
[DISPOSABLE] Verify #17526 mixed tooling and runtime scope

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -134,7 +134,8 @@
         "allowInterfaces": "always"
       }
     ],
-    "vue/no-import-compiler-macros": "error"
+    "vue/no-import-compiler-macros": "error",
+    "no-debugger": "error"
   },
   "overrides": [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ Object.assign(globalThis, {
 
 const maybeLocalOptions: PlaywrightTestConfig = process.env.PLAYWRIGHT_LOCAL
   ? {
-      timeout: 30_000,
+      timeout: 31_000,
       retries: 0,
       workers: 1,
       use: {

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -23,7 +23,10 @@ export function useKeybindingService() {
 
     const target = event.composedPath()[0] as HTMLElement
     // Let the active menu own Escape without also triggering the global shortcut.
-    if (event.key === 'Escape' && target.closest('[role="menu"]')) {
+    if (
+      event.key === 'Escape' &&
+      target.closest('[role="menu"], [role="menubar"]')
+    ) {
       return
     }
 


### PR DESCRIPTION
Disposable verification fixture for #17526. **DO NOT MERGE.**

Combines the tooling fixture with the Escape menubar runtime fix from #17309.

Expected: neutral `review-required` for both `risk:high` and `risk:medium`, even while an intentionally failing metadata check exists. The synthetic failure is part of verification, not a product test failure.

Candidate: `e17f329bc54a5cb56038e18a16a74c5fdcd3091e`. The temporary runner executes that pinned policy, never this fixture's code. This PR will be closed after recording evidence.

Created by Codex
