### PR TITLE
fix: stop workspaceAuth flag watcher on destroy

### DIFF
--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -2900,6 +2900,44 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
+    it('destroy stops the flag watcher so a later flag flip cannot reattach or mint', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      vi.mocked(useAuthStore().getIdToken).mockResolvedValue(
+        'firebase-token-xyz'
+      )
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(personalTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+      expect(portListeners.size).toBe(1)
+
+      store.destroy()
+      expect(portListeners.size, 'destroy must detach the identity port').toBe(
+        0
+      )
+
+      mockFetch.mockClear()
+      mockUnifiedCloudAuthEnabled.value = false
+      await nextTick()
+      mockUnifiedCloudAuthEnabled.value = true
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(
+        portListeners.size,
+        'a destroyed store must not reattach identity when the flag flips'
+      ).toBe(0)
+      expect(
+        mockFetch,
+        'a destroyed store must not mint when the flag flips'
+      ).not.toHaveBeenCalled()
+      expect(store.getUnifiedToken()).toBeUndefined()
+    })
+
     it('turning the flag OFF detaches the identity, clears the slot, and stops refreshing', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       vi.mocked(useAuthStore().getIdToken).mockResolvedValue(

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -323,6 +323,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
   function destroy(): void {
     stopRefreshTimer()
+    stopUnifiedFlagWatch()
     detachUnifiedIdentity?.()
     detachUnifiedIdentity = undefined
     clearUnifiedContext()
@@ -909,7 +910,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   // session starts sending no auth header; a rollback must stop the unified
   // scheduler and cross-tab lease, or they keep rotating the cookie and
   // refilling the slot the API callers no longer read.
-  watch(
+  const stopUnifiedFlagWatch = watch(
     () => flags.unifiedCloudAuthEnabled,
     (enabled) => {
       if (enabled) {


### PR DESCRIPTION
## Summary

`useWorkspaceAuthStore.destroy()` tore down the timer, the identity port, the unified context, and the snapshot subscription, but never stopped the watcher on the `unified_cloud_auth` feature flag. That watcher outlived the store, so flipping the flag after teardown reattached the identity port and minted a fresh token against a store nobody was using. DrJKL flagged it as a P1 on #17283: the focused OFF-to-ON test toggled the flag after destroy and observed a reattachment plus a mint.

The `watch()` call already returned a stop handle; we were throwing it away. This keeps it and calls it in `destroy()`.

## Changes

- Capture the `watch()` stop handle as `stopUnifiedFlagWatch` and invoke it in `destroy()`, before detaching identity and invalidating the unified context so nothing the watcher would re-arm can run afterward.

## Review Focus

The stop call sits first in `destroy()` on purpose: it has to fire before `detachUnifiedIdentity` and `clearUnifiedContext`, or a queued flag change could reattach what those lines just cleared.

## QA

Added a red-green regression to the unified lifecycle suite: it mints under the flag, calls `destroy()`, then toggles the flag off and back on and asserts the identity port stays detached, no mint fires, and the unified token stays gone. Proven red against main (the live watcher reattached the port, `expected 1 to be 0`) and green with the fix. Full `useWorkspaceAuth` and `authTokenPriority` suites pass (129 tests). typecheck, eslint, oxfmt, and knip all clean.

Fixes FE-2177


Resolves review comment on #17283 from @DrJKL — [r3984130773](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130773).



Linear: [FE-2177](https://linear.app/comfyorg/issue/FE-2177/bug-stop-workspace-auth-feature-watcher-on-store-destroy)
