### PR TITLE
test(history): a multi-operation chain survives undo-all then redo-all

### DIFF
--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -208,22 +208,32 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
     await source.connectOutput(0, target, destinationIndex)
     await source.dragBy({ x: 40, y: 70 })
     await target.dragBy({ x: -30, y: 45 })
-    await comfyPage.page.evaluate((id) => {
-      const graph = window.app!.canvas.graph!
-      graph.remove(graph.getNodeById(id)!)
-    }, source.id)
-    await comfyPage.nextFrame()
 
-    // The last mutation goes straight to the graph, so the tracker has not
-    // necessarily captured it yet. `graphMatchesActiveState` is the signal that
-    // it has: sampling `depth` before that returns a short count, and the first
-    // undo then fires into a pending capture and is swallowed — which is exactly
-    // how this failed on CI (undo=2/redo=0 where undo=1/redo=1 was expected).
+    // Delete through the UI. `graph.remove()` from `page.evaluate` mutates the
+    // graph without the change tracker ever capturing it, so `activeState`
+    // never catches up: `graphMatchesActiveState` stays false forever and the
+    // deletion is missing from the history the loops below walk.
+    const nodeCountBeforeDelete = await comfyPage.nodeOps.getNodeCount()
+    await source.click('title')
+    await comfyPage.page.keyboard.press('Delete')
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(nodeCountBeforeDelete - 1)
+
+    // Sampling `depth` before the tracker has settled returns a short count, and
+    // the first undo then fires into a pending capture and is swallowed —
+    // exactly how this failed on CI (undo=2/redo=0 where 1/1 was expected).
+    //
+    // `graphMatchesActiveState` is deliberately NOT the gate. It was observed
+    // to stay false indefinitely after a node deletion: `removeNode()` captures
+    // inside its own `afterChange()`, then runs `updateExecutionOrder()`, which
+    // rewrites serialized node order after the capture. The undo queue settling
+    // is the signal that matters here, and the per-step sizes below are direct
+    // evidence that each press landed.
     await expect
       .poll(() => getChangeTrackerDebugState(comfyPage))
       .toMatchObject({
         changeCount: 0,
-        graphMatchesActiveState: true,
         isLoadingGraph: false,
         restoringState: false
       })
@@ -232,11 +242,16 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
     // the tracker checkpoints is not what this row is about, and asserting a
     // count here would turn a round-trip test into a probe of the transaction
     // model.
-    const depth = (await comfyPage.workflow.getUndoQueueSize()) ?? 0
-    expect(
-      depth,
-      'the chain should have produced several undo steps'
-    ).toBeGreaterThan(1)
+    let previousDepth = -1
+    await expect
+      .poll(async () => {
+        const current = (await comfyPage.workflow.getUndoQueueSize()) ?? 0
+        const stable = current > 1 && current === previousDepth
+        previousDepth = current
+        return stable
+      })
+      .toBe(true)
+    const depth = previousDepth
 
     const after = await snapshot()
     expect(after, 'the chain must actually have changed the graph').not.toEqual(
@@ -254,7 +269,6 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
         .poll(() => getChangeTrackerDebugState(comfyPage))
         .toMatchObject({
           changeCount: 0,
-          graphMatchesActiveState: true,
           isLoadingGraph: false,
           redoQueueSize,
           restoringState: false,

--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -155,6 +155,112 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
     })
   })
 
+  test('A multi-operation chain survives undo-all then redo-all', async ({
+    comfyPage
+  }) => {
+    const snapshot = () =>
+      comfyPage.page.evaluate(() => {
+        const graph = window.app!.canvas.graph!
+        return {
+          nodes: graph.nodes
+            .map((node) => ({
+              id: String(node.id),
+              pos: [...node.pos],
+              type: node.type
+            }))
+            .sort((left, right) => left.id.localeCompare(right.id)),
+          links: [...graph.links.values()]
+            .map((link) =>
+              [
+                String(link.origin_id),
+                link.origin_slot,
+                String(link.target_id),
+                link.target_slot
+              ].join(':')
+            )
+            .sort()
+        }
+      })
+
+    await expect.poll(() => comfyPage.workflow.getUndoQueueSize()).toBe(0)
+    const before = await snapshot()
+
+    const source = await comfyPage.nodeOps.addNode('EmptyImage', undefined, {
+      x: 120,
+      y: 460
+    })
+    const target = await comfyPage.nodeOps.addNode(
+      'ImageCompositeMasked',
+      undefined,
+      { x: 620, y: 460 }
+    )
+    await comfyPage.nextFrame()
+
+    const destinationIndex = await comfyPage.page.evaluate((id) => {
+      const node = window.app!.canvas.graph!.getNodeById(id)!
+      return node.inputs.findIndex((input) => input.name === 'destination')
+    }, target.id)
+    expect(
+      destinationIndex,
+      'ImageCompositeMasked should expose a destination input'
+    ).toBeGreaterThanOrEqual(0)
+
+    await source.connectOutput(0, target, destinationIndex)
+    await source.dragBy({ x: 40, y: 70 })
+    await target.dragBy({ x: -30, y: 45 })
+    await comfyPage.page.evaluate((id) => {
+      const graph = window.app!.canvas.graph!
+      graph.remove(graph.getNodeById(id)!)
+    }, source.id)
+    await comfyPage.nextFrame()
+
+    // Read the depth rather than assuming one entry per operation. How finely
+    // the tracker checkpoints is not what this row is about, and asserting a
+    // count here would turn a round-trip test into a probe of the transaction
+    // model.
+    const depth = (await comfyPage.workflow.getUndoQueueSize()) ?? 0
+    expect(
+      depth,
+      'the chain should have produced several undo steps'
+    ).toBeGreaterThan(1)
+
+    const after = await snapshot()
+    expect(after, 'the chain must actually have changed the graph').not.toEqual(
+      before
+    )
+
+    // Settle on the queue sizes only. `waitForChangeTrackerSettled` also pins
+    // `isModified`, which depends on a saved baseline this describe does not
+    // establish — and which is not what this row is about.
+    const waitForQueues = async (
+      undoQueueSize: number,
+      redoQueueSize: number
+    ) => {
+      await expect
+        .poll(() => getChangeTrackerDebugState(comfyPage))
+        .toMatchObject({
+          changeCount: 0,
+          graphMatchesActiveState: true,
+          isLoadingGraph: false,
+          redoQueueSize,
+          restoringState: false,
+          undoQueueSize
+        })
+    }
+
+    for (let step = 0; step < depth; step++) {
+      await comfyPage.keyboard.undo(null)
+      await waitForQueues(depth - step - 1, step + 1)
+    }
+    expect(await snapshot()).toEqual(before)
+
+    for (let step = 0; step < depth; step++) {
+      await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+      await waitForQueues(step + 1, depth - step - 1)
+    }
+    expect(await snapshot()).toEqual(after)
+  })
+
   test('Can group multiple change actions into a single transaction', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -214,6 +214,20 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
     }, source.id)
     await comfyPage.nextFrame()
 
+    // The last mutation goes straight to the graph, so the tracker has not
+    // necessarily captured it yet. `graphMatchesActiveState` is the signal that
+    // it has: sampling `depth` before that returns a short count, and the first
+    // undo then fires into a pending capture and is swallowed — which is exactly
+    // how this failed on CI (undo=2/redo=0 where undo=1/redo=1 was expected).
+    await expect
+      .poll(() => getChangeTrackerDebugState(comfyPage))
+      .toMatchObject({
+        changeCount: 0,
+        graphMatchesActiveState: true,
+        isLoadingGraph: false,
+        restoringState: false
+      })
+
     // Read the depth rather than assuming one entry per operation. How finely
     // the tracker checkpoints is not what this row is about, and asserting a
     // count here would turn a round-trip test into a probe of the transaction


### PR DESCRIPTION
## Summary

ECS 1.53 Area 2: *"Add two nodes, connect them, move each once, change two widget values,
disconnect and reconnect the link, then delete one node. Undo each action, then redo each →
verify the final canvas matches the state immediately before the first undo."*

The nearest existing test, `Can undo multiple operations` in this file, covers **two**
operations (collapse, bypass) and only walks the stack **down**. Nothing redoes back up, and
nothing compares the resulting canvas to where it started.

## What it does

`add → add → connect → move → move → delete`, then undo `depth` times and redo `depth` times,
comparing full graph snapshots — node ids, types, positions, and every link endpoint — in both
directions.

## Reads the depth instead of assuming it

`getUndoQueueSize()` is read after the chain rather than asserting "six operations, six
entries". How finely the tracker checkpoints is not what this row is about, and pinning a count
would turn a round-trip test into a probe of the transaction model. The queue sizes *are*
asserted after every individual undo and redo, so a press that silently did nothing cannot be
absorbed by the loop.

## Deliberately not included

**The two widget edits from the row.** Widget value changes are not bracketed by
`beforeChange`/`afterChange` — the only explicit callers are clipboard, node replacement, the
image-preview widget and the layer editor — so they checkpoint via the periodic canvas capture.
Including them would make this test assert a coalescing rule I have not established. The row is
therefore **partly** retired; the plan records which part.

**Disconnect-and-reconnect.** `canvasOps.disconnectEdge()` uses `DefaultGraphPositions`, which
is calibrated for the default graph. The chain adds its own nodes, so those coordinates do not
apply.

## Other choices

- Settles on queue sizes only, not `waitForChangeTrackerSettled`, whose `isModified` field
  depends on a saved baseline this describe does not establish — the nested `Undo/Redo`
  describe saves a workflow first, the outer one does not.
- `keyboard.undo(null)` and `page.keyboard.press` rather than the canvas locator: the canvas
  locator fails actionability whenever a node covers the click point.
- `EmptyImage` and `ImageCompositeMasked` are both already constructed by
  `autogrowSlotDrop.spec.ts` on `main`, so their availability in the e2e backend is established
  rather than assumed.

## Test plan

```
$ pnpm exec playwright test --list browser_tests/tests/changeTracker.spec.ts
  [chromium] › …:158:3 › Change Tracker › A multi-operation chain survives undo-all then redo-all
Total: 9 tests in 1 file

$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/changeTracker.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/changeTracker.spec.ts               # exit 0
```

Test-only change; no source files touched. Uses the default workflow, so no new asset.
