### PR TITLE
test: agent session replay video demo (Langfuse fixture)

### DIFF
--- a/browser_tests/tests/agent/agentReplayVideoDemo.spec.ts
+++ b/browser_tests/tests/agent/agentReplayVideoDemo.spec.ts
@@ -4,7 +4,7 @@ import { agentConversationTest as test } from '@e2e/fixtures/agentConversationFi
 
 const RECORDED_CASE = 'agent-rec-two-turn-dependent-edit'
 
-test.describe('Agent replay video demo', () => {
+test.describe('Agent replay video demo', { tag: '@cloud' }, () => {
   test.use({ conversationCase: RECORDED_CASE })
 
   test('replays a recorded two-turn agent session', async ({

--- a/browser_tests/tests/agent/agentReplayVideoDemo.spec.ts
+++ b/browser_tests/tests/agent/agentReplayVideoDemo.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test'
+
+import { agentConversationTest as test } from '@e2e/fixtures/agentConversationFixture'
+
+const RECORDED_CASE = 'agent-rec-two-turn-dependent-edit'
+
+test.describe('Agent replay video demo', () => {
+  test.use({ conversationCase: RECORDED_CASE })
+
+  test('replays a recorded two-turn agent session', async ({
+    agentConversation
+  }) => {
+    test.setTimeout(90_000)
+    await agentConversation.runTurns()
+
+    await expect(
+      agentConversation.panel.getByRole('button', {
+        name: `Open ${agentConversation.conversation.workflow.name}`
+      })
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
Replays a real recorded two-turn agent session for CI video capture.

<details><summary>Full context for agent readers</summary>

- Uses the existing provenance-backed `agent-rec-two-turn-dependent-edit` fixture.
- Exercises both recorded turns through the real agent panel and canvas replay harness.
- Intentionally targets the video-detector branch so the PR diff is only the demo spec and CI captures `playwright-report-new-tests`.
- The fixture was captured from the real cloud agent full stack; no synthetic empty delay or secrets are included.

</details>