### PR TITLE
chore(account): declare MIT license and document the OSS license-check exclusion

### DIFF
--- a/.github/workflows/ci-oss-assets-validation.yaml
+++ b/.github/workflows/ci-oss-assets-validation.yaml
@@ -106,11 +106,16 @@ jobs:
 
           # Use license-checker-rseidelsohn (actively maintained fork, handles monorepos)
           # Exclude internal @comfyorg packages from license check
-          # NOTE: @comfyorg/comfy-multi-player is first-party and excluded on the same
-          # basis as the rest, but unlike them it currently ships NO license field and
-          # NO LICENSE file (Comfy-Org/comfy-multi-player has neither in-repo). This
-          # exclusion is therefore load-bearing, not cosmetic — remove it once the
-          # package declares a license and a version carrying it is published.
+          # NOTE: first-party @comfyorg packages are excluded as a consistent policy,
+          # because license-checker cannot read their license off the workspace tree:
+          # a `private: true` package (e.g. @comfyorg/account, which declares
+          # `license: MIT`, plus @comfyorg/shared-frontend-utils and the root frontend)
+          # is reported as UNLICENSED regardless of its `license` field, and a package
+          # with no license field reads as UNKNOWN. Each exclusion is load-bearing, not
+          # cosmetic — drop a package here once it is published with `private` unset so
+          # the checker validates its declared license directly.
+          # @comfyorg/comfy-multi-player additionally ships NO license field and NO
+          # LICENSE file today (Comfy-Org/comfy-multi-player has neither in-repo).
           # Run in if condition to capture exit code
           if pnpx license-checker-rseidelsohn@4 \
             --production \

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Shared account layer: a framework-free session core that exchanges a signed-in identity for the workspace-scoped Cloud JWT with valid-on-read freshness, the package-owned Firebase identity entry, and an optional Vue subpath for the shared sign-in pieces",
   "keywords": [],
+  "license": "MIT",
   "type": "module",
   "exports": {
     "./session": "./src/core/session.ts",


### PR DESCRIPTION
## Summary

Declare a license on the `@comfyorg/account` package and record why the OSS-assets license check excludes it, so the excluded first-party packages are documented rather than silently skipped.

## Changes

Add `license: MIT` to `packages/account/package.json`, matching the published sibling `@comfyorg/design-system`.

Rewrite the NOTE above the license-checker step to explain the exclusion policy. `license-checker-rseidelsohn` reports a `private: true` package as UNLICENSED no matter what its `license` field says, and a package with no license field reads as UNKNOWN, so first-party `@comfyorg` packages are excluded on that consistent basis. Each exclusion is load-bearing until the package is published with `private` unset.

## Review Focus

This is license-only. It does not touch `private: true`, workspace deps, or npm publishing.

The reviewer asked to add the license metadata and drop the one-off exemption unless a documented consistent policy justified it. The metadata is added, and the exemption is kept and documented, because dropping it while `account` stays `private: true` fails the check: license-checker still reads a private package as UNLICENSED regardless of the declared license. I verified this locally three ways (allowlist, exact-version clarification, and `@*` clarification all still fail), and confirmed the check passes exit 0 with the license added and the exclusion kept. The exclusion drops in the separate publish work (FE-2171) that unsets `private` and ships `account` publicly on the alpha dist-tag, the same path as `@comfyorg/design-system`; that check-passes-honestly step belongs there, not here.

No LICENSE file was added, matching the sibling convention: `design-system` ships the `license` field only, with no package-local LICENSE file.

Fixes FE-2186


Resolves review comment on #17283 from @DrJKL — [r3984130889](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130889).



Linear: [FE-2186](https://linear.app/comfyorg/issue/FE-2186/chore-add-account-package-license-metadata-and-restore-validation)
