### PR TITLE
fix(account): keep cross-tab refresh failures from unwinding a committed credential

### DIFF
--- a/packages/account/src/core/refreshScheduler.ts
+++ b/packages/account/src/core/refreshScheduler.ts
@@ -127,26 +127,35 @@ export function createRefreshScheduler(
     teardownCoordination()
     coordinationKey = key
     const generationAtRequest = coordinationGeneration
-    stopCredentialFeed = crossTab.port.onCredential(
-      key,
-      adoptPublishedCredential
-    )
-    releaseLeadership = crossTab.port.requestLeadership(key, () => {
-      // A grant is honored only for the coordination generation that issued
-      // the request: abandoned requests can still win the grant race in the
-      // lock manager, and after a same-user round trip their key is
-      // byte-identical to the live request's.
-      if (generationAtRequest !== coordinationGeneration) return
+    // Cross-tab coordination is optional: a port that throws during setup
+    // must never propagate past a committed credential. Tear down whatever
+    // partial wiring landed and lead this tab on its own schedule.
+    try {
+      stopCredentialFeed = crossTab.port.onCredential(
+        key,
+        adoptPublishedCredential
+      )
+      releaseLeadership = crossTab.port.requestLeadership(key, () => {
+        // A grant is honored only for the coordination generation that issued
+        // the request: abandoned requests can still win the grant race in the
+        // lock manager, and after a same-user round trip their key is
+        // byte-identical to the live request's.
+        if (generationAtRequest !== coordinationGeneration) return
+        isRefreshLeader = true
+        // Promotion retakes the schedule unconditionally — the follower timer
+        // may be jittered, mid-retry, or already dead from exhausted retries.
+        // The latch skips the redundant re-arm when the grant fires
+        // synchronously inside armScheduledRefresh itself.
+        const live = host.getCredential()
+        if (live !== undefined && !armingScheduledRefresh) {
+          armScheduledRefresh(live.expiresAt, host.now())
+        }
+      })
+    } catch (error) {
+      console.warn('Cross-tab refresh coordination setup failed:', error)
+      teardownCoordination()
       isRefreshLeader = true
-      // Promotion retakes the schedule unconditionally — the follower timer
-      // may be jittered, mid-retry, or already dead from exhausted retries.
-      // The latch skips the redundant re-arm when the grant fires
-      // synchronously inside armScheduledRefresh itself.
-      const live = host.getCredential()
-      if (live !== undefined && !armingScheduledRefresh) {
-        armScheduledRefresh(live.expiresAt, host.now())
-      }
-    })
+    }
   }
 
   /**
@@ -159,7 +168,13 @@ export function createRefreshScheduler(
    */
   function publishToSiblings(session: AccountCredential): void {
     if (coordinationKey === undefined) return
-    crossTab?.port.publishCredential(coordinationKey, session)
+    // Publication is optional: a throwing port must not unwind a mint that
+    // already committed and persisted its credential.
+    try {
+      crossTab?.port.publishCredential(coordinationKey, session)
+    } catch (error) {
+      console.warn('Cross-tab refresh credential publish failed:', error)
+    }
   }
 
   function adoptPublishedCredential(message: unknown): void {

--- a/packages/account/src/core/refreshScheduler.ts
+++ b/packages/account/src/core/refreshScheduler.ts
@@ -58,6 +58,17 @@ export interface RefreshScheduler {
   stop: () => void
 }
 
+function disposeQuietly(
+  dispose: (() => void) | undefined,
+  label: string
+): void {
+  try {
+    dispose?.()
+  } catch (error) {
+    console.warn(`Cross-tab refresh ${label} teardown failed:`, error)
+  }
+}
+
 export function createRefreshScheduler(
   options: RefreshSchedulerOptions,
   host: RefreshHost
@@ -107,9 +118,9 @@ export function createRefreshScheduler(
 
   function teardownCoordination(): void {
     coordinationGeneration += 1
-    releaseLeadership?.()
+    disposeQuietly(releaseLeadership, 'leadership release')
     releaseLeadership = undefined
-    stopCredentialFeed?.()
+    disposeQuietly(stopCredentialFeed, 'credential feed')
     stopCredentialFeed = undefined
     coordinationKey = undefined
     isRefreshLeader = crossTab === undefined

--- a/packages/account/src/core/session.scheduler.test.ts
+++ b/packages/account/src/core/session.scheduler.test.ts
@@ -5,7 +5,8 @@ import type {
   AccountUser,
   CredentialStorage,
   CrossTabRefreshPort,
-  SessionClientOptions
+  SessionClientOptions,
+  SessionSnapshot
 } from './session.js'
 import { createTestIdentity } from '../testing.js'
 import { createSessionClient } from './session.js'
@@ -1067,5 +1068,90 @@ describe('cross-tab refresh coordination', () => {
       client.getToken(),
       'a late own mint resolving after an adoption must not overwrite it'
     ).toBe('jwt-from-leader')
+  })
+
+  it('a committed mint survives a throwing credential publish and still reaches subscribers', async () => {
+    let minted = 0
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      mintResponse(`jwt-${(minted += 1)}`)
+    )
+    const port: CrossTabRefreshPort = {
+      requestLeadership: (_key, onAcquired) => {
+        onAcquired()
+        return vi.fn()
+      },
+      publishCredential: () => {
+        throw new Error('postMessage failed')
+      },
+      onCredential: () => vi.fn()
+    }
+    const snapshots: SessionSnapshot[] = []
+    const client = makeClient({
+      fetchImpl,
+      refreshScheduler: { crossTab: { port } }
+    })
+    const identity = manualIdentity()
+    client.attachIdentity(identity.port, { autoMint: false })
+    client.subscribe((snapshot) => snapshots.push(snapshot))
+
+    identity.fire(testUser())
+
+    await expect(
+      client.ensureFresh(),
+      'a failing sibling publish must not reject a mint whose credential already committed'
+    ).resolves.toMatchObject({ status: 'ok' })
+    expect(
+      snapshots.at(-1),
+      'the committed credential must still reach subscribers after the publish throws'
+    ).toMatchObject({ phase: 'authenticated', session: { token: 'jwt-1' } })
+
+    await vi.advanceTimersByTimeAsync(
+      NINETY_MINUTES_MS - DEFAULT_BUFFER_MS + 10
+    )
+    expect(
+      client.getToken(),
+      'the scheduler keeps rotating despite the throwing publish port'
+    ).toBe('jwt-2')
+  })
+
+  it('a committed mint survives a throwing coordination setup and degrades to per-tab scheduling', async () => {
+    let minted = 0
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      mintResponse(`jwt-${(minted += 1)}`)
+    )
+    const port: CrossTabRefreshPort = {
+      requestLeadership: () => {
+        throw new Error('locks.request threw')
+      },
+      publishCredential: vi.fn(),
+      onCredential: () => vi.fn()
+    }
+    const snapshots: SessionSnapshot[] = []
+    const client = makeClient({
+      fetchImpl,
+      refreshScheduler: { crossTab: { port } }
+    })
+    const identity = manualIdentity()
+    client.attachIdentity(identity.port, { autoMint: false })
+    client.subscribe((snapshot) => snapshots.push(snapshot))
+
+    identity.fire(testUser())
+
+    await expect(
+      client.ensureFresh(),
+      'a throwing leadership request must not reject a mint whose credential already committed'
+    ).resolves.toMatchObject({ status: 'ok' })
+    expect(
+      snapshots.at(-1),
+      'the committed credential must still reach subscribers after coordination setup throws'
+    ).toMatchObject({ phase: 'authenticated', session: { token: 'jwt-1' } })
+
+    await vi.advanceTimersByTimeAsync(
+      NINETY_MINUTES_MS - DEFAULT_BUFFER_MS + 10
+    )
+    expect(
+      client.getToken(),
+      'a failed coordination setup degrades this tab to per-tab scheduling and keeps rotating'
+    ).toBe('jwt-2')
   })
 })

--- a/packages/account/src/core/session.scheduler.test.ts
+++ b/packages/account/src/core/session.scheduler.test.ts
@@ -1119,12 +1119,13 @@ describe('cross-tab refresh coordination', () => {
     const fetchImpl = vi.fn<typeof fetch>(async () =>
       mintResponse(`jwt-${(minted += 1)}`)
     )
+    const stopCredentialFeed = vi.fn()
     const port: CrossTabRefreshPort = {
       requestLeadership: () => {
         throw new Error('locks.request threw')
       },
       publishCredential: vi.fn(),
-      onCredential: () => vi.fn()
+      onCredential: () => stopCredentialFeed
     }
     const snapshots: SessionSnapshot[] = []
     const client = makeClient({
@@ -1142,6 +1143,10 @@ describe('cross-tab refresh coordination', () => {
       'a throwing leadership request must not reject a mint whose credential already committed'
     ).resolves.toMatchObject({ status: 'ok' })
     expect(
+      stopCredentialFeed,
+      'setup-failure teardown must remove the listener it installed before the throw'
+    ).toHaveBeenCalled()
+    expect(
       snapshots.at(-1),
       'the committed credential must still reach subscribers after coordination setup throws'
     ).toMatchObject({ phase: 'authenticated', session: { token: 'jwt-1' } })
@@ -1152,6 +1157,48 @@ describe('cross-tab refresh coordination', () => {
     expect(
       client.getToken(),
       'a failed coordination setup degrades this tab to per-tab scheduling and keeps rotating'
+    ).toBe('jwt-2')
+  })
+
+  it('a throwing cleanup callback during setup-failure teardown still degrades to per-tab scheduling', async () => {
+    let minted = 0
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      mintResponse(`jwt-${(minted += 1)}`)
+    )
+    const stopCredentialFeed = vi.fn(() => {
+      throw new Error('removeEventListener threw')
+    })
+    const port: CrossTabRefreshPort = {
+      requestLeadership: () => {
+        throw new Error('locks.request threw')
+      },
+      publishCredential: vi.fn(),
+      onCredential: () => stopCredentialFeed
+    }
+    const client = makeClient({
+      fetchImpl,
+      refreshScheduler: { crossTab: { port } }
+    })
+    const identity = manualIdentity()
+    client.attachIdentity(identity.port, { autoMint: false })
+
+    identity.fire(testUser())
+
+    await expect(
+      client.ensureFresh(),
+      'a throwing cleanup callback must not abort the standalone fallback'
+    ).resolves.toMatchObject({ status: 'ok' })
+    expect(
+      stopCredentialFeed,
+      'setup-failure teardown still runs the listener disposer even when it throws'
+    ).toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(
+      NINETY_MINUTES_MS - DEFAULT_BUFFER_MS + 10
+    )
+    expect(
+      client.getToken(),
+      'an isolated disposer throw still leaves this tab leading its own schedule'
     ).toBe('jwt-2')
   })
 })


### PR DESCRIPTION
## Summary

Cross-tab refresh coordination is optional, but a port that threw could take down a session that had already succeeded. When leadership setup or the sibling publish threw, the error escaped after the credential was committed and persisted, so `ensureFresh()` rejected even though storage held the fresh token and subscribers were never told about it. This keeps the committed mint alive and degrades the tab to per-tab scheduling instead.

Fixes FE-2176

## Changes

- `refreshScheduler.ts` now wraps the `onCredential`/`requestLeadership` setup in `ensureCoordination()` in a try/catch: a throw tears down the partial wiring and marks this tab its own refresh leader, so it schedules per-tab instead of waiting on coordination that never armed.
- `publishToSiblings()` catches a throwing `publishCredential` so a failed broadcast never unwinds the mint whose credential already committed.
- Both catch paths log through the package's existing `console.warn` channel (the same one the web cross-tab port uses) rather than swallowing silently.
- Added two scheduler tests covering a throwing publish and a throwing coordination setup: each asserts `ensureFresh()` resolves, the committed credential reaches subscribers, and the scheduler keeps rotating.

## Review Focus

- DrJKL's comment also lists port-level hardening (close ephemeral `BroadcastChannel`s in `finally`, catch synchronous `locks.request()` throws). Those live in `packages/account/src/web/crossTabRefresh.ts`, a different file this bucket does not own, so they are out of scope here. This PR closes the escape at the scheduler boundary the reviewer measured (`ensureFresh()` rejecting, subscribers missed); the port-level items want their own change.

## QA

- [x] Red then green: both new tests fail against current `main` (`ensureFresh()` rejects with the port's error at `refreshScheduler.ts:162` and `:134`), and pass with the fix.
- [x] Unit: 30/30 in `session.scheduler.test.ts`, 311/311 across the account package.
- [x] Gates: typecheck, eslint, oxlint (type-aware), oxfmt, knip, and devshop comment hygiene all clean on the two changed files.
- No browser/e2e run: this is a unit-level change inside `@comfyorg/account` with no rendered surface.


Resolves review comment on #17283 from @DrJKL — [r3984130768](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130768).



Linear: [FE-2176](https://linear.app/comfyorg/issue/FE-2176/bug-isolate-optional-cross-tab-failures-from-committed-session-mints)
