### PR TITLE
fix(ci): select video specs from immutable PR head

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -288,6 +288,7 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -297,8 +298,7 @@ jobs:
             exit 0
           fi
 
-          DIFF_RANGE="${BASE_SHA}...HEAD"
-          NEW_FILES=$(git diff --name-only --diff-filter=AMR "$DIFF_RANGE" -- 'browser_tests/**/*.spec.ts')
+          NEW_FILES=$(bash scripts/cicd/select-pr-playwright-specs.sh "$BASE_SHA" "$HEAD_SHA")
           : > /tmp/fallback-specs.txt
 
           while IFS= read -r file; do

--- a/scripts/cicd/select-pr-playwright-specs.sh
+++ b/scripts/cicd/select-pr-playwright-specs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_sha=${1:?base SHA is required}
+head_sha=${2:?PR head SHA is required}
+
+for sha in "$base_sha" "$head_sha"; do
+  git cat-file -e "${sha}^{commit}" || {
+    echo "Required PR commit is not available: $sha" >&2
+    exit 1
+  }
+done
+
+git diff --name-only --diff-filter=AMR "${base_sha}...${head_sha}" -- \
+  'browser_tests/**/*.spec.ts'

--- a/scripts/cicd/select-pr-playwright-specs.test.ts
+++ b/scripts/cicd/select-pr-playwright-specs.test.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const SCRIPT = join(import.meta.dirname, 'select-pr-playwright-specs.sh')
+
+const git = (cwd: string, ...args: string[]) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+
+describe('select-pr-playwright-specs.sh', () => {
+  it('is called with the pull request head SHA by the video workflow', () => {
+    const workflow = readFileSync('.github/workflows/ci-tests-e2e.yaml', 'utf8')
+
+    expect(workflow).toContain(
+      'HEAD_SHA: ${{ github.event.pull_request.head.sha }}'
+    )
+    expect(workflow).toContain(
+      'select-pr-playwright-specs.sh "$BASE_SHA" "$HEAD_SHA"'
+    )
+  })
+
+  it('diffs the immutable PR head instead of the synthetic merge checkout', () => {
+    const root = mkdtempSync(join(tmpdir(), 'playwright-spec-selector-'))
+    try {
+      git(root, 'init', '-q')
+      git(root, 'config', 'user.email', 'ci@example.com')
+      git(root, 'config', 'user.name', 'CI')
+      git(root, 'config', 'core.hooksPath', '/dev/null')
+      git(root, 'checkout', '-q', '-b', 'main')
+      writeFileSync(join(root, 'README.md'), 'base\n')
+      git(root, 'add', '.')
+      git(root, 'commit', '-qm', 'base')
+      const base = git(root, 'rev-parse', 'HEAD')
+
+      git(root, 'checkout', '-q', '-b', 'pr')
+      execFileSync('mkdir', ['-p', join(root, 'browser_tests/tests/pr')])
+      writeFileSync(
+        join(root, 'browser_tests/tests/pr/actual.spec.ts'),
+        'test("actual", () => {})\n'
+      )
+      git(root, 'add', '.')
+      git(root, 'commit', '-qm', 'PR spec')
+      const head = git(root, 'rev-parse', 'HEAD')
+
+      git(root, 'checkout', '-q', 'main')
+      execFileSync('mkdir', ['-p', join(root, 'browser_tests/tests/main')])
+      writeFileSync(
+        join(root, 'browser_tests/tests/main/unrelated.spec.ts'),
+        'test("unrelated", () => {})\n'
+      )
+      git(root, 'add', '.')
+      git(root, 'commit', '-qm', 'incoming main spec')
+      git(root, 'merge', '--no-ff', '-qm', 'synthetic merge', 'pr')
+
+      expect(git(root, 'cat-file', '-t', base)).toBe('commit')
+      expect(git(root, 'cat-file', '-t', head)).toBe('commit')
+      expect(
+        execFileSync('bash', [SCRIPT, base, head], {
+          cwd: root,
+          encoding: 'utf8'
+        }).trim()
+      ).toBe('browser_tests/tests/pr/actual.spec.ts')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/cicd/select-pr-playwright-specs.test.ts
+++ b/scripts/cicd/select-pr-playwright-specs.test.ts
@@ -1,7 +1,13 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -9,6 +15,42 @@ const SCRIPT = join(import.meta.dirname, 'select-pr-playwright-specs.sh')
 
 const git = (cwd: string, ...args: string[]) =>
   execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+
+const select = (cwd: string, baseSha: string, headSha: string) =>
+  execFileSync('bash', [SCRIPT, baseSha, headSha], {
+    cwd,
+    encoding: 'utf8'
+  }).trim()
+
+const writeSpec = (root: string, path: string, title: string) => {
+  mkdirSync(join(root, dirname(path)), { recursive: true })
+  writeFileSync(join(root, path), `test(${JSON.stringify(title)}, () => {})\n`)
+}
+
+const commitAll = (root: string, message: string) => {
+  git(root, 'add', '-A')
+  git(root, 'commit', '-qm', message)
+  return git(root, 'rev-parse', 'HEAD')
+}
+
+/**
+ * Builds a throwaway repository whose `main` holds one commit, hands it to the
+ * caller, and removes it afterwards.
+ */
+const withRepo = (run: (root: string, base: string) => void) => {
+  const root = mkdtempSync(join(tmpdir(), 'playwright-spec-selector-'))
+  try {
+    git(root, 'init', '-q')
+    git(root, 'config', 'user.email', 'ci@example.com')
+    git(root, 'config', 'user.name', 'CI')
+    git(root, 'config', 'core.hooksPath', '/dev/null')
+    git(root, 'checkout', '-q', '-b', 'main')
+    writeFileSync(join(root, 'README.md'), 'base\n')
+    run(root, commitAll(root, 'base'))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
 
 describe('select-pr-playwright-specs.sh', () => {
   it('is called with the pull request head SHA by the video workflow', () => {
@@ -23,48 +65,87 @@ describe('select-pr-playwright-specs.sh', () => {
   })
 
   it('diffs the immutable PR head instead of the synthetic merge checkout', () => {
-    const root = mkdtempSync(join(tmpdir(), 'playwright-spec-selector-'))
-    try {
-      git(root, 'init', '-q')
-      git(root, 'config', 'user.email', 'ci@example.com')
-      git(root, 'config', 'user.name', 'CI')
-      git(root, 'config', 'core.hooksPath', '/dev/null')
-      git(root, 'checkout', '-q', '-b', 'main')
-      writeFileSync(join(root, 'README.md'), 'base\n')
-      git(root, 'add', '.')
-      git(root, 'commit', '-qm', 'base')
-      const base = git(root, 'rev-parse', 'HEAD')
-
+    withRepo((root, base) => {
       git(root, 'checkout', '-q', '-b', 'pr')
-      execFileSync('mkdir', ['-p', join(root, 'browser_tests/tests/pr')])
-      writeFileSync(
-        join(root, 'browser_tests/tests/pr/actual.spec.ts'),
-        'test("actual", () => {})\n'
-      )
-      git(root, 'add', '.')
-      git(root, 'commit', '-qm', 'PR spec')
-      const head = git(root, 'rev-parse', 'HEAD')
+      writeSpec(root, 'browser_tests/tests/pr/actual.spec.ts', 'actual')
+      const head = commitAll(root, 'PR spec')
 
       git(root, 'checkout', '-q', 'main')
-      execFileSync('mkdir', ['-p', join(root, 'browser_tests/tests/main')])
-      writeFileSync(
-        join(root, 'browser_tests/tests/main/unrelated.spec.ts'),
-        'test("unrelated", () => {})\n'
-      )
-      git(root, 'add', '.')
-      git(root, 'commit', '-qm', 'incoming main spec')
+      writeSpec(root, 'browser_tests/tests/main/unrelated.spec.ts', 'unrelated')
+      commitAll(root, 'incoming main spec')
       git(root, 'merge', '--no-ff', '-qm', 'synthetic merge', 'pr')
 
       expect(git(root, 'cat-file', '-t', base)).toBe('commit')
       expect(git(root, 'cat-file', '-t', head)).toBe('commit')
-      expect(
-        execFileSync('bash', [SCRIPT, base, head], {
-          cwd: root,
-          encoding: 'utf8'
-        }).trim()
-      ).toBe('browser_tests/tests/pr/actual.spec.ts')
-    } finally {
-      rmSync(root, { recursive: true, force: true })
-    }
+      expect(select(root, base, head)).toBe(
+        'browser_tests/tests/pr/actual.spec.ts'
+      )
+    })
+  })
+
+  it('selects a spec the pull request only modified', () => {
+    withRepo((root) => {
+      writeSpec(root, 'browser_tests/tests/pr/existing.spec.ts', 'before')
+      const base = commitAll(root, 'existing spec')
+
+      writeSpec(root, 'browser_tests/tests/pr/existing.spec.ts', 'after')
+      const head = commitAll(root, 'strengthen the assertion')
+
+      expect(select(root, base, head)).toBe(
+        'browser_tests/tests/pr/existing.spec.ts'
+      )
+    })
+  })
+
+  it('selects a renamed spec under its new path only', () => {
+    withRepo((root) => {
+      writeSpec(root, 'browser_tests/tests/pr/old.spec.ts', 'moved')
+      const base = commitAll(root, 'spec at its old path')
+
+      git(
+        root,
+        'mv',
+        'browser_tests/tests/pr/old.spec.ts',
+        'browser_tests/tests/pr/new.spec.ts'
+      )
+      const head = commitAll(root, 'move the spec')
+
+      expect(select(root, base, head)).toBe(
+        'browser_tests/tests/pr/new.spec.ts'
+      )
+    })
+  })
+
+  it('selects nothing when the pull request changes no spec', () => {
+    withRepo((root, base) => {
+      mkdirSync(join(root, 'src'), { recursive: true })
+      writeFileSync(join(root, 'src/thing.ts'), 'export const thing = 1\n')
+      const head = commitAll(root, 'source-only change')
+
+      // Without this the empty selection could equally mean an empty range.
+      expect(git(root, 'diff', '--name-only', `${base}...${head}`)).toBe(
+        'src/thing.ts'
+      )
+      expect(select(root, base, head)).toBe('')
+    })
+  })
+
+  it('fails loudly when a required commit is missing from the checkout', () => {
+    withRepo((root, base) => {
+      const absent = '0'.repeat(40)
+      expect(git(root, 'cat-file', '-t', base)).toBe('commit')
+
+      let failure: { status?: number; stderr?: string } | undefined
+      try {
+        select(root, base, absent)
+      } catch (error) {
+        failure = error as { status?: number; stderr?: string }
+      }
+
+      expect(failure?.status).toBeGreaterThan(0)
+      expect(failure?.stderr).toContain(
+        `Required PR commit is not available: ${absent}`
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary

Select only the pull request's tests. Exclude incoming-main specs.

**Human owner:** `DrJKL`

<details><summary>Full context for agent readers</summary>

## Changes

- **What:** Compare the event's immutable base and head commits for video spec selection, rather than the synthetic merge checkout. Preserve whole-file fallback and fork skipping.
- Add a small shell selector with a synthetic Git-history regression fixture. An incoming-main spec must not appear beside the actual pull-request spec.

## Review Focus

The checkout uses complete history; both required commits must exist or selection fails rather than silently reporting no tests. No timeout, required-check policy, or application behavior changes.

The failure affected the [dialog test video job](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/34734339858/job/103663285421): its synthetic merge range selected 183 spec files and the recording ran 1,267 tests before the 15-minute timeout. The actual pull-request range selects four files.

The [separate workflow portability repair](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17595) changes rsync/shell handling, not this selector.

## Testing

Run the focused Git-history fixture and Shellcheck. The fixture creates a disposable repository;
it does not launch a browser or contact a backend.

### E2E Verification Steps

When hosted checks run, inspect the video job's changed-spec list. It must match the immutable
pull-request diff and exclude unrelated incoming-main specs. No manual rerun is requested.

## Verification Evidence

```text
$ ./node_modules/.bin/vitest run scripts/cicd/select-pr-playwright-specs.test.ts
Test Files 1 passed (1)
Tests 2 passed (2)
$ shellcheck scripts/cicd/select-pr-playwright-specs.sh
exit 0
$ git diff --check
exit 0
```

Causal control: temporarily selecting HEAD instead of the supplied PR head failed the history test on the extra incoming-main spec; the wiring control passed. Restoring the fix passed both tests. The real incident's immutable commits independently selected four files with the repair versus 183 using the synthetic merge.

Hosted checks have not run on this new branch. No manual workflow rerun or deployment was performed.

## Checklist

- [x] Scope limited to video spec selection.
- [x] Regression fixture distinguishes PR changes from incoming main.
- [x] Old selector mutation fails for the intended extra-file reason.
- [x] Restored tests and Shellcheck pass.
- [x] No application behavior or timeout policy changed.
- [ ] Hosted checks and human review complete.

Glossary: synthetic merge = GitHub's temporary merge of a pull request into the current target branch; PR = pull request; CI = automated integration checks.

</details>
