### PR TITLE
feat(load3d) FE-1197: show model statistics overlay in the 3D viewport

### DIFF
--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -31,6 +31,7 @@
       :can-use-recording="canUseRecording && !isPreview"
       :material-modes="materialModes"
       :has-skeleton="hasSkeleton"
+      :model-stats="modelStats"
       :source-format="sourceFormat"
       @update-background-image="handleBackgroundImageUpdate"
       @update-hdri-file="handleHDRIFileUpdate"
@@ -120,6 +121,7 @@ const {
   canExport,
   materialModes,
   hasSkeleton,
+  modelStats,
   sourceFormat,
   hasRecording,
   recordingDuration,

--- a/src/components/load3d/Load3DMenuBar.test.ts
+++ b/src/components/load3d/Load3DMenuBar.test.ts
@@ -107,6 +107,17 @@ async function openCategoryMenu(user: ReturnType<typeof userEvent.setup>) {
 }
 
 describe('Load3DMenuBar', () => {
+  it('shows the model stats overlay only when stats are provided', async () => {
+    const { rerender } = renderMenuBar()
+    expect(screen.queryByTestId('load3d-model-stats')).not.toBeInTheDocument()
+
+    await rerender({
+      modelStats: { vertices: 8, edges: 12, triangles: 12 }
+    })
+
+    expect(screen.getByTestId('load3d-model-stats')).toBeInTheDocument()
+  })
+
   it('shows scene controls by default', () => {
     renderMenuBar()
     expect(

--- a/src/components/load3d/Load3DMenuBar.test.ts
+++ b/src/components/load3d/Load3DMenuBar.test.ts
@@ -109,13 +109,14 @@ async function openCategoryMenu(user: ReturnType<typeof userEvent.setup>) {
 describe('Load3DMenuBar', () => {
   it('shows the model stats overlay only when stats are provided', async () => {
     const { rerender } = renderMenuBar()
-    expect(screen.queryByTestId('load3d-model-stats')).not.toBeInTheDocument()
+    expect(screen.queryByText('Vertices')).not.toBeInTheDocument()
 
     await rerender({
       modelStats: { vertices: 8, edges: 12, triangles: 12 }
     })
 
-    expect(screen.getByTestId('load3d-model-stats')).toBeInTheDocument()
+    expect(screen.getByText('Vertices')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
   })
 
   it('shows scene controls by default', () => {

--- a/src/components/load3d/Load3DMenuBar.vue
+++ b/src/components/load3d/Load3DMenuBar.vue
@@ -92,6 +92,7 @@
 
     <div class="relative min-h-0 flex-1 overflow-hidden">
       <slot />
+      <ModelStatsOverlay v-if="modelStats" :stats="modelStats" />
       <div
         v-if="isRecording"
         class="pointer-events-none absolute inset-0 border-2 border-node-component-executing"
@@ -204,6 +205,7 @@ import {
   tip
 } from '@/components/load3d/menubar/menuBarStyles'
 import ModelMenuGroup from '@/components/load3d/menubar/ModelMenuGroup.vue'
+import ModelStatsOverlay from '@/components/load3d/menubar/ModelStatsOverlay.vue'
 import RecordMenuControl from '@/components/load3d/menubar/RecordMenuControl.vue'
 import SceneMenuGroup from '@/components/load3d/menubar/SceneMenuGroup.vue'
 import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
@@ -212,6 +214,7 @@ import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import { getExportFormatOptions } from '@/extensions/core/load3d/constants'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { ModelStats } from '@/extensions/core/load3d/modelStats'
 import type {
   AnimationItem,
   CameraConfig,
@@ -238,6 +241,7 @@ const {
   node = null,
   materialModes = ['original', 'clay', 'normal', 'wireframe'],
   hasSkeleton = false,
+  modelStats = null,
   sourceFormat = null
 } = defineProps<{
   animations?: AnimationItem[]
@@ -254,6 +258,7 @@ const {
   node?: LGraphNode | null
   materialModes?: readonly MaterialMode[]
   hasSkeleton?: boolean
+  modelStats?: ModelStats | null
   sourceFormat?: string | null
 }>()
 

--- a/src/components/load3d/menubar/ModelStatsOverlay.test.ts
+++ b/src/components/load3d/menubar/ModelStatsOverlay.test.ts
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import ModelStatsOverlay from '@/components/load3d/menubar/ModelStatsOverlay.vue'
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+describe('ModelStatsOverlay', () => {
+  it('lists every statistic with locale-formatted counts', () => {
+    render(ModelStatsOverlay, {
+      props: {
+        stats: { vertices: 25921, edges: 51520, triangles: 51200 }
+      },
+      global: { plugins: [i18n] }
+    })
+
+    expect(screen.getAllByRole('term').map((el) => el.textContent)).toEqual([
+      'Vertices',
+      'Edges',
+      'Triangles'
+    ])
+    expect(
+      screen.getAllByRole('definition').map((el) => el.textContent)
+    ).toEqual(['25,921', '51,520', '51,200'])
+  })
+})

--- a/src/components/load3d/menubar/ModelStatsOverlay.vue
+++ b/src/components/load3d/menubar/ModelStatsOverlay.vue
@@ -1,7 +1,6 @@
 <template>
   <dl
     class="pointer-events-none absolute top-2 right-2 z-10 m-0 grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5 rounded-md bg-backdrop/50 px-2 py-1 text-xs text-base-foreground tabular-nums"
-    data-testid="load3d-model-stats"
   >
     <template v-for="row in rows" :key="row.key">
       <dt class="opacity-70">{{ row.label }}</dt>

--- a/src/components/load3d/menubar/ModelStatsOverlay.vue
+++ b/src/components/load3d/menubar/ModelStatsOverlay.vue
@@ -1,0 +1,39 @@
+<template>
+  <dl
+    class="pointer-events-none absolute top-2 right-2 z-10 m-0 grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5 rounded-md bg-backdrop/50 px-2 py-1 text-xs text-base-foreground tabular-nums"
+    data-testid="load3d-model-stats"
+  >
+    <template v-for="row in rows" :key="row.key">
+      <dt class="opacity-70">{{ row.label }}</dt>
+      <dd class="m-0 text-right">{{ row.value }}</dd>
+    </template>
+  </dl>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { ModelStats } from '@/extensions/core/load3d/modelStats'
+
+const { stats } = defineProps<{ stats: ModelStats }>()
+
+const { t, locale } = useI18n()
+
+const rows = computed(() => {
+  const formatter = new Intl.NumberFormat(locale.value)
+  return [
+    {
+      key: 'vertices',
+      label: t('load3d.stats.vertices'),
+      count: stats.vertices
+    },
+    { key: 'edges', label: t('load3d.stats.edges'), count: stats.edges },
+    {
+      key: 'triangles',
+      label: t('load3d.stats.triangles'),
+      count: stats.triangles
+    }
+  ].map(({ count, ...row }) => ({ ...row, value: formatter.format(count) }))
+})
+</script>

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -169,6 +169,7 @@ describe('useLoad3d', () => {
         fitTargetSize: 5
       }),
       hasSkeleton: vi.fn().mockReturnValue(false),
+      getModelStats: vi.fn().mockResolvedValue(null),
       setShowSkeleton: vi.fn(),
       loadHDRI: vi.fn().mockResolvedValue(undefined),
       setHDRIEnabled: vi.fn(),
@@ -960,13 +961,29 @@ describe('useLoad3d', () => {
 
       await composable.initializeLoad3d(containerRef)
 
+      const stats = { vertices: 4, edges: 5, triangles: 2 }
+      const signals: AbortSignal[] = []
+      vi.mocked(mockLoad3d.getModelStats!).mockImplementation(
+        async (signal?: AbortSignal) => {
+          if (signal) signals.push(signal)
+          return stats
+        }
+      )
+
       modelLoadingStartHandler?.()
       expect(composable.loading.value).toBe(true)
       expect(composable.loadingMessage.value).toBe('load3d.loadingModel')
+      expect(composable.modelStats.value).toBeNull()
 
       modelLoadingEndHandler?.()
       expect(composable.loading.value).toBe(false)
       expect(composable.loadingMessage.value).toBe('')
+      await vi.waitFor(() => expect(composable.modelStats.value).toEqual(stats))
+
+      modelLoadingStartHandler?.()
+      expect(signals).toHaveLength(1)
+      expect(signals[0].aborted).toBe(true)
+      expect(composable.modelStats.value).toBeNull()
     })
 
     it('should handle recordingStatusChange event', async () => {

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -14,6 +14,7 @@ import {
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
+import type { ModelStats } from '@/extensions/core/load3d/modelStats'
 import type { Size } from '@/lib/litegraph/src/interfaces'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -962,13 +963,7 @@ describe('useLoad3d', () => {
       await composable.initializeLoad3d(containerRef)
 
       const stats = { vertices: 4, edges: 5, triangles: 2 }
-      const signals: AbortSignal[] = []
-      vi.mocked(mockLoad3d.getModelStats!).mockImplementation(
-        async (signal?: AbortSignal) => {
-          if (signal) signals.push(signal)
-          return stats
-        }
-      )
+      vi.mocked(mockLoad3d.getModelStats!).mockResolvedValue(stats)
 
       modelLoadingStartHandler?.()
       expect(composable.loading.value).toBe(true)
@@ -979,10 +974,49 @@ describe('useLoad3d', () => {
       expect(composable.loading.value).toBe(false)
       expect(composable.loadingMessage.value).toBe('')
       await vi.waitFor(() => expect(composable.modelStats.value).toEqual(stats))
+    })
+
+    it('discards model stats that settle after the next load has started', async () => {
+      let modelLoadingStartHandler: (() => void) | undefined
+      let modelLoadingEndHandler: (() => void) | undefined
+
+      vi.mocked(mockLoad3d.addEventListener!).mockImplementation(
+        (event: string, handler: unknown) => {
+          if (event === 'modelLoadingStart') {
+            modelLoadingStartHandler = handler as () => void
+          } else if (event === 'modelLoadingEnd') {
+            modelLoadingEndHandler = handler as () => void
+          }
+        }
+      )
+
+      const composable = useLoad3d(mockNode)
+      await composable.initializeLoad3d(document.createElement('div'))
+
+      const signals: AbortSignal[] = []
+      let resolveFirstStats: (stats: ModelStats | null) => void = () => {}
+      const firstStats = new Promise<ModelStats | null>((resolve) => {
+        resolveFirstStats = resolve
+      })
+      vi.mocked(mockLoad3d.getModelStats!).mockImplementation(
+        (signal?: AbortSignal) => {
+          if (signal) signals.push(signal)
+          return firstStats
+        }
+      )
 
       modelLoadingStartHandler?.()
+      modelLoadingEndHandler?.()
       expect(signals).toHaveLength(1)
+      expect(signals[0].aborted).toBe(false)
+
+      modelLoadingStartHandler?.()
       expect(signals[0].aborted).toBe(true)
+
+      resolveFirstStats({ vertices: 4, edges: 5, triangles: 2 })
+      await firstStats
+      await nextTick()
+
       expect(composable.modelStats.value).toBeNull()
     })
 

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -7,6 +7,7 @@ import { ref, toRaw, watch } from 'vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+import type { ModelStats } from '@/extensions/core/load3d/modelStats'
 import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
 import { isLoad3dResultViewerNode } from '@/extensions/core/load3d/nodeTypes'
 import {
@@ -140,6 +141,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   })
 
   const hasSkeleton = ref(false)
+  const modelStats = ref<ModelStats | null>(null)
+  let modelStatsAbort: AbortController | null = null
 
   const cameraConfig = ref<CameraConfig>({
     cameraType: 'perspective',
@@ -923,6 +926,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     modelLoadingStart: () => {
       loadingMessage.value = t('load3d.loadingModel')
       loading.value = true
+      modelStats.value = null
+      abortModelStats()
       if (!isFirstModelLoad) {
         modelConfig.value = {
           upDirection: 'original',
@@ -956,6 +961,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         'wireframe'
       ]
       hasSkeleton.value = load3d?.hasSkeleton() ?? false
+      refreshModelStats()
       applyGizmoConfigToLoad3d()
       syncSceneModels()
       isFirstModelLoad = false
@@ -1086,7 +1092,27 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     })
   }
 
+  const abortModelStats = () => {
+    modelStatsAbort?.abort()
+    modelStatsAbort = null
+  }
+
+  const refreshModelStats = () => {
+    abortModelStats()
+    const controller = new AbortController()
+    modelStatsAbort = controller
+    void load3d
+      ?.getModelStats(controller.signal)
+      .then((stats) => {
+        modelStats.value = stats
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) throw error
+      })
+  }
+
   const cleanup = () => {
+    abortModelStats()
     handleEvents('remove')
 
     const node = toRaw(nodeRef.value)
@@ -1118,6 +1144,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     canExport,
     materialModes,
     hasSkeleton,
+    modelStats,
     hasRecording,
     recordingDuration,
     animations,

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -1104,6 +1104,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     void load3d
       ?.getModelStats(controller.signal)
       .then((stats) => {
+        if (modelStatsAbort !== controller) return
         modelStats.value = stats
       })
       .catch((error: unknown) => {

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -763,6 +763,47 @@ describe('Load3d', () => {
       makeWithAdapter('mesh')
       expect(ctx.load3d.isPlyModel()).toBe(false)
     })
+
+    it('getModelStats counts the current model for meshes and skips splats', async () => {
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3)
+      )
+      Object.assign(ctx.modelManager, {
+        currentModel: new THREE.Mesh(geometry)
+      })
+
+      makeWithAdapter('mesh')
+      await expect(ctx.load3d.getModelStats()).resolves.toEqual({
+        vertices: 3,
+        edges: 3,
+        triangles: 1
+      })
+
+      makeWithAdapter('splat')
+      await expect(ctx.load3d.getModelStats()).resolves.toBeNull()
+
+      Object.assign(ctx.modelManager, { currentModel: null })
+      makeWithAdapter('mesh')
+      await expect(ctx.load3d.getModelStats()).resolves.toBeNull()
+    })
+
+    it('getModelStats forwards the abort signal to the computation', async () => {
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3)
+      )
+      Object.assign(ctx.modelManager, {
+        currentModel: new THREE.Mesh(geometry)
+      })
+      makeWithAdapter('mesh')
+
+      await expect(
+        ctx.load3d.getModelStats(AbortSignal.abort())
+      ).rejects.toThrow(/abort/i)
+    })
   })
 
   describe('setCameraFromMatrices', () => {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -23,6 +23,8 @@ import type {
   UpDirection
 } from './interfaces'
 import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
+import { computeModelStats } from './modelStats'
+import type { ModelStats } from './modelStats'
 
 export type Load3dDeps = Viewport3dDeps & {
   hdriManager: HDRIManager
@@ -525,6 +527,12 @@ class Load3d extends Viewport3d {
 
   public hasSkeleton(): boolean {
     return this.modelManager.hasSkeleton()
+  }
+
+  public async getModelStats(signal?: AbortSignal): Promise<ModelStats | null> {
+    const model = this.modelManager.currentModel
+    if (!model || this.isSplatModel()) return null
+    return computeModelStats(model, signal)
   }
 
   public setShowSkeleton(show: boolean): void {

--- a/src/extensions/core/load3d/modelStats.test.ts
+++ b/src/extensions/core/load3d/modelStats.test.ts
@@ -109,6 +109,17 @@ describe('computeModelStats', () => {
     await expect(pending).rejects.toThrow(/abort/i)
   })
 
+  it('rejects when aborted while a small mesh is still being counted', async () => {
+    const controller = new AbortController()
+    const pending = computeModelStats(
+      new THREE.Mesh(makeQuadGeometry()),
+      controller.signal
+    )
+    controller.abort()
+
+    await expect(pending).rejects.toThrow(/abort/i)
+  })
+
   it('rejects immediately for an already aborted signal', async () => {
     await expect(
       computeModelStats(new THREE.Mesh(makeQuadGeometry()), AbortSignal.abort())

--- a/src/extensions/core/load3d/modelStats.test.ts
+++ b/src/extensions/core/load3d/modelStats.test.ts
@@ -1,0 +1,128 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { computeModelStats, hasGeometry } from './modelStats'
+
+function makeQuadGeometry() {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0], 3)
+  )
+  geometry.setIndex([0, 1, 2, 0, 2, 3])
+  return geometry
+}
+
+describe('computeModelStats', () => {
+  it('counts shared edges once for indexed geometry', async () => {
+    const mesh = new THREE.Mesh(makeQuadGeometry())
+
+    await expect(computeModelStats(mesh)).resolves.toEqual({
+      vertices: 4,
+      edges: 5,
+      triangles: 2
+    })
+  })
+
+  it('welds duplicated positions so non-indexed geometry reports topology', async () => {
+    const mesh = new THREE.Mesh(makeQuadGeometry().toNonIndexed())
+
+    await expect(computeModelStats(mesh)).resolves.toEqual({
+      vertices: 4,
+      edges: 5,
+      triangles: 2
+    })
+  })
+
+  it('welds seam-duplicated vertices in indexed geometry', async () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(
+        [0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0],
+        3
+      )
+    )
+    geometry.setIndex([0, 1, 2, 3, 4, 5])
+
+    await expect(computeModelStats(new THREE.Mesh(geometry))).resolves.toEqual({
+      vertices: 4,
+      edges: 5,
+      triangles: 2
+    })
+  })
+
+  it('drops degenerate and duplicate triangles like Blender does', async () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0], 3)
+    )
+    geometry.setIndex([0, 1, 2, 0, 2, 3, 2, 0, 1, 0, 0, 3])
+
+    await expect(computeModelStats(new THREE.Mesh(geometry))).resolves.toEqual({
+      vertices: 4,
+      edges: 5,
+      triangles: 2
+    })
+  })
+
+  it('sums meshes across the hierarchy and multiplies instanced meshes', async () => {
+    const root = new THREE.Group()
+    const child = new THREE.Group()
+    child.add(new THREE.Mesh(makeQuadGeometry()))
+    root.add(child)
+    root.add(new THREE.InstancedMesh(makeQuadGeometry(), undefined, 3))
+
+    await expect(computeModelStats(root)).resolves.toEqual({
+      vertices: 16,
+      edges: 20,
+      triangles: 8
+    })
+  })
+
+  it('counts point clouds as vertices only', async () => {
+    const points = new THREE.Points(makeQuadGeometry())
+
+    await expect(computeModelStats(points)).resolves.toEqual({
+      vertices: 4,
+      edges: 0,
+      triangles: 0
+    })
+  })
+
+  it('stops at the next yield point once the signal is aborted', async () => {
+    const vertexCount = 60_000
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(new Float32Array(vertexCount * 3), 3)
+    )
+    const controller = new AbortController()
+
+    const pending = computeModelStats(
+      new THREE.Mesh(geometry),
+      controller.signal
+    )
+    controller.abort()
+
+    await expect(pending).rejects.toThrow(/abort/i)
+  })
+
+  it('rejects immediately for an already aborted signal', async () => {
+    await expect(
+      computeModelStats(new THREE.Mesh(makeQuadGeometry()), AbortSignal.abort())
+    ).rejects.toThrow(/abort/i)
+  })
+
+  it('skips objects without geometry', async () => {
+    const root = new THREE.Group()
+    root.add(new THREE.Object3D())
+    root.add(new THREE.Mesh(new THREE.BufferGeometry()))
+
+    const stats = await computeModelStats(root)
+
+    expect(stats.vertices).toBe(0)
+    expect(hasGeometry(stats)).toBe(false)
+  })
+})

--- a/src/extensions/core/load3d/modelStats.ts
+++ b/src/extensions/core/load3d/modelStats.ts
@@ -1,0 +1,134 @@
+import * as THREE from 'three'
+
+export interface ModelStats {
+  vertices: number
+  edges: number
+  triangles: number
+}
+
+const EMPTY_STATS: ModelStats = {
+  vertices: 0,
+  edges: 0,
+  triangles: 0
+}
+
+const CHUNK_SIZE = 50_000
+
+async function yieldToEventLoop(signal?: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  signal?.throwIfAborted()
+}
+
+async function weldByPosition(
+  position: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+  signal?: AbortSignal
+): Promise<{ remap: Uint32Array; uniqueCount: number }> {
+  const ids = new Map<string, number>()
+  const remap = new Uint32Array(position.count)
+  for (let i = 0; i < position.count; i++) {
+    if (i > 0 && i % CHUNK_SIZE === 0) await yieldToEventLoop(signal)
+    const key = `${position.getX(i)},${position.getY(i)},${position.getZ(i)}`
+    const existing = ids.get(key)
+    if (existing === undefined) {
+      remap[i] = ids.size
+      ids.set(key, ids.size)
+    } else {
+      remap[i] = existing
+    }
+  }
+  return { remap, uniqueCount: ids.size }
+}
+
+async function countTopology(
+  cornerIndices: ArrayLike<number>,
+  remap: Uint32Array,
+  vertexCount: number,
+  signal?: AbortSignal
+): Promise<{ edges: number; triangles: number }> {
+  const edges = new Set<number>()
+  const triangles = new Set<string>()
+  const cornerTriangles = Math.floor(cornerIndices.length / 3)
+  for (let t = 0; t < cornerTriangles; t++) {
+    if (t > 0 && t % CHUNK_SIZE === 0) await yieldToEventLoop(signal)
+    const corners = [
+      remap[cornerIndices[t * 3]],
+      remap[cornerIndices[t * 3 + 1]],
+      remap[cornerIndices[t * 3 + 2]]
+    ].sort((a, b) => a - b)
+    const [a, b, c] = corners
+    const isDegenerate = a === b || b === c
+    if (isDegenerate) continue
+    const triangleKey = corners.join(',')
+    if (triangles.has(triangleKey)) continue
+    triangles.add(triangleKey)
+    edges.add(a * vertexCount + b)
+    edges.add(b * vertexCount + c)
+    edges.add(a * vertexCount + c)
+  }
+  return { edges: edges.size, triangles: triangles.size }
+}
+
+function sequentialCorners(count: number): Uint32Array {
+  return Uint32Array.from({ length: count }, (_, i) => i)
+}
+
+async function meshStats(
+  mesh: THREE.Mesh,
+  signal?: AbortSignal
+): Promise<ModelStats> {
+  const position = mesh.geometry.getAttribute('position')
+  if (!position) return EMPTY_STATS
+
+  const { remap, uniqueCount } = await weldByPosition(position, signal)
+  const corners = mesh.geometry.index?.array ?? sequentialCorners(remap.length)
+  const { edges, triangles } = await countTopology(
+    corners,
+    remap,
+    uniqueCount,
+    signal
+  )
+  const instances = mesh instanceof THREE.InstancedMesh ? mesh.count : 1
+
+  return {
+    vertices: uniqueCount * instances,
+    edges: edges * instances,
+    triangles: triangles * instances
+  }
+}
+
+function pointsStats(points: THREE.Points): ModelStats {
+  const position = points.geometry.getAttribute('position')
+  return { ...EMPTY_STATS, vertices: position?.count ?? 0 }
+}
+
+function addStats(a: ModelStats, b: ModelStats): ModelStats {
+  return {
+    vertices: a.vertices + b.vertices,
+    edges: a.edges + b.edges,
+    triangles: a.triangles + b.triangles
+  }
+}
+
+export async function computeModelStats(
+  root: THREE.Object3D,
+  signal?: AbortSignal
+): Promise<ModelStats> {
+  signal?.throwIfAborted()
+  const meshes: THREE.Mesh[] = []
+  let total = EMPTY_STATS
+  root.traverse((child) => {
+    if (child instanceof THREE.Mesh) {
+      meshes.push(child)
+    } else if (child instanceof THREE.Points) {
+      total = addStats(total, pointsStats(child))
+    }
+  })
+  for (const mesh of meshes) {
+    total = addStats(total, await meshStats(mesh, signal))
+  }
+  return total
+}
+
+export function hasGeometry(stats: ModelStats): boolean {
+  return stats.vertices > 0
+}

--- a/src/extensions/core/load3d/modelStats.ts
+++ b/src/extensions/core/load3d/modelStats.ts
@@ -124,7 +124,9 @@ export async function computeModelStats(
     }
   })
   for (const mesh of meshes) {
-    total = addStats(total, await meshStats(mesh, signal))
+    const stats = await meshStats(mesh, signal)
+    signal?.throwIfAborted()
+    total = addStats(total, stats)
   }
   return total
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2256,6 +2256,11 @@
       "playbackSpeed": "Playback speed",
       "animationClip": "Animation clip"
     },
+    "stats": {
+      "vertices": "Vertices",
+      "edges": "Edges",
+      "triangles": "Triangles"
+    },
     "materialModes": {
       "normal": "Normal",
       "wireframe": "Wireframe",


### PR DESCRIPTION
## Summary
Display vertex, edge, and triangle counts in the top-right corner of the Load3D viewport once a model finishes loading. Counts follow Blender's statistics overlay: positions are welded so non-indexed exports report topology rather than GPU buffer size, and degenerate or duplicate triangles are dropped. The work is chunked so large meshes do not block the main thread, and loading another model aborts the pending count.

## Screenshots (if applicable)
<img width="831" height="894" alt="image" src="https://github.com/user-attachments/assets/01d3e18a-cc57-4030-8671-eeffa6abf230" />

