### PR TITLE
test(agent): cover PM-655 canvas edits between turns

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1628,6 +1628,71 @@ describe('AgentPanelRoot canvas draft on send', () => {
     expect(prepareForSave).toHaveBeenCalledOnce()
   })
 
+  it('T-03 / PM-655 sends the edited visible graph on the next turn', async () => {
+    const messageBodies: unknown[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('/messages') && init?.method === 'POST') {
+          messageBodies.push(JSON.parse(String(init.body)))
+          return json(202, ack('wf-edited', `m-${messageBodies.length}`))
+        }
+        if (url.includes('/assets'))
+          return json(200, { assets: [], total: 0, has_more: false })
+        if (url.includes('/workflows'))
+          return json(200, {
+            data: [{ id: 'wf-edited', name: 'edited-between-turns' }],
+            pagination: {
+              offset: 0,
+              limit: 100,
+              total: 1,
+              has_more: false
+            }
+          })
+        return json(200, agentThreadList())
+      })
+    )
+
+    let visibleGraph = fromPartial<ComfyWorkflowJSON>({
+      nodes: [{ id: 1, type: 'LoadImage' }],
+      links: []
+    })
+    const activeWorkflow = addTab('workflows/edited-between-turns.json', {
+      activeState: visibleGraph
+    })
+    activeWorkflow.changeTracker = createMockChangeTracker({
+      prepareForSave: vi.fn(() => {
+        activeWorkflow.activeState = visibleGraph
+      })
+    })
+    workflowStore.activeWorkflow = activeWorkflow
+
+    renderWithSelectedTarget()
+    await sendFromComposer('first question')
+    expect(messageBodies[0]).toMatchObject({
+      draft: { content: visibleGraph }
+    })
+
+    ws.emit('agent_message_done', {
+      message_id: 'm-1',
+      thread_id: 'th-1'
+    })
+    visibleGraph = fromPartial<ComfyWorkflowJSON>({
+      nodes: [
+        { id: 1, type: 'LoadImage' },
+        { id: 2, type: 'KSampler' }
+      ],
+      links: [[1, 1, 0, 2, 0, 'IMAGE']]
+    })
+
+    await sendFromComposer('what changed?')
+
+    expect(messageBodies[1]).toMatchObject({
+      content: 'what changed?',
+      draft: { content: visibleGraph }
+    })
+  })
+
   it('does not send or clear the prompt when there is no selected target', async () => {
     const messageBodies: unknown[] = []
     vi.stubGlobal(


### PR DESCRIPTION
<!-- authored-by:agent relaunch-lin-PM-655-c17 -->
- Adds the missing PM-655 integration regression.
- Verifies a second turn sends the graph visible after a manual edit.
- Test-only change; no runtime behavior changed.

<details><summary>Full context for agent readers</summary>

The component-level integration test renders `AgentPanelRoot`, sends one turn, completes it, updates the visible workflow through the production `changeTracker.prepareForSave()` seam, and sends again. It compares the second outbound `draft.content` with the edited graph, including the newly added node and link.

Linear: https://linear.app/comfyorg/issue/PM-655/t-03-fe-1311-surface-correct-canvas-state

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/AgentPanelRoot.test.ts` — 215 passed
- `pnpm typecheck` — passed
- `pnpm exec eslint src/workbench/extensions/agent/AgentPanelRoot.test.ts` — passed
- `pnpm exec oxfmt --check src/workbench/extensions/agent/AgentPanelRoot.test.ts` — passed after formatting
- Head: `d9c3571954c5270bd184ec2cada2a8ca9a71eefe`

Glossary: canvas state = serialized visible workflow; draft = per-turn graph snapshot sent to the agent.

</details>