### PR TITLE
test(credits): pricing badge hides and returns when the setting is toggled

### DIFF
--- a/browser_tests/tests/creditHelpers.spec.ts
+++ b/browser_tests/tests/creditHelpers.spec.ts
@@ -227,9 +227,7 @@ testWithMockedObjectInfo.describe(
         )
         await expect(badge).toBeHidden()
 
-        // Turning it back on must restore the badge on the *same* node. The
-        // setting is read once when the badge renders, so a node placed before
-        // the toggle is exactly the case that can end up stuck either way.
+        // Derived badge rows for an existing node must react to live setting changes.
         await comfyPage.settings.setSetting(
           'Comfy.NodeBadge.ShowApiPricing',
           true

--- a/browser_tests/tests/creditHelpers.spec.ts
+++ b/browser_tests/tests/creditHelpers.spec.ts
@@ -205,18 +205,16 @@ testWithMockedObjectInfo.describe(
 
         await comfyPage.nodeOps.clearGraph()
 
-        const nodeId = await comfyPage.page.evaluate(() => {
+        await comfyPage.page.evaluate(() => {
           const node = window.LiteGraph!.createNode('TestCreditApiNodeUsd')
           window.app!.graph.add(node)
-          return node!.id
         })
         await comfyPage.nextFrame()
 
-        const header = comfyPage.page.locator(
-          `[data-testid="node-header-${nodeId}"]`
-        )
+        const { header, priceBadge } =
+          await comfyPage.vueNodes.getFixtureByTitle('Test Credit API Node USD')
         await expect(header).toBeVisible()
-        const badge = header.getByTestId('credit-badge-required')
+        const badge = priceBadge.required
 
         // Precondition: there is a badge to hide. Without it, "hidden after
         // turning the setting off" also holds for a node that never rendered

--- a/browser_tests/tests/creditHelpers.spec.ts
+++ b/browser_tests/tests/creditHelpers.spec.ts
@@ -210,6 +210,7 @@ testWithMockedObjectInfo.describe(
           window.app!.graph.add(node)
           return node!.id
         })
+        await comfyPage.nextFrame()
 
         const header = comfyPage.page.locator(
           `[data-testid="node-header-${nodeId}"]`

--- a/browser_tests/tests/creditHelpers.spec.ts
+++ b/browser_tests/tests/creditHelpers.spec.ts
@@ -233,7 +233,6 @@ testWithMockedObjectInfo.describe(
           true
         )
         await expect(badge).toBeVisible()
-        await expect(header).toBeVisible()
       }
     )
   }

--- a/browser_tests/tests/creditHelpers.spec.ts
+++ b/browser_tests/tests/creditHelpers.spec.ts
@@ -193,5 +193,51 @@ testWithMockedObjectInfo.describe(
           .toContain('4.2/10.6')
       }
     )
+
+    testWithMockedObjectInfo(
+      'hides and restores the pricing badge on an existing node when the setting is toggled',
+      { tag: '@vue-nodes' },
+      async ({ comfyPage }) => {
+        await comfyPage.settings.setSetting(
+          'Comfy.NodeBadge.ShowApiPricing',
+          true
+        )
+
+        await comfyPage.nodeOps.clearGraph()
+
+        const nodeId = await comfyPage.page.evaluate(() => {
+          const node = window.LiteGraph!.createNode('TestCreditApiNodeUsd')
+          window.app!.graph.add(node)
+          return node!.id
+        })
+
+        const header = comfyPage.page.locator(
+          `[data-testid="node-header-${nodeId}"]`
+        )
+        await expect(header).toBeVisible()
+        const badge = header.getByTestId('credit-badge-required')
+
+        // Precondition: there is a badge to hide. Without it, "hidden after
+        // turning the setting off" also holds for a node that never rendered
+        // one, which is the way this test would pass vacuously.
+        await expect(badge).toBeVisible()
+
+        await comfyPage.settings.setSetting(
+          'Comfy.NodeBadge.ShowApiPricing',
+          false
+        )
+        await expect(badge).toBeHidden()
+
+        // Turning it back on must restore the badge on the *same* node. The
+        // setting is read once when the badge renders, so a node placed before
+        // the toggle is exactly the case that can end up stuck either way.
+        await comfyPage.settings.setSetting(
+          'Comfy.NodeBadge.ShowApiPricing',
+          true
+        )
+        await expect(badge).toBeVisible()
+        await expect(header).toBeVisible()
+      }
+    )
   }
 )


### PR DESCRIPTION
## Summary

ECS 1.53 Area 8: *"In Settings → Comfy → API Nodes, turn **Show API node pricing badge** off
and on → verify the pricing badge disappears and returns on the same API node."* Nothing in
the suite turns that setting off.

All four existing tests in `creditHelpers.spec.ts` set `Comfy.NodeBadge.ShowApiPricing` to
`true` and assert a badge renders. They cover the formats (USD, range, list); they do not cover
the setting being a setting.

## Why the node is placed *before* the toggle

That is the case that proves derived badge rows on an existing node react to live setting
changes. A test that toggles first and places the node afterwards would only verify
construction-time behavior.

## Why the visible assertion comes first

`toBeHidden()` on its own is satisfied by a node that never rendered a badge — a broken mock,
a changed testid, an API node that stopped being recognised as one. Asserting the badge is
visible before turning the setting off makes the hidden assertion mean what it says. The final
`toBeVisible()` on the badge proves it returns after the live setting change.

## Scope

Vue nodes only, and the tag says so. The legacy renderer draws badges onto the canvas, where
there is no DOM node to assert visibility on, so the plan's "both renderers" would need a
screenshot comparison rather than this assertion — a different test, not a wider version of
this one.

## Test plan

```
$ pnpm exec playwright test --list browser_tests/tests/creditHelpers.spec.ts
  [chromium] › …:197:5 › Credit helper pricing badges › hides and restores the pricing badge on an existing node when the setting is toggled
Total: 5 tests in 1 file

$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/creditHelpers.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/creditHelpers.spec.ts               # exit 0
```

Test-only change; no source files touched. Reuses the file's existing mocked `object_info`
fixture, so no new asset.