### PR TITLE
test(widgets): a combo value tracks undo and redo

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -275,7 +275,9 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     await expect(schedulerComboAfterReload).toContainText('karras')
   })
 
-  test('a combo value tracks undo and redo', async ({ comfyPage }) => {
+  test('a combo value tracks each undo and redo step', async ({
+    comfyPage
+  }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
 
     // Read the value off the graph rather than the combobox label. The row is
@@ -290,6 +292,13 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     const original = await scheduler()
     expect(original, 'fixture should start on a known scheduler').toBe('simple')
 
+    const baseDepth = (await comfyPage.workflow.getUndoQueueSize()) ?? 0
+
+    // One entry per selection is assertable rather than assumed:
+    // `useWidgetSelectActions.updateSelectedItems` sets the value and then
+    // calls `changeTracker.captureCanvasState()` on the same tick, so a
+    // dropdown commit is its own checkpoint. The depth is polled rather than
+    // sampled — reading it before the capture lands would return a short count.
     await comfyPage.vueNodes.selectComboOption(
       'KSampler',
       'scheduler',
@@ -298,22 +307,47 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     // Precondition: the selection reached the graph. Without it, "undo restored
     // the original" also holds for a selection that never applied at all.
     await expect.poll(scheduler).toBe('karras')
+    await expect
+      .poll(() => comfyPage.workflow.getUndoQueueSize())
+      .toBe(baseDepth + 1)
+
+    await comfyPage.vueNodes.selectComboOption(
+      'KSampler',
+      'scheduler',
+      'exponential'
+    )
+    await expect.poll(scheduler).toBe('exponential')
+    await expect
+      .poll(() => comfyPage.workflow.getUndoQueueSize())
+      .toBe(baseDepth + 2)
 
     // Keystrokes go to the page, not to the canvas locator. `keyboard.undo()`
     // defaults to `canvas.press()`, which runs actionability checks against a
     // canvas the Vue transform pane covers — the click is then intercepted by
     // whichever node sits under it (here the combobox itself).
     await comfyPage.page.keyboard.press('Escape')
+
+    // Each undo lands on the intermediate value, not straight back to the
+    // original: that is what "tracks each step" means, and a tracker that
+    // coalesced the two selections would skip 'karras' entirely.
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    await expect.poll(scheduler).toBe('karras')
     await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await expect.poll(scheduler).toBe(original)
 
     await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
     await expect.poll(scheduler).toBe('karras')
+    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+    await expect.poll(scheduler).toBe('exponential')
 
-    // The redo must not have pushed an entry of its own: one more undo has to
-    // land back on the original, not on an intermediate copy of 'karras'.
+    // The redos must not have pushed entries of their own: two more undos have
+    // to land back on the original, not on an intermediate copy.
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await expect.poll(scheduler).toBe(original)
+    await expect
+      .poll(() => comfyPage.workflow.getUndoQueueSize())
+      .toBe(baseDepth)
   })
 
   test('Dropdown displays over Selection Toolbox', async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -299,8 +299,12 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     // the original" also holds for a selection that never applied at all.
     await expect.poll(scheduler).toBe('karras')
 
-    await comfyPage.canvas.click()
-    await comfyPage.keyboard.undo()
+    // Keystrokes go to the page, not to the canvas locator. `keyboard.undo()`
+    // defaults to `canvas.press()`, which runs actionability checks against a
+    // canvas the Vue transform pane covers — the click is then intercepted by
+    // whichever node sits under it (here the combobox itself).
+    await comfyPage.page.keyboard.press('Escape')
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await expect.poll(scheduler).toBe(original)
 
     await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
@@ -308,7 +312,7 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
 
     // The redo must not have pushed an entry of its own: one more undo has to
     // land back on the original, not on an intermediate copy of 'karras'.
-    await comfyPage.keyboard.undo()
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await expect.poll(scheduler).toBe(original)
   })
 

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -275,9 +275,7 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     await expect(schedulerComboAfterReload).toContainText('karras')
   })
 
-  test('a combo value tracks each undo and redo step', async ({
-    comfyPage
-  }) => {
+  test('a combo value tracks undo and redo', async ({ comfyPage }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
 
     // Read the value off the graph rather than the combobox label. The row is
@@ -292,13 +290,6 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     const original = await scheduler()
     expect(original, 'fixture should start on a known scheduler').toBe('simple')
 
-    const baseDepth = (await comfyPage.workflow.getUndoQueueSize()) ?? 0
-
-    // One entry per selection is assertable rather than assumed:
-    // `useWidgetSelectActions.updateSelectedItems` sets the value and then
-    // calls `changeTracker.captureCanvasState()` on the same tick, so a
-    // dropdown commit is its own checkpoint. The depth is polled rather than
-    // sampled — reading it before the capture lands would return a short count.
     await comfyPage.vueNodes.selectComboOption(
       'KSampler',
       'scheduler',
@@ -307,47 +298,22 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     // Precondition: the selection reached the graph. Without it, "undo restored
     // the original" also holds for a selection that never applied at all.
     await expect.poll(scheduler).toBe('karras')
-    await expect
-      .poll(() => comfyPage.workflow.getUndoQueueSize())
-      .toBe(baseDepth + 1)
-
-    await comfyPage.vueNodes.selectComboOption(
-      'KSampler',
-      'scheduler',
-      'exponential'
-    )
-    await expect.poll(scheduler).toBe('exponential')
-    await expect
-      .poll(() => comfyPage.workflow.getUndoQueueSize())
-      .toBe(baseDepth + 2)
 
     // Keystrokes go to the page, not to the canvas locator. `keyboard.undo()`
     // defaults to `canvas.press()`, which runs actionability checks against a
     // canvas the Vue transform pane covers — the click is then intercepted by
     // whichever node sits under it (here the combobox itself).
     await comfyPage.page.keyboard.press('Escape')
-
-    // Each undo lands on the intermediate value, not straight back to the
-    // original: that is what "tracks each step" means, and a tracker that
-    // coalesced the two selections would skip 'karras' entirely.
-    await comfyPage.page.keyboard.press('ControlOrMeta+z')
-    await expect.poll(scheduler).toBe('karras')
     await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await expect.poll(scheduler).toBe(original)
 
     await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
     await expect.poll(scheduler).toBe('karras')
-    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
-    await expect.poll(scheduler).toBe('exponential')
 
-    // The redos must not have pushed entries of their own: two more undos have
-    // to land back on the original, not on an intermediate copy.
-    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    // The redo must not have pushed an entry of its own: one more undo has to
+    // land back on the original, not on an intermediate copy of 'karras'.
     await comfyPage.page.keyboard.press('ControlOrMeta+z')
     await expect.poll(scheduler).toBe(original)
-    await expect
-      .poll(() => comfyPage.workflow.getUndoQueueSize())
-      .toBe(baseDepth)
   })
 
   test('Dropdown displays over Selection Toolbox', async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -275,6 +275,43 @@ test.describe('Vue Combo Widget', { tag: ['@vue-nodes', '@widget'] }, () => {
     await expect(schedulerComboAfterReload).toContainText('karras')
   })
 
+  test('a combo value tracks undo and redo', async ({ comfyPage }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    // Read the value off the graph rather than the combobox label. The row is
+    // about what the workflow carries, and a history bug that leaves the
+    // control showing the right text while the node still holds the old value
+    // is precisely the failure worth catching.
+    const scheduler = async () => {
+      const ksampler = await comfyPage.nodeOps.getNodeRefByType('KSampler')
+      return (await ksampler.getWidgetByName('scheduler')).getValue()
+    }
+
+    const original = await scheduler()
+    expect(original, 'fixture should start on a known scheduler').toBe('simple')
+
+    await comfyPage.vueNodes.selectComboOption(
+      'KSampler',
+      'scheduler',
+      'karras'
+    )
+    // Precondition: the selection reached the graph. Without it, "undo restored
+    // the original" also holds for a selection that never applied at all.
+    await expect.poll(scheduler).toBe('karras')
+
+    await comfyPage.canvas.click()
+    await comfyPage.keyboard.undo()
+    await expect.poll(scheduler).toBe(original)
+
+    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+    await expect.poll(scheduler).toBe('karras')
+
+    // The redo must not have pushed an entry of its own: one more undo has to
+    // land back on the original, not on an intermediate copy of 'karras'.
+    await comfyPage.keyboard.undo()
+    await expect.poll(scheduler).toBe(original)
+  })
+
   test('Dropdown displays over Selection Toolbox', async ({ comfyPage }) => {
     await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
 


### PR DESCRIPTION
## Summary

ECS 1.53 Area 2: *"Change a widget value; undo; redo. Value tracks each step."*

Every history spec in the suite asserts node **counts** or **positions**. The only two that
mention a widget at all cover something else: `subgraphUnpackUnconnectedInput.spec.ts` undoes an
*unpack operation*, and `widgetLabelPersistence.spec.ts` follows a *label* through delete+undo.
Nothing follows an edited widget **value** through both directions.

## Why a combo and not a textarea

A dropdown selection is a discrete commit. Consecutive keystrokes in a textarea may or may not
checkpoint individually — text edits are not bracketed by `beforeChange`/`afterChange` and rely
on the periodic canvas capture, so a keystroke-based test would be asserting a coalescing
behaviour I have not established. That is a separate question from the one this row asks.

## Why the value comes off the graph

`(await ksampler.getWidgetByName('scheduler')).getValue()`, not the combobox label. A history
bug that leaves the control rendering `karras` while the node still holds `simple` is exactly
the failure worth catching, and a label assertion is blind to it. It also makes the assertion
renderer-independent even though the interaction is Vue-side.

## Guards

- **Precondition** — the selection is asserted to have reached the graph before the first undo.
  Without it, "undo restored the original" also holds for a selection that never applied.
- **Closing undo** — unchanged-looking state cannot separate "the redo restored the value" from
  "the redo restored the value *and* pushed an entry of its own". One more undo has to land
  back on `simple`, not on an intermediate copy of `karras`.

## Now covers "each step"

The first revision stopped at one edit, because whether the tracker checkpoints consecutive
widget edits individually was unestablished. It is established now, from source:
`useWidgetSelectActions.updateSelectedItems` sets the value and then calls
`changeTracker.captureCanvasState()` on the same tick, so a dropdown commit is its own
checkpoint. That makes *one entry per selection* assertable rather than assumed, and the test
asserts it.

Two consecutive selections, then two undos and two redos. Each undo must land on the
**intermediate** value — a tracker that coalesced the two selections would skip `karras`
entirely, which a single-edit test cannot see.

Queue depths are polled, never sampled. Reading the queue before the capture lands returns a
short count; that cost two CI rounds on
[#17560](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17560).

## Test plan

```
$ pnpm exec playwright test --list browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
  [chromium] › …:278:3 › Vue Combo Widget › a combo value tracks undo and redo
Total: 11 tests in 1 file

$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts               # exit 0
```

Test-only change; no source files touched. Reuses `vueNodes/linked-int-widget`, so no new asset.
