### PR TITLE
test(stores): pin silent rejection of conflicting nodeDataStore registration

### DIFF
--- a/src/stores/storeCollisionContracts.test.ts
+++ b/src/stores/storeCollisionContracts.test.ts
@@ -153,7 +153,12 @@ describe('store collision contracts (EX-002)', () => {
     assert(incumbent)
 
     const usurper = nodeState(1, rootA, 'Usurper')
+    // ADR ECS-IDENTITY-0016 pins the collision rejection as silent: the store
+    // must not log, because it lacks the caller's re-mint recovery context.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(store.registerNode(scopeA, usurper)).toBeUndefined()
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
 
     expect(incumbent.title).toBe('Incumbent')
     expect(store.getGraphNodesFor(rootA, rootA)).toHaveLength(1)


### PR DESCRIPTION
Reconciles the surviving review request on the source PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15720#discussion_r3943150171

## What

The `nodeDataStore` conflicting-registration test in `src/stores/storeCollisionContracts.test.ts` asserted rejection (`toBeUndefined()`) and incumbent retention, but not **silence**. Adds a scoped `console.warn` spy + `expect(warn).not.toHaveBeenCalled()` with cleanup to that existing test.

## Why this request is valid

- ADR `docs/adr/ECS-IDENTITY-0016-entity-id-collision-policy-and-recovery.md` documents the per-store contract explicitly: `nodeDataStore` collision rejection — "**The store is silent**; an ID-owning caller diagnoses any re-mint" — and the alternatives section records that logging inside every store was **rejected** because a store lacks the caller's recovery context (unlike `linkStore`/`rerouteStore`, which do log per the same table).
- The review request's "path instructions" phrase "silent rejection of conflicting node registrations" therefore has a concrete, testable meaning for this store, and the suite did not pin it.
- The two other human requests on that review thread (removal of vacuous cross-store/lifecycle tests) already have addressing-author replies and are not resurrected here.

Warning-emission assertions remain in `nodeShellLifecycle.test.ts`, where reminting owns the warning, per the review request's own scoping.

## Verification

- `pnpm vitest run src/stores/storeCollisionContracts.test.ts`: 7/7 passed (including the new silence assertion) at base head `7d2d4a8c01`.
- `oxlint` + `oxfmt --check` clean on the touched file; pre-commit lint-staged (oxfmt / oxlint type-aware / eslint / typecheck) passed.

No product code changed — test-only.