### PR TITLE
fix(models): a category-aware back control, and the rest of the UI review

### DIFF
--- a/apps/website/e2e/workshop.spec.ts
+++ b/apps/website/e2e/workshop.spec.ts
@@ -85,6 +85,55 @@ test.describe('Models catalog', () => {
     await expect(page.getByTestId('workshop-hero')).toBeVisible()
   })
 
+  test('a model page returns to the shelf it was opened from', async ({
+    page
+  }) => {
+    await page.goto('/models/')
+    await page.getByTestId('section-generate-videos-open').click()
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(
+      'Generate videos'
+    )
+    await page
+      .getByTestId('workshop-models-grid')
+      .getByTestId('workshop-model-card')
+      .first()
+      .click()
+
+    const back = page.getByTestId('model-back')
+    await expect(back).toHaveText('Back to Generate videos')
+    await back.click()
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(
+      'Generate videos'
+    )
+    await expect(page.getByTestId('workshop-sections')).toHaveCount(0)
+  })
+
+  test('the search field stays put as the results swap under it', async ({
+    page
+  }) => {
+    await page.goto('/models/')
+    await expect(page.getByTestId('workshop-sections')).toBeVisible()
+    await page.evaluate(() => window.scrollTo(0, 700))
+    const search = page.getByTestId('workshop-search')
+
+    // Nothing else is clicked between the two measurements: a click scrolls its
+    // own target into view first, which would move the page under the field.
+    await search.fill('kling')
+    await expect(
+      page
+        .getByTestId('workshop-models-grid')
+        .getByTestId('workshop-model-card')
+        .first()
+    ).toContainText('Kling')
+    const searching = await search.boundingBox()
+
+    await search.fill('')
+    await expect(page.getByTestId('workshop-sections')).toBeVisible()
+    const cleared = await search.boundingBox()
+
+    expect(cleared?.y).toBeCloseTo(searching?.y ?? 0, 0)
+  })
+
   test('cards open canonical model pages with related models', async ({
     page
   }) => {

--- a/apps/website/e2e/workshop.spec.ts
+++ b/apps/website/e2e/workshop.spec.ts
@@ -131,7 +131,9 @@ test.describe('Models catalog', () => {
     await expect(page.getByTestId('workshop-sections')).toBeVisible()
     const cleared = await search.boundingBox()
 
-    expect(cleared?.y).toBeCloseTo(searching?.y ?? 0, 0)
+    if (!searching || !cleared)
+      throw new Error('the search field was never on screen to measure')
+    expect(cleared.y).toBeCloseTo(searching.y, 0)
   })
 
   test('cards open canonical model pages with related models', async ({

--- a/apps/website/src/components/workshop/CatalogueBackLink.test.ts
+++ b/apps/website/src/components/workshop/CatalogueBackLink.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from '@testing-library/vue'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { rememberShelf } from '../../lib/workshop/shelf-memory'
+import CatalogueBackLink from './CatalogueBackLink.vue'
+
+afterEach(() => {
+  sessionStorage.clear()
+})
+
+describe('CatalogueBackLink', () => {
+  it('offers the whole catalogue when no shelf was left behind', () => {
+    render(CatalogueBackLink)
+
+    const link = screen.getByTestId('model-back')
+    expect(link.textContent.trim()).toBe('Back to all models')
+    expect(link.getAttribute('href')).toBe('/models')
+  })
+
+  it('offers the shelf the visitor came from', async () => {
+    rememberShelf('generate-videos')
+    render(CatalogueBackLink)
+
+    await waitFor(() => {
+      const link = screen.getByTestId('model-back')
+      expect(link.textContent.trim()).toBe('Back to Generate videos')
+      expect(link.getAttribute('href')).toBe('/models?useCase=generate-videos')
+    })
+  })
+})

--- a/apps/website/src/components/workshop/CatalogueBackLink.vue
+++ b/apps/website/src/components/workshop/CatalogueBackLink.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ChevronLeft } from '@lucide/vue'
+import { onMounted, ref } from 'vue'
+
+import { catalogSearch } from '../../config/models-catalogue'
+import { getRoutes } from '../../config/routes'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import { lastShelf } from '../../lib/workshop/shelf-memory'
+import { useCaseLabelKey } from '../../lib/workshop/use-case-label'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+
+const routes = getRoutes(locale)
+const href = ref(routes.workshop)
+const category = ref<string>()
+
+// Most visitors reach a model from a shelf, and the way back they want is that
+// shelf, not the whole catalogue. Opened in a new tab, or reached from a link
+// somebody shared, there is no shelf to return to and the catalogue answers.
+onMounted(() => {
+  const shelf = lastShelf()
+  if (!shelf || shelf === 'all') return
+  href.value = `${routes.workshop}${catalogSearch({ useCase: shelf })}`
+  category.value = t(useCaseLabelKey[shelf], locale)
+})
+</script>
+
+<template>
+  <a
+    :href
+    class="hover:text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 -ml-1 inline-flex items-center gap-1 rounded-lg px-1 text-sm font-medium text-primary-warm-gray opacity-60 transition hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-3"
+    data-testid="model-back"
+  >
+    <ChevronLeft class="size-4" aria-hidden="true" />
+    {{
+      category
+        ? t('workshop.model.backTo', locale).replace('{category}', category)
+        : t('workshop.model.back', locale)
+    }}
+  </a>
+</template>

--- a/apps/website/src/components/workshop/ExamplesTab.vue
+++ b/apps/website/src/components/workshop/ExamplesTab.vue
@@ -73,7 +73,7 @@ function actionFor(example: PlaygroundExample, active = false) {
       they fit in a row of their own. -->
     <ul
       v-else
-      class="flex scrollbar-hide snap-x gap-3 overflow-x-auto max-sm:-mx-6 max-sm:-my-1 max-sm:scroll-px-6 max-sm:px-6 max-sm:py-1 sm:grid sm:max-w-2xl sm:grid-cols-3 sm:overflow-visible"
+      class="flex scrollbar-hide snap-x gap-3 overflow-x-auto max-sm:-mx-6 max-sm:-my-1 max-sm:scroll-px-6 max-sm:px-6 max-sm:py-1 sm:grid sm:max-w-5xl sm:grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] sm:overflow-visible"
     >
       <li
         v-for="example in examples"
@@ -147,7 +147,7 @@ function actionFor(example: PlaygroundExample, active = false) {
             <span
               :class="
                 cn(
-                  'line-clamp-2 text-xs transition-colors',
+                  'line-clamp-1 text-xs transition-colors',
                   example.id === activeId
                     ? 'text-primary-warm-white'
                     : 'text-primary-comfy-canvas group-hover:text-primary-warm-white'

--- a/apps/website/src/components/workshop/ExamplesTab.vue
+++ b/apps/website/src/components/workshop/ExamplesTab.vue
@@ -82,15 +82,18 @@ function actionFor(example: PlaygroundExample, active = false) {
       >
         <button
           type="button"
-          :aria-label="
+          :aria-label="`${example.title}: ${
             example.sampleOnly
               ? actionFor(example)
               : t('workshop.examples.open', locale)
-          "
+          }`"
           :aria-current="example.id === activeId ? 'true' : undefined"
           class="group flex w-full cursor-pointer flex-col gap-2 text-left outline-none"
           data-testid="example-card"
-          :title="actionFor(example, example.id === activeId)"
+          :title="`${example.title} · ${actionFor(
+            example,
+            example.id === activeId
+          )}`"
           @click="emit('open', example)"
         >
           <span

--- a/apps/website/src/components/workshop/FeaturedBanner.vue
+++ b/apps/website/src/components/workshop/FeaturedBanner.vue
@@ -118,7 +118,11 @@ const fill = computed(() =>
         class="sm:short:gap-3 relative flex h-full flex-col justify-end gap-4 p-6 pb-16 sm:max-w-2xl sm:justify-center lg:p-8 lg:pb-16"
       >
         <div class="flex flex-wrap items-center gap-2">
-          <Badge variant="subtle" size="md" class="text-primary-comfy-canvas">
+          <Badge
+            variant="subtle"
+            size="md"
+            class="text-primary-comfy-canvas backdrop-blur-md"
+          >
             {{ active.task }}
           </Badge>
           <Badge
@@ -126,19 +130,19 @@ const fill = computed(() =>
             :key="capability"
             variant="subtle"
             size="md"
-            class="text-content-secondary max-sm:hidden"
+            class="text-content-secondary backdrop-blur-md max-sm:hidden"
           >
             {{ capability }}
           </Badge>
         </div>
 
-        <h2 class="text-4xl font-bold text-primary-warm-white">
+        <h2 class="text-2xl font-bold text-primary-warm-white lg:text-3xl">
           {{ active.model.name }}
         </h2>
 
         <p
           v-if="active.model.summary"
-          class="text-content-secondary line-clamp-2 max-w-prose"
+          class="text-content-secondary line-clamp-2 max-w-prose max-sm:line-clamp-1"
         >
           {{ active.model.summary }}
         </p>

--- a/apps/website/src/components/workshop/FileSourceInput.test.ts
+++ b/apps/website/src/components/workshop/FileSourceInput.test.ts
@@ -68,15 +68,14 @@ describe('file source selection', () => {
         screen.getByLabelText('Images', { selector: 'input' }),
         file
       )
-      if (type.startsWith('video/') || type.startsWith('audio/')) {
+      if (type.startsWith('video/')) {
         const preview = screen.getByLabelText(name)
-        expect(preview).toBeInstanceOf(HTMLMediaElement)
-        expect(preview).toHaveProperty('controls', true)
+        expect(preview).toBeInstanceOf(HTMLVideoElement)
         expect(preview.getAttribute('src')).toMatch(/^blob:/)
       } else {
         expect(screen.getByText(label)).toBeTruthy()
-        expect(screen.getByText('2 KB')).toBeTruthy()
       }
+      expect(screen.getByText('2 KB')).toBeTruthy()
       expect(screen.queryByRole('img')).toBeNull()
       expect(values.value).toMatchObject([{ file }])
       expect(screen.getByText('Choose files or drop them here')).toBeTruthy()

--- a/apps/website/src/components/workshop/FileSourceInput.vue
+++ b/apps/website/src/components/workshop/FileSourceInput.vue
@@ -1,16 +1,14 @@
 <script setup lang="ts">
-import { Upload, X } from '@lucide/vue'
+import { Upload } from '@lucide/vue'
 import { useDropZone } from '@vueuse/core'
 import { computed, nextTick, ref, useTemplateRef } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
-import { formatSize } from '@comfyorg/shared-frontend-utils/formatUtil'
 
 import type { FieldSchema, FileValue } from '../../config/workshop-playground'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
-import ImageSourcePreview from './ImageSourcePreview.vue'
-import VideoSourcePreview from './VideoSourcePreview.vue'
+import SelectedFileRow from './SelectedFileRow.vue'
 
 const {
   field,
@@ -53,6 +51,31 @@ const description = computed(
       .filter(Boolean)
       .join(' ') || undefined
 )
+
+const prompt = computed(() => {
+  const replacing = selectedFiles.value.length > 0 && !field.multiple
+  if (replacing)
+    return imageOnly.value
+      ? 'workshop.field.replaceOrDropImage'
+      : 'workshop.field.replaceOrDropFile'
+  return imageOnly.value
+    ? 'workshop.field.chooseOrDropImages'
+    : 'workshop.field.chooseOrDropFiles'
+})
+
+const acceptedTypes = computed(() =>
+  field.accept
+    .map((type) => type.split('/')[1].replace('x-', '').toUpperCase())
+    .join(', ')
+)
+
+const rejectionMessage = computed(() => {
+  if (!rejection.value) return ''
+  const unchanged = imageOnly.value
+    ? 'workshop.field.imagesUnchanged'
+    : 'workshop.field.filesUnchanged'
+  return `${t(rejection.value, locale).replace('{count}', String(limit.value))} ${t(unchanged, locale)}`
+})
 
 function choose(files: File[], index?: number) {
   if (disabled || !files.length) return
@@ -109,13 +132,6 @@ function remove(index: number) {
     : undefined
   rejection.value = undefined
 }
-
-function fileType(file: FileValue): string {
-  return (
-    /\.([a-z\d]{1,12})$/i.exec(file.name)?.[1].toUpperCase() ??
-    t('workshop.field.file', locale)
-  )
-}
 </script>
 
 <template>
@@ -137,61 +153,15 @@ function fileType(file: FileValue): string {
       v-if="selectedFiles.length"
       class="flex min-w-0 flex-col gap-2 px-3 pt-3"
     >
-      <li
+      <SelectedFileRow
         v-for="(file, index) in selectedFiles"
         :key="index"
-        class="bg-transparency-white-t4 flex min-w-0 items-center gap-3 rounded-xl p-2"
-      >
-        <ImageSourcePreview
-          v-if="file.type.startsWith('image/')"
-          :file="file.file"
-          :src="file.previewUrl"
-          :name="file.name"
-          :locale
-        />
-        <VideoSourcePreview
-          v-else-if="file.type.startsWith('video/')"
-          :file="file.file"
-          :src="file.previewUrl"
-          :name="file.name"
-        />
-        <span
-          v-else
-          class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-transparency-white-t8 text-xs font-bold text-primary-warm-gray"
-        >
-          {{ fileType(file) }}
-        </span>
-        <button
-          type="button"
-          :disabled
-          :aria-label="
-            t('workshop.field.replaceFile', locale).replace('{name}', file.name)
-          "
-          class="focus-visible:outline-primary-comfy-yellow min-w-0 flex-1 cursor-pointer truncate text-left text-sm text-primary-warm-white underline-offset-4 hover:underline"
-          @click="replace(index)"
-        >
-          {{ file.name }}
-        </button>
-        <span
-          v-if="file.size"
-          class="shrink-0 text-xs text-primary-warm-gray"
-          >{{ formatSize(file.size) }}</span
-        >
-        <button
-          type="button"
-          :disabled
-          :aria-label="
-            t('workshop.field.removeNamedFile', locale).replace(
-              '{name}',
-              file.name
-            )
-          "
-          class="focus-visible:outline-primary-comfy-yellow flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-primary-warm-gray hover:bg-transparency-white-t8 hover:text-primary-warm-white"
-          @click="remove(index)"
-        >
-          <X class="size-4" aria-hidden="true" />
-        </button>
-      </li>
+        :file
+        :disabled
+        :locale
+        @replace="replace(index)"
+        @remove="remove(index)"
+      />
     </ul>
     <label
       :for="`field-${field.name}`"
@@ -204,27 +174,9 @@ function fileType(file: FileValue): string {
       @click="replacement = undefined"
     >
       <Upload class="size-5" aria-hidden="true" />
-      <span>{{
-        t(
-          selectedFiles.length && !field.multiple
-            ? imageOnly
-              ? 'workshop.field.replaceOrDropImage'
-              : 'workshop.field.replaceOrDropFile'
-            : imageOnly
-              ? 'workshop.field.chooseOrDropImages'
-              : 'workshop.field.chooseOrDropFiles',
-          locale
-        )
-      }}</span>
+      <span>{{ t(prompt, locale) }}</span>
       <span>
-        <template v-if="field.accept.length"
-          >{{
-            field.accept
-              .map((type) => type.split('/')[1].replace('x-', '').toUpperCase())
-              .join(', ')
-          }}
-          ·
-        </template>
+        <template v-if="acceptedTypes">{{ acceptedTypes }} · </template>
         {{ t('workshop.field.uploadLimit', locale) }}
       </span>
     </label>
@@ -250,15 +202,7 @@ function fileType(file: FileValue): string {
       role="alert"
       class="text-primary-comfy-red text-xs"
     >
-      {{ t(rejection, locale).replace('{count}', String(limit)) }}
-      {{
-        t(
-          imageOnly
-            ? 'workshop.field.imagesUnchanged'
-            : 'workshop.field.filesUnchanged',
-          locale
-        )
-      }}
+      {{ rejectionMessage }}
     </p>
   </div>
 </template>

--- a/apps/website/src/components/workshop/FileSourceInput.vue
+++ b/apps/website/src/components/workshop/FileSourceInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { File as FileIcon, Upload, X } from '@lucide/vue'
+import { Upload, X } from '@lucide/vue'
 import { useDropZone } from '@vueuse/core'
 import { computed, nextTick, ref, useTemplateRef } from 'vue'
 
@@ -10,7 +10,7 @@ import type { FieldSchema, FileValue } from '../../config/workshop-playground'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import ImageSourcePreview from './ImageSourcePreview.vue'
-import MediaSourcePreview from './MediaSourcePreview.vue'
+import VideoSourcePreview from './VideoSourcePreview.vue'
 
 const {
   field,
@@ -133,19 +133,14 @@ function fileType(file: FileValue): string {
       )
     "
   >
-    <div
+    <ul
       v-if="selectedFiles.length"
-      :class="
-        cn(
-          'grid min-w-0 gap-3 px-3 pt-3',
-          imageOnly && selectedFiles.length > 1 ? 'grid-cols-2' : 'grid-cols-1'
-        )
-      "
+      class="flex min-w-0 flex-col gap-2 px-3 pt-3"
     >
-      <div
+      <li
         v-for="(file, index) in selectedFiles"
         :key="index"
-        class="flex min-w-0 flex-col gap-2"
+        class="bg-transparency-white-t4 flex min-w-0 items-center gap-3 rounded-xl p-2"
       >
         <ImageSourcePreview
           v-if="file.type.startsWith('image/')"
@@ -154,60 +149,50 @@ function fileType(file: FileValue): string {
           :name="file.name"
           :locale
         />
-        <MediaSourcePreview
-          v-else-if="
-            file.type.startsWith('video/') || file.type.startsWith('audio/')
-          "
+        <VideoSourcePreview
+          v-else-if="file.type.startsWith('video/')"
           :file="file.file"
           :src="file.previewUrl"
-          :kind="file.type.startsWith('video/') ? 'video' : 'audio'"
           :name="file.name"
         />
-        <div
+        <span
           v-else
-          class="bg-transparency-white-t4 flex items-center gap-3 rounded-xl p-3 text-sm text-primary-warm-white"
+          class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-transparency-white-t8 text-xs font-bold text-primary-warm-gray"
         >
-          <FileIcon
-            class="size-8 shrink-0 text-primary-warm-gray"
-            aria-hidden="true"
-          />
-          <span class="font-bold">{{ fileType(file) }}</span>
-          <span class="ml-auto text-xs text-primary-warm-gray">{{
-            formatSize(file.size)
-          }}</span>
-        </div>
-        <div class="flex min-w-0 items-center gap-2">
-          <button
-            type="button"
-            :disabled
-            :aria-label="
-              t('workshop.field.replaceFile', locale).replace(
-                '{name}',
-                file.name
-              )
-            "
-            class="focus-visible:outline-primary-comfy-yellow min-w-0 flex-1 cursor-pointer truncate text-left text-xs text-primary-warm-white underline underline-offset-4"
-            @click="replace(index)"
-          >
-            {{ file.name }}
-          </button>
-          <button
-            type="button"
-            :disabled
-            :aria-label="
-              t('workshop.field.removeNamedFile', locale).replace(
-                '{name}',
-                file.name
-              )
-            "
-            class="focus-visible:outline-primary-comfy-yellow flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-primary-warm-gray hover:bg-transparency-white-t8 hover:text-primary-warm-white"
-            @click="remove(index)"
-          >
-            <X class="size-4" aria-hidden="true" />
-          </button>
-        </div>
-      </div>
-    </div>
+          {{ fileType(file) }}
+        </span>
+        <button
+          type="button"
+          :disabled
+          :aria-label="
+            t('workshop.field.replaceFile', locale).replace('{name}', file.name)
+          "
+          class="focus-visible:outline-primary-comfy-yellow min-w-0 flex-1 cursor-pointer truncate text-left text-sm text-primary-warm-white underline-offset-4 hover:underline"
+          @click="replace(index)"
+        >
+          {{ file.name }}
+        </button>
+        <span
+          v-if="file.size"
+          class="shrink-0 text-xs text-primary-warm-gray"
+          >{{ formatSize(file.size) }}</span
+        >
+        <button
+          type="button"
+          :disabled
+          :aria-label="
+            t('workshop.field.removeNamedFile', locale).replace(
+              '{name}',
+              file.name
+            )
+          "
+          class="focus-visible:outline-primary-comfy-yellow flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-primary-warm-gray hover:bg-transparency-white-t8 hover:text-primary-warm-white"
+          @click="remove(index)"
+        >
+          <X class="size-4" aria-hidden="true" />
+        </button>
+      </li>
+    </ul>
     <label
       :for="`field-${field.name}`"
       :class="

--- a/apps/website/src/components/workshop/FileSourceInput.vue
+++ b/apps/website/src/components/workshop/FileSourceInput.vue
@@ -125,7 +125,7 @@ function fileType(file: FileValue): string {
     :aria-label="field.label"
     :class="
       cn(
-        'focus-within:ring-primary-comfy-yellow flex min-w-0 flex-col gap-3 rounded-2xl border border-dashed p-3 focus-within:ring-2',
+        'focus-within:ring-primary-comfy-yellow flex min-w-0 flex-col gap-3 rounded-2xl border border-dashed focus-within:ring-2',
         isOverDropZone && !disabled
           ? 'border-primary-comfy-yellow'
           : 'border-transparency-white-t20',
@@ -137,7 +137,7 @@ function fileType(file: FileValue): string {
       v-if="selectedFiles.length"
       :class="
         cn(
-          'grid min-w-0 gap-3',
+          'grid min-w-0 gap-3 px-3 pt-3',
           imageOnly && selectedFiles.length > 1 ? 'grid-cols-2' : 'grid-cols-1'
         )
       "
@@ -212,7 +212,7 @@ function fileType(file: FileValue): string {
       :for="`field-${field.name}`"
       :class="
         cn(
-          'hover:bg-transparency-white-t4 flex min-h-20 cursor-pointer flex-col items-center justify-center gap-1 rounded-xl text-xs text-primary-warm-gray',
+          'hover:bg-transparency-white-t4 flex min-h-20 cursor-pointer flex-col items-center justify-center gap-1 rounded-2xl text-xs text-primary-warm-gray',
           disabled && 'pointer-events-none'
         )
       "

--- a/apps/website/src/components/workshop/HeaderAccount.test.ts
+++ b/apps/website/src/components/workshop/HeaderAccount.test.ts
@@ -137,7 +137,7 @@ describe('HeaderAccount', () => {
       await userEvent
         .setup()
         .click(screen.getByRole('button', { name: /account/i }))
-      const buy = screen.getByRole('menuitem', { name: 'Buy credits' })
+      const buy = screen.getByRole('menuitem', { name: 'Add credits' })
       expect(buy.getAttribute('href')).toBe(
         `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
       )

--- a/apps/website/src/components/workshop/ImageSourcePreview.vue
+++ b/apps/website/src/components/workshop/ImageSourcePreview.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ImageOff } from '@lucide/vue'
 import { useMounted, useObjectUrl } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
@@ -29,10 +30,17 @@ const failedSource = ref<string>()
     :src="source"
     :alt="name"
     referrerpolicy="no-referrer"
-    class="bg-transparency-white-t4 h-32 w-full rounded-xl object-contain"
+    class="size-12 shrink-0 rounded-lg bg-transparency-white-t8 object-cover"
     @error="failedSource = source"
   />
-  <p v-else-if="source" role="status" class="text-xs text-primary-warm-gray">
-    {{ t('workshop.field.imagePreviewUnavailable', locale) }}
-  </p>
+  <span
+    v-else-if="source"
+    role="status"
+    class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-transparency-white-t8"
+  >
+    <ImageOff class="size-5 text-primary-warm-gray" aria-hidden="true" />
+    <span class="sr-only">{{
+      t('workshop.field.imagePreviewUnavailable', locale)
+    }}</span>
+  </span>
 </template>

--- a/apps/website/src/components/workshop/ModelDetail.ssr.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.ssr.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+import type { WorkshopModelDetail } from '../../config/models-catalogue'
+import ModelDetail from './ModelDetail.vue'
+
+vi.mock<unknown>(import('../../scripts/posthog'), async () => {
+  const { ref } = await import('vue')
+  return {
+    useWorkshopAuthFlag: () => ref(true),
+    useWorkshopAuthFlagSettled: () => ref(true)
+  }
+})
+
+vi.mock<unknown>(import('../../config/workshop-session-state'), async () => {
+  const { ref } = await import('vue')
+  return {
+    useWorkshopSession: () => ({
+      user: ref(null),
+      session: ref(undefined),
+      sessionFailure: ref(undefined),
+      settled: ref(true),
+      signedIn: ref(false),
+      ensureFresh: vi.fn(),
+      remint: vi.fn(),
+      signOut: vi.fn()
+    })
+  }
+})
+
+vi.mock<unknown>(import('../../config/workshop-credits'), async () => {
+  const { ref } = await import('vue')
+  return {
+    useWorkshopCredits: () => ({
+      balance: ref({ status: 'unknown' }),
+      session: ref(undefined)
+    }),
+    refreshWorkshopCredits: vi.fn()
+  }
+})
+
+const model: WorkshopModelDetail = {
+  slug: 'demo',
+  name: 'Demo',
+  workflowCount: 1,
+  href: '/models/demo/',
+  routerId: 'demo/demo',
+  capabilities: [],
+  provider: 'Demo',
+  modality: 'image',
+  task: 'text-to-image',
+  creditsPerRun: 8,
+  nodeDisplayName: 'Demo Text to Image',
+  fields: [
+    {
+      kind: 'text',
+      name: 'prompt',
+      label: 'Prompt',
+      multiline: true,
+      required: true
+    }
+  ],
+  defaults: {},
+  examples: []
+}
+
+describe('ModelDetail on the server', () => {
+  it('arrives with its playground already rendered, since a browser global read at setup would empty the island', async () => {
+    expect(typeof window, 'this file must run without a window').toBe(
+      'undefined'
+    )
+
+    const html = await renderToString(
+      createSSRApp({ render: () => h(ModelDetail, { model }) })
+    )
+
+    expect(html).toContain('Playground')
+    expect(html).toContain('Prompt')
+  })
+})

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -256,7 +256,6 @@ describe('ModelDetail', () => {
               player
           )
       ).toBe(true)
-      expect(player.hasAttribute('controls')).toBe(true)
       expect(runWorkshopRouter).not.toHaveBeenCalled()
       if (slug === 'bria--replace-video-background--edit-videos')
         expect(

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -443,9 +443,9 @@ describe('ModelDetail', () => {
     await user().type(screen.getByTestId('field-prompt'), 'A red teapot')
     await user().click(screen.getByTestId('run-button'))
     await vi.waitFor(() =>
-      expect(screen.getByRole('link', { name: 'Buy credits' })).toBeDefined()
+      expect(screen.getByRole('link', { name: 'Add credits' })).toBeDefined()
     )
-    const link = screen.getByRole('link', { name: 'Buy credits' })
+    const link = screen.getByRole('link', { name: 'Add credits' })
     expect(link.getAttribute('href')).toBe(
       new URL('/?settings=plan-credits', WORKSHOP_CLOUD_BASE_URL).href
     )
@@ -468,7 +468,7 @@ describe('ModelDetail', () => {
       'A red teapot'
     )
 
-    const buy = screen.getByRole('link', { name: 'Buy credits' })
+    const buy = screen.getByRole('link', { name: 'Add credits' })
     expect(buy.getAttribute('href')).toBe(
       `${WORKSHOP_CLOUD_BASE_URL}/?settings=plan-credits`
     )
@@ -479,7 +479,7 @@ describe('ModelDetail', () => {
     credits.balance.value = { status: 'ok', credits: 100 }
     await nextTick()
     expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
     expect(screen.getByRole('textbox', { name: /Prompt/ })).toHaveProperty(
       'value',
       'A red teapot'
@@ -494,7 +494,7 @@ describe('ModelDetail', () => {
       mountDetail({ model: runnable })
       await nextTick()
       expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy()
-      expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
+      expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
     }
   )
 
@@ -519,7 +519,7 @@ describe('ModelDetail', () => {
       'Keep me'
     )
     expect(screen.getByText(/Studio has no credits left/)).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
     await visitor.click(
       screen.getByRole('button', { name: 'Switch to personal workspace' })
     )
@@ -552,7 +552,7 @@ describe('ModelDetail', () => {
         name: 'Switch to personal workspace'
       })
     ).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull()
   })
 
@@ -561,7 +561,7 @@ describe('ModelDetail', () => {
     credits.balance.value = { status: 'ok', credits: 0 }
     mountDetail()
     expect(screen.getByTestId('run-button').hasAttribute('disabled')).toBe(true)
-    expect(screen.queryByRole('link', { name: 'Buy credits' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Add credits' })).toBeNull()
   })
 
   it('keeps cancellation available if the balance becomes zero during a run', async () => {
@@ -585,7 +585,7 @@ describe('ModelDetail', () => {
     expect(
       screen.getByTestId('playground-output').getAttribute('data-state')
     ).toBe('cancelled')
-    expect(screen.getByRole('link', { name: 'Buy credits' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Add credits' })).toBeTruthy()
     pending.resolve(routerResult)
     await vi.waitFor(() => expect(refreshWorkshopCredits).toHaveBeenCalled())
   })

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -1188,11 +1188,13 @@ describe('ModelDetail', () => {
         ? '{"prompt":"My edited draft"}'
         : 'My edited draft'
       await fireEvent.update(input, edited)
-      await user().click(screen.getByRole('button', { name: 'View sample' }))
+      await user().click(
+        screen.getByRole('button', { name: 'Start and end frame: View sample' })
+      )
       expect(input.value).toBe(edited)
       expect(input.isConnected).toBe(true)
       expect(screen.getByTestId('example-card').getAttribute('title')).toBe(
-        'Viewing sample'
+        'Start and end frame · Viewing sample'
       )
       expect(
         screen.getByTestId('playground-output').getAttribute('data-state')

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -590,6 +590,30 @@ describe('ModelDetail', () => {
     await vi.waitFor(() => expect(refreshWorkshopCredits).toHaveBeenCalled())
   })
 
+  it('asks before the tab is closed on a run in flight, and only then', async () => {
+    auth.session.value = credential
+    const pending = Promise.withResolvers<typeof routerResult>()
+    vi.mocked(runWorkshopRouter).mockReturnValue(pending.promise)
+    mountDetail({ model: runnable })
+
+    const leaving = () =>
+      window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    expect(leaving()).toBe(true)
+
+    await user().type(screen.getByTestId('field-prompt'), 'A teapot')
+    await user().click(screen.getByTestId('run-button'))
+    await vi.waitFor(() => expect(runWorkshopRouter).toHaveBeenCalledTimes(1))
+    expect(leaving()).toBe(false)
+
+    pending.resolve(routerResult)
+    await vi.waitFor(() =>
+      expect(
+        screen.getByTestId('playground-output').getAttribute('data-state')
+      ).toBe('succeeded')
+    )
+    expect(leaving()).toBe(true)
+  })
+
   it('retries an unchanged failed request with its original key, but a deliberate new run gets a new key', async () => {
     auth.session.value = credential
     vi.mocked(runWorkshopRouter)

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -1217,9 +1217,12 @@ describe('ModelDetail', () => {
       )
       expect(input.value).toBe(edited)
       expect(input.isConnected).toBe(true)
-      expect(screen.getByTestId('example-card').getAttribute('title')).toBe(
-        'Start and end frame · Viewing sample'
-      )
+      expect(
+        screen.getByRole('button', {
+          name: 'Start and end frame: View sample',
+          current: true
+        })
+      ).toBeTruthy()
       expect(
         screen.getByTestId('playground-output').getAttribute('data-state')
       ).toBe('example')

--- a/apps/website/src/components/workshop/ModelDetail.test.ts
+++ b/apps/website/src/components/workshop/ModelDetail.test.ts
@@ -807,7 +807,7 @@ describe('ModelDetail', () => {
     mountDetail({ model: runnable })
     expect(
       screen.getByRole('button', {
-        name: 'Router execution is not enabled for this model yet.'
+        name: 'Comfy Router execution is not enabled for this model yet.'
       })
     ).toHaveProperty('disabled', true)
     expect(runWorkshopRouter).not.toHaveBeenCalled()
@@ -907,7 +907,7 @@ describe('ModelDetail', () => {
       expect(screen.queryByRole('link', { name: 'Sign in to run' })).toBeNull()
       expect(
         screen.getByRole('button', {
-          name: 'Router execution is not enabled for this model yet.'
+          name: 'Comfy Router execution is not enabled for this model yet.'
         })
       ).toHaveProperty('disabled', true)
     }
@@ -1041,7 +1041,7 @@ describe('ModelDetail', () => {
     expect(button.getAttribute('data-gate')).toBe('unavailable')
     expect(button.hasAttribute('disabled')).toBe(true)
     expect(button.textContent).toContain(
-      'Router execution is not enabled for this model yet'
+      'Comfy Router execution is not enabled for this model yet'
     )
   })
 

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -188,7 +188,7 @@ const isRunning = computed(() => runState.value.status === 'running')
 
 // A run in flight is money and minutes: leaving the page throws both away, so
 // the browser asks first.
-useEventListener(window, 'beforeunload', (event: BeforeUnloadEvent) => {
+useEventListener('beforeunload', (event: BeforeUnloadEvent) => {
   if (!isRunning.value) return
   event.preventDefault()
 })

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -187,11 +187,14 @@ const errors = computed<FieldErrors>(() =>
 const isRunning = computed(() => runState.value.status === 'running')
 
 // A run in flight is money and minutes: leaving the page throws both away, so
-// the browser asks first.
-useEventListener('beforeunload', (event: BeforeUnloadEvent) => {
-  if (!isRunning.value) return
-  event.preventDefault()
-})
+// the browser asks first. The listener only exists while the run does, since a
+// standing one costs the idle page its place in the back/forward cache.
+// globalThis.window, not window: on the server the island has neither.
+useEventListener(
+  () => (isRunning.value ? globalThis.window : undefined),
+  'beforeunload',
+  (event: BeforeUnloadEvent) => event.preventDefault()
+)
 const hasFileInputs = computed(() =>
   schema.value.some((field) => field.kind === 'file' || urlUploadField(field))
 )

--- a/apps/website/src/components/workshop/ModelDetail.vue
+++ b/apps/website/src/components/workshop/ModelDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Download } from '@lucide/vue'
-import { useMounted, useTimestamp } from '@vueuse/core'
+import { useEventListener, useMounted, useTimestamp } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, useSlots, watch } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
@@ -185,6 +185,13 @@ const errors = computed<FieldErrors>(() =>
   runState.value.status === 'failed' ? runState.value.fieldErrors : {}
 )
 const isRunning = computed(() => runState.value.status === 'running')
+
+// A run in flight is money and minutes: leaving the page throws both away, so
+// the browser asks first.
+useEventListener(window, 'beforeunload', (event: BeforeUnloadEvent) => {
+  if (!isRunning.value) return
+  event.preventDefault()
+})
 const hasFileInputs = computed(() =>
   schema.value.some((field) => field.kind === 'file' || urlUploadField(field))
 )

--- a/apps/website/src/components/workshop/PlaygroundField.test.ts
+++ b/apps/website/src/components/workshop/PlaygroundField.test.ts
@@ -246,7 +246,7 @@ describe('PlaygroundField', () => {
     }
   )
 
-  it('shows a playable source video when an example URL is prefilled', () => {
+  it('shows the source video frame when an example URL is prefilled', () => {
     mountField(
       {
         kind: 'text',
@@ -268,7 +268,6 @@ describe('PlaygroundField', () => {
     const slot = within(screen.getByRole('group', { name: 'Source video' }))
     const player = slot.getByLabelText('source.mp4', { selector: 'video' })
     expect(player.getAttribute('src')).toBe('https://example.com/source.mp4')
-    expect(player.hasAttribute('controls')).toBe(true)
     expect(player.getAttribute('preload')).toBe('metadata')
     expect(
       screen

--- a/apps/website/src/components/workshop/PlaygroundOutput.test.ts
+++ b/apps/website/src/components/workshop/PlaygroundOutput.test.ts
@@ -59,8 +59,8 @@ describe('PlaygroundOutput', () => {
   })
 
   it.for([
-    { locale: 'en' as const, label: 'Buy credits' },
-    { locale: 'zh-CN' as const, label: '购买积分' }
+    { locale: 'en' as const, label: 'Add credits' },
+    { locale: 'zh-CN' as const, label: '添加积分' }
   ])(
     'takes an insufficient-credit failure to billing in $locale',
     ({ locale, label }) => {

--- a/apps/website/src/components/workshop/PlaygroundOutput.test.ts
+++ b/apps/website/src/components/workshop/PlaygroundOutput.test.ts
@@ -47,6 +47,28 @@ describe('PlaygroundOutput', () => {
     await waitFor(() => expect(trigger).toHaveFocus())
   })
 
+  it('opens a video result full screen, the same as a still', async () => {
+    const user = userEvent.setup()
+    render(PlaygroundOutput, {
+      props: {
+        state: succeeded({
+          kind: 'video',
+          url: 'https://example.com/run.mp4',
+          fileName: 'run.mp4'
+        }),
+        modality: 'video',
+        now: 2_000
+      }
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Expand' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Output' })
+    expect(within(dialog).getByTestId('output-expanded-video')).toHaveAttribute(
+      'src',
+      'https://example.com/run.mp4'
+    )
+  })
+
   it('announces expiration when a completed output is no longer available', async () => {
     const { rerender } = render(PlaygroundOutput, {
       props: { state: succeeded(output('latest')), now: 2_000 }

--- a/apps/website/src/components/workshop/PlaygroundOutput.test.ts
+++ b/apps/website/src/components/workshop/PlaygroundOutput.test.ts
@@ -188,6 +188,33 @@ describe('PlaygroundOutput', () => {
     ).toContain('latest')
   })
 
+  it('lines the session up in the order it was generated, newest last', async () => {
+    const user = userEvent.setup()
+    render(PlaygroundOutput, {
+      props: {
+        state: succeeded(output('third')),
+        earlier: [
+          { output: output('second'), attachments: [] },
+          { output: output('first'), attachments: [] }
+        ],
+        now: 2_000
+      }
+    })
+    const strip = within(screen.getByTestId('earlier-runs'))
+    expect(
+      strip
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Earlier run 2', 'Earlier run 1', 'Latest'])
+    expect(
+      strip.getByRole('button', { name: 'Latest', pressed: true })
+    ).toBeTruthy()
+    await user.click(strip.getByRole('button', { name: 'Earlier run 2' }))
+    expect(
+      screen.getByTestId('output-download').getAttribute('href')
+    ).toContain('first')
+  })
+
   it('downloads the selected batch item and the selected earlier run', async () => {
     const user = userEvent.setup()
     render(PlaygroundOutput, {

--- a/apps/website/src/components/workshop/PlaygroundOutput.vue
+++ b/apps/website/src/components/workshop/PlaygroundOutput.vue
@@ -117,7 +117,9 @@ const shown = computed(() => selectedAttachment.value ?? primary.value)
 // Only a result the visitor produced opens full screen; the example is a
 // sample of what the model makes, not their picture to inspect.
 const expandable = computed(
-  () => state.status === 'succeeded' && shown.value?.kind === 'image'
+  () =>
+    state.status === 'succeeded' &&
+    (shown.value?.kind === 'image' || shown.value?.kind === 'video')
 )
 const outputs = computed(() =>
   shown.value
@@ -420,7 +422,7 @@ const earlierClass = (active: boolean) =>
           @click="selected = index"
         >
           <video
-            v-if="shown.kind === 'video'"
+            v-if="shown?.kind === 'video'"
             :src="url"
             class="size-full object-cover"
             muted
@@ -588,7 +590,18 @@ const earlierClass = (active: boolean) =>
           >
             <X class="size-4" aria-hidden="true" />
           </button>
+          <video
+            v-if="shown?.kind === 'video'"
+            :src="currentUrl"
+            data-testid="output-expanded-video"
+            class="max-h-full max-w-full rounded-2xl object-contain"
+            controls
+            autoplay
+            loop
+            playsinline
+          />
           <img
+            v-else
             :src="currentUrl"
             :alt="t('workshop.output.title', locale)"
             class="max-h-full max-w-full rounded-2xl object-contain"

--- a/apps/website/src/components/workshop/PlaygroundOutput.vue
+++ b/apps/website/src/components/workshop/PlaygroundOutput.vue
@@ -162,6 +162,32 @@ watch(shown, () => {
   expanded.value = false
 })
 
+// Oldest first, so the strip reads in the order the runs happened and the
+// newest result is the last stop, selected by default.
+const runStops = computed(() =>
+  latest.value === undefined
+    ? []
+    : [
+        ...earlier
+          .map((record, index) => ({
+            record: record as RunRecord | undefined,
+            output: record.output,
+            name: t('workshop.output.earlierRun', locale).replace(
+              '{number}',
+              String(index + 1)
+            ),
+            testId: `earlier-run-${index}`
+          }))
+          .reverse(),
+        {
+          record: undefined,
+          output: latest.value,
+          name: t('workshop.output.latest', locale),
+          testId: 'earlier-latest'
+        }
+      ]
+)
+
 const earlierClass = (active: boolean) =>
   cn(
     'flex size-12 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-xl border-2 text-xs text-primary-warm-white transition-opacity',
@@ -459,48 +485,40 @@ const earlierClass = (active: boolean) =>
 
       <div
         v-if="earlier.length && state.status === 'succeeded'"
+        role="group"
+        :aria-label="t('workshop.output.earlier', locale)"
         class="flex items-center gap-2 overflow-x-auto border-t border-transparency-white-t8 px-4 py-3"
         data-testid="earlier-runs"
       >
-        <span
-          class="shrink-0 text-2xs font-bold tracking-wider text-primary-warm-gray uppercase"
-        >
-          {{ t('workshop.output.earlier', locale) }}
-        </span>
         <button
+          v-for="stop in runStops"
+          :key="stop.testId"
           type="button"
-          :aria-pressed="!viewing"
-          :class="cn(earlierClass(!viewing), 'w-auto px-3')"
-          data-testid="earlier-latest"
-          @click="viewing = undefined"
-        >
-          {{ t('workshop.output.latest', locale) }}
-        </button>
-        <button
-          v-for="(run, index) in earlier"
-          :key="index"
-          type="button"
-          :aria-pressed="viewing === run"
-          :aria-label="`${t('workshop.output.earlier', locale)} ${index + 1}`"
-          :class="earlierClass(viewing === run)"
-          :data-testid="`earlier-run-${index}`"
-          @click="viewing = run"
+          :aria-pressed="viewing === stop.record"
+          :aria-label="stop.name"
+          :class="earlierClass(viewing === stop.record)"
+          :data-testid="stop.testId"
+          @click="viewing = stop.record"
         >
           <video
-            v-if="run.output.kind === 'video'"
-            :src="run.output.url"
-            :class="cn('size-full object-cover', run.output.nsfw && 'blur-md')"
+            v-if="stop.output.kind === 'video'"
+            :src="stop.output.url"
+            :class="cn('size-full object-cover', stop.output.nsfw && 'blur-md')"
             muted
             playsinline
             preload="metadata"
           />
           <img
-            v-else-if="run.output.kind === 'image'"
-            :src="run.output.url"
+            v-else-if="stop.output.kind === 'image'"
+            :src="stop.output.url"
             alt=""
-            :class="cn('size-full object-cover', run.output.nsfw && 'blur-md')"
+            :class="cn('size-full object-cover', stop.output.nsfw && 'blur-md')"
           />
-          <span v-else>{{ index + 2 }}</span>
+          <FileIcon
+            v-else
+            class="size-5 text-primary-warm-gray"
+            aria-hidden="true"
+          />
         </button>
       </div>
 

--- a/apps/website/src/components/workshop/SelectedFileRow.vue
+++ b/apps/website/src/components/workshop/SelectedFileRow.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { X } from '@lucide/vue'
+import { computed } from 'vue'
+
+import { formatSize } from '@comfyorg/shared-frontend-utils/formatUtil'
+
+import type { FileValue } from '../../config/workshop-playground'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import ImageSourcePreview from './ImageSourcePreview.vue'
+import VideoSourcePreview from './VideoSourcePreview.vue'
+
+const {
+  file,
+  disabled = false,
+  locale = 'en'
+} = defineProps<{
+  file: FileValue
+  disabled?: boolean
+  locale?: Locale
+}>()
+defineEmits<{ replace: []; remove: [] }>()
+
+const fileType = computed(
+  () =>
+    /\.([a-z\d]{1,12})$/i.exec(file.name)?.[1].toUpperCase() ??
+    t('workshop.field.file', locale)
+)
+</script>
+
+<template>
+  <li
+    class="bg-transparency-white-t4 flex min-w-0 items-center gap-3 rounded-xl p-2"
+  >
+    <ImageSourcePreview
+      v-if="file.type.startsWith('image/')"
+      :file="file.file"
+      :src="file.previewUrl"
+      :name="file.name"
+      :locale
+    />
+    <VideoSourcePreview
+      v-else-if="file.type.startsWith('video/')"
+      :file="file.file"
+      :src="file.previewUrl"
+      :name="file.name"
+    />
+    <span
+      v-else
+      class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-transparency-white-t8 text-xs font-bold text-primary-warm-gray"
+    >
+      {{ fileType }}
+    </span>
+    <button
+      type="button"
+      :disabled
+      :aria-label="
+        t('workshop.field.replaceFile', locale).replace('{name}', file.name)
+      "
+      class="focus-visible:outline-primary-comfy-yellow min-w-0 flex-1 cursor-pointer truncate text-left text-sm text-primary-warm-white underline-offset-4 hover:underline"
+      @click="$emit('replace')"
+    >
+      {{ file.name }}
+    </button>
+    <span v-if="file.size" class="shrink-0 text-xs text-primary-warm-gray">{{
+      formatSize(file.size)
+    }}</span>
+    <button
+      type="button"
+      :disabled
+      :aria-label="
+        t('workshop.field.removeNamedFile', locale).replace('{name}', file.name)
+      "
+      class="focus-visible:outline-primary-comfy-yellow flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-primary-warm-gray hover:bg-transparency-white-t8 hover:text-primary-warm-white"
+      @click="$emit('remove')"
+    >
+      <X class="size-4" aria-hidden="true" />
+    </button>
+  </li>
+</template>

--- a/apps/website/src/components/workshop/VideoSourcePreview.test.ts
+++ b/apps/website/src/components/workshop/VideoSourcePreview.test.ts
@@ -4,20 +4,20 @@ import { expect, it, vi } from 'vitest'
 import { createSSRApp, h } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
-import MediaSourcePreview from './MediaSourcePreview.vue'
+import VideoSourcePreview from './VideoSourcePreview.vue'
 
 it('waits until mounting before creating a local media URL', async () => {
   const create = vi.spyOn(URL, 'createObjectURL')
   const file = new File(['video'], 'source.mp4', { type: 'video/mp4' })
-  const props = { file, name: 'Source video', kind: 'video' as const }
+  const props = { file, name: 'Source video' }
   const html = await renderToString(
     createSSRApp({
-      render: () => h(MediaSourcePreview, props)
+      render: () => h(VideoSourcePreview, props)
     })
   )
   expect(create).not.toHaveBeenCalled()
   expect(html).not.toContain('blob:')
-  render(MediaSourcePreview, { props })
+  render(VideoSourcePreview, { props })
   const video = await screen.findByLabelText('Source video')
   expect(video.getAttribute('src')).toMatch(/^blob:/)
   expect(create).toHaveBeenCalledWith(file)
@@ -30,11 +30,10 @@ it('switches between remote examples and local uploads, revoking only its owned 
     .mockReturnValueOnce('blob:second')
   const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
   const props = {
-    kind: 'video' as const,
     name: 'Input video',
     src: 'https://assets.example/source.mp4'
   }
-  const { rerender, unmount } = render(MediaSourcePreview, { props })
+  const { rerender, unmount } = render(VideoSourcePreview, { props })
   function video() {
     const element = screen.getByLabelText('Input video')
     if (!(element instanceof HTMLVideoElement))
@@ -58,17 +57,4 @@ it('switches between remote examples and local uploads, revoking only its owned 
   expect(revoke).toHaveBeenCalledWith('blob:second')
   unmount()
   expect(revoke).not.toHaveBeenCalledWith(props.src)
-})
-
-it('renders an audio source as an accessible audio element', () => {
-  render(MediaSourcePreview, {
-    props: {
-      kind: 'audio',
-      name: 'Input audio',
-      src: 'https://assets.example/source.mp3'
-    }
-  })
-  const element = screen.getByLabelText('Input audio')
-  expect(element).toBeInstanceOf(HTMLAudioElement)
-  expect(element.getAttribute('src')).toBe('https://assets.example/source.mp3')
 })

--- a/apps/website/src/components/workshop/VideoSourcePreview.vue
+++ b/apps/website/src/components/workshop/VideoSourcePreview.vue
@@ -2,10 +2,9 @@
 import { useMounted, useObjectUrl } from '@vueuse/core'
 import { computed } from 'vue'
 
-const { file, src, kind, name } = defineProps<{
+const { file, src, name } = defineProps<{
   file?: File
   src?: string
-  kind: 'video' | 'audio'
   name: string
 }>()
 const mounted = useMounted()
@@ -15,22 +14,13 @@ const source = computed(() => objectUrl.value ?? src)
 
 <template>
   <video
-    v-if="source && kind === 'video'"
+    v-if="source"
     :key="source"
     :src="source"
     :aria-label="name"
-    controls
+    muted
     playsinline
     preload="metadata"
-    class="bg-transparency-white-t4 h-32 w-full rounded-xl object-contain"
-  />
-  <audio
-    v-else-if="source"
-    :key="source"
-    :src="source"
-    :aria-label="name"
-    controls
-    preload="metadata"
-    class="w-full"
+    class="size-12 shrink-0 rounded-lg bg-transparency-white-t8 object-cover"
   />
 </template>

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.test.ts
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.test.ts
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/vue'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type { WorkshopModel } from '../../config/models-catalogue'
+import { lastShelf } from '../../lib/workshop/shelf-memory'
 import WorkshopModelsGrid from './WorkshopModelsGrid.vue'
 
 const models: WorkshopModel[] = [
@@ -54,6 +55,7 @@ function search() {
 describe('WorkshopModelsGrid', () => {
   afterEach(() => {
     history.replaceState(null, '', '/')
+    sessionStorage.clear()
   })
 
   it('searches by name and provider', async () => {
@@ -152,6 +154,13 @@ describe('WorkshopModelsGrid', () => {
       await screen.findByRole('menuitemradio', { name: 'Name A to Z' })
     )
     expect(cardNames()[0]).toContain('Flux')
+  })
+
+  it('forgets the shelf a previous visit was left on', () => {
+    sessionStorage.setItem('comfy-models-shelf', 'generate-videos')
+    render(WorkshopModelsGrid, { props: { models } })
+
+    expect(lastShelf()).toBe('all')
   })
 
   it('clears search and filters together from the empty state', async () => {

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.vue
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.vue
@@ -8,7 +8,7 @@ import {
   DropdownMenuRoot,
   DropdownMenuTrigger
 } from 'reka-ui'
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import { groupModels } from '../../config/model-family'
@@ -31,6 +31,8 @@ import {
 } from '../../config/models-catalogue'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
+import { rememberShelf } from '../../lib/workshop/shelf-memory'
+import { useCaseLabelKey } from '../../lib/workshop/use-case-label'
 import type { FacetMenuOption } from './WorkshopFilterMenu.vue'
 import WorkshopFilterMenu from './WorkshopFilterMenu.vue'
 import WorkshopModelCard from './WorkshopModelCard.vue'
@@ -62,20 +64,20 @@ onMounted(() => {
 
 // A row title clicked far down the page opens a much shorter screen, which
 // would otherwise leave the viewport parked on the footer.
-watch(useCase, () => void nextTick(() => window.scrollTo({ top: 0 })))
+watch(useCase, (shelf) => {
+  rememberShelf(shelf)
+  void nextTick(() => window.scrollTo({ top: 0 }))
+})
 
-const useCaseLabelKey: Record<UseCase | 'all' | 'other', TranslationKey> = {
-  all: 'workshop.useCase.all',
-  other: 'workshop.sections.otherFormats',
-  'generate-images': 'workshop.useCase.generateImages',
-  'edit-images': 'workshop.useCase.editImages',
-  'generate-videos': 'workshop.useCase.generateVideos',
-  'animate-images': 'workshop.useCase.animateImages',
-  'edit-videos': 'workshop.useCase.editVideos',
-  '3d': 'workshop.useCase.3d',
-  audio: 'workshop.useCase.audio',
-  text: 'workshop.useCase.text'
-}
+// Typing swaps the rows for a grid and clearing swaps them back, which moves
+// everything under the search field. Following the field keeps it in the same
+// place both ways, instead of the page landing wherever the new height falls.
+const toolbar = useTemplateRef<HTMLElement>('toolbar')
+watch(
+  () => query.value.trim() !== '',
+  () => void nextTick(() => toolbar.value?.scrollIntoView({ block: 'start' }))
+)
+
 const sortLabelKey: Record<SortOrder, TranslationKey> = {
   popular: 'workshop.sort.popular',
   name: 'workshop.sort.name',
@@ -227,7 +229,8 @@ const menuItemClass =
       </button>
 
       <div
-        class="bg-page sticky top-20 z-30 mb-8 flex flex-wrap items-center justify-end gap-3 py-4 max-sm:mb-4 max-sm:py-2 lg:top-26"
+        ref="toolbar"
+        class="bg-page sticky top-20 z-30 mb-8 flex scroll-mt-20 flex-wrap items-center justify-end gap-3 py-4 max-sm:mb-4 max-sm:py-2 lg:top-26 lg:scroll-mt-26"
       >
         <h1
           v-if="inSection"

--- a/apps/website/src/components/workshop/WorkshopModelsGrid.vue
+++ b/apps/website/src/components/workshop/WorkshopModelsGrid.vue
@@ -60,6 +60,9 @@ onMounted(() => {
   capabilities.value = [...(initial.capabilities ?? [])]
   providers.value = [...(initial.providers ?? [])]
   modalities.value = [...(initial.modalities ?? [])]
+  // The whole catalogue is a shelf too, and it has to replace the one the tab
+  // was left on, or the way back leads to a category never visited.
+  rememberShelf(useCase.value)
 })
 
 // A row title clicked far down the page opens a much shorter screen, which

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9775,6 +9775,10 @@ Enterprise`
     en: 'Earlier runs this session',
     'zh-CN': '本次会话的早前运行'
   },
+  'workshop.output.earlierRun': {
+    en: 'Earlier run {number}',
+    'zh-CN': '早前运行 {number}'
+  },
   'workshop.output.latest': { en: 'Latest', 'zh-CN': '最新' },
   'workshop.output.placeholder': {
     en: 'Your output will appear here.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -9682,9 +9682,9 @@ Enterprise`
     'zh-CN': '请先登录再上传文件。你的提示词和设置会保留。'
   },
   'workshop.form.requestTooLarge': {
-    en: 'The combined images and prompt exceed Router’s 10 MiB request limit. Use smaller images or a shorter prompt.',
+    en: 'The combined images and prompt exceed Comfy Router’s 10 MiB request limit. Use smaller images or a shorter prompt.',
     'zh-CN':
-      '图片和提示词的总大小超过 Router 的 10 MiB 请求限制。请使用更小的图片或缩短提示词。'
+      '图片和提示词的总大小超过 Comfy Router 的 10 MiB 请求限制。请使用更小的图片或缩短提示词。'
   },
   'workshop.form.badType': {
     en: 'File type not supported',
@@ -9716,8 +9716,8 @@ Enterprise`
   'workshop.dialogue.add': { en: 'Add turn', 'zh-CN': '添加一段' },
   'workshop.dialogue.remove': { en: 'Remove turn', 'zh-CN': '移除此段' },
   'workshop.run.mappingUnavailable': {
-    en: 'Router execution is not enabled for this model yet.',
-    'zh-CN': '此模型尚未启用 Router 执行。'
+    en: 'Comfy Router execution is not enabled for this model yet.',
+    'zh-CN': '此模型尚未启用 Comfy Router 执行。'
   },
   'workshop.model.incomplete': { en: 'Incomplete', 'zh-CN': '尚未完善' },
   'workshop.model.viewDetails': { en: 'View details', 'zh-CN': '查看详情' },
@@ -9726,9 +9726,9 @@ Enterprise`
     'zh-CN': '暂不支持运行'
   },
   'workshop.model.missingInputSchema': {
-    en: 'This model is listed by Router, but its input schema is not available yet. You can browse its known details; Run and API snippets will be enabled when the schema is added.',
+    en: 'This model is listed by Comfy Router, but its input schema is not available yet. You can browse its known details; Run and API snippets will be enabled when the schema is added.',
     'zh-CN':
-      'Router 已列出此模型，但其输入架构尚未提供。你可以查看已有信息；添加架构后将启用运行和 API 代码示例。'
+      'Comfy Router 已列出此模型，但其输入架构尚未提供。你可以查看已有信息；添加架构后将启用运行和 API 代码示例。'
   },
   'workshop.run.requestId': { en: 'Request ID:', 'zh-CN': '请求 ID：' },
   'workshop.run.cancel': { en: 'Cancel', 'zh-CN': '取消' },
@@ -9938,8 +9938,9 @@ Enterprise`
     'zh-CN': '输出样例'
   },
   'workshop.examples.samplesSubtitle': {
-    en: 'View a sample without changing your inputs. Verified Router presets are not available for these samples yet.',
-    'zh-CN': '查看样例不会更改你的输入。这些样例尚无已验证的 Router 参数预设。'
+    en: 'View a sample without changing your inputs. Verified Comfy Router presets are not available for these samples yet.',
+    'zh-CN':
+      '查看样例不会更改你的输入。这些样例尚无已验证的 Comfy Router 参数预设。'
   },
   'workshop.examples.view': {
     en: 'View sample',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -69,6 +69,11 @@ const translations = {
     'zh-CN': '显示更多模型'
   },
   'workshop.model.breadcrumb': { en: 'Models', 'zh-CN': '模型' },
+  'workshop.model.back': { en: 'Back to all models', 'zh-CN': '返回全部模型' },
+  'workshop.model.backTo': {
+    en: 'Back to {category}',
+    'zh-CN': '返回{category}'
+  },
   'workshop.model.inputs': { en: 'Model inputs', 'zh-CN': '模型输入' },
   'workshop.model.select': { en: 'Select an option', 'zh-CN': '选择一个选项' },
   'workshop.model.maxFiles': {
@@ -9257,7 +9262,7 @@ Enterprise`
   'nav.accountMenu': { en: 'Account menu', 'zh-CN': '账户菜单' },
   'nav.credits': { en: 'credits', 'zh-CN': '积分' },
   'nav.noCredits': { en: 'No credits', 'zh-CN': '无积分' },
-  'nav.buyCredits': { en: 'Buy credits', 'zh-CN': '购买积分' },
+  'nav.buyCredits': { en: 'Add credits', 'zh-CN': '添加积分' },
   'nav.creditsLabel': { en: 'Credits', 'zh-CN': '积分' },
   'nav.workspaces': { en: 'Workspaces', 'zh-CN': '工作区' },
   'nav.planAndCredits': { en: 'Plan & credits', 'zh-CN': '套餐与积分' },
@@ -9818,7 +9823,7 @@ Enterprise`
     'zh-CN': '内容或工作区策略阻止了此请求。'
   },
   'workshop.error.noCredits': {
-    en: 'Not enough credits. Buy credits to continue.',
+    en: 'Not enough credits. Add credits to continue.',
     'zh-CN': '积分不足。请购买积分后继续。'
   },
   'workshop.error.unavailable': {
@@ -9835,7 +9840,7 @@ Enterprise`
     'zh-CN': '提供方响应超时。未扣费。'
   },
   'workshop.error.lowCredits': {
-    en: 'You have {credits} credits and this run needs {n}. Buy credits to continue; your inputs stay here.',
+    en: 'You have {credits} credits and this run needs {n}. Add credits to continue; your inputs stay here.',
     'zh-CN':
       '你有 {credits} 积分，本次运行需要 {n}。购买积分后继续，你的输入会保留。'
   },

--- a/apps/website/src/lib/workshop/shelf-memory.test.ts
+++ b/apps/website/src/lib/workshop/shelf-memory.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { lastShelf, rememberShelf } from './shelf-memory'
+
+afterEach(() => {
+  sessionStorage.clear()
+})
+
+describe('shelf memory', () => {
+  it('reads back the shelf the visitor was standing on', () => {
+    rememberShelf('generate-videos')
+    expect(lastShelf()).toBe('generate-videos')
+  })
+
+  it('remembers nothing before the catalogue has been browsed', () => {
+    expect(lastShelf()).toBeUndefined()
+  })
+
+  it('ignores a value that is no longer a shelf', () => {
+    sessionStorage.setItem('comfy-models-shelf', 'retired-category')
+    expect(lastShelf()).toBeUndefined()
+  })
+})

--- a/apps/website/src/lib/workshop/shelf-memory.test.ts
+++ b/apps/website/src/lib/workshop/shelf-memory.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { lastShelf, rememberShelf } from './shelf-memory'
 
@@ -20,5 +20,23 @@ describe('shelf memory', () => {
   it('ignores a value that is no longer a shelf', () => {
     sessionStorage.setItem('comfy-models-shelf', 'retired-category')
     expect(lastShelf()).toBeUndefined()
+  })
+
+  it('says nothing when the stored value is empty', () => {
+    sessionStorage.setItem('comfy-models-shelf', '')
+    expect(lastShelf()).toBeUndefined()
+  })
+
+  it('browses on when the browser refuses its own storage', () => {
+    const denied = vi
+      .spyOn(window, 'sessionStorage', 'get')
+      .mockImplementation(() => {
+        throw new Error('access to storage is denied')
+      })
+
+    expect(() => rememberShelf('generate-videos')).not.toThrow()
+    expect(lastShelf()).toBeUndefined()
+
+    denied.mockRestore()
   })
 })

--- a/apps/website/src/lib/workshop/shelf-memory.test.ts
+++ b/apps/website/src/lib/workshop/shelf-memory.test.ts
@@ -34,9 +34,11 @@ describe('shelf memory', () => {
         throw new Error('access to storage is denied')
       })
 
-    expect(() => rememberShelf('generate-videos')).not.toThrow()
-    expect(lastShelf()).toBeUndefined()
-
-    denied.mockRestore()
+    try {
+      expect(() => rememberShelf('generate-videos')).not.toThrow()
+      expect(lastShelf()).toBeUndefined()
+    } finally {
+      denied.mockRestore()
+    }
   })
 })

--- a/apps/website/src/lib/workshop/shelf-memory.ts
+++ b/apps/website/src/lib/workshop/shelf-memory.ts
@@ -1,0 +1,31 @@
+import type { UseCase } from '../../config/models-catalogue'
+import { USE_CASES } from '../../config/models-catalogue'
+
+export type Shelf = UseCase | 'all' | 'other'
+
+const KEY = 'comfy-models-shelf'
+
+// The catalogue navigates with the client router, which leaves no referrer, so
+// the shelf a visitor is standing on is remembered for the page they open from
+// it. It lives in session storage: their tab, their journey, gone when it ends.
+export function rememberShelf(shelf: Shelf): void {
+  try {
+    sessionStorage.setItem(KEY, shelf)
+  } catch {
+    // A browser that refuses storage still browses; it just starts each page
+    // from the whole catalogue.
+  }
+}
+
+export function lastShelf(): Shelf | undefined {
+  try {
+    return asShelf(sessionStorage.getItem(KEY))
+  } catch {
+    return undefined
+  }
+}
+
+function asShelf(value: string | null): Shelf | undefined {
+  if (value === 'all' || value === 'other') return value
+  return USE_CASES.find((useCase) => useCase === value)
+}

--- a/apps/website/src/lib/workshop/use-case-label.ts
+++ b/apps/website/src/lib/workshop/use-case-label.ts
@@ -1,0 +1,18 @@
+import type { UseCase } from '../../config/models-catalogue'
+import type { TranslationKey } from '../../i18n/translations'
+
+export const useCaseLabelKey: Record<
+  UseCase | 'all' | 'other',
+  TranslationKey
+> = {
+  all: 'workshop.useCase.all',
+  other: 'workshop.sections.otherFormats',
+  'generate-images': 'workshop.useCase.generateImages',
+  'edit-images': 'workshop.useCase.editImages',
+  'generate-videos': 'workshop.useCase.generateVideos',
+  'animate-images': 'workshop.useCase.animateImages',
+  'edit-videos': 'workshop.useCase.editVideos',
+  '3d': 'workshop.useCase.3d',
+  audio: 'workshop.useCase.audio',
+  text: 'workshop.useCase.text'
+}

--- a/apps/website/src/routes/models/[slug].astro
+++ b/apps/website/src/routes/models/[slug].astro
@@ -2,6 +2,7 @@
 import { ArrowRight } from '@lucide/vue'
 import type { GetStaticPaths } from 'astro'
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import CatalogueBackLink from '../../components/workshop/CatalogueBackLink.vue'
 import ModelDetail from '../../components/workshop/ModelDetail.vue'
 import ModelStatus from '../../components/workshop/ModelStatus.vue'
 import ModelSupport from '../../components/workshop/ModelSupport.vue'
@@ -34,23 +35,7 @@ const pillClass =
   noindex
 >
   <div class="mx-auto max-w-10xl px-6 py-10 lg:px-8 lg:py-14">
-    <nav aria-label="Breadcrumb" class="mb-8 text-xs text-primary-warm-gray sm:px-8 lg:px-10">
-      <ol class="flex flex-wrap items-center gap-2">
-        <li>
-          <a href={routes.home} class="hover:text-primary-warm-white">
-            {t('breadcrumb.home')}
-          </a>
-        </li>
-        <li aria-hidden="true">›</li>
-        <li>
-          <a href={`${routes.workshop}?tab=models`} class="hover:text-primary-warm-white">
-            {t('workshop.title')}
-          </a>
-        </li>
-        <li aria-hidden="true">›</li>
-        <li class="text-primary-warm-white" aria-current="page">{model.name}</li>
-      </ol>
-    </nav>
+    <CatalogueBackLink client:load class="mb-8 sm:px-8 lg:px-10" />
     <header class="mb-12 sm:mx-8 lg:mx-10" data-testid="model-hero">
       <div class="flex flex-col gap-6 pr-8 lg:flex-row lg:items-end lg:justify-between lg:pr-10">
         <div class="flex max-w-2xl flex-col gap-4">


### PR DESCRIPTION
## Summary

Pablo's UI notes on `/models`, fixed against the integrated catalogue from #17382. Take the changes as they are, or take the diagnosis and write them your way.

## Merging this alongside #17379

**Read this before merging, human or agent.** This PR and #17379 (Alex's catalogue port) touch the same two files. Neither is wrong and nothing needs removing from either; both resolutions are additive. Verified by merging the two branches locally with `git merge-tree`.

- **`WorkshopModelsGrid.vue`, the scroll-to-top watcher.** It already exists on `main`. #17379 moves it below `isFiltered` and adds `browseAll` to its dependencies; this PR keeps it in place and calls `rememberShelf` inside it, which is what makes the back control return to the category the visitor came from. Take both:

  ```ts
  watch([useCase, browseAll], () => {
    rememberShelf(useCase.value)
    void nextTick(() => window.scrollTo({ top: 0 }))
  })
  ```

  This PR also adds `rememberShelf(useCase.value)` at the end of `onMounted`, after the route is parsed. **That line has to survive the merge**, or landing on the unfiltered catalogue leaves a stale category remembered and the back control points somewhere the visitor never was. It conflicts with nothing.

- **`e2e/workshop.spec.ts`.** Both PRs append tests. Keep both sets; they cover different things.

Nothing else overlaps in either direction.

## Changes

- **What**:
  - **One way back.** The model page sent people to comfy.org through a breadcrumb, while a category screen offered a back button. Both now carry the same control, and it returns to the category the visitor left ("Back to Generate videos"), or to the whole catalogue when there is none. The catalogue navigates with the client router, which leaves no referrer, so the shelf is remembered in `sessionStorage` for that tab.
  - **A run in flight asks before it is thrown away.** `beforeunload` while the run is running, and only then. The listener exists only for the length of the run, so an idle model page keeps its place in the back/forward cache.
  - **The search field keeps its place.** Typing swaps the rows for a grid and clearing swaps them back, which moved everything under the field; the toolbar is now the anchor, so the field sits in the same place both ways.
  - **Examples fill their row.** The row was capped at `max-w-2xl` inside a much wider column, so three cards hugged the left and their titles wrapped. It now fits however many examples there are, up to `max-w-5xl`, one line per title, with the title carried in the button's accessible name so the clamp hides nothing.
  - **A video result opens full screen**, the same as a still.
  - **The file drop zone stops drawing a box inside a box.** The dashed frame padded its contents, so the clickable area was a second rounded rectangle inset 13px inside the first and the hover tint stopped short of the dashes. The padding moved to the previews, and the drop area now fills its frame.
  - **One row per selected file.** The field stacked a 128px preview over the file name, so two reference images turned the form into a column of boxes. A file is now one row: a 48px thumbnail, the name, its size when known, and the remove control at the right edge. A video shows its first frame instead of an inline player, which is all a tile that size can carry; audio and other files show their type. `MediaSourcePreview` only previewed video after that, so it is now `VideoSourcePreview`.
  - **The session strip is the runs themselves.** It read "Earlier runs this session", then a button saying "Latest", then thumbnails: two thirds text where the visitor is looking for a picture, and the newest result was the only one with no thumbnail at all. It is now thumbnails alone, in the order the runs happened, oldest at the left and the newest last and selected. The names survive as accessible labels and the strip carries the section name for anyone reading it aloud.
  - **Credits say Add, not Buy**, in the account menu, the run bar and the insufficient-balance failure.
  - **Comfy Router is introduced by its full name.** Inside Models the word arrived bare, and usually in a failure: a run that cannot start, a request over the size limit, a model with no schema yet. Those four strings now say Comfy Router; the API tab keeps the short form, since its own copy introduces the product a line above.
- **Dependencies**: none. Conflicts with #17379 as described above.

## Review Focus

1. **The back control replaces the breadcrumb rather than trimming it.** Dropping the home link was the ask; keeping a two-level crumb for one level of hierarchy was not worth it. If SEO wants a `BreadcrumbList`, it belongs in JSON-LD, not in a control people click by mistake.
2. **The remembered shelf is per tab and forgotten when it ends.** Opened in a new tab, or reached from a shared link, the control says "Back to all models". `workshop.model.breadcrumb` stays in the bundle because the retired `/workshop` tree still uses it.
3. **An uploaded video is no longer playable in the form.** The row is 64px tall, so the tile shows the first frame and nothing else; replace and remove are unchanged. Say so if the inline player was load-bearing for a model that takes video or audio, and it comes back as a click rather than as a permanent player.
4. **Not included, on purpose:** switching category without leaving the page, a design decision, since it moves V1 towards the layout that was discarded.
5. **Sorting by "Most examples"** is worth a second look, and it is a product call, so it is untouched here. The ordering itself is defensible and does more than fill a dropdown: it is the default, and it also picks what appears in the featured banner. The label is the weak part. The example count is never rendered anywhere in Models, so "Most examples" names a number the reader cannot see or compare, and "Most popular" would not fix it either, since the catalogue carries no popularity or usage signal at all. "Recommended" would be honest today, with a real "Most popular" added when there is data behind it.
6. **Still unaddressed, and not this PR's to decide:** the row of output files under a result shows raw file names, so a run reads as `byteplus-seedream-4-5-251128-1.jpg` next to `byteplus-seedream-4-5-251128-response.json`, with nothing saying which one is the picture and which one is the raw Router response.

**A correction to an earlier version of this description.** It argued that "Router docs" should be renamed because the word Router is never introduced to the reader. That was wrong on both halves. Comfy Router is the product name, with its own page at `/platform/router`, the docs this button already links to, and matching functions in the Python and TypeScript SDKs; and the site does introduce it, on the home page, on the platform page and in the API tab's own copy. What was actually missing is smaller and is fixed above: inside Models the first mention could land cold, in an error message.

One finding from the first review round is worth flagging, because it is not specific to this diff: binding `beforeunload` to `window` at `setup` made the whole `ModelDetail` island render **zero characters** server-side. The page still looked right in a browser, because hydration filled it in, so only a build inspection caught it: 0 characters with the explicit target, 41,643 without. `ModelDetail.ssr.test.ts` now renders the component with no `window` present, so any browser global read at setup fails the suite instead of silently emptying the page.

Verified with the full website unit suite (4,428 tests), `astro check`, lint and format, and in a browser on a `WORKSHOP_IN_BUILD=1` build: the back control returns to `/models?useCase=generate-videos`, four examples sit in one row of 247px, the search field stays at the same 120px from the top of the viewport whether you type or clear, and a selected file is a 64px row whose thumbnail is 48px and whose remove control sits 8px from the frame.

This PR needs the `workshop-test` label to get a preview with Models in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnpMtHjZzK5xfgS9aSEjvT