### PR TITLE
comfy-test: add `recorder` alias for `record`

### DIFF
--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -177,6 +177,8 @@ If you're a QA tester or non-developer, use the interactive recorder:
 pnpm comfy-test record
 ```
 
+`pnpm comfy-test recorder` is an equivalent alias and accepts the same flags.
+
 This guides you through a 6-step flow:
 
 1. **Environment check** — verifies the tools, the backend, and the dev server (with install instructions if anything is missing)

--- a/tools/test-recorder/README.md
+++ b/tools/test-recorder/README.md
@@ -8,7 +8,7 @@ Interactive CLI for recording and transforming Playwright browser tests for Comf
 
 ```bash
 pnpm comfy-test check       # Verify your environment is ready
-pnpm comfy-test record      # Record a new test interactively (needs a real terminal)
+pnpm comfy-test record      # Record a new test interactively (alias: recorder; needs a real terminal)
 pnpm comfy-test plan --description "<what to test>"  # Non-interactive: print a plan for an agent to hand to playwright-test-generator
 pnpm comfy-test transform <file>  # Transform raw codegen to conventions
 pnpm comfy-test pr <file>   # Open a PR for a generated test
@@ -27,6 +27,9 @@ pnpm comfy-test record --distribution cloud --workflow default --tags @canvas,@w
 
 Supplied answers are confirmed and their prompts are skipped. Invalid values
 show a warning and return to the corresponding prompt.
+
+`pnpm comfy-test recorder` is an alias of `pnpm comfy-test record`; both accept
+the same flags.
 
 Record flags:
 

--- a/tools/test-recorder/src/index.ts
+++ b/tools/test-recorder/src/index.ts
@@ -10,7 +10,8 @@ intro(pc.bgCyan(pc.black(' 🎭 ComfyUI Test Recorder ')))
 
 try {
   switch (command) {
-    case 'record': {
+    case 'record':
+    case 'recorder': {
       const { parseFlags } = await import('./cli/flags')
       const { flags } = parseFlags(args.slice(1), [
         'distribution',
@@ -208,7 +209,7 @@ try {
 Usage: comfy-test <command>
 
 Commands:
-  record [--distribution <id>] [--backend <url>] [--workflow <name>]
+  record (alias: recorder) [--distribution <id>] [--backend <url>] [--workflow <name>]
          [--tags <a,b>] [--feature-flags <specs>] [--use-case <id>]
          [--description <text>] [--name <slug>] [--pr <number>]
               Record a browser test; supplied answers skip setup prompts


### PR DESCRIPTION
Adds the requested `recorder` spelling without changing behavior.

<details><summary>Full context for agent readers</summary>

- Dispatches `recorder` through the existing `record` implementation and flags.
- Lists the alias in CLI help.
- Documents it in both recorder and browser-test guides.
- Verified with typecheck, scoped lint/format, CLI help, and unit tests.

</details>