### PR TITLE
docs(adr): drop speculative future-system paragraph from ADR-0006 (review follow-up to PR 16862)

### DIFF
--- a/docs/adr/WIDGET-SERIALIZATION-0006-preserve-primitive-widget-values-across-copy-and-paste.md
+++ b/docs/adr/WIDGET-SERIALIZATION-0006-preserve-primitive-widget-values-across-copy-and-paste.md
@@ -45,10 +45,7 @@ and has not materialized its widget. The first complete link-derived widget
 build consumes the state through the generic lookup path. A completed build,
 type mismatch, or disconnect clears any unconsumed state.
 
-Do not add a Primitive-specific restoration type, store, or scheduler. A general
-connectivity-to-widget-materialization system can replace the remaining
-lifecycle ordering when the application has an authoritative coordinator for
-that phase.
+Do not add a Primitive-specific restoration type, store, or scheduler.
 
 ## Consequences
 


### PR DESCRIPTION
Resolves the surviving review request from [PR 16862 (PrimitiveNode widget restoration ADR follow-up)](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16862): [DrJKL asked to delete the speculative future-system paragraph](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16862#discussion_r3931653113) in the widget-values copy/paste ADR (WIDGET-SERIALIZATION-0006, file [`docs/adr/WIDGET-SERIALIZATION-0006-preserve-primitive-widget-values-across-copy-and-paste.md`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/adr/WIDGET-SERIALIZATION-0006-preserve-primitive-widget-values-across-copy-and-paste.md)).

## What changed

Removes one sentence from the Decision section:

> A general connectivity-to-widget-materialization system can replace the remaining lifecycle ordering when the application has an authoritative coordinator for that phase.

Per the review: [PR 16459 (the ADR's implementation PR)](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16459) implements no connectivity-to-widget-materialization system or authoritative coordinator, and the ADR defines no invariant or adoption condition for one, so the sentence reads as accepted design direction while adding nothing to the restoration contract.

## What is preserved

The accepted restoration contract is intact:

- "Do not add a Primitive-specific restoration type, store, or scheduler." (kept, immediately preceding the removed sentence)
- The Alternatives Considered entry rejecting a Primitive-only restoration store/System
- All Consequences unchanged

## Verification

- `grep` confirms no remaining connectivity-to-widget-materialization / authoritative-coordinator references in the ADR
- `oxfmt --check` passes on the changed file (lint-staged hook green at commit)

Task row: srx-20260948.
