### PR TITLE
Report insertWorkflow abort via reportError telemetry

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1662,7 +1662,7 @@ describe('useWorkflowService', () => {
         )
       } as unknown as ComfyWorkflow
 
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      reportErrorMock.mockClear()
 
       try {
         const pending = useWorkflowService().insertWorkflow(workflow)
@@ -1675,13 +1675,20 @@ describe('useWorkflowService', () => {
 
         expect(deserialize).not.toHaveBeenCalled()
         expect(app.canvas._deserializeItems).not.toHaveBeenCalled()
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining(
-            'insertWorkflow aborted: canvas or graph was replaced'
-          )
-        )
+        expect(reportErrorMock).toHaveBeenCalledTimes(1)
+        expect(reportErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+          errorType: 'workflow_insert_aborted_canvas_changed',
+          level: 'warning',
+          tags: {
+            failure_kind: 'degraded',
+            feature_area: 'workflow',
+            operation: 'insert',
+            outcome: 'degraded',
+            assert_mode: 'soft'
+          },
+          context: { replacement_kind: 'canvas' }
+        })
       } finally {
-        warnSpy.mockRestore()
         Reflect.set(app, 'canvas', originalCanvas)
         Reflect.set(originalCanvas, 'graph', priorGraph)
         Reflect.set(originalCanvas, '_deserializeItems', priorDeserialize)
@@ -1706,7 +1713,7 @@ describe('useWorkflowService', () => {
         )
       } as unknown as ComfyWorkflow
 
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      reportErrorMock.mockClear()
 
       try {
         const pending = useWorkflowService().insertWorkflow(workflow)
@@ -1715,13 +1722,20 @@ describe('useWorkflowService', () => {
         await pending
 
         expect(deserialize).not.toHaveBeenCalled()
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining(
-            'insertWorkflow aborted: canvas or graph was replaced'
-          )
-        )
+        expect(reportErrorMock).toHaveBeenCalledTimes(1)
+        expect(reportErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+          errorType: 'workflow_insert_aborted_canvas_changed',
+          level: 'warning',
+          tags: {
+            failure_kind: 'degraded',
+            feature_area: 'workflow',
+            operation: 'insert',
+            outcome: 'degraded',
+            assert_mode: 'soft'
+          },
+          context: { replacement_kind: 'graph' }
+        })
       } finally {
-        warnSpy.mockRestore()
         Reflect.set(canvas, 'graph', priorGraph)
         Reflect.set(canvas, '_deserializeItems', priorDeserialize)
       }

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -782,8 +782,23 @@ export const useWorkflowService = () => {
     const graph = canvas.graph
     const loadedWorkflow = await workflow.load()
     if (app.canvas !== canvas || canvas.graph !== graph) {
-      console.warn(
-        '[workflowService] insertWorkflow aborted: canvas or graph was replaced while the workflow loaded'
+      const replacementKind = app.canvas !== canvas ? 'canvas' : 'graph'
+      reportError(
+        new Error(
+          'insertWorkflow aborted: canvas or graph was replaced while the workflow loaded'
+        ),
+        {
+          errorType: 'workflow_insert_aborted_canvas_changed',
+          level: 'warning',
+          tags: {
+            failure_kind: 'degraded',
+            feature_area: 'workflow',
+            operation: 'insert',
+            outcome: 'degraded',
+            assert_mode: 'soft'
+          },
+          context: { replacement_kind: replacementKind }
+        }
       )
       return
     }


### PR DESCRIPTION
## Summary

`insertWorkflow` aborts silently when `app.canvas` or `app.canvas.graph` is replaced while the workflow JSON is loading (for example the user opened another tab mid-insert). The abort is correct behaviour, but it left no trace: the caller sees nothing inserted and telemetry sees nothing at all.

This PR keeps the early return and reports it through `reportError` as a soft-assert warning so the case is countable in Sentry:

- `error_type=workflow_insert_aborted_canvas_changed`
- tags `failure_kind=degraded`, `feature_area=workflow`, `operation=insert`, `outcome=degraded`, `assert_mode=soft`
- context `replacement_kind` = `canvas` (canvas object swapped) or `graph` (same canvas, graph swapped). Canvas takes precedence when both changed.

No behavioural change to insertion itself.

## Evidence

- Local: `pnpm vitest run src/platform/workflow/core/services/workflowService.test.ts` -> 1 file passed, 106/106 tests passed (5.85s). The two existing race tests (`canvas replaced`, `graph changed`) now also assert exactly one `reportError` call with the tags above and the matching `replacement_kind`; the positive-control test still asserts zero calls.
- `oxlint` on the two touched files: clean.
- Branch head: `9df88742c6415ec528800b73e28b56e7442316f0` on `c4afd4750b8c63d59d914db962e1f73a11167064` (origin/main).

## Notes for reviewers

Tag values `operation=insert` and `outcome=degraded` are new to the agent telemetry taxonomy (program ADR-029); the registry amendment is landing in the program repo alongside this PR. Veto points: canvas-over-graph precedence for `replacement_kind`, and the exact Error message text.

Program row: tele-22.

<!-- authored-by:agent role-hard-problem -->
