### PR TITLE
fix(agent): cap CRDT debug report exports

### DIFF
--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -30,6 +30,7 @@ vi.mock(import('@/platform/telemetry/reportError'), () => ({
 
 import type { ReportIdentifiers, ReportSources } from './crdtDebugReport'
 import type { CrdtDebugSnapshot } from './crdtSnapshot'
+import type { DevEvent } from './devPanelLog'
 import { collectCrdtDebugReport } from './crdtDebugReport'
 
 const ALL_SOURCES: ReportSources = {
@@ -527,5 +528,45 @@ describe('collectCrdtDebugReport', () => {
     })
 
     expect(report).toContain('workflow omitted')
+  })
+
+  it('deterministically caps an oversized report without dropping its contract markers', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-12T00:00:00Z'))
+    const oversizedEvents: DevEvent[] = Array.from({ length: 4 }, (_, seq) => ({
+      seq,
+      at: seq,
+      kind: 'doc_update',
+      scope: 'doc',
+      level: 'info',
+      detail: { trace: '🧪'.repeat(80_000) }
+    }))
+
+    const first = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: oversizedEvents,
+      testerNote: 'n'.repeat(300_000)
+    })
+    const second = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: oversizedEvents,
+      testerNote: 'n'.repeat(300_000)
+    })
+
+    try {
+      expect(first.length).toBeLessThanOrEqual(256_000)
+      expect(second).toBe(first)
+      expect(first).toContain('report truncated')
+      expect(first).toContain(
+        'Report format version: 1 · Document schema version: 1'
+      )
+      expect(first).toContain('Schema version:** 1')
+      expect(first).toContain('[redacted by the debug report]')
+      expect(first).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -33,6 +33,7 @@ const MAX_LOG_CHARS = 40_000
 const MAX_WORKFLOW_CHARS = 200_000
 /** The event log and the stamp ledger both grow without bound with session length. */
 const MAX_SECTION_CHARS = 60_000
+const MAX_REPORT_CHARS = 256_000
 const MAX_REDACTION_DEPTH = 12
 const DEPTH_LIMIT_REDACTED = '[redacted at depth limit]'
 const SOURCE_TIMEOUT_MS = 5_000
@@ -253,7 +254,31 @@ function redactEventPayloads(value: unknown): unknown {
 
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text
-  return `…(${text.length - max} earlier characters trimmed)…\n${text.slice(-max)}`
+  const start = text.length - max
+  const safeStart =
+    text.charCodeAt(start) >= 0xdc00 && text.charCodeAt(start) <= 0xdfff
+      ? start + 1
+      : start
+  return `…(${safeStart} earlier characters trimmed)…\n${text.slice(safeStart)}`
+}
+
+function truncateReport(text: string): string {
+  if (text.length <= MAX_REPORT_CHARS) return text
+
+  const marker = `\n\n[report truncated to ${MAX_REPORT_CHARS} characters]\n\n`
+  const available = MAX_REPORT_CHARS - marker.length
+  const headLength = Math.floor(available * 0.75)
+  const tailStart = text.length - (available - headLength)
+  const safeHeadLength =
+    text.charCodeAt(headLength - 1) >= 0xd800 &&
+    text.charCodeAt(headLength - 1) <= 0xdbff
+      ? headLength - 1
+      : headLength
+  const safeTailStart =
+    text.charCodeAt(tailStart) >= 0xdc00 && text.charCodeAt(tailStart) <= 0xdfff
+      ? tailStart + 1
+      : tailStart
+  return `${text.slice(0, safeHeadLength)}${marker}${text.slice(safeTailStart)}`
 }
 
 type SystemStats = Awaited<ReturnType<typeof api.getSystemStats>>
@@ -380,6 +405,7 @@ function identifiersSection(identifiers: ReportIdentifiers): string {
 
 function crdtSection(crdt: CrdtDebugSnapshot): string {
   return [
+    `- **Schema version:** ${crdt.meta.schema_version ?? 'unknown'}`,
     `- **Enabled:** ${crdt.status.enabled}`,
     `- **Connected:** ${crdt.status.connected}`,
     `- **Doc id:** ${crdt.status.workflowId ?? 'none'}`,
@@ -432,6 +458,7 @@ export async function collectCrdtDebugReport(
   const sections: string[] = [
     '# ComfyUI Agent — CRDT debug report',
     `Generated ${new Date().toISOString()}`,
+    `Report format version: 1 · Document schema version: ${input.crdt.meta.schema_version ?? 'unknown'} · Redaction marker: ${REDACTED}`,
     '## Identifiers',
     'Paste this block into a bug report or search Datadog/logs by any of these fields.',
     identifiersSection(input.identifiers ?? EMPTY_REPORT_IDENTIFIERS)
@@ -474,7 +501,7 @@ export async function collectCrdtDebugReport(
 
   sections.push(
     '## CRDT event log',
-    `${SHARING_WARNING} Operation payload values are redacted; op ids and workflow ids appear verbatim.`,
+    `${SHARING_WARNING} Operation payload values appear as \`${REDACTED}\`; op ids and workflow ids appear verbatim.`,
     fence(
       'json',
       truncate(json(redactEventPayloads(input.events)), MAX_SECTION_CHARS)
@@ -528,5 +555,5 @@ export async function collectCrdtDebugReport(
         ].join('\n\n')
   )
 
-  return sections.join('\n\n')
+  return truncateReport(sections.join('\n\n'))
 }


### PR DESCRIPTION
## Summary

Caps copied CRDT debug reports at 256,000 characters while preserving the report contract header and Unicode validity.

## Changes

- **What**: Deterministically retains the first 75% and final 25% around a truncation marker; exposes report-format and document-schema versions plus the redaction sentinel in the retained header; makes section and report cuts surrogate-pair safe.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Please verify that the fixed header is sufficient for downstream parsers and that a character cap, rather than a UTF-8 byte cap, matches the clipboard export contract.

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts` — 25/25 passed.
- `pnpm typecheck` — passed on Node 26.8.2.
- Targeted ESLint and oxfmt checks — passed.
- Commit and push hooks — passed, including type-aware Oxlint, typecheck, and knip.

Linear: https://linear.app/comfyorg/issue/FE-2157/deliver-agent-diagnostics-telemetry-and-safe-exports

<!-- authored-by:agent gap-fe2157-export-size-cap-c17 -->