### PR TITLE
[DISPOSABLE] Verify #17526 high-risk runtime without a flag

### DIFF
--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -705,7 +705,7 @@ export const workspaceApi = {
     try {
       const response = await workspaceApiClient.get<BillingOpStatusResponse>(
         workspaceApiUrl(`/billing/ops/${encodeURIComponent(opId)}`),
-        { headers, timeout: 30_000 }
+        { headers, timeout: 31_000 }
       )
       return response.data
     } catch (err) {


### PR DESCRIPTION
Disposable verification fixture for #17526. **DO NOT MERGE.**

Changes a billing API request timeout without declaring a feature flag.

Expected: neutral `needs-flag` for both `risk:high` and `risk:medium`, even while an intentionally failing metadata check exists. The synthetic failure is part of verification, not a product test failure.

Candidate: `e17f329bc54a5cb56038e18a16a74c5fdcd3091e`. The temporary runner executes that pinned policy, never this fixture's code. This PR will be closed after recording evidence.

Created by Codex
