### PR TITLE
fix: retain labels for connected Vue node inputs

### DIFF
--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -1,10 +1,22 @@
 import { render, screen } from '@testing-library/vue'
 import { defineComponent, markRaw } from 'vue'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
 
 import WidgetGrid from '@/renderer/extensions/vueNodes/components/WidgetGrid.vue'
 import type { WidgetGridItem } from '@/renderer/extensions/vueNodes/types/widgetGrid'
 import { toNodeId } from '@/types/nodeId'
+
+vi.mock(
+  import('@/renderer/extensions/vueNodes/composables/useSlotLinkInteraction'),
+  () => ({
+    useSlotLinkInteraction: () => ({
+      onClick: vi.fn(),
+      onDoubleClick: vi.fn(),
+      onPointerDown: vi.fn()
+    })
+  })
+)
 
 const WidgetStub = markRaw(
   defineComponent({
@@ -48,6 +60,83 @@ function widget(name: string, type: string, index: number): WidgetGridItem {
 }
 
 describe('WidgetGrid', () => {
+  it('shows socket-only labels and restores controls when disconnected', async () => {
+    const connectedWidgets = ['width', 'height', 'prompt'].map(
+      (name, index) => ({
+        ...widget(name, name === 'prompt' ? 'text' : 'number', index),
+        slotMetadata: {
+          index,
+          linked: true,
+          promoted: false,
+          type: name === 'prompt' ? 'STRING' : 'INT'
+        },
+        visible: false,
+        suppressedByConnection: true
+      })
+    )
+    const otherWidgets = [
+      { ...widget('seed', 'converted-widget', 3), visible: false },
+      {
+        ...widget('hidden_by_extension', 'number', 4),
+        visible: false
+      },
+      {
+        ...widget('hidden_no_slot', 'text', 5),
+        visible: false,
+        suppressedByConnection: true,
+        slotMetadata: undefined
+      },
+      widget('steps', 'number', 6)
+    ]
+    const { rerender } = render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        syncLayout: false,
+        processedWidgets: [...connectedWidgets, ...otherWidgets]
+      },
+      global: {
+        plugins: [
+          createI18n({
+            legacy: false,
+            locale: 'en',
+            messages: { en: { g: { inputTooltip: 'Input: {name}' } } }
+          })
+        ],
+        directives: { tooltip: {} },
+        stubs: { AppInput: AppInputStub }
+      }
+    })
+
+    for (const name of ['width', 'height', 'prompt', 'seed']) {
+      expect(screen.getByText(name)).toBeVisible()
+    }
+    expect(screen.queryByText('steps')).not.toBeInTheDocument()
+    expect(screen.queryByText('hidden_by_extension')).not.toBeInTheDocument()
+    expect(screen.queryByText('hidden_no_slot')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('slot-connection-dot')).toHaveLength(5)
+    expect(screen.getAllByTestId('widget-control')).toHaveLength(1)
+
+    await rerender({
+      processedWidgets: [
+        ...connectedWidgets.map((item) => ({
+          ...item,
+          slotMetadata: { ...item.slotMetadata, linked: false },
+          visible: true,
+          suppressedByConnection: false
+        })),
+        ...otherWidgets
+      ]
+    })
+
+    for (const name of ['width', 'height', 'prompt', 'steps']) {
+      expect(screen.queryByText(name)).not.toBeInTheDocument()
+    }
+    expect(screen.getByText('seed')).toBeVisible()
+    expect(screen.getAllByTestId('slot-connection-dot')).toHaveLength(5)
+    expect(screen.getAllByTestId('widget-control')).toHaveLength(4)
+  })
+
   it('renders hidden converted widgets as input sockets without controls', () => {
     render(WidgetGrid, {
       props: {

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
@@ -21,7 +21,10 @@
         <div
           :class="
             cn(
-              'z-10 flex w-3 items-stretch opacity-0 transition-opacity duration-150 group-hover:opacity-100',
+              'z-10 flex items-stretch',
+              row.showsControl
+                ? 'w-3 opacity-0 transition-opacity duration-150 group-hover:opacity-100'
+                : 'col-span-full',
               row.widget.slotMetadata?.linked && 'opacity-100'
             )
           "
@@ -39,7 +42,7 @@
             :index="row.widget.slotMetadata.index"
             :socketless="row.widget.simplified.spec?.socketless"
             :standalone="row.standalone"
-            dot-only
+            :dot-only="row.showsControl"
           />
         </div>
         <AppInput


### PR DESCRIPTION
## Summary

Keep input names visible when a connected widget's control is hidden, in every Vue node, including the MiniMax H3 subgraph that reported it.

## Cause and fix

`WidgetGrid` rendered a connected input whose control is hidden as a bare dot, so the name disappeared with the control. Rows without a control now render the existing `InputSlot` label; connected controls stay hidden and the connection topology is unchanged.

Product intent: a connected input always shows its name. This is not limited to the subgraph case; every node with a connected widget input gains a labeled row, so node heights and wire endpoints change wherever that happens.

Which text the row shows: the widget's display label, falling back to its internal name when there is none. Promotion keeps the user-facing label in `simplified.label` while the name carries a collision-resolved identifier, so the grid forwards the label into `InputSlot`, which already prefers it over the name for both the visible text and the accessible name. Without that, a connected promoted input announced `value_1` and `vae_name_1` instead of `duration` and `audio_vae`.

Wire endpoints: a labeled row is taller than the dot strip it replaces, so rows move without the grid's own box changing, and the outer ResizeObserver never fires. `WidgetGrid` already resyncs slot offsets through a post-flush `syncSlotOffsets` call keyed on `layoutKey`, but that key carried only the render key and slot index, both of which survive a connection. `layoutKey` now also carries `showsControl`, so connecting or disconnecting an input invalidates it and the existing sync runs. `useVueNodeResizeTracking` keeps its root-only contract.

## Testing

- `WidgetGrid.test.ts`: the control-to-label geometry regression asserted through the layout store, keeping the same widget name, render key and slot index while control visibility changes; a `syncLayout=false` case; control restoration when the connection goes away; and the suppressed-widget case, which now pins a row whose name and label differ so the displayed and accessible text is the label.
- Regression proof, layout key: removing `showsControl` from `layoutKey` fails the focused test with a stale `y: 114` instead of `y: 74`; restoring it passes.
- Regression proof, label: dropping the forwarded `label` fails the suppressed-widget case, which then finds `value_1` in the DOM instead of `duration`; restoring it passes.
- `pnpm test:unit src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts`: 2 files, 18 tests pass at this head. Typecheck, lint and format run in CI on this head.
- Visual QA still pending for the MiniMax H3 subgraph, subgraph input and output nodes, promoted widgets, converted widgets (`seed` path) and long slot names that now truncate in a full-width row.

Related: https://linear.app/comfyorg/issue/PM-1067

This fixes the missing labels, not missing models or node installations.
