### PR TITLE
fix(ci): main red after merge of PR 16177 — PR: Update Playwright Expectations

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -507,6 +507,11 @@ jobs:
         with:
           comment-id: ${{ needs.setup.outputs.comment-id }}
           issue-number: ${{ needs.setup.outputs.pr-number }}
+          # The action requires `body`/`body-path` even when only editing an
+          # existing comment's reactions; re-supply the same body the
+          # "Add Starting Reaction" step wrote.
+          body: |
+            Updating Playwright Expectations
           reactions: +1
           reactions-edit-mode: replace
 


### PR DESCRIPTION
## Evidence

- Failing run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34736581154 (workflow `PR: Update Playwright Expectations`, event `issue_comment`, head `c4afd4750b8c63d59d914db962e1f73a11167064`, conclusion `failure`, 2026-09-13T03:53:19Z; attribution: `c4afd4750b` is the merge head of https://github.com/Comfy-Org/ComfyUI_frontend/pull/16177)
- Failing job: `merge-and-commit`, step `Add Done Reaction`: `##[error]Missing comment 'body' or 'body-path'.`
- All snapshot-shard jobs (`update-snapshots-sharded (1..4, cloud)`) and the commit/push step succeeded — the expectations commit landed on the PR branch; only the reaction step failed.
- Root cause: `peter-evans/create-or-update-comment@v5` requires `body` or `body-path` on every invocation. The `Add Done Reaction` step edits only the existing bot comment's reactions but omitted `body`, so it fails deterministically whenever it runs (`has-changes == 'true'` on an `issue_comment` run).
- Fix: re-supply the same `body: 'Updating Playwright Expectations'` that the `Add Starting Reaction` step wrote (content no-op for the existing comment) and keep `reactions: +1` + `reactions-edit-mode: replace`.
- Local validation: YAML parse OK, `actionlint` clean for the edited step (only pre-existing SC2086 info notes in unrelated steps), `git diff --check` OK.

Justification: restores green main after the deterministic `PR: Update Playwright Expectations` failure on head `c4afd4750b8c63d59d914db962e1f73a11167064`; CI-only change (workflow YAML input fix, no product code).