### PR TITLE
fix(ci): playwright-video-new-tests rsync/shell errors

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -458,7 +458,8 @@ jobs:
           if [ "$CLOUD_HAS_TESTS" = true ]; then
             # The ComfyUI server serves web_root per request, so swapping the
             # built frontend in place switches it to the cloud build.
-            rsync -a --delete dist-cloud/ dist/
+            # The CI container has no rsync, so replace the directory outright.
+            rm -rf dist && cp -a dist-cloud dist
             PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-cloud pnpm exec playwright test --project=cloud --output=test-results-cloud --timeout=180000 --retries=0 "${FILES[@]}"
           fi
 
@@ -477,6 +478,7 @@ jobs:
 
       - name: Write video comment
         if: ${{ !cancelled() && steps.recordable.outputs.has-tests == 'true' }}
+        shell: bash
         env:
           NEW_TEST_TITLES: ${{ steps.detect.outputs.titles }}
           FALLBACK_SPEC_FILES: ${{ steps.detect.outputs.fallback-files }}


### PR DESCRIPTION
Unblocks any PR that adds a test (e.g. https://github.com/Comfy-Org/ComfyUI_frontend/pull/17221): the `playwright-video-new-tests` job added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/17504 fails on every such PR, which fails `e2e-status`.

<details><summary>Full context for agent readers</summary>

Two defects in the `playwright-video-new-tests` job of `.github/workflows/ci-tests-e2e.yaml`, both visible in run https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34739121675:

1. **`rsync: command not found`** in "Run new test(s) with video recording". The CI container `ghcr.io/comfy-org/comfyui-ci-container:0.0.22` does not ship rsync. Replaced with `rm -rf dist && cp -a dist-cloud dist`.
2. **bash arrays under `sh`** in "Write video comment". The container's default shell is `sh`, so `arr+=(...)` and `${#arr[@]}` are syntax errors. Added `shell: bash` to the step.

Why main is green: `has-new-tests` is false on push events so the job is skipped. It only runs on PRs that add or change a spec file, so every such PR (currently https://github.com/Comfy-Org/ComfyUI_frontend/pull/17221) fails `e2e-status`.

Scope: workflow-only, no production code, no change to `ci-tests-e2e-forks.yaml` (that workflow does not run the video job). Harness/CI class; merged under the standing exception with review requested post-merge.

</details>
