### PR TITLE
fix: keep unrelated same-name widgets enabled after linking

### DIFF
--- a/browser_tests/tests/widgets/sameNameSocketWidget.spec.ts
+++ b/browser_tests/tests/widgets/sameNameSocketWidget.spec.ts
@@ -1,0 +1,61 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { toNodeId } from '@/types/nodeId'
+
+test(
+  'linking a same-name non-widget socket keeps the Vue button usable',
+  { tag: ['@canvas', '@node', '@widget'] },
+  async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+    const producerId = toNodeId('same-name-producer')
+    const consumerId = toNodeId('same-name-consumer')
+    await comfyPage.page.evaluate(
+      ([producerId, consumerId]) => {
+        const producer = window.LiteGraph!.createNode('Note')!
+        producer.id = producerId
+        producer.pos = [100, 100]
+        producer.addOutput('model', 'MODEL')
+        const consumer = window.LiteGraph!.createNode('Note')!
+        consumer.id = consumerId
+        consumer.pos = [500, 100]
+        consumer.addInput('model', 'MODEL')
+        consumer.properties.clicks = 0
+        consumer.addWidget('button', 'model', undefined, () => {
+          consumer.properties.clicks = Number(consumer.properties.clicks) + 1
+        })
+        window.app!.graph.add(producer)
+        window.app!.graph.add(consumer)
+      },
+      [producerId, consumerId] as const
+    )
+    await comfyPage.vueNodes.waitForNodes()
+    const control = comfyPage.vueNodes
+      .getNodeLocator(consumerId)
+      .getByRole('button', { name: 'model', exact: true })
+    const clicks = () =>
+      comfyPage.page.evaluate(
+        (id) => window.app!.graph.getNodeById(id)!.properties.clicks,
+        consumerId
+      )
+
+    await expect(control).toHaveCount(1)
+    await expect(control).toBeVisible()
+    await control.click()
+    await expect.poll(clicks).toBe(1)
+
+    const producer = await comfyPage.nodeOps.getNodeRefById(producerId)
+    const consumer = await comfyPage.nodeOps.getNodeRefById(consumerId)
+    await producer.connectOutput(0, consumer, 0)
+    await expect
+      .poll(() => consumer.getInput(0).then((input) => input.getLinkCount()))
+      .toBe(1)
+    await expect(control).toHaveCount(1)
+    await expect(control).toBeVisible()
+    await expect(control).toBeEnabled()
+    await control.click()
+    await expect.poll(clicks).toBe(2)
+  }
+)

--- a/browser_tests/tests/widgets/sameNameSocketWidget.spec.ts
+++ b/browser_tests/tests/widgets/sameNameSocketWidget.spec.ts
@@ -4,58 +4,162 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import { toNodeId } from '@/types/nodeId'
 
-test(
-  'linking a same-name non-widget socket keeps the Vue button usable',
-  { tag: ['@canvas', '@node', '@widget'] },
-  async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-    await comfyPage.menu.topbar.newWorkflowButton.click()
-    const producerId = toNodeId('same-name-producer')
-    const consumerId = toNodeId('same-name-consumer')
-    await comfyPage.page.evaluate(
-      ([producerId, consumerId]) => {
-        const producer = window.LiteGraph!.createNode('Note')!
-        producer.id = producerId
-        producer.pos = [100, 100]
-        producer.addOutput('model', 'MODEL')
-        const consumer = window.LiteGraph!.createNode('Note')!
-        consumer.id = consumerId
-        consumer.pos = [500, 100]
-        consumer.addInput('model', 'MODEL')
-        consumer.properties.clicks = 0
-        consumer.addWidget('button', 'model', undefined, () => {
-          consumer.properties.clicks = Number(consumer.properties.clicks) + 1
-        })
-        window.app!.graph.add(producer)
-        window.app!.graph.add(consumer)
-      },
-      [producerId, consumerId] as const
-    )
-    await comfyPage.vueNodes.waitForNodes()
-    const control = comfyPage.vueNodes
-      .getNodeLocator(consumerId)
-      .getByRole('button', { name: 'model', exact: true })
-    const clicks = () =>
-      comfyPage.page.evaluate(
-        (id) => window.app!.graph.getNodeById(id)!.properties.clicks,
-        consumerId
+test.afterEach(async ({ comfyPage }) => {
+  await comfyPage.workflow.loadWorkflow('default')
+})
+
+for (const vueNodesEnabled of [false, true] as const) {
+  const renderer = vueNodesEnabled ? 'Vue' : 'legacy'
+
+  test(
+    `linking a same-name non-widget socket keeps the ${renderer} button usable`,
+    { tag: ['@canvas', '@node', '@widget'] },
+    async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.VueNodes.Enabled',
+        vueNodesEnabled
       )
+      await comfyPage.menu.topbar.newWorkflowButton.click()
+      const producerId = toNodeId('same-name-producer')
+      const consumerId = toNodeId('same-name-consumer')
+      await comfyPage.page.evaluate(
+        ([producerId, consumerId]) => {
+          const producer = window.LiteGraph!.createNode('Note')!
+          producer.id = producerId
+          producer.pos = [100, 100]
+          producer.addOutput('model', 'MODEL')
+          const consumer = window.LiteGraph!.createNode('Note')!
+          consumer.id = consumerId
+          consumer.pos = [500, 100]
+          consumer.addInput('model', 'MODEL')
+          consumer.properties.clicks = 0
+          consumer.addWidget('button', 'model', undefined, () => {
+            consumer.properties.clicks = Number(consumer.properties.clicks) + 1
+          })
+          window.app!.graph.add(producer)
+          window.app!.graph.add(consumer)
+        },
+        [producerId, consumerId] as const
+      )
+      if (vueNodesEnabled) await comfyPage.vueNodes.waitForNodes()
+      else {
+        await comfyPage.page.evaluate((id) => {
+          const node = window.app!.graph.getNodeById(id)!
+          const drawWidgets = node.drawWidgets
+          node.properties.drawFrames = 0
+          node.drawWidgets = function (ctx, options) {
+            let labels = 0
+            const fillText = ctx.fillText
+            ctx.fillText = function (text, ...args) {
+              fillText.call(this, text, ...args)
+              if (text === 'model') labels++
+            }
+            try {
+              drawWidgets.call(this, ctx, options)
+              node.properties.drawnModelLabels = labels
+              node.properties.drawFrames =
+                Number(node.properties.drawFrames) + 1
+            } finally {
+              ctx.fillText = fillText
+            }
+          }
+        }, consumerId)
+      }
+      const control = vueNodesEnabled
+        ? comfyPage.vueNodes
+            .getNodeLocator(consumerId)
+            .getByRole('button', { name: 'model', exact: true })
+        : null
+      const clicks = () =>
+        comfyPage.page.evaluate(
+          (id) => window.app!.graph.getNodeById(id)!.properties.clicks,
+          consumerId
+        )
+      const sourceRowCount = () =>
+        comfyPage.page.evaluate(
+          (id) =>
+            window
+              .app!.graph.getNodeById(id)!
+              .widgets?.filter((widget) => widget.name === 'model').length ?? 0,
+          consumerId
+        )
+      const consumer = await comfyPage.nodeOps.getNodeRefById(consumerId)
+      const legacyControl = await consumer.getWidgetByName('model')
+      const legacyControlCenter = async () => {
+        const position = await legacyControl.getPosition()
+        return { x: position.x, y: position.y + 10 }
+      }
+      const expectLegacyControlDrawn = async () => {
+        const beforeFrame = await comfyPage.page.evaluate((id) => {
+          const node = window.app!.graph.getNodeById(id)!
+          node.setDirtyCanvas(true, true)
+          return Number(node.properties.drawFrames)
+        }, consumerId)
+        await expect
+          .poll(() =>
+            comfyPage.page.evaluate((id) => {
+              const node = window.app!.graph.getNodeById(id)!
+              return Number(node.properties.drawFrames)
+            }, consumerId)
+          )
+          .toBeGreaterThan(beforeFrame)
+        expect(
+          await comfyPage.page.evaluate(
+            (id) =>
+              window.app!.graph.getNodeById(id)!.properties.drawnModelLabels,
+            consumerId
+          )
+        ).toBe(1)
+        const position = await legacyControlCenter()
+        const distinctColors = await comfyPage.canvas.evaluate(
+          (canvas: HTMLCanvasElement, { x, y }) => {
+            const rect = canvas.getBoundingClientRect()
+            const scaleX = canvas.width / rect.width
+            const scaleY = canvas.height / rect.height
+            const pixels = canvas
+              .getContext('2d')!
+              .getImageData(
+                Math.round((x - rect.left - 50) * scaleX),
+                Math.round((y - rect.top - 8) * scaleY),
+                Math.round(100 * scaleX),
+                Math.round(16 * scaleY)
+              ).data
+            const colors = new Set<string>()
+            for (let index = 0; index < pixels.length; index += 4) {
+              colors.add(
+                `${pixels[index]},${pixels[index + 1]},${pixels[index + 2]}`
+              )
+            }
+            return colors.size
+          },
+          position
+        )
+        expect(distinctColors).toBeGreaterThan(1)
+      }
+      const expectControlUsable = async (expectedClicks: number) => {
+        await expect.poll(sourceRowCount).toBe(1)
+        if (control) {
+          await expect(control).toHaveCount(1)
+          await expect(control).toBeVisible()
+          await expect(control).toBeEnabled()
+          await control.click()
+        } else {
+          await expectLegacyControlDrawn()
+          const position = await legacyControlCenter()
+          await comfyPage.page.mouse.click(position.x, position.y)
+          await comfyPage.nextFrame()
+        }
+        await expect.poll(clicks).toBe(expectedClicks)
+      }
 
-    await expect(control).toHaveCount(1)
-    await expect(control).toBeVisible()
-    await control.click()
-    await expect.poll(clicks).toBe(1)
+      await expectControlUsable(1)
 
-    const producer = await comfyPage.nodeOps.getNodeRefById(producerId)
-    const consumer = await comfyPage.nodeOps.getNodeRefById(consumerId)
-    await producer.connectOutput(0, consumer, 0)
-    await expect
-      .poll(() => consumer.getInput(0).then((input) => input.getLinkCount()))
-      .toBe(1)
-    await expect(control).toHaveCount(1)
-    await expect(control).toBeVisible()
-    await expect(control).toBeEnabled()
-    await control.click()
-    await expect.poll(clicks).toBe(2)
-  }
-)
+      const producer = await comfyPage.nodeOps.getNodeRefById(producerId)
+      await producer.connectOutput(0, consumer, 0)
+      await expect
+        .poll(() => consumer.getInput(0).then((input) => input.getLinkCount()))
+        .toBe(1)
+      await expectControlUsable(2)
+    }
+  )
+}

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -135,15 +135,10 @@ function createSlotMetadata(
   }
 }
 
-function getSlotWidgetName(
-  input: INodeInputSlot,
-  linked: boolean
-): string | undefined {
+function getSlotWidgetName(input: INodeInputSlot): string | undefined {
   return (
     input.widget?.name ||
-    ((input.widgetId !== undefined || linked) && input.name
-      ? input.name
-      : undefined)
+    (input.widgetId !== undefined && input.name ? input.name : undefined)
   )
 }
 
@@ -159,7 +154,7 @@ function buildSlotMetadata(
     const link = scope
       ? linkStore.getInputSlotLink(scope, nodeId, index)
       : undefined
-    const widgetName = getSlotWidgetName(input, link !== undefined)
+    const widgetName = getSlotWidgetName(input)
     if (!widgetName || metadata.has(widgetName)) continue
     metadata.set(widgetName, createSlotMetadata(input, index, link, graphRef))
   }

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -159,6 +159,50 @@ describe('widget slot ownership', () => {
     expect(processedWidget.slotMetadata).toBeUndefined()
   })
 
+  it.for([false, true])(
+    'respects explicit widget ownership on linked same-name sockets (owned: %s)',
+    (ownsWidget) => {
+      const nodeId = toNodeId(1)
+      const { graph, node } = createGraphWithNode([], nodeId)
+      node.addInput('model', 'MODEL')
+      node.addWidget('custom', 'model', null, () => {})
+      if (ownsWidget) node.inputs[0].widget = { name: 'model' }
+      useLinkStore().registerLink(
+        {
+          rootGraphId: toRootGraphId(GRAPH_ID),
+          owningGraphId: toOwningGraphId(GRAPH_ID)
+        },
+        {
+          id: toLinkId(1),
+          graphId: toOwningGraphId(GRAPH_ID),
+          originNodeId: toNodeId(2),
+          originSlot: 0,
+          targetNodeId: nodeId,
+          targetSlot: 0,
+          type: 'MODEL'
+        }
+      )
+
+      const [processedWidget] = computeProcessedWidgets({
+        nodeData: node._state,
+        widgetIds: undefined,
+        graphId: GRAPH_ID,
+        showAdvanced: false,
+        isGraphReady: true,
+        rootGraph: graph,
+        ui: noopUi
+      })
+
+      if (ownsWidget) {
+        expect(processedWidget.slotMetadata?.linked).toBe(true)
+        expect(processedWidget.simplified.options?.disabled).toBe(true)
+      } else {
+        expect(processedWidget.slotMetadata).toBeUndefined()
+        expect(processedWidget.simplified.options?.disabled).not.toBe(true)
+      }
+    }
+  )
+
   it('uses the first same-named widget input slot', () => {
     const nodeId = toNodeId(1)
     const { graph, node } = createGraphWithNode([], nodeId)
@@ -239,6 +283,7 @@ describe('widget visibility', () => {
       {
         name: 'w',
         type: 'STRING',
+        widget: { name: 'w' },
         link: toLinkId(1),
         boundingRect: [0, 0, 0, 0]
       }

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -159,14 +159,17 @@ describe('widget slot ownership', () => {
     expect(processedWidget.slotMetadata).toBeUndefined()
   })
 
-  it.for([false, true])(
-    'respects explicit widget ownership on linked same-name sockets (owned: %s)',
-    (ownsWidget) => {
+  it.for(['none', 'widget', 'widgetId'] as const)(
+    'respects explicit widget ownership on linked same-name sockets (%s)',
+    (ownership) => {
       const nodeId = toNodeId(1)
       const { graph, node } = createGraphWithNode([], nodeId)
       node.addInput('model', 'MODEL')
       node.addWidget('custom', 'model', null, () => {})
-      if (ownsWidget) node.inputs[0].widget = { name: 'model' }
+      if (ownership === 'widget') node.inputs[0].widget = { name: 'model' }
+      if (ownership === 'widgetId') {
+        node.inputs[0].widgetId = widgetId(GRAPH_ID, nodeId, 'model')
+      }
       useLinkStore().registerLink(
         {
           rootGraphId: toRootGraphId(GRAPH_ID),
@@ -193,7 +196,7 @@ describe('widget slot ownership', () => {
         ui: noopUi
       })
 
-      if (ownsWidget) {
+      if (ownership !== 'none') {
         expect(processedWidget.slotMetadata?.linked).toBe(true)
         expect(processedWidget.simplified.options?.disabled).toBe(true)
       } else {


### PR DESCRIPTION
## Summary

Keep unrelated same-name widgets usable after linking in both renderers.

**Human owner:** DrJKL. Christian Byrne owns CI repair until exact-head checks are green.

<details><summary>Full context for agent readers</summary>

## Changes

- Require explicit `input.widget` or promoted `widgetId` ownership before applying linked-slot state to a widget. A matching socket name and a link alone do not establish ownership.
- Cover unowned, `input.widget`-owned, and `widgetId`-only linked sockets in the unit ownership matrix.
- Verify the same unrelated-name button remains rendered and usable before and after linking in both the legacy canvas and Vue node renderers.
- Keep legitimate linked widget inputs disabled and preserve existing visibility behavior.

## Review Focus

The unlinked guard in [the earlier ownership fix](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16122) left a linked-socket fallback. That fallback attached slot metadata to an unrelated custom widget and disabled it. [The subgraph boundary presentation PR](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17128) consumes linked metadata but does not repair this ownership decision.

This is a generic custom-widget mechanism test, not certification of an installed third-party pack. No serialization, link topology, or widget value behavior changes.

## Testing

The surrounding composable suite passed 101 tests across 10 files. The focused browser test passed for both legacy and Vue renderers.

### E2E Verification Steps

1. Run the scenario once with legacy nodes and once with Vue nodes.
2. Construct a node with an unbound `model` input socket plus a separate `model` button widget.
3. Assert the button is rendered and usable before linking.
4. Link the producer output to the unrelated same-name input.
5. Assert the button remains rendered and usable after linking.

### Verification Evidence

```text
$ node node_modules/vitest/vitest.mjs run src/renderer/extensions/vueNodes/composables
Test Files 10 passed (10)
Tests 101 passed (101)

$ PLAYWRIGHT_TEST_URL=http://127.0.0.1:5233 PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:8293 node node_modules/@playwright/test/cli.js test sameNameSocketWidget.spec.ts --project=chromium --workers=1 --reporter=line
2 passed (13.1s)

Mutation: remove the widgetId ownership fallback
1 failed, 36 passed; the intended widgetId-only ownership assertion failed.

Mutation: suppress the legacy production label draw
1 failed; expected one rendered label, received zero.
```

The browser run used the candidate checkout's Vite server on port 5233 with a dedicated test backend on port 8293. The full browser suite and release builds were not run locally. Exact-head CI is pending.

## Checklist

- [x] Root cause reproduced in unit and browser tests.
- [x] Unowned linked widgets remain enabled.
- [x] `input.widget` and `widgetId` ownership remain linked and disabled.
- [x] Both legacy and Vue renderers retain the unrelated control.
- [x] Causal production mutations fail the intended assertions.
- [ ] Exact-head CI and human review complete.

Glossary: CI means automated pull-request checks; ownership metadata associates an input socket with its widget; legacy renderer means the canvas-drawn node UI; Vue renderer means the DOM-based node UI.

</details>
