### PR TITLE
test(keyboard): redo past the end of the history is a no-op

### DIFF
--- a/browser_tests/tests/keyboardShortcutActions.spec.ts
+++ b/browser_tests/tests/keyboardShortcutActions.spec.ts
@@ -40,6 +40,56 @@ test.describe('Keyboard shortcut actions', { tag: '@keyboard' }, () => {
     })
   })
 
+  test('A second Ctrl+Shift+Z past the end of the history changes nothing', async ({
+    comfyPage
+  }) => {
+    // Every node's position, not just the dragged one: a redo that re-applies
+    // its delta to the wrong node would leave the dragged node correct and be
+    // invisible to a single-node comparison.
+    const positions = () =>
+      comfyPage.page.evaluate(() =>
+        Object.fromEntries(
+          window.app!.graph.nodes.map((node) => [
+            String(node.id),
+            [...node.pos]
+          ])
+        )
+      )
+
+    const before = await positions()
+    expect(
+      Object.keys(before).length,
+      'Default graph should have nodes'
+    ).toBeGreaterThan(0)
+
+    const node = await comfyPage.nodeOps.getNodeRefByTitle('KSampler')
+    await node.dragBy({ x: 96, y: 64 })
+    await expect.poll(positions).not.toEqual(before)
+    const moved = await positions()
+
+    await comfyPage.canvas.click()
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    await expect.poll(positions).toEqual(before)
+
+    // The first redo restores the move. It is also the control for the two
+    // assertions below: it proves the keystroke reaches the app and that a redo
+    // with something on the stack visibly changes the graph.
+    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+    await expect.poll(positions).toEqual(moved)
+
+    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+    await comfyPage.nextFrame()
+    expect(await positions(), 'Redo past the end must be a no-op').toEqual(
+      moved
+    )
+
+    // And it must not have pushed an entry of its own. If it had, one undo
+    // would land on an intermediate state instead of the pre-drag one — which
+    // "positions are unchanged" above cannot distinguish on its own.
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    await expect.poll(positions).toEqual(before)
+  })
+
   test('Ctrl+S opens save dialog', async ({ comfyPage }) => {
     await comfyPage.canvas.click()
     await comfyPage.page.keyboard.press('ControlOrMeta+s')


### PR DESCRIPTION
## Summary

ECS 1.53 Area 2: *"Move a node, press Ctrl+Z, then Ctrl+Shift+Z **twice** → verify the first
redo restores the moved position and the second redo changes nothing."*

The existing test in this file — `Ctrl+Z undoes and Ctrl+Shift+Z redoes the last graph change`
— covers add → undo → **one** redo, and only by node count. Redoing past the end of the stack
is untested, and that is where a redo pointer over-applies.

## What it asserts

1. Drag `KSampler`, undo, assert every position is back to pre-drag.
2. Redo once → positions are back to the moved state.
3. Redo again → positions are **still** the moved state.
4. Undo once → positions are back to pre-drag.

## Why each guard is there

- **Every node's position, not the dragged one.** A redo that re-applies its delta to the
  wrong node leaves `KSampler` correct, so a single-node comparison would not see it. The
  snapshot is `{id: [x, y]}` over the whole graph, compared with `toEqual`.
- **Step 2 is the control for step 3.** "Nothing changed" passes trivially if the keystroke
  never reached the app — a focus problem, a keybinding rename. The first redo uses the same
  keystroke and has a visible effect, so a green run means the key works and the second press
  genuinely had nothing to apply.
- **Step 4 is the second discriminator.** Unchanged positions cannot tell "the redo did
  nothing" from "the redo did nothing visible but pushed a history entry". If an entry had been
  pushed, one undo would land on an intermediate state rather than the pre-drag one.

## Test plan

```
$ pnpm exec playwright test --list browser_tests/tests/keyboardShortcutActions.spec.ts
  [chromium] › …:43:3 › Keyboard shortcut actions › A second Ctrl+Shift+Z past the end of the history changes nothing
Total: 6 tests in 1 file

$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/keyboardShortcutActions.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/keyboardShortcutActions.spec.ts               # exit 0
```

Test-only change; no source files touched. Uses the default workflow, so no new asset.
