### PR TITLE
fix(website): gate GTM preconnect hints behind the prod guard

### DIFF
--- a/apps/website/src/components/common/GoogleTagManager.astro
+++ b/apps/website/src/components/common/GoogleTagManager.astro
@@ -15,11 +15,11 @@ const gtmEnabled = import.meta.env.PROD
 ---
 
 {
-  part === 'head' && (
-    <>
-      <link rel="preconnect" href="https://www.googletagmanager.com" />
-      <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-      {gtmEnabled && (
+  part === 'head' &&
+    gtmEnabled && (
+      <>
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
         <script is:inline define:vars={{ gtmId }}>
           ;(function (w, d, s, l, i) {
             w[l] = w[l] || []
@@ -32,9 +32,8 @@ const gtmEnabled = import.meta.env.PROD
             f.parentNode.insertBefore(j, f)
           })(window, document, 'script', 'dataLayer', gtmId)
         </script>
-      )}
-    </>
-  )
+      </>
+    )
 }
 
 {


### PR DESCRIPTION
## Summary

The Google `preconnect` and `dns-prefetch` hints in `GoogleTagManager.astro` rendered on every build, but the GTM loader they warm up is production-only (`import.meta.env.PROD`). So in dev and preview builds we still emitted `<link>` tags pointing at `www.googletagmanager.com` even though nothing on the page ever talks to Google. That leaks the Google network path in non-production environments for no benefit. This moves the hints under the same production condition that already guards the loader script, so a non-prod render emits no Google hints and production is unchanged.

Scope note: this is the preconnect-guard part of FE-2183 only. Whether GTM should be included on auth pages at all is a separate analytics/privacy policy decision and is deliberately not touched here.

## Changes

- `apps/website/src/components/common/GoogleTagManager.astro`: hoist the shared `gtmEnabled` guard so it wraps the two resource-hint `<link>`s and the loader together, instead of gating only the loader. The `noscript` branch is unchanged.

## Review Focus

- The `head` branch now renders nothing when `gtmEnabled` is false; confirm that matches the intended behavior (no preconnect/dns-prefetch in dev/preview).
- Production output is byte-for-byte the same set of hints plus loader as before.

## Testing

Rendered the component in isolation through Astro's own vite pipeline (`getViteConfig` + the Container API), toggling `import.meta.env.PROD`, to prove the conditional rather than a snapshot:

- Before the fix: non-prod render emitted both `preconnect` and `dns-prefetch` hints (the disclosure); prod emitted hints + loader.
- After the fix: non-prod render is empty; prod still emits both hints + loader.

Gates: `pnpm typecheck` (astro check) 0 errors, `pnpm format:check`, `pnpm knip` all pass. ESLint does not lint `.astro` files in the current config.

Fixes FE-2183


Resolves review comment on #17283 from @DrJKL — [r3984130847](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130847).



Linear: [FE-2183](https://linear.app/comfyorg/issue/FE-2183/design-define-analytics-policy-for-credential-entry-routes)
