### PR TITLE
test(canvas): a dragged link lands on the aimed slot under device scaling

### DIFF
--- a/browser_tests/tests/deviceScaleLinkDrop.spec.ts
+++ b/browser_tests/tests/deviceScaleLinkDrop.spec.ts
@@ -49,7 +49,9 @@ test.describe('Link drop under device scaling', { tag: '@canvas' }, () => {
     const destination = imageInputs.find(
       (input) => input.name === 'destination'
     )
-    expect(destination, 'expected a destination input').toBeDefined()
+    if (!destination) {
+      throw new Error('ImageCompositeMasked should expose a destination input')
+    }
 
     const linkedNames = () =>
       comfyPage.page.evaluate((id) => {
@@ -63,7 +65,7 @@ test.describe('Link drop under device scaling', { tag: '@canvas' }, () => {
 
     expect(await linkedNames(), 'node should start unconnected').toEqual([])
 
-    await source.connectOutput(0, target, destination!.index)
+    await source.connectOutput(0, target, destination.index)
 
     // Exactly the aimed slot, by name. A count would pass for a wire that
     // landed on the neighbouring IMAGE input, which is the failure mode
@@ -77,7 +79,7 @@ test.describe('Link drop under device scaling', { tag: '@canvas' }, () => {
         const link = node.inputs[slot]?.link
         return link == null ? null : (graph.links.get(link)?.origin_id ?? null)
       },
-      { id: target.id, slot: destination!.index }
+      { id: target.id, slot: destination.index }
     )
     expect(String(origin)).toBe(String(source.id))
   })

--- a/browser_tests/tests/deviceScaleLinkDrop.spec.ts
+++ b/browser_tests/tests/deviceScaleLinkDrop.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from '@playwright/test'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+/**
+ * ECS 1.53 Area 10 asks that, under non-default display scaling, a link dragged
+ * between two nodes attaches to the slot it was aimed at. Client coordinates do
+ * not change with `deviceScaleFactor`, but the canvas does — LiteGraph converts
+ * client points to graph space using the canvas backing size, so a wrong
+ * conversion lands the wire on a neighbouring slot rather than failing outright.
+ *
+ * The title carries `@2x @0.5x`, so this runs in `chromium-2x`
+ * (deviceScaleFactor 2) and `chromium-0.5x` (0.5). The base `chromium` project
+ * does not grep those out, so it also runs at scale 1 — which is the control:
+ * the same assertions must hold at every scale, and a failure only under
+ * scaling is the defect this row is about.
+ */
+test.describe('Link drop under device scaling', { tag: '@canvas' }, () => {
+  test('@2x @0.5x A dragged link lands on the slot it was aimed at', async ({
+    comfyPage
+  }) => {
+    await comfyPage.nodeOps.clearGraph()
+
+    const source = await comfyPage.nodeOps.addNode('EmptyImage', undefined, {
+      x: 120,
+      y: 240
+    })
+    const target = await comfyPage.nodeOps.addNode(
+      'ImageCompositeMasked',
+      undefined,
+      { x: 620, y: 240 }
+    )
+    await comfyPage.nextFrame()
+
+    const imageInputs = await comfyPage.page.evaluate((id) => {
+      const node = window.app!.canvas.graph!.getNodeById(id)!
+      return node.inputs
+        .map((input, index) => ({ index, name: input.name, type: input.type }))
+        .filter((input) => input.type === 'IMAGE')
+    }, target.id)
+
+    // Precondition: there is more than one IMAGE slot to get wrong. With a
+    // single candidate, "landed on the right slot" is not a claim about
+    // coordinate conversion at all — any drop that connects would satisfy it.
+    expect(
+      imageInputs.length,
+      'ImageCompositeMasked should expose several IMAGE inputs'
+    ).toBeGreaterThan(1)
+
+    const destination = imageInputs.find(
+      (input) => input.name === 'destination'
+    )
+    expect(destination, 'expected a destination input').toBeDefined()
+
+    const linkedNames = () =>
+      comfyPage.page.evaluate((id) => {
+        const graph = window.app!.canvas.graph!
+        const node = graph.getNodeById(id)!
+        return node.inputs
+          .filter((input) => input.link != null)
+          .map((input) => input.name)
+          .sort()
+      }, target.id)
+
+    expect(await linkedNames(), 'node should start unconnected').toEqual([])
+
+    await source.connectOutput(0, target, destination!.index)
+
+    // Exactly the aimed slot, by name. A count would pass for a wire that
+    // landed on the neighbouring IMAGE input, which is the failure mode
+    // scaling produces — the link exists, just in the wrong place.
+    await expect.poll(linkedNames).toEqual(['destination'])
+
+    const origin = await comfyPage.page.evaluate(
+      ({ id, slot }) => {
+        const graph = window.app!.canvas.graph!
+        const node = graph.getNodeById(id)!
+        const link = node.inputs[slot]?.link
+        return link == null ? null : (graph.links.get(link)?.origin_id ?? null)
+      },
+      { id: target.id, slot: destination!.index }
+    )
+    expect(String(origin)).toBe(String(source.id))
+  })
+})


### PR DESCRIPTION
## Summary

ECS 1.53 Area 10: *"Set OS/browser display scaling to 150% … then drag a link between two nodes
and box-select → verify wires attach to the correct slots and the selection rectangle matches
the cursor."*

Only two specs carry `@2x` today — `interaction.spec.ts` → *Can highlight selected* and
`rerouteNode.spec.ts` → *Can add reroute by alt clicking on link*. Neither drops a link onto a
**chosen** slot.

## Why this is a real scaling case

Client coordinates do not change with `deviceScaleFactor` — but the canvas backing size does,
and LiteGraph converts client points into graph space through it. A wrong conversion does not
fail outright: the wire lands on a **neighbouring** slot. So the assertion is the slot **name**,
not a link count; a count passes for exactly the defect the row exists to catch.

## Guards

- **More than one IMAGE slot must exist** before connecting. With a single candidate the test
  says nothing about coordinate conversion — any drop that connects would satisfy it.
- **The node starts unconnected**, asserted, so "landed on `destination`" cannot be inherited
  from the fixture.
- The link's `origin_id` is checked as well as the target slot, so a wire from somewhere else
  cannot satisfy it.

## Runs at three scales, and scale 1 is the control

The title carries `@2x @0.5x`, so it runs in `chromium-2x` (dSF 2) and `chromium-0.5x` (dSF 0.5).
The base `chromium` project's `grepInvert` does not exclude those tags, so it also runs at
scale 1. The same assertions must hold at every scale — a failure only under scaling is the
defect, and a failure at all three is a plain bug in the test or the drop logic.

```
$ pnpm exec playwright test --list browser_tests/tests/deviceScaleLinkDrop.spec.ts
  [chromium]        › … › @2x @0.5x A dragged link lands on the slot it was aimed at
  [chromium-2x]     › … › @2x @0.5x A dragged link lands on the slot it was aimed at
  [chromium-0.5x]   › … › @2x @0.5x A dragged link lands on the slot it was aimed at
Total: 3 tests in 1 file
```

## Not covered

The row's **box-select** half. `vueNodes/interactions/canvas/selection.spec.ts` covers marquee
selection at default scale, and extending that to the scaled projects is a separate change with
its own fixture and renderer assumptions. Recorded as a residual on the plan rather than bundled
here.

`150%` specifically: the configured lanes are 2× and 0.5×. The row names 150% as an instance of
non-default scaling, and those two bracket it in both directions.

## Test plan

```
$ pnpm typecheck:browser   # exit 0
$ pnpm exec oxlint --type-aware browser_tests/tests/deviceScaleLinkDrop.spec.ts   # exit 0
$ pnpm exec eslint browser_tests/tests/deviceScaleLinkDrop.spec.ts               # exit 0
```

Test-only change; no source files touched. `EmptyImage` and `ImageCompositeMasked` are both
already constructed by `autogrowSlotDrop.spec.ts` on `main`, so no new asset and no assumption
about node availability.
