### PR TITLE
fix(website): invalidate and bound the forgot-password reset lifecycle

### DIFF
--- a/apps/website/src/components/auth/AuthForgotPassword.test.ts
+++ b/apps/website/src/components/auth/AuthForgotPassword.test.ts
@@ -2,6 +2,7 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import { removeAllToasts, useAuthToasts } from '../../config/auth-toast-state'
 import AuthForgotPassword from './AuthForgotPassword.vue'
@@ -39,6 +40,13 @@ const clickSend = () =>
   userEvent
     .setup()
     .click(screen.getByRole('button', { name: /send reset link/i }))
+
+// Fake timers are on, so a late resolve settles on the microtask queue rather
+// than any real delay; drain the queue and let Vue react without a sleep.
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await nextTick()
+}
 
 beforeEach(() => {
   h.flag!.value = true
@@ -222,15 +230,16 @@ describe('AuthForgotPassword', () => {
 
     h.flag!.value = false
     release()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(
       toasts.value,
       'a request abandoned mid-flight must not toast success when it resolves late'
     ).toEqual([])
+    await vi.advanceTimersByTimeAsync(3000)
     expect(
       assign,
-      'and must not redirect the visitor back to login'
+      'and must not schedule a redirect back to login'
     ).not.toHaveBeenCalled()
   })
 
@@ -245,11 +254,58 @@ describe('AuthForgotPassword', () => {
 
     unmount()
     release()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(
       toasts.value,
       'an unmounted flow may not toast success when its request resolves late'
+    ).toEqual([])
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(
+      assign,
+      'an unmounted flow may not schedule a redirect when its request resolves late'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('drops a send abandoned by the flag turning off when it rejects late: no error toast', async () => {
+    let reject!: (reason: unknown) => void
+    h.sendReset.mockImplementation(
+      () => new Promise<void>((_resolve, rejectFn) => (reject = rejectFn))
+    )
+    render(AuthForgotPassword)
+    await typeEmail('user@example.com')
+    await clickSend()
+
+    h.flag!.value = false
+    reject({ code: 'auth/network-request-failed', message: 'x' })
+    await flushMicrotasks()
+
+    expect(
+      toasts.value,
+      'a request abandoned mid-flight must not toast an error when it rejects late'
+    ).toEqual([])
+    expect(
+      h.captureAuthFailed,
+      'and must not report a failure for a request nobody is waiting on'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('drops a send abandoned by unmount when it rejects late: no error toast', async () => {
+    let reject!: (reason: unknown) => void
+    h.sendReset.mockImplementation(
+      () => new Promise<void>((_resolve, rejectFn) => (reject = rejectFn))
+    )
+    const { unmount } = render(AuthForgotPassword)
+    await typeEmail('user@example.com')
+    await clickSend()
+
+    unmount()
+    reject({ code: 'auth/network-request-failed', message: 'x' })
+    await flushMicrotasks()
+
+    expect(
+      toasts.value,
+      'an unmounted flow may not toast an error when its request rejects late'
     ).toEqual([])
   })
 
@@ -267,6 +323,25 @@ describe('AuthForgotPassword', () => {
     expect(
       send.hasAttribute('disabled'),
       'a reset that never resolves must not leave the control disabled forever'
+    ).toBe(false)
+  })
+
+  it('re-enables the send immediately when the flag flickers off then back on mid-send', async () => {
+    h.sendReset.mockImplementation(() => new Promise<void>(() => {}))
+    render(AuthForgotPassword)
+    await typeEmail('user@example.com')
+    await clickSend()
+
+    const send = screen.getByRole('button', { name: /send/i })
+    expect(send.hasAttribute('disabled')).toBe(true)
+
+    h.flag!.value = false
+    h.flag!.value = true
+    await nextTick()
+
+    expect(
+      screen.getByRole('button', { name: /send/i }).hasAttribute('disabled'),
+      'a flag that flickers back on before the bounding timeout must leave the form retryable, not stuck disabled'
     ).toBe(false)
   })
 

--- a/apps/website/src/components/auth/AuthForgotPassword.test.ts
+++ b/apps/website/src/components/auth/AuthForgotPassword.test.ts
@@ -211,6 +211,65 @@ describe('AuthForgotPassword', () => {
     await waitFor(() => expect(h.sendReset).toHaveBeenCalledOnce())
   })
 
+  it('drops a send abandoned by the flag turning off: no success toast, no redirect', async () => {
+    let release!: () => void
+    h.sendReset.mockImplementation(
+      () => new Promise<void>((resolve) => (release = resolve))
+    )
+    render(AuthForgotPassword)
+    await typeEmail('user@example.com')
+    await clickSend()
+
+    h.flag!.value = false
+    release()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(
+      toasts.value,
+      'a request abandoned mid-flight must not toast success when it resolves late'
+    ).toEqual([])
+    expect(
+      assign,
+      'and must not redirect the visitor back to login'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('drops a send abandoned by unmount: no success toast when it resolves late', async () => {
+    let release!: () => void
+    h.sendReset.mockImplementation(
+      () => new Promise<void>((resolve) => (release = resolve))
+    )
+    const { unmount } = render(AuthForgotPassword)
+    await typeEmail('user@example.com')
+    await clickSend()
+
+    unmount()
+    release()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(
+      toasts.value,
+      'an unmounted flow may not toast success when its request resolves late'
+    ).toEqual([])
+  })
+
+  it('re-enables the send after a stalled reset so it stays retryable', async () => {
+    h.sendReset.mockImplementation(() => new Promise<void>(() => {}))
+    render(AuthForgotPassword)
+    await typeEmail('user@example.com')
+    await clickSend()
+
+    const send = screen.getByRole('button', { name: /send/i })
+    expect(send.hasAttribute('disabled')).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(16_000)
+
+    expect(
+      send.hasAttribute('disabled'),
+      'a reset that never resolves must not leave the control disabled forever'
+    ).toBe(false)
+  })
+
   it('carries a safe return destination back to login on click', async () => {
     window.history.replaceState(
       {},

--- a/apps/website/src/components/auth/AuthForgotPassword.test.ts
+++ b/apps/website/src/components/auth/AuthForgotPassword.test.ts
@@ -326,6 +326,36 @@ describe('AuthForgotPassword', () => {
     ).toBe(false)
   })
 
+  it('re-enables the send after a stalled Firebase load so it stays retryable', async () => {
+    // eslint-disable-next-line no-restricted-properties -- only doMock can suspend a dynamic import for one case; a hoisted vi.mock factory resolves the module once and memoises it
+    vi.doMock(
+      import('../../config/workshop-firebase'),
+      () => new Promise<never>(() => {})
+    )
+    vi.resetModules()
+    try {
+      const { default: FreshAuthForgotPassword } =
+        await import('./AuthForgotPassword.vue')
+      render(FreshAuthForgotPassword)
+      await typeEmail('user@example.com')
+      await clickSend()
+
+      const send = () => screen.getByRole('button', { name: /send/i })
+      expect(send().hasAttribute('disabled')).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(16_000)
+      await flushMicrotasks()
+
+      expect(
+        send().hasAttribute('disabled'),
+        'a Firebase load that never resolves must not leave the control disabled forever'
+      ).toBe(false)
+    } finally {
+      vi.doUnmock(import('../../config/workshop-firebase'))
+      vi.resetModules()
+    }
+  })
+
   it('re-enables the send immediately when the flag flickers off then back on mid-send', async () => {
     h.sendReset.mockImplementation(() => new Promise<void>(() => {}))
     render(AuthForgotPassword)

--- a/apps/website/src/components/auth/AuthForgotPassword.vue
+++ b/apps/website/src/components/auth/AuthForgotPassword.vue
@@ -93,32 +93,36 @@ function goToSignIn(event: MouseEvent): void {
   window.location.assign(signInDestination())
 }
 
-async function submit() {
-  if (state.value === 'sending' || state.value === 'sent') return
+function validEmail(): boolean {
   const parsed = authSchemasFor(locale).signInSchema.shape.email.safeParse(
     email.value
   )
-  if (!parsed.success) {
-    errorMessage.value = parsed.error.issues[0]?.message ?? ''
-    return
-  }
-  errorMessage.value = ''
-  state.value = 'sending'
+  if (parsed.success) return true
+  errorMessage.value = parsed.error.issues[0]?.message ?? ''
+  return false
+}
+
+/**
+ * Opens a bounded attempt: a fresh generation and a timer that, if the load or
+ * send stalls, drops the control back to a retryable idle. The returned guard
+ * is false once this attempt is superseded (flag flip, unmount, or the bound
+ * timeout firing), so a late resolve falls through instead of settling the UI.
+ */
+function beginBoundedSend(): () => boolean {
   const attempt = resetGeneration
-  const live = () => attempt === resetGeneration && enabled.value
-  // A stalled load or send drops the attempt back to a retryable state; the
-  // generation bump makes the eventual late resolve fall to the !live() guards.
   boundTimer = setTimeout(() => {
     resetGeneration++
     state.value = 'idle'
   }, RESET_TIMEOUT_MS)
+  return () => attempt === resetGeneration && enabled.value
+}
 
+async function deliverReset(live: () => boolean) {
   const firebase = await loadWorkshopFirebase().catch(() => undefined)
   if (!live()) return
   if (!firebase) {
     clearTimeout(boundTimer)
-    state.value = 'error'
-    errorMessage.value = t('auth.forgot.error', locale)
+    reportLoadFailure()
     return
   }
   // An unknown email already resolves as sent (the package keeps that
@@ -135,6 +139,19 @@ async function submit() {
   if (!live()) return
   clearTimeout(boundTimer)
   reportSent()
+}
+
+async function submit() {
+  if (state.value === 'sending' || state.value === 'sent') return
+  if (!validEmail()) return
+  errorMessage.value = ''
+  state.value = 'sending'
+  await deliverReset(beginBoundedSend())
+}
+
+function reportLoadFailure() {
+  state.value = 'error'
+  errorMessage.value = t('auth.forgot.error', locale)
 }
 
 function reportSendFailure(error: unknown) {

--- a/apps/website/src/components/auth/AuthForgotPassword.vue
+++ b/apps/website/src/components/auth/AuthForgotPassword.vue
@@ -59,7 +59,20 @@ let boundTimer: ReturnType<typeof setTimeout> | undefined
 // in-flight send, so a late resolve of an abandoned request cannot toast success
 // or redirect. Sync so even a same-tick flicker is counted, not collapsed.
 let resetGeneration = 0
-watch(enabled, () => resetGeneration++, { flush: 'sync' })
+watch(
+  enabled,
+  (isEnabled) => {
+    resetGeneration++
+    // Disabling mid-send abandons the request; drop the control back to idle so
+    // a flag flicker back on leaves the form immediately retryable, not stuck
+    // disabled until the bounding timeout elapses.
+    if (!isEnabled) {
+      clearTimeout(boundTimer)
+      state.value = 'idle'
+    }
+  },
+  { flush: 'sync' }
+)
 
 function signInDestination(): string {
   const destination = requestedReturnPath(window.location.search)

--- a/apps/website/src/components/auth/AuthForgotPassword.vue
+++ b/apps/website/src/components/auth/AuthForgotPassword.vue
@@ -37,6 +37,8 @@ const RETURN_TO_LOGIN_MS = 3000
 const TOAST_LIFE_MS = 5000
 /** The cloud app's router gives auth this long to answer before its timeout view. */
 const AUTH_FLAG_TIMEOUT_MS = 16_000
+/** A stalled Firebase load or send is dropped here so the controls become retryable again. */
+const RESET_TIMEOUT_MS = 16_000
 
 const enabled = useWorkshopAuthFlag()
 const flagSettled = useWorkshopAuthFlagSettled()
@@ -51,6 +53,13 @@ const state = ref<ResetState>('idle')
 const signInHref = ref('/login/')
 let returnTimer: ReturnType<typeof setTimeout> | undefined
 let flagTimer: ReturnType<typeof setTimeout> | undefined
+let boundTimer: ReturnType<typeof setTimeout> | undefined
+
+// Any rollout-flag transition, an unmount, or a bounding timeout invalidates the
+// in-flight send, so a late resolve of an abandoned request cannot toast success
+// or redirect. Sync so even a same-tick flicker is counted, not collapsed.
+let resetGeneration = 0
+watch(enabled, () => resetGeneration++, { flush: 'sync' })
 
 function signInDestination(): string {
   const destination = requestedReturnPath(window.location.search)
@@ -82,8 +91,19 @@ async function submit() {
   }
   errorMessage.value = ''
   state.value = 'sending'
+  const attempt = resetGeneration
+  const live = () => attempt === resetGeneration && enabled.value
+  // A stalled load or send drops the attempt back to a retryable state; the
+  // generation bump makes the eventual late resolve fall to the !live() guards.
+  boundTimer = setTimeout(() => {
+    resetGeneration++
+    state.value = 'idle'
+  }, RESET_TIMEOUT_MS)
+
   const firebase = await loadWorkshopFirebase().catch(() => undefined)
+  if (!live()) return
   if (!firebase) {
+    clearTimeout(boundTimer)
     state.value = 'error'
     errorMessage.value = t('auth.forgot.error', locale)
     return
@@ -94,9 +114,13 @@ async function submit() {
   try {
     await firebase.sendWorkshopPasswordReset(email.value)
   } catch (error) {
+    if (!live()) return
+    clearTimeout(boundTimer)
     reportSendFailure(error)
     return
   }
+  if (!live()) return
+  clearTimeout(boundTimer)
   reportSent()
 }
 
@@ -142,8 +166,10 @@ watch(flagSettled, (settled) => {
 })
 
 onBeforeUnmount(() => {
+  resetGeneration++
   clearTimeout(returnTimer)
   clearTimeout(flagTimer)
+  clearTimeout(boundTimer)
 })
 </script>
 


### PR DESCRIPTION
## Summary

The forgot-password page could show a success toast for a request the visitor already abandoned, and a stalled reset left the send button disabled with no way to recover. This ties the submitted request to a generation and bounds the operation so a late resolve changes nothing and a hung send becomes retryable.

Fixes FE-2178

## Changes

- `submit()` in `AuthForgotPassword.vue` captures a `resetGeneration` on entry and re-checks `live()` after loading Firebase and after `sendWorkshopPasswordReset`, so a request invalidated mid-flight returns without toasting or redirecting.
- A flag transition (`watch(enabled, ...)`, sync) and `onBeforeUnmount` both bump `resetGeneration`, which is what marks an in-flight send as abandoned.
- A `RESET_TIMEOUT_MS` bound restores the `idle` state and bumps the generation, so a Firebase load or send that never resolves re-enables the send button instead of holding it disabled.

## Review Focus

- `AuthForgotPassword.vue:98-101`: the bound timeout doubles as the abandonment signal (it bumps the generation), so a late resolve after the timeout falls to the same `!live()` guards as a flag flip. Worth confirming that single mechanism reads clearly against the sign-in controller's version, which bounds nothing today.

## QA

- [x] Unit: 17 passing in `AuthForgotPassword.test.ts` (14 existing plus 3 new)
- [x] Red-green: the 3 new tests fail against `origin/main` (late resolve toasts success; unmounted flow toasts success; stalled send stays disabled after 16s) and pass with the fix
- [x] Typecheck: 0 errors; eslint, oxfmt, knip, comment-hygiene clean on the two changed files
- [ ] Not covered: no e2e; this is verified at the component level only


Resolves review comments on #17283 from @DrJKL — [r3984130778](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130778), [r3984130788](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17283#discussion_r3984130788).



Linear: [FE-2178](https://linear.app/comfyorg/issue/FE-2178/bug-bound-and-cancel-forgot-password-requests)
