### PR TITLE
fix(agent): honour Retry-After for funds_unavailable admission denials

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5288,6 +5288,7 @@
     "friend": "there",
     "sendFailed": "Message failed to send",
     "sendBusy": "A message is already being sent",
+    "retryAfterSeconds": "You can try again in {seconds}s.",
     "malformedEvent": "The agent sent an event this panel could not read",
     "coachTitle": "Meet the agent",
     "coachBody": "Ask it to build or edit graphs.",

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
@@ -469,6 +469,55 @@ describe('AgentMessage fallback content', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Could not publish')
   })
 
+  it('renders a retry-after hint on an error notice that carries retryAfterSeconds', () => {
+    const message: AssistantMessage = {
+      ...thinkingMessage(),
+      streaming: false,
+      thinking: false,
+      parts: [
+        {
+          type: 'notice',
+          level: 'error',
+          text: 'Billing status is temporarily unavailable; please retry.',
+          retryAfterSeconds: 30
+        }
+      ]
+    }
+
+    render(AgentMessage, {
+      props: { message },
+      global: { plugins: [i18n] }
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent(
+      'Billing status is temporarily unavailable; please retry.'
+    )
+    expect(alert).toHaveTextContent('You can try again in 30s.')
+  })
+
+  it('omits the retry-after hint when the notice has no retryAfterSeconds', () => {
+    const message: AssistantMessage = {
+      ...thinkingMessage(),
+      streaming: false,
+      thinking: false,
+      parts: [
+        {
+          type: 'notice',
+          level: 'error',
+          text: 'This workspace is blocked. Contact support to restore access.'
+        }
+      ]
+    }
+
+    render(AgentMessage, {
+      props: { message },
+      global: { plugins: [i18n] }
+    })
+
+    expect(screen.queryByText(/try again in/i)).not.toBeInTheDocument()
+  })
+
   it('hides completed thinking when the response did not use tools', () => {
     const message: AssistantMessage = {
       ...thinkingMessage(),

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
@@ -186,7 +186,19 @@ const status = computed(() => {
         "
       >
         <span class="mt-0.5 icon-[lucide--triangle-alert] size-4 shrink-0" />
-        <span>{{ group.part.text }}</span>
+        <span class="flex flex-col gap-0.5">
+          <span>{{ group.part.text }}</span>
+          <span
+            v-if="group.part.retryAfterSeconds !== undefined"
+            class="text-agent-fg-muted text-xs"
+          >
+            {{
+              t('agent.retryAfterSeconds', {
+                seconds: group.part.retryAfterSeconds
+              })
+            }}
+          </span>
+        </span>
       </div>
     </template>
 

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -188,7 +188,8 @@ type AgentAdmissionReason = AgentAdmissionError['error']['reason']
 
 function admissionError(
   reason: AgentAdmissionReason,
-  message: string
+  message: string,
+  retryAfterSeconds?: number
 ): AgentApiError {
   const serviceUnavailable = reason === 'funds_unavailable'
   const body = zAgentAdmissionError.parse({
@@ -198,7 +199,12 @@ function admissionError(
       reason
     }
   })
-  return new AgentApiError(message, serviceUnavailable ? 503 : 402, body)
+  return new AgentApiError(
+    message,
+    serviceUnavailable ? 503 : 402,
+    body,
+    retryAfterSeconds
+  )
 }
 
 describe('useAgentSession (v1 composition root)', () => {
@@ -637,6 +643,56 @@ describe('useAgentSession (v1 composition root)', () => {
       role: 'assistant',
       parts: [{ type: 'notice', level: 'error', text: message }]
     })
+  })
+
+  it('carries retryAfterSeconds through on a funds_unavailable denial so the UI can honour Retry-After', async () => {
+    const message = 'Billing status is temporarily unavailable; please retry.'
+    const postMessage = vi
+      .fn<
+        (threadId: string, req: PostMessageInput) => Promise<AgentTurnAccepted>
+      >()
+      .mockRejectedValue(admissionError('funds_unavailable', message, 30))
+    const session = useAgentSession({
+      rest: fakeRest({ postMessage }),
+      events: fakeEvents().source
+    })
+    session.start()
+
+    expect(await session.sendMessage('make a cat')).toBe(false)
+    expect(session.entries.value.at(-1)).toMatchObject({
+      role: 'assistant',
+      parts: [
+        { type: 'notice', level: 'error', text: message, retryAfterSeconds: 30 }
+      ]
+    })
+  })
+
+  it('never attaches retryAfterSeconds to a manual_block denial, even if the transport carried one', async () => {
+    const message =
+      'This workspace is blocked. Contact support to restore access.'
+    const postMessage = vi
+      .fn<
+        (threadId: string, req: PostMessageInput) => Promise<AgentTurnAccepted>
+      >()
+      // A 402 has no standard Retry-After semantics; assert the reason gate,
+      // not merely the header's absence, in case a proxy ever forwards one.
+      .mockRejectedValue(admissionError('manual_block', message, 30))
+    const session = useAgentSession({
+      rest: fakeRest({ postMessage }),
+      events: fakeEvents().source
+    })
+    session.start()
+
+    expect(await session.sendMessage('make a cat')).toBe(false)
+    const notice = session.entries.value.at(-1)
+    expect(notice).toMatchObject({
+      role: 'assistant',
+      parts: [{ type: 'notice', level: 'error', text: message }]
+    })
+    expect(
+      (notice as { parts: Array<{ retryAfterSeconds?: number }> }).parts[0]
+        .retryAfterSeconds
+    ).toBeUndefined()
   })
 
   it('does not infer no_funds from a 402 without an admission reason', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -340,10 +340,21 @@ export function useAgentSession(deps: AgentSessionDeps) {
         return false
       }
       if (admission !== undefined) {
+        // `funds_unavailable` is a transient billing-lookup failure (503) the
+        // server asks the client to retry after a delay; `manual_block` is a
+        // deliberate 402 with no retry semantics. Only the former carries
+        // `retryAfterSeconds` through, so the UI never implies a countdown
+        // for an operator-imposed block. See FE-2005.
+        const retryAfterSeconds =
+          admission.reason === 'funds_unavailable' &&
+          error instanceof AgentApiError
+            ? error.retryAfterSeconds
+            : undefined
         conversationStore.recordFailedSend(
           nextLocalErrorId(),
           text,
-          admission.message
+          admission.message,
+          retryAfterSeconds
         )
         return false
       }

--- a/src/workbench/extensions/agent/services/agent/agentMessageParts.ts
+++ b/src/workbench/extensions/agent/services/agent/agentMessageParts.ts
@@ -28,6 +28,14 @@ export interface NoticePart {
   type: 'notice'
   level: 'info' | 'warning' | 'error'
   text: string
+  /**
+   * Seconds the server asked the client to wait before retrying (parsed from
+   * a `Retry-After` response header), e.g. on `funds_unavailable` admission
+   * denials. Presentation-only - the caller decides whether/how to honour it
+   * (countdown, disabled input, auto-retry); never implies a scheduled retry
+   * on its own.
+   */
+  retryAfterSeconds?: number
 }
 
 export interface TabLinkPart {

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
@@ -100,10 +100,11 @@ export const useAgentConversationStore = defineStore(
     function recordFailedSend(
       turnId: TurnId,
       text: string,
-      noticeText: string
+      noticeText: string,
+      retryAfterSeconds?: number
     ): void {
       recordSettledReply(turnId, text, [
-        { type: 'notice', level: 'error', text: noticeText }
+        { type: 'notice', level: 'error', text: noticeText, retryAfterSeconds }
       ])
     }
 


### PR DESCRIPTION
## Summary

`AgentAdmissionError.reason` already branched `no_funds` into the paywall path in `useAgentSession.ts`, but `manual_block` and `funds_unavailable` were collapsed into one identical treatment: the server-provided `message` was shown either way, and the already-parsed `Retry-After` header (`AgentApiError.retryAfterSeconds`) was discarded. Per [FE-2005](https://linear.app/comfyorg/issue/FE-2005/fe-main-has-no-branching-for-agentadmissionerrorreason-no-funds-manual)'s acceptance criteria, `funds_unavailable` (a transient 503 billing-lookup failure) should honour `Retry-After`; `manual_block` (a deliberate, non-retryable 402) should not.

## Changes

- `agentMessageParts.ts`: `NoticePart` gains an optional `retryAfterSeconds` (presentation-only).
- `agentConversationStore.ts`: `recordFailedSend` forwards it.
- `useAgentSession.ts`: only sets `retryAfterSeconds` when `admission.reason === 'funds_unavailable'`, gated on the error actually being an `AgentApiError`; `manual_block` is unaffected.
- `AgentMessage.vue`: renders a small "you can try again in Ns" hint under the notice text when `retryAfterSeconds` is present.
- `src/locales/en/main.json`: new `agent.retryAfterSeconds` string.
- Tests added to `useAgentSession.test.ts` and `AgentMessage.test.ts` covering both the presence and the absence of the hint.

## Scope note

This PR does not add new `no_funds` / `manual_block` / `funds_unavailable` reason branching from scratch — that already exists on `main` (paywall for `no_funds`, generic notice for the other two, with a passing negative test that a `402` without an admission `reason` is never inferred as `no_funds`). The literal, verified gap against the ticket's Gherkin acceptance criteria is the missing `Retry-After` honouring for `funds_unavailable`, which this PR adds.

## Testing

Focused Vitest (all passing):
```
useAgentSession.test.ts        (102 tests)
agentConversationStore.test.ts
AgentMessage.test.ts           (21 tests)
```
Full-repo `vue-tsc --noEmit` also passes clean with these changes (run with an increased Node heap due to shared-worker memory pressure at review time; unrelated to this diff).

Draft PR — do not merge.
