### PR TITLE
fix(workshop): stash unsaved form before a modified sign-in click

### DIFF
--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -260,6 +260,28 @@ describe('HeaderAccount sign-in link', () => {
     ).toBe('/login/?returnTo=%2Fworkshop%2Fmodels%2Fexample%2F%3Ftab%3Dapi')
   })
 
+  it('stashes unsaved work even when a modified click opens sign-in in a new tab', async () => {
+    const stash = vi.fn()
+    const stop = onBeforeSignInLeave(stash)
+    onTestFinished(stop)
+    render(HeaderAccount)
+
+    const link = screen.getByRole('link', { name: /sign in/i })
+    await fireEvent(link, new Event('pointerdown', { bubbles: true }))
+    link.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true
+      })
+    )
+
+    expect(
+      stash,
+      'a new tab must carry the latest form, so the stash runs even when the click is not the primary navigation'
+    ).toHaveBeenCalledOnce()
+  })
+
   it('prepares the destination on focus, so a keyboard open-in-new-tab keeps it too', async () => {
     window.history.replaceState({}, '', '/workshop/models/example/')
     render(HeaderAccount)

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -268,7 +268,7 @@ describe('HeaderAccount sign-in link', () => {
 
     const link = screen.getByRole('link', { name: /sign in/i })
     await fireEvent(link, new Event('pointerdown', { bubbles: true }))
-    link.dispatchEvent(
+    const notPrevented = link.dispatchEvent(
       new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
@@ -280,6 +280,10 @@ describe('HeaderAccount sign-in link', () => {
       stash,
       'a new tab must carry the latest form, so the stash runs even when the click is not the primary navigation'
     ).toHaveBeenCalledOnce()
+    expect(
+      notPrevented,
+      'the modified click must reach the browser, so its default new-tab navigation is never prevented'
+    ).toBe(true)
   })
 
   it('prepares the destination on focus, so a keyboard open-in-new-tab keeps it too', async () => {

--- a/apps/website/src/components/workshop/HeaderAccount.vue
+++ b/apps/website/src/components/workshop/HeaderAccount.vue
@@ -39,10 +39,10 @@ function prepareSignInHref(): void {
 }
 
 function goToSignIn(event: MouseEvent): void {
+  runBeforeSignInLeave()
   if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0)
     return
   event.preventDefault()
-  runBeforeSignInLeave()
   window.location.assign(signInDestination())
 }
 


### PR DESCRIPTION
## Summary

Run the sign-in leave stash before the modified-click early return, so a Workshop visitor who opens sign-in in a new tab still lands back with their latest form.

## Changes

`goToSignIn` now calls `runBeforeSignInLeave()` first, before the modifier-key guard returns. Ctrl/Cmd/Shift and middle clicks let the browser open the sign-in link in a new tab, and until now they skipped the stash entirely, so the new tab carried the return URL but none of the form the visitor had typed. `preventDefault()` and `location.assign()` stay scoped to the plain primary click.

## Review Focus

The stash now runs on every click of the sign-in link, including ones that do not navigate this tab. That is intended: the registered island stashes are idempotent writes to sessionStorage, so running one on a modified click that opens a new tab is harmless and is exactly what keeps the form intact across the round trip.

Fixes FE-2180


Resolves review comment on #17283 from @DrJKL — [r3984130812](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130812).



Linear: [FE-2180](https://linear.app/comfyorg/issue/FE-2180/bug-stash-workshop-form-before-modified-click-sign-in-navigation)
