### PR TITLE
agent: normalize icon sizing to the established scale tokens

### DIFF
--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -167,7 +167,7 @@ describe('Composer', () => {
     })
     expect(addNodes).toBeVisible()
     expect(addNodes).toContainHTML(
-      '<span class="icon-[lucide--mouse-pointer-click] size-[14px] shrink-0"></span>'
+      '<span class="icon-[lucide--mouse-pointer-click] size-3.5 shrink-0"></span>'
     )
     expect(
       text.compareDocumentPosition(addNodes) & Node.DOCUMENT_POSITION_FOLLOWING

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -459,7 +459,7 @@ defineExpose({
                 @click="onSelectNodes"
               >
                 <span
-                  class="icon-[lucide--mouse-pointer-click] size-[14px] shrink-0"
+                  class="icon-[lucide--mouse-pointer-click] size-3.5 shrink-0"
                 />
                 <span class="underline decoration-dashed underline-offset-2">{{
                   placeholderHint.mentionNodes

--- a/src/workbench/extensions/agent/components/agent/composer/RunModePopover.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/RunModePopover.vue
@@ -125,7 +125,7 @@ const options: {
       "
     >
       <span>{{ triggerLabel }}</span>
-      <span class="icon-[lucide--chevron-down] size-3" />
+      <span class="icon-[lucide--chevron-down] size-4" />
     </PopoverTrigger>
     <PopoverPortal>
       <PopoverContent

--- a/src/workbench/extensions/agent/components/agent/composer/WorkflowSelectorChip.vue
+++ b/src/workbench/extensions/agent/components/agent/composer/WorkflowSelectorChip.vue
@@ -143,7 +143,7 @@ function onSearchKeydown(event: KeyboardEvent): void {
                 <span
                   v-else
                   data-testid="workflow-selector-icon"
-                  class="text-agent-fg-subtle group-hover:text-agent-fg icon-[comfy--workflow] size-3.5 shrink-0"
+                  class="text-agent-fg-subtle group-hover:text-agent-fg icon-[comfy--workflow] size-4 shrink-0"
                 />
                 <span class="min-w-0 truncate">{{
                   current?.name ?? t('agent.selectWorkflowForAgent')


### PR DESCRIPTION
Make the Agent composer workflow icon and run-permissions chevron 16px. The workflow icon now matches the existing 16px working spinner.

<details><summary>Changes and verification</summary>

Updated against main without restoring the removed Agent-specific theme tokens. The mention-nodes icon cleanup from the original version already landed on main, so it is no longer part of this change.

- 101 focused component tests passed.
- Browser checks passed for rendered icon dimensions, the open run-permissions popover, and the existing save/draft flow.
- The new sizing check fails against the unchanged workflow icon at 14px and passes here at 16px.
- Inspected the settled popover screenshot; text and controls are legible and aligned.
- Application and browser typechecks, targeted lint/format checks, and the pre-push Knip check passed. GitHub checks are running.

Review focus: both changed icons use the existing sizing scale and keep the surrounding controls unchanged. No agent behavior or workflow selection logic changes.

Glossary: Knip checks for unused code and dependencies.

</details>
