### PR TITLE
refactor(website): make WorkshopProvisioningError module-private

### DIFF
--- a/apps/website/src/config/workshop-firebase.ts
+++ b/apps/website/src/config/workshop-firebase.ts
@@ -40,7 +40,7 @@ interface ProvisionableUser {
   getIdToken: () => Promise<string>
 }
 
-export class WorkshopProvisioningError extends Error {
+class WorkshopProvisioningError extends Error {
   constructor(
     readonly user: User,
     options: ErrorOptions


### PR DESCRIPTION
## Summary

`WorkshopProvisioningError` was exported from `workshop-firebase.ts`, but nothing outside the module ever imported the class. Every consumer narrows through the exported `isWorkshopProvisioningError` predicate instead, and only this module constructs the error. This drops the `export` so the class stays module-private and cannot drift into an accidental public contract.

Companion to #17447. Both come out of the FE-2190 changed-scope review of the account package surface; #17447 covered the identity-guard finding (B6) and this covers the second finding (provisioning-error visibility, DrJKL r3984130896).

## Changes

- `apps/website/src/config/workshop-firebase.ts`: remove `export` from the `WorkshopProvisioningError` class. The `isWorkshopProvisioningError` predicate stays exported for callers.

## Review Focus

The predicate remains the only exported entry point for this error type, so callers keep narrowing exactly as before. knip stays clean, which confirms the class had no external need.

## Testing

- `pnpm typecheck` (apps/website): 0 errors
- `pnpm knip`: clean
- eslint + oxfmt on the touched file: clean
- website vitest for the touched area (`workshop-firebase.test.ts`, `AuthSignIn.test.ts`): 75 passing

Fixes FE-2190


Resolves review comment on #17283 from @DrJKL — [r3984130896](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130896).



Linear: [FE-2190](https://linear.app/comfyorg/issue/FE-2190/refactor-narrow-the-account-package-public-surface)
