### PR TITLE
fix: enforce import-x/no-named-as-default

### DIFF
--- a/apps/website/src/config/workshop-json-schema.ts
+++ b/apps/website/src/config/workshop-json-schema.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv'
+import { Ajv } from 'ajv'
 import type { ValidateFunction } from 'ajv'
 import addFormats from 'ajv-formats'
 import { isHttpImageSource } from './workshop-image-source'

--- a/apps/website/src/scripts/gsapSetup.ts
+++ b/apps/website/src/scripts/gsapSetup.ts
@@ -1,4 +1,4 @@
-import gsap from 'gsap'
+import { gsap } from 'gsap'
 import { ScrollToPlugin } from 'gsap/ScrollToPlugin'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 

--- a/apps/website/src/scripts/posthog.test.ts
+++ b/apps/website/src/scripts/posthog.test.ts
@@ -32,7 +32,7 @@ const postHogMock = {
 // The real default export carries 130+ members, so only the boundary handoff
 // is asserted; the shape itself is checked against PostHogMock above.
 vi.mock(import('posthog-js'), () => ({
-  default: postHogMock as unknown as typeof PostHogModule.default
+  posthog: postHogMock as unknown as typeof PostHogModule.posthog
 }))
 
 /** Fire the callback PostHog registered with onFeatureFlags. */

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -1,4 +1,4 @@
-import posthog from 'posthog-js'
+import { posthog } from 'posthog-js'
 import { readonly, ref } from 'vue'
 import type { Ref } from 'vue'
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -275,6 +275,7 @@ export default defineConfig([
       '@typescript-eslint/consistent-type-imports': 'error',
       'import-x/no-useless-path-segments': 'error',
       'import-x/no-relative-packages': 'error',
+      'import-x/no-named-as-default': 'error',
       'unused-imports/no-unused-imports': 'error',
       'vue/no-v-html': 'off',
       // Prohibit dark-theme: and dark: prefixes

--- a/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/InlinePromptEditor.vue
@@ -6,7 +6,7 @@ import { keymap } from '@tiptap/pm/keymap'
 import { EditorState, TextSelection } from '@tiptap/pm/state'
 import { Decoration, DecorationSet, EditorView } from '@tiptap/pm/view'
 import { onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
-import DOMPurify from 'dompurify'
+import { default as DOMPurify } from 'dompurify'
 import { useI18n } from 'vue-i18n'
 
 import type { PromptEditor } from '../../../types/promptEditor'


### PR DESCRIPTION
## Summary

Promote `import-x/no-named-as-default` to error after fixing all four warnings on main.

## Changes

- Use equivalent named exports for Ajv, GSAP, and PostHog; update the existing PostHog mock export.
- Retain DOMPurify’s runtime default using the existing explicit-default import convention. Its named `DOMPurify` export is type-only.
- Add one ESLint severity setting. No other rules, exclusions, dependencies, or runtime initialization change.

## Review Focus

Verified upstream contracts and installed Ajv 8.20.0, GSAP 3.15.0, and PostHog 1.402.3 export identity across their relevant CJS/ESM entry points. DOMPurify keeps the same default instance.

Validation: full `pnpm lint` passed; ESLint scanned 4,544 files with zero rule violations and zero errors, leaving 235 unrelated warnings. A stdin violation probe returned severity 2 and exit 1. Frontend/account and website typechecks, formatter, Knip, normal commit/push hooks, 93 composer tests, and 1,437 website tests passed. No UI appearance changes.