### PR TITLE
fix(website): clear cached Workshop credential when the auth flag settles off

### DIFF
--- a/apps/website/src/config/workshop-session-state.failure.test.ts
+++ b/apps/website/src/config/workshop-session-state.failure.test.ts
@@ -9,7 +9,11 @@ const h = vi.hoisted(() => ({
 vi.mock<unknown>(import('../scripts/posthog'), async () => {
   const { ref } = await import('vue')
   const flag = ref(true)
-  return { useWorkshopAuthFlag: () => flag }
+  const settled = ref(true)
+  return {
+    useWorkshopAuthFlag: () => flag,
+    useWorkshopAuthFlagSettled: () => settled
+  }
 })
 
 vi.mock<unknown>(import('./workshop-firebase'), async () => {

--- a/apps/website/src/config/workshop-session-state.scope.test.ts
+++ b/apps/website/src/config/workshop-session-state.scope.test.ts
@@ -10,8 +10,12 @@ const h = vi.hoisted(() => ({
 vi.mock<unknown>(import('../scripts/posthog'), async () => {
   const { ref } = await import('vue')
   const flag = ref(true)
+  const settled = ref(true)
   h.flag = flag
-  return { useWorkshopAuthFlag: () => flag }
+  return {
+    useWorkshopAuthFlag: () => flag,
+    useWorkshopAuthFlagSettled: () => settled
+  }
 })
 
 vi.mock<unknown>(import('./workshop-firebase'), async () => {

--- a/apps/website/src/config/workshop-session-state.settled.test.ts
+++ b/apps/website/src/config/workshop-session-state.settled.test.ts
@@ -22,8 +22,12 @@ const h = vi.hoisted(() => {
 vi.mock<unknown>(import('../scripts/posthog'), async () => {
   const { ref } = await import('vue')
   const flag = ref(true)
+  const settled = ref(true)
   h.flag = flag
-  return { useWorkshopAuthFlag: () => flag }
+  return {
+    useWorkshopAuthFlag: () => flag,
+    useWorkshopAuthFlagSettled: () => settled
+  }
 })
 
 vi.mock<unknown>(import('./workshop-firebase'), async () => {

--- a/apps/website/src/config/workshop-session-state.test.ts
+++ b/apps/website/src/config/workshop-session-state.test.ts
@@ -1,12 +1,16 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { Ref } from 'vue'
 
 import type { WorkshopSession } from './workshop-session-state'
 
 const h = vi.hoisted(() => {
   const state = {
     initialFlag: true,
-    flag: undefined as { value: boolean } | undefined,
+    initialSettled: true,
+    flag: undefined as Ref<boolean> | undefined,
+    settled: undefined as Ref<boolean> | undefined,
     listeners: new Set<(snapshot: unknown) => void>(),
     snapshot: {
       phase: 'signed-out',
@@ -26,11 +30,11 @@ const h = vi.hoisted(() => {
   return state
 })
 
-vi.mock<unknown>(import('../scripts/posthog'), async () => {
-  const { ref } = await import('vue')
-  const flag = ref(h.initialFlag)
-  h.flag = flag
-  return { useWorkshopAuthFlag: () => flag }
+vi.mock<unknown>(import('../scripts/posthog'), () => {
+  return {
+    useWorkshopAuthFlag: () => h.flag,
+    useWorkshopAuthFlagSettled: () => h.settled
+  }
 })
 
 vi.mock<unknown>(import('./workshop-firebase'), async () => {
@@ -80,6 +84,8 @@ function authenticatedSnapshot() {
 
 async function importFresh() {
   vi.resetModules()
+  h.flag = ref(h.initialFlag)
+  h.settled = ref(h.initialSettled)
   const mod = await import('./workshop-session-state')
   const session = mod.useWorkshopSession()
   if (h.initialFlag) {
@@ -90,8 +96,12 @@ async function importFresh() {
 
 beforeEach(() => {
   h.initialFlag = true
+  h.initialSettled = true
   h.listeners.clear()
   h.snapshot = { phase: 'signed-out', user: null, session: undefined }
+  h.firebaseEvaluated.mockClear()
+  h.attachIdentity.mockClear()
+  h.clearStoredCredential.mockClear()
 })
 
 describe('useWorkshopSession', () => {
@@ -156,7 +166,7 @@ describe('useWorkshopSession', () => {
 
   it('keeps the cached credential on a cold load while the flag is still unanswered', async () => {
     h.initialFlag = false
-    h.clearStoredCredential.mockClear()
+    h.initialSettled = false
 
     await importFresh()
 
@@ -164,6 +174,21 @@ describe('useWorkshopSession', () => {
       h.clearStoredCredential,
       'the flag starts false until PostHog answers; wiping the cache here re-mints on every reload'
     ).not.toHaveBeenCalled()
+  })
+
+  it('clears the cached credential once the flag settles off without ever turning on', async () => {
+    h.initialFlag = false
+    h.initialSettled = false
+    await importFresh()
+
+    h.settled!.value = true
+
+    await vi.waitFor(() =>
+      expect(
+        h.clearStoredCredential,
+        'a settled-off flag means Workshop is disabled; the cache must go even with no on->off transition'
+      ).toHaveBeenCalled()
+    )
   })
 
   it('clears the cache when the flag turns off', async () => {

--- a/apps/website/src/config/workshop-session-state.test.ts
+++ b/apps/website/src/config/workshop-session-state.test.ts
@@ -191,6 +191,26 @@ describe('useWorkshopSession', () => {
     )
   })
 
+  it('keeps the live session when the flag settles on without ever turning off', async () => {
+    h.initialSettled = false
+    const s = await importFresh()
+    h.publish(authenticatedSnapshot())
+    await vi.waitFor(() => expect(s.session.value).toEqual(okSession))
+    const attachesBefore = h.attachIdentity.mock.calls.length
+
+    h.settled!.value = true
+
+    await vi.waitFor(() => expect(h.settled!.value).toBe(true))
+    expect(
+      h.attachIdentity.mock.calls.length,
+      'a settlement-only change while enabled stays on must not re-attach the identity listener'
+    ).toBe(attachesBefore)
+    expect(
+      s.session.value,
+      'the live session must survive a settlement-only change; restarting would reset it to PENDING'
+    ).toEqual(okSession)
+  })
+
   it('clears the cache when the flag turns off', async () => {
     await importFresh()
     const callsBefore = h.clearStoredCredential.mock.calls.length

--- a/apps/website/src/config/workshop-session-state.ts
+++ b/apps/website/src/config/workshop-session-state.ts
@@ -42,6 +42,7 @@ const PENDING: SessionSnapshot<User> = {
 
 const snapshot = shallowRef<SessionSnapshot<User>>(PENDING)
 let started = false
+let running = false
 let lifecycle: EffectScope | undefined
 let generation = 0
 let detachIdentity: (() => void) | undefined
@@ -50,6 +51,7 @@ let stopTelemetry: (() => void) | undefined
 let stopFocusListener: (() => void) | undefined
 
 function stopListeners(): void {
+  running = false
   detachIdentity?.()
   detachIdentity = undefined
   stopSnapshot?.()
@@ -64,6 +66,7 @@ async function begin(expectedGeneration: number): Promise<void> {
   const firebase = await import('./workshop-firebase')
   if (generation !== expectedGeneration) return
 
+  running = true
   stopSnapshot = workshopSessionClient.subscribe((next) => {
     snapshot.value = next
   })
@@ -91,6 +94,9 @@ function start(): void {
     watch(
       [enabled, settled],
       ([on, isSettled]) => {
+        // A settlement-only change while a session is already live must not
+        // tear it down; only enabling from a stopped state begins a lifecycle.
+        if (on && running) return
         const expectedGeneration = ++generation
         stopListeners()
         snapshot.value = PENDING

--- a/apps/website/src/config/workshop-session-state.ts
+++ b/apps/website/src/config/workshop-session-state.ts
@@ -20,7 +20,10 @@ import type { EffectScope } from 'vue'
 
 import type { SessionSnapshot } from '@comfyorg/account/session'
 
-import { useWorkshopAuthFlag } from '../scripts/posthog'
+import {
+  useWorkshopAuthFlag,
+  useWorkshopAuthFlagSettled
+} from '../scripts/posthog'
 import {
   subscribeAuthRefreshTelemetry,
   workshopSessionClient
@@ -83,17 +86,18 @@ function start(): void {
   // of binding its watcher to whichever component calls this first.
   lifecycle = effectScope(true)
   const enabled = useWorkshopAuthFlag()
+  const settled = useWorkshopAuthFlagSettled()
   lifecycle.run(() => {
     watch(
-      enabled,
-      (on, wasOn) => {
+      [enabled, settled],
+      ([on, isSettled]) => {
         const expectedGeneration = ++generation
         stopListeners()
         snapshot.value = PENDING
         if (!on) {
-          // The flag starts false on every cold load until PostHog answers;
-          // only a real on->off transition means the credential must go.
-          if (wasOn) workshopSessionClient.clearStoredCredential()
+          // Retain the cached credential while the flag is unresolved; only a
+          // settled-off answer means Workshop is disabled and it must go.
+          if (isSettled) workshopSessionClient.clearStoredCredential()
           return
         }
         void begin(expectedGeneration).catch((error: unknown) => {


### PR DESCRIPTION
## Summary

Disabling the Workshop auth flag remotely now clears the cached credential, so a settled-off flag actually drops the stored session instead of leaving a stale credential behind.

## Changes

`workshop-session-state` watched only the flag's boolean, so a cold `false` (PostHog has not answered yet) looked identical to a settled `false` (PostHog answered "disabled"). Settling to false never changed the boolean, so the credential was never cleared. The watcher now tracks the settled state alongside the flag: it keeps the cached credential while the flag is unresolved and clears it once the flag settles off, which covers both a fresh remote disable and a genuine on to off transition.

## Review Focus

- The clear now fires on `!enabled && settled` instead of on a `wasOn` on-to-off transition. The regression test proves both halves against `main`: an unresolved flag keeps the credential, and a settled-off flag clears it.
- The unit mock used to create its flag ref once, so every module instance shared a single ref and detached watchers piled up across `resetModules`. It now mints fresh refs per import, so orphaned watchers observe dead refs and the suite stays deterministic.

Fixes FE-2184


Resolves review comment on #17283 from @DrJKL — [r3984130857](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130857).



Linear: [FE-2184](https://linear.app/comfyorg/issue/FE-2184/bug-clear-cached-workshop-credentials-when-the-flag-settles-off)
