### PR TITLE
fix(ci): avoid release checkout API discovery

### DIFF
--- a/.github/workflows/release-weekly-comfyui.yaml
+++ b/.github/workflows/release-weekly-comfyui.yaml
@@ -294,6 +294,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: ${{ inputs.comfyui_fork || 'Comfy-Org/ComfyUI' }}
+          ref: master
           token: ${{ secrets.PR_GH_TOKEN }}
           path: comfyui
 

--- a/scripts/cicd/release-weekly-comfyui.test.ts
+++ b/scripts/cicd/release-weekly-comfyui.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  uses?: string
+  with?: {
+    repository?: string
+    ref?: string
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isWorkflowStep = (value: unknown): value is WorkflowStep =>
+  isRecord(value) &&
+  (value.name === undefined || typeof value.name === 'string') &&
+  (value.uses === undefined || typeof value.uses === 'string') &&
+  (value.with === undefined || isRecord(value.with))
+
+const readCreateComfyUiPrSteps = (): WorkflowStep[] => {
+  const parsed: unknown = parse(
+    readFileSync('.github/workflows/release-weekly-comfyui.yaml', 'utf8')
+  )
+  expect(isRecord(parsed)).toBe(true)
+
+  const jobs = (parsed as Record<string, unknown>).jobs
+  expect(isRecord(jobs)).toBe(true)
+
+  const job = (jobs as Record<string, unknown>)['create-comfyui-pr']
+  expect(isRecord(job)).toBe(true)
+
+  const steps = (job as Record<string, unknown>).steps
+  expect(Array.isArray(steps)).toBe(true)
+  expect((steps as unknown[]).every(isWorkflowStep)).toBe(true)
+
+  return steps as WorkflowStep[]
+}
+
+describe('weekly ComfyUI release', () => {
+  it('checks out the known ComfyUI base branch without API discovery', () => {
+    const checkout = readCreateComfyUiPrSteps().find(
+      (step) => step.name === 'Checkout ComfyUI fork'
+    )
+
+    expect(checkout?.uses).toMatch(/^actions\/checkout@/)
+    expect(checkout?.with?.repository).toBe(
+      "${{ inputs.comfyui_fork || 'Comfy-Org/ComfyUI' }}"
+    )
+    expect(checkout?.with?.ref).toBe('master')
+  })
+})

--- a/scripts/cicd/release-weekly-comfyui.test.ts
+++ b/scripts/cicd/release-weekly-comfyui.test.ts
@@ -6,6 +6,7 @@ import { parse } from 'yaml'
 interface WorkflowStep {
   name?: string
   uses?: string
+  run?: string
   with?: {
     repository?: string
     ref?: string
@@ -19,6 +20,7 @@ const isWorkflowStep = (value: unknown): value is WorkflowStep =>
   isRecord(value) &&
   (value.name === undefined || typeof value.name === 'string') &&
   (value.uses === undefined || typeof value.uses === 'string') &&
+  (value.run === undefined || typeof value.run === 'string') &&
   (value.with === undefined || isRecord(value.with))
 
 const readCreateComfyUiPrSteps = (): WorkflowStep[] => {
@@ -42,14 +44,23 @@ const readCreateComfyUiPrSteps = (): WorkflowStep[] => {
 
 describe('weekly ComfyUI release', () => {
   it('checks out the known ComfyUI base branch without API discovery', () => {
-    const checkout = readCreateComfyUiPrSteps().find(
+    const steps = readCreateComfyUiPrSteps()
+    const checkoutIndex = steps.findIndex(
       (step) => step.name === 'Checkout ComfyUI fork'
     )
+    const checkout = steps[checkoutIndex]
 
-    expect(checkout?.uses).toMatch(/^actions\/checkout@/)
-    expect(checkout?.with?.repository).toBe(
+    expect(checkoutIndex).toBeGreaterThanOrEqual(0)
+    expect(
+      steps
+        .slice(0, checkoutIndex)
+        .map((step) => step.run ?? '')
+        .join('\n')
+    ).not.toMatch(/\bgh api\b/)
+    expect(checkout.uses).toMatch(/^actions\/checkout@/)
+    expect(checkout.with?.repository).toBe(
       "${{ inputs.comfyui_fork || 'Comfy-Org/ComfyUI' }}"
     )
-    expect(checkout?.with?.ref).toBe('master')
+    expect(checkout.with?.ref).toBe('master')
   })
 })

--- a/scripts/cicd/release-weekly-comfyui.test.ts
+++ b/scripts/cicd/release-weekly-comfyui.test.ts
@@ -56,7 +56,7 @@ describe('weekly ComfyUI release', () => {
         .slice(0, checkoutIndex)
         .map((step) => step.run ?? '')
         .join('\n')
-    ).not.toMatch(/\bgh api\b/)
+    ).not.toMatch(/\bgh\s+api\b/)
     expect(checkout.uses).toMatch(/^actions\/checkout@/)
     expect(checkout.with?.repository).toBe(
       "${{ inputs.comfyui_fork || 'Comfy-Org/ComfyUI' }}"


### PR DESCRIPTION
## Summary

Avoid a redundant GitHub API lookup in the weekly release’s ComfyUI checkout after the shared release token exhausted its API quota.

## Changes

- **What**: Pin the known ComfyUI base ref to `master` and enforce it with a workflow-contract test.

## Review Focus

The checkout still uses `PR_GH_TOKEN` for the later automation-branch push; only default-branch discovery is removed.

Failure evidence: [Release: ComfyUI run 34652778287](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34652778287/job/103450085546).

Validation: 129 CI-script tests, typecheck, ESLint, Oxlint, and oxfmt pass.