### PR TITLE
test(renderer): edits in each renderer survive a toggle and a round trip

### DIFF
--- a/browser_tests/tests/rendererToggleRoundTrip.spec.ts
+++ b/browser_tests/tests/rendererToggleRoundTrip.spec.ts
@@ -1,0 +1,104 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+
+const LEGACY_EDIT_TITLE = 'KSampler'
+const VUE_EDIT_TITLE = 'Load Checkpoint'
+
+/** Graph positions, keyed by node id. Renderer-independent, and exactly what
+ * serialization writes — so the same read works in both modes. */
+async function getPositions(comfyPage: ComfyPage) {
+  return comfyPage.page.evaluate(() =>
+    Object.fromEntries(
+      window.app!.graph.nodes.map((node) => [String(node.id), [...node.pos]])
+    )
+  )
+}
+
+async function getPosition(comfyPage: ComfyPage, title: string) {
+  const node = await comfyPage.nodeOps.getNodeRefByTitle(title)
+  return node.getProperty<[number, number]>('pos')
+}
+
+/** Toggling renderers can shift a position by a sub-pixel amount, which
+ * `rendererToggleStability.spec.ts` already accepts at the same precision.
+ * Reserved for comparisons that cross a toggle — the round-trip comparison
+ * below uses exact equality, because serialized values must not move at all. */
+function expectSamePositionAcrossToggle(
+  actual: [number, number],
+  expected: [number, number],
+  label: string
+) {
+  expect(actual[0], `${label} x`).toBeCloseTo(expected[0], 1)
+  expect(actual[1], `${label} y`).toBeCloseTo(expected[1], 1)
+}
+
+/**
+ * ECS 1.53 Area 6: build in legacy, toggle to 2.0, edit, toggle back, save,
+ * reload — nothing lost in either direction. `rendererToggleStability.spec.ts`
+ * toggles five times but never edits between toggles, and nothing in the suite
+ * crosses a save/reload after editing in both modes.
+ */
+test.describe(
+  'Renderer toggle round trip',
+  { tag: ['@node', '@canvas', '@vue-nodes'] },
+  () => {
+    test('edits made in each renderer survive the toggle and a round trip', async ({
+      comfyPage,
+      comfyMouse
+    }) => {
+      test.slow()
+      await comfyPage.menu.topbar.setVueNodesEnabled(false)
+
+      const legacyBefore = await getPosition(comfyPage, LEGACY_EDIT_TITLE)
+      const legacyNode =
+        await comfyPage.nodeOps.getNodeRefByTitle(LEGACY_EDIT_TITLE)
+      await legacyNode.dragBy({ x: 90, y: 60 })
+      // Precondition: the legacy edit landed. Without it, "the edit survived"
+      // also holds for an edit that never happened.
+      const legacyEdited = await getPosition(comfyPage, LEGACY_EDIT_TITLE)
+      expect(legacyEdited, 'legacy drag should move the node').not.toEqual(
+        legacyBefore
+      )
+
+      await comfyPage.menu.topbar.setVueNodesEnabled(true)
+      await comfyPage.vueNodes.waitForNodes()
+      expectSamePositionAcrossToggle(
+        await getPosition(comfyPage, LEGACY_EDIT_TITLE),
+        legacyEdited,
+        'legacy edit after switching to Nodes 2.0'
+      )
+
+      const vueBefore = await getPosition(comfyPage, VUE_EDIT_TITLE)
+      const vueNode = await comfyPage.vueNodes.getFixtureByTitle(VUE_EDIT_TITLE)
+      await comfyMouse.dragElementBy(vueNode.header, { x: -60, y: 80 })
+      const vueEdited = await getPosition(comfyPage, VUE_EDIT_TITLE)
+      expect(vueEdited, 'Nodes 2.0 drag should move the node').not.toEqual(
+        vueBefore
+      )
+
+      await comfyPage.menu.topbar.setVueNodesEnabled(false)
+      expectSamePositionAcrossToggle(
+        await getPosition(comfyPage, LEGACY_EDIT_TITLE),
+        legacyEdited,
+        'legacy edit after switching back'
+      )
+      expectSamePositionAcrossToggle(
+        await getPosition(comfyPage, VUE_EDIT_TITLE),
+        vueEdited,
+        'Nodes 2.0 edit after switching back'
+      )
+
+      // Every node, not just the two edited: a round trip that dropped an
+      // untouched node would leave both edits correct and be invisible to a
+      // two-node comparison.
+      const beforeRoundTrip = await getPositions(comfyPage)
+      const serialized = await comfyPage.workflow.getExportedWorkflow()
+      await comfyPage.workflow.loadGraphData(serialized)
+
+      await expect.poll(() => getPositions(comfyPage)).toEqual(beforeRoundTrip)
+    })
+  }
+)


### PR DESCRIPTION
## Summary

ECS 1.53 Area 6: *"Build a workflow in legacy mode, toggle to 2.0, edit (move a node, change a
widget), toggle back, save, reload. Nothing lost in either direction."*

`rendererToggleStability.spec.ts` toggles five times and checks positions do not drift — but it
never **edits** between toggles. `vueNodes/layout/rendererToggleGeometry.spec.ts` covers slot
geometry and z-order through a toggle. Nothing in the suite crosses a save/reload after editing
in both modes.

## What it does

1. Legacy: drag `KSampler`, assert it moved.
2. Toggle to Nodes 2.0: assert the legacy edit is still there.
3. Nodes 2.0: drag `Load Checkpoint` via `comfyMouse.dragElementBy(node.header, …)`, assert it
   moved.
4. Toggle back to legacy: assert **both** edits are still there.
5. Round-trip through `getExportedWorkflow()` → `loadGraphData()` and compare every node's
   position exactly.

## Choices worth noting

- **Positions come off the graph, not the DOM.** `node.pos` reads identically in both renderers
  and is exactly what serialization writes, so the same helper works on both sides of a toggle.
- **Each drag asserts the node actually moved** before anything claims it survived. Without
  that, "the edit is still there" also holds for an edit that never happened — the drag
  threshold in `useNodePointerInteractions` makes that a real possibility, not a hypothetical.
- **Two precisions, deliberately.** Cross-toggle comparisons use `toBeCloseTo(…, 1)`, matching
  what `rendererToggleStability.spec.ts` already accepts for sub-pixel drift across a renderer
  switch. The round-trip comparison is **exact** — a serialized position that moves at all is a
  defect, and a tolerance there would hide it.
- **The round trip compares every node**, not the two edited. One that dropped an untouched node
  would leave both edits correct and be invisible to a two-node check.

## Not covered

The row also says "change a widget". Widget-edit history and commit semantics are unsettled in
this suite — a plain combo renders `WidgetSelectDefault.vue`, whose `selectOption` assigns the
model value with no checkpoint call, and text widgets are a third path again. Including a widget
edit here would make this test depend on that unknown. Node moves are unambiguous in both
renderers, so the row is covered for geometry and recorded as partial on the plan.

## Test plan

```
$ pnpm exec playwright test --list browser_tests/tests/rendererToggleRoundTrip.spec.ts
  [chromium] › tests/rendererToggleRoundTrip.spec.ts:48:5 › Renderer toggle round trip › edits made in each renderer survive the toggle and a round trip
Total: 1 test in 1 file

$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/rendererToggleRoundTrip.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/rendererToggleRoundTrip.spec.ts               # exit 0
```

Test-only change; no source files touched. Uses the default workflow, so no new asset.
